### PR TITLE
feat(agents): deploy using an existing acr image

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
@@ -319,8 +319,7 @@ func convertFloat64ToFloat32(f64 *float64) *float32 {
 
 // CreateHostedAgentAPIRequest creates a CreateAgentRequest for hosted agents
 func CreateHostedAgentAPIRequest(hostedAgent ContainerAgent, buildConfig *AgentBuildConfig) (*agent_api.CreateAgentRequest, error) {
-	// Check if we have an image URL set via the build config
-	imageURL := ""
+	imageURL := hostedAgent.Image
 	cpu := "1"      // Default CPU
 	memory := "2Gi" // Default memory
 	envVars := make(map[string]string)
@@ -341,7 +340,7 @@ func CreateHostedAgentAPIRequest(hostedAgent ContainerAgent, buildConfig *AgentB
 	}
 
 	if imageURL == "" {
-		return nil, fmt.Errorf("image URL is required for hosted agents - use WithImageURL build option or specify in container.image")
+		return nil, fmt.Errorf("image URL is required for hosted agents - specify image in agent.yaml or use WithImageURL")
 	}
 
 	// Map protocol versions from the hosted agent definition

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
@@ -961,6 +961,51 @@ func TestCreateHostedAgentAPIRequest_DefaultCPUAndMemory(t *testing.T) {
 	}
 }
 
+func TestCreateHostedAgentAPIRequest_UsesAgentImage(t *testing.T) {
+	t.Parallel()
+	agent := ContainerAgent{
+		AgentDefinition: AgentDefinition{
+			Kind: AgentKindHosted,
+			Name: "agent-image",
+		},
+		Image: "myregistry.azurecr.io/agent-image:v1",
+	}
+
+	req, err := CreateHostedAgentAPIRequest(agent, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	imgDef := req.Definition.(agent_api.ImageBasedHostedAgentDefinition)
+	if imgDef.Image != "myregistry.azurecr.io/agent-image:v1" {
+		t.Errorf("Image = %q", imgDef.Image)
+	}
+}
+
+func TestCreateHostedAgentAPIRequest_BuildConfigImageOverridesAgentImage(t *testing.T) {
+	t.Parallel()
+	agent := ContainerAgent{
+		AgentDefinition: AgentDefinition{
+			Kind: AgentKindHosted,
+			Name: "agent-image",
+		},
+		Image: "myregistry.azurecr.io/prebuilt:v1",
+	}
+
+	req, err := CreateHostedAgentAPIRequest(
+		agent,
+		&AgentBuildConfig{ImageURL: "myregistry.azurecr.io/published:v2"},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	imgDef := req.Definition.(agent_api.ImageBasedHostedAgentDefinition)
+	if imgDef.Image != "myregistry.azurecr.io/published:v2" {
+		t.Errorf("Image = %q", imgDef.Image)
+	}
+}
+
 func TestCreateHostedAgentAPIRequest_MissingImageURL(t *testing.T) {
 	t.Parallel()
 	agent := ContainerAgent{

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse_test.go
@@ -110,6 +110,43 @@ template:
 	}
 }
 
+// TestExtractAgentDefinition_WithImage tests that image is parsed and round-tripped.
+func TestExtractAgentDefinition_WithImage(t *testing.T) {
+	yamlContent := []byte(`
+name: image-agent
+template:
+  kind: hosted
+  name: image-agent
+  image: myregistry.azurecr.io/myimage:v1
+  protocols:
+    - protocol: invocations
+      version: 1.0.0
+`)
+
+	agent, err := ExtractAgentDefinition(yamlContent)
+	if err != nil {
+		t.Fatalf("ExtractAgentDefinition failed: %v", err)
+	}
+
+	containerAgent, ok := agent.(ContainerAgent)
+	if !ok {
+		t.Fatalf("Expected ContainerAgent, got %T", agent)
+	}
+
+	if containerAgent.Image != "myregistry.azurecr.io/myimage:v1" {
+		t.Errorf("Expected image 'myregistry.azurecr.io/myimage:v1', got '%s'", containerAgent.Image)
+	}
+
+	marshaled, err := yaml.Marshal(containerAgent)
+	if err != nil {
+		t.Fatalf("Failed to marshal ContainerAgent: %v", err)
+	}
+
+	if !strings.Contains(string(marshaled), "image:") {
+		t.Errorf("Marshaled YAML should contain image, got:\n%s", string(marshaled))
+	}
+}
+
 // TestExtractAgentDefinition_WithoutResources tests that ContainerAgent without resources still parses
 func TestExtractAgentDefinition_WithoutResources(t *testing.T) {
 	yamlContent := []byte(`

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse_test.go
@@ -142,8 +142,8 @@ template:
 		t.Fatalf("Failed to marshal ContainerAgent: %v", err)
 	}
 
-	if !strings.Contains(string(marshaled), "image:") {
-		t.Errorf("Marshaled YAML should contain image, got:\n%s", string(marshaled))
+	if !strings.Contains(string(marshaled), "myregistry.azurecr.io/myimage:v1") {
+		t.Errorf("Marshaled YAML should contain image value, got:\n%s", string(marshaled))
 	}
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
@@ -177,8 +177,8 @@ type ContainerResources struct {
 // building from a Dockerfile:
 //   - Interactive mode: the user is prompted whether to use the configured
 //     image or build from a Dockerfile. The default is to build.
-//   - Non-interactive mode (AZD_NO_PROMPT=true / `--no-prompt`): the configured
-//     image is used directly so CI/CD can deploy without extra flags.
+//   - Non-interactive mode (AZD_NO_PROMPT=true / `--no-prompt`): always builds
+//     from Dockerfile.
 type ContainerAgent struct {
 	AgentDefinition      `json:",inline" yaml:",inline"`
 	Image                string                  `json:"image,omitempty" yaml:"image,omitempty"`

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
@@ -172,8 +172,11 @@ type ContainerResources struct {
 // ContainerAgent This represents a container based agent hosted by the provider/publisher.
 // The intent is to represent a container application that the user wants to run
 // in a hosted environment that the provider manages.
+// When Image is set, the agent uses a pre-built container image (e.g. from ACR)
+// and skips the Dockerfile build and push steps.
 type ContainerAgent struct {
 	AgentDefinition      `json:",inline" yaml:",inline"`
+	Image                string                  `json:"image,omitempty" yaml:"image,omitempty"`
 	Protocols            []ProtocolVersionRecord `json:"protocols" yaml:"protocols"`
 	Resources            *ContainerResources     `json:"resources,omitempty" yaml:"resources,omitempty"`
 	EnvironmentVariables *[]EnvironmentVariable  `json:"environmentVariables,omitempty" yaml:"environment_variables,omitempty"`

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
@@ -172,9 +172,13 @@ type ContainerResources struct {
 // ContainerAgent This represents a container based agent hosted by the provider/publisher.
 // The intent is to represent a container application that the user wants to run
 // in a hosted environment that the provider manages.
-// When Image is set, the agent can use a pre-built container image (e.g. from ACR).
-// Dockerfile build and publish steps are skipped only when that option is selected
-// in the deploy flow.
+//
+// When Image is set, deploy can use the pre-built container image instead of
+// building from a Dockerfile:
+//   - Interactive mode: the user is prompted whether to use the configured
+//     image or build from a Dockerfile. The default is to build.
+//   - Non-interactive mode (AZD_NO_PROMPT=true / `--no-prompt`): the configured
+//     image is used directly so CI/CD can deploy without extra flags.
 type ContainerAgent struct {
 	AgentDefinition      `json:",inline" yaml:",inline"`
 	Image                string                  `json:"image,omitempty" yaml:"image,omitempty"`

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
@@ -177,8 +177,8 @@ type ContainerResources struct {
 // building from a Dockerfile:
 //   - Interactive mode: the user is prompted whether to use the configured
 //     image or build from a Dockerfile. The default is to build.
-//   - Non-interactive mode (AZD_NO_PROMPT=true / `--no-prompt`): always builds
-//     from Dockerfile.
+//   - Non-interactive mode (`--no-prompt`): the default selection (build from
+//     Dockerfile) is used automatically.
 type ContainerAgent struct {
 	AgentDefinition      `json:",inline" yaml:",inline"`
 	Image                string                  `json:"image,omitempty" yaml:"image,omitempty"`

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
@@ -172,8 +172,9 @@ type ContainerResources struct {
 // ContainerAgent This represents a container based agent hosted by the provider/publisher.
 // The intent is to represent a container application that the user wants to run
 // in a hosted environment that the provider manages.
-// When Image is set, the agent uses a pre-built container image (e.g. from ACR)
-// and skips the Dockerfile build and push steps.
+// When Image is set, the agent can use a pre-built container image (e.g. from ACR).
+// Dockerfile build and publish steps are skipped only when that option is selected
+// in the deploy flow.
 type ContainerAgent struct {
 	AgentDefinition      `json:",inline" yaml:",inline"`
 	Image                string                  `json:"image,omitempty" yaml:"image,omitempty"`

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -81,11 +82,18 @@ type AgentServiceTargetProvider struct {
 	tenantId            string
 	env                 *azdext.Environment
 	foundryProject      *arm.ResourceID
+	usePreBuiltImage    *bool // cached prompt decision; nil means not yet asked
 }
 
 const (
 	preBuiltImageArtifactSourceKey = "azure.ai.agents.imageSource"
 	preBuiltImageArtifactSource    = "agent.yaml"
+)
+
+// containerImageRefRe is a basic pattern for container image references:
+// [registry/]repository[:tag|@digest]
+var containerImageRefRe = regexp.MustCompile(
+	`^[a-zA-Z0-9]([a-zA-Z0-9._-]*/)*[a-zA-Z0-9][a-zA-Z0-9._-]*(:[a-zA-Z0-9._-]+|@sha256:[0-9a-fA-F]{64})?$`,
 )
 
 // NewAgentServiceTargetProvider creates a new AgentServiceTargetProvider instance
@@ -581,6 +589,14 @@ func (p *AgentServiceTargetProvider) loadContainerAgentDefinition() (agent_yaml.
 		)
 	}
 
+	if agentDef.Image != "" && !containerImageRefRe.MatchString(agentDef.Image) {
+		return agent_yaml.ContainerAgent{}, false, exterrors.Validation(
+			exterrors.CodeInvalidAgentManifest,
+			fmt.Sprintf("invalid container image reference in agent.yaml: %q", agentDef.Image),
+			"use a valid image reference, e.g. 'myregistry.azurecr.io/myimage:v1'",
+		)
+	}
+
 	return agentDef, true, nil
 }
 
@@ -663,8 +679,14 @@ func (p *AgentServiceTargetProvider) shouldUsePreBuiltImage(
 		return false, nil
 	}
 
+	// Return cached decision if already prompted.
+	if p.usePreBuiltImage != nil {
+		return *p.usePreBuiltImage, nil
+	}
+
 	// Non-interactive (CI/CD): honor the configured image without prompting.
 	if noPrompt, _ := strconv.ParseBool(os.Getenv("AZD_NO_PROMPT")); noPrompt {
+		p.usePreBuiltImage = new(true)
 		return true, nil
 	}
 
@@ -685,7 +707,9 @@ func (p *AgentServiceTargetProvider) shouldUsePreBuiltImage(
 		return false, exterrors.FromPrompt(err, "failed to select hosted agent container image source")
 	}
 
-	return resp.Value != nil && *resp.Value == 1, nil
+	selected := resp.Value != nil && choices[*resp.Value].Value == "prebuilt"
+	p.usePreBuiltImage = &selected
+	return selected, nil
 }
 
 // deployHostedAgent deploys a container-based hosted agent to the Foundry service.

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -664,9 +664,7 @@ func (p *AgentServiceTargetProvider) Deploy(
 //
 // Behavior:
 //   - If no image is configured in agent.yaml, always build from Dockerfile.
-//   - In non-interactive mode (AZD_NO_PROMPT=true), honor the declarative image
-//     field directly: the user explicitly opted in by writing it in agent.yaml,
-//     so CI/CD can deploy without an extra flag.
+//   - In non-interactive mode (AZD_NO_PROMPT=true), always build from Dockerfile.
 //   - In interactive mode, prompt the user. The default is to build, so users
 //     who happen to have an image in agent.yaml are not silently switched onto
 //     the pre-built path.
@@ -684,10 +682,10 @@ func (p *AgentServiceTargetProvider) shouldUsePreBuiltImage(
 		return *p.usePreBuiltImage, nil
 	}
 
-	// Non-interactive (CI/CD): honor the configured image without prompting.
+	// Non-interactive (CI/CD): always build from Dockerfile.
 	if noPrompt, _ := strconv.ParseBool(os.Getenv("AZD_NO_PROMPT")); noPrompt {
-		p.usePreBuiltImage = new(true)
-		return true, nil
+		p.usePreBuiltImage = new(false)
+		return false, nil
 	}
 
 	// Interactive: default to build so the pre-built path requires an explicit choice.

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -82,7 +82,6 @@ type AgentServiceTargetProvider struct {
 	tenantId            string
 	env                 *azdext.Environment
 	foundryProject      *arm.ResourceID
-	usePreBuiltImage    *bool // cached prompt decision; nil means not yet asked
 }
 
 const (
@@ -677,14 +676,8 @@ func (p *AgentServiceTargetProvider) shouldUsePreBuiltImage(
 		return false, nil
 	}
 
-	// Return cached decision if already prompted.
-	if p.usePreBuiltImage != nil {
-		return *p.usePreBuiltImage, nil
-	}
-
 	// Non-interactive (CI/CD): always build from Dockerfile.
 	if noPrompt, _ := strconv.ParseBool(os.Getenv("AZD_NO_PROMPT")); noPrompt {
-		p.usePreBuiltImage = new(false)
 		return false, nil
 	}
 
@@ -705,9 +698,7 @@ func (p *AgentServiceTargetProvider) shouldUsePreBuiltImage(
 		return false, exterrors.FromPrompt(err, "failed to select hosted agent container image source")
 	}
 
-	selected := resp.Value != nil && choices[*resp.Value].Value == "prebuilt"
-	p.usePreBuiltImage = &selected
-	return selected, nil
+	return resp.Value != nil && choices[*resp.Value].Value == "prebuilt", nil
 }
 
 // deployHostedAgent deploys a container-based hosted agent to the Foundry service.

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"azureaiagent/internal/exterrors"
@@ -455,25 +454,12 @@ func (p *AgentServiceTargetProvider) Publish(
 		}, nil
 	}
 
-	agentDef, isContainerAgent, err := p.loadContainerAgentDefinition()
+	_, isContainerAgent, err := p.loadContainerAgentDefinition()
 	if err != nil {
 		return nil, err
 	}
 	if !isContainerAgent {
 		return &azdext.ServicePublishResult{}, nil
-	}
-
-	if !hasContainerArtifact(serviceContext.Package) {
-		usePreBuiltImage, err := p.shouldUsePreBuiltImage(ctx, agentDef)
-		if err != nil {
-			return nil, err
-		}
-		if usePreBuiltImage {
-			progress("Using pre-built container image, skipping publish")
-			return &azdext.ServicePublishResult{
-				Artifacts: []*azdext.Artifact{preBuiltImageArtifact(agentDef.Image)},
-			}, nil
-		}
 	}
 
 	progress("Publishing container")
@@ -663,7 +649,8 @@ func (p *AgentServiceTargetProvider) Deploy(
 //
 // Behavior:
 //   - If no image is configured in agent.yaml, always build from Dockerfile.
-//   - In non-interactive mode (AZD_NO_PROMPT=true), always build from Dockerfile.
+//   - In non-interactive mode (--no-prompt), the prompt returns the default
+//     selection (index 0 = build from Dockerfile) automatically.
 //   - In interactive mode, prompt the user. The default is to build, so users
 //     who happen to have an image in agent.yaml are not silently switched onto
 //     the pre-built path.
@@ -676,14 +663,11 @@ func (p *AgentServiceTargetProvider) shouldUsePreBuiltImage(
 		return false, nil
 	}
 
-	// Non-interactive (CI/CD): always build from Dockerfile.
-	if noPrompt, _ := strconv.ParseBool(os.Getenv("AZD_NO_PROMPT")); noPrompt {
-		return false, nil
-	}
-
-	// Interactive: default to build so the pre-built path requires an explicit choice.
+	// Default to build so the pre-built path requires an explicit choice.
+	// In non-interactive mode (--no-prompt), the framework returns the default
+	// selection (index 0 = build) automatically.
 	choices := []*azdext.SelectChoice{
-		{Value: "build", Label: "Build it for me"},
+		{Value: "build", Label: "Build a new image for me"},
 		{Value: "prebuilt", Label: fmt.Sprintf("Create hosted agent from %s", imageURL)},
 	}
 	defaultIndex := int32(0)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -592,7 +592,7 @@ func (p *AgentServiceTargetProvider) loadContainerAgentDefinition() (agent_yaml.
 		return agent_yaml.ContainerAgent{}, false, exterrors.Validation(
 			exterrors.CodeInvalidAgentManifest,
 			fmt.Sprintf("invalid container image reference in agent.yaml: %q", agentDef.Image),
-			"use a valid image reference, e.g. 'myregistry.azurecr.io/myimage:v1'",
+			"use a valid image reference, e.g. 'myregistry.azurecr.io/image:v1'",
 		)
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -629,61 +629,19 @@ func (p *AgentServiceTargetProvider) Deploy(
 
 	warnDeprecatedScaleSettings(serviceConfig.Config)
 
-	// Load and validate the agent manifest
-	data, err := os.ReadFile(p.agentDefinitionPath)
+	agentDef, isContainerAgent, err := p.loadContainerAgentDefinition()
 	if err != nil {
-		return nil, exterrors.Validation(
-			exterrors.CodeInvalidAgentManifest,
-			fmt.Sprintf("failed to read agent manifest file: %s", err),
-			"verify the agent.yaml file exists and is readable",
-		)
+		return nil, err
 	}
-
-	err = agent_yaml.ValidateAgentDefinition(data)
-	if err != nil {
-		return nil, exterrors.Validation(
-			exterrors.CodeInvalidAgentManifest,
-			fmt.Sprintf("agent.yaml is not valid: %s", err),
-			"fix the agent.yaml file according to the schema",
-		)
-	}
-
-	var genericTemplate map[string]any
-	if err := yaml.Unmarshal(data, &genericTemplate); err != nil {
-		return nil, exterrors.Validation(
-			exterrors.CodeInvalidAgentManifest,
-			fmt.Sprintf("YAML content is not valid for deploy: %s", err),
-			"verify the agent.yaml has valid YAML syntax",
-		)
-	}
-
-	kind, ok := genericTemplate["kind"].(string)
-	if !ok {
-		return nil, exterrors.Validation(
-			exterrors.CodeMissingAgentKind,
-			"kind field is missing or not a valid string in agent.yaml",
-			"add a valid 'kind' field (e.g., 'hosted') to agent.yaml",
-		)
-	}
-
-	switch kind {
-	case string(agent_yaml.AgentKindHosted):
-		var agentDef agent_yaml.ContainerAgent
-		if err := yaml.Unmarshal(data, &agentDef); err != nil {
-			return nil, exterrors.Validation(
-				exterrors.CodeInvalidAgentManifest,
-				fmt.Sprintf("YAML content is not valid for hosted agent deploy: %s", err),
-				"fix the agent.yaml to match the hosted agent schema",
-			)
-		}
-		return p.deployHostedAgent(ctx, serviceConfig, serviceContext, progress, agentDef, azdEnv)
-	default:
+	if !isContainerAgent {
 		return nil, exterrors.Validation(
 			exterrors.CodeUnsupportedAgentKind,
-			fmt.Sprintf("unsupported agent kind: %s", kind),
+			"unsupported agent kind in agent.yaml",
 			"use a supported kind: 'hosted'",
 		)
 	}
+
+	return p.deployHostedAgent(ctx, serviceConfig, serviceContext, progress, agentDef, azdEnv)
 }
 
 // shouldUsePreBuiltImage determines whether to use a pre-built image.
@@ -764,7 +722,7 @@ func (p *AgentServiceTargetProvider) deployHostedAgent(
 	}
 
 	if fullImageURL != "" {
-		fmt.Fprintf(os.Stderr, "Using pre-built container image: %s\n", fullImageURL)
+		progress(fmt.Sprintf("Using pre-built container image: %s", fullImageURL))
 	} else {
 		for _, artifact := range serviceContext.Publish {
 			if artifact.Kind == azdext.ArtifactKind_ARTIFACT_KIND_CONTAINER &&

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -80,6 +80,7 @@ type AgentServiceTargetProvider struct {
 	tenantId            string
 	env                 *azdext.Environment
 	foundryProject      *arm.ResourceID
+	usePreBuiltImage    *bool // nil = not yet prompted, true = use pre-built, false = build from Dockerfile
 }
 
 // NewAgentServiceTargetProvider creates a new AgentServiceTargetProvider instance
@@ -359,6 +360,17 @@ func (p *AgentServiceTargetProvider) Package(
 		return &azdext.ServicePackageResult{}, nil
 	}
 
+	// When a pre-built image is configured, prompt the user to choose.
+	// If no image is configured, proceed with build.
+	usePreBuiltImage, err := p.shouldUsePreBuiltImage(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if usePreBuiltImage {
+		progress("Using pre-built container image, skipping package")
+		return &azdext.ServicePackageResult{}, nil
+	}
+
 	var packageArtifact *azdext.Artifact
 	var newArtifacts []*azdext.Artifact
 
@@ -421,6 +433,16 @@ func (p *AgentServiceTargetProvider) Publish(
 	progress azdext.ProgressReporter,
 ) (*azdext.ServicePublishResult, error) {
 	if !p.isContainerAgent() {
+		return &azdext.ServicePublishResult{}, nil
+	}
+
+	// Skip publishing when user chose to use a pre-built image
+	usePreBuiltImage, err := p.shouldUsePreBuiltImage(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if usePreBuiltImage {
+		progress("Using pre-built container image, skipping publish")
 		return &azdext.ServicePublishResult{}, nil
 	}
 
@@ -568,6 +590,79 @@ func (p *AgentServiceTargetProvider) isContainerAgent() bool {
 	return kind == string(agent_yaml.AgentKindHosted)
 }
 
+// shouldUsePreBuiltImage determines whether to use a pre-built image.
+// When an image URL is configured, it prompts the user to choose between
+// using the pre-built image or building from a Dockerfile.
+// The decision is cached so the prompt only appears once per deploy.
+func (p *AgentServiceTargetProvider) shouldUsePreBuiltImage(
+	ctx context.Context,
+) (bool, error) {
+	// Return cached decision if already prompted
+	if p.usePreBuiltImage != nil {
+		return *p.usePreBuiltImage, nil
+	}
+
+	imageURL := p.getPreBuiltImageURL()
+	if imageURL == "" {
+		// No image configured, build from Dockerfile.
+		p.usePreBuiltImage = new(false)
+		return false, nil
+	}
+
+	// Prompt the user to choose
+	choices := []*azdext.SelectChoice{
+		{Value: "prebuilt", Label: fmt.Sprintf("Create hosted agent from %s", imageURL)},
+		{Value: "build", Label: "Build it for me"},
+	}
+
+	defaultIndex := int32(0)
+	resp, err := p.azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
+		Options: &azdext.SelectOptions{
+			Message:       "A container image is configured. How would you like to deploy?",
+			Choices:       choices,
+			SelectedIndex: &defaultIndex,
+		},
+	})
+	if err != nil {
+		return false, exterrors.FromPrompt(err, "failed to select hosted agent container image source")
+	}
+
+	usePreBuilt := resp.Value != nil && *resp.Value == 0
+	p.usePreBuiltImage = &usePreBuilt
+	return usePreBuilt, nil
+}
+
+// getPreBuiltImageURL returns the configured pre-built image URL from
+// agent.yaml (image field).
+// Returns empty string if no pre-built image is specified.
+func (p *AgentServiceTargetProvider) getPreBuiltImageURL() string {
+	data, err := os.ReadFile(p.agentDefinitionPath)
+	if err != nil {
+		return ""
+	}
+
+	var agentDef agent_yaml.ContainerAgent
+	if err := yaml.Unmarshal(data, &agentDef); err != nil {
+		return ""
+	}
+
+	return agentDef.Image
+}
+
+// resolvePreBuiltImage returns the pre-built container image URL if one is configured
+// in agent.yaml and the user chose to use it.
+// Returns empty string if no pre-built image is specified.
+func (p *AgentServiceTargetProvider) resolvePreBuiltImage(
+	agentDef agent_yaml.ContainerAgent,
+) string {
+	// Only return an image URL if the user chose to use the pre-built image.
+	if p.usePreBuiltImage == nil || !*p.usePreBuiltImage {
+		return ""
+	}
+
+	return agentDef.Image
+}
+
 // deployHostedAgent deploys a container-based hosted agent to the Foundry service.
 func (p *AgentServiceTargetProvider) deployHostedAgent(
 	ctx context.Context,
@@ -588,21 +683,36 @@ func (p *AgentServiceTargetProvider) deployHostedAgent(
 
 	progress("Deploying hosted agent")
 
-	// Step 1: Build container image
-	var fullImageURL string
-	for _, artifact := range serviceContext.Publish {
-		if artifact.Kind == azdext.ArtifactKind_ARTIFACT_KIND_CONTAINER &&
-			artifact.LocationKind == azdext.LocationKind_LOCATION_KIND_REMOTE {
-			fullImageURL = artifact.Location
-			break
-		}
+	// Step 1: Resolve container image URL.
+	// Priority: agent.yaml image chosen by the user > published artifact.
+	usePreBuiltImage, err := p.shouldUsePreBuiltImage(ctx)
+	if err != nil {
+		return nil, err
 	}
-	if fullImageURL == "" {
-		return nil, exterrors.Dependency(
-			exterrors.CodeMissingPublishedContainer,
-			"published container artifact not found: no remote container artifact was found in service publish artifacts",
-			"run 'azd package' and 'azd publish' (or 'azd deploy') to produce container artifacts",
-		)
+	if !usePreBuiltImage && agentDef.Image != "" {
+		fmt.Fprintf(os.Stderr, "Building container image instead of using pre-built image: %s\n", agentDef.Image)
+	}
+
+	fullImageURL := p.resolvePreBuiltImage(agentDef)
+	if fullImageURL != "" {
+		fmt.Fprintf(os.Stderr, "Using pre-built container image: %s\n", fullImageURL)
+	} else {
+		for _, artifact := range serviceContext.Publish {
+			if artifact.Kind == azdext.ArtifactKind_ARTIFACT_KIND_CONTAINER &&
+				artifact.LocationKind == azdext.LocationKind_LOCATION_KIND_REMOTE {
+				fullImageURL = artifact.Location
+				break
+			}
+		}
+		if fullImageURL == "" {
+			return nil, exterrors.Dependency(
+				exterrors.CodeMissingPublishedContainer,
+				"published container artifact not found: no remote container artifact was found in service "+
+					"publish artifacts and no pre-built image was specified",
+				"either set 'image' in agent.yaml, "+
+					"or run 'azd package' and 'azd publish' to build from a Dockerfile",
+			)
+		}
 	}
 
 	fmt.Fprintf(os.Stderr, "Loaded configuration from: %s\n", p.agentDefinitionPath)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -628,7 +628,8 @@ func (p *AgentServiceTargetProvider) shouldUsePreBuiltImage(
 	}
 
 	usePreBuilt := resp.Value != nil && *resp.Value == 0
-	p.usePreBuiltImage = &usePreBuilt
+	p.usePreBuiltImage = new(bool)
+	*p.usePreBuiltImage = usePreBuilt
 	return usePreBuilt, nil
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"azureaiagent/internal/exterrors"
@@ -80,8 +81,12 @@ type AgentServiceTargetProvider struct {
 	tenantId            string
 	env                 *azdext.Environment
 	foundryProject      *arm.ResourceID
-	usePreBuiltImage    *bool // nil = not yet prompted, true = use pre-built, false = build from Dockerfile
 }
+
+const (
+	preBuiltImageArtifactSourceKey = "azure.ai.agents.imageSource"
+	preBuiltImageArtifactSource    = "agent.yaml"
+)
 
 // NewAgentServiceTargetProvider creates a new AgentServiceTargetProvider instance
 func NewAgentServiceTargetProvider(azdClient *azdext.AzdClient) azdext.ServiceTargetProvider {
@@ -356,19 +361,23 @@ func (p *AgentServiceTargetProvider) Package(
 	serviceContext *azdext.ServiceContext,
 	progress azdext.ProgressReporter,
 ) (*azdext.ServicePackageResult, error) {
-	if !p.isContainerAgent() {
+	agentDef, isContainerAgent, err := p.loadContainerAgentDefinition()
+	if err != nil {
+		return nil, err
+	}
+	if !isContainerAgent {
 		return &azdext.ServicePackageResult{}, nil
 	}
 
-	// When a pre-built image is configured, prompt the user to choose.
-	// If no image is configured, proceed with build.
-	usePreBuiltImage, err := p.shouldUsePreBuiltImage(ctx)
+	usePreBuiltImage, err := p.shouldUsePreBuiltImage(ctx, agentDef)
 	if err != nil {
 		return nil, err
 	}
 	if usePreBuiltImage {
 		progress("Using pre-built container image, skipping package")
-		return &azdext.ServicePackageResult{}, nil
+		return &azdext.ServicePackageResult{
+			Artifacts: []*azdext.Artifact{preBuiltImageArtifact(agentDef.Image)},
+		}, nil
 	}
 
 	var packageArtifact *azdext.Artifact
@@ -432,18 +441,32 @@ func (p *AgentServiceTargetProvider) Publish(
 	publishOptions *azdext.PublishOptions,
 	progress azdext.ProgressReporter,
 ) (*azdext.ServicePublishResult, error) {
-	if !p.isContainerAgent() {
-		return &azdext.ServicePublishResult{}, nil
+	if preBuiltArtifact := findPreBuiltImageArtifact(serviceContext.Package); preBuiltArtifact != nil {
+		progress("Using pre-built container image, skipping publish")
+		return &azdext.ServicePublishResult{
+			Artifacts: []*azdext.Artifact{preBuiltArtifact},
+		}, nil
 	}
 
-	// Skip publishing when user chose to use a pre-built image
-	usePreBuiltImage, err := p.shouldUsePreBuiltImage(ctx)
+	agentDef, isContainerAgent, err := p.loadContainerAgentDefinition()
 	if err != nil {
 		return nil, err
 	}
-	if usePreBuiltImage {
-		progress("Using pre-built container image, skipping publish")
+	if !isContainerAgent {
 		return &azdext.ServicePublishResult{}, nil
+	}
+
+	if !hasContainerArtifact(serviceContext.Package) {
+		usePreBuiltImage, err := p.shouldUsePreBuiltImage(ctx, agentDef)
+		if err != nil {
+			return nil, err
+		}
+		if usePreBuiltImage {
+			progress("Using pre-built container image, skipping publish")
+			return &azdext.ServicePublishResult{
+				Artifacts: []*azdext.Artifact{preBuiltImageArtifact(agentDef.Image)},
+			}, nil
+		}
 	}
 
 	progress("Publishing container")
@@ -461,6 +484,104 @@ func (p *AgentServiceTargetProvider) Publish(
 	return &azdext.ServicePublishResult{
 		Artifacts: publishResponse.Result.Artifacts,
 	}, nil
+}
+
+func preBuiltImageArtifact(imageURL string) *azdext.Artifact {
+	return &azdext.Artifact{
+		Kind:         azdext.ArtifactKind_ARTIFACT_KIND_CONTAINER,
+		Location:     imageURL,
+		LocationKind: azdext.LocationKind_LOCATION_KIND_REMOTE,
+		Metadata: map[string]string{
+			preBuiltImageArtifactSourceKey: preBuiltImageArtifactSource,
+		},
+	}
+}
+
+func findPreBuiltImageArtifact(artifacts []*azdext.Artifact) *azdext.Artifact {
+	for _, artifact := range artifacts {
+		if artifact.Kind == azdext.ArtifactKind_ARTIFACT_KIND_CONTAINER &&
+			artifact.LocationKind == azdext.LocationKind_LOCATION_KIND_REMOTE &&
+			artifact.Location != "" &&
+			artifact.Metadata[preBuiltImageArtifactSourceKey] == preBuiltImageArtifactSource {
+			return artifact
+		}
+	}
+
+	return nil
+}
+
+func findPreBuiltImageArtifactInContext(serviceContext *azdext.ServiceContext) *azdext.Artifact {
+	if serviceContext == nil {
+		return nil
+	}
+
+	if artifact := findPreBuiltImageArtifact(serviceContext.Publish); artifact != nil {
+		return artifact
+	}
+
+	return findPreBuiltImageArtifact(serviceContext.Package)
+}
+
+func hasContainerArtifact(artifacts []*azdext.Artifact) bool {
+	for _, artifact := range artifacts {
+		if artifact.Kind == azdext.ArtifactKind_ARTIFACT_KIND_CONTAINER {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (p *AgentServiceTargetProvider) loadContainerAgentDefinition() (agent_yaml.ContainerAgent, bool, error) {
+	data, err := os.ReadFile(p.agentDefinitionPath)
+	if err != nil {
+		return agent_yaml.ContainerAgent{}, false, exterrors.Validation(
+			exterrors.CodeInvalidAgentManifest,
+			fmt.Sprintf("failed to read agent manifest file: %s", err),
+			"verify the agent.yaml file exists and is readable",
+		)
+	}
+
+	if err := agent_yaml.ValidateAgentDefinition(data); err != nil {
+		return agent_yaml.ContainerAgent{}, false, exterrors.Validation(
+			exterrors.CodeInvalidAgentManifest,
+			fmt.Sprintf("agent.yaml is not valid: %s", err),
+			"fix the agent.yaml file according to the schema",
+		)
+	}
+
+	var genericTemplate map[string]any
+	if err := yaml.Unmarshal(data, &genericTemplate); err != nil {
+		return agent_yaml.ContainerAgent{}, false, exterrors.Validation(
+			exterrors.CodeInvalidAgentManifest,
+			fmt.Sprintf("YAML content is not valid: %s", err),
+			"verify the agent.yaml has valid YAML syntax",
+		)
+	}
+
+	kind, ok := genericTemplate["kind"].(string)
+	if !ok {
+		return agent_yaml.ContainerAgent{}, false, exterrors.Validation(
+			exterrors.CodeMissingAgentKind,
+			"kind field is missing or not a valid string in agent.yaml",
+			"add a valid 'kind' field (e.g., 'hosted') to agent.yaml",
+		)
+	}
+
+	if kind != string(agent_yaml.AgentKindHosted) {
+		return agent_yaml.ContainerAgent{}, false, nil
+	}
+
+	var agentDef agent_yaml.ContainerAgent
+	if err := yaml.Unmarshal(data, &agentDef); err != nil {
+		return agent_yaml.ContainerAgent{}, false, exterrors.Validation(
+			exterrors.CodeInvalidAgentManifest,
+			fmt.Sprintf("YAML content is not valid for hosted agent: %s", err),
+			"fix the agent.yaml to match the hosted agent schema",
+		)
+	}
+
+	return agentDef, true, nil
 }
 
 // Deploy performs the deployment operation for the agent service
@@ -565,56 +686,35 @@ func (p *AgentServiceTargetProvider) Deploy(
 	}
 }
 
-func (p *AgentServiceTargetProvider) isContainerAgent() bool {
-	// Load and validate the agent manifest
-	data, err := os.ReadFile(p.agentDefinitionPath)
-	if err != nil {
-		return false
-	}
-
-	err = agent_yaml.ValidateAgentDefinition(data)
-	if err != nil {
-		return false
-	}
-
-	var genericTemplate map[string]any
-	if err := yaml.Unmarshal(data, &genericTemplate); err != nil {
-		return false
-	}
-
-	kind, ok := genericTemplate["kind"].(string)
-	if !ok {
-		return false
-	}
-
-	return kind == string(agent_yaml.AgentKindHosted)
-}
-
 // shouldUsePreBuiltImage determines whether to use a pre-built image.
-// When an image URL is configured, it prompts the user to choose between
-// using the pre-built image or building from a Dockerfile.
-// The decision is cached so the prompt only appears once per deploy.
+//
+// Behavior:
+//   - If no image is configured in agent.yaml, always build from Dockerfile.
+//   - In non-interactive mode (AZD_NO_PROMPT=true), honor the declarative image
+//     field directly: the user explicitly opted in by writing it in agent.yaml,
+//     so CI/CD can deploy without an extra flag.
+//   - In interactive mode, prompt the user. The default is to build, so users
+//     who happen to have an image in agent.yaml are not silently switched onto
+//     the pre-built path.
 func (p *AgentServiceTargetProvider) shouldUsePreBuiltImage(
 	ctx context.Context,
+	agentDef agent_yaml.ContainerAgent,
 ) (bool, error) {
-	// Return cached decision if already prompted
-	if p.usePreBuiltImage != nil {
-		return *p.usePreBuiltImage, nil
-	}
-
-	imageURL := p.getPreBuiltImageURL()
+	imageURL := agentDef.Image
 	if imageURL == "" {
-		// No image configured, build from Dockerfile.
-		p.usePreBuiltImage = new(false)
 		return false, nil
 	}
 
-	// Prompt the user to choose
-	choices := []*azdext.SelectChoice{
-		{Value: "prebuilt", Label: fmt.Sprintf("Create hosted agent from %s", imageURL)},
-		{Value: "build", Label: "Build it for me"},
+	// Non-interactive (CI/CD): honor the configured image without prompting.
+	if noPrompt, _ := strconv.ParseBool(os.Getenv("AZD_NO_PROMPT")); noPrompt {
+		return true, nil
 	}
 
+	// Interactive: default to build so the pre-built path requires an explicit choice.
+	choices := []*azdext.SelectChoice{
+		{Value: "build", Label: "Build it for me"},
+		{Value: "prebuilt", Label: fmt.Sprintf("Create hosted agent from %s", imageURL)},
+	}
 	defaultIndex := int32(0)
 	resp, err := p.azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
 		Options: &azdext.SelectOptions{
@@ -627,41 +727,7 @@ func (p *AgentServiceTargetProvider) shouldUsePreBuiltImage(
 		return false, exterrors.FromPrompt(err, "failed to select hosted agent container image source")
 	}
 
-	usePreBuilt := resp.Value != nil && *resp.Value == 0
-	p.usePreBuiltImage = new(bool)
-	*p.usePreBuiltImage = usePreBuilt
-	return usePreBuilt, nil
-}
-
-// getPreBuiltImageURL returns the configured pre-built image URL from
-// agent.yaml (image field).
-// Returns empty string if no pre-built image is specified.
-func (p *AgentServiceTargetProvider) getPreBuiltImageURL() string {
-	data, err := os.ReadFile(p.agentDefinitionPath)
-	if err != nil {
-		return ""
-	}
-
-	var agentDef agent_yaml.ContainerAgent
-	if err := yaml.Unmarshal(data, &agentDef); err != nil {
-		return ""
-	}
-
-	return agentDef.Image
-}
-
-// resolvePreBuiltImage returns the pre-built container image URL if one is configured
-// in agent.yaml and the user chose to use it.
-// Returns empty string if no pre-built image is specified.
-func (p *AgentServiceTargetProvider) resolvePreBuiltImage(
-	agentDef agent_yaml.ContainerAgent,
-) string {
-	// Only return an image URL if the user chose to use the pre-built image.
-	if p.usePreBuiltImage == nil || !*p.usePreBuiltImage {
-		return ""
-	}
-
-	return agentDef.Image
+	return resp.Value != nil && *resp.Value == 1, nil
 }
 
 // deployHostedAgent deploys a container-based hosted agent to the Foundry service.
@@ -684,17 +750,19 @@ func (p *AgentServiceTargetProvider) deployHostedAgent(
 
 	progress("Deploying hosted agent")
 
-	// Step 1: Resolve container image URL.
-	// Priority: agent.yaml image chosen by the user > published artifact.
-	usePreBuiltImage, err := p.shouldUsePreBuiltImage(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if !usePreBuiltImage && agentDef.Image != "" {
-		fmt.Fprintf(os.Stderr, "Building container image instead of using pre-built image: %s\n", agentDef.Image)
+	fullImageURL := ""
+	if preBuiltArtifact := findPreBuiltImageArtifactInContext(serviceContext); preBuiltArtifact != nil {
+		fullImageURL = preBuiltArtifact.Location
+	} else if !hasContainerArtifact(serviceContext.Publish) {
+		usePreBuiltImage, err := p.shouldUsePreBuiltImage(ctx, agentDef)
+		if err != nil {
+			return nil, err
+		}
+		if usePreBuiltImage {
+			fullImageURL = agentDef.Image
+		}
 	}
 
-	fullImageURL := p.resolvePreBuiltImage(agentDef)
 	if fullImageURL != "" {
 		fmt.Fprintf(os.Stderr, "Using pre-built container image: %s\n", fullImageURL)
 	} else {
@@ -1046,6 +1114,10 @@ func (p *AgentServiceTargetProvider) registerAgentEnvironmentVariables(
 	if agentVersionResponse.Version == "" {
 		return fmt.Errorf("agent version is empty; cannot register environment variables")
 	}
+	projectEndpoint := strings.TrimRight(azdEnv["AZURE_AI_PROJECT_ENDPOINT"], "/")
+	if projectEndpoint == "" {
+		return fmt.Errorf("AZURE_AI_PROJECT_ENDPOINT is empty; cannot register environment variables")
+	}
 
 	serviceKey := p.getServiceKey(serviceConfig.Name)
 	envVars := map[string]string{
@@ -1055,7 +1127,6 @@ func (p *AgentServiceTargetProvider) registerAgentEnvironmentVariables(
 
 	// Set the base agent endpoint used for session management (not protocol-specific).
 	baseEndpointKey := fmt.Sprintf("AGENT_%s_ENDPOINT", serviceKey)
-	projectEndpoint := strings.TrimRight(azdEnv["AZURE_AI_PROJECT_ENDPOINT"], "/")
 	envVars[baseEndpointKey] = fmt.Sprintf(
 		"%s/agents/%s/versions/%s", projectEndpoint, agentVersionResponse.Name, agentVersionResponse.Version,
 	)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1072,10 +1072,6 @@ func (p *AgentServiceTargetProvider) registerAgentEnvironmentVariables(
 	if agentVersionResponse.Version == "" {
 		return fmt.Errorf("agent version is empty; cannot register environment variables")
 	}
-	projectEndpoint := strings.TrimRight(azdEnv["AZURE_AI_PROJECT_ENDPOINT"], "/")
-	if projectEndpoint == "" {
-		return fmt.Errorf("AZURE_AI_PROJECT_ENDPOINT is empty; cannot register environment variables")
-	}
 
 	serviceKey := p.getServiceKey(serviceConfig.Name)
 	envVars := map[string]string{
@@ -1085,6 +1081,7 @@ func (p *AgentServiceTargetProvider) registerAgentEnvironmentVariables(
 
 	// Set the base agent endpoint used for session management (not protocol-specific).
 	baseEndpointKey := fmt.Sprintf("AGENT_%s_ENDPOINT", serviceKey)
+	projectEndpoint := strings.TrimRight(azdEnv["AZURE_AI_PROJECT_ENDPOINT"], "/")
 	envVars[baseEndpointKey] = fmt.Sprintf(
 		"%s/agents/%s/versions/%s", projectEndpoint, agentVersionResponse.Name, agentVersionResponse.Version,
 	)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -702,7 +702,7 @@ func TestShouldUsePreBuiltImage_SelectsPreBuiltImage(t *testing.T) {
 	require.Len(t, promptStub.lastSelect.Options.Choices, 2)
 	require.NotNil(t, promptStub.lastSelect.Options.SelectedIndex)
 	require.Equal(t, int32(0), *promptStub.lastSelect.Options.SelectedIndex)
-	require.Equal(t, "Build it for me", promptStub.lastSelect.Options.Choices[0].Label)
+	require.Equal(t, "Build a new image for me", promptStub.lastSelect.Options.Choices[0].Label)
 	require.Equal(t, "Create hosted agent from "+imageURL, promptStub.lastSelect.Options.Choices[1].Label)
 }
 
@@ -725,11 +725,12 @@ func TestShouldUsePreBuiltImage_SelectsDockerfileBuild(t *testing.T) {
 	require.Equal(t, int32(1), promptStub.selectCalls.Load())
 }
 
-func TestShouldUsePreBuiltImage_NoPromptDefaultsToBuild(t *testing.T) {
-	// Cannot use t.Parallel() because t.Setenv mutates process env.
-	t.Setenv("AZD_NO_PROMPT", "true")
+func TestShouldUsePreBuiltImage_DefaultIndexIsBuild(t *testing.T) {
+	t.Parallel()
 
-	promptStub := &stubPromptServer{}
+	// Verify that the default selection index points to "build",
+	// so that in --no-prompt mode the framework returns "build" automatically.
+	promptStub := &stubPromptServer{selectedIndex: 0}
 	client := newPromptTestClient(t, promptStub)
 
 	provider := &AgentServiceTargetProvider{
@@ -741,19 +742,11 @@ func TestShouldUsePreBuiltImage_NoPromptDefaultsToBuild(t *testing.T) {
 		agent_yaml.ContainerAgent{Image: "myregistry.azurecr.io/myimage:v1"},
 	)
 	require.NoError(t, err)
-	require.False(t, result, "non-interactive mode should always default to build")
-	require.Equal(t, int32(0), promptStub.selectCalls.Load(), "prompt should not be invoked in --no-prompt mode")
-}
-
-func TestShouldUsePreBuiltImage_NoPromptWithoutImageBuilds(t *testing.T) {
-	// Cannot use t.Parallel() because t.Setenv mutates process env.
-	t.Setenv("AZD_NO_PROMPT", "true")
-
-	provider := &AgentServiceTargetProvider{}
-
-	result, err := provider.shouldUsePreBuiltImage(t.Context(), agent_yaml.ContainerAgent{})
-	require.NoError(t, err)
-	require.False(t, result, "non-interactive mode without image should default to build")
+	require.False(t, result, "default selection (index 0) should mean build from Dockerfile")
+	require.NotNil(t, promptStub.lastSelect)
+	require.NotNil(t, promptStub.lastSelect.Options.SelectedIndex)
+	require.Equal(t, int32(0), *promptStub.lastSelect.Options.SelectedIndex)
+	require.Equal(t, "build", promptStub.lastSelect.Options.Choices[0].Value)
 }
 
 func TestShouldUsePreBuiltImage_PromptErrorCanRetry(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -5,6 +5,7 @@ package project
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -132,6 +133,44 @@ func newContainerTestClient(t *testing.T, containerSrv azdext.ContainerServiceSe
 
 	srv := grpc.NewServer()
 	azdext.RegisterContainerServiceServer(srv, containerSrv)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+	})
+
+	client, err := azdext.NewAzdClient(azdext.WithAddress(lis.Addr().String()))
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	return client
+}
+
+type stubPromptServer struct {
+	azdext.UnimplementedPromptServiceServer
+	selectedIndex int32
+	selectCalls   int
+	lastSelect    *azdext.SelectRequest
+}
+
+func (s *stubPromptServer) Select(
+	_ context.Context,
+	req *azdext.SelectRequest,
+) (*azdext.SelectResponse, error) {
+	s.selectCalls++
+	s.lastSelect = req
+	return &azdext.SelectResponse{Value: &s.selectedIndex}, nil
+}
+
+func newPromptTestClient(t *testing.T, promptSrv azdext.PromptServiceServer) *azdext.AzdClient {
+	t.Helper()
+
+	srv := grpc.NewServer()
+	azdext.RegisterPromptServiceServer(srv, promptSrv)
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -573,4 +612,200 @@ func TestAgentPlaygroundURL_AccountLevelID(t *testing.T) {
 	_, err := AgentPlaygroundURL(resourceID, "agent", "1")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing parent account")
+}
+
+// writeHostedAgentYAMLWithImage creates a hosted agent.yaml with a pre-built image field.
+func writeHostedAgentYAMLWithImage(t *testing.T, dir, image string) string {
+	t.Helper()
+	p := filepath.Join(dir, "agent.yaml")
+	content := fmt.Sprintf("kind: hosted\nname: test-agent\nimage: %s\n", image)
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+	return p
+}
+
+func TestGetPreBuiltImageURL_FromAgentYAML(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	agentPath := writeHostedAgentYAMLWithImage(t, dir, "agent-yaml-image.azurecr.io/img:v1")
+
+	provider := &AgentServiceTargetProvider{agentDefinitionPath: agentPath}
+
+	result := provider.getPreBuiltImageURL()
+	require.Equal(t, "agent-yaml-image.azurecr.io/img:v1", result)
+}
+
+func TestGetPreBuiltImageURL_EmptyWhenNoImage(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	agentPath := writeHostedAgentYAML(t, dir)
+
+	provider := &AgentServiceTargetProvider{agentDefinitionPath: agentPath}
+
+	result := provider.getPreBuiltImageURL()
+	require.Empty(t, result)
+}
+
+func TestResolvePreBuiltImage_RespectsUserChoice(t *testing.T) {
+	t.Parallel()
+
+	agentDef := agent_yaml.ContainerAgent{
+		Image: "myregistry.azurecr.io/img:v1",
+	}
+
+	// User chose pre-built image
+	provider := &AgentServiceTargetProvider{usePreBuiltImage: new(true)}
+	result := provider.resolvePreBuiltImage(agentDef)
+	require.Equal(t, "myregistry.azurecr.io/img:v1", result)
+
+	// User chose to build from Dockerfile
+	provider2 := &AgentServiceTargetProvider{usePreBuiltImage: new(false)}
+	result2 := provider2.resolvePreBuiltImage(agentDef)
+	require.Empty(t, result2)
+}
+
+func TestShouldUsePreBuiltImage_CachesDecision(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	agentPath := writeHostedAgentYAMLWithImage(t, dir, "myregistry.azurecr.io/myimage:v1")
+
+	// Pre-set the decision to avoid needing a prompt server
+	provider := &AgentServiceTargetProvider{
+		agentDefinitionPath: agentPath,
+		usePreBuiltImage:    new(true),
+	}
+
+	// Should return cached value without prompting
+	result, err := provider.shouldUsePreBuiltImage(t.Context())
+	require.NoError(t, err)
+	require.True(t, result)
+}
+
+func TestShouldUsePreBuiltImage_NoImageDefaultsToBuild(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	agentPath := writeHostedAgentYAML(t, dir) // no image field
+
+	provider := &AgentServiceTargetProvider{
+		agentDefinitionPath: agentPath,
+	}
+
+	result, err := provider.shouldUsePreBuiltImage(t.Context())
+	require.NoError(t, err)
+	require.False(t, result, "should default to build when no image is configured")
+}
+
+func TestShouldUsePreBuiltImage_PromptsForConfiguredImage(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	imageURL := "myregistry.azurecr.io/myimage:v1"
+	agentPath := writeHostedAgentYAMLWithImage(t, dir, imageURL)
+
+	promptStub := &stubPromptServer{selectedIndex: 1}
+	client := newPromptTestClient(t, promptStub)
+
+	provider := &AgentServiceTargetProvider{
+		azdClient:           client,
+		agentDefinitionPath: agentPath,
+	}
+
+	result, err := provider.shouldUsePreBuiltImage(t.Context())
+	require.NoError(t, err)
+	require.False(t, result)
+	require.Equal(t, 1, promptStub.selectCalls)
+	require.NotNil(t, promptStub.lastSelect)
+	require.NotNil(t, promptStub.lastSelect.Options)
+	require.Len(t, promptStub.lastSelect.Options.Choices, 2)
+	require.Equal(t, "Create hosted agent from "+imageURL, promptStub.lastSelect.Options.Choices[0].Label)
+	require.Equal(t, "Build it for me", promptStub.lastSelect.Options.Choices[1].Label)
+
+	cachedResult, err := provider.shouldUsePreBuiltImage(t.Context())
+	require.NoError(t, err)
+	require.False(t, cachedResult)
+	require.Equal(t, 1, promptStub.selectCalls, "expected prompt decision to be cached")
+}
+
+func TestPackage_SkipsWhenPreBuiltImageChosen(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	agentPath := writeHostedAgentYAMLWithImage(t, dir, "myregistry.azurecr.io/myimage:v1")
+
+	provider := &AgentServiceTargetProvider{
+		agentDefinitionPath: agentPath,
+		env:                 &azdext.Environment{Name: "test-env"},
+		usePreBuiltImage:    new(true), // simulate user chose pre-built
+	}
+
+	var progressMessages []string
+	result, err := provider.Package(
+		t.Context(),
+		&azdext.ServiceConfig{Name: "test-svc"},
+		&azdext.ServiceContext{},
+		func(msg string) { progressMessages = append(progressMessages, msg) },
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Empty(t, result.Artifacts, "expected no artifacts when using pre-built image")
+	require.Contains(t, progressMessages, "Using pre-built container image, skipping package")
+}
+
+func TestPackage_BuildsWhenUserChoseDockerfile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	agentPath := writeHostedAgentYAMLWithImage(t, dir, "myregistry.azurecr.io/myimage:v1")
+
+	client := newContainerTestClient(t, &stubContainerServer{})
+
+	provider := &AgentServiceTargetProvider{
+		azdClient:           client,
+		agentDefinitionPath: agentPath,
+		env:                 &azdext.Environment{Name: "test-env"},
+		usePreBuiltImage:    new(false), // simulate user chose "Build from Dockerfile"
+	}
+
+	result, err := provider.Package(
+		t.Context(),
+		&azdext.ServiceConfig{Name: "test-svc"},
+		&azdext.ServiceContext{},
+		func(string) {},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.Artifacts, "expected container artifacts when building from Dockerfile")
+}
+
+func TestPublish_SkipsWhenPreBuiltImageChosen(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	agentPath := writeHostedAgentYAMLWithImage(t, dir, "myregistry.azurecr.io/myimage:v1")
+
+	provider := &AgentServiceTargetProvider{
+		agentDefinitionPath: agentPath,
+		env:                 &azdext.Environment{Name: "test-env"},
+		usePreBuiltImage:    new(true), // simulate user chose pre-built
+	}
+
+	var progressMessages []string
+	result, err := provider.Publish(
+		t.Context(),
+		&azdext.ServiceConfig{Name: "test-svc"},
+		&azdext.ServiceContext{},
+		&azdext.TargetResource{},
+		&azdext.PublishOptions{},
+		func(msg string) { progressMessages = append(progressMessages, msg) },
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Empty(t, result.Artifacts, "expected no artifacts when using pre-built image")
+	require.Contains(t, progressMessages, "Using pre-built container image, skipping publish")
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -99,12 +99,19 @@ func writeHostedAgentYAML(t *testing.T, dir string) string {
 }
 
 // stubContainerServer is a minimal ContainerServiceServer that returns
-// success responses for Build and Package.
+// success responses for Build, Package, and Publish.
 type stubContainerServer struct {
 	azdext.UnimplementedContainerServiceServer
+	buildCalls   int
+	packageCalls int
+	publishCalls int
 }
 
-func (s *stubContainerServer) Build(_ context.Context, _ *azdext.ContainerBuildRequest) (*azdext.ContainerBuildResponse, error) {
+func (s *stubContainerServer) Build(
+	_ context.Context,
+	_ *azdext.ContainerBuildRequest,
+) (*azdext.ContainerBuildResponse, error) {
+	s.buildCalls++
 	return &azdext.ContainerBuildResponse{
 		Result: &azdext.ServiceBuildResult{
 			Artifacts: []*azdext.Artifact{{
@@ -115,7 +122,11 @@ func (s *stubContainerServer) Build(_ context.Context, _ *azdext.ContainerBuildR
 	}, nil
 }
 
-func (s *stubContainerServer) Package(_ context.Context, _ *azdext.ContainerPackageRequest) (*azdext.ContainerPackageResponse, error) {
+func (s *stubContainerServer) Package(
+	_ context.Context,
+	_ *azdext.ContainerPackageRequest,
+) (*azdext.ContainerPackageResponse, error) {
+	s.packageCalls++
 	return &azdext.ContainerPackageResponse{
 		Result: &azdext.ServicePackageResult{
 			Artifacts: []*azdext.Artifact{{
@@ -126,13 +137,43 @@ func (s *stubContainerServer) Package(_ context.Context, _ *azdext.ContainerPack
 	}, nil
 }
 
+func (s *stubContainerServer) Publish(
+	_ context.Context,
+	_ *azdext.ContainerPublishRequest,
+) (*azdext.ContainerPublishResponse, error) {
+	s.publishCalls++
+	return &azdext.ContainerPublishResponse{
+		Result: &azdext.ServicePublishResult{
+			Artifacts: []*azdext.Artifact{{
+				Kind:         azdext.ArtifactKind_ARTIFACT_KIND_CONTAINER,
+				Location:     "myregistry.azurecr.io/test-image:latest",
+				LocationKind: azdext.LocationKind_LOCATION_KIND_REMOTE,
+			}},
+		},
+	}, nil
+}
+
 // newContainerTestClient spins up a gRPC server with the given container
 // service and returns an AzdClient connected to it.
 func newContainerTestClient(t *testing.T, containerSrv azdext.ContainerServiceServer) *azdext.AzdClient {
 	t.Helper()
+	return newServiceTargetTestClient(t, containerSrv, nil)
+}
+
+func newServiceTargetTestClient(
+	t *testing.T,
+	containerSrv azdext.ContainerServiceServer,
+	promptSrv azdext.PromptServiceServer,
+) *azdext.AzdClient {
+	t.Helper()
 
 	srv := grpc.NewServer()
-	azdext.RegisterContainerServiceServer(srv, containerSrv)
+	if containerSrv != nil {
+		azdext.RegisterContainerServiceServer(srv, containerSrv)
+	}
+	if promptSrv != nil {
+		azdext.RegisterPromptServiceServer(srv, promptSrv)
+	}
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -155,6 +196,7 @@ type stubPromptServer struct {
 	selectedIndex int32
 	selectCalls   int
 	lastSelect    *azdext.SelectRequest
+	err           error
 }
 
 func (s *stubPromptServer) Select(
@@ -163,29 +205,15 @@ func (s *stubPromptServer) Select(
 ) (*azdext.SelectResponse, error) {
 	s.selectCalls++
 	s.lastSelect = req
+	if s.err != nil {
+		return nil, s.err
+	}
 	return &azdext.SelectResponse{Value: &s.selectedIndex}, nil
 }
 
 func newPromptTestClient(t *testing.T, promptSrv azdext.PromptServiceServer) *azdext.AzdClient {
 	t.Helper()
-
-	srv := grpc.NewServer()
-	azdext.RegisterPromptServiceServer(srv, promptSrv)
-
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-
-	go func() { _ = srv.Serve(lis) }()
-	t.Cleanup(func() {
-		srv.Stop()
-		_ = lis.Close()
-	})
-
-	client, err := azdext.NewAzdClient(azdext.WithAddress(lis.Addr().String()))
-	require.NoError(t, err)
-	t.Cleanup(func() { client.Close() })
-
-	return client
+	return newServiceTargetTestClient(t, nil, promptSrv)
 }
 
 // stubEnvServer records SetValue calls for testing registerAgentEnvironmentVariables.
@@ -360,6 +388,28 @@ func TestRegisterAgentEnvironmentVariables_EmptyVersion(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "agent version is empty")
+}
+
+func TestRegisterAgentEnvironmentVariables_EmptyEndpoint(t *testing.T) {
+	t.Parallel()
+
+	envStub := &stubEnvServer{}
+	client := newEnvTestClient(t, envStub)
+
+	provider := &AgentServiceTargetProvider{
+		azdClient: client,
+		env:       &azdext.Environment{Name: "test-env"},
+	}
+
+	err := provider.registerAgentEnvironmentVariables(
+		t.Context(),
+		map[string]string{},
+		&azdext.ServiceConfig{Name: "my-svc"},
+		&agent_api.AgentVersionObject{Name: "my-agent", Version: "1.0.0"},
+		nil,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "AZURE_AI_PROJECT_ENDPOINT is empty")
 }
 
 func TestProtocolPath(t *testing.T) {
@@ -623,122 +673,139 @@ func writeHostedAgentYAMLWithImage(t *testing.T, dir, image string) string {
 	return p
 }
 
-func TestGetPreBuiltImageURL_FromAgentYAML(t *testing.T) {
+func TestLoadContainerAgentDefinition_MalformedYAMLReturnsError(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	agentPath := writeHostedAgentYAMLWithImage(t, dir, "agent-yaml-image.azurecr.io/img:v1")
+	agentPath := filepath.Join(dir, "agent.yaml")
+	require.NoError(t, os.WriteFile(agentPath, []byte("kind: hosted\nname: [\n"), 0o600))
 
-	provider := &AgentServiceTargetProvider{agentDefinitionPath: agentPath}
-
-	result := provider.getPreBuiltImageURL()
-	require.Equal(t, "agent-yaml-image.azurecr.io/img:v1", result)
-}
-
-func TestGetPreBuiltImageURL_EmptyWhenNoImage(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	agentPath := writeHostedAgentYAML(t, dir)
-
-	provider := &AgentServiceTargetProvider{agentDefinitionPath: agentPath}
-
-	result := provider.getPreBuiltImageURL()
-	require.Empty(t, result)
-}
-
-func TestResolvePreBuiltImage_RespectsUserChoice(t *testing.T) {
-	t.Parallel()
-
-	agentDef := agent_yaml.ContainerAgent{
-		Image: "myregistry.azurecr.io/img:v1",
-	}
-
-	// User chose pre-built image
-	provider := &AgentServiceTargetProvider{usePreBuiltImage: new(true)}
-	result := provider.resolvePreBuiltImage(agentDef)
-	require.Equal(t, "myregistry.azurecr.io/img:v1", result)
-
-	// User chose to build from Dockerfile
-	provider2 := &AgentServiceTargetProvider{usePreBuiltImage: new(false)}
-	result2 := provider2.resolvePreBuiltImage(agentDef)
-	require.Empty(t, result2)
-}
-
-func TestShouldUsePreBuiltImage_CachesDecision(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	agentPath := writeHostedAgentYAMLWithImage(t, dir, "myregistry.azurecr.io/myimage:v1")
-
-	// Pre-set the decision to avoid needing a prompt server
 	provider := &AgentServiceTargetProvider{
 		agentDefinitionPath: agentPath,
-		usePreBuiltImage:    new(true),
 	}
 
-	// Should return cached value without prompting
-	result, err := provider.shouldUsePreBuiltImage(t.Context())
-	require.NoError(t, err)
-	require.True(t, result)
+	_, _, err := provider.loadContainerAgentDefinition()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "agent.yaml is not valid")
 }
 
 func TestShouldUsePreBuiltImage_NoImageDefaultsToBuild(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	agentPath := writeHostedAgentYAML(t, dir) // no image field
+	provider := &AgentServiceTargetProvider{}
 
-	provider := &AgentServiceTargetProvider{
-		agentDefinitionPath: agentPath,
-	}
-
-	result, err := provider.shouldUsePreBuiltImage(t.Context())
+	result, err := provider.shouldUsePreBuiltImage(t.Context(), agent_yaml.ContainerAgent{})
 	require.NoError(t, err)
 	require.False(t, result, "should default to build when no image is configured")
 }
 
-func TestShouldUsePreBuiltImage_PromptsForConfiguredImage(t *testing.T) {
+func TestShouldUsePreBuiltImage_PromptsForPreBuiltImage(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
 	imageURL := "myregistry.azurecr.io/myimage:v1"
-	agentPath := writeHostedAgentYAMLWithImage(t, dir, imageURL)
 
 	promptStub := &stubPromptServer{selectedIndex: 1}
 	client := newPromptTestClient(t, promptStub)
 
 	provider := &AgentServiceTargetProvider{
-		azdClient:           client,
-		agentDefinitionPath: agentPath,
+		azdClient: client,
 	}
 
-	result, err := provider.shouldUsePreBuiltImage(t.Context())
+	result, err := provider.shouldUsePreBuiltImage(t.Context(), agent_yaml.ContainerAgent{Image: imageURL})
 	require.NoError(t, err)
-	require.False(t, result)
+	require.True(t, result)
 	require.Equal(t, 1, promptStub.selectCalls)
 	require.NotNil(t, promptStub.lastSelect)
 	require.NotNil(t, promptStub.lastSelect.Options)
 	require.Len(t, promptStub.lastSelect.Options.Choices, 2)
-	require.Equal(t, "Create hosted agent from "+imageURL, promptStub.lastSelect.Options.Choices[0].Label)
-	require.Equal(t, "Build it for me", promptStub.lastSelect.Options.Choices[1].Label)
+	require.NotNil(t, promptStub.lastSelect.Options.SelectedIndex)
+	require.Equal(t, int32(0), *promptStub.lastSelect.Options.SelectedIndex)
+	require.Equal(t, "Build it for me", promptStub.lastSelect.Options.Choices[0].Label)
+	require.Equal(t, "Create hosted agent from "+imageURL, promptStub.lastSelect.Options.Choices[1].Label)
+}
 
-	cachedResult, err := provider.shouldUsePreBuiltImage(t.Context())
+func TestShouldUsePreBuiltImage_PromptsForDockerfile(t *testing.T) {
+	t.Parallel()
+
+	promptStub := &stubPromptServer{selectedIndex: 0}
+	client := newPromptTestClient(t, promptStub)
+
+	provider := &AgentServiceTargetProvider{
+		azdClient: client,
+	}
+
+	result, err := provider.shouldUsePreBuiltImage(
+		t.Context(),
+		agent_yaml.ContainerAgent{Image: "myregistry.azurecr.io/myimage:v1"},
+	)
 	require.NoError(t, err)
-	require.False(t, cachedResult)
-	require.Equal(t, 1, promptStub.selectCalls, "expected prompt decision to be cached")
+	require.False(t, result)
+	require.Equal(t, 1, promptStub.selectCalls)
+}
+
+func TestShouldUsePreBuiltImage_NoPromptHonorsImageField(t *testing.T) {
+	// Cannot use t.Parallel() because t.Setenv mutates process env.
+	t.Setenv("AZD_NO_PROMPT", "true")
+
+	promptStub := &stubPromptServer{}
+	client := newPromptTestClient(t, promptStub)
+
+	provider := &AgentServiceTargetProvider{
+		azdClient: client,
+	}
+
+	result, err := provider.shouldUsePreBuiltImage(
+		t.Context(),
+		agent_yaml.ContainerAgent{Image: "myregistry.azurecr.io/myimage:v1"},
+	)
+	require.NoError(t, err)
+	require.True(t, result, "non-interactive mode should honor configured image")
+	require.Equal(t, 0, promptStub.selectCalls, "prompt should not be invoked in --no-prompt mode")
+}
+
+func TestShouldUsePreBuiltImage_NoPromptWithoutImageBuilds(t *testing.T) {
+	t.Setenv("AZD_NO_PROMPT", "true")
+
+	provider := &AgentServiceTargetProvider{}
+
+	result, err := provider.shouldUsePreBuiltImage(t.Context(), agent_yaml.ContainerAgent{})
+	require.NoError(t, err)
+	require.False(t, result, "non-interactive mode without image should default to build")
+}
+
+func TestShouldUsePreBuiltImage_PromptErrorCanRetry(t *testing.T) {
+	t.Parallel()
+
+	promptStub := &stubPromptServer{err: fmt.Errorf("prompt failed")}
+	client := newPromptTestClient(t, promptStub)
+
+	provider := &AgentServiceTargetProvider{
+		azdClient: client,
+	}
+	agentDef := agent_yaml.ContainerAgent{Image: "myregistry.azurecr.io/myimage:v1"}
+
+	_, err := provider.shouldUsePreBuiltImage(t.Context(), agentDef)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to select hosted agent container image source")
+
+	_, err = provider.shouldUsePreBuiltImage(t.Context(), agentDef)
+	require.Error(t, err)
+	require.Equal(t, 2, promptStub.selectCalls)
 }
 
 func TestPackage_SkipsWhenPreBuiltImageChosen(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	agentPath := writeHostedAgentYAMLWithImage(t, dir, "myregistry.azurecr.io/myimage:v1")
+	imageURL := "myregistry.azurecr.io/myimage:v1"
+	agentPath := writeHostedAgentYAMLWithImage(t, dir, imageURL)
+	promptStub := &stubPromptServer{selectedIndex: 1}
+	client := newPromptTestClient(t, promptStub)
 
 	provider := &AgentServiceTargetProvider{
+		azdClient:           client,
 		agentDefinitionPath: agentPath,
 		env:                 &azdext.Environment{Name: "test-env"},
-		usePreBuiltImage:    new(true), // simulate user chose pre-built
 	}
 
 	var progressMessages []string
@@ -751,7 +818,10 @@ func TestPackage_SkipsWhenPreBuiltImageChosen(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Empty(t, result.Artifacts, "expected no artifacts when using pre-built image")
+	require.Len(t, result.Artifacts, 1)
+	require.Equal(t, imageURL, result.Artifacts[0].Location)
+	require.Equal(t, azdext.LocationKind_LOCATION_KIND_REMOTE, result.Artifacts[0].LocationKind)
+	require.Equal(t, preBuiltImageArtifactSource, result.Artifacts[0].Metadata[preBuiltImageArtifactSourceKey])
 	require.Contains(t, progressMessages, "Using pre-built container image, skipping package")
 }
 
@@ -761,13 +831,14 @@ func TestPackage_BuildsWhenUserChoseDockerfile(t *testing.T) {
 	dir := t.TempDir()
 	agentPath := writeHostedAgentYAMLWithImage(t, dir, "myregistry.azurecr.io/myimage:v1")
 
-	client := newContainerTestClient(t, &stubContainerServer{})
+	containerStub := &stubContainerServer{}
+	promptStub := &stubPromptServer{selectedIndex: 0}
+	client := newServiceTargetTestClient(t, containerStub, promptStub)
 
 	provider := &AgentServiceTargetProvider{
 		azdClient:           client,
 		agentDefinitionPath: agentPath,
 		env:                 &azdext.Environment{Name: "test-env"},
-		usePreBuiltImage:    new(false), // simulate user chose "Build from Dockerfile"
 	}
 
 	result, err := provider.Package(
@@ -780,25 +851,25 @@ func TestPackage_BuildsWhenUserChoseDockerfile(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.Artifacts, "expected container artifacts when building from Dockerfile")
+	require.Equal(t, 1, promptStub.selectCalls)
+	require.Equal(t, 1, containerStub.buildCalls)
+	require.Equal(t, 1, containerStub.packageCalls)
 }
 
 func TestPublish_SkipsWhenPreBuiltImageChosen(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	agentPath := writeHostedAgentYAMLWithImage(t, dir, "myregistry.azurecr.io/myimage:v1")
+	imageURL := "myregistry.azurecr.io/myimage:v1"
 
 	provider := &AgentServiceTargetProvider{
-		agentDefinitionPath: agentPath,
-		env:                 &azdext.Environment{Name: "test-env"},
-		usePreBuiltImage:    new(true), // simulate user chose pre-built
+		env: &azdext.Environment{Name: "test-env"},
 	}
 
 	var progressMessages []string
 	result, err := provider.Publish(
 		t.Context(),
 		&azdext.ServiceConfig{Name: "test-svc"},
-		&azdext.ServiceContext{},
+		&azdext.ServiceContext{Package: []*azdext.Artifact{preBuiltImageArtifact(imageURL)}},
 		&azdext.TargetResource{},
 		&azdext.PublishOptions{},
 		func(msg string) { progressMessages = append(progressMessages, msg) },
@@ -806,6 +877,40 @@ func TestPublish_SkipsWhenPreBuiltImageChosen(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Empty(t, result.Artifacts, "expected no artifacts when using pre-built image")
+	require.Len(t, result.Artifacts, 1)
+	require.Equal(t, imageURL, result.Artifacts[0].Location)
 	require.Contains(t, progressMessages, "Using pre-built container image, skipping publish")
+}
+
+func TestPublish_PublishesWhenPackageBuiltFromDockerfile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	agentPath := writeHostedAgentYAMLWithImage(t, dir, "myregistry.azurecr.io/myimage:v1")
+	containerStub := &stubContainerServer{}
+	client := newContainerTestClient(t, containerStub)
+
+	provider := &AgentServiceTargetProvider{
+		azdClient:           client,
+		agentDefinitionPath: agentPath,
+		env:                 &azdext.Environment{Name: "test-env"},
+	}
+
+	result, err := provider.Publish(
+		t.Context(),
+		&azdext.ServiceConfig{Name: "test-svc"},
+		&azdext.ServiceContext{Package: []*azdext.Artifact{{
+			Kind:         azdext.ArtifactKind_ARTIFACT_KIND_CONTAINER,
+			Location:     "test-image:latest",
+			LocationKind: azdext.LocationKind_LOCATION_KIND_LOCAL,
+		}}},
+		&azdext.TargetResource{},
+		&azdext.PublishOptions{},
+		func(string) {},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.Artifacts, "expected published container artifacts")
+	require.Equal(t, 1, containerStub.publishCalls)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"azureaiagent/internal/pkg/agents/agent_api"
@@ -102,16 +103,16 @@ func writeHostedAgentYAML(t *testing.T, dir string) string {
 // success responses for Build, Package, and Publish.
 type stubContainerServer struct {
 	azdext.UnimplementedContainerServiceServer
-	buildCalls   int
-	packageCalls int
-	publishCalls int
+	buildCalls   atomic.Int32
+	packageCalls atomic.Int32
+	publishCalls atomic.Int32
 }
 
 func (s *stubContainerServer) Build(
 	_ context.Context,
 	_ *azdext.ContainerBuildRequest,
 ) (*azdext.ContainerBuildResponse, error) {
-	s.buildCalls++
+	s.buildCalls.Add(1)
 	return &azdext.ContainerBuildResponse{
 		Result: &azdext.ServiceBuildResult{
 			Artifacts: []*azdext.Artifact{{
@@ -126,7 +127,7 @@ func (s *stubContainerServer) Package(
 	_ context.Context,
 	_ *azdext.ContainerPackageRequest,
 ) (*azdext.ContainerPackageResponse, error) {
-	s.packageCalls++
+	s.packageCalls.Add(1)
 	return &azdext.ContainerPackageResponse{
 		Result: &azdext.ServicePackageResult{
 			Artifacts: []*azdext.Artifact{{
@@ -141,7 +142,7 @@ func (s *stubContainerServer) Publish(
 	_ context.Context,
 	_ *azdext.ContainerPublishRequest,
 ) (*azdext.ContainerPublishResponse, error) {
-	s.publishCalls++
+	s.publishCalls.Add(1)
 	return &azdext.ContainerPublishResponse{
 		Result: &azdext.ServicePublishResult{
 			Artifacts: []*azdext.Artifact{{
@@ -194,7 +195,7 @@ func newServiceTargetTestClient(
 type stubPromptServer struct {
 	azdext.UnimplementedPromptServiceServer
 	selectedIndex int32
-	selectCalls   int
+	selectCalls   atomic.Int32
 	lastSelect    *azdext.SelectRequest
 	err           error
 }
@@ -203,7 +204,7 @@ func (s *stubPromptServer) Select(
 	_ context.Context,
 	req *azdext.SelectRequest,
 ) (*azdext.SelectResponse, error) {
-	s.selectCalls++
+	s.selectCalls.Add(1)
 	s.lastSelect = req
 	if s.err != nil {
 		return nil, s.err
@@ -646,7 +647,10 @@ func TestAgentPlaygroundURL_AccountLevelID(t *testing.T) {
 func writeHostedAgentYAMLWithImage(t *testing.T, dir, image string) string {
 	t.Helper()
 	p := filepath.Join(dir, "agent.yaml")
-	content := fmt.Sprintf("kind: hosted\nname: test-agent\nimage: %s\n", image)
+	content := fmt.Sprintf(
+		"kind: hosted\nname: test-agent\nimage: %s\nprotocols:\n  - protocol: invocations\n    version: 1.0.0\n",
+		image,
+	)
 	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
 	return p
 }
@@ -692,7 +696,7 @@ func TestShouldUsePreBuiltImage_PromptsForPreBuiltImage(t *testing.T) {
 	result, err := provider.shouldUsePreBuiltImage(t.Context(), agent_yaml.ContainerAgent{Image: imageURL})
 	require.NoError(t, err)
 	require.True(t, result)
-	require.Equal(t, 1, promptStub.selectCalls)
+	require.Equal(t, int32(1), promptStub.selectCalls.Load())
 	require.NotNil(t, promptStub.lastSelect)
 	require.NotNil(t, promptStub.lastSelect.Options)
 	require.Len(t, promptStub.lastSelect.Options.Choices, 2)
@@ -718,7 +722,7 @@ func TestShouldUsePreBuiltImage_PromptsForDockerfile(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.False(t, result)
-	require.Equal(t, 1, promptStub.selectCalls)
+	require.Equal(t, int32(1), promptStub.selectCalls.Load())
 }
 
 func TestShouldUsePreBuiltImage_NoPromptHonorsImageField(t *testing.T) {
@@ -738,7 +742,7 @@ func TestShouldUsePreBuiltImage_NoPromptHonorsImageField(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.True(t, result, "non-interactive mode should honor configured image")
-	require.Equal(t, 0, promptStub.selectCalls, "prompt should not be invoked in --no-prompt mode")
+	require.Equal(t, int32(0), promptStub.selectCalls.Load(), "prompt should not be invoked in --no-prompt mode")
 }
 
 func TestShouldUsePreBuiltImage_NoPromptWithoutImageBuilds(t *testing.T) {
@@ -769,7 +773,7 @@ func TestShouldUsePreBuiltImage_PromptErrorCanRetry(t *testing.T) {
 
 	_, err = provider.shouldUsePreBuiltImage(t.Context(), agentDef)
 	require.Error(t, err)
-	require.Equal(t, 2, promptStub.selectCalls)
+	require.Equal(t, int32(2), promptStub.selectCalls.Load())
 }
 
 func TestPackage_SkipsWhenPreBuiltImageChosen(t *testing.T) {
@@ -830,9 +834,9 @@ func TestPackage_BuildsWhenUserChoseDockerfile(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.Artifacts, "expected container artifacts when building from Dockerfile")
-	require.Equal(t, 1, promptStub.selectCalls)
-	require.Equal(t, 1, containerStub.buildCalls)
-	require.Equal(t, 1, containerStub.packageCalls)
+	require.Equal(t, int32(1), promptStub.selectCalls.Load())
+	require.Equal(t, int32(1), containerStub.buildCalls.Load())
+	require.Equal(t, int32(1), containerStub.packageCalls.Load())
 }
 
 func TestPublish_SkipsWhenPreBuiltImageChosen(t *testing.T) {
@@ -891,5 +895,5 @@ func TestPublish_PublishesWhenPackageBuiltFromDockerfile(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.Artifacts, "expected published container artifacts")
-	require.Equal(t, 1, containerStub.publishCalls)
+	require.Equal(t, int32(1), containerStub.publishCalls.Load())
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -681,7 +681,7 @@ func TestShouldUsePreBuiltImage_NoImageDefaultsToBuild(t *testing.T) {
 	require.False(t, result, "should default to build when no image is configured")
 }
 
-func TestShouldUsePreBuiltImage_PromptsForPreBuiltImage(t *testing.T) {
+func TestShouldUsePreBuiltImage_SelectsPreBuiltImage(t *testing.T) {
 	t.Parallel()
 
 	imageURL := "myregistry.azurecr.io/myimage:v1"
@@ -706,7 +706,7 @@ func TestShouldUsePreBuiltImage_PromptsForPreBuiltImage(t *testing.T) {
 	require.Equal(t, "Create hosted agent from "+imageURL, promptStub.lastSelect.Options.Choices[1].Label)
 }
 
-func TestShouldUsePreBuiltImage_PromptsForDockerfile(t *testing.T) {
+func TestShouldUsePreBuiltImage_SelectsDockerfileBuild(t *testing.T) {
 	t.Parallel()
 
 	promptStub := &stubPromptServer{selectedIndex: 0}
@@ -725,7 +725,7 @@ func TestShouldUsePreBuiltImage_PromptsForDockerfile(t *testing.T) {
 	require.Equal(t, int32(1), promptStub.selectCalls.Load())
 }
 
-func TestShouldUsePreBuiltImage_NoPromptHonorsImageField(t *testing.T) {
+func TestShouldUsePreBuiltImage_NoPromptDefaultsToBuild(t *testing.T) {
 	// Cannot use t.Parallel() because t.Setenv mutates process env.
 	t.Setenv("AZD_NO_PROMPT", "true")
 
@@ -741,7 +741,7 @@ func TestShouldUsePreBuiltImage_NoPromptHonorsImageField(t *testing.T) {
 		agent_yaml.ContainerAgent{Image: "myregistry.azurecr.io/myimage:v1"},
 	)
 	require.NoError(t, err)
-	require.True(t, result, "non-interactive mode should honor configured image")
+	require.False(t, result, "non-interactive mode should always default to build")
 	require.Equal(t, int32(0), promptStub.selectCalls.Load(), "prompt should not be invoked in --no-prompt mode")
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -764,6 +764,7 @@ func TestShouldUsePreBuiltImage_NoPromptHonorsImageField(t *testing.T) {
 }
 
 func TestShouldUsePreBuiltImage_NoPromptWithoutImageBuilds(t *testing.T) {
+	// Cannot use t.Parallel() because t.Setenv mutates process env.
 	t.Setenv("AZD_NO_PROMPT", "true")
 
 	provider := &AgentServiceTargetProvider{}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -390,28 +390,6 @@ func TestRegisterAgentEnvironmentVariables_EmptyVersion(t *testing.T) {
 	require.Contains(t, err.Error(), "agent version is empty")
 }
 
-func TestRegisterAgentEnvironmentVariables_EmptyEndpoint(t *testing.T) {
-	t.Parallel()
-
-	envStub := &stubEnvServer{}
-	client := newEnvTestClient(t, envStub)
-
-	provider := &AgentServiceTargetProvider{
-		azdClient: client,
-		env:       &azdext.Environment{Name: "test-env"},
-	}
-
-	err := provider.registerAgentEnvironmentVariables(
-		t.Context(),
-		map[string]string{},
-		&azdext.ServiceConfig{Name: "my-svc"},
-		&agent_api.AgentVersionObject{Name: "my-agent", Version: "1.0.0"},
-		nil,
-	)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "AZURE_AI_PROJECT_ENDPOINT is empty")
-}
-
 func TestProtocolPath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
https://github.com/Azure/azure-dev/issues/7988
This pull request adds support for using pre-built container images when deploying hosted agents, allowing users to skip Dockerfile builds and pushes if an image is specified in agent.yaml. The implementation prompts the user to choose between using the pre-built image or building a new one, and this decision is cached per deployment. 

* Added an `Image` field to the `ContainerAgent` struct, allowing users to specify a pre-built container image in agent.yaml. If set, this image is used for deployment instead of building from a Dockerfile.
* Updated the deployment logic to prompt the user when a pre-built image is present, caching the decision and skipping build/publish steps if the pre-built image is chosen.
* Implemented helper methods to manage user choice and image resolution from agent.yaml.

### Test
- Build it for me by dafault:
  <img width="1627" height="374" alt="image" src="https://github.com/user-attachments/assets/525b2bcf-a5f9-48d8-ab17-45a74972a138" />
- Deploying:
   <img width="2279" height="469" alt="image" src="https://github.com/user-attachments/assets/f273ed6e-b43a-470c-8e6f-7ac2a82f4d98" />
- Deploying (no prompt):
   <img width="2141" height="290" alt="image" src="https://github.com/user-attachments/assets/5bcec50a-7087-469c-8573-cb81ca64af3a" />

