### PR TITLE
Enrich error telemetry with chain types and a shared classifier

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -27,6 +27,7 @@ words:
   - cooldown
   - customtype
   - devcontainers
+  - errchain
   - errgroup
   - errorhandler
   - extendee
@@ -63,6 +64,7 @@ words:
   - syncmap
   - syscall
   - tsx
+  - triaging
   - Retryable
   - runcontext
   - surveyterm
@@ -115,6 +117,7 @@ words:
   - exfiltration
   - Fprintf
   - gocritic
+  - gocyclo
   - gradlew
   - IMDS
   - managedhsm

--- a/cli/azd/internal/cmd/errors.go
+++ b/cli/azd/internal/cmd/errors.go
@@ -13,7 +13,6 @@ import (
 	"log"
 	"net"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"strings"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/agent/consent"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
+	"github.com/azure/azure-dev/cli/azd/internal/tracing/errchain"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
@@ -40,173 +40,247 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
-// MapError maps the given error to a telemetry span, setting relevant status and attributes.
+// MapError maps the given error to a telemetry span, setting status (the
+// AppInsights ResultCode), a small set of error.* attributes, and the
+// full wrapped-type chain. The classification ladder lives in classify;
+// this function is responsible only for stamping its result onto the
+// span.
 func MapError(err error, span tracing.Span) {
-	var errCode string
-	var errDetails []attribute.KeyValue
+	code, attrs := classify(err)
+
+	// Always emit the wrapped-error type chain so engineers can see
+	// what hides behind a generic ResultCode like internal.unclassified
+	// without needing to repro. Type names are code-defined and PII-free.
+	span.SetAttributes(fields.ErrChainTypes.StringSlice(errchain.Types(err)))
+
+	if len(attrs) > 0 {
+		// Prefix all detail attributes with "error." so they group in
+		// AppInsights without colliding with span-scope keys.
+		for i, a := range attrs {
+			attrs[i].Key = fields.ErrorKey(a.Key)
+		}
+		span.SetAttributes(attrs...)
+	}
+
+	span.SetStatus(codes.Error, code)
+}
+
+// classify runs the typed/sentinel decision tree and returns the
+// telemetry ResultCode together with any structured attributes the
+// matched branch wants to expose. Attribute keys returned from this
+// function are NOT yet "error."-prefixed — MapError applies the prefix.
+//
+// The branch count mirrors azd's typed error surface; splitting it
+// makes the telemetry contract harder to audit.
+//
+//nolint:gocyclo
+func classify(err error) (string, []attribute.KeyValue) {
+	if err == nil {
+		// Preserve historical behavior for the nil-error edge case.
+		return "internal.<nil>", []attribute.KeyValue{fields.ErrType.String("<nil>")}
+	}
 
 	if updateErr, ok := errors.AsType[*update.UpdateError](err); ok {
-		errCode = updateErr.Code
-	} else if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
-		errCode = "auth.login_required"
-		errDetails = append(errDetails, fields.ErrCategory.String("auth"))
-	} else if errWithSuggestion, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
-		errCode = "error.suggestion"
-		innerErr := errWithSuggestion.Unwrap()
-		span.SetAttributes(fields.ErrType.String(classifySuggestionType(innerErr)))
-		if authFailedErr, ok := errors.AsType[*auth.AuthFailedError](innerErr); ok {
-			errDetails = append(errDetails, authFailedTelemetryDetails(authFailedErr)...)
-		}
-	} else if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
-		serviceName := "other"
-		statusCode := -1
-		errDetails = append(errDetails, fields.ServiceErrorCode.String(respErr.ErrorCode))
-
-		if respErr.RawResponse != nil {
-			statusCode = respErr.RawResponse.StatusCode
-			errDetails = append(errDetails, fields.ServiceStatusCode.Int(statusCode))
-
-			if respErr.RawResponse.Request != nil {
-				var hostName string
-				serviceName, hostName = mapService(respErr.RawResponse.Request.Host)
-				errDetails = append(errDetails,
-					fields.ServiceHost.String(hostName),
-					fields.ServiceMethod.String(respErr.RawResponse.Request.Method),
-					fields.ServiceName.String(serviceName),
-				)
-			}
-		}
-
-		errCode = fmt.Sprintf("service.%s.%d", serviceName, statusCode)
-	} else if armDeployErr, ok := errors.AsType[*azapi.AzureDeploymentError](err); ok {
-		errDetails = append(errDetails, fields.ServiceName.String("arm"))
-		codes := []*deploymentErrorCode{}
-		var collect func(details []*azapi.DeploymentErrorLine, frame int)
-		collect = func(details []*azapi.DeploymentErrorLine, frame int) {
-			code := collectCode(details, frame)
-			if code != nil {
-				codes = append(codes, code)
-				frame = frame + 1
-			}
-
-			for _, detail := range details {
-				if detail.Inner != nil {
-					collect(detail.Inner, frame)
-				}
-			}
-		}
-
-		collect([]*azapi.DeploymentErrorLine{armDeployErr.Details}, 0)
-		if len(codes) > 0 {
-			if codesJson, err := json.Marshal(codes); err != nil {
-				log.Println("telemetry: failed to marshal arm error codes", err)
-			} else {
-				errDetails = append(errDetails, fields.ServiceErrorCode.String(string(codesJson)))
-			}
-		}
-
-		// Use operation-specific error code if available
-		operation := armDeployErr.Operation
-		if operation == azapi.DeploymentOperationDeploy {
-			// use 'deployment' instead of 'deploy' for consistency with prior naming
-			operation = "deployment"
-		}
-		errCode = fmt.Sprintf("service.arm.%s.failed", operation)
-	} else if extServiceErr, ok := errors.AsType[*azdext.ServiceError](err); ok {
-		// Handle structured service errors from extensions.
-		// Emit whatever details are available rather than requiring all fields.
-		serviceName := ""
-		if extServiceErr.ServiceName != "" {
-			var hostDomain string
-			serviceName, hostDomain = mapService(extServiceErr.ServiceName)
-			errDetails = append(errDetails,
-				fields.ServiceName.String(serviceName),
-				fields.ServiceHost.String(hostDomain),
-			)
-		}
-		if extServiceErr.StatusCode > 0 {
-			errDetails = append(errDetails, fields.ServiceStatusCode.Int(extServiceErr.StatusCode))
-		}
-		if extServiceErr.ErrorCode != "" {
-			errDetails = append(errDetails, fields.ServiceErrorCode.String(extServiceErr.ErrorCode))
-		}
-
-		// Use operation.errorCode (e.g. "ext.service.start_container.invalid_payload") for actionable
-		// classification instead of host.statusCode which groups unrelated failures together.
-		switch {
-		case extServiceErr.ErrorCode != "":
-			errCode = fmt.Sprintf("ext.service.%s", normalizeCodeSegment(extServiceErr.ErrorCode, "failed"))
-		case extServiceErr.StatusCode > 0 && serviceName != "":
-			errCode = fmt.Sprintf("ext.service.%s.%d", serviceName, extServiceErr.StatusCode)
-		case extServiceErr.StatusCode > 0:
-			errCode = fmt.Sprintf("ext.service.unknown.%d", extServiceErr.StatusCode)
-		default:
-			errCode = "ext.service.unknown.failed"
-		}
-	} else if extLocalErr, ok := errors.AsType[*azdext.LocalError](err); ok {
-		domain := string(azdext.NormalizeLocalErrorCategory(extLocalErr.Category))
-		code := normalizeCodeSegment(extLocalErr.Code, "failed")
-
-		errDetails = append(errDetails,
-			fields.ErrCategory.String(domain),
-			fields.ErrCode.String(code),
-		)
-
-		errCode = fmt.Sprintf("ext.%s.%s", domain, code)
-	} else if _, ok := errors.AsType[*extensions.ExtensionRunError](err); ok {
-		errCode = "ext.run.failed"
-	} else if toolExecErr, ok := errors.AsType[*exec.ExitError](err); ok {
+		return updateErr.Code, nil
+	}
+	if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
+		return "auth.login_required", []attribute.KeyValue{fields.ErrCategory.String("auth")}
+	}
+	if errWithSuggestion, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
+		return classifyErrorWithSuggestion(errWithSuggestion)
+	}
+	if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
+		return classifyResponseError(respErr)
+	}
+	if armDeployErr, ok := errors.AsType[*azapi.AzureDeploymentError](err); ok {
+		return classifyArmDeployError(armDeployErr)
+	}
+	if extServiceErr, ok := errors.AsType[*azdext.ServiceError](err); ok {
+		return classifyExtServiceError(extServiceErr)
+	}
+	if extLocalErr, ok := errors.AsType[*azdext.LocalError](err); ok {
+		return classifyExtLocalError(extLocalErr)
+	}
+	if _, ok := errors.AsType[*extensions.ExtensionRunError](err); ok {
+		return "ext.run.failed", nil
+	}
+	if toolExecErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		toolName := "other"
-		cmdName := cmdAsName(toolExecErr.Cmd)
-		if cmdName != "" {
+		if cmdName := cmdAsName(toolExecErr.Cmd); cmdName != "" {
 			toolName = cmdName
 		}
-
-		errDetails = append(errDetails,
+		return fmt.Sprintf("tool.%s.failed", toolName), []attribute.KeyValue{
 			fields.ToolExitCode.Int(toolExecErr.ExitCode),
-			fields.ToolName.String(toolName))
-
-		errCode = fmt.Sprintf("tool.%s.failed", toolName)
-	} else if toolCheckErr, ok := errors.AsType[*tools.MissingToolErrors](err); ok {
+			fields.ToolName.String(toolName),
+		}
+	}
+	if toolCheckErr, ok := errors.AsType[*tools.MissingToolErrors](err); ok {
 		if len(toolCheckErr.ToolNames) == 1 {
 			toolName := toolCheckErr.ToolNames[0]
-			errCode = fmt.Sprintf("tool.%s.missing", toolName)
-			errDetails = append(errDetails, fields.ToolName.String(toolName))
+			return fmt.Sprintf("tool.%s.missing", toolName),
+				[]attribute.KeyValue{fields.ToolName.String(toolName)}
+		}
+		return "tool.multiple.missing", []attribute.KeyValue{
+			fields.ToolName.String(strings.Join(toolCheckErr.ToolNames, ",")),
+		}
+	}
+	if authFailedErr, ok := errors.AsType[*auth.AuthFailedError](err); ok {
+		return "service.aad.failed", authFailedTelemetryDetails(authFailedErr)
+	}
+	if errors.Is(err, auth.ErrNoCurrentUser) {
+		return "auth.not_logged_in", []attribute.KeyValue{fields.ErrCategory.String("auth")}
+	}
+	if _, ok := errors.AsType[*azidentity.AuthenticationFailedError](err); ok {
+		return "auth.identity_failed", []attribute.KeyValue{fields.ErrCategory.String("auth")}
+	}
+	if code := classifySentinel(err); code != "" {
+		return code, nil
+	}
+	if isNetworkError(err) {
+		return "internal.network", []attribute.KeyValue{
+			fields.ErrType.String(errchain.DeepestNamedType(err)),
+		}
+	}
+
+	// Generic fallback: walk the chain and keep the deepest non-generic
+	// type so wrappers like *fmt.wrapError or *errorhandler.ErrorWithSuggestion
+	// don't mask the real error. internal.unclassified only fires
+	// when no chain entry has a meaningful named type.
+	deepest := errchain.DeepestNamedType(err)
+	if deepest == "" || errchain.IsGenericWrapper(deepest) {
+		return "internal.unclassified", []attribute.KeyValue{fields.ErrType.String(deepest)}
+	}
+	return fmt.Sprintf("internal.%s", sanitizeTypeName(deepest)),
+		[]attribute.KeyValue{fields.ErrType.String(deepest)}
+}
+
+// classifyErrorWithSuggestion handles *internal.ErrorWithSuggestion.
+// It preserves the historical narrow attribute set (only error.type
+// from the inner classification, plus the auth special case) and
+// emits the legacy `error.suggestion` ResultCode.
+func classifyErrorWithSuggestion(
+	ews *internal.ErrorWithSuggestion,
+) (string, []attribute.KeyValue) {
+	innerErr := ews.Unwrap()
+	innerCode, _ := classify(innerErr)
+
+	attrs := []attribute.KeyValue{fields.ErrType.String(innerCode)}
+
+	// Preserve the AAD-detail enrichment when an AuthFailedError is
+	// wrapped by a suggestion so it still surfaces on the outer span.
+	if authFailedErr, ok := errors.AsType[*auth.AuthFailedError](innerErr); ok {
+		attrs = append(attrs, authFailedTelemetryDetails(authFailedErr)...)
+	}
+
+	return "error.suggestion", attrs
+}
+
+func classifyResponseError(respErr *azcore.ResponseError) (string, []attribute.KeyValue) {
+	serviceName := "other"
+	statusCode := -1
+	attrs := []attribute.KeyValue{fields.ServiceErrorCode.String(respErr.ErrorCode)}
+
+	if respErr.RawResponse != nil {
+		statusCode = respErr.RawResponse.StatusCode
+		attrs = append(attrs, fields.ServiceStatusCode.Int(statusCode))
+
+		if respErr.RawResponse.Request != nil {
+			var hostName string
+			serviceName, hostName = mapService(respErr.RawResponse.Request.Host)
+			attrs = append(attrs,
+				fields.ServiceHost.String(hostName),
+				fields.ServiceMethod.String(respErr.RawResponse.Request.Method),
+				fields.ServiceName.String(serviceName),
+			)
+		}
+	}
+
+	return fmt.Sprintf("service.%s.%d", serviceName, statusCode), attrs
+}
+
+func classifyArmDeployError(armDeployErr *azapi.AzureDeploymentError) (string, []attribute.KeyValue) {
+	attrs := []attribute.KeyValue{fields.ServiceName.String("arm")}
+	codes := []*deploymentErrorCode{}
+	var collect func(details []*azapi.DeploymentErrorLine, frame int)
+	collect = func(details []*azapi.DeploymentErrorLine, frame int) {
+		code := collectCode(details, frame)
+		if code != nil {
+			codes = append(codes, code)
+			frame = frame + 1
+		}
+
+		for _, detail := range details {
+			if detail.Inner != nil {
+				collect(detail.Inner, frame)
+			}
+		}
+	}
+
+	collect([]*azapi.DeploymentErrorLine{armDeployErr.Details}, 0)
+	if len(codes) > 0 {
+		if codesJson, err := json.Marshal(codes); err != nil {
+			log.Println("telemetry: failed to marshal arm error codes", err)
 		} else {
-			errCode = "tool.multiple.missing"
-			errDetails = append(errDetails, fields.ToolName.String(strings.Join(toolCheckErr.ToolNames, ",")))
+			attrs = append(attrs, fields.ServiceErrorCode.String(string(codesJson)))
 		}
-	} else if authFailedErr, ok := errors.AsType[*auth.AuthFailedError](err); ok {
-		errDetails = append(errDetails, authFailedTelemetryDetails(authFailedErr)...)
-		errCode = "service.aad.failed"
-	} else if errors.Is(err, auth.ErrNoCurrentUser) {
-		errCode = "auth.not_logged_in"
-		errDetails = append(errDetails, fields.ErrCategory.String("auth"))
-	} else if _, ok := errors.AsType[*azidentity.AuthenticationFailedError](err); ok {
-		errCode = "auth.identity_failed"
-		errDetails = append(errDetails, fields.ErrCategory.String("auth"))
-	} else if code := classifySentinel(err); code != "" {
-		errCode = code
-	} else if isNetworkError(err) {
-		errCode = "internal.network"
-		errType := errorType(err)
-		span.SetAttributes(fields.ErrType.String(errType))
-	} else {
-		errType := errorType(err)
-		span.SetAttributes(fields.ErrType.String(errType))
-		errCode = fmt.Sprintf("internal.%s",
-			strings.ReplaceAll(strings.ReplaceAll(errType, ".", "_"), "*", ""))
 	}
 
-	if len(errDetails) > 0 {
-		for i, detail := range errDetails {
-			errDetails[i].Key = fields.ErrorKey(detail.Key)
-		}
+	// Use operation-specific error code if available
+	operation := armDeployErr.Operation
+	if operation == azapi.DeploymentOperationDeploy {
+		// use 'deployment' instead of 'deploy' for consistency with prior naming
+		operation = "deployment"
+	}
+	return fmt.Sprintf("service.arm.%s.failed", operation), attrs
+}
 
-		span.SetAttributes(errDetails...)
+func classifyExtServiceError(extServiceErr *azdext.ServiceError) (string, []attribute.KeyValue) {
+	// Handle structured service errors from extensions.
+	// Emit whatever details are available rather than requiring all fields.
+	serviceName := ""
+	var attrs []attribute.KeyValue
+	if extServiceErr.ServiceName != "" {
+		var hostDomain string
+		serviceName, hostDomain = mapService(extServiceErr.ServiceName)
+		attrs = append(attrs,
+			fields.ServiceName.String(serviceName),
+			fields.ServiceHost.String(hostDomain),
+		)
+	}
+	if extServiceErr.StatusCode > 0 {
+		attrs = append(attrs, fields.ServiceStatusCode.Int(extServiceErr.StatusCode))
+	}
+	if extServiceErr.ErrorCode != "" {
+		attrs = append(attrs, fields.ServiceErrorCode.String(extServiceErr.ErrorCode))
 	}
 
-	span.SetStatus(codes.Error, errCode)
+	// Use operation.errorCode (e.g. "ext.service.start_container.invalid_payload") for actionable
+	// classification instead of host.statusCode which groups unrelated failures together.
+	switch {
+	case extServiceErr.ErrorCode != "":
+		return fmt.Sprintf("ext.service.%s", normalizeCodeSegment(extServiceErr.ErrorCode, "failed")), attrs
+	case extServiceErr.StatusCode > 0 && serviceName != "":
+		return fmt.Sprintf("ext.service.%s.%d", serviceName, extServiceErr.StatusCode), attrs
+	case extServiceErr.StatusCode > 0:
+		return fmt.Sprintf("ext.service.unknown.%d", extServiceErr.StatusCode), attrs
+	default:
+		return "ext.service.unknown.failed", attrs
+	}
+}
+
+func classifyExtLocalError(extLocalErr *azdext.LocalError) (string, []attribute.KeyValue) {
+	domain := string(azdext.NormalizeLocalErrorCategory(extLocalErr.Category))
+	code := normalizeCodeSegment(extLocalErr.Code, "failed")
+	return fmt.Sprintf("ext.%s.%s", domain, code), []attribute.KeyValue{
+		fields.ErrCategory.String(domain),
+		fields.ErrCode.String(code),
+	}
+}
+
+// sanitizeTypeName converts a Go type name (e.g. "*azcore.ResponseError")
+// into a telemetry-safe segment ("azcore_ResponseError").
+func sanitizeTypeName(name string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(name, ".", "_"), "*", "")
 }
 
 func authFailedTelemetryDetails(authFailedErr *auth.AuthFailedError) []attribute.KeyValue {
@@ -320,148 +394,19 @@ func classifySentinel(err error) string {
 	}
 }
 
