### PR TITLE
Create unified `pullrequest` pipeline

### DIFF
--- a/eng/pipelines/build-notice.yml
+++ b/eng/pipelines/build-notice.yml
@@ -10,41 +10,8 @@ trigger:
   branches:
     include: [main]
 
-
-variables:
-  - template: /eng/pipelines/templates/variables/globals.yml
-  - name: EnableGoCliScan
-    value: true
-
-jobs:
-  - job: PoliCheck
-    pool:
-      name: azsdk-pool
-      demands: ImageOverride -equals windows-2022
-    timeoutInMinutes: 120
-    steps:
-      - template: /eng/common/pipelines/templates/steps/policheck.yml
-        parameters:
-          ExclusionDataBaseFileName: AzDevPoliCheckExclusion
-          PublishAnalysisLogs: false
-
-  - template: /eng/pipelines/templates/jobs/build-scan-cli.yml
-
-  - template: /eng/pipelines/templates/jobs/build-scan-vscode.yml
-
-  - job: GenerateNoticeTxt
-    pool:
-      name: azsdk-pool
-      demands: ImageOverride -equals ubuntu-22.04
-
-    steps:
-      - task: ComponentGovernanceComponentDetection@0
-
-      - task: notice@0
-        displayName: Generate NOTICE.txt file
-        inputs:
-          outputfile: $(Build.SourcesDirectory)/NOTICE.txt
-          outputformat: text
-
-      - publish: NOTICE.txt
-        artifact: notice
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+      - template: /eng/pipelines/templates/stages/notice-build-and-test.yml

--- a/eng/pipelines/templates/jobs/build-scan-cli.yml
+++ b/eng/pipelines/templates/jobs/build-scan-cli.yml
@@ -37,6 +37,12 @@ jobs:
         CLI_VERSION: 1.0.0-alpha.1
         ${{ insert }}: ${{ build.value.Variables }}
 
+      templateContext:
+        outputs:
+          - output: pipelineArtifact
+            targetPath: cli/azd/$(BuildTarget)
+            artifactName: $(BuildTarget)
+
       steps:
         - checkout: self
         - template: /eng/pipelines/templates/steps/setup-go.yml
@@ -55,8 +61,5 @@ jobs:
         - pwsh: Move-Item $(BuildOutputName) $(BuildTarget)
           workingDirectory: cli/azd
           displayName: Rename binaries
-
-        - publish: cli/azd/$(BuildTarget)
-          artifact: $(BuildTarget)
 
         - task: ComponentGovernanceComponentDetection@0

--- a/eng/pipelines/templates/stages/azuredevops-build-and-test.yml
+++ b/eng/pipelines/templates/stages/azuredevops-build-and-test.yml
@@ -1,4 +1,13 @@
 parameters:
+  - name: StageName
+    type: string
+    default: BuildAndTest
+  - name: StageDependsOn
+    type: object
+    default: []
+  - name: StageCondition
+    type: string
+    default: ''
   - name: BuildMatrix
     type: object
     default:
@@ -28,7 +37,10 @@ parameters:
         Variables: {}
 
 stages:
-  - stage: BuildAndTest
+  - stage: ${{ parameters.StageName }}
+    dependsOn: ${{ parameters.StageDependsOn }}
+    ${{ if ne(parameters.StageCondition, '') }}:
+      condition: ${{ parameters.StageCondition }}
     variables: 
       - template: /eng/pipelines/templates/variables/globals.yml
       - template: /eng/pipelines/templates/variables/image.yml

--- a/eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+++ b/eng/pipelines/templates/stages/build-and-test-azd-extension.yml
@@ -1,4 +1,13 @@
 parameters:
+  - name: StageName
+    type: string
+    default: BuildAndTest
+  - name: StageDependsOn
+    type: object
+    default: []
+  - name: StageCondition
+    type: string
+    default: ''
   - name: BuildMatrix
     type: object
   - name: AzdExtensionId
@@ -66,7 +75,10 @@ parameters:
           GOOS: windows
           GOARCH: arm64
 stages:
-  - stage: BuildAndTest
+  - stage: ${{ parameters.StageName }}
+    dependsOn: ${{ parameters.StageDependsOn }}
+    ${{ if ne(parameters.StageCondition, '') }}:
+      condition: ${{ parameters.StageCondition }}
     variables:
       - template: /eng/pipelines/templates/variables/globals.yml
       - template: /eng/pipelines/templates/variables/image.yml

--- a/eng/pipelines/templates/stages/build-and-test.yml
+++ b/eng/pipelines/templates/stages/build-and-test.yml
@@ -1,4 +1,13 @@
 parameters: 
+  - name: StageName
+    type: string
+    default: BuildAndTest
+  - name: StageDependsOn
+    type: object
+    default: []
+  - name: StageCondition
+    type: string
+    default: ''
   - name: AzureRecordMode
     type: string
     default: playback
@@ -61,7 +70,10 @@ parameters:
           GOARCH: arm64
 
 stages: 
-  - stage: BuildAndTest
+  - stage: ${{ parameters.StageName }}
+    dependsOn: ${{ parameters.StageDependsOn }}
+    ${{ if ne(parameters.StageCondition, '') }}:
+      condition: ${{ parameters.StageCondition }}
     variables:
       - template: /eng/pipelines/templates/variables/globals.yml
       - template: /eng/pipelines/templates/variables/image.yml

--- a/eng/pipelines/templates/stages/code-coverage-upload.yml
+++ b/eng/pipelines/templates/stages/code-coverage-upload.yml
@@ -14,10 +14,13 @@ parameters:
   - name: MaxTotalTestSeconds
     type: number
     default: 0
+  - name: DependsOnStage
+    type: string
+    default: BuildAndTest
 stages: 
 - stage: CodeCoverage_Upload
   condition: and(succeeded(), ne(variables['Skip.LiveTest'], 'true'))
-  dependsOn: BuildAndTest
+  dependsOn: ${{ parameters.DependsOnStage }}
 
   variables:
     - template: /eng/pipelines/templates/variables/globals.yml

