### PR TITLE
fix: functional tests fail in playback when OIDC endpoint times out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ cli/azd/cover_*
 review-*.diff
 
 .playwright-mcp/
+.worktrees/

--- a/cli/azd/pkg/account/subscriptions_manager.go
+++ b/cli/azd/pkg/account/subscriptions_manager.go
@@ -167,14 +167,27 @@ func (m *SubscriptionsManager) getSubscriptions(ctx context.Context) (getSubscri
 
 	subscriptions, err := m.cache.Load(ctx, uid)
 	if err != nil {
-		subscriptions, err = m.ListSubscriptions(ctx)
-		if err != nil {
-			return getSubscriptionsResult{}, fmt.Errorf("listing subscriptions: %w", err)
-		}
+		// When running in playback mode with a synthetic subscription, skip the real ARM call
+		// to list subscriptions. The synthetic subscription is sufficient for the test to proceed,
+		// and the recording cassette won't contain the /tenants API responses needed by ListSubscriptions.
+		syntheticId := os.Getenv("AZD_DEBUG_SYNTHETIC_SUBSCRIPTION")
+		if syntheticId != "" {
+			subscriptions = []Subscription{{
+				Id:                 syntheticId,
+				Name:               "AZD Synthetic Test Subscription",
+				TenantId:           claims.TenantId,
+				UserAccessTenantId: claims.TenantId,
+			}}
+		} else {
+			subscriptions, err = m.ListSubscriptions(ctx)
+			if err != nil {
+				return getSubscriptionsResult{}, fmt.Errorf("listing subscriptions: %w", err)
+			}
 
-		err = m.cache.Save(ctx, uid, subscriptions)
-		if err != nil {
-			return getSubscriptionsResult{}, fmt.Errorf("saving subscriptions to cache: %w", err)
+			err = m.cache.Save(ctx, uid, subscriptions)
+			if err != nil {
+				return getSubscriptionsResult{}, fmt.Errorf("saving subscriptions to cache: %w", err)
+			}
 		}
 	}
 

--- a/cli/azd/pkg/account/subscriptions_manager_test.go
+++ b/cli/azd/pkg/account/subscriptions_manager_test.go
@@ -197,6 +197,42 @@ func (c *staticSubCache) Clear(ctx context.Context) error {
 	return nil
 }
 
+func TestSubscriptionsManager_SyntheticSubscription_SkipsListOnCacheMiss(t *testing.T) {
+	syntheticSubId := "SYNTHETIC-SUB-ID-123"
+	t.Setenv("AZD_DEBUG_SYNTHETIC_SUBSCRIPTION", syntheticSubId)
+
+	listSubscriptionsCalled := false
+	mockHttp := mockhttp.NewMockHttpUtil()
+	// If ListSubscriptions is called, it would hit this handler. We set a flag to detect it.
+	mockHttp.When(func(request *http.Request) bool {
+		return true
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		listSubscriptionsCalled = true
+		return &http.Response{
+			Request:    request,
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewBufferString(`{"error": "should not be called"}`)),
+		}, nil
+	})
+
+	subManager := &SubscriptionsManager{
+		service: NewSubscriptionsService(
+			&mocks.MockMultiTenantCredentialProvider{},
+			armClientOptions(mockHttp),
+		),
+		cache:         &BypassSubscriptionsCache{},
+		principalInfo: &principalInfoProviderMock{},
+		console:       mockinput.NewMockConsole(),
+	}
+
+	result, err := subManager.getSubscriptions(t.Context())
+	require.NoError(t, err)
+	require.False(t, listSubscriptionsCalled, "ListSubscriptions should not be called when synthetic subscription is set")
+	require.Len(t, result.subscriptions, 1)
+	require.Equal(t, syntheticSubId, result.subscriptions[0].Id)
+	require.Equal(t, "AZD Synthetic Test Subscription", result.subscriptions[0].Name)
+}
+
 func TestSubscriptionsManager_GetSubscription_PreservesTenantFields(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/test/azdcli/cli.go
+++ b/cli/azd/test/azdcli/cli.go
@@ -102,7 +102,10 @@ func NewCLI(t *testing.T, opts ...Options) *CLI {
 				credentialServer.Close()
 			})
 
-			cli.Env = append(cli.Env, fmt.Sprintf("AZD_AUTH_ENDPOINT=%s", credentialServer.URL))
+			cli.Env = append(cli.Env,
+				fmt.Sprintf("AZD_AUTH_ENDPOINT=%s", credentialServer.URL),
+				"AZD_AUTH_KEY=playback-test-key",
+			)
 		}
 	}
 

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_Deploy_SlotDeployment.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_Deploy_SlotDeployment.yaml
@@ -15928,3 +15928,4 @@ interactions:
 ---
 env_name: azdtest-d347996
 time: "1775837621"
+subscription_id: 4d042dc6-fe17-4698-a23f-ec6a8d1e98f4

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_DevCenter_Init_Up_Down.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_DevCenter_Init_Up_Down.yaml
@@ -5635,3 +5635,4 @@ interactions:
 ---
 env_name: azdtest-wb1885c
 time: "1718400745"
