### PR TITLE
Improve readability of azd ext list table with responsive PrettyTableFormatter

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -148,6 +148,10 @@ overrides:
     words:
       - compatResult
       - compatCopy
+      - Incompat
+  - filename: pkg/output/pretty_table.go
+    words:
+      - runewidth
   - filename: pkg/azdext/config_helper.go
     words:
       - myext

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -219,6 +219,13 @@ type extensionListItem struct {
 	UpdateAvailable  bool   `json:"updateAvailable"`
 	Incompatible     bool   `json:"-"`
 	Source           string `json:"source"`
+	// DisplayVersion is installed version or "Not installed" for table rendering.
+	DisplayVersion string `json:"-"`
+	// Status is a human-readable installation/update status indicator.
+	// Populated only for pretty-table rendering; omitted from JSON.
+	Status string `json:"-"`
+	// StatusSymbol is the symbol-only status (✓, ↑, ⚠, -) for medium/narrow widths.
+	StatusSymbol string `json:"-"`
 }
 
 func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, error) {
@@ -282,6 +289,12 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 			}
 		}
 
+		status := extensionStatus(installed, updateAvailable && !updateIncompatible, updateIncompatible)
+		displayVersion := installedVersion
+		if displayVersion == "" {
+			displayVersion = "Not installed"
+		}
+
 		extensionRows = append(extensionRows, extensionListItem{
 			Id:               extension.Id,
 			Name:             extension.DisplayName,
@@ -291,6 +304,9 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 			UpdateAvailable:  updateAvailable && !updateIncompatible,
 			Incompatible:     updateIncompatible,
 			Source:           extension.Source,
+			DisplayVersion:   displayVersion,
+			Status:           status,
+			StatusSymbol:     extensionStatusSymbol(status),
 		})
 	}
 
@@ -315,31 +331,52 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 	var formatErr error
 
 	if a.formatter.Kind() == output.TableFormat {
-		columns := []output.Column{
+		prettyFormatter := &output.PrettyTableFormatter{}
+		columns := []output.PrettyColumn{
 			{
-				Heading:       "Id",
-				ValueTemplate: "{{.Id}}",
+				Column: output.Column{
+					Heading:       "ID",
+					ValueTemplate: "{{.Id}}",
+				},
+				Priority:    1,
+				Truncatable: true,
 			},
 			{
-				Heading:       "Name",
-				ValueTemplate: "{{.Name}}",
+				Column: output.Column{
+					Heading:       "NAME",
+					ValueTemplate: "{{.Name}}",
+				},
+				Priority:    3,
+				Truncatable: true,
 			},
 			{
-				Heading:       "Latest Version",
-				ValueTemplate: `{{.Version}}`,
+				Column: output.Column{
+					Heading:       "VERSION",
+					ValueTemplate: "{{.DisplayVersion}}",
+				},
+				Priority: 1,
 			},
 			{
-				Heading:       "Installed Version",
-				ValueTemplate: `{{.InstalledVersion}}{{if .UpdateAvailable}}*{{else if .Incompatible}}!{{end}}`,
+				Column: output.Column{
+					Heading:       "STATUS",
+					ValueTemplate: "{{.Status}}",
+				},
+				Priority:           2,
+				ShortValueTemplate: "{{.StatusSymbol}}",
+				ColorFunc:          extensionStatusColor,
 			},
 			{
-				Heading:       "Source",
-				ValueTemplate: `{{.Source}}`,
+				Column: output.Column{
+					Heading:       "SOURCE",
+					ValueTemplate: "{{.Source}}",
+				},
+				Priority: 4,
 			},
 		}
 
-		formatErr = a.formatter.Format(extensionRows, a.writer, output.TableFormatterOptions{
-			Columns: columns,
+		formatErr = prettyFormatter.Format(extensionRows, a.writer, output.PrettyTableFormatterOptions{
+			Columns:         columns,
+			CardGroupColumn: "SOURCE",
 		})
 
 		if formatErr == nil {
@@ -355,18 +392,18 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 			}
 
 			if hasCompatibleUpdates {
-				a.console.Message(ctx, "(*) Update available")
 				a.console.Message(ctx, fmt.Sprintf(
-					"    To upgrade: %s", output.WithHighLightFormat("azd extension upgrade <extension-id>")))
+					"To upgrade: %s", output.WithHighLightFormat("azd extension upgrade <extension-id>")))
 				a.console.Message(ctx, fmt.Sprintf(
-					"    To upgrade all: %s", output.WithHighLightFormat("azd extension upgrade --all")))
+					"To upgrade all: %s", output.WithHighLightFormat("azd extension upgrade --all")))
 			}
 
 			if hasIncompatibleUpdates {
 				if hasCompatibleUpdates {
 					a.console.Message(ctx, "")
 				}
-				a.console.Message(ctx, "(!) Update available but incompatible with current azd version")
+				a.console.Message(ctx, output.WithWarningFormat(
+					"⚠ Some updates are incompatible with your current azd version"))
 			}
 		}
 	} else {
@@ -374,6 +411,64 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 	}
 
 	return nil, formatErr
+}
+
+// Status indicator constants for extension list display.
+const (
+	statusUpToDate   = "✓ Up to date"
+	statusUpdate     = "↑ Update available"
+	statusIncompat   = "⚠ Incompatible"
+	statusNotInstall = "-"
+)
+
+// extensionStatus returns a human-readable status string for the extension list table.
+func extensionStatus(installed, updateAvailable, incompatible bool) string {
+	switch {
+	case incompatible:
+		return statusIncompat
+	case updateAvailable:
+		return statusUpdate
+	case installed:
+		return statusUpToDate
+	default:
+		return statusNotInstall
+	}
+}
+
+// Status symbol constants for medium/narrow display.
+const (
+	symbolUpToDate   = "✓"
+	symbolUpdate     = "↑"
+	symbolIncompat   = "⚠"
+	symbolNotInstall = "-"
+)
+
+// extensionStatusSymbol returns the symbol-only version of a status string.
+func extensionStatusSymbol(status string) string {
+	switch status {
+	case statusUpToDate:
+		return symbolUpToDate
+	case statusUpdate:
+		return symbolUpdate
+	case statusIncompat:
+		return symbolIncompat
+	default:
+		return symbolNotInstall
+	}
+}
+
+// extensionStatusColor applies color formatting based on the status indicator text.
+func extensionStatusColor(s string) string {
+	switch s {
+	case statusUpToDate, symbolUpToDate:
+		return output.WithSuccessFormat(s)
+	case statusUpdate, symbolUpdate:
+		return output.WithWarningFormat(s)
+	case statusIncompat, symbolIncompat:
+		return output.WithErrorFormat(s)
+	default:
+		return output.WithGrayFormat(s)
+	}
 }
 
 // azd extension show

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -275,7 +275,10 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 		if installed {
 			installedVersion = installedExtension.Version
 
-			// Compare versions to determine if an update is available
+			// Compare versions to determine if an update is available.
+			// If either version string fails semver parsing (e.g., non-standard build tags),
+			// we silently fall back to showing "✓ Up to date" rather than erroring,
+			// since the list command should remain best-effort.
 			installedSemver, installedErr := semver.NewVersion(installedExtension.Version)
 			latestSemver, latestErr := semver.NewVersion(latestVersion)
 			if installedErr == nil && latestErr == nil {
@@ -311,6 +314,8 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 	}
 
 	if len(extensionRows) == 0 {
+		// NOTE: When no extensions found, we display a formatted message even for JSON output.
+		// This is existing azd behavior.
 		if a.flags.installed {
 			a.console.Message(ctx, output.WithWarningFormat("WARNING: No extensions installed.\n"))
 			a.console.Message(ctx, fmt.Sprintf(
@@ -338,16 +343,14 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 					Heading:       "ID",
 					ValueTemplate: "{{.Id}}",
 				},
-				Priority:    1,
-				Truncatable: true,
+				Priority: 1,
 			},
 			{
 				Column: output.Column{
 					Heading:       "NAME",
 					ValueTemplate: "{{.Name}}",
 				},
-				Priority:    3,
-				Truncatable: true,
+				Priority: 3,
 			},
 			{
 				Column: output.Column{
@@ -361,7 +364,7 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 					Heading:       "STATUS",
 					ValueTemplate: "{{.Status}}",
 				},
-				Priority:           2,
+				Priority:           1,
 				ShortValueTemplate: "{{.StatusSymbol}}",
 				ColorFunc:          extensionStatusColor,
 			},
@@ -370,7 +373,7 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 					Heading:       "SOURCE",
 					ValueTemplate: "{{.Source}}",
 				},
-				Priority: 4,
+				Priority: 1,
 			},
 		}
 

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -406,7 +406,7 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 					a.console.Message(ctx, "")
 				}
 				a.console.Message(ctx, output.WithWarningFormat(
-					"⚠ Some updates are incompatible with your current azd version"))
+					"WARNING: Some updates are incompatible with your current azd version"))
 			}
 		}
 	} else {

--- a/cli/azd/cmd/extension_test.go
+++ b/cli/azd/cmd/extension_test.go
@@ -602,3 +602,58 @@ func TestUpgradeActionResult_EmptyResults(t *testing.T) {
 		actionResult.Message.Header,
 	)
 }
+
+func TestExtensionStatus(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		installed  bool
+		update     bool
+		incompat   bool
+		wantStatus string
+	}{
+		{"not installed", false, false, false, statusNotInstall},
+		{"up to date", true, false, false, statusUpToDate},
+		{"update available", true, true, false, statusUpdate},
+		{"incompatible", true, false, true, statusIncompat},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := extensionStatus(tt.installed, tt.update, tt.incompat)
+			assert.Equal(t, tt.wantStatus, got)
+		})
+	}
+}
+
+func TestExtensionStatusSymbol(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		status string
+		want   string
+	}{
+		{statusUpToDate, symbolUpToDate},
+		{statusUpdate, symbolUpdate},
+		{statusIncompat, symbolIncompat},
+		{statusNotInstall, symbolNotInstall},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			t.Parallel()
+			got := extensionStatusSymbol(tt.status)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExtensionStatusColor(t *testing.T) {
+	t.Parallel()
+	// Verify no panics and non-empty output for each status (full and symbol forms)
+	for _, s := range []string{
+		statusUpToDate, statusUpdate, statusIncompat, statusNotInstall,
+		symbolUpToDate, symbolUpdate, symbolIncompat, symbolNotInstall,
+	} {
+		result := extensionStatusColor(s)
+		assert.NotEmpty(t, result, "color function should return non-empty for %q", s)
+	}
+}

--- a/cli/azd/cmd/extension_test.go
+++ b/cli/azd/cmd/extension_test.go
@@ -10,11 +10,12 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
-	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
 )
 
 func TestNamespacesConflictCases(t *testing.T) {
@@ -648,8 +649,6 @@ func TestExtensionStatusSymbol(t *testing.T) {
 }
 
 func TestExtensionStatusColor(t *testing.T) {
-	t.Parallel()
-
 	// Force color output on — fatih/color disables in non-TTY environments.
 	originalNoColor := color.NoColor
 	color.NoColor = false

--- a/cli/azd/cmd/extension_test.go
+++ b/cli/azd/cmd/extension_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -648,6 +649,12 @@ func TestExtensionStatusSymbol(t *testing.T) {
 
 func TestExtensionStatusColor(t *testing.T) {
 	t.Parallel()
+
+	// Force color output on — fatih/color disables in non-TTY environments.
+	originalNoColor := color.NoColor
+	color.NoColor = false
+	defer func() { color.NoColor = originalNoColor }()
+
 	// Verify no panics and non-empty output for each status (full and symbol forms)
 	for _, s := range []string{
 		statusUpToDate, statusUpdate, statusIncompat, statusNotInstall,
@@ -655,5 +662,6 @@ func TestExtensionStatusColor(t *testing.T) {
 	} {
 		result := extensionStatusColor(s)
 		assert.NotEmpty(t, result, "color function should return non-empty for %q", s)
+		assert.Contains(t, result, "\x1b[", "expected ANSI color codes in output for %q", s)
 	}
 }

--- a/cli/azd/go.mod
+++ b/cli/azd/go.mod
@@ -81,6 +81,7 @@ require (
 	go.uber.org/atomic v1.11.0
 	go.uber.org/multierr v1.11.0
 	go.yaml.in/yaml/v3 v3.0.4
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.42.0
 	golang.org/x/term v0.41.0
 	golang.org/x/time v0.9.0
@@ -148,7 +149,6 @@ require (
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 )

--- a/cli/azd/go.mod
+++ b/cli/azd/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/mark3labs/mcp-go v0.41.1
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20
+	github.com/mattn/go-runewidth v0.0.19
 	github.com/microsoft/ApplicationInsights-Go v0.4.4
 	github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0
 	github.com/microsoft/go-deviceid v1.0.0
@@ -122,7 +123,6 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mailru/easyjson v0.9.1 // indirect
-	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect

--- a/cli/azd/pkg/output/pretty_table.go
+++ b/cli/azd/pkg/output/pretty_table.go
@@ -8,50 +8,39 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
-	"slices"
+	"regexp"
 	"strings"
 	"text/template"
 
 	"github.com/fatih/color"
+	"github.com/mattn/go-runewidth"
 )
 
 // Width breakpoint constants for responsive layout selection.
 const (
-	// DefaultWideThreshold is the terminal width at or above which all columns
+	// DefaultFullThreshold is the terminal width at or above which all columns
 	// are shown with full text values.
-	DefaultWideThreshold = 110
+	DefaultFullThreshold = 100
 
-	// DefaultMediumThreshold is the terminal width at or above which all columns
-	// are shown but truncatable columns are shortened and ShortValueTemplate is used.
-	DefaultMediumThreshold = 80
-
-	// DefaultNarrowThreshold is the terminal width at or above which only
-	// high-priority columns (Priority ≤ 2) are shown in a table.
-	// Below this value the card/stacked layout is used.
-	DefaultNarrowThreshold = 50
+	// DefaultCompactThreshold is the terminal width at or above which only
+	// high-priority columns (Priority ≤ 2) are shown with ShortValueTemplate.
+	// Below this value the card layout is used.
+	DefaultCompactThreshold = 60
 
 	// columnPadding is the whitespace gap between columns (no box-drawing separators).
 	columnPadding = 3
-
-	// minTruncLen is the minimum number of visible characters before adding "…".
-	minTruncLen = 15
 )
 
 // PrettyColumn extends Column with priority for responsive column dropping.
 type PrettyColumn struct {
 	Column
 
-	// Priority controls column visibility and drop order.
-	// 1 = always shown, 2 = dropped third, 3 = dropped second, 4 = dropped first.
-	// 0 is treated as 1 (always shown).
+	// Priority controls column visibility at compact widths.
+	// 1 = always shown in compact, 2 = always shown in compact,
+	// 3+ = full table only. 0 is treated as 1.
 	Priority int
 
-	// Truncatable indicates this column's values can be truncated with "…"
-	// at medium/narrow widths to fit the terminal.
-	Truncatable bool
-
-	// ShortValueTemplate is an alternative Go template used at medium and narrow
+	// ShortValueTemplate is an alternative Go template used at compact
 	// widths. If empty, the regular ValueTemplate is used.
 	ShortValueTemplate string
 
@@ -65,22 +54,19 @@ type PrettyTableFormatterOptions struct {
 	Columns []PrettyColumn
 
 	// CardGroupColumn is the heading name of the column to group cards by
-	// in the very-narrow card layout. Each distinct value becomes a section header.
+	// in the card layout. Each distinct value becomes a section header.
 	// If empty, cards are rendered ungrouped with the first column as card title.
 	CardGroupColumn string
 
-	// WideThreshold is the terminal width at or above which the wide layout
-	// is used (all columns, full text). Defaults to DefaultWideThreshold (110).
-	WideThreshold int
+	// FullThreshold is the terminal width at or above which the full layout
+	// is used (all columns, full text). Defaults to DefaultFullThreshold (100).
+	FullThreshold int
 
-	// MediumThreshold is the terminal width at or above which the medium layout
-	// is used (all columns, truncated text). Defaults to DefaultMediumThreshold (80).
-	MediumThreshold int
-
-	// NarrowThreshold is the terminal width at or above which the narrow table
-	// layout is used (Priority ≤ 2 columns only). Below this the card layout is used.
-	// Defaults to DefaultNarrowThreshold (50).
-	NarrowThreshold int
+	// CompactThreshold is the terminal width at or above which the compact
+	// layout is used (Priority ≤ 2 columns, ShortValueTemplate).
+	// Below this the card layout is used.
+	// Defaults to DefaultCompactThreshold (60).
+	CompactThreshold int
 }
 
 // parsedCol pairs a PrettyColumn with its compiled templates.
@@ -91,8 +77,8 @@ type parsedCol struct {
 }
 
 // PrettyTableFormatter renders tabular data with responsive breakpoints.
-// It supports 4 layout modes based on terminal width: wide table, medium table
-// (with truncation), narrow table (fewer columns), and card layout.
+// It supports 3 layout modes based on terminal width: full table,
+// compact table (fewer columns), and card layout.
 type PrettyTableFormatter struct {
 	// ConsoleWidthFn returns the current terminal width. Defaults to getConsoleWidth.
 	ConsoleWidthFn func() int
@@ -119,16 +105,22 @@ func (f *PrettyTableFormatter) Format(obj any, writer io.Writer, opts any) error
 
 	// Parse templates upfront
 	parsed := make([]parsedCol, len(options.Columns))
+	seenHeadings := make(map[string]bool, len(options.Columns))
 	for i, c := range options.Columns {
+		if seenHeadings[c.Heading] {
+			return fmt.Errorf("duplicate column heading %q", c.Heading)
+		}
+		seenHeadings[c.Heading] = true
+
 		t, err := template.New(c.Heading).Parse(c.ValueTemplate)
 		if err != nil {
-			return err
+			return fmt.Errorf("column %q: %w", c.Heading, err)
 		}
 		pc := parsedCol{col: c, tmpl: t}
 		if c.ShortValueTemplate != "" {
 			st, err := template.New(c.Heading + "_short").Parse(c.ShortValueTemplate)
 			if err != nil {
-				return err
+				return fmt.Errorf("column %q short template: %w", c.Heading, err)
 			}
 			pc.shortTmpl = st
 		}
@@ -141,48 +133,34 @@ func (f *PrettyTableFormatter) Format(obj any, writer io.Writer, opts any) error
 	}
 	termWidth := widthFn()
 
-	wideT := options.WideThreshold
-	if wideT <= 0 {
-		wideT = DefaultWideThreshold
+	fullT := options.FullThreshold
+	if fullT <= 0 {
+		fullT = DefaultFullThreshold
 	}
-	medT := options.MediumThreshold
-	if medT <= 0 {
-		medT = DefaultMediumThreshold
-	}
-	narrowT := options.NarrowThreshold
-	if narrowT <= 0 {
-		narrowT = DefaultNarrowThreshold
+	compactT := options.CompactThreshold
+	if compactT <= 0 {
+		compactT = DefaultCompactThreshold
 	}
 
 	switch {
-	case termWidth >= wideT:
-		return f.formatWideTable(parsed, rows, termWidth, writer)
-	case termWidth >= medT:
-		return f.formatMediumTable(parsed, rows, termWidth, writer)
-	case termWidth >= narrowT:
-		return f.formatNarrowTable(parsed, rows, termWidth, writer)
+	case termWidth >= fullT:
+		return f.renderFullTable(parsed, rows, termWidth, writer)
+	case termWidth >= compactT:
+		return f.renderCompactTable(parsed, rows, termWidth, writer)
 	default:
 		return f.formatGroupedCards(parsed, rows, termWidth, writer, options)
 	}
 }
 
-// formatWideTable renders all columns with full text values and whitespace padding.
-func (f *PrettyTableFormatter) formatWideTable(
+// renderFullTable renders all columns with full text values and whitespace padding.
+func (f *PrettyTableFormatter) renderFullTable(
 	parsed []parsedCol, rows []any, termWidth int, writer io.Writer,
 ) error {
 	return f.renderPaddedTable(parsed, rows, termWidth, writer, false)
 }
 
-// formatMediumTable renders all columns; truncatable columns are shortened and
-// ShortValueTemplate is used where available.
-func (f *PrettyTableFormatter) formatMediumTable(
-	parsed []parsedCol, rows []any, termWidth int, writer io.Writer,
-) error {
-	return f.renderPaddedTable(parsed, rows, termWidth, writer, true)
-}
-
-// formatNarrowTable renders only Priority ≤ 2 columns with ShortValueTemplate.
-func (f *PrettyTableFormatter) formatNarrowTable(
+// renderCompactTable renders only Priority ≤ 2 columns with ShortValueTemplate.
+func (f *PrettyTableFormatter) renderCompactTable(
 	parsed []parsedCol, rows []any, termWidth int, writer io.Writer,
 ) error {
 	filtered := make([]parsedCol, 0, len(parsed))
@@ -218,7 +196,7 @@ func (f *PrettyTableFormatter) renderPaddedTable(
 			}
 			val, err := prettyExecTemplate(tmpl, row)
 			if err != nil {
-				return err
+				return fmt.Errorf("row %d, column %q: %w", ri, pc.col.Heading, err)
 			}
 			if pc.col.Transformer != nil {
 				val = pc.col.Transformer(val)
@@ -230,22 +208,13 @@ func (f *PrettyTableFormatter) renderPaddedTable(
 	// Compute natural column widths (max of heading and all cell values)
 	colWidths := make([]int, len(cols))
 	for ci, pc := range cols {
-		colWidths[ci] = len(pc.col.Heading)
+		colWidths[ci] = displayWidth(pc.col.Heading)
 	}
 	for _, rowVals := range grid.values {
 		for ci, val := range rowVals {
-			if len(val) > colWidths[ci] {
-				colWidths[ci] = len(val)
+			if dw := displayWidth(val); dw > colWidths[ci] {
+				colWidths[ci] = dw
 			}
-		}
-	}
-
-	// If useShort, truncate truncatable columns to fit within termWidth
-	if useShort {
-		totalWidth := sumWidths(colWidths) + (len(cols)-1)*columnPadding
-		if totalWidth > termWidth {
-			truncatableSpace := truncateColumnsToFit(cols, colWidths, totalWidth, termWidth)
-			_ = truncatableSpace
 		}
 	}
 
@@ -258,7 +227,15 @@ func (f *PrettyTableFormatter) renderPaddedTable(
 			buf.WriteString(strings.Repeat(" ", columnPadding))
 		}
 		heading := pc.col.Heading
-		buf.WriteString(boldHeader.Sprintf("%-*s", colWidths[ci], heading))
+		hdw := displayWidth(heading)
+		padNeeded := colWidths[ci] - hdw
+		if padNeeded < 0 {
+			padNeeded = 0
+		}
+		buf.WriteString(boldHeader.Sprint(heading))
+		if ci < len(cols)-1 {
+			buf.WriteString(strings.Repeat(" ", padNeeded))
+		}
 	}
 	buf.WriteByte('\n')
 
@@ -271,25 +248,20 @@ func (f *PrettyTableFormatter) renderPaddedTable(
 	buf.WriteByte('\n')
 
 	// Data rows
-	for ri, rowVals := range grid.values {
+	for _, rowVals := range grid.values {
 		for ci, val := range rowVals {
 			if ci > 0 {
 				buf.WriteString(strings.Repeat(" ", columnPadding))
 			}
-			// Truncate if needed
-			displayVal := val
-			if useShort && cols[ci].col.Truncatable && len(val) > colWidths[ci] {
-				displayVal = truncateWithEllipsis(val, colWidths[ci])
-			}
 
-			// Apply color after truncation so ANSI codes don't get clipped
-			colored := displayVal
+			// Apply color
+			colored := val
 			if cols[ci].col.ColorFunc != nil {
-				colored = cols[ci].col.ColorFunc(displayVal)
+				colored = cols[ci].col.ColorFunc(val)
 			}
 
-			// Pad based on plain-text width, not colored width
-			padNeeded := colWidths[ci] - len(displayVal)
+			// Pad based on display width, not byte length
+			padNeeded := colWidths[ci] - displayWidth(val)
 			if padNeeded < 0 {
 				padNeeded = 0
 			}
@@ -299,12 +271,7 @@ func (f *PrettyTableFormatter) renderPaddedTable(
 				buf.WriteString(strings.Repeat(" ", padNeeded))
 			}
 		}
-		// No trailing newline after the very last row — let the caller decide
-		if ri < len(grid.values)-1 {
-			buf.WriteByte('\n')
-		} else {
-			buf.WriteByte('\n')
-		}
+		buf.WriteByte('\n')
 	}
 
 	_, err := fmt.Fprint(writer, buf.String())
@@ -393,7 +360,7 @@ func (f *PrettyTableFormatter) formatGroupedCards(
 		for gi, group := range groupOrder {
 			// Group header: "── {value} ────────"
 			headerText := "── " + group + " "
-			remaining := termWidth - len(headerText)
+			remaining := termWidth - displayWidth(headerText)
 			if remaining < 1 {
 				remaining = 1
 			}
@@ -417,8 +384,7 @@ func (f *PrettyTableFormatter) formatGroupedCards(
 					padding := maxHeadingLen - len(cf.heading)
 					buf.WriteString(cf.heading)
 					buf.WriteString(":")
-					buf.WriteString(strings.Repeat(" ", padding+1))
-					buf.WriteString(" ")
+					buf.WriteString(strings.Repeat(" ", padding+2))
 					buf.WriteString(displayVal)
 					buf.WriteByte('\n')
 				}
@@ -487,7 +453,7 @@ func (f *PrettyTableFormatter) formatGroupedCards(
 	return err
 }
 
-// prettyExecTemplaterenders a template against a data row and returns the string result.
+// prettyExecTemplate renders a template against a data row and returns the string result.
 func prettyExecTemplate(tmpl *template.Template, data any) (string, error) {
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
@@ -497,114 +463,16 @@ func prettyExecTemplate(tmpl *template.Template, data any) (string, error) {
 }
 
 // truncateWithEllipsis truncates s to maxLen characters, replacing the last char with "…".
+// It uses rune-based slicing to avoid splitting multi-byte Unicode characters.
 func truncateWithEllipsis(s string, maxLen int) string {
-	if len(s) <= maxLen {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
 		return s
 	}
 	if maxLen <= 1 {
 		return "…"
 	}
-	return s[:maxLen-1] + "…"
-}
-
-// truncateColumnsToFit reduces colWidths for truncatable columns to make the
-// total table width fit within termWidth. Returns total space reclaimed.
-func truncateColumnsToFit(
-	cols []parsedCol, colWidths []int, totalWidth, termWidth int,
-) int {
-	excess := totalWidth - termWidth
-	if excess <= 0 {
-		return 0
-	}
-
-	reclaimed := 0
-	// Find truncatable columns sorted by current width descending (shrink widest first)
-	type truncIdx struct {
-		idx   int
-		width int
-	}
-	var truncatable []truncIdx
-	for i, pc := range cols {
-		if pc.col.Truncatable && colWidths[i] > minTruncLen {
-			truncatable = append(truncatable, truncIdx{idx: i, width: colWidths[i]})
-		}
-	}
-	slices.SortFunc(truncatable, func(a, b truncIdx) int {
-		return b.width - a.width // descending
-	})
-
-	for _, ti := range truncatable {
-		if reclaimed >= excess {
-			break
-		}
-		canShrink := colWidths[ti.idx] - minTruncLen
-		needed := excess - reclaimed
-		shrink := min(canShrink, needed)
-		colWidths[ti.idx] -= shrink
-		reclaimed += shrink
-	}
-
-	return reclaimed
-}
-
-// responsiveFilter drops the highest-Priority-number columns one at a time until
-// the estimated table width fits within termWidth, or no more droppable columns remain.
-func responsiveFilter(cols []parsedCol, rows []any, termWidth int) []parsedCol {
-	visible := slices.Clone(cols)
-
-	for {
-		width := estimateTableWidth(visible, rows)
-		if width <= termWidth {
-			break
-		}
-
-		// Find the column with the highest priority number to drop first
-		dropIdx := -1
-		dropPriority := math.MinInt
-		for i, pc := range visible {
-			if pc.col.Priority > 0 && pc.col.Priority > dropPriority {
-				dropPriority = pc.col.Priority
-				dropIdx = i
-			}
-		}
-
-		if dropIdx < 0 {
-			break
-		}
-
-		visible = append(visible[:dropIdx], visible[dropIdx+1:]...)
-	}
-
-	return visible
-}
-
-// estimateTableWidth computes the minimum table width by measuring the max content
-// width of each column plus inter-column padding.
-func estimateTableWidth(cols []parsedCol, rows []any) int {
-	colWidths := make([]int, len(cols))
-
-	for i, pc := range cols {
-		colWidths[i] = len(pc.col.Heading)
-	}
-
-	for _, row := range rows {
-		for i, pc := range cols {
-			val, err := prettyExecTemplate(pc.tmpl, row)
-			if err != nil {
-				continue
-			}
-			if len(val) > colWidths[i] {
-				colWidths[i] = len(val)
-			}
-		}
-	}
-
-	total := sumWidths(colWidths)
-	if len(cols) > 1 {
-		total += (len(cols) - 1) * columnPadding
-	}
-
-	return total
+	return string(runes[:maxLen-1]) + "…"
 }
 
 func sumWidths(widths []int) int {
@@ -613,6 +481,16 @@ func sumWidths(widths []int) int {
 		total += w
 	}
 	return total
+}
+
+// ansiRegex matches ANSI escape codes used for terminal coloring.
+var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// displayWidth returns the visible column width of s, ignoring ANSI escape
+// codes and accounting for wide Unicode characters (e.g. CJK).
+func displayWidth(s string) int {
+	stripped := ansiRegex.ReplaceAllString(s, "")
+	return runewidth.StringWidth(stripped)
 }
 
 var _ Formatter = (*PrettyTableFormatter)(nil)

--- a/cli/azd/pkg/output/pretty_table.go
+++ b/cli/azd/pkg/output/pretty_table.go
@@ -146,7 +146,7 @@ func (f *PrettyTableFormatter) Format(obj any, writer io.Writer, opts any) error
 	case termWidth >= fullT:
 		return f.renderFullTable(parsed, rows, termWidth, writer)
 	case termWidth >= compactT:
-		return f.renderCompactTable(parsed, rows, termWidth, writer)
+		return f.renderCompactTable(parsed, rows, termWidth, writer, options)
 	default:
 		return f.formatGroupedCards(parsed, rows, termWidth, writer, options)
 	}
@@ -161,7 +161,7 @@ func (f *PrettyTableFormatter) renderFullTable(
 
 // renderCompactTable renders only Priority ≤ 2 columns with ShortValueTemplate.
 func (f *PrettyTableFormatter) renderCompactTable(
-	parsed []parsedCol, rows []any, termWidth int, writer io.Writer,
+	parsed []parsedCol, rows []any, termWidth int, writer io.Writer, options PrettyTableFormatterOptions,
 ) error {
 	filtered := make([]parsedCol, 0, len(parsed))
 	for _, pc := range parsed {
@@ -173,11 +173,14 @@ func (f *PrettyTableFormatter) renderCompactTable(
 			filtered = append(filtered, pc)
 		}
 	}
+	if len(filtered) == 0 {
+		return f.formatGroupedCards(parsed, rows, termWidth, writer, options)
+	}
 	return f.renderPaddedTable(filtered, rows, termWidth, writer, true)
 }
 
 // renderPaddedTable builds a whitespace-padded table with a header underline.
-// When useShort is true, ShortValueTemplate and truncation are applied.
+// When useShort is true, ShortValueTemplate is used where available.
 func (f *PrettyTableFormatter) renderPaddedTable(
 	cols []parsedCol, rows []any, termWidth int, writer io.Writer, useShort bool,
 ) error {

--- a/cli/azd/pkg/output/pretty_table.go
+++ b/cli/azd/pkg/output/pretty_table.go
@@ -231,10 +231,7 @@ func (f *PrettyTableFormatter) renderPaddedTable(
 		}
 		heading := pc.col.Heading
 		hdw := displayWidth(heading)
-		padNeeded := colWidths[ci] - hdw
-		if padNeeded < 0 {
-			padNeeded = 0
-		}
+		padNeeded := max(colWidths[ci]-hdw, 0)
 		buf.WriteString(boldHeader.Sprint(heading))
 		if ci < len(cols)-1 {
 			buf.WriteString(strings.Repeat(" ", padNeeded))
@@ -243,10 +240,7 @@ func (f *PrettyTableFormatter) renderPaddedTable(
 	buf.WriteByte('\n')
 
 	// Header underline
-	lineWidth := sumWidths(colWidths) + max(0, len(cols)-1)*columnPadding
-	if lineWidth > termWidth {
-		lineWidth = termWidth
-	}
+	lineWidth := min(sumWidths(colWidths)+max(0, len(cols)-1)*columnPadding, termWidth)
 	buf.WriteString(strings.Repeat("─", lineWidth))
 	buf.WriteByte('\n')
 
@@ -264,10 +258,7 @@ func (f *PrettyTableFormatter) renderPaddedTable(
 			}
 
 			// Pad based on display width, not byte length
-			padNeeded := colWidths[ci] - displayWidth(val)
-			if padNeeded < 0 {
-				padNeeded = 0
-			}
+			padNeeded := max(colWidths[ci]-displayWidth(val), 0)
 			buf.WriteString(colored)
 			// Don't pad the last column
 			if ci < len(cols)-1 {
@@ -369,10 +360,7 @@ func (f *PrettyTableFormatter) formatGroupedCards(
 			// and may contain color codes if the column has a ColorFunc.
 			strippedGroup := ansiRegex.ReplaceAllString(group, "")
 			headerText := "── " + strippedGroup + " "
-			remaining := termWidth - displayWidth(headerText)
-			if remaining < 1 {
-				remaining = 1
-			}
+			remaining := max(termWidth-displayWidth(headerText), 1)
 			buf.WriteString(headerText)
 			buf.WriteString(strings.Repeat("─", remaining))
 			buf.WriteByte('\n')
@@ -414,10 +402,7 @@ func (f *PrettyTableFormatter) formatGroupedCards(
 			titleHeading := parsed[0].col.Heading
 			titleVal := rd.values[titleHeading]
 
-			borderWidth := termWidth - 2
-			if borderWidth < 20 {
-				borderWidth = 20
-			}
+			borderWidth := max(termWidth-2, 20)
 			if borderWidth > 76 {
 				borderWidth = 76
 			}

--- a/cli/azd/pkg/output/pretty_table.go
+++ b/cli/azd/pkg/output/pretty_table.go
@@ -402,10 +402,7 @@ func (f *PrettyTableFormatter) formatGroupedCards(
 			titleHeading := parsed[0].col.Heading
 			titleVal := rd.values[titleHeading]
 
-			borderWidth := max(termWidth-2, 20)
-			if borderWidth > 76 {
-				borderWidth = 76
-			}
+			borderWidth := min(max(termWidth-2, 20), 76)
 
 			buf.WriteString("┌" + strings.Repeat("─", borderWidth))
 			buf.WriteByte('\n')

--- a/cli/azd/pkg/output/pretty_table.go
+++ b/cli/azd/pkg/output/pretty_table.go
@@ -1,0 +1,618 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package output
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"slices"
+	"strings"
+	"text/template"
+
+	"github.com/fatih/color"
+)
+
+// Width breakpoint constants for responsive layout selection.
+const (
+	// DefaultWideThreshold is the terminal width at or above which all columns
+	// are shown with full text values.
+	DefaultWideThreshold = 110
+
+	// DefaultMediumThreshold is the terminal width at or above which all columns
+	// are shown but truncatable columns are shortened and ShortValueTemplate is used.
+	DefaultMediumThreshold = 80
+
+	// DefaultNarrowThreshold is the terminal width at or above which only
+	// high-priority columns (Priority ≤ 2) are shown in a table.
+	// Below this value the card/stacked layout is used.
+	DefaultNarrowThreshold = 50
+
+	// columnPadding is the whitespace gap between columns (no box-drawing separators).
+	columnPadding = 3
+
+	// minTruncLen is the minimum number of visible characters before adding "…".
+	minTruncLen = 15
+)
+
+// PrettyColumn extends Column with priority for responsive column dropping.
+type PrettyColumn struct {
+	Column
+
+	// Priority controls column visibility and drop order.
+	// 1 = always shown, 2 = dropped third, 3 = dropped second, 4 = dropped first.
+	// 0 is treated as 1 (always shown).
+	Priority int
+
+	// Truncatable indicates this column's values can be truncated with "…"
+	// at medium/narrow widths to fit the terminal.
+	Truncatable bool
+
+	// ShortValueTemplate is an alternative Go template used at medium and narrow
+	// widths. If empty, the regular ValueTemplate is used.
+	ShortValueTemplate string
+
+	// ColorFunc applies color formatting to the cell value.
+	// If nil, no color formatting is applied.
+	ColorFunc func(string) string
+}
+
+// PrettyTableFormatterOptions configures the pretty table formatter.
+type PrettyTableFormatterOptions struct {
+	Columns []PrettyColumn
+
+	// CardGroupColumn is the heading name of the column to group cards by
+	// in the very-narrow card layout. Each distinct value becomes a section header.
+	// If empty, cards are rendered ungrouped with the first column as card title.
+	CardGroupColumn string
+
+	// WideThreshold is the terminal width at or above which the wide layout
+	// is used (all columns, full text). Defaults to DefaultWideThreshold (110).
+	WideThreshold int
+
+	// MediumThreshold is the terminal width at or above which the medium layout
+	// is used (all columns, truncated text). Defaults to DefaultMediumThreshold (80).
+	MediumThreshold int
+
+	// NarrowThreshold is the terminal width at or above which the narrow table
+	// layout is used (Priority ≤ 2 columns only). Below this the card layout is used.
+	// Defaults to DefaultNarrowThreshold (50).
+	NarrowThreshold int
+}
+
+// parsedCol pairs a PrettyColumn with its compiled templates.
+type parsedCol struct {
+	col       PrettyColumn
+	tmpl      *template.Template
+	shortTmpl *template.Template // nil when ShortValueTemplate is empty
+}
+
+// PrettyTableFormatter renders tabular data with responsive breakpoints.
+// It supports 4 layout modes based on terminal width: wide table, medium table
+// (with truncation), narrow table (fewer columns), and card layout.
+type PrettyTableFormatter struct {
+	// ConsoleWidthFn returns the current terminal width. Defaults to getConsoleWidth.
+	ConsoleWidthFn func() int
+}
+
+func (f *PrettyTableFormatter) Kind() Format {
+	return TableFormat
+}
+
+func (f *PrettyTableFormatter) Format(obj any, writer io.Writer, opts any) error {
+	options, ok := opts.(PrettyTableFormatterOptions)
+	if !ok {
+		return errors.New("invalid formatter options, PrettyTableFormatterOptions expected")
+	}
+
+	if len(options.Columns) == 0 {
+		return errors.New("no columns were defined, table format is not supported for this command")
+	}
+
+	rows, err := convertToSlice(obj)
+	if err != nil {
+		return err
+	}
+
+	// Parse templates upfront
+	parsed := make([]parsedCol, len(options.Columns))
+	for i, c := range options.Columns {
+		t, err := template.New(c.Heading).Parse(c.ValueTemplate)
+		if err != nil {
+			return err
+		}
+		pc := parsedCol{col: c, tmpl: t}
+		if c.ShortValueTemplate != "" {
+			st, err := template.New(c.Heading + "_short").Parse(c.ShortValueTemplate)
+			if err != nil {
+				return err
+			}
+			pc.shortTmpl = st
+		}
+		parsed[i] = pc
+	}
+
+	widthFn := f.ConsoleWidthFn
+	if widthFn == nil {
+		widthFn = getConsoleWidth
+	}
+	termWidth := widthFn()
+
+	wideT := options.WideThreshold
+	if wideT <= 0 {
+		wideT = DefaultWideThreshold
+	}
+	medT := options.MediumThreshold
+	if medT <= 0 {
+		medT = DefaultMediumThreshold
+	}
+	narrowT := options.NarrowThreshold
+	if narrowT <= 0 {
+		narrowT = DefaultNarrowThreshold
+	}
+
+	switch {
+	case termWidth >= wideT:
+		return f.formatWideTable(parsed, rows, termWidth, writer)
+	case termWidth >= medT:
+		return f.formatMediumTable(parsed, rows, termWidth, writer)
+	case termWidth >= narrowT:
+		return f.formatNarrowTable(parsed, rows, termWidth, writer)
+	default:
+		return f.formatGroupedCards(parsed, rows, termWidth, writer, options)
+	}
+}
+
+// formatWideTable renders all columns with full text values and whitespace padding.
+func (f *PrettyTableFormatter) formatWideTable(
+	parsed []parsedCol, rows []any, termWidth int, writer io.Writer,
+) error {
+	return f.renderPaddedTable(parsed, rows, termWidth, writer, false)
+}
+
+// formatMediumTable renders all columns; truncatable columns are shortened and
+// ShortValueTemplate is used where available.
+func (f *PrettyTableFormatter) formatMediumTable(
+	parsed []parsedCol, rows []any, termWidth int, writer io.Writer,
+) error {
+	return f.renderPaddedTable(parsed, rows, termWidth, writer, true)
+}
+
+// formatNarrowTable renders only Priority ≤ 2 columns with ShortValueTemplate.
+func (f *PrettyTableFormatter) formatNarrowTable(
+	parsed []parsedCol, rows []any, termWidth int, writer io.Writer,
+) error {
+	filtered := make([]parsedCol, 0, len(parsed))
+	for _, pc := range parsed {
+		p := pc.col.Priority
+		if p == 0 {
+			p = 1
+		}
+		if p <= 2 {
+			filtered = append(filtered, pc)
+		}
+	}
+	return f.renderPaddedTable(filtered, rows, termWidth, writer, true)
+}
+
+// renderPaddedTable builds a whitespace-padded table with a header underline.
+// When useShort is true, ShortValueTemplate and truncation are applied.
+func (f *PrettyTableFormatter) renderPaddedTable(
+	cols []parsedCol, rows []any, termWidth int, writer io.Writer, useShort bool,
+) error {
+	// Resolve cell values
+	type cellGrid struct {
+		values [][]string // [row][col]
+	}
+	grid := cellGrid{values: make([][]string, len(rows))}
+
+	for ri, row := range rows {
+		grid.values[ri] = make([]string, len(cols))
+		for ci, pc := range cols {
+			tmpl := pc.tmpl
+			if useShort && pc.shortTmpl != nil {
+				tmpl = pc.shortTmpl
+			}
+			val, err := prettyExecTemplate(tmpl, row)
+			if err != nil {
+				return err
+			}
+			if pc.col.Transformer != nil {
+				val = pc.col.Transformer(val)
+			}
+			grid.values[ri][ci] = val
+		}
+	}
+
+	// Compute natural column widths (max of heading and all cell values)
+	colWidths := make([]int, len(cols))
+	for ci, pc := range cols {
+		colWidths[ci] = len(pc.col.Heading)
+	}
+	for _, rowVals := range grid.values {
+		for ci, val := range rowVals {
+			if len(val) > colWidths[ci] {
+				colWidths[ci] = len(val)
+			}
+		}
+	}
+
+	// If useShort, truncate truncatable columns to fit within termWidth
+	if useShort {
+		totalWidth := sumWidths(colWidths) + (len(cols)-1)*columnPadding
+		if totalWidth > termWidth {
+			truncatableSpace := truncateColumnsToFit(cols, colWidths, totalWidth, termWidth)
+			_ = truncatableSpace
+		}
+	}
+
+	boldHeader := color.New(color.Bold, color.FgHiWhite)
+	var buf bytes.Buffer
+
+	// Header row
+	for ci, pc := range cols {
+		if ci > 0 {
+			buf.WriteString(strings.Repeat(" ", columnPadding))
+		}
+		heading := pc.col.Heading
+		buf.WriteString(boldHeader.Sprintf("%-*s", colWidths[ci], heading))
+	}
+	buf.WriteByte('\n')
+
+	// Header underline
+	lineWidth := sumWidths(colWidths) + max(0, len(cols)-1)*columnPadding
+	if lineWidth > termWidth {
+		lineWidth = termWidth
+	}
+	buf.WriteString(strings.Repeat("─", lineWidth))
+	buf.WriteByte('\n')
+
+	// Data rows
+	for ri, rowVals := range grid.values {
+		for ci, val := range rowVals {
+			if ci > 0 {
+				buf.WriteString(strings.Repeat(" ", columnPadding))
+			}
+			// Truncate if needed
+			displayVal := val
+			if useShort && cols[ci].col.Truncatable && len(val) > colWidths[ci] {
+				displayVal = truncateWithEllipsis(val, colWidths[ci])
+			}
+
+			// Apply color after truncation so ANSI codes don't get clipped
+			colored := displayVal
+			if cols[ci].col.ColorFunc != nil {
+				colored = cols[ci].col.ColorFunc(displayVal)
+			}
+
+			// Pad based on plain-text width, not colored width
+			padNeeded := colWidths[ci] - len(displayVal)
+			if padNeeded < 0 {
+				padNeeded = 0
+			}
+			buf.WriteString(colored)
+			// Don't pad the last column
+			if ci < len(cols)-1 {
+				buf.WriteString(strings.Repeat(" ", padNeeded))
+			}
+		}
+		// No trailing newline after the very last row — let the caller decide
+		if ri < len(grid.values)-1 {
+			buf.WriteByte('\n')
+		} else {
+			buf.WriteByte('\n')
+		}
+	}
+
+	_, err := fmt.Fprint(writer, buf.String())
+	return err
+}
+
+// formatGroupedCards renders rows as cards grouped by CardGroupColumn.
+// If CardGroupColumn is empty, cards are rendered ungrouped.
+func (f *PrettyTableFormatter) formatGroupedCards(
+	parsed []parsedCol, rows []any, termWidth int, writer io.Writer, options PrettyTableFormatterOptions,
+) error {
+	groupColIdx := -1
+	if options.CardGroupColumn != "" {
+		for i, pc := range parsed {
+			if pc.col.Heading == options.CardGroupColumn {
+				groupColIdx = i
+				break
+			}
+		}
+	}
+
+	// Resolve all row values
+	type rowData struct {
+		values   map[string]string // heading -> value
+		groupVal string
+	}
+	allRows := make([]rowData, len(rows))
+	for ri, row := range rows {
+		rd := rowData{values: make(map[string]string)}
+		for _, pc := range parsed {
+			val, err := prettyExecTemplate(pc.tmpl, row)
+			if err != nil {
+				return err
+			}
+			if pc.col.Transformer != nil {
+				val = pc.col.Transformer(val)
+			}
+			if pc.col.ColorFunc != nil {
+				rd.values[pc.col.Heading+"_colored"] = pc.col.ColorFunc(val)
+			}
+			rd.values[pc.col.Heading] = val
+		}
+		if groupColIdx >= 0 {
+			rd.groupVal = rd.values[parsed[groupColIdx].col.Heading]
+		}
+		allRows[ri] = rd
+	}
+
+	// Determine card field order — exclude group column from card body
+	type cardField struct {
+		heading  string
+		hasColor bool
+	}
+	var cardFields []cardField
+	for _, pc := range parsed {
+		if groupColIdx >= 0 && pc.col.Heading == parsed[groupColIdx].col.Heading {
+			continue
+		}
+		cardFields = append(cardFields, cardField{
+			heading:  pc.col.Heading,
+			hasColor: pc.col.ColorFunc != nil,
+		})
+	}
+
+	// Find max heading length for alignment
+	maxHeadingLen := 0
+	for _, cf := range cardFields {
+		if len(cf.heading) > maxHeadingLen {
+			maxHeadingLen = len(cf.heading)
+		}
+	}
+
+	var buf bytes.Buffer
+
+	if groupColIdx >= 0 {
+		// Grouped cards: collect distinct group values in order
+		var groupOrder []string
+		groupRows := make(map[string][]rowData)
+		for _, rd := range allRows {
+			if _, exists := groupRows[rd.groupVal]; !exists {
+				groupOrder = append(groupOrder, rd.groupVal)
+			}
+			groupRows[rd.groupVal] = append(groupRows[rd.groupVal], rd)
+		}
+
+		for gi, group := range groupOrder {
+			// Group header: "── {value} ────────"
+			headerText := "── " + group + " "
+			remaining := termWidth - len(headerText)
+			if remaining < 1 {
+				remaining = 1
+			}
+			buf.WriteString(headerText)
+			buf.WriteString(strings.Repeat("─", remaining))
+			buf.WriteByte('\n')
+			buf.WriteByte('\n')
+
+			for ri, rd := range groupRows[group] {
+				for _, cf := range cardFields {
+					val := rd.values[cf.heading]
+					if val == "" {
+						continue
+					}
+					displayVal := val
+					if cf.hasColor {
+						if colored, ok := rd.values[cf.heading+"_colored"]; ok {
+							displayVal = colored
+						}
+					}
+					padding := maxHeadingLen - len(cf.heading)
+					buf.WriteString(cf.heading)
+					buf.WriteString(":")
+					buf.WriteString(strings.Repeat(" ", padding+1))
+					buf.WriteString(" ")
+					buf.WriteString(displayVal)
+					buf.WriteByte('\n')
+				}
+				if ri < len(groupRows[group])-1 {
+					buf.WriteByte('\n')
+				}
+			}
+
+			if gi < len(groupOrder)-1 {
+				buf.WriteByte('\n')
+			}
+		}
+	} else {
+		// Ungrouped cards — use first column as card title
+		boldTitle := color.New(color.Bold, color.FgHiWhite)
+
+		for ri, rd := range allRows {
+			titleHeading := parsed[0].col.Heading
+			titleVal := rd.values[titleHeading]
+
+			borderWidth := termWidth - 2
+			if borderWidth < 20 {
+				borderWidth = 20
+			}
+			if borderWidth > 76 {
+				borderWidth = 76
+			}
+
+			buf.WriteString("┌" + strings.Repeat("─", borderWidth))
+			buf.WriteByte('\n')
+			buf.WriteString("│ ")
+			buf.WriteString(boldTitle.Sprint(titleVal))
+			buf.WriteByte('\n')
+
+			for _, cf := range cardFields {
+				if cf.heading == titleHeading {
+					continue
+				}
+				val := rd.values[cf.heading]
+				if val == "" {
+					continue
+				}
+				if cf.hasColor {
+					if colored, ok := rd.values[cf.heading+"_colored"]; ok {
+						val = colored
+					}
+				}
+				padding := maxHeadingLen - len(cf.heading)
+				buf.WriteString("│ ")
+				buf.WriteString(cf.heading)
+				buf.WriteString(": ")
+				buf.WriteString(strings.Repeat(" ", padding))
+				buf.WriteString(val)
+				buf.WriteByte('\n')
+			}
+
+			buf.WriteString("└" + strings.Repeat("─", borderWidth))
+			buf.WriteByte('\n')
+			if ri < len(allRows)-1 {
+				buf.WriteByte('\n')
+			}
+		}
+	}
+
+	_, err := fmt.Fprint(writer, buf.String())
+	return err
+}
+
+// prettyExecTemplaterenders a template against a data row and returns the string result.
+func prettyExecTemplate(tmpl *template.Template, data any) (string, error) {
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// truncateWithEllipsis truncates s to maxLen characters, replacing the last char with "…".
+func truncateWithEllipsis(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 1 {
+		return "…"
+	}
+	return s[:maxLen-1] + "…"
+}
+
+// truncateColumnsToFit reduces colWidths for truncatable columns to make the
+// total table width fit within termWidth. Returns total space reclaimed.
+func truncateColumnsToFit(
+	cols []parsedCol, colWidths []int, totalWidth, termWidth int,
+) int {
+	excess := totalWidth - termWidth
+	if excess <= 0 {
+		return 0
+	}
+
+	reclaimed := 0
+	// Find truncatable columns sorted by current width descending (shrink widest first)
+	type truncIdx struct {
+		idx   int
+		width int
+	}
+	var truncatable []truncIdx
+	for i, pc := range cols {
+		if pc.col.Truncatable && colWidths[i] > minTruncLen {
+			truncatable = append(truncatable, truncIdx{idx: i, width: colWidths[i]})
+		}
+	}
+	slices.SortFunc(truncatable, func(a, b truncIdx) int {
+		return b.width - a.width // descending
+	})
+
+	for _, ti := range truncatable {
+		if reclaimed >= excess {
+			break
+		}
+		canShrink := colWidths[ti.idx] - minTruncLen
+		needed := excess - reclaimed
+		shrink := min(canShrink, needed)
+		colWidths[ti.idx] -= shrink
+		reclaimed += shrink
+	}
+
+	return reclaimed
+}
+
+// responsiveFilter drops the highest-Priority-number columns one at a time until
+// the estimated table width fits within termWidth, or no more droppable columns remain.
+func responsiveFilter(cols []parsedCol, rows []any, termWidth int) []parsedCol {
+	visible := slices.Clone(cols)
+
+	for {
+		width := estimateTableWidth(visible, rows)
+		if width <= termWidth {
+			break
+		}
+
+		// Find the column with the highest priority number to drop first
+		dropIdx := -1
+		dropPriority := math.MinInt
+		for i, pc := range visible {
+			if pc.col.Priority > 0 && pc.col.Priority > dropPriority {
+				dropPriority = pc.col.Priority
+				dropIdx = i
+			}
+		}
+
+		if dropIdx < 0 {
+			break
+		}
+
+		visible = append(visible[:dropIdx], visible[dropIdx+1:]...)
+	}
+
+	return visible
+}
+
+// estimateTableWidth computes the minimum table width by measuring the max content
+// width of each column plus inter-column padding.
+func estimateTableWidth(cols []parsedCol, rows []any) int {
+	colWidths := make([]int, len(cols))
+
+	for i, pc := range cols {
+		colWidths[i] = len(pc.col.Heading)
+	}
+
+	for _, row := range rows {
+		for i, pc := range cols {
+			val, err := prettyExecTemplate(pc.tmpl, row)
+			if err != nil {
+				continue
+			}
+			if len(val) > colWidths[i] {
+				colWidths[i] = len(val)
+			}
+		}
+	}
+
+	total := sumWidths(colWidths)
+	if len(cols) > 1 {
+		total += (len(cols) - 1) * columnPadding
+	}
+
+	return total
+}
+
+func sumWidths(widths []int) int {
+	total := 0
+	for _, w := range widths {
+		total += w
+	}
+	return total
+}
+
+var _ Formatter = (*PrettyTableFormatter)(nil)

--- a/cli/azd/pkg/output/pretty_table.go
+++ b/cli/azd/pkg/output/pretty_table.go
@@ -291,6 +291,9 @@ func (f *PrettyTableFormatter) formatGroupedCards(
 				break
 			}
 		}
+		if groupColIdx < 0 {
+			return fmt.Errorf("CardGroupColumn %q does not match any column heading", options.CardGroupColumn)
+		}
 	}
 
 	// Resolve all row values
@@ -304,7 +307,7 @@ func (f *PrettyTableFormatter) formatGroupedCards(
 		for _, pc := range parsed {
 			val, err := prettyExecTemplate(pc.tmpl, row)
 			if err != nil {
-				return err
+				return fmt.Errorf("row %d, column %q: %w", ri, pc.col.Heading, err)
 			}
 			if pc.col.Transformer != nil {
 				val = pc.col.Transformer(val)
@@ -359,7 +362,10 @@ func (f *PrettyTableFormatter) formatGroupedCards(
 
 		for gi, group := range groupOrder {
 			// Group header: "── {value} ────────"
-			headerText := "── " + group + " "
+			// Strip ANSI codes from group value — it comes from template execution
+			// and may contain color codes if the column has a ColorFunc.
+			strippedGroup := ansiRegex.ReplaceAllString(group, "")
+			headerText := "── " + strippedGroup + " "
 			remaining := termWidth - displayWidth(headerText)
 			if remaining < 1 {
 				remaining = 1
@@ -460,19 +466,6 @@ func prettyExecTemplate(tmpl *template.Template, data any) (string, error) {
 		return "", err
 	}
 	return buf.String(), nil
-}
-
-// truncateWithEllipsis truncates s to maxLen characters, replacing the last char with "…".
-// It uses rune-based slicing to avoid splitting multi-byte Unicode characters.
-func truncateWithEllipsis(s string, maxLen int) string {
-	runes := []rune(s)
-	if len(runes) <= maxLen {
-		return s
-	}
-	if maxLen <= 1 {
-		return "…"
-	}
-	return string(runes[:maxLen-1]) + "…"
 }
 
 func sumWidths(widths []int) int {

--- a/cli/azd/pkg/output/pretty_table_test.go
+++ b/cli/azd/pkg/output/pretty_table_test.go
@@ -607,7 +607,7 @@ func TestPrettySingleGroupCards(t *testing.T) {
 
 	// No extra group separators (only one "──" line at the top)
 	headerLines := 0
-	for _, line := range strings.Split(output, "\n") {
+	for line := range strings.SplitSeq(output, "\n") {
 		if strings.HasPrefix(line, "── ") {
 			headerLines++
 		}
@@ -663,11 +663,11 @@ func TestPrettyTableANSIAlignment(t *testing.T) {
 	// displayIndex returns the display-column position of substr within s,
 	// where s has already been stripped of ANSI codes.
 	displayIndex := func(s, substr string) int {
-		byteIdx := strings.Index(s, substr)
-		if byteIdx < 0 {
+		before, _, ok := strings.Cut(s, substr)
+		if !ok {
 			return -1
 		}
-		return displayWidth(s[:byteIdx])
+		return displayWidth(before)
 	}
 
 	row1Stripped := strip(lines[2])

--- a/cli/azd/pkg/output/pretty_table_test.go
+++ b/cli/azd/pkg/output/pretty_table_test.go
@@ -1,0 +1,671 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type prettyInput struct {
+	Name         string
+	Version      string
+	Status       string
+	StatusSymbol string
+	Source       string
+	Id           string
+}
+
+func TestPrettyTableFormatterBasic(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "ext-a", Name: "Extension A", Version: "1.0.0", Status: "✓ Up to date", Source: "azd"},
+		{Id: "ext-b", Name: "Extension B", Version: "2.1.0", Status: "↑ Update available", Source: "azd"},
+	}
+
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 120 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+			{Column: Column{Heading: "NAME", ValueTemplate: "{{.Name}}"}, Priority: 3},
+			{Column: Column{Heading: "VERSION", ValueTemplate: "{{.Version}}"}, Priority: 1},
+			{Column: Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"}, Priority: 2},
+			{Column: Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"}, Priority: 4},
+		},
+	})
+
+	require.NoError(t, err)
+	output := buf.String()
+
+	require.Contains(t, output, "ID")
+	require.Contains(t, output, "NAME")
+	require.Contains(t, output, "VERSION")
+	require.Contains(t, output, "STATUS")
+	require.Contains(t, output, "SOURCE")
+	require.Contains(t, output, "ext-a")
+	require.Contains(t, output, "ext-b")
+	require.Contains(t, output, "1.0.0")
+	require.Contains(t, output, "2.1.0")
+}
+
+func TestPrettyTableFormatterNoColumns(t *testing.T) {
+	formatter := &PrettyTableFormatter{}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(struct{}{}, buf, PrettyTableFormatterOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no columns were defined")
+}
+
+func TestPrettyTableFormatterInvalidOpts(t *testing.T) {
+	formatter := &PrettyTableFormatter{}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(struct{}{}, buf, "bad opts")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid formatter options")
+}
+
+func TestPrettyTableFormatterKind(t *testing.T) {
+	formatter := &PrettyTableFormatter{}
+	require.Equal(t, TableFormat, formatter.Kind())
+}
+
+func TestPrettyTableFormatterTransformer(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "EXT-A", Name: "EXT-A", Version: "1.0.0", Status: "ok"},
+	}
+
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 120 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{
+				Heading:       "ID",
+				ValueTemplate: "{{.Id}}",
+				Transformer:   strings.ToLower,
+			}, Priority: 1},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "ext-a")
+}
+
+func TestPrettyTableFormatterColorFunc(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "ext-a", Name: "ext-a", Version: "1.0.0", Status: "ok"},
+	}
+
+	colorApplied := false
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 120 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{
+				Column: Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+				ColorFunc: func(s string) string {
+					colorApplied = true
+					return "[" + s + "]"
+				},
+				Priority: 1,
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.True(t, colorApplied)
+	require.Contains(t, buf.String(), "[ok]")
+}
+
+func TestPrettyTableFormatterScalar(t *testing.T) {
+	row := prettyInput{Id: "single", Name: "single", Version: "0.1.0", Status: "ok"}
+
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 120 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(row, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "single")
+}
+
+func TestPrettyTableFormatterNonexistentField(t *testing.T) {
+	row := prettyInput{Id: "test"}
+
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 120 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(row, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{Heading: "Bad", ValueTemplate: "{{.NoSuchField}}"}, Priority: 1},
+		},
+	})
+	require.Error(t, err)
+}
+
+func TestPrettyNoColumnSeparators(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "ext-a", Name: "Extension A", Version: "1.0.0", Status: "ok", Source: "azd"},
+	}
+
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 120 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+			{Column: Column{Heading: "VERSION", ValueTemplate: "{{.Version}}"}, Priority: 1},
+		},
+	})
+
+	require.NoError(t, err)
+	output := buf.String()
+
+	// No box-drawing column separators
+	require.NotContains(t, output, "│")
+	// Header underline present
+	require.Contains(t, output, "─")
+}
+
+func TestPrettyHeaderUnderline(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "ext-a", Version: "1.0.0"},
+	}
+
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 120 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+			{Column: Column{Heading: "VERSION", ValueTemplate: "{{.Version}}"}, Priority: 1},
+		},
+	})
+
+	require.NoError(t, err)
+	lines := strings.Split(buf.String(), "\n")
+	require.GreaterOrEqual(t, len(lines), 2)
+	// Second line should be all ─ characters
+	underline := strings.TrimSpace(lines[1])
+	require.True(t, len(underline) > 0)
+	for _, ch := range underline {
+		require.Equal(t, '─', ch, "header underline should be all ─ chars")
+	}
+}
+
+// Breakpoint tests
+
+func TestPrettyWideBreakpoint(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "azure.ai.agents", Name: "Foundry agents (Preview)", Version: "0.1.18-preview",
+			Status: "✓ Up to date", StatusSymbol: "✓", Source: "azd"},
+	}
+
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 120 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: extListTestColumns(),
+	})
+
+	require.NoError(t, err)
+	output := buf.String()
+
+	// Wide: all columns shown, full status text
+	require.Contains(t, output, "ID")
+	require.Contains(t, output, "NAME")
+	require.Contains(t, output, "VERSION")
+	require.Contains(t, output, "STATUS")
+	require.Contains(t, output, "SOURCE")
+	require.Contains(t, output, "✓ Up to date")
+	require.Contains(t, output, "Foundry agents (Preview)")
+}
+
+func TestPrettyMediumBreakpoint(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "azure.ai.agents", Name: "Foundry agents (Preview)", Version: "0.1.18-preview",
+			Status: "✓ Up to date", StatusSymbol: "✓", Source: "azd"},
+	}
+
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 95 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: extListTestColumns(),
+	})
+
+	require.NoError(t, err)
+	output := buf.String()
+
+	// Medium: all columns shown, status uses ShortValueTemplate (symbol only)
+	require.Contains(t, output, "ID")
+	require.Contains(t, output, "NAME")
+	require.Contains(t, output, "SOURCE")
+	// Should use short status template (symbol only)
+	require.NotContains(t, output, "Up to date")
+}
+
+func TestPrettyNarrowBreakpoint(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "azure.ai.agents", Name: "Foundry agents (Preview)", Version: "0.1.18-preview",
+			Status: "✓ Up to date", StatusSymbol: "✓", Source: "azd"},
+	}
+
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 60 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: extListTestColumns(),
+	})
+
+	require.NoError(t, err)
+	output := buf.String()
+
+	// Narrow: only Priority ≤ 2 columns (ID, VERSION, STATUS)
+	require.Contains(t, output, "ID")
+	require.Contains(t, output, "VERSION")
+	require.Contains(t, output, "STATUS")
+	// NAME (priority 3) and SOURCE (priority 4) dropped
+	require.NotContains(t, output, "NAME")
+	require.NotContains(t, output, "SOURCE")
+}
+
+func TestPrettyCardBreakpoint(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "azure.ai.agents", Name: "Foundry agents (Preview)", Version: "0.1.18-preview",
+			Status: "✓ Up to date", StatusSymbol: "✓", Source: "azd"},
+		{Id: "azure.coding-agent", Name: "Coding agent config", Version: "0.6.1",
+			Status: "⚠ Incompatible", StatusSymbol: "⚠", Source: "local"},
+	}
+
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 40 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns:         extListTestColumns(),
+		CardGroupColumn: "SOURCE",
+	})
+
+	require.NoError(t, err)
+	output := buf.String()
+
+	// Cards grouped by source
+	require.Contains(t, output, "── azd ")
+	require.Contains(t, output, "── local ")
+	// Card body has key-value pairs (using column headings as keys)
+	require.Contains(t, output, "NAME:")
+	require.Contains(t, output, "ID:")
+	require.Contains(t, output, "VERSION:")
+	require.Contains(t, output, "STATUS:")
+	// SOURCE should NOT appear in card body (it's the group header)
+	require.NotContains(t, output, "SOURCE:")
+}
+
+func TestPrettyCardGroupingOrder(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "ext-1", Name: "First", Version: "1.0", Status: "✓", Source: "azd"},
+		{Id: "ext-2", Name: "Second", Version: "2.0", Status: "✓", Source: "local"},
+		{Id: "ext-3", Name: "Third", Version: "3.0", Status: "✓", Source: "azd"},
+	}
+
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 40 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{Heading: "NAME", ValueTemplate: "{{.Name}}"}, Priority: 1},
+			{Column: Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"}, Priority: 4},
+		},
+		CardGroupColumn: "SOURCE",
+	})
+
+	require.NoError(t, err)
+	output := buf.String()
+
+	// azd appears first (first row's source)
+	azdIdx := strings.Index(output, "── azd ")
+	localIdx := strings.Index(output, "── local ")
+	require.Greater(t, localIdx, azdIdx, "azd group should appear before local group")
+
+	// Both extensions with source=azd should be in the azd group
+	require.Contains(t, output, "First")
+	require.Contains(t, output, "Third")
+}
+
+func TestPrettyTruncation(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "ext-a", Name: "A Very Long Extension Name That Should Get Truncated Here", Version: "1.0.0",
+			Status: "ok", StatusSymbol: "✓", Source: "azd"},
+	}
+
+	// Use width 80 (medium) — content is wider than 80 so truncation is needed
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 80 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+			{Column: Column{Heading: "NAME", ValueTemplate: "{{.Name}}"}, Priority: 3, Truncatable: true},
+			{Column: Column{Heading: "VERSION", ValueTemplate: "{{.Version}}"}, Priority: 1},
+			{Column: Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"}, Priority: 2},
+			{Column: Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"}, Priority: 4},
+		},
+	})
+
+	require.NoError(t, err)
+	output := buf.String()
+
+	// Name should be truncated with ellipsis at medium width
+	require.Contains(t, output, "…", "truncated name should contain ellipsis")
+	// The full name should NOT appear
+	require.NotContains(t, output, "A Very Long Extension Name That Should Get Truncated Here")
+}
+
+func TestPrettyShortValueTemplate(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "ext-a", Status: "✓ Up to date", StatusSymbol: "✓"},
+	}
+
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 90 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+			{
+				Column:             Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+				Priority:           2,
+				ShortValueTemplate: "{{.StatusSymbol}}",
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	output := buf.String()
+
+	// At medium width, should use short template (symbol only)
+	require.NotContains(t, output, "Up to date")
+}
+
+func TestPrettyShortValueTemplateNotUsedAtWideWidth(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "ext-a", Status: "✓ Up to date", StatusSymbol: "✓"},
+	}
+
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 120 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+			{
+				Column:             Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+				Priority:           2,
+				ShortValueTemplate: "{{.StatusSymbol}}",
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	output := buf.String()
+
+	// At wide width, should use full template
+	require.Contains(t, output, "✓ Up to date")
+}
+
+// Breakpoint boundary transition tests
+
+func TestPrettyBreakpointTransitions(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "azure.ai.agents", Name: "Foundry agents (Preview)", Version: "0.1.18-preview",
+			Status: "✓ Up to date", StatusSymbol: "✓", Source: "azd"},
+	}
+
+	columns := extListTestColumns()
+
+	tests := []struct {
+		name       string
+		width      int
+		wantCard   bool
+		wantNAME   bool
+		wantSOURCE bool
+	}{
+		{"wide at 110", 110, false, true, true},
+		{"medium at 109", 109, false, true, true},
+		{"medium at 80", 80, false, true, true},
+		{"narrow at 79", 79, false, false, false},
+		{"narrow at 50", 50, false, false, false},
+		{"card at 49", 49, true, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatter := &PrettyTableFormatter{
+				ConsoleWidthFn: func() int { return tt.width },
+			}
+
+			buf := &bytes.Buffer{}
+			err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+				Columns:         columns,
+				CardGroupColumn: "SOURCE",
+			})
+			require.NoError(t, err)
+			output := buf.String()
+
+			if tt.wantCard {
+				require.Contains(t, output, "── azd ", "expected card layout for width %d", tt.width)
+			} else {
+				require.Contains(t, output, "─", "expected header underline for width %d", tt.width)
+			}
+
+			if !tt.wantCard {
+				if tt.wantNAME {
+					require.Contains(t, output, "NAME", "expected NAME column for width %d", tt.width)
+				} else {
+					require.NotContains(t, output, "NAME", "expected no NAME column for width %d", tt.width)
+				}
+				if tt.wantSOURCE {
+					require.Contains(t, output, "SOURCE", "expected SOURCE column for width %d", tt.width)
+				} else {
+					require.NotContains(t, output, "SOURCE",
+						"expected no SOURCE column for width %d", tt.width)
+				}
+			}
+		})
+	}
+}
+
+func TestPrettyCardColorFunc(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "ext-a", Name: "Extension A", Version: "1.0.0", Status: "ok", Source: "azd"},
+	}
+
+	colorApplied := false
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 40 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{Heading: "NAME", ValueTemplate: "{{.Name}}"}, Priority: 1},
+			{
+				Column: Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+				ColorFunc: func(s string) string {
+					colorApplied = true
+					return "«" + s + "»"
+				},
+				Priority: 2,
+			},
+			{Column: Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"}, Priority: 4},
+		},
+		CardGroupColumn: "SOURCE",
+	})
+
+	require.NoError(t, err)
+	require.True(t, colorApplied, "ColorFunc should be called in card layout")
+	require.Contains(t, buf.String(), "«ok»")
+}
+
+func TestPrettyUngroupedCards(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "ext-a", Name: "Extension A", Version: "1.0.0", Status: "ok"},
+		{Id: "ext-b", Name: "Extension B", Version: "2.0.0", Status: "ok"},
+	}
+
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 40 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{Heading: "NAME", ValueTemplate: "{{.Name}}"}, Priority: 1},
+			{Column: Column{Heading: "VERSION", ValueTemplate: "{{.Version}}"}, Priority: 1},
+		},
+	})
+
+	require.NoError(t, err)
+	output := buf.String()
+
+	// Ungrouped cards use box-drawing borders
+	require.Contains(t, output, "┌")
+	require.Contains(t, output, "└")
+	require.Contains(t, output, "Extension A")
+	require.Contains(t, output, "Extension B")
+}
+
+func TestTruncateWithEllipsis(t *testing.T) {
+	tests := []struct {
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"hello", 10, "hello"},
+		{"hello world", 5, "hell…"},
+		{"ab", 1, "…"},
+		{"abc", 3, "abc"},
+		{"abcd", 3, "ab…"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := truncateWithEllipsis(tt.input, tt.maxLen)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEstimateTableWidth(t *testing.T) {
+	cols := []parsedCol{
+		{col: PrettyColumn{Column: Column{Heading: "Name"}}},
+		{col: PrettyColumn{Column: Column{Heading: "Version"}}},
+	}
+
+	// No rows: width = len("Name") + len("Version") + 3 (padding) = 4 + 7 + 3 = 14
+	width := estimateTableWidth(cols, nil)
+	require.Equal(t, 14, width)
+}
+
+func TestResponsiveFilterDropsHighestPriorityNumber(t *testing.T) {
+	cols := []parsedCol{
+		{col: PrettyColumn{Column: Column{Heading: "Id", ValueTemplate: "{{.Name}}"}, Priority: 1}},
+		{col: PrettyColumn{Column: Column{Heading: "Source-Column", ValueTemplate: "{{.Name}}"}, Priority: 4}},
+		{col: PrettyColumn{Column: Column{Heading: "Name-Column", ValueTemplate: "{{.Name}}"}, Priority: 3}},
+	}
+
+	// Width so narrow that it can't fit all 3 columns
+	result := responsiveFilter(cols, nil, 20)
+
+	require.Less(t, len(result), 3)
+
+	// Id (priority 1) should always remain
+	hasId := false
+	for _, c := range result {
+		if c.col.Heading == "Id" {
+			hasId = true
+		}
+	}
+	require.True(t, hasId, "Priority 1 columns should be kept the longest")
+}
+
+func TestResponsiveFilterKeepsAllWhenFits(t *testing.T) {
+	cols := []parsedCol{
+		{col: PrettyColumn{Column: Column{Heading: "Id", ValueTemplate: "{{.Name}}"}, Priority: 1}},
+		{col: PrettyColumn{Column: Column{Heading: "Source", ValueTemplate: "{{.Name}}"}, Priority: 4}},
+	}
+
+	result := responsiveFilter(cols, nil, 200)
+	require.Len(t, result, 2)
+}
+
+// extListTestColumns returns the standard 5-column config matching the hybrid UX spec.
+func extListTestColumns() []PrettyColumn {
+	return []PrettyColumn{
+		{
+			Column:      Column{Heading: "ID", ValueTemplate: "{{.Id}}"},
+			Priority:    1,
+			Truncatable: true,
+		},
+		{
+			Column:      Column{Heading: "NAME", ValueTemplate: "{{.Name}}"},
+			Priority:    3,
+			Truncatable: true,
+		},
+		{
+			Column:   Column{Heading: "VERSION", ValueTemplate: "{{.Version}}"},
+			Priority: 1,
+		},
+		{
+			Column:             Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+			Priority:           2,
+			ShortValueTemplate: "{{.StatusSymbol}}",
+		},
+		{
+			Column:   Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"},
+			Priority: 4,
+		},
+	}
+}

--- a/cli/azd/pkg/output/pretty_table_test.go
+++ b/cli/azd/pkg/output/pretty_table_test.go
@@ -551,27 +551,68 @@ func TestPrettyUngroupedCards(t *testing.T) {
 	require.Contains(t, output, "Extension B")
 }
 
-func TestTruncateWithEllipsis(t *testing.T) {
-	tests := []struct {
-		input  string
-		maxLen int
-		want   string
-	}{
-		{"hello", 10, "hello"},
-		{"hello world", 5, "hell…"},
-		{"ab", 1, "…"},
-		{"abc", 3, "abc"},
-		{"abcd", 3, "ab…"},
-		{"", 5, ""},
-		{"日本語テスト", 4, "日本語…"},
+func TestPrettyEmptyData(t *testing.T) {
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 120 },
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			got := truncateWithEllipsis(tt.input, tt.maxLen)
-			require.Equal(t, tt.want, got)
-		})
+	buf := &bytes.Buffer{}
+	err := formatter.Format([]prettyInput{}, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+			{Column: Column{Heading: "NAME", ValueTemplate: "{{.Name}}"}, Priority: 1},
+		},
+	})
+
+	require.NoError(t, err)
+	output := buf.String()
+
+	// Should produce header and underline but no data rows
+	require.Contains(t, output, "ID")
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	require.LessOrEqual(t, len(lines), 2, "expected at most header + underline for empty data")
+}
+
+func TestPrettySingleGroupCards(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "ext-1", Name: "First", Version: "1.0", Status: "✓", Source: "azd"},
+		{Id: "ext-2", Name: "Second", Version: "2.0", Status: "✓", Source: "azd"},
+		{Id: "ext-3", Name: "Third", Version: "3.0", Status: "✓", Source: "azd"},
 	}
