### PR TITLE
[Agents Extension] Fix for session persistence

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/show.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/show.go
@@ -212,12 +212,12 @@ func (a *ShowAction) resolveEndpointURLs(ctx context.Context) map[string]string 
 		endpoints[ps.Label] = v.Value
 	}
 
-	// Fall back to legacy single-endpoint var for older deployments
+	// Fall back to single-endpoint var for older deployments
 	if len(endpoints) == 0 {
-		legacyKey := fmt.Sprintf("AGENT_%s_ENDPOINT", a.serviceKey)
+		singleEndpointKey := fmt.Sprintf("AGENT_%s_ENDPOINT", a.serviceKey)
 		v, err := a.azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
 			EnvName: a.envName,
-			Key:     legacyKey,
+			Key:     singleEndpointKey,
 		})
 		if err == nil && v.Value != "" {
 			endpoints["Agent"] = v.Value

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -937,7 +937,9 @@ func (p *AgentServiceTargetProvider) registerAgentEnvironmentVariables(
 
 	// Set the base agent endpoint used for session management (not protocol-specific).
 	baseEndpointKey := fmt.Sprintf("AGENT_%s_ENDPOINT", serviceKey)
-	envVars[baseEndpointKey] = fmt.Sprintf("%s/agents/%s", azdEnv["AZURE_AI_PROJECT_ENDPOINT"], agentVersionResponse.Name)
+	envVars[baseEndpointKey] = fmt.Sprintf(
+		"%s/agents/%s/versions/%s", azdEnv["AZURE_AI_PROJECT_ENDPOINT"], agentVersionResponse.Name, agentVersionResponse.Version,
+	)
 
 	endpoints := agentInvocationEndpoints(
 		azdEnv["AZURE_AI_PROJECT_ENDPOINT"],

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -920,7 +920,8 @@ func (p *AgentServiceTargetProvider) displayAgentInfo(request *agent_api.CreateA
 
 // registerAgentEnvironmentVariables registers agent information as azd environment variables.
 // Per-protocol endpoint vars are set (e.g. AGENT_{KEY}_RESPONSES_ENDPOINT).
-// The legacy single-endpoint var (AGENT_{KEY}_ENDPOINT) is cleared to avoid stale data.
+// The base agent endpoint (AGENT_{KEY}_ENDPOINT) is set to <projectEndpoint>/agents/<agentName>
+// for session management.
 func (p *AgentServiceTargetProvider) registerAgentEnvironmentVariables(
 	ctx context.Context,
 	azdEnv map[string]string,
@@ -934,9 +935,9 @@ func (p *AgentServiceTargetProvider) registerAgentEnvironmentVariables(
 		fmt.Sprintf("AGENT_%s_VERSION", serviceKey): agentVersionResponse.Version,
 	}
 
-	// Clear legacy single-endpoint var so upgraded environments don't retain stale URLs.
-	legacyKey := fmt.Sprintf("AGENT_%s_ENDPOINT", serviceKey)
-	envVars[legacyKey] = ""
+	// Set the base agent endpoint used for session management (not protocol-specific).
+	baseEndpointKey := fmt.Sprintf("AGENT_%s_ENDPOINT", serviceKey)
+	envVars[baseEndpointKey] = fmt.Sprintf("%s/agents/%s", azdEnv["AZURE_AI_PROJECT_ENDPOINT"], agentVersionResponse.Name)
 
 	endpoints := agentInvocationEndpoints(
 		azdEnv["AZURE_AI_PROJECT_ENDPOINT"],

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -929,6 +929,13 @@ func (p *AgentServiceTargetProvider) registerAgentEnvironmentVariables(
 	agentVersionResponse *agent_api.AgentVersionObject,
 	protocols []agent_yaml.ProtocolVersionRecord,
 ) error {
+	if agentVersionResponse.Name == "" {
+		return fmt.Errorf("agent name is empty; cannot register environment variables")
+	}
+	if agentVersionResponse.Version == "" {
+		return fmt.Errorf("agent version is empty; cannot register environment variables")
+	}
+
 	serviceKey := p.getServiceKey(serviceConfig.Name)
 	envVars := map[string]string{
 		fmt.Sprintf("AGENT_%s_NAME", serviceKey):    agentVersionResponse.Name,
@@ -937,8 +944,9 @@ func (p *AgentServiceTargetProvider) registerAgentEnvironmentVariables(
 
 	// Set the base agent endpoint used for session management (not protocol-specific).
 	baseEndpointKey := fmt.Sprintf("AGENT_%s_ENDPOINT", serviceKey)
+	projectEndpoint := strings.TrimRight(azdEnv["AZURE_AI_PROJECT_ENDPOINT"], "/")
 	envVars[baseEndpointKey] = fmt.Sprintf(
-		"%s/agents/%s/versions/%s", azdEnv["AZURE_AI_PROJECT_ENDPOINT"], agentVersionResponse.Name, agentVersionResponse.Version,
+		"%s/agents/%s/versions/%s", projectEndpoint, agentVersionResponse.Name, agentVersionResponse.Version,
 	)
 
 	endpoints := agentInvocationEndpoints(

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -240,9 +240,9 @@ func TestRegisterAgentEnvironmentVariables(t *testing.T) {
 		envStub.values["AGENT_MY_SVC_INVOCATIONS_ENDPOINT"],
 		"/agents/my-agent/endpoint/protocols/invocations")
 
-	// Legacy env var cleared
+	// Base agent endpoint for session management
 	require.Contains(t, envStub.values, "AGENT_MY_SVC_ENDPOINT")
-	require.Empty(t, envStub.values["AGENT_MY_SVC_ENDPOINT"])
+	require.Equal(t, "https://proj.azure.com/agents/my-agent", envStub.values["AGENT_MY_SVC_ENDPOINT"])
 }
 
 func TestProtocolPath(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -245,6 +245,84 @@ func TestRegisterAgentEnvironmentVariables(t *testing.T) {
 	require.Equal(t, "https://proj.azure.com/agents/my-agent/versions/1.0.0", envStub.values["AGENT_MY_SVC_ENDPOINT"])
 }
 
+func TestRegisterAgentEnvironmentVariables_TrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	envStub := &stubEnvServer{}
+	client := newEnvTestClient(t, envStub)
+
+	provider := &AgentServiceTargetProvider{
+		azdClient: client,
+		env:       &azdext.Environment{Name: "test-env"},
+	}
+
+	azdEnv := map[string]string{
+		"AZURE_AI_PROJECT_ENDPOINT": "https://proj.azure.com/",
+	}
+	protocols := []agent_yaml.ProtocolVersionRecord{
+		{Protocol: "responses", Version: "1.0.0"},
+	}
+	agentVersion := &agent_api.AgentVersionObject{
+		Name:    "my-agent",
+		Version: "2.0.0",
+	}
+
+	err := provider.registerAgentEnvironmentVariables(
+		t.Context(), azdEnv,
+		&azdext.ServiceConfig{Name: "my-svc"},
+		agentVersion,
+		protocols,
+	)
+	require.NoError(t, err)
+
+	// Trailing slash must not produce a double-slash in the base endpoint
+	require.Equal(t, "https://proj.azure.com/agents/my-agent/versions/2.0.0", envStub.values["AGENT_MY_SVC_ENDPOINT"])
+}
+
+func TestRegisterAgentEnvironmentVariables_EmptyName(t *testing.T) {
+	t.Parallel()
+
+	envStub := &stubEnvServer{}
+	client := newEnvTestClient(t, envStub)
+
+	provider := &AgentServiceTargetProvider{
+		azdClient: client,
+		env:       &azdext.Environment{Name: "test-env"},
+	}
+
+	err := provider.registerAgentEnvironmentVariables(
+		t.Context(),
+		map[string]string{"AZURE_AI_PROJECT_ENDPOINT": "https://proj.azure.com"},
+		&azdext.ServiceConfig{Name: "my-svc"},
+		&agent_api.AgentVersionObject{Name: "", Version: "1.0.0"},
+		nil,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "agent name is empty")
+}
+
+func TestRegisterAgentEnvironmentVariables_EmptyVersion(t *testing.T) {
+	t.Parallel()
+
+	envStub := &stubEnvServer{}
+	client := newEnvTestClient(t, envStub)
+
+	provider := &AgentServiceTargetProvider{
+		azdClient: client,
+		env:       &azdext.Environment{Name: "test-env"},
+	}
+
+	err := provider.registerAgentEnvironmentVariables(
+		t.Context(),
+		map[string]string{"AZURE_AI_PROJECT_ENDPOINT": "https://proj.azure.com"},
+		&azdext.ServiceConfig{Name: "my-svc"},
+		&agent_api.AgentVersionObject{Name: "my-agent", Version: ""},
+		nil,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "agent version is empty")
+}
+
 func TestProtocolPath(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -242,7 +242,7 @@ func TestRegisterAgentEnvironmentVariables(t *testing.T) {
 
 	// Base agent endpoint for session management
 	require.Contains(t, envStub.values, "AGENT_MY_SVC_ENDPOINT")
-	require.Equal(t, "https://proj.azure.com/agents/my-agent", envStub.values["AGENT_MY_SVC_ENDPOINT"])
+	require.Equal(t, "https://proj.azure.com/agents/my-agent/versions/1.0.0", envStub.values["AGENT_MY_SVC_ENDPOINT"])
 }
 
 func TestProtocolPath(t *testing.T) {


### PR DESCRIPTION
Fixes #8094

Reverts change which was declaring the base agent endpoint as legacy, and uses it for session state. This needs to be used since sessions are independent of /invocations or /responses routes