--- a/eng/pipelines/templates/stages/notice-build-and-test.yml
+++ b/eng/pipelines/templates/stages/notice-build-and-test.yml
@@ -1,0 +1,53 @@
+parameters:
+  - name: StageName
+    type: string
+    default: Notice
+  - name: StageDependsOn
+    type: object
+    default: []
+  - name: StageCondition
+    type: string
+    default: ''
+
+stages:
+  - stage: ${{ parameters.StageName }}
+    dependsOn: ${{ parameters.StageDependsOn }}
+    ${{ if ne(parameters.StageCondition, '') }}:
+      condition: ${{ parameters.StageCondition }}
+    variables:
+      - template: /eng/pipelines/templates/variables/globals.yml
+      - name: EnableGoCliScan
+        value: true
+
+    jobs:
+      - job: PoliCheck
+        pool:
+          name: azsdk-pool
+          demands: ImageOverride -equals windows-2022
+        timeoutInMinutes: 120
+        steps:
+          - template: /eng/common/pipelines/templates/steps/policheck.yml
+            parameters:
+              ExclusionDataBaseFileName: AzDevPoliCheckExclusion
+              PublishAnalysisLogs: false
+
+      - template: /eng/pipelines/templates/jobs/build-scan-cli.yml
+
+      - template: /eng/pipelines/templates/jobs/build-scan-vscode.yml
+
+      - job: GenerateNoticeTxt
+        pool:
+          name: azsdk-pool
+          demands: ImageOverride -equals ubuntu-22.04
+
+        steps:
+          - task: ComponentGovernanceComponentDetection@0
+
+          - task: notice@0
+            displayName: Generate NOTICE.txt file
+            inputs:
+              outputfile: $(Build.SourcesDirectory)/NOTICE.txt
+              outputformat: text
+
+          - publish: NOTICE.txt
+            artifact: notice

--- a/eng/pipelines/templates/stages/notice-build-and-test.yml
+++ b/eng/pipelines/templates/stages/notice-build-and-test.yml
@@ -40,6 +40,12 @@ stages:
           name: azsdk-pool
           demands: ImageOverride -equals ubuntu-22.04
 
+        templateContext:
+          outputs:
+            - output: pipelineArtifact
+              targetPath: $(Build.SourcesDirectory)/NOTICE.txt
+              artifactName: notice
+
         steps:
           - task: ComponentGovernanceComponentDetection@0
 
@@ -48,6 +54,3 @@ stages:
             inputs:
               outputfile: $(Build.SourcesDirectory)/NOTICE.txt
               outputformat: text
-
-          - publish: NOTICE.txt
-            artifact: notice

--- a/eng/pipelines/templates/stages/release-azd-extension.yml
+++ b/eng/pipelines/templates/stages/release-azd-extension.yml
@@ -8,10 +8,22 @@ parameters:
   - name: SkipTests
     type: boolean
     default: false
+  - name: StageName
+    type: string
+    default: BuildAndTest
+  - name: StageDependsOn
+    type: object
+    default: []
+  - name: StageCondition
+    type: string
+    default: ''
 
 stages: 
   - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
     parameters:
+      StageName: ${{ parameters.StageName }}
+      StageDependsOn: ${{ parameters.StageDependsOn }}
+      StageCondition: ${{ parameters.StageCondition }}
       AzdExtensionId: ${{ parameters.AzdExtensionId }}
       AzdExtensionDirectory: ${{ parameters.AzdExtensionDirectory }}
       SkipTests: ${{ parameters.SkipTests }}

--- a/eng/pipelines/templates/stages/vscode-build-and-test.yml
+++ b/eng/pipelines/templates/stages/vscode-build-and-test.yml
@@ -1,4 +1,13 @@
 parameters:
+  - name: StageName
+    type: string
+    default: BuildAndTest
+  - name: StageDependsOn
+    type: object
+    default: []
+  - name: StageCondition
+    type: string
+    default: ''
   - name: BuildMatrix
     type: object
     default:
@@ -28,7 +37,10 @@ parameters:
         Variables: {}
 
 stages:
-  - stage: BuildAndTest
+  - stage: ${{ parameters.StageName }}
+    dependsOn: ${{ parameters.StageDependsOn }}
+    ${{ if ne(parameters.StageCondition, '') }}:
+      condition: ${{ parameters.StageCondition }}
     variables: 
       - template: /eng/pipelines/templates/variables/globals.yml
       - template: /eng/pipelines/templates/variables/image.yml

--- a/eng/pullrequest.yml
+++ b/eng/pullrequest.yml
@@ -35,14 +35,6 @@ extends:
               os: linux
             steps:
               - checkout: self
-                fetchDepth: 1
-
-              - pwsh: |
-                  # Shallow-fetch the target branch so get-changedfiles.ps1 can diff against it
-                  $targetBranch = "$(System.PullRequest.TargetBranchName)"
-                  if (-not $targetBranch) { $targetBranch = "main" }
-                  git fetch --no-tags --depth=1 origin $targetBranch
-                displayName: Fetch target branch
 
               - pwsh: |
                   # Get changed files using the shared helper (uses ADO PR env vars automatically)

--- a/eng/pullrequest.yml
+++ b/eng/pullrequest.yml
@@ -26,6 +26,7 @@ extends:
       - stage: Detect
         variables:
           - template: /eng/pipelines/templates/variables/globals.yml
+          - template: /eng/pipelines/templates/variables/image.yml
         jobs:
           - job: DiffAnalysis
             pool:

--- a/eng/pullrequest.yml
+++ b/eng/pullrequest.yml
@@ -8,7 +8,7 @@ trigger: none
 
 pr:
   branches:
-    include: ['*']
+    include: ['pipelinev3*']
   paths:
     include:
       - cli/
@@ -37,23 +37,19 @@ extends:
                 fetchDepth: 1
 
               - pwsh: |
-                  # Fetch the target branch for diffing
+                  # Shallow-fetch the target branch so get-changedfiles.ps1 can diff against it
                   $targetBranch = "$(System.PullRequest.TargetBranchName)"
-                  if (-not $targetBranch) {
-                    $targetBranch = "main"
-                  }
+                  if (-not $targetBranch) { $targetBranch = "main" }
                   git fetch --no-tags --depth=1 origin $targetBranch
+                displayName: Fetch target branch
 
-                  # Get changed files using three-dot diff (same as GitHub PR diff)
-                  $sourceCommit = "$(Build.SourceVersion)"
-                  $changedFiles = git -c core.quotepath=off diff --name-only "origin/$targetBranch...$sourceCommit"
+              - pwsh: |
+                  # Get changed files using the shared helper (uses ADO PR env vars automatically)
+                  $changedFiles = & "$(Build.SourcesDirectory)/eng/common/scripts/get-changedfiles.ps1"
 
                   if (-not $changedFiles) {
                     Write-Host "No changed files detected."
                     $changedFiles = @()
-                  } else {
-                    Write-Host "Changed files:"
-                    $changedFiles | ForEach-Object { Write-Host "  $_" }
                   }
 
                   # ---- Helper: test if any changed file matches a set of path prefixes ----

--- a/eng/pullrequest.yml
+++ b/eng/pullrequest.yml
@@ -37,10 +37,15 @@ extends:
               - checkout: self
 
               - pwsh: |
+                  # ADO checkout doesn't configure remote tracking refspecs, so a
+                  # plain "git fetch origin <branch>" writes to FETCH_HEAD instead
+                  # of creating origin/<branch>.  Use an explicit refspec so that
+                  # get-changedfiles.ps1 can resolve "origin/<branch>" in its
+                  # three-dot diff.
                   $targetBranch = "$(System.PullRequest.TargetBranchName)"
                   if (-not $targetBranch) { $targetBranch = "main" }
                   Write-Host "Fetching target branch ref: $targetBranch"
-                  git fetch --no-tags origin $targetBranch
+                  git fetch --no-tags origin "+refs/heads/${targetBranch}:refs/remotes/origin/${targetBranch}"
                 displayName: Fetch target branch
 
               - pwsh: |

--- a/eng/pullrequest.yml
+++ b/eng/pullrequest.yml
@@ -35,6 +35,7 @@ extends:
               os: linux
             steps:
               - checkout: self
+                fetchDepth: 0
 
               - pwsh: |
                   # ADO checkout doesn't configure remote tracking refspecs, so a

--- a/eng/pullrequest.yml
+++ b/eng/pullrequest.yml
@@ -1,0 +1,430 @@
+# Consolidated PR validation pipeline for Azure/azure-dev.
+#
+# This pipeline replaces the individual PR triggers on the release pipelines.
+# A thin Detect stage calculates which legs to run based on the PR diff, then
+# each leg runs in parallel, gated by the corresponding output variable.
+
+trigger: none
+
+pr:
+  branches:
+    include: ['*']
+  paths:
+    include:
+      - cli/
+      - ext/
+      - eng/
+      - go.mod
+
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+      # ================================================================
+      # Stage: Detect — analyse the PR diff and set leg variables
+      # ================================================================
+      - stage: Detect
+        variables:
+          - template: /eng/pipelines/templates/variables/globals.yml
+        jobs:
+          - job: DiffAnalysis
+            pool:
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
+              os: linux
+            steps:
+              - checkout: self
+                fetchDepth: 1
+
+              - pwsh: |
+                  # Fetch the target branch for diffing
+                  $targetBranch = "$(System.PullRequest.TargetBranchName)"
+                  if (-not $targetBranch) {
+                    $targetBranch = "main"
+                  }
+                  git fetch --no-tags --depth=1 origin $targetBranch
+
+                  # Get changed files using three-dot diff (same as GitHub PR diff)
+                  $sourceCommit = "$(Build.SourceVersion)"
+                  $changedFiles = git -c core.quotepath=off diff --name-only "origin/$targetBranch...$sourceCommit"
+
+                  if (-not $changedFiles) {
+                    Write-Host "No changed files detected."
+                    $changedFiles = @()
+                  } else {
+                    Write-Host "Changed files:"
+                    $changedFiles | ForEach-Object { Write-Host "  $_" }
+                  }
+
+                  # ---- Helper: test if any changed file matches a set of path prefixes ----
+                  function Test-PathMatch {
+                    param(
+                      [string[]]$Files,
+                      [string[]]$IncludePrefixes,
+                      [string[]]$ExcludePrefixes = @()
+                    )
+                    foreach ($file in $Files) {
+                      $excluded = $false
+                      foreach ($ex in $ExcludePrefixes) {
+                        if ($file -like "$ex*") { $excluded = $true; break }
+                      }
+                      if ($excluded) { continue }
+
+                      foreach ($inc in $IncludePrefixes) {
+                        if ($file -like "$inc*") { return $true }
+                      }
+                    }
+                    return $false
+                  }
+
+                  # ---- Helper: test if any changed file matches an exact path ----
+                  function Test-ExactMatch {
+                    param([string[]]$Files, [string[]]$Paths)
+                    foreach ($file in $Files) {
+                      foreach ($p in $Paths) {
+                        if ($file -eq $p) { return $true }
+                      }
+                    }
+                    return $false
+                  }
+
+                  # ================================================================
+                  # Shared template changes that fan out to multiple legs
+                  # ================================================================
+                  $sharedExtTemplatePaths = @(
+                    "eng/pipelines/templates/stages/release-azd-extension.yml",
+                    "eng/pipelines/templates/stages/build-and-test-azd-extension.yml",
+                    "eng/pipelines/templates/jobs/build-azd-extension.yml",
+                    "eng/pipelines/templates/jobs/cross-build-azd-extension.yml"
+                  )
+                  $sharedAllPaths = @(
+                    "eng/pipelines/templates/steps/publish-cli.yml",
+                    "eng/pipelines/templates/variables/image.yml"
+                  )
+
+                  $sharedExtChanged = Test-ExactMatch -Files $changedFiles -Paths $sharedExtTemplatePaths
+                  $sharedAllChanged = Test-ExactMatch -Files $changedFiles -Paths $sharedAllPaths
+                  $goModChanged = Test-ExactMatch -Files $changedFiles -Paths @("go.mod")
+
+                  # ================================================================
+                  # CLI leg
+                  # ================================================================
+                  $cliSpecific = Test-PathMatch -Files $changedFiles `
+                    -IncludePrefixes @("cli/", "eng/pipelines/release-cli.yml", "eng/pipelines/templates/jobs/build-cli.yml", "eng/pipelines/templates/jobs/cross-build-cli.yml") `
+                    -ExcludePrefixes @("cli/azd/extensions/", "cli/azd/docs/", "cli/azd/.vscode/cspell", "cli/azd/AGENTS.md", "cli/azd/cmd/testdata/TestFigSpec.ts")
+                  $runCli = $cliSpecific -or $sharedAllChanged -or $goModChanged
+                  Write-Host "RunCli = $runCli"
+
+                  # ================================================================
+                  # Notice leg
+                  # ================================================================
+                  $runNotice = Test-ExactMatch -Files $changedFiles -Paths @("eng/pipelines/build-notice.yml")
+                  Write-Host "RunNotice = $runNotice"
+
+                  # ================================================================
+                  # VS Code extension leg
+                  # ================================================================
+                  $runVscode = Test-PathMatch -Files $changedFiles `
+                    -IncludePrefixes @("ext/vscode/", "eng/pipelines/release-vscode.yml")
+                  Write-Host "RunVscode = $runVscode"
+
+                  # ================================================================
+                  # Azure DevOps extension leg
+                  # ================================================================
+                  $runAzDevOps = Test-PathMatch -Files $changedFiles `
+                    -IncludePrefixes @("ext/azuredevops/", "eng/pipelines/release-azuredevops.yml")
+                  Write-Host "RunAzDevOps = $runAzDevOps"
+
+                  # ================================================================
+                  # Extension legs
+                  # ================================================================
+                  $extensions = @(
+                    @{ Var = "RunExt_AzureAiAgents";    Path = "cli/azd/extensions/azure.ai.agents/";         Yml = "eng/pipelines/release-ext-azure-ai-agents.yml";              GoMod = $true  },
+                    @{ Var = "RunExt_AzureAiFinetune";  Path = "cli/azd/extensions/azure.ai.finetune/";       Yml = "eng/pipelines/release-ext-azure-ai-finetune.yml";            GoMod = $true  },
+                    @{ Var = "RunExt_AzureAiModels";    Path = "cli/azd/extensions/azure.ai.models/";         Yml = "eng/pipelines/release-ext-azure-ai-models.yml";              GoMod = $true  },
+                    @{ Var = "RunExt_AzureAppservice";  Path = "cli/azd/extensions/azure.appservice/";        Yml = "eng/pipelines/release-ext-azure-appservice.yml";             GoMod = $true  },
+                    @{ Var = "RunExt_AzureCodingAgent"; Path = "cli/azd/extensions/azure.coding-agent/";      Yml = "eng/pipelines/release-ext-azure-coding-agent.yml";           GoMod = $false },
+                    @{ Var = "RunExt_MsAzdAiBuilder";   Path = "cli/azd/extensions/microsoft.azd.ai.builder/";Yml = "eng/pipelines/release-ext-microsoft-azd-ai-builder.yml";     GoMod = $true  },
+                    @{ Var = "RunExt_MsAzdConcurx";     Path = "cli/azd/extensions/microsoft.azd.concurx/";   Yml = "eng/pipelines/release-ext-microsoft-azd-concurx.yml";        GoMod = $false },
+                    @{ Var = "RunExt_MsAzdDemo";        Path = "cli/azd/extensions/microsoft.azd.demo/";      Yml = "eng/pipelines/release-ext-microsoft-azd-demo.yml";           GoMod = $true  },
+                    @{ Var = "RunExt_MsAzdExtensions";  Path = "cli/azd/extensions/microsoft.azd.extensions/";Yml = "eng/pipelines/release-ext-microsoft-azd-extensions.yml";     GoMod = $false }
+                  )
+
+                  foreach ($ext in $extensions) {
+                    $extSpecific = Test-PathMatch -Files $changedFiles `
+                      -IncludePrefixes @($ext.Path) `
+                      -ExcludePrefixes @("cli/azd/docs/")
+                    $extYml = Test-ExactMatch -Files $changedFiles -Paths @($ext.Yml)
+                    $extGoMod = $ext.GoMod -and $goModChanged
+
+                    $run = $extSpecific -or $extYml -or $sharedExtChanged -or $sharedAllChanged -or $extGoMod
+                    Write-Host "$($ext.Var) = $run"
+                    Write-Host "##vso[task.setvariable variable=$($ext.Var);isOutput=true]$run"
+                  }
+
+                  # Set core leg variables
+                  Write-Host "##vso[task.setvariable variable=RunCli;isOutput=true]$runCli"
+                  Write-Host "##vso[task.setvariable variable=RunNotice;isOutput=true]$runNotice"
+                  Write-Host "##vso[task.setvariable variable=RunVscode;isOutput=true]$runVscode"
+                  Write-Host "##vso[task.setvariable variable=RunAzDevOps;isOutput=true]$runAzDevOps"
+                name: diff
+                displayName: Analyze PR diff and set leg variables
+
+      # ================================================================
+      # Leg: CLI build + test (playback mode)
+      # ================================================================
+      - template: /eng/pipelines/templates/stages/build-and-test.yml
+        parameters:
+          StageName: CLI_BuildAndTest
+          StageDependsOn:
+            - Detect
+          StageCondition: >-
+            and(
+              not(canceled()),
+              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunCli'], 'True')
+            )
+          AzureRecordMode: playback
+          BuildMatrix:
+            Windows:
+              Pool: $(WINDOWSPOOL)
+              OSVmImage: $(WINDOWSVMIMAGE)
+              OS: windows
+              ImageKey: image
+              UploadArtifact: true
+              Variables:
+                BuildTarget: azd-windows-amd64.exe
+                BuildOutputName: azd.exe
+                BuildTestMsi: true
+                AZURE_DEV_CI_OS: win
+                Codeql.Enabled: true
+                Codeql.SkipTaskAutoInjection: false
+                Codeql.BuildIdentifier: cli_windows
+            Linux:
+              Pool: $(LINUXPOOL)
+              OSVmImage: $(LINUXVMIMAGE)
+              OS: linux
+              ImageKey: image
+              UploadArtifact: true
+              Variables:
+                BuildTarget: azd-linux-amd64
+                BuildOutputName: azd
+                SetExecutableBit: true
+                SetShieldInfo: true
+                BuildLinuxPackages: true
+                AZURE_DEV_CI_OS: lin
+                Codeql.Enabled: true
+                Codeql.SkipTaskAutoInjection: false
+                Codeql.BuildIdentifier: cli_linux
+                CGO_ENABLED: 0
+                DOCKER_TMPDIR: $(Agent.TempDirectory)
+                TMPDIR: $(Agent.TempDirectory)
+                NUGET_PACKAGES: $(Agent.TempDirectory)/nuget
+                GOCACHE: $(Agent.TempDirectory)/go-cache
+            Mac:
+              Pool: Azure Pipelines
+              OSVmImage: $(MACVMIMAGE)
+              OS: macOS
+              ImageKey: vmImage
+              UploadArtifact: true
+              Variables:
+                BuildTarget: azd-darwin-amd64
+                BuildOutputName: azd
+                MacLocalSign: false
+                SetExecutableBit: true
+                AZURE_DEV_CI_OS: mac
+
+      # CLI code coverage upload
+      - template: /eng/pipelines/templates/stages/code-coverage-upload.yml
+        parameters:
+          DependsOnStage: CLI_BuildAndTest
+          MinimumCoveragePercent: 65
+          DownloadArtifacts:
+            - cover-win
+            - cover-lin
+            - cover-mac
+
+      # ================================================================
+      # Leg: NOTICE generation
+      # ================================================================
+      - template: /eng/pipelines/templates/stages/notice-build-and-test.yml
+        parameters:
+          StageName: Notice_BuildAndTest
+          StageDependsOn:
+            - Detect
+          StageCondition: >-
+            and(
+              not(canceled()),
+              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunNotice'], 'True')
+            )
+
+      # ================================================================
+      # Leg: VS Code extension
+      # ================================================================
+      - template: /eng/pipelines/templates/stages/vscode-build-and-test.yml
+        parameters:
+          StageName: VSCode_BuildAndTest
+          StageDependsOn:
+            - Detect
+          StageCondition: >-
+            and(
+              not(canceled()),
+              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunVscode'], 'True')
+            )
+
+      # ================================================================
+      # Leg: Azure DevOps extension
+      # ================================================================
+      - template: /eng/pipelines/templates/stages/azuredevops-build-and-test.yml
+        parameters:
+          StageName: AzDevOps_BuildAndTest
+          StageDependsOn:
+            - Detect
+          StageCondition: >-
+            and(
+              not(canceled()),
+              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunAzDevOps'], 'True')
+            )
+
+      # ================================================================
+      # Leg: Extension — azure.ai.agents
+      # ================================================================
+      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+        parameters:
+          StageName: Ext_AzureAiAgents_BuildAndTest
+          StageDependsOn:
+            - Detect
+          StageCondition: >-
+            and(
+              not(canceled()),
+              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAiAgents'], 'True')
+            )
+          AzdExtensionId: azure.ai.agents
+          AzdExtensionDirectory: cli/azd/extensions/azure.ai.agents
+
+      # ================================================================
+      # Leg: Extension — azure.ai.finetune
+      # ================================================================
+      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+        parameters:
+          StageName: Ext_AzureAiFinetune_BuildAndTest
+          StageDependsOn:
+            - Detect
+          StageCondition: >-
+            and(
+              not(canceled()),
+              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAiFinetune'], 'True')
+            )
+          AzdExtensionId: azure.ai.finetune
+          AzdExtensionDirectory: cli/azd/extensions/azure.ai.finetune
+
+      # ================================================================
+      # Leg: Extension — azure.ai.models
+      # ================================================================
+      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+        parameters:
+          StageName: Ext_AzureAiModels_BuildAndTest
+          StageDependsOn:
+            - Detect
+          StageCondition: >-
+            and(
+              not(canceled()),
+              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAiModels'], 'True')
+            )
+          AzdExtensionId: azure.ai.models
+          AzdExtensionDirectory: cli/azd/extensions/azure.ai.models
+
+      # ================================================================
+      # Leg: Extension — azure.appservice
+      # ================================================================
+      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+        parameters:
+          StageName: Ext_AzureAppservice_BuildAndTest
+          StageDependsOn:
+            - Detect
+          StageCondition: >-
+            and(
+              not(canceled()),
+              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAppservice'], 'True')
+            )
+          AzdExtensionId: azure.appservice
+          AzdExtensionDirectory: cli/azd/extensions/azure.appservice
+
+      # ================================================================
+      # Leg: Extension — azure.coding-agent
+      # ================================================================
+      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+        parameters:
+          StageName: Ext_AzureCodingAgent_BuildAndTest
+          StageDependsOn:
+            - Detect
+          StageCondition: >-
+            and(
+              not(canceled()),
+              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureCodingAgent'], 'True')
+            )
+          AzdExtensionId: azure.coding-agent
+          AzdExtensionDirectory: cli/azd/extensions/azure.coding-agent
+
+      # ================================================================
+      # Leg: Extension — microsoft.azd.ai.builder
+      # ================================================================
+      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+        parameters:
+          StageName: Ext_MsAzdAiBuilder_BuildAndTest
+          StageDependsOn:
+            - Detect
+          StageCondition: >-
+            and(
+              not(canceled()),
+              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdAiBuilder'], 'True')
+            )
+          AzdExtensionId: microsoft.azd.ai.builder
+          AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.ai.builder
+
+      # ================================================================
+      # Leg: Extension — microsoft.azd.concurx
+      # ================================================================
+      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+        parameters:
+          StageName: Ext_MsAzdConcurx_BuildAndTest
+          StageDependsOn:
+            - Detect
+          StageCondition: >-
+            and(
+              not(canceled()),
+              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdConcurx'], 'True')
+            )
+          AzdExtensionId: microsoft.azd.concurx
+          AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.concurx
+
+      # ================================================================
+      # Leg: Extension — microsoft.azd.demo
+      # ================================================================
+      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+        parameters:
+          StageName: Ext_MsAzdDemo_BuildAndTest
+          StageDependsOn:
+            - Detect
+          StageCondition: >-
+            and(
+              not(canceled()),
+              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdDemo'], 'True')
+            )
+          AzdExtensionId: microsoft.azd.demo
+          AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.demo
+
+      # ================================================================
+      # Leg: Extension — microsoft.azd.extensions
+      # ================================================================
+      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+        parameters:
+          StageName: Ext_MsAzdExtensions_BuildAndTest
+          StageDependsOn:
+            - Detect
+          StageCondition: >-
+            and(
+              not(canceled()),
+              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdExtensions'], 'True')
+            )
+          AzdExtensionId: microsoft.azd.extensions
+          AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.extensions

--- a/eng/pullrequest.yml
+++ b/eng/pullrequest.yml
@@ -182,7 +182,7 @@ extends:
           StageName: CLI_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunCli'], 'true'))
+          StageCondition: and(not(canceled()), eq(dependencies.Detect.outputs['DiffAnalysis.diff.RunCli'], 'true'))
           AzureRecordMode: playback
           BuildMatrix:
             Windows:
@@ -251,7 +251,7 @@ extends:
           StageName: Notice_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunNotice'], 'true'))
+          StageCondition: and(not(canceled()), eq(dependencies.Detect.outputs['DiffAnalysis.diff.RunNotice'], 'true'))
 
       # ================================================================
       # Leg: VS Code extension
@@ -261,7 +261,7 @@ extends:
           StageName: VSCode_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunVscode'], 'true'))
+          StageCondition: and(not(canceled()), eq(dependencies.Detect.outputs['DiffAnalysis.diff.RunVscode'], 'true'))
 
       # ================================================================
       # Leg: Azure DevOps extension
@@ -271,7 +271,7 @@ extends:
           StageName: AzDevOps_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunAzDevOps'], 'true'))
+          StageCondition: and(not(canceled()), eq(dependencies.Detect.outputs['DiffAnalysis.diff.RunAzDevOps'], 'true'))
 
       # ================================================================
       # Leg: Extension — azure.ai.agents
