### PR TITLE
Add validations for UAMI requirement

### DIFF
--- a/cli/azd/extensions/azure.ai.training/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/init.go
@@ -37,6 +37,10 @@ type FoundryProject struct {
 	ResourceGroupName string
 	AiAccountName     string
 	AiProjectName     string
+	// HasUAMI is true when the project has at least one user-assigned
+	// managed identity attached (identity.type contains "UserAssigned" and
+	// identity.userAssignedIdentities is non-empty).
+	HasUAMI bool
 }
 
 func newInitCommand(rootFlags rootFlagsDefinition) *cobra.Command {
@@ -106,11 +110,13 @@ func newInitCommand(rootFlags rootFlagsDefinition) *cobra.Command {
 					utils.EnvAzureLocation:       project.Location,
 					utils.EnvAzureAccountName:    project.AiAccountName,
 					utils.EnvAzureProjectName:    project.AiProjectName,
+					utils.EnvAzureHasUAMI:        utils.BoolEnv(project.HasUAMI),
 				}); err != nil {
 					return err
 				}
 
 				fmt.Printf("\n✓ Environment configured for project '%s'\n", projectName)
+				utils.WarnIfNoUAMI(projectName, project.HasUAMI)
 				return nil
 			}
 
@@ -165,11 +171,13 @@ func newInitCommand(rootFlags rootFlagsDefinition) *cobra.Command {
 				utils.EnvAzureLocation:       project.Location,
 				utils.EnvAzureAccountName:    project.AiAccountName,
 				utils.EnvAzureProjectName:    project.AiProjectName,
+				utils.EnvAzureHasUAMI:        utils.BoolEnv(project.HasUAMI),
 			}); err != nil {
 				return err
 			}
 
 			fmt.Printf("\n✓ Environment configured for project '%s'\n", projectName)
+			utils.WarnIfNoUAMI(projectName, project.HasUAMI)
 			return nil
 		},
 	}
@@ -237,6 +245,7 @@ func findProjectByEndpoint(
 		AiAccountName:     accountName,
 		AiProjectName:     projectName,
 		Location:          *projectResp.Location,
+		HasUAMI:           utils.ProjectHasUAMI(projectResp.Identity),
 	}, nil
 }
 

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/job_submit.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/job_submit.go
@@ -79,6 +79,12 @@ func newJobSubmitCommand() *cobra.Command {
 				return fmt.Errorf("failed to create azure credential: %w", err)
 			}
 
+			// Gate on User-Assigned Managed Identity. Use cached value when
+			// available; otherwise make a single ARM call to populate it.
+			if err := ensureUAMIBeforeSubmit(ctx, azdClient, envValues, credential); err != nil {
+				return err
+			}
+
 			endpoint := buildProjectEndpoint(accountName, projectName)
 			apiClient, err := client.NewClient(endpoint, credential)
 			if err != nil {

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/uami.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/uami.go
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"azure.ai.training/internal/utils"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+)
+
+// ensureUAMIBeforeSubmit gates 'job submit' on the project having a UAMI.
+//
+// Behavior:
+//   - If AZURE_AI_TRAINING_HAS_UAMI == "true" → allow.
+//   - If AZURE_AI_TRAINING_HAS_UAMI == "false" → block with error.
+//   - If unset → make one ARM call to resolve. On success, persist the
+//     value to the azd env and act on it. On any failure (auth, network,
+//     404 — e.g. project deleted), allow the submit to proceed and do
+//     not write anything to the env, so the next submit retries.
+func ensureUAMIBeforeSubmit(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	envValues map[string]string,
+	credential azcore.TokenCredential,
+) error {
+	projectName := envValues[utils.EnvAzureProjectName]
+
+	switch envValues[utils.EnvAzureHasUAMI] {
+	case "true":
+		return nil
+	case "false":
+		return fmt.Errorf("%s", utils.NoUAMIMessage(projectName))
+	}
+
+	// Unset → resolve lazily via ARM (single call).
+	subscriptionId := envValues[utils.EnvAzureSubscriptionID]
+	accountName := envValues[utils.EnvAzureAccountName]
+	if subscriptionId == "" || accountName == "" || projectName == "" {
+		// Insufficient context to make the ARM call; allow submit (the
+		// downstream call will fail with its own clearer error).
+		return nil
+	}
+
+	project, err := findProjectByEndpoint(ctx, subscriptionId, accountName, projectName, credential)
+	if err != nil {
+		// Soft-fail: don't block, don't persist. Next submit will retry.
+		return nil
+	}
+
+	// Persist the resolved value so subsequent submits use the cached value.
+	currentEnv, err := azdClient.Environment().GetCurrent(ctx, &azdext.EmptyRequest{})
+	if err == nil && currentEnv.Environment != nil {
+		_ = setEnvValues(ctx, azdClient, currentEnv.Environment.Name, map[string]string{
+			utils.EnvAzureHasUAMI: utils.BoolEnv(project.HasUAMI),
+		})
+	}
+
+	if !project.HasUAMI {
+		return fmt.Errorf("%s", utils.NoUAMIMessage(projectName))
+	}
+	return nil
+}

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/validation.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/validation.go
@@ -195,6 +195,7 @@ func overrideEnvWithFlags(
 		utils.EnvAzureLocation:       project.Location,
 		utils.EnvAzureAccountName:    project.AiAccountName,
 		utils.EnvAzureProjectName:    project.AiProjectName,
+		utils.EnvAzureHasUAMI:        utils.BoolEnv(project.HasUAMI),
 	}); err != nil {
 		return fmt.Errorf("failed to update azd environment %q: %w", envName, err)
 	}
