### PR TITLE
Update Bicep CLI to v0.43.8

### DIFF
--- a/.github/workflows/lint-bicep.yml
+++ b/.github/workflows/lint-bicep.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Upgrade bicep
         run: |
           which bicep
-          sudo curl -o $(which bicep) -L https://github.com/Azure/bicep/releases/download/v0.42.1/bicep-linux-x64
+          sudo curl -o $(which bicep) -L https://github.com/Azure/bicep/releases/download/v0.43.8/bicep-linux-x64
           sudo chmod +x $(which bicep)
       - name: Lint .bicep files
         run: $ErrorActionPreference='Continue'; eng/scripts/Test-BicepLint.ps1 -Verbose

--- a/cli/azd/pkg/tools/bicep/bicep.go
+++ b/cli/azd/pkg/tools/bicep/bicep.go
@@ -30,7 +30,7 @@ import (
 
 // Version is the minimum version of bicep that we require (and the one we fetch when we fetch bicep on behalf of a
 // user).
-var Version semver.Version = semver.MustParse("0.42.1")
+var Version semver.Version = semver.MustParse("0.43.8")
 
 // Cli is a wrapper around the bicep CLI.
 // The CLI automatically ensures bicep is installed before executing commands.


### PR DESCRIPTION
Updates the bundled Bicep CLI version from 0.42.1 to 0.43.8.

Fixes #8147

Release: https://github.com/Azure/bicep/releases/tag/v0.43.8

## Changes

- Bumped `Version` constant in `cli/azd/pkg/tools/bicep/bicep.go`
- Updated download URL in `.github/workflows/lint-bicep.yml`