@@ -281,7 +281,7 @@ extends:
           StageName: Ext_AzureAiAgents_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAiAgents'], 'true'))
+          StageCondition: and(not(canceled()), eq(dependencies.Detect.outputs['DiffAnalysis.diff.RunExt_AzureAiAgents'], 'true'))
           AzdExtensionId: azure.ai.agents
           SanitizedExtensionId: azure-ai-agents
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.agents
@@ -294,7 +294,7 @@ extends:
           StageName: Ext_AzureAiFinetune_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAiFinetune'], 'true'))
+          StageCondition: and(not(canceled()), eq(dependencies.Detect.outputs['DiffAnalysis.diff.RunExt_AzureAiFinetune'], 'true'))
           AzdExtensionId: azure.ai.finetune
           SanitizedExtensionId: azure-ai-finetune
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.finetune
@@ -307,7 +307,7 @@ extends:
           StageName: Ext_AzureAiModels_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAiModels'], 'true'))
+          StageCondition: and(not(canceled()), eq(dependencies.Detect.outputs['DiffAnalysis.diff.RunExt_AzureAiModels'], 'true'))
           AzdExtensionId: azure.ai.models
           SanitizedExtensionId: azure-ai-models
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.models
@@ -320,7 +320,7 @@ extends:
           StageName: Ext_AzureAppservice_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAppservice'], 'true'))
+          StageCondition: and(not(canceled()), eq(dependencies.Detect.outputs['DiffAnalysis.diff.RunExt_AzureAppservice'], 'true'))
           AzdExtensionId: azure.appservice
           SanitizedExtensionId: azure-appservice
           AzdExtensionDirectory: cli/azd/extensions/azure.appservice
@@ -333,7 +333,7 @@ extends:
           StageName: Ext_AzureCodingAgent_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureCodingAgent'], 'true'))
+          StageCondition: and(not(canceled()), eq(dependencies.Detect.outputs['DiffAnalysis.diff.RunExt_AzureCodingAgent'], 'true'))
           AzdExtensionId: azure.coding-agent
           SanitizedExtensionId: azure-coding-agent
           AzdExtensionDirectory: cli/azd/extensions/azure.coding-agent
@@ -346,7 +346,7 @@ extends:
           StageName: Ext_MsAzdAiBuilder_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdAiBuilder'], 'true'))
+          StageCondition: and(not(canceled()), eq(dependencies.Detect.outputs['DiffAnalysis.diff.RunExt_MsAzdAiBuilder'], 'true'))
           AzdExtensionId: microsoft.azd.ai.builder
           SanitizedExtensionId: microsoft-azd-ai-builder
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.ai.builder
@@ -359,7 +359,7 @@ extends:
           StageName: Ext_MsAzdConcurx_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdConcurx'], 'true'))
+          StageCondition: and(not(canceled()), eq(dependencies.Detect.outputs['DiffAnalysis.diff.RunExt_MsAzdConcurx'], 'true'))
           AzdExtensionId: microsoft.azd.concurx
           SanitizedExtensionId: microsoft-azd-concurx
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.concurx
@@ -372,7 +372,7 @@ extends:
           StageName: Ext_MsAzdDemo_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdDemo'], 'true'))
+          StageCondition: and(not(canceled()), eq(dependencies.Detect.outputs['DiffAnalysis.diff.RunExt_MsAzdDemo'], 'true'))
           AzdExtensionId: microsoft.azd.demo
           SanitizedExtensionId: microsoft-azd-demo
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.demo
@@ -385,7 +385,7 @@ extends:
           StageName: Ext_MsAzdExtensions_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdExtensions'], 'true'))
+          StageCondition: and(not(canceled()), eq(dependencies.Detect.outputs['DiffAnalysis.diff.RunExt_MsAzdExtensions'], 'true'))
           AzdExtensionId: microsoft.azd.extensions
           SanitizedExtensionId: microsoft-azd-extensions
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.extensions

--- a/eng/pullrequest.yml
+++ b/eng/pullrequest.yml
@@ -37,6 +37,13 @@ extends:
               - checkout: self
 
               - pwsh: |