@@ -206,6 +207,7 @@ func overrideEnvWithFlags(
 			"Run 'azd ai training init' to reconfigure interactively.\n",
 		envName,
 	)
+	utils.WarnIfNoUAMI(project.AiProjectName, project.HasUAMI)
 	return nil
 }
 

--- a/cli/azd/extensions/azure.ai.training/internal/utils/environment.go
+++ b/cli/azd/extensions/azure.ai.training/internal/utils/environment.go
@@ -17,6 +17,13 @@ const (
 	EnvAzureLocation       = "AZURE_LOCATION"
 	EnvAzureAccountName    = "AZURE_ACCOUNT_NAME"
 	EnvAzureProjectName    = "AZURE_PROJECT_NAME"
+	// EnvAzureHasUAMI caches whether the project has a User-Assigned Managed
+	// Identity assigned. Set to "true" or "false" by 'init' and the -e/-s
+	// override path; consumed by 'job submit' to gate execution. Empty means
+	// the value hasn't been determined yet (typically because the ARM call
+	// failed during init/override) and 'job submit' should attempt to
+	// resolve it lazily.
+	EnvAzureHasUAMI = "AZURE_AI_TRAINING_HAS_UAMI"
 )
 
 // GetEnvironmentValues retrieves Azure environment configuration from azd client.

--- a/cli/azd/extensions/azure.ai.training/internal/utils/uami.go
+++ b/cli/azd/extensions/azure.ai.training/internal/utils/uami.go
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices"
+	"github.com/fatih/color"
+)
+
+// ProjectHasUAMI reports whether the given project identity has a populated
+// User-Assigned Managed Identity. We require both:
+//   - identity.type contains "UserAssigned" (covers "UserAssigned" and
+//     combined values like "SystemAssigned, UserAssigned")
+//   - identity.userAssignedIdentities is non-empty
+//
+// System-assigned alone does not satisfy this check by design — Foundry
+// training submit currently requires a UAMI specifically.
+func ProjectHasUAMI(identity *armcognitiveservices.Identity) bool {
+	if identity == nil || identity.Type == nil {
+		return false
+	}
+	if !strings.Contains(strings.ToLower(string(*identity.Type)), "userassigned") {
+		return false
+	}
+	return len(identity.UserAssignedIdentities) > 0
+}
+
+// BoolEnv returns the canonical env-var representation for a bool.
+func BoolEnv(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// NoUAMIMessage returns the wording shown to the user when a project has no
+// User-Assigned Managed Identity. The same text is used as a warning during
+// init / -e / -s flows and as an error during 'job submit'.
+func NoUAMIMessage(projectName string) string {
+	return fmt.Sprintf(
+		"project %q has no User-Assigned Managed Identity. "+
+			"Without it, 'azd ai training job submit' operation will fail.",
+		projectName,
+	)
+}
+
+// WarnIfNoUAMI prints a yellow warning when the project is missing a UAMI.
+// No-op when hasUAMI is true.
+func WarnIfNoUAMI(projectName string, hasUAMI bool) {
+	if hasUAMI {
+		return
+	}
+	color.Yellow("Warning: " + NoUAMIMessage(projectName))
+}

--- a/cli/azd/extensions/azure.ai.training/internal/utils/uami_test.go
+++ b/cli/azd/extensions/azure.ai.training/internal/utils/uami_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices"
+)
+
+func TestProjectHasUAMI(t *testing.T) {
+	uami := map[string]*armcognitiveservices.UserAssignedIdentity{
+		"/subscriptions/x/resourceGroups/y/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi": {},
+	}
+
+	tests := []struct {
+		name     string
+		identity *armcognitiveservices.Identity
+		want     bool
+	}{
+		{
+			name:     "nil identity",
+			identity: nil,
+			want:     false,
+		},
+		{
+			name:     "nil type",
+			identity: &armcognitiveservices.Identity{Type: nil, UserAssignedIdentities: uami},
+			want:     false,
+		},
+		{
+			name: "SystemAssigned only",
+			identity: &armcognitiveservices.Identity{
+				Type: to.Ptr(armcognitiveservices.ResourceIdentityTypeSystemAssigned),
+			},
+			want: false,
+		},
+		{
+			name: "UserAssigned type but empty map",
+			identity: &armcognitiveservices.Identity{
+				Type:                   to.Ptr(armcognitiveservices.ResourceIdentityTypeUserAssigned),
+				UserAssignedIdentities: nil,
+			},
+			want: false,
+		},
+		{
+			name: "UserAssigned type with populated map",
+			identity: &armcognitiveservices.Identity{
+				Type:                   to.Ptr(armcognitiveservices.ResourceIdentityTypeUserAssigned),
+				UserAssignedIdentities: uami,
+			},
+			want: true,
+		},
+		{
+			name: "SystemAssigned, UserAssigned with populated map",
+			identity: &armcognitiveservices.Identity{
+				Type:                   to.Ptr(armcognitiveservices.ResourceIdentityTypeSystemAssignedUserAssigned),
+				UserAssignedIdentities: uami,
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive 'userassigned' substring",
+			identity: &armcognitiveservices.Identity{
+				Type:                   to.Ptr(armcognitiveservices.ResourceIdentityType("userassigned")),
+				UserAssignedIdentities: uami,
+			},
+			want: true,
+		},
+		{
+			name: "None type",
+			identity: &armcognitiveservices.Identity{
+				Type:                   to.Ptr(armcognitiveservices.ResourceIdentityTypeNone),
+				UserAssignedIdentities: uami,
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ProjectHasUAMI(tc.identity)
+			if got != tc.want {
+				t.Errorf("ProjectHasUAMI() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBoolEnv(t *testing.T) {
+	if BoolEnv(true) != "true" {
+		t.Errorf("BoolEnv(true) = %q, want %q", BoolEnv(true), "true")
+	}
+	if BoolEnv(false) != "false" {
+		t.Errorf("BoolEnv(false) = %q, want %q", BoolEnv(false), "false")
+	}
+}
+
+func TestNoUAMIMessage(t *testing.T) {
+	msg := NoUAMIMessage("my-project")
+
+	if !strings.Contains(msg, `"my-project"`) {
+		t.Errorf("expected message to quote project name, got: %s", msg)
+	}
+	if !strings.Contains(msg, "User-Assigned Managed Identity") {
+		t.Errorf("expected message to mention 'User-Assigned Managed Identity', got: %s", msg)
+	}
+	if !strings.Contains(msg, "azd ai training job submit") {
+		t.Errorf("expected message to mention the failing command, got: %s", msg)
+	}
+}


### PR DESCRIPTION
### Notes
- Foundry training jobs require a UAMI on the project for submit operation. This PR surfaces it early as a warning during init/override, and blocks submit upfront when we know the project lacks one.
- Env caching strategy: 
   - Caches result in `AZURE_AI_TRAINING_HAS_UAMI` to avoid an ARM call on every submit. 
   - Lazy-resolves when missing
   - Tolerates ARM failures (proceeds without blocking).

### Testing
- If UAMI is missing during init flow
 
<img width="2148" height="286" alt="image" src="https://github.com/user-attachments/assets/91bc8f2e-128f-4856-9e28-e4c55a4603a6" />

- If UAMI is missing during azd env override flow
<img width="2312" height="830" alt="image" src="https://github.com/user-attachments/assets/1af96420-704b-4019-86bb-cdb60b8c20a1" />

- If AZURE_AI_TRAINING_HAS_UAMI is not already set, Submit call makes a call to ARM API and set it
<img width="1745" height="860" alt="image" src="https://github.com/user-attachments/assets/795a5f95-c7ce-4b22-bc56-89e7266bdc5b" />

<img width="1066" height="251" alt="image" src="https://github.com/user-attachments/assets/6c072562-c770-4d65-aa2c-cbc519e020cd" />

- After setting AZURE_AI_TRAINING_HAS_UAMI as false, the Submit call fails upfront with right messaging
<img width="2119" height="124" alt="image" src="https://github.com/user-attachments/assets/a4d8347b-b3eb-42c9-b8ca-6af2dbbcfd6a" />