-// classifySuggestionType returns a telemetry error type string for an inner error wrapped by ErrorWithSuggestion.
-// It preserves the suggestion result code while improving the error.type attribute when the inner error is structured.
+// deploymentErrorCode is the per-frame ARM error breakdown that gets
+// JSON-encoded into the service.errorCode telemetry property.
 //
-// The check order here should match MapError to ensure consistent classification.
-// Structured error types are checked first, then sentinels, then network errors, then fallback.
-func classifySuggestionType(err error) string {
-	if updateErr, ok := errors.AsType[*update.UpdateError](err); ok {
-		return updateErr.Code
-	}
-
-	if _, ok := errors.AsType[*auth.ReLoginRequiredError](err); ok {
-		return "auth.login_required"
-	}
-
-	if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
-		serviceName := "other"
-		statusCode := -1
-
-		if respErr.RawResponse != nil {
-			statusCode = respErr.RawResponse.StatusCode
-			if respErr.RawResponse.Request != nil {
-				serviceName, _ = mapService(respErr.RawResponse.Request.Host)
-			}
-		}
-
-		return fmt.Sprintf("service.%s.%d", serviceName, statusCode)
-	}
-
-	if armDeployErr, ok := errors.AsType[*azapi.AzureDeploymentError](err); ok {
-		operationName := armDeployErr.Operation
-		if operationName == azapi.DeploymentOperationDeploy {
-			operationName = "deployment"
-		}
-
-		return fmt.Sprintf("service.arm.%s.failed", operationName)
-	}
-
-	if extServiceErr, ok := errors.AsType[*azdext.ServiceError](err); ok {
-		serviceName := ""
-		if extServiceErr.ServiceName != "" {
-			serviceName, _ = mapService(extServiceErr.ServiceName)
-		}
-
-		switch {
-		case extServiceErr.ErrorCode != "":
-			return fmt.Sprintf("ext.service.%s", normalizeCodeSegment(extServiceErr.ErrorCode, "failed"))
-		case extServiceErr.StatusCode > 0 && serviceName != "":
-			return fmt.Sprintf("ext.service.%s.%d", serviceName, extServiceErr.StatusCode)
-		case extServiceErr.StatusCode > 0:
-			return fmt.Sprintf("ext.service.unknown.%d", extServiceErr.StatusCode)
-		default:
-			return "ext.service.unknown.failed"
-		}
-	}
-
-	if extLocalErr, ok := errors.AsType[*azdext.LocalError](err); ok {
-		domain := string(azdext.NormalizeLocalErrorCategory(extLocalErr.Category))
-		code := normalizeCodeSegment(extLocalErr.Code, "failed")
-
-		return fmt.Sprintf("ext.%s.%s", domain, code)
-	}
-
-	if _, ok := errors.AsType[*extensions.ExtensionRunError](err); ok {
-		return "ext.run.failed"
-	}
-
-	if toolExecErr, ok := errors.AsType[*exec.ExitError](err); ok {
-		toolName := "other"
-		if cmdName := cmdAsName(toolExecErr.Cmd); cmdName != "" {
-			toolName = cmdName
-		}
-
-		return fmt.Sprintf("tool.%s.failed", toolName)
-	}
-
-	if toolCheckErr, ok := errors.AsType[*tools.MissingToolErrors](err); ok {
-		if len(toolCheckErr.ToolNames) == 1 {
-			return fmt.Sprintf("tool.%s.missing", toolCheckErr.ToolNames[0])
-		}
-
-		return "tool.multiple.missing"
-	}
-
-	if _, ok := errors.AsType[*auth.AuthFailedError](err); ok {
-		return "service.aad.failed"
-	}
-
-	if errors.Is(err, auth.ErrNoCurrentUser) {
-		return "auth.not_logged_in"
-	}
-
-	if _, ok := errors.AsType[*azidentity.AuthenticationFailedError](err); ok {
-		return "auth.identity_failed"
-	}
-
-	if code := classifySentinel(err); code != "" {
-		return code
-	}
-
-	if isNetworkError(err) {
-		return "internal.network"
-	}
-
-	return errorType(err)
-}
-
-// errorType returns the type name of the given error, unwrapping as needed to find the root cause(s).
-func errorType(err error) string {
-	if err == nil {
-		return "<nil>"
-	}
-
-	//nolint:errorlint // Type switch is intentionally used to check for Unwrap() methods
-	for {
-		switch x := err.(type) {
-		case interface{ Unwrap() error }:
-			err = x.Unwrap()
-			if err == nil {
-				return reflect.TypeOf(x).String()
-			}
-		case interface{ Unwrap() []error }:
-			result := ""
-			for _, err := range x.Unwrap() {
-				if err == nil {
-					continue
-				}
-				if result != "" {
-					result += ","
-				}
-
-				result += reflect.TypeOf(err).String()
-			}
-			return result
-		default:
-			return reflect.TypeOf(x).String()
-		}
-	}
-}
-
+// "error.arm.frame_index" is an integer encoding the depth of the
+// current line within the ARM deployment-error tree, not a Go runtime
+// frame. It used to be named "error.frame", which conflicted with the
+// (now removed) fields.ErrFrame attribute key.
+//
+// Field declaration order matches the alphabetical order of the json
+// tags so encoding/json output matches map[string]any output in tests.
 type deploymentErrorCode struct {
+	Frame int    `json:"error.arm.frame_index"`
 	Code  string `json:"error.code"`
-	Frame int    `json:"error.frame"`
 }
 
 func collectCode(lines []*azapi.DeploymentErrorLine, frame int) *deploymentErrorCode {

--- a/cli/azd/internal/cmd/errors.go
+++ b/cli/azd/internal/cmd/errors.go
@@ -70,6 +70,10 @@ func MapError(err error, span tracing.Span) {
 // matched branch wants to expose. Attribute keys returned from this
 // function are NOT yet "error."-prefixed — MapError applies the prefix.
 //
+// Ordering matters: wrapper types that intentionally control outer
+// classification, such as ErrorWithSuggestion, must run before their
+// wrapped typed errors. The generic fallback must remain last.
+//
 // The branch count mirrors azd's typed error surface; splitting it
 // makes the telemetry contract harder to audit.
 //
@@ -150,7 +154,7 @@ func classify(err error) (string, []attribute.KeyValue) {
 	if deepest == "" || errchain.IsGenericWrapper(deepest) {
 		return "internal.unclassified", []attribute.KeyValue{fields.ErrType.String(deepest)}
 	}
-	return fmt.Sprintf("internal.%s", sanitizeTypeName(deepest)),
+	return fmt.Sprintf("internal.%s", errchain.SanitizeTypeName(deepest)),
 		[]attribute.KeyValue{fields.ErrType.String(deepest)}
 }
 
@@ -275,12 +279,6 @@ func classifyExtLocalError(extLocalErr *azdext.LocalError) (string, []attribute.
 		fields.ErrCategory.String(domain),
 		fields.ErrCode.String(code),
 	}
-}
-
-// sanitizeTypeName converts a Go type name (e.g. "*azcore.ResponseError")
-// into a telemetry-safe segment ("azcore_ResponseError").
-func sanitizeTypeName(name string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(name, ".", "_"), "*", "")
 }
 
 func authFailedTelemetryDetails(authFailedErr *auth.AuthFailedError) []attribute.KeyValue {

--- a/cli/azd/internal/cmd/errors_test.go
+++ b/cli/azd/internal/cmd/errors_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -31,10 +32,8 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
-	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/pipeline"
-	"github.com/azure/azure-dev/cli/azd/pkg/tools"
 	"github.com/azure/azure-dev/cli/azd/pkg/tools/git"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mocktracing"
 	"github.com/stretchr/testify/require"
@@ -60,7 +59,7 @@ func Test_MapError(t *testing.T) {
 		{
 			name:          "WithOtherError",
 			err:           errors.New("something bad happened!"),
-			wantErrReason: "internal.errors_errorString",
+			wantErrReason: "internal.unclassified",
 			wantErrDetails: []attribute.KeyValue{
 				fields.ErrType.String("*errors.errorString"),
 			},
@@ -115,20 +114,20 @@ func Test_MapError(t *testing.T) {
 				fields.ErrorKey(fields.ServiceErrorCode.Key).String(mustMarshalJson(
 					[]map[string]any{
 						{
-							string(fields.ErrCode.Key):  "Conflict,PreconditionFailed",
-							string(fields.ErrFrame.Key): 0,
+							string(fields.ErrCode.Key): "Conflict,PreconditionFailed",
+							"error.arm.frame_index":    0,
 						},
 						{
-							string(fields.ErrCode.Key):  "OutOfCapacity,RegionOutOfCapacity",
-							string(fields.ErrFrame.Key): 1,
+							string(fields.ErrCode.Key): "OutOfCapacity,RegionOutOfCapacity",
+							"error.arm.frame_index":    1,
 						},
 						{
-							string(fields.ErrCode.Key):  "ServiceUnavailable",
-							string(fields.ErrFrame.Key): 1,
+							string(fields.ErrCode.Key): "ServiceUnavailable",
+							"error.arm.frame_index":    1,
 						},
 						{
-							string(fields.ErrCode.Key):  "UnknownError",
-							string(fields.ErrFrame.Key): 2,
+							string(fields.ErrCode.Key): "UnknownError",
+							"error.arm.frame_index":    2,
 						},
 					})),
 			},
@@ -150,12 +149,12 @@ func Test_MapError(t *testing.T) {
 				fields.ErrorKey(fields.ServiceErrorCode.Key).String(mustMarshalJson(
 					[]map[string]any{
 						{
-							string(fields.ErrCode.Key):  "InvalidTemplate",
-							string(fields.ErrFrame.Key): 0,
+							string(fields.ErrCode.Key): "InvalidTemplate",
+							"error.arm.frame_index":    0,
 						},
 						{
-							string(fields.ErrCode.Key):  "TemplateValidationFailed",
-							string(fields.ErrFrame.Key): 1,
+							string(fields.ErrCode.Key): "TemplateValidationFailed",
+							"error.arm.frame_index":    1,
 						},
 					})),
 			},
@@ -479,7 +478,9 @@ func Test_MapError(t *testing.T) {
 			},
 			wantErrReason: "error.suggestion",
 			wantErrDetails: []attribute.KeyValue{
-				fields.ErrType.String("*errors.errorString"),
+				// Inner is a plain errors.errorString (no named type),
+				// so the inner classification is the catch-all.
+				fields.ErrType.String("internal.unclassified"),
 			},
 		},
 		// Sentinel error test cases — verify typed errors wrapped in
@@ -844,14 +845,26 @@ func Test_MapError(t *testing.T) {
 			MapError(tt.err, span)
 
 			require.Equal(t, tt.wantErrReason, span.Status.Description)
-			require.ElementsMatch(t, tt.wantErrDetails, span.Attributes)
 
-			// Enforcement: no test case should produce the opaque errors_errorString
-			// unless explicitly allowed. This catches regressions where new error paths
-			// return bare errors.New() without typed sentinels.
+			// MapError always emits error.chain.types. Per-case
+			// wantErrDetails asserts the remaining structured error.*
+			// attributes exactly; error.chain.types is exercised in
+			// Test_MapError_ChainTypes.
+			gotErrDetails := slices.DeleteFunc(slices.Clone(span.Attributes), func(a attribute.KeyValue) bool {
+				return a.Key == fields.ErrChainTypes.Key
+			})
+			require.ElementsMatch(t, tt.wantErrDetails, gotErrDetails)
+
+			// Enforcement: no test case should produce the opaque
+			// internal.unclassified bucket (or its predecessor
+			// errors_errorString) unless explicitly allowed. Catches
+			// regressions where new error paths return bare
+			// errors.New() without typed sentinels.
 			if !allowedCatchAll[tt.name] {
 				require.NotContains(t, span.Status.Description, "errors_errorString",
 					"test case %q produces opaque errors_errorString — use a typed sentinel error instead", tt.name)
+				require.NotEqual(t, "internal.unclassified", span.Status.Description,
+					"test case %q produces opaque internal.unclassified — use a typed sentinel error instead", tt.name)
 			}
 		})
 	}
@@ -918,13 +931,13 @@ func TestMapError_ErrorWithSuggestionSetsErrorType(t *testing.T) {
 			wantErrType: "service.arm.deployment.failed",
 		},
 		{
-			name: "PlainError_falls_back_to_go_type",
+			name: "PlainError_falls_back_to_unclassified",
 			err: &internal.ErrorWithSuggestion{
 				Err:        errors.New("unknown failure"),
 				Suggestion: "Try again.",
 			},
 			wantErrCode: "error.suggestion",
-			wantErrType: "*errors.errorString",
+			wantErrType: "internal.unclassified",
 		},
 	}
 
@@ -944,128 +957,73 @@ func TestMapError_ErrorWithSuggestionSetsErrorType(t *testing.T) {
 	}
 }
 
-// Test_ClassifySuggestionType_MatchesMapError verifies that classifySuggestionType produces
-// the same errCode as MapError for every structured error type and sentinel.
-// This catches drift if someone updates the classification logic in one function but not the other.
-func Test_ClassifySuggestionType_MatchesMapError(t *testing.T) {
+// Test_MapError_ChainTypes verifies that MapError emits the
+// `error.chain.types` span attribute (outermost first). This lets
+// triagers group on the underlying type chain in Kusto without
+// scraping message text.
+func Test_MapError_ChainTypes(t *testing.T) {
 	t.Parallel()
+
 	tests := []struct {
 		name string
 		err  error
+		want []string
 	}{
 		{
-			name: "ResponseError",
-			err: &azcore.ResponseError{
-				ErrorCode:  "QuotaExceeded",
-				StatusCode: 429,
-				RawResponse: &http.Response{
+			name: "BareError",
+			err:  errors.New("boom"),
+			want: []string{"*errors.errorString"},
+		},
+		{
+			name: "FmtErrorfWrapsTyped",
+			err:  fmt.Errorf("ctx: %w", &exec.ExitError{Cmd: "tool", ExitCode: 1}),
+			want: []string{"*fmt.wrapError", "*exec.ExitError"},
+		},
+		{
+			name: "SuggestionWrapsTyped",
+			err: &internal.ErrorWithSuggestion{
+				Err: &azcore.ResponseError{
+					ErrorCode:  "QuotaExceeded",
 					StatusCode: 429,
-					Request: &http.Request{
-						Method: "POST",
-						Host:   "management.azure.com",
+					RawResponse: &http.Response{
+						StatusCode: 429,
+						Request: &http.Request{
+							Method: "POST",
+							Host:   "management.azure.com",
+						},
 					},
 				},
 			},
-		},
-		{
-			name: "ArmDeploymentError",
-			err: &azapi.AzureDeploymentError{
-				Operation: azapi.DeploymentOperationDeploy,
-				Details: &azapi.DeploymentErrorLine{
-					Code: "Conflict",
-				},
+			want: []string{
+				"*errorhandler.ErrorWithSuggestion",
+				fmt.Sprintf("%T", &azcore.ResponseError{}),
 			},
 		},
 		{
-			name: "ArmValidationError",
-			err: &azapi.AzureDeploymentError{
-				Operation: azapi.DeploymentOperationValidate,
-				Details:   &azapi.DeploymentErrorLine{Code: "InvalidTemplate"},
+			name: "Joined",
+			err:  errors.Join(errors.New("a"), &exec.ExitError{Cmd: "x", ExitCode: 2}),
+			want: []string{
+				"*errors.joinError",
+				"*errors.errorString",
+				"*exec.ExitError",
 			},
-		},
-		{
-			name: "ExtServiceError",
-			err: &azdext.ServiceError{
-				Message:     "Rate limit",
-				ErrorCode:   "create_agent.RateLimitExceeded",
-				StatusCode:  429,
-				ServiceName: "openai.azure.com",
-			},
-		},
-		{
-			name: "ExtLocalError",
-			err: &azdext.LocalError{
-				Message:  "invalid config",
-				Code:     "Invalid-Config",
-				Category: azdext.LocalErrorCategoryValidation,
-			},
-		},
-		{
-			name: "ExtensionRunError",
-			err:  &extensions.ExtensionRunError{ExtensionId: "test", Err: errors.New("fail")},
-		},
-		{
-			name: "ExitError",
-			err:  &exec.ExitError{Cmd: "docker", ExitCode: 1},
-		},
-		{
-			name: "MissingToolErrors_single",
-			err:  &tools.MissingToolErrors{ToolNames: []string{"docker"}},
-		},
-		{
-			name: "MissingToolErrors_multiple",
-			err:  &tools.MissingToolErrors{ToolNames: []string{"docker", "kubectl"}},
-		},
-		{
-			name: "AuthFailedError",
-			err: &auth.AuthFailedError{
-				Parsed: &auth.AadErrorResponse{Error: "invalid_grant"},
-			},
-		},
-		{
-			name: "ReLoginRequiredError",
-			err:  &auth.ReLoginRequiredError{},
-		},
-		{
-			name: "AzidentityAuthenticationFailedError",
-			err:  &azidentity.AuthenticationFailedError{},
-		},
-		// Sentinels
-		{name: "context.Canceled", err: context.Canceled},
-		{name: "context.DeadlineExceeded", err: context.DeadlineExceeded},
-		{name: "ErrNoCurrentUser", err: auth.ErrNoCurrentUser},
-		{name: "ErrNoProject", err: azdcontext.ErrNoProject},
-		{name: "ErrNotFound", err: environment.ErrNotFound},
-		{name: "ErrToolExecutionDenied", err: consent.ErrToolExecutionDenied},
-		{name: "ErrNotRepository", err: git.ErrNotRepository},
-		{name: "ErrPreviewNotSupported", err: azapi.ErrPreviewNotSupported},
-		{name: "ErrBindMountDisabled", err: provisioning.ErrBindMountOperationDisabled},
-		{name: "ErrRemoteHostIsNotAzDo", err: pipeline.ErrRemoteHostIsNotAzDo},
-		{name: "ErrInfraNotProvisioned", err: internal.ErrInfraNotProvisioned},
-		{name: "ErrKeyNotFound", err: internal.ErrKeyNotFound},
-		{name: "ErrExtensionNotFound", err: internal.ErrExtensionNotFound},
-		{name: "ErrOperationCancelled", err: internal.ErrOperationCancelled},
-		{name: "ErrAbortedByUser", err: internal.ErrAbortedByUser},
-		// Network error
-		{
-			name: "DNSError",
-			err:  &net.DNSError{Err: "no such host", Name: "example.com"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			// Get errCode from MapError
 			span := &mocktracing.Span{}
 			MapError(tt.err, span)
-			mapErrorCode := span.Status.Description
 
-			// Get code from classifySuggestionType
-			suggestionCode := classifySuggestionType(tt.err)
-
-			require.Equal(t, mapErrorCode, suggestionCode,
-				"classifySuggestionType and MapError must produce the same code for %T", tt.err)
+			var got []string
+			for _, a := range span.Attributes {
+				if a.Key == fields.ErrChainTypes.Key {
+					got = a.Value.AsStringSlice()
+					break
+				}
+			}
+			require.Equal(t, tt.want, got, string(fields.ErrChainTypes.Key))
 		})
 	}
 }
@@ -1118,106 +1076,10 @@ func Test_normalizeCodeSegment(t *testing.T) {
 	}
 }
 
-func Test_errorType(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name string
-		err  error
-		want string
-	}{
-		{
-			name: "NilError",
-			err:  nil,
-			want: "<nil>",
-		},
-		{
-			name: "SimpleError",
-			err:  errors.New("simple error"),
-			want: "*errors.errorString",
-		},
-		{
-			name: "SingleUnwrapError",
-			err: &exec.ExitError{
-				Cmd:      "test",
-				ExitCode: 1,
-			},
-			want: "*exec.ExitError",
-		},
-		{
-			name: "NestedUnwrapError",
-			err: func() error {
-				inner := errors.New("inner error")
-				return &singleUnwrapError{
-					msg: "wrapped error",
-					err: inner,
-				}
-			}(),
-			want: "*errors.errorString",
-		},
-		{
-			name: "MultipleUnwrapErrors",
-			err: func() error {
-				err1 := errors.New("error 1")
-				err2 := errors.New("error 2")
-				return &multiUnwrapError{
-					errs: []error{err1, err2},
-				}
-			}(),
-			want: "*errors.errorString,*errors.errorString",
-		},
-		{
-			name: "MultipleUnwrapErrorsWithNil",
-			err: func() error {
-				err1 := errors.New("error 1")
-				return &multiUnwrapError{
-					errs: []error{err1, nil, errors.New("error 2")},
-				}
-			}(),
-			want: "*errors.errorString,*errors.errorString",
-		},
-		{
-			name: "UnwrapReturnsNil",
-			err: &singleUnwrapError{
-				msg: "test error",
-				err: nil,
-			},
-			want: "*cmd.singleUnwrapError",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := errorType(tt.err)
-			require.Equal(t, tt.want, got)
-		})
-	}
-}
-
-// Test helper types for errorType tests
-type singleUnwrapError struct {
-	msg string
-	err error
-}
-
-func (e *singleUnwrapError) Error() string {
-	return e.msg
-}
-
-func (e *singleUnwrapError) Unwrap() error {
-	return e.err
-}
-
-type multiUnwrapError struct {
-	errs []error
-}
-
-func (e *multiUnwrapError) Error() string {
-	return "multiple errors"
-}
-
-func (e *multiUnwrapError) Unwrap() []error {
-	return e.errs
-}
+// Test_errorType and Test_ClassifySuggestionType_MatchesMapError were
+// removed when their targets (`errorType`, `classifySuggestionType`)
+// were collapsed into a shared `classify` ladder. The leaf-walk
+// behavior is exercised in `internal/tracing/errchain` tests.
 
 func mustMarshalJson(v any) string {
 	b, err := json.Marshal(v)

--- a/cli/azd/internal/cmd/errors_test.go
+++ b/cli/azd/internal/cmd/errors_test.go
@@ -939,6 +939,18 @@ func TestMapError_ErrorWithSuggestionSetsErrorType(t *testing.T) {
 			wantErrCode: "error.suggestion",
 			wantErrType: "internal.unclassified",
 		},
+		{
+			name: "NestedSuggestion_uses_inner_suggestion_type",
+			err: &internal.ErrorWithSuggestion{
+				Err: &internal.ErrorWithSuggestion{
+					Err:        internal.ErrKeyNotFound,
+					Suggestion: "Run 'azd env get-values'.",
+				},
+				Suggestion: "Check the selected environment.",
+			},
+			wantErrCode: "error.suggestion",
+			wantErrType: "error.suggestion",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cli/azd/internal/tracing/errchain/errchain.go
+++ b/cli/azd/internal/tracing/errchain/errchain.go
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Package errchain provides low-level, dependency-free helpers for
+// inspecting Go error chains. It is intentionally separate from the
+// classifier in internal/cmd so telemetry sub-spans in low-level
+// packages can emit chain context without pulling in the full typed
+// classifier graph.
+package errchain
+
+import (
+	"reflect"
+)
+
+// MaxChainLen caps the number of types collected from a single error
+// chain. The cap is global to bound telemetry cardinality and to
+// stop pathological errors that unwrap to themselves.
+const MaxChainLen = 16
+
+// genericWrappers names Go types that preserve an error chain or
+// attach UX metadata but tell engineers nothing about origin. The
+// classifier skips them when picking the deepest named type so a
+// fmt.Errorf wrap doesn't mask the underlying error.
+var genericWrappers = map[string]bool{
+	// Standard library wrappers
+	"*errors.errorString": true,
+	"*fmt.wrapError":      true,
+	"*fmt.wrapErrors":     true,
+	"*errors.joinError":   true,
+
+	// azd UX wrappers — these attach a suggestion or trace ID for
+	// presentation only; the inner is the meaningful classification.
+	"*errorhandler.ErrorWithSuggestion": true,
+	"*internal.ErrorWithTraceId":        true,
+}
+
+// Types returns the wrapped-error type chain (outermost first) as a
+// slice of Go type names (e.g. "*fmt.wrapError",
+// "*azcore.ResponseError"). The traversal:
+//   - follows Unwrap() error linearly,
+//   - depth-first walks Unwrap() []error in slice order,
+//   - skips nil children,
+//   - is globally capped at MaxChainLen.
+//
+// Returns nil for a nil error.
+func Types(err error) []string {
+	if err == nil {
+		return nil
+	}
+	out := make([]string, 0, 4)
+	walk(err, &out)
+	return out
+}
+
+func walk(err error, out *[]string) {
+	if err == nil || len(*out) >= MaxChainLen {
+		return
+	}
+
+	*out = append(*out, reflect.TypeOf(err).String())
+
+	//nolint:errorlint // Type switch is intentionally used to check for Unwrap() methods.
+	switch x := err.(type) {
+	case interface{ Unwrap() error }:
+		walk(x.Unwrap(), out)
+	case interface{ Unwrap() []error }:
+		for _, child := range x.Unwrap() {
+			if len(*out) >= MaxChainLen {
+				return
+			}
+			walk(child, out)
+		}
+	}
+}
+
+// DeepestNamedType returns the deepest non-generic type name from the
+// chain, skipping the wrappers in genericWrappers so a fmt.Errorf or
+// suggestion wrap doesn't mask the real error. Falls back to the leaf
+// type when nothing in the chain is non-generic. Returns "<nil>" for
+// a nil error.
+func DeepestNamedType(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+
+	var deepest string  // last non-generic type observed
+	var leafType string // last type observed regardless
+
+	count := 0
+	visit := func(e error) bool {
+		if e == nil || count >= MaxChainLen {
+			return false
+		}
+		count++
+		t := reflect.TypeOf(e).String()
+		leafType = t
+		if !genericWrappers[t] {
+			deepest = t
+		}
+		return true
+	}
+
+	for err != nil {
+		if !visit(err) {
+			break
+		}
+		//nolint:errorlint // Type switch is intentionally used to check for Unwrap() methods.
+		switch x := err.(type) {
+		case interface{ Unwrap() error }:
+			err = x.Unwrap()
+		case interface{ Unwrap() []error }:
+			// For joined errors, classify only the first non-nil
+			// child. Picking a single branch keeps "deepest named"
+			// well-defined; full chain coverage is in Types().
+			err = nil
+			for _, child := range x.Unwrap() {
+				if child != nil {
+					err = child
+					break
+				}
+			}
+		default:
+			err = nil
+		}
+	}
+
+	if deepest != "" {
+		return deepest
+	}
+	return leafType
+}
+
+// IsGenericWrapper reports whether the given Go type name (as
+// produced by reflect.TypeOf(err).String()) is a generic chain
+// wrapper. Exposed so the typed classifier in internal/cmd can apply
+// the same logic when picking a fallback ResultCode.
+func IsGenericWrapper(typeName string) bool {
+	return genericWrappers[typeName]
+}

--- a/cli/azd/internal/tracing/errchain/errchain.go
+++ b/cli/azd/internal/tracing/errchain/errchain.go
@@ -10,6 +10,7 @@ package errchain
 
 import (
 	"reflect"
+	"strings"
 )
 
 // MaxChainLen caps the number of types collected from a single error
@@ -17,10 +18,9 @@ import (
 // stop pathological errors that unwrap to themselves.
 const MaxChainLen = 16
 
-// genericWrappers names Go types that preserve an error chain or
-// attach UX metadata but tell engineers nothing about origin. The
-// classifier skips them when picking the deepest named type so a
-// fmt.Errorf wrap doesn't mask the underlying error.
+// genericWrappers names Go types that preserve an error chain or attach UX metadata but tell engineers nothing
+// about origin. Adding a type here makes fallback classification skip it, which can move spans from a
+// type-specific ResultCode to internal.unclassified when no deeper non-generic type exists.
 var genericWrappers = map[string]bool{
 	// Standard library wrappers
 	"*errors.errorString": true,
@@ -136,4 +136,10 @@ func DeepestNamedType(err error) string {
 // the same logic when picking a fallback ResultCode.
 func IsGenericWrapper(typeName string) bool {
 	return genericWrappers[typeName]
+}
+
+// SanitizeTypeName converts a Go type name (e.g. "*azcore.ResponseError") into a telemetry-safe segment
+// ("azcore_ResponseError").
+func SanitizeTypeName(name string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(name, ".", "_"), "*", "")
 }

--- a/cli/azd/internal/tracing/errchain/errchain_test.go
+++ b/cli/azd/internal/tracing/errchain/errchain_test.go
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package errchain
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type typedErr struct{ msg string }
+
+func (t *typedErr) Error() string { return t.msg }
+
+type wrappedErr struct {
+	msg   string
+	inner error
+}
+
+func (w *wrappedErr) Error() string { return w.msg }
+func (w *wrappedErr) Unwrap() error { return w.inner }
+
+// selfRefErr unwraps to itself to exercise the cycle cap.
+type selfRefErr struct{}
+
+func (s *selfRefErr) Error() string { return "self-ref" }
+func (s *selfRefErr) Unwrap() error { return s }
+
+func TestTypes_Nil(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, Types(nil))
+}
+
+func TestTypes_BareError(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, []string{"*errors.errorString"}, Types(errors.New("boom")))
+}
+
+func TestTypes_FmtErrorfWraps(t *testing.T) {
+	t.Parallel()
+	inner := &typedErr{msg: "typed"}
+	err := fmt.Errorf("ctx: %w", inner)
+	require.Equal(t, []string{"*fmt.wrapError", "*errchain.typedErr"}, Types(err))
+}
+
+func TestTypes_DeeplyWrapped(t *testing.T) {
+	t.Parallel()
+	leaf := &typedErr{msg: "leaf"}
+	mid := &wrappedErr{msg: "mid", inner: leaf}
+	outer := fmt.Errorf("outer: %w", mid)
+	require.Equal(
+		t,
+		[]string{"*fmt.wrapError", "*errchain.wrappedErr", "*errchain.typedErr"},
+		Types(outer),
+	)
+}
+
+func TestTypes_Joined(t *testing.T) {
+	t.Parallel()
+	a := &typedErr{msg: "a"}
+	b := &typedErr{msg: "b"}
+	joined := errors.Join(a, b)
+	require.Equal(
+		t,
+		// joinError walks depth-first across slice order
+		[]string{"*errors.joinError", "*errchain.typedErr", "*errchain.typedErr"},
+		Types(joined),
+	)
+}
+
+func TestTypes_FmtMultipleWraps(t *testing.T) {
+	t.Parallel()
+	a := &typedErr{msg: "a"}
+	b := &typedErr{msg: "b"}
+	err := fmt.Errorf("two: %w / %w", a, b)
+	require.Equal(
+		t,
+		// fmt.Errorf with multiple %w produces *fmt.wrapErrors
+		[]string{"*fmt.wrapErrors", "*errchain.typedErr", "*errchain.typedErr"},
+		Types(err),
+	)
+}
+
+func TestTypes_NilChildSkipped(t *testing.T) {
+	t.Parallel()
+	a := &typedErr{msg: "a"}
+	joined := errors.Join(nil, a, nil)
+	require.Equal(
+		t,
+		[]string{"*errors.joinError", "*errchain.typedErr"},
+		Types(joined),
+	)
+}
+
+func TestTypes_RespectsCap(t *testing.T) {
+	t.Parallel()
+	// Build a chain longer than MaxChainLen.
+	var err error = &typedErr{msg: "leaf"}
+	for range 100 {
+		err = fmt.Errorf("wrap: %w", err)
+	}
+	got := Types(err)
+	require.Len(t, got, MaxChainLen)
+}
+
+func TestTypes_CycleSafe(t *testing.T) {
+	t.Parallel()
+	// selfRefErr.Unwrap() returns itself; only the cap stops us.
+	got := Types(&selfRefErr{})
+	require.Len(t, got, MaxChainLen)
+	for _, n := range got {
+		require.Equal(t, "*errchain.selfRefErr", n)
+	}
+}
+
+func TestDeepestNamedType_Nil(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "<nil>", DeepestNamedType(nil))
+}
+
+func TestDeepestNamedType_BareError(t *testing.T) {
+	t.Parallel()
+	// No named non-generic type → fall back to leaf.
+	require.Equal(t, "*errors.errorString", DeepestNamedType(errors.New("boom")))
+}
+
+func TestDeepestNamedType_TypedLeaf(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "*errchain.typedErr", DeepestNamedType(&typedErr{msg: "x"}))
+}
+
+func TestDeepestNamedType_FmtWrapsTyped(t *testing.T) {
+	t.Parallel()
+	inner := &typedErr{msg: "x"}
+	err := fmt.Errorf("ctx: %w", inner)
+	require.Equal(t, "*errchain.typedErr", DeepestNamedType(err))
+}
+
+func TestDeepestNamedType_NestedTypedSurvives(t *testing.T) {
+	t.Parallel()
+	leaf := &typedErr{msg: "x"}
+	mid := &wrappedErr{msg: "mid", inner: leaf}
+	err := fmt.Errorf("outer: %w", mid)
+	// Both wrappedErr and typedErr are non-generic; deepest wins.
+	require.Equal(t, "*errchain.typedErr", DeepestNamedType(err))
+}
+
+func TestDeepestNamedType_JoinedFirstChild(t *testing.T) {
+	t.Parallel()
+	a := &typedErr{msg: "a"}
+	b := &wrappedErr{msg: "b"}
+	joined := errors.Join(a, b)
+	// Joined: deepest-named follows the first non-nil child.
+	require.Equal(t, "*errchain.typedErr", DeepestNamedType(joined))
+}
+
+func TestDeepestNamedType_AllGeneric(t *testing.T) {
+	t.Parallel()
+	// All wrappers are generic; we expect the leaf type.
+	err := fmt.Errorf("ctx: %w", errors.New("boom"))
+	require.Equal(t, "*errors.errorString", DeepestNamedType(err))
+}
+
+func TestIsGenericWrapper(t *testing.T) {
+	t.Parallel()
+	require.True(t, IsGenericWrapper("*errors.errorString"))
+	require.True(t, IsGenericWrapper("*fmt.wrapError"))
+	require.True(t, IsGenericWrapper("*fmt.wrapErrors"))
+	require.True(t, IsGenericWrapper("*errors.joinError"))
+	require.True(t, IsGenericWrapper("*errorhandler.ErrorWithSuggestion"))
+	require.True(t, IsGenericWrapper("*internal.ErrorWithTraceId"))
+	require.False(t, IsGenericWrapper("*azcore.ResponseError"))
+	require.False(t, IsGenericWrapper("*errchain.typedErr"))
+}

--- a/cli/azd/internal/tracing/fields/fields.go
+++ b/cli/azd/internal/tracing/fields/fields.go
@@ -611,16 +611,11 @@ var (
 		Purpose:        PerformanceAndHealth,
 	}
 
-	// Inner error.
-	ErrInner = AttributeKey{
-		Key:            attribute.Key("error.inner"),
-		Classification: SystemMetadata,
-		Purpose:        PerformanceAndHealth,
-	}
-
-	// The frame of the error.
-	ErrFrame = AttributeKey{
-		Key:            attribute.Key("error.frame"),
+	// ErrChainTypes records the wrapped-error type chain (outermost
+	// first). Type names are code-defined and PII-free, so they're
+	// emitted as system metadata for triaging the catch-all bucket.
+	ErrChainTypes = AttributeKey{
+		Key:            attribute.Key("error.chain.types"),
 		Classification: SystemMetadata,
 		Purpose:        PerformanceAndHealth,
 	}

--- a/cli/azd/internal/tracing/tracer.go
+++ b/cli/azd/internal/tracing/tracer.go
@@ -5,15 +5,14 @@ package tracing
 
 import (
 	"context"
-	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/baggage"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/errchain"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
-	"go.opentelemetry.io/otel/codes"
-
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // It is often valuable to extend functionality of 3rd-party library types.
@@ -159,15 +158,11 @@ func (s *wrapperSpan) TracerProvider() trace.TracerProvider {
 	return s.span.TracerProvider()
 }
 
-func sanitizeTypeName(name string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(name, ".", "_"), "*", "")
-}
-
 func subSpanErrorDescription(err error) string {
 	deepest := errchain.DeepestNamedType(err)
 	if deepest == "" || errchain.IsGenericWrapper(deepest) {
 		return "internal.unclassified"
 	}
 
-	return "internal." + sanitizeTypeName(deepest)
+	return "internal." + errchain.SanitizeTypeName(deepest)
 }

--- a/cli/azd/internal/tracing/tracer.go
+++ b/cli/azd/internal/tracing/tracer.go
@@ -5,10 +5,11 @@ package tracing
 
 import (
 	"context"
-	"reflect"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/baggage"
+	"github.com/azure/azure-dev/cli/azd/internal/tracing/errchain"
+	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
 	"go.opentelemetry.io/otel/codes"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -107,7 +108,13 @@ func (s *wrapperSpan) End(options ...trace.SpanEndOption) {
 
 func (s *wrapperSpan) EndWithStatus(err error, options ...trace.SpanEndOption) {
 	if err != nil {
-		s.span.SetStatus(codes.Error, "internal."+errorDescription(err))
+		// Sub-spans don't run the full typed/sentinel ladder — that
+		// lives at the command boundary in internal/cmd.MapError to
+		// avoid pulling auth/azapi/exec/extensions into a low-level
+		// package. Emit the chain plus a deepest-named description
+		// here so engineers still see the underlying error shape.
+		s.span.SetAttributes(fields.ErrChainTypes.StringSlice(errchain.Types(err)))
+		s.span.SetStatus(codes.Error, subSpanErrorDescription(err))
 	} else {
 		s.span.SetStatus(codes.Ok, "")
 	}
@@ -152,41 +159,15 @@ func (s *wrapperSpan) TracerProvider() trace.TracerProvider {
 	return s.span.TracerProvider()
 }
 
-// errorDescription returns a description for the error suitable for use as a span status description.
-// It unwraps errors to find the root cause type, producing values like "errors_errorString" or
-// "azcore_ResponseError". For joined errors (Unwrap() []error), it returns comma-separated type names.
-func errorDescription(err error) string {
-	if err == nil {
-		return "<nil>"
-	}
-
-	//nolint:errorlint // Type switch is intentionally used to check for Unwrap() methods
-	for {
-		switch x := err.(type) {
-		case interface{ Unwrap() error }:
-			inner := x.Unwrap()
-			if inner == nil {
-				return sanitizeTypeName(reflect.TypeOf(x).String())
-			}
-			err = inner
-		case interface{ Unwrap() []error }:
-			result := ""
-			for _, e := range x.Unwrap() {
-				if e == nil {
-					continue
-				}
-				if result != "" {
-					result += ","
-				}
-				result += sanitizeTypeName(reflect.TypeOf(e).String())
-			}
-			return result
-		default:
-			return sanitizeTypeName(reflect.TypeOf(x).String())
-		}
-	}
-}
-
 func sanitizeTypeName(name string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(name, ".", "_"), "*", "")
+}
+
+func subSpanErrorDescription(err error) string {
+	deepest := errchain.DeepestNamedType(err)
+	if deepest == "" || errchain.IsGenericWrapper(deepest) {
+		return "internal.unclassified"
+	}
+
+	return "internal." + sanitizeTypeName(deepest)
 }

--- a/cli/azd/internal/tracing/tracer_test.go
+++ b/cli/azd/internal/tracing/tracer_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package tracing
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type typedSubSpanErr struct{}
+
+func (typedSubSpanErr) Error() string {
+	return "typed sub-span error"
+}
+
+func TestSubSpanErrorDescription(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "PlainErrorUsesUnclassified",
+			err:  errors.New("boom"),
+			want: "internal.unclassified",
+		},
+		{
+			name: "WrappedPlainErrorUsesUnclassified",
+			err:  fmt.Errorf("ctx: %w", errors.New("boom")),
+			want: "internal.unclassified",
+		},
+		{
+			name: "WrappedTypedErrorUsesDeepestType",
+			err:  fmt.Errorf("ctx: %w", &typedSubSpanErr{}),
+			want: "internal.tracing_typedSubSpanErr",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, subSpanErrorDescription(tt.err))
+		})
+	}
+}

--- a/docs/specs/metrics-audit/privacy-review-checklist.md
+++ b/docs/specs/metrics-audit/privacy-review-checklist.md
@@ -73,7 +73,7 @@ Classifications are defined in `cli/azd/internal/tracing/fields/fields.go`.
 |----------------|-------------|----------|-----------|
 | **PublicPersonalData** | Data the user has intentionally made public | GitHub username | Standard |
 | **SystemMetadata** | Non-personal metadata about the system or environment | OS type, Go version, feature flags | Standard |
-| **CallstackOrException** | Stack traces, panic details, error frames | `error.frame` | Reduced |
+| **CallstackOrException** | Stack traces, panic details, error frames | Panic stack trace | Reduced |
 | **CustomerContent** | Content created by the user | File contents, messages | Highest restriction — avoid in telemetry |
 | **EndUserPseudonymizedInformation** | User identifiers that have been pseudonymized | Hashed MAC address (`machine.id`), SQM User ID | Standard |
 | **OrganizationalIdentifiableInformation** | Identifiers scoped to an organization | Azure subscription ID, tenant ID | Standard |

--- a/docs/specs/metrics-audit/telemetry-schema.md
+++ b/docs/specs/metrics-audit/telemetry-schema.md
@@ -87,18 +87,22 @@ These are set once at process startup via `resource.New()` and attached to every
 
 ### Error Attributes
 
-| Field | OTel Key | Classification | Purpose |
-|-------|----------|----------------|---------|
-| Error category | `error.category` | SystemMetadata | PerformanceAndHealth |
-| Error code | `error.code` | SystemMetadata | PerformanceAndHealth |
-| Error type | `error.type` | SystemMetadata | PerformanceAndHealth |
-| Inner error | `error.inner` | SystemMetadata | PerformanceAndHealth |
-| Error frame | `error.frame` | SystemMetadata | PerformanceAndHealth |
+| Field | OTel Key | Classification | Purpose | Notes |
+|-------|----------|----------------|---------|-------|
+| Error category | `error.category` | SystemMetadata | PerformanceAndHealth | |
+| Error code | `error.code` | SystemMetadata | PerformanceAndHealth | |
+| Error type | `error.type` | SystemMetadata | PerformanceAndHealth | ResultCode or Go type for the classified error |
+| Error chain types | `error.chain.types` | SystemMetadata | PerformanceAndHealth | Wrapped Go error type chain, outermost first |
 
 Error classification is handled by `MapError` in `internal/cmd/errors.go`, which categorizes
 errors into: update errors, auth errors, service (Azure) errors, deployment errors, extension
 errors, tool errors, sentinel errors, and network errors. Each receives an `error.code`,
 `error.category`, and contextual attributes.
+
+Generic-only error chains now use the catch-all ResultCode `internal.unclassified` instead of
+the previous `internal.errors_errorString`. Use `error.chain.types` to inspect the concrete
+wrapper types behind that bucket. The removed `error.inner` and `error.frame` attributes were
+not emitted by azd spans.
 
 ### Service Attributes
 
@@ -108,7 +112,7 @@ errors, tool errors, sentinel errors, and network errors. Each receives an `erro
 | Service name | `service.name` | SystemMetadata | PerformanceAndHealth | |
 | Status code | `service.statusCode` | SystemMetadata | PerformanceAndHealth | **Measurement** |
 | Method | `service.method` | SystemMetadata | PerformanceAndHealth | |
-| Error code | `service.errorCode` | SystemMetadata | PerformanceAndHealth | **Measurement** |
+| Error code | `service.errorCode` | SystemMetadata | PerformanceAndHealth | **Measurement**; ARM deployment errors encode JSON objects with `error.code` and `error.arm.frame_index` |
 | Correlation ID | `service.correlationId` | SystemMetadata | PerformanceAndHealth | |
 
 ### Tool Attributes


### PR DESCRIPTION
Resolves #8015 
Resolves #8017

This PR makes azd error telemetry easier to triage without needing to reproduce a failure. It is the first wave of work under epic #8011 and covers sub-issues #8015 and #8017.

Every error span now emits an `error.chain.types` attribute that records the wrapped-error type chain in outermost-first order. This gives engineers a PII-free way to group residual catch-all errors in Kusto by code-defined error types instead of scraping message text.

The error classifier now uses a shared classification path instead of separate decision trees for telemetry, suggestions, and tracing. Its fallback behavior also reports the deepest meaningful non-generic error type instead of collapsing many wrapped errors to `*errors.errorString`, making typed underlying errors visible in telemetry. The legacy catch-all bucket is renamed from `internal.errors_errorString` to `internal.unclassified`.

This PR also removes unused error telemetry fields that were never emitted and renames the ARM `service.errorCode` payload's frame field to `error.arm.frame_index` to better reflect that it represents ARM nesting depth rather than a Go runtime frame.

For example, a wrapped ARM deployment failure now includes the wrapped error chain on both sub-spans and the command span:

```json
{
  "Name": "cmd.provision",
  "Status": {
    "Code": "Error",
    "Description": "error.suggestion"
  },
  "Attributes": [
    {
      "Key": "error.chain.types",
      "Value": {
        "Type": "STRINGSLICE",
        "Value": [
          "*errorhandler.ErrorWithSuggestion",
          "*fmt.wrapError",
          "*azapi.AzureDeploymentError",
          "*azapi.DeploymentErrorLine"
        ]
      }
    },
    {
      "Key": "error.type",
      "Value": {
        "Type": "STRING",
        "Value": "service.arm.deployment.failed"
      }
    }
  ]
}
```

For plain or generic-only errors, the status now uses the clearer catch-all bucket while keeping the concrete chain available for investigation:

```json
{
  "Status": {
    "Code": "Error",
    "Description": "internal.unclassified"
  },
  "Attributes": [
    {
      "Key": "error.chain.types",
      "Value": {
        "Type": "STRINGSLICE",
        "Value": [
          "*fmt.wrapError",
          "*errors.errorString"
        ]
      }
    }
  ]
}
```

A follow-up PR will be made to address https://github.com/Azure/azure-dev/issues/8018, which adds rule IDs to YAML-based error suggestions and emits result codes as `suggest.<rule_id>` instead of `error.suggestion`.