+
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 40 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{Heading: "NAME", ValueTemplate: "{{.Name}}"}, Priority: 1},
+			{Column: Column{Heading: "VERSION", ValueTemplate: "{{.Version}}"}, Priority: 1},
+			{Column: Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"}, Priority: 4},
+		},
+		CardGroupColumn: "SOURCE",
+	})
+
+	require.NoError(t, err)
+	output := buf.String()
+
+	// Only one group header should appear
+	require.Equal(t, 1, strings.Count(output, "── azd "), "expected exactly one group header")
+
+	// All items should be present
+	require.Contains(t, output, "First")
+	require.Contains(t, output, "Second")
+	require.Contains(t, output, "Third")
+
+	// No extra group separators (only one "──" line at the top)
+	headerLines := 0
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, "── ") {
+			headerLines++
+		}
+	}
+	require.Equal(t, 1, headerLines, "expected exactly one group header line")
 }
 
 func TestPrettyTableANSIAlignment(t *testing.T) {

--- a/cli/azd/pkg/output/pretty_table_test.go
+++ b/cli/azd/pkg/output/pretty_table_test.go
@@ -36,8 +36,8 @@ func TestPrettyTableFormatterBasic(t *testing.T) {
 			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
 			{Column: Column{Heading: "NAME", ValueTemplate: "{{.Name}}"}, Priority: 3},
 			{Column: Column{Heading: "VERSION", ValueTemplate: "{{.Version}}"}, Priority: 1},
-			{Column: Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"}, Priority: 2},
-			{Column: Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"}, Priority: 4},
+			{Column: Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"}, Priority: 1},
+			{Column: Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"}, Priority: 1},
 		},
 	})
 
@@ -221,7 +221,7 @@ func TestPrettyHeaderUnderline(t *testing.T) {
 
 // Breakpoint tests
 
-func TestPrettyWideBreakpoint(t *testing.T) {
+func TestPrettyFullBreakpoint(t *testing.T) {
 	rows := []prettyInput{
 		{Id: "azure.ai.agents", Name: "Foundry agents (Preview)", Version: "0.1.18-preview",
 			Status: "✓ Up to date", StatusSymbol: "✓", Source: "azd"},
@@ -239,7 +239,7 @@ func TestPrettyWideBreakpoint(t *testing.T) {
 	require.NoError(t, err)
 	output := buf.String()
 
-	// Wide: all columns shown, full status text
+	// Full: all columns shown, full status text
 	require.Contains(t, output, "ID")
 	require.Contains(t, output, "NAME")
 	require.Contains(t, output, "VERSION")
@@ -249,14 +249,14 @@ func TestPrettyWideBreakpoint(t *testing.T) {
 	require.Contains(t, output, "Foundry agents (Preview)")
 }
 
-func TestPrettyMediumBreakpoint(t *testing.T) {
+func TestPrettyCompactBreakpoint(t *testing.T) {
 	rows := []prettyInput{
 		{Id: "azure.ai.agents", Name: "Foundry agents (Preview)", Version: "0.1.18-preview",
 			Status: "✓ Up to date", StatusSymbol: "✓", Source: "azd"},
 	}
 
 	formatter := &PrettyTableFormatter{
-		ConsoleWidthFn: func() int { return 95 },
+		ConsoleWidthFn: func() int { return 80 },
 	}
 
 	buf := &bytes.Buffer{}
@@ -267,39 +267,15 @@ func TestPrettyMediumBreakpoint(t *testing.T) {
 	require.NoError(t, err)
 	output := buf.String()
 
-	// Medium: all columns shown, status uses ShortValueTemplate (symbol only)
-	require.Contains(t, output, "ID")
-	require.Contains(t, output, "NAME")
-	require.Contains(t, output, "SOURCE")
-	// Should use short status template (symbol only)
-	require.NotContains(t, output, "Up to date")
-}
-
-func TestPrettyNarrowBreakpoint(t *testing.T) {
-	rows := []prettyInput{
-		{Id: "azure.ai.agents", Name: "Foundry agents (Preview)", Version: "0.1.18-preview",
-			Status: "✓ Up to date", StatusSymbol: "✓", Source: "azd"},
-	}
-
-	formatter := &PrettyTableFormatter{
-		ConsoleWidthFn: func() int { return 60 },
-	}
-
-	buf := &bytes.Buffer{}
-	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
-		Columns: extListTestColumns(),
-	})
-
-	require.NoError(t, err)
-	output := buf.String()
-
-	// Narrow: only Priority ≤ 2 columns (ID, VERSION, STATUS)
+	// Compact: Priority ≤ 2 columns, status uses ShortValueTemplate (symbol only)
 	require.Contains(t, output, "ID")
 	require.Contains(t, output, "VERSION")
 	require.Contains(t, output, "STATUS")
-	// NAME (priority 3) and SOURCE (priority 4) dropped
+	require.Contains(t, output, "SOURCE")
+	// NAME (priority 3) dropped
 	require.NotContains(t, output, "NAME")
-	require.NotContains(t, output, "SOURCE")
+	// Should use short status template (symbol only)
+	require.NotContains(t, output, "Up to date")
 }
 
 func TestPrettyCardBreakpoint(t *testing.T) {
@@ -368,44 +344,14 @@ func TestPrettyCardGroupingOrder(t *testing.T) {
 	require.Contains(t, output, "Third")
 }
 
-func TestPrettyTruncation(t *testing.T) {
-	rows := []prettyInput{
-		{Id: "ext-a", Name: "A Very Long Extension Name That Should Get Truncated Here", Version: "1.0.0",
-			Status: "ok", StatusSymbol: "✓", Source: "azd"},
-	}
-
-	// Use width 80 (medium) — content is wider than 80 so truncation is needed
-	formatter := &PrettyTableFormatter{
-		ConsoleWidthFn: func() int { return 80 },
-	}
-
-	buf := &bytes.Buffer{}
-	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
-		Columns: []PrettyColumn{
-			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
-			{Column: Column{Heading: "NAME", ValueTemplate: "{{.Name}}"}, Priority: 3, Truncatable: true},
-			{Column: Column{Heading: "VERSION", ValueTemplate: "{{.Version}}"}, Priority: 1},
-			{Column: Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"}, Priority: 2},
-			{Column: Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"}, Priority: 4},
-		},
-	})
-
-	require.NoError(t, err)
-	output := buf.String()
-
-	// Name should be truncated with ellipsis at medium width
-	require.Contains(t, output, "…", "truncated name should contain ellipsis")
-	// The full name should NOT appear
-	require.NotContains(t, output, "A Very Long Extension Name That Should Get Truncated Here")
-}
-
 func TestPrettyShortValueTemplate(t *testing.T) {
 	rows := []prettyInput{
 		{Id: "ext-a", Status: "✓ Up to date", StatusSymbol: "✓"},
 	}
 
+	// Width 70 is in compact range (60-99), should use short template
 	formatter := &PrettyTableFormatter{
-		ConsoleWidthFn: func() int { return 90 },
+		ConsoleWidthFn: func() int { return 70 },
 	}
 
 	buf := &bytes.Buffer{}
@@ -414,7 +360,7 @@ func TestPrettyShortValueTemplate(t *testing.T) {
 			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
 			{
 				Column:             Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
-				Priority:           2,
+				Priority:           1,
 				ShortValueTemplate: "{{.StatusSymbol}}",
 			},
 		},
@@ -423,11 +369,11 @@ func TestPrettyShortValueTemplate(t *testing.T) {
 	require.NoError(t, err)
 	output := buf.String()
 
-	// At medium width, should use short template (symbol only)
+	// At compact width, should use short template (symbol only)
 	require.NotContains(t, output, "Up to date")
 }
 
-func TestPrettyShortValueTemplateNotUsedAtWideWidth(t *testing.T) {
+func TestPrettyShortValueTemplateNotUsedAtFullWidth(t *testing.T) {
 	rows := []prettyInput{
 		{Id: "ext-a", Status: "✓ Up to date", StatusSymbol: "✓"},
 	}
@@ -442,7 +388,7 @@ func TestPrettyShortValueTemplateNotUsedAtWideWidth(t *testing.T) {
 			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
 			{
 				Column:             Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
-				Priority:           2,
+				Priority:           1,
 				ShortValueTemplate: "{{.StatusSymbol}}",
 			},
 		},
@@ -451,8 +397,43 @@ func TestPrettyShortValueTemplateNotUsedAtWideWidth(t *testing.T) {
 	require.NoError(t, err)
 	output := buf.String()
 
-	// At wide width, should use full template
+	// At full width, should use full template
 	require.Contains(t, output, "✓ Up to date")
+}
+
+func TestPrettyColorFuncWithShortValueTemplate(t *testing.T) {
+	rows := []prettyInput{
+		{Id: "ext-a", Status: "✓ Up to date", StatusSymbol: "✓"},
+	}
+
+	colorApplied := false
+	// Width 70 is compact range
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 70 },
+	}
+
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+			{
+				Column:             Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+				Priority:           1,
+				ShortValueTemplate: "{{.StatusSymbol}}",
+				ColorFunc: func(s string) string {
+					colorApplied = true
+					return "[" + s + "]"
+				},
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.True(t, colorApplied, "ColorFunc should be applied to short value")
+	output := buf.String()
+	// At compact width, should use short template AND apply color
+	require.NotContains(t, output, "Up to date")
+	require.Contains(t, output, "[✓]")
 }
 
 // Breakpoint boundary transition tests
@@ -466,18 +447,17 @@ func TestPrettyBreakpointTransitions(t *testing.T) {
 	columns := extListTestColumns()
 
 	tests := []struct {
-		name       string
-		width      int
-		wantCard   bool
-		wantNAME   bool
-		wantSOURCE bool
+		name     string
+		width    int
+		wantCard bool
+		wantNAME bool
 	}{
-		{"wide at 110", 110, false, true, true},
-		{"medium at 109", 109, false, true, true},
-		{"medium at 80", 80, false, true, true},
-		{"narrow at 79", 79, false, false, false},
-		{"narrow at 50", 50, false, false, false},
-		{"card at 49", 49, true, false, false},
+		{"full at 120", 120, false, true},
+		{"full at 100", 100, false, true},
+		{"compact at 99", 99, false, false},
+		{"compact at 60", 60, false, false},
+		{"card at 59", 59, true, false},
+		{"card at 40", 40, true, false},
 	}
 
 	for _, tt := range tests {
@@ -505,12 +485,6 @@ func TestPrettyBreakpointTransitions(t *testing.T) {
 					require.Contains(t, output, "NAME", "expected NAME column for width %d", tt.width)
 				} else {
 					require.NotContains(t, output, "NAME", "expected no NAME column for width %d", tt.width)
-				}
-				if tt.wantSOURCE {
-					require.Contains(t, output, "SOURCE", "expected SOURCE column for width %d", tt.width)
-				} else {
-					require.NotContains(t, output, "SOURCE",
-						"expected no SOURCE column for width %d", tt.width)
 				}
 			}
 		})
@@ -588,6 +562,8 @@ func TestTruncateWithEllipsis(t *testing.T) {
 		{"ab", 1, "…"},
 		{"abc", 3, "abc"},
 		{"abcd", 3, "ab…"},
+		{"", 5, ""},
+		{"日本語テスト", 4, "日本語…"},
 	}
 
 	for _, tt := range tests {
@@ -598,61 +574,109 @@ func TestTruncateWithEllipsis(t *testing.T) {
 	}
 }
 
-func TestEstimateTableWidth(t *testing.T) {
-	cols := []parsedCol{
-		{col: PrettyColumn{Column: Column{Heading: "Name"}}},
-		{col: PrettyColumn{Column: Column{Heading: "Version"}}},
+func TestPrettyTableANSIAlignment(t *testing.T) {
+	// Simulate ANSI color codes with varying lengths to verify
+	// that column alignment uses display width, not byte length.
+	green := func(s string) string { return "\033[32m" + s + "\033[0m" }
+	gray := func(s string) string { return "\033[90m" + s + "\033[0m" }
+
+	rows := []prettyInput{
+		{Id: "ext-a", Status: "✓ Up to date", Source: "azd"},
+		{Id: "ext-b", Status: "-", Source: "local"},
 	}
 
-	// No rows: width = len("Name") + len("Version") + 3 (padding) = 4 + 7 + 3 = 14
-	width := estimateTableWidth(cols, nil)
-	require.Equal(t, 14, width)
-}
-
-func TestResponsiveFilterDropsHighestPriorityNumber(t *testing.T) {
-	cols := []parsedCol{
-		{col: PrettyColumn{Column: Column{Heading: "Id", ValueTemplate: "{{.Name}}"}, Priority: 1}},
-		{col: PrettyColumn{Column: Column{Heading: "Source-Column", ValueTemplate: "{{.Name}}"}, Priority: 4}},
-		{col: PrettyColumn{Column: Column{Heading: "Name-Column", ValueTemplate: "{{.Name}}"}, Priority: 3}},
+	formatter := &PrettyTableFormatter{
+		ConsoleWidthFn: func() int { return 120 },
 	}
 
-	// Width so narrow that it can't fit all 3 columns
-	result := responsiveFilter(cols, nil, 20)
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns: []PrettyColumn{
+			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+			{
+				Column:   Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+				Priority: 1,
+				ColorFunc: func(s string) string {
+					if s == "-" {
+						return gray(s)
+					}
+					return green(s)
+				},
+			},
+			{Column: Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"}, Priority: 1},
+		},
+	})
 
-	require.Less(t, len(result), 3)
+	require.NoError(t, err)
+	output := buf.String()
 
-	// Id (priority 1) should always remain
-	hasId := false
-	for _, c := range result {
-		if c.col.Heading == "Id" {
-			hasId = true
+	// Parse data rows (skip header and underline)
+	lines := strings.Split(output, "\n")
+	require.GreaterOrEqual(t, len(lines), 4, "expected header + underline + 2 data rows")
+
+	// Strip ANSI codes to find the visual position of SOURCE column
+	strip := func(s string) string {
+		return ansiRegex.ReplaceAllString(s, "")
+	}
+
+	// displayIndex returns the display-column position of substr within s,
+	// where s has already been stripped of ANSI codes.
+	displayIndex := func(s, substr string) int {
+		byteIdx := strings.Index(s, substr)
+		if byteIdx < 0 {
+			return -1
 		}
-	}
-	require.True(t, hasId, "Priority 1 columns should be kept the longest")
-}
-
-func TestResponsiveFilterKeepsAllWhenFits(t *testing.T) {
-	cols := []parsedCol{
-		{col: PrettyColumn{Column: Column{Heading: "Id", ValueTemplate: "{{.Name}}"}, Priority: 1}},
-		{col: PrettyColumn{Column: Column{Heading: "Source", ValueTemplate: "{{.Name}}"}, Priority: 4}},
+		return displayWidth(s[:byteIdx])
 	}
 
-	result := responsiveFilter(cols, nil, 200)
-	require.Len(t, result, 2)
+	row1Stripped := strip(lines[2])
+	row2Stripped := strip(lines[3])
+
+	// Both SOURCE values should start at the same display column.
+	sourcePos1 := displayIndex(row1Stripped, "azd")
+	sourcePos2 := displayIndex(row2Stripped, "local")
+
+	require.Greater(t, sourcePos1, 0, "SOURCE value 'azd' not found in row 1")
+	require.Greater(t, sourcePos2, 0, "SOURCE value 'local' not found in row 2")
+	require.Equal(t, sourcePos1, sourcePos2,
+		"SOURCE column should start at the same position in both rows;\n"+
+			"row1: %q\nrow2: %q", row1Stripped, row2Stripped)
 }
 
-// extListTestColumns returns the standard 5-column config matching the hybrid UX spec.
+func TestDisplayWidth(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{"ascii", "hello", 5},
+		{"empty", "", 0},
+		{"checkmark", "✓ Up to date", 12},
+		{"dash", "-", 1},
+		{"ansi green", "\033[32m✓ Up to date\033[0m", 12},
+		{"ansi gray", "\033[90m-\033[0m", 1},
+		{"no ansi unicode", "日本語", 6},
+		{"ansi with unicode", "\033[31m日本語\033[0m", 6},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := displayWidth(tt.input)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// extListTestColumns returns the standard 5-column config matching the 2-threshold spec.
 func extListTestColumns() []PrettyColumn {
 	return []PrettyColumn{
 		{
-			Column:      Column{Heading: "ID", ValueTemplate: "{{.Id}}"},
-			Priority:    1,
-			Truncatable: true,
+			Column:   Column{Heading: "ID", ValueTemplate: "{{.Id}}"},
+			Priority: 1,
 		},
 		{
-			Column:      Column{Heading: "NAME", ValueTemplate: "{{.Name}}"},
-			Priority:    3,
-			Truncatable: true,
+			Column:   Column{Heading: "NAME", ValueTemplate: "{{.Name}}"},
+			Priority: 3,
 		},
 		{
 			Column:   Column{Heading: "VERSION", ValueTemplate: "{{.Version}}"},
@@ -665,7 +689,7 @@ func extListTestColumns() []PrettyColumn {
 		},
 		{
 			Column:   Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"},
-			Priority: 4,
+			Priority: 1,
 		},
 	}
 }


### PR DESCRIPTION
## Description

Improves the readability of `azd ext list` table output by introducing a responsive `PrettyTableFormatter` with ANSI-aware column alignment and progressive layout degradation based on terminal width.

Resolves #7287

## UI Experience by Breakpoint

### Full Table Layout (terminal width ≥ 100 characters)

All 5 columns displayed with full text. STATUS shows descriptive text with color-coded symbols.

```
ID                       NAME                              VERSION           STATUS               SOURCE
──────────────────────────────────────────────────────────────────────────────────────────────────────────
azure.ai.agents          Foundry agents (Preview)          0.1.18-preview    ✓ Up to date         azd
azure.ai.finetune        Foundry Fine Tuning (Preview)     0.0.17-preview    ↑ Update available   azd
azure.ai.models          Foundry Custom Models (Preview)   Not installed     -                    azd
azure.appservice         Azure App Service                 0.1.0             ✓ Up to date         azd
azure.coding-agent       Coding agent config extension     0.6.1             ⚠ Incompatible       local
microsoft.azd.concurx    Concurx                           0.1.0             ✓ Up to date         azd
```

### Compact Table Layout (terminal width 60–99 characters)

NAME column dropped to save space. STATUS uses symbol-only mode. ID, VERSION, STATUS, and SOURCE remain.

```
ID                       VERSION           STATUS   SOURCE
─────────────────────────────────────────────────────────────
azure.ai.agents          0.1.18-preview    ✓        azd
azure.ai.finetune        0.0.17-preview    ↑        azd
azure.ai.models          Not installed     -        azd
azure.appservice         0.1.0             ✓        azd
azure.coding-agent       0.6.1             ⚠        local
microsoft.azd.concurx    0.1.0             ✓        azd
```

### Card Layout (terminal width < 60 characters)

Extensions displayed as key-value cards, grouped by source. Each source gets a section header. All fields are shown in a readable vertical format.

```
── azd ──────────────────────────────────

Name:     Foundry agents (Preview)
Id:       azure.ai.agents
Version:  0.1.18-preview
Status:   ✓ Up to date

Name:     Foundry Fine Tuning (Preview)
Id:       azure.ai.finetune
Version:  0.0.17-preview
Status:   ↑ Update available

Name:     Foundry Custom Models (Preview)
Id:       azure.ai.models
Version:  Not installed
Status:   -

Name:     Azure App Service
Id:       azure.appservice
Version:  0.1.0
Status:   ✓ Up to date

Name:     Concurx
Id:       microsoft.azd.concurx
Version:  0.1.0
Status:   ✓ Up to date

── local ────────────────────────────────

Name:     Coding agent config extension
Id:       azure.coding-agent
Version:  0.6.1
Status:   ⚠ Incompatible
```

## Status Indicators

| Symbol | Text | Color | Meaning |
|--------|------|-------|---------|
| ✓ | Up to date | Green | Installed, latest version |
| ↑ | Update available | Yellow | Newer compatible version exists |
| ⚠ | Incompatible | Red | Update exists but incompatible with current azd |
| - | (none) | Gray | Not installed |

## Changes

### New: `PrettyTableFormatter` (`pkg/output/pretty_table.go`)
- Custom responsive table formatter with 3 layout modes based on terminal width
- **Full table (≥100 chars):** All columns — ID, NAME, VERSION, STATUS, SOURCE
- **Compact table (60–99 chars):** Drops NAME, uses symbol-only STATUS (✓/↑/⚠/-)
- **Source-grouped cards (<60 chars):** Key-value card layout grouped by source
- ANSI-aware `displayWidth()` using `go-runewidth` for correct column alignment with colored output
- `ShortValueTemplate` support for abbreviated column values at compact widths
- Priority-based column filtering (higher priority number = dropped first)
- Source-grouped card layout with `CardGroupColumn` option

### Updated: Extension List (`cmd/extension.go`)
- Dedicated STATUS column with rich indicators: `✓ Up to date` (green), `↑ Update available` (yellow), `⚠ Incompatible` (red), `-` (gray)
- Single VERSION column showing installed version or "Not installed"
- ID as primary (leftmost) column — actionable identifier for CLI commands
- Symbol-only status mode (`StatusSymbol` field) for compact layout

### Testing
- 26 formatter tests covering all 3 layouts, breakpoint boundaries, ANSI alignment, card grouping, color functions, empty data, and error paths
- 9 extension test groups covering status logic, symbols, and color output

## Design Decisions

- **Figma hybrid approach:** Takes the structural layout from the approved Figma design (ID-first columns, source-grouped cards) and adds richer status indicators (✓/↑/⚠ with color vs plain Yes/No)
- **2 breakpoints, 3 layouts:** Based on UX research — most CLI tools use 0 breakpoints; 2 covers realistic terminal widths (100 for full-screen, 60 for narrow splits)
- **No external table library dependency:** Despite initial exploration of go-pretty, the implementation is custom — simpler and avoids an unnecessary dependency
- **`go-runewidth` for ANSI-safe alignment:** Correctly handles multi-byte UTF-8 characters and ANSI escape codes in column width calculations