+                  $targetBranch = "$(System.PullRequest.TargetBranchName)"
+                  if (-not $targetBranch) { $targetBranch = "main" }
+                  Write-Host "Fetching target branch ref: $targetBranch"
+                  git fetch --no-tags origin $targetBranch
+                displayName: Fetch target branch
+
+              - pwsh: |
                   # Get changed files using the shared helper (uses ADO PR env vars automatically)
                   $changedFiles = & "$(Build.SourcesDirectory)/eng/common/scripts/get-changedfiles.ps1"
 

--- a/eng/pullrequest.yml
+++ b/eng/pullrequest.yml
@@ -160,15 +160,17 @@ extends:
                     $extGoMod = $ext.GoMod -and $goModChanged
 
                     $run = $extSpecific -or $extYml -or $sharedExtChanged -or $sharedAllChanged -or $extGoMod
-                    Write-Host "$($ext.Var) = $run"
-                    Write-Host "##vso[task.setvariable variable=$($ext.Var);isOutput=true]$run"
+                    $runStr = if ($run) { "true" } else { "false" }
+                    Write-Host "$($ext.Var) = $runStr"
+                    Write-Host "##vso[task.setvariable variable=$($ext.Var);isOutput=true]$runStr"
                   }
 
                   # Set core leg variables
-                  Write-Host "##vso[task.setvariable variable=RunCli;isOutput=true]$runCli"
-                  Write-Host "##vso[task.setvariable variable=RunNotice;isOutput=true]$runNotice"
-                  Write-Host "##vso[task.setvariable variable=RunVscode;isOutput=true]$runVscode"
-                  Write-Host "##vso[task.setvariable variable=RunAzDevOps;isOutput=true]$runAzDevOps"
+                  function BoolStr($v) { if ($v) { "true" } else { "false" } }
+                  Write-Host "##vso[task.setvariable variable=RunCli;isOutput=true]$(BoolStr $runCli)"
+                  Write-Host "##vso[task.setvariable variable=RunNotice;isOutput=true]$(BoolStr $runNotice)"
+                  Write-Host "##vso[task.setvariable variable=RunVscode;isOutput=true]$(BoolStr $runVscode)"
+                  Write-Host "##vso[task.setvariable variable=RunAzDevOps;isOutput=true]$(BoolStr $runAzDevOps)"
                 name: diff
                 displayName: Analyze PR diff and set leg variables
 
@@ -180,11 +182,7 @@ extends:
           StageName: CLI_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: >-
-            and(
-              not(canceled()),
-              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunCli'], 'True')
-            )
+          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunCli'], 'true'))
           AzureRecordMode: playback
           BuildMatrix:
             Windows:
@@ -253,11 +251,7 @@ extends:
           StageName: Notice_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: >-
-            and(
-              not(canceled()),
-              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunNotice'], 'True')
-            )
+          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunNotice'], 'true'))
 
       # ================================================================
       # Leg: VS Code extension
@@ -267,11 +261,7 @@ extends:
           StageName: VSCode_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: >-
-            and(
-              not(canceled()),
-              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunVscode'], 'True')
-            )
+          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunVscode'], 'true'))
 
       # ================================================================
       # Leg: Azure DevOps extension
@@ -281,11 +271,7 @@ extends:
           StageName: AzDevOps_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: >-
-            and(
-              not(canceled()),
-              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunAzDevOps'], 'True')
-            )
+          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunAzDevOps'], 'true'))
 
       # ================================================================
       # Leg: Extension — azure.ai.agents
@@ -295,11 +281,7 @@ extends:
           StageName: Ext_AzureAiAgents_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: >-
-            and(
-              not(canceled()),
-              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAiAgents'], 'True')
-            )
+          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAiAgents'], 'true'))
           AzdExtensionId: azure.ai.agents
           SanitizedExtensionId: azure-ai-agents
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.agents
@@ -312,11 +294,7 @@ extends:
           StageName: Ext_AzureAiFinetune_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: >-
-            and(
-              not(canceled()),
-              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAiFinetune'], 'True')
-            )
+          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAiFinetune'], 'true'))
           AzdExtensionId: azure.ai.finetune
           SanitizedExtensionId: azure-ai-finetune
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.finetune
@@ -329,11 +307,7 @@ extends:
           StageName: Ext_AzureAiModels_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: >-
-            and(
-              not(canceled()),
-              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAiModels'], 'True')
-            )
+          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAiModels'], 'true'))
           AzdExtensionId: azure.ai.models
           SanitizedExtensionId: azure-ai-models
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.models
@@ -346,11 +320,7 @@ extends:
           StageName: Ext_AzureAppservice_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: >-
-            and(
-              not(canceled()),
-              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAppservice'], 'True')
-            )
+          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAppservice'], 'true'))
           AzdExtensionId: azure.appservice
           SanitizedExtensionId: azure-appservice
           AzdExtensionDirectory: cli/azd/extensions/azure.appservice
@@ -363,11 +333,7 @@ extends:
           StageName: Ext_AzureCodingAgent_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: >-
-            and(
-              not(canceled()),
-              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureCodingAgent'], 'True')
-            )
+          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureCodingAgent'], 'true'))
           AzdExtensionId: azure.coding-agent
           SanitizedExtensionId: azure-coding-agent
           AzdExtensionDirectory: cli/azd/extensions/azure.coding-agent
@@ -380,11 +346,7 @@ extends:
           StageName: Ext_MsAzdAiBuilder_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: >-
-            and(
-              not(canceled()),
-              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdAiBuilder'], 'True')
-            )
+          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdAiBuilder'], 'true'))
           AzdExtensionId: microsoft.azd.ai.builder
           SanitizedExtensionId: microsoft-azd-ai-builder
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.ai.builder
@@ -397,11 +359,7 @@ extends:
           StageName: Ext_MsAzdConcurx_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: >-
-            and(
-              not(canceled()),
-              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdConcurx'], 'True')
-            )
+          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdConcurx'], 'true'))
           AzdExtensionId: microsoft.azd.concurx
           SanitizedExtensionId: microsoft-azd-concurx
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.concurx
@@ -414,11 +372,7 @@ extends:
           StageName: Ext_MsAzdDemo_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: >-