+subscription_id: 0a86e8d0-8c17-4765-90eb-aa50dae47299

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_Extension_Capabilities.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_Extension_Capabilities.yaml
@@ -2118,3 +2118,4 @@ interactions:
 ---
 env_name: azdtest-l8f0aee
 time: "1763590301"
+subscription_id: faa080af-c1d8-40ad-9cce-e1a450ca5b57

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_PreflightQuota_RG_DefaultCapacity.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_PreflightQuota_RG_DefaultCapacity.yaml
@@ -5515,3 +5515,4 @@ interactions:
 ---
 env_name: azdtest-dc8cf09
 time: "1776961040"
+subscription_id: 4d042dc6-fe17-4698-a23f-ec6a8d1e98f4

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_PreflightQuota_RG_InvalidModelName.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_PreflightQuota_RG_InvalidModelName.yaml
@@ -5515,3 +5515,4 @@ interactions:
 ---
 env_name: azdtest-dfd4aed
 time: "1776961040"
+subscription_id: 4d042dc6-fe17-4698-a23f-ec6a8d1e98f4

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_PreflightQuota_RG_InvalidVersion.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_PreflightQuota_RG_InvalidVersion.yaml
@@ -5515,3 +5515,4 @@ interactions:
 ---
 env_name: azdtest-d32c056
 time: "1776961040"
+subscription_id: 4d042dc6-fe17-4698-a23f-ec6a8d1e98f4

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_PreflightQuota_Sub_DefaultCapacity.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_PreflightQuota_Sub_DefaultCapacity.yaml
@@ -355,3 +355,4 @@ interactions:
 ---
 env_name: azdtest-d3d50a8
 time: "1776961040"
+subscription_id: 4d042dc6-fe17-4698-a23f-ec6a8d1e98f4

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_PreflightQuota_Sub_DifferentLocation.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_PreflightQuota_Sub_DifferentLocation.yaml
@@ -355,3 +355,4 @@ interactions:
 ---
 env_name: azdtest-d1bbe81
 time: "1776961040"
+subscription_id: 4d042dc6-fe17-4698-a23f-ec6a8d1e98f4

--- a/cli/azd/test/functional/testdata/recordings/Test_CLI_PreflightQuota_Sub_InvalidModelName.yaml
+++ b/cli/azd/test/functional/testdata/recordings/Test_CLI_PreflightQuota_Sub_InvalidModelName.yaml
@@ -355,3 +355,4 @@ interactions:
 ---
 env_name: azdtest-d03b50d
 time: "1776961040"
+subscription_id: 4d042dc6-fe17-4698-a23f-ec6a8d1e98f4

--- a/cli/azd/test/recording/recording.go
+++ b/cli/azd/test/recording/recording.go
@@ -332,7 +332,11 @@ func Start(t *testing.T, opts ...Options) *Session {
 			strings.Contains(req.URL.Host, "azuresdkartifacts.z5.web.core.windows.net") ||
 			strings.Contains(req.URL.Host, "default.exp-tas.com") ||
 			(strings.Contains(req.URL.Host, "dev.azure.com") &&
-				strings.Contains(req.URL.Path, "/oidctoken"))
+				strings.Contains(req.URL.Path, "/oidctoken")) ||
+			// Passthrough requests to the local test credential server (AZD_AUTH_ENDPOINT).
+			// In playback mode, RemoteCredential calls this server for tokens.
+			(strings.Contains(req.URL.Host, "127.0.0.1") &&
+				req.URL.Path == "/token")
 	})
 
 	proxy := &connectHandler{


### PR DESCRIPTION
Fixes #8157

## Problem

Functional tests like `Test_CLI_Publish_ContainerApp_RemoteBuild` intermittently fail in CI with:

`
AzurePipelinesCredential: unable to resolve an endpoint: context deadline exceeded
`

## Root Cause

In playback mode, the test framework set `AZD_AUTH_ENDPOINT` (pointing to the local test credential server) but never set `AZD_AUTH_KEY`. Since `UseExternalAuth()` requires **both** to be non-empty, it returned false, causing azd to fall through to real `AzurePipelinesCredential`. When the OIDC endpoint is slow/unreachable, the test times out.

## Fix (three parts)

1. **test/azdcli/cli.go** - Set `AZD_AUTH_KEY=playback-test-key` alongside `AZD_AUTH_ENDPOINT` so `UseExternalAuth()` returns true and `RemoteCredential` is used.

2. **test/recording/recording.go** - Add `127.0.0.1` with path `/token` to the recording proxy passthrough list so the local credential server isn't intercepted.

3. **pkg/account/subscriptions_manager.go** - When `AZD_DEBUG_SYNTHETIC_SUBSCRIPTION` is set and cache load fails, skip calling `ListSubscriptions()` (which calls ARM `/tenants` API not in the cassette) and directly create the synthetic subscription.

## Testing

- All `pkg/account` unit tests pass
- All `test/recording` tests pass
- Full `go build ./...` succeeds