-            and(
-              not(canceled()),
-              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdDemo'], 'True')
-            )
+          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdDemo'], 'true'))
           AzdExtensionId: microsoft.azd.demo
           SanitizedExtensionId: microsoft-azd-demo
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.demo
@@ -431,11 +385,7 @@ extends:
           StageName: Ext_MsAzdExtensions_BuildAndTest
           StageDependsOn:
             - Detect
-          StageCondition: >-
-            and(
-              not(canceled()),
-              eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdExtensions'], 'True')
-            )
+          StageCondition: and(not(canceled()), eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdExtensions'], 'true'))
           AzdExtensionId: microsoft.azd.extensions
           SanitizedExtensionId: microsoft-azd-extensions
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.extensions

--- a/eng/pullrequest.yml
+++ b/eng/pullrequest.yml
@@ -284,7 +284,7 @@ extends:
       # ================================================================
       # Leg: Extension — azure.ai.agents
       # ================================================================
-      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+      - template: /eng/pipelines/templates/stages/release-azd-extension.yml
         parameters:
           StageName: Ext_AzureAiAgents_BuildAndTest
           StageDependsOn:
@@ -295,12 +295,13 @@ extends:
               eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAiAgents'], 'True')
             )
           AzdExtensionId: azure.ai.agents
+          SanitizedExtensionId: azure-ai-agents
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.agents
 
       # ================================================================
       # Leg: Extension — azure.ai.finetune
       # ================================================================
-      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+      - template: /eng/pipelines/templates/stages/release-azd-extension.yml
         parameters:
           StageName: Ext_AzureAiFinetune_BuildAndTest
           StageDependsOn:
@@ -311,12 +312,13 @@ extends:
               eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAiFinetune'], 'True')
             )
           AzdExtensionId: azure.ai.finetune
+          SanitizedExtensionId: azure-ai-finetune
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.finetune
 
       # ================================================================
       # Leg: Extension — azure.ai.models
       # ================================================================
-      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+      - template: /eng/pipelines/templates/stages/release-azd-extension.yml
         parameters:
           StageName: Ext_AzureAiModels_BuildAndTest
           StageDependsOn:
@@ -327,12 +329,13 @@ extends:
               eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAiModels'], 'True')
             )
           AzdExtensionId: azure.ai.models
+          SanitizedExtensionId: azure-ai-models
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.models
 
       # ================================================================
       # Leg: Extension — azure.appservice
       # ================================================================
-      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+      - template: /eng/pipelines/templates/stages/release-azd-extension.yml
         parameters:
           StageName: Ext_AzureAppservice_BuildAndTest
           StageDependsOn:
@@ -343,12 +346,13 @@ extends:
               eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureAppservice'], 'True')
             )
           AzdExtensionId: azure.appservice
+          SanitizedExtensionId: azure-appservice
           AzdExtensionDirectory: cli/azd/extensions/azure.appservice
 
       # ================================================================
       # Leg: Extension — azure.coding-agent
       # ================================================================
-      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+      - template: /eng/pipelines/templates/stages/release-azd-extension.yml
         parameters:
           StageName: Ext_AzureCodingAgent_BuildAndTest
           StageDependsOn:
@@ -359,12 +363,13 @@ extends:
               eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_AzureCodingAgent'], 'True')
             )
           AzdExtensionId: azure.coding-agent
+          SanitizedExtensionId: azure-coding-agent
           AzdExtensionDirectory: cli/azd/extensions/azure.coding-agent
 
       # ================================================================
       # Leg: Extension — microsoft.azd.ai.builder
       # ================================================================
-      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+      - template: /eng/pipelines/templates/stages/release-azd-extension.yml
         parameters:
           StageName: Ext_MsAzdAiBuilder_BuildAndTest
           StageDependsOn:
@@ -375,12 +380,13 @@ extends:
               eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdAiBuilder'], 'True')
             )
           AzdExtensionId: microsoft.azd.ai.builder
+          SanitizedExtensionId: microsoft-azd-ai-builder
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.ai.builder
 
       # ================================================================
       # Leg: Extension — microsoft.azd.concurx
       # ================================================================
-      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+      - template: /eng/pipelines/templates/stages/release-azd-extension.yml
         parameters:
           StageName: Ext_MsAzdConcurx_BuildAndTest
           StageDependsOn:
@@ -391,12 +397,13 @@ extends:
               eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdConcurx'], 'True')
             )
           AzdExtensionId: microsoft.azd.concurx
+          SanitizedExtensionId: microsoft-azd-concurx
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.concurx
 
       # ================================================================
       # Leg: Extension — microsoft.azd.demo
       # ================================================================
-      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+      - template: /eng/pipelines/templates/stages/release-azd-extension.yml
         parameters:
           StageName: Ext_MsAzdDemo_BuildAndTest
           StageDependsOn:
@@ -407,12 +414,13 @@ extends:
               eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdDemo'], 'True')
             )
           AzdExtensionId: microsoft.azd.demo
+          SanitizedExtensionId: microsoft-azd-demo
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.demo
 
       # ================================================================
       # Leg: Extension — microsoft.azd.extensions
       # ================================================================
-      - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
+      - template: /eng/pipelines/templates/stages/release-azd-extension.yml
         parameters:
           StageName: Ext_MsAzdExtensions_BuildAndTest
           StageDependsOn:
@@ -423,4 +431,5 @@ extends:
               eq(stageDependencies.Detect.DiffAnalysis.outputs['diff.RunExt_MsAzdExtensions'], 'True')
             )
           AzdExtensionId: microsoft.azd.extensions
+          SanitizedExtensionId: microsoft-azd-extensions
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.extensions


### PR DESCRIPTION
If we went with this, it would look like:

- Due to the limitation of `cli` which only has `livetests`, we need a single internal unified build that will account for the surface area
  - This will shift and contract, but still is based upon the existing build yaml. Less a rework and more a combination of the builds.
- ~~Need to account for the fact this this new pipeline isn't grandfathered into CFSClean~~
- Account for PR feedback / acceptance from existing team

This is related to Azure/azure-sdk-tools#15160