### PR TITLE
doc: design spec for azd ai project context commands and endpoint resolution

### DIFF
--- a/cli/azd/docs/design/azure-ai-project-commands.md
+++ b/cli/azd/docs/design/azure-ai-project-commands.md
@@ -1,4 +1,4 @@
-<!-- cspell:ignore foundry -->
+<!-- cspell:ignore foundry huimiu exterrors -->
 
 # Design Spec: `azd ai project` Context Commands + Shared Endpoint Resolution
 

--- a/cli/azd/docs/design/azure-ai-project-commands.md
+++ b/cli/azd/docs/design/azure-ai-project-commands.md
@@ -1,0 +1,271 @@
+<!-- cspell:ignore foundry -->
+
+# Design Spec: `azd ai project` Context Commands + Shared Endpoint Resolution
+
+- Feature spec: `azd ai` Direct Commands (CLI Surface for Foundry)
+- Tracking issue: [Azure/azure-dev#8124](https://github.com/Azure/azure-dev/issues/8124)
+- Owner: @huimiu
+- Status: Draft
+
+## 1. Summary
+
+This spec covers the workspace-level project-context commands:
+
+- `azd ai project set <endpoint>` — persist an active Foundry project endpoint in azd global config.
+- `azd ai project unset` — clear the persisted endpoint.
+- `azd ai project show` — display the currently resolved endpoint and the source that provided it.
+
+It also defines the endpoint-resolution behavior these commands rely on.
+
+## 2. Scope and Non-Goals
+
+In scope:
+
+- The three `project` subcommands above.
+- The 5-level endpoint-resolution chain used by these commands.
+- Cross-cutting flags (`--output table|json`, `--no-prompt`, `--debug`, `-p` / `--project-endpoint`) on the new commands.
+
+Out of scope:
+
+- Any service-side calls. These commands are pure local state management against `~/.azd/config.json`.
+- A new top-level extension. The project commands live **inside the existing `azure.ai.agents` extension** for now, in clearly-separated files so they can be lifted into a future `azure.ai.project` extension without rewrite.
+
+## 3. Extension Placement
+
+The `project` subtree is added under the existing `azure.ai.agents` extension, in clearly-separated files so it can later be lifted into a dedicated extension without rewrite. No new module and no change to `registry.json`.
+
+> **Command surface note.** The existing agents extension registers its root as `agent`, so commands surface as `azd ai agent …`. The feature spec uses the unprefixed form `azd ai project …`. Because we are not creating a new extension yet, the v1 implementation will surface as **`azd ai agent project set | unset | show`**. The command names and config layout are chosen so a future move to `azd ai project …` is a registration-only change with no behavior diff. See Open Question 1.
+
+## 4. Endpoint Resolution
+
+### 4.1 Resolution Order
+
+The 5-level cascade (matches feature spec § "AZD Environment Scoping"):
+
+1. `-p` / `--project-endpoint` flag on the invoked command.
+2. Active azd env value (`AZURE_AI_PROJECT_ENDPOINT`) when inside an azd project.
+3. Global config: `extensions.ai-agents.context.endpoint` in `~/.azd/config.json`.
+4. Environment variable `FOUNDRY_PROJECT_ENDPOINT`.
+5. Structured error printed to stderr with an actionable suggestion (see §4.3).
+
+Only `FOUNDRY_PROJECT_ENDPOINT` is honored as a host env var — no aliases. `AZURE_AI_PROJECT_ENDPOINT` is read **only** from the azd env, not from the host environment, to avoid silent precedence ambiguity.
+
+> **Flag scope.** Level 1 (`-p` / `--project-endpoint`) applies to the new `project` subcommands and future resource commands (`connection`, `toolbox`, `skill`). It is **not** added to existing `agent` commands (`show`, `invoke`, `monitor`, `files`, `session`), which already have their own endpoint overrides (`--account-name` + `--project-name`, `--agent-endpoint`). The existing agent commands benefit from levels 2–5 via the widened `resolveAgentEndpoint` body. Note: `-p` as a short flag is already taken on `agent run` (`--port`) and `agent invoke` (`--protocol`), so the long form `--project-endpoint` is the stable cross-command flag name.
+
+### 4.2 Endpoint Validation
+
+All five sources go through the same validator:
+
+- Must parse as an absolute `https://` URL.
+- Hostname must end with the Foundry suffix `.services.ai.azure.com`.
+- Path is expected to look like `/api/projects/<proj>`. Absence is a warning, not a hard failure, to leave room for future host shapes.
+- Whitespace trimmed; trailing `/` stripped before persistence.
+
+`project set` runs the same validator before writing — invalid endpoints never reach config.
+
+### 4.3 Error Shape
+
+When nothing resolves, the resolver returns a structured validation error. Human-readable form:
+
+```text
+Error: No Foundry project endpoint resolved.
+
+Suggestion: Run `azd ai agent project set <endpoint>` to set one,
+            or pass `--project-endpoint <url>` on this command,
+            or set the FOUNDRY_PROJECT_ENDPOINT environment variable.
+```
+
+> The suggestion text uses the v1 surface form (`azd ai agent project set`). When the command moves to `azd ai project set` (see Open Question 1), update the suggestion accordingly.
+
+With `--output json`, the same information is emitted as a structured error envelope so coding agents can parse it.
+
+Implementation: the structured error uses `exterrors.Dependency` with a new code (e.g., `exterrors.CodeMissingProjectEndpoint`) so the azd host renders the message/suggestion/links consistently with other extension errors. Commands should **not** write a separate JSON error to stdout — the `exterrors` gRPC pipeline already handles JSON rendering when `--output json` is active.
+
+## 5. Config Store
+
+The persisted state lives in azd user config (`~/.azd/config.json`) under the prefix `extensions.ai-agents.context`:
+
+```jsonc
+{
+  "extensions": {
+    "ai-agents": {
+      "context": {
+        "endpoint": "https://my-project.services.ai.azure.com/api/projects/my-project",
+        "setAt": "2026-05-12T10:23:00Z",
+      },
+    },
+  },
+}
+```
+
+- `endpoint` — the normalized URL written by `project set`.
+- `setAt` — RFC3339 UTC timestamp, written for diagnostics. Surfaced only in `project show --output json`.
+
+`project unset` removes the `context` subtree but leaves other sibling keys under `extensions.ai-agents` untouched.
+
+## 6. Command Behavior
+
+### 6.1 `azd ai project set <endpoint>`
+
+Flags:
+
+| Flag          | Type                 | Default | Notes                                                              |
+| ------------- | -------------------- | ------- | ------------------------------------------------------------------ |
+| `<endpoint>`  | positional, required | —       | Validated per §4.2.                                                |
+| `--output`    | enum                 | `table` | `table` \| `json`.                                                 |
+| `--no-prompt` | bool                 | `false` | Currently no prompts; flag accepted for cross-cutting consistency. |
+| `--debug`     | bool                 | `false` | Inherits root persistent flag.                                     |
+
+Behavior:
+
+1. Validate the endpoint.
+2. Persist `endpoint` + `setAt` to global config.
+3. If invoked inside an azd project (an active azd environment exists), print a single-line warning to stderr:
+
+   ```text
+   warning: an active azd environment is present; its AZURE_AI_PROJECT_ENDPOINT takes precedence over global context.
+   ```
+
+   Informational, not an error. Suppressed when `--output json` and `--no-prompt` are both set.
+
+4. Confirmation:
+   - Table: `Project endpoint set: <endpoint>`
+   - JSON: `{ "endpoint": "...", "source": "global config (~/.azd/config.json)", "setAt": "..." }`
+
+Exit code `0` on success.
+
+### 6.2 `azd ai project unset`
+
+Flags: `--output`, `--no-prompt`, `--debug`.
+
+Behavior:
+
+1. If no context is currently set: print `No active project endpoint to clear.` and exit `0` (idempotent).
+2. Otherwise: clear the `context` subtree.
+3. Output:
+   - Table: `Project endpoint cleared.`
+   - JSON: `{ "cleared": true, "previousEndpoint": "..." }`
+
+### 6.3 `azd ai project show`
+
+Flags: `-p` / `--project-endpoint`, `--output`, `--no-prompt`, `--debug`.
+
+Behavior:
+
+1. Run the resolver, passing the flag value if present.
+2. If unresolved: return the `exterrors.Dependency` structured error (non-zero exit). The azd host renders the human text to stderr and, when `--output json` is active, the structured envelope to stdout.
+3. On success:
+   - Table (default):
+
+     ```text
+     Project endpoint:  https://my-project.services.ai.azure.com/api/projects/my-project
+     Source:            global config (~/.azd/config.json)
+     ```
+
+     When the source is the azd env, the source line includes the env name, e.g. `azd env (dev)`.
+
+   - JSON:
+
+     ```json
+     {
+       "endpoint": "https://...",
+       "source": "globalConfig",
+       "sourceDetail": "~/.azd/config.json",
+       "azdEnv": ""
+     }
+     ```
+
+### 6.4 Output Formatting
+
+- Default is `table` (human-readable). JSON is opt-in.
+- The JSON shapes above are part of the public contract and must not change without a deprecation.
+
+## 7. Test Plan
+
+Unit tests (no network):
+
+- Resolver: each level wins when higher levels are absent; each level overrides lower levels when both are present; invalid endpoint at any source surfaces a validation error rather than being silently dropped; URL normalization (trailing slash, whitespace).
+- Config store: round-trip read/write/clear; `unset` is idempotent; `unset` does not delete sibling keys.
+- Per command: table and JSON output snapshots; inside-azd-project warning is emitted exactly once and only when applicable; `show` source labeling for each possible source.
+
+E2E:
+
+- Smoke test that runs `project set` → `project show` → `project unset` → `project show` against the built extension and asserts exit codes plus stderr/stdout shape.
+
+## 8. Impact on Existing Commands
+
+Today, the agents extension already has a 2-level endpoint resolver (`resolveAgentEndpoint`): explicit `--account-name` + `--project-name` flags first, then the active azd env's `AZURE_AI_PROJECT_ENDPOINT`. This resolver is called by the existing commands:
+
+- `azd ai agent show`
+- `azd ai agent invoke`
+- `azd ai agent monitor`
+- `azd ai agent files`
+- `azd ai agent session`
+
+(Plus the deployment path `service_target_agent.go`, which reads `AZURE_AI_PROJECT_ENDPOINT` directly from the azd env and is **not** in scope for this change.)
+
+The proposal: route this existing resolver through the new 5-level chain. The `--account-name` / `--project-name` path is unchanged (still wins, still validated together), and the azd-env path is unchanged. The new behavior is purely additive at the tail of the cascade:
+
+| Scenario                                                                      | Before              | After                                       |
+| ----------------------------------------------------------------------------- | ------------------- | ------------------------------------------- |
+| `--account-name` + `--project-name` provided                                  | Used                | Used (unchanged)                            |
+| Only one of the two provided                                                  | Error               | Error (unchanged)                           |
+| Inside azd project, `AZURE_AI_PROJECT_ENDPOINT` set                           | Used                | Used (unchanged)                            |
+| Inside azd project, `AZURE_AI_PROJECT_ENDPOINT` unset, **`project set` done** | Error               | **Uses global config**                      |
+| Outside azd project, **`project set` done**                                   | Error               | **Uses global config**                      |
+| `FOUNDRY_PROJECT_ENDPOINT` set, nothing else                                  | Error               | **Uses env var**                            |
+| Nothing resolvable                                                            | Error (old message) | Error (new structured message + suggestion) |
+
+Implications:
+
+- **Back-compat is preserved**: every input combination that produced a valid endpoint today produces the same endpoint after the change.
+- **Error message changes** when nothing resolves. The old text ("Provide `--account-name` and `--project-name` flags, or run `azd init`...") is replaced by the structured error in §4.3, which is the right surface for both `agent` commands and the new `project` commands.
+- **`azd ai agent` commands now work in more situations than before** — specifically, when only global config or `FOUNDRY_PROJECT_ENDPOINT` is set. This is a strict expansion, not a regression. The practical impact varies by command:
+  - **`show`, `monitor`, `files`, `session`** — these call `resolveAgentServiceFromProject` *before* the endpoint resolver, which requires `azure.yaml` and a deployed agent. Widening the endpoint resolver alone does not make them standalone; they still fail without an azd project.
+  - **`run`** — requires `azure.yaml` for the service source directory and startup command. Still not standalone.
+  - **`invoke`** (without `--agent-endpoint`) — when a positional agent name is provided, `resolveAgentServiceFromProject` failure is best-effort (the name comes from the argument). After this change, `azd ai agent invoke my-agent "hi"` can succeed outside an azd project if global config or `FOUNDRY_PROJECT_ENDPOINT` resolves. This is an intentional expansion, consistent with the existing `--agent-endpoint` standalone path, and acceptable because the feature spec's "agent commands require an azd project" constraint applies to `run | eval | optimize` (which need `azure.yaml` for service config), not to one-shot invocations where the user supplies both agent name and endpoint.
+- **No call-site signature change required.** `resolveAgentEndpoint(ctx, accountName, projectName)` keeps its current signature. The new global-config and env-var levels are self-contained lookups added to the function body (reading `UserConfig` and `os.Getenv`), so callers do not need to pass additional parameters. `newAgentContext` is similarly unchanged. Existing tests in `show_test.go` continue to pass for the explicit-flag and partial-flag cases; new tests cover the additive levels.
+
+Out of scope for this change (called out so they aren't surprised later):
+
+- `service_target_agent.go` still reads `AZURE_AI_PROJECT_ENDPOINT` directly from the azd env at deploy time. Reconciling that with the broader cascade is a separate decision tied to the orchestrated (`azd up`) model.
+- No flag deprecations. `--account-name` / `--project-name` remain supported on the agent commands that accept them today.
+
+## 9. Migration / Back-Compat
+
+- No config-schema migration required: the `extensions.ai-agents.context` subtree is created on first `project set`. Absence is the v0 state.
+- The new resolution chain is additive — a user who never runs `project set` and has no `FOUNDRY_PROJECT_ENDPOINT` set behaves exactly as today.
+
+## 10. Telemetry
+
+One event per command, reusing the extension's existing telemetry surface:
+
+- `azd.ai.project.set` — properties: `hasAzdProject` (bool), `endpointHostHash` (sha256 of host).
+- `azd.ai.project.unset` — properties: `hadValue` (bool).
+- `azd.ai.project.show` — properties: `source` (enum string), `resolved` (bool).
+
+No PII; endpoints are hashed.
+
+## 11. Security Considerations
+
+- The endpoint URL is not a credential. No secret material is written to or read from this config path.
+- File permissions on `~/.azd/config.json` are managed by azd core; no change.
+- The validator rejects non-`https` schemes and non-Foundry hostnames, preventing accidental persistence of arbitrary URLs.
+
+## 12. Open Questions
+
+| #   | Question                                                                                                                                                                                                                                                                      | Owner   |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| 1   | Surface form: `azd ai agent project …` (v1, no new extension) vs. `azd ai project …` (requires either a top-level passthrough in azd core or a new `azure.ai.project` extension). Decision affects only command-tree registration; everything else in this spec is invariant. | TBD     |
+| 2   | Should the inside-azd-project warning on `project set` be suppressible via a flag (e.g. `--quiet`) or always-on? Current proposal: always-on, auto-suppressed when `--output json` + `--no-prompt`.                                                                           | @huimiu |
+| 3   | Should `project show` also accept `-p` as an override (useful for "what would I resolve to if I passed this flag?"), or is that semantically odd? Current proposal: yes, accept it — keeps the resolver pure and aids debugging via coding agents.                            | @huimiu |
+
+## 13. Reference: Command Summary
+
+```bash
+azd ai [agent] project set <endpoint>     [--output table|json] [--no-prompt] [--debug]
+azd ai [agent] project unset              [--output table|json] [--no-prompt] [--debug]
+azd ai [agent] project show               [-p <url>] [--output table|json] [--no-prompt] [--debug]
+```
+
+Resolution cascade: `-p` flag → azd env (`AZURE_AI_PROJECT_ENDPOINT`) → `~/.azd/config.json` (`extensions.ai-agents.context.endpoint`) → `FOUNDRY_PROJECT_ENDPOINT` → structured error.

--- a/cli/azd/docs/design/azure-ai-project-commands.md
+++ b/cli/azd/docs/design/azure-ai-project-commands.md
@@ -17,7 +17,7 @@ It also defines the endpoint-resolution behavior these commands rely on.
 In scope:
 
 - The three `project` subcommands above.
-- The 5-level endpoint-resolution chain used by these commands.
+- The 5-level endpoint-resolution cascade used by these commands.
 - Cross-cutting flags (`--output table|json`, `--no-prompt`, `--debug`, `-p` / `--project-endpoint`) on the new commands.
 
 Out of scope:
@@ -27,7 +27,7 @@ Out of scope:
 
 ## 3. Extension Placement
 
-The `project` subtree is added under the existing `azure.ai.agents` extension, in clearly-separated files so it can later be lifted into a dedicated extension without rewrite. No new module and no change to `registry.json`.
+The `project` subtree is added under the existing `azure.ai.agents` extension. No new module and no change to `registry.json`.
 
 > **Command surface.** The existing agents extension registers its root as `agent`, so the `project` commands surface as **`azd ai agent project set | unset | show`**. The command names and config layout are chosen so a future move to a standalone `azd ai project …` extension is a registration-only change with no behavior diff.
 
@@ -69,8 +69,6 @@ Suggestion: Run `azd ai agent project set <endpoint>` to set one,
             or pass `--project-endpoint <url>` on this command,
             or set the FOUNDRY_PROJECT_ENDPOINT environment variable.
 ```
-
-
 
 With `--output json`, the same information is emitted as a structured error envelope so coding agents can parse it.
 
@@ -121,7 +119,7 @@ Behavior:
    warning: an active azd environment is present; its AZURE_AI_PROJECT_ENDPOINT takes precedence over global context.
    ```
 
-   Informational, not an error. Suppressed when `--output json` and `--no-prompt` are both set.
+   Informational, not an error. Suppressed when `--output json` or `--no-prompt` is set.
 
 4. Confirmation:
    - Table: `Project endpoint set: <endpoint>`
@@ -170,10 +168,7 @@ Behavior:
      }
      ```
 
-### 6.4 Output Formatting
-
-- Default is `table` (human-readable). JSON is opt-in.
-- The JSON shapes above are part of the public contract and must not change without a deprecation.
+> The JSON shapes above are part of the public contract and must not change without a deprecation.
 
 ## 7. Test Plan
 
@@ -196,8 +191,6 @@ Today, the agents extension already has a 2-level endpoint resolver (`resolveAge
 - `azd ai agent monitor`
 - `azd ai agent files`
 - `azd ai agent session`
-
-(Plus the deployment path `service_target_agent.go`, which reads `AZURE_AI_PROJECT_ENDPOINT` directly from the azd env and is **not** in scope for this change.)
 
 The proposal: route this existing resolver through the new 5-level chain. The `--account-name` / `--project-name` path is unchanged (still wins, still validated together), and the azd-env path is unchanged. The new behavior is purely additive at the tail of the cascade:
 
@@ -223,12 +216,7 @@ Out of scope for this change (called out so they aren't surprised later):
 - `service_target_agent.go` still reads `AZURE_AI_PROJECT_ENDPOINT` directly from the azd env at deploy time. Reconciling that with the broader cascade is a separate decision tied to the orchestrated (`azd up`) model.
 - No flag deprecations. `--account-name` / `--project-name` remain supported on the agent commands that accept them today.
 
-## 9. Migration / Back-Compat
-
-- No config-schema migration required: the `extensions.ai-agents.context` subtree is created on first `project set`. Absence is the v0 state.
-- The new resolution chain is additive — a user who never runs `project set` and has no `FOUNDRY_PROJECT_ENDPOINT` set behaves exactly as today.
-
-## 10. Telemetry
+## 9. Telemetry
 
 One event per command, reusing the extension's existing telemetry surface:
 
@@ -238,18 +226,18 @@ One event per command, reusing the extension's existing telemetry surface:
 
 No PII; endpoints are hashed.
 
-## 11. Security Considerations
+## 10. Security Considerations
 
 - The endpoint URL is not a credential. No secret material is written to or read from this config path.
 - File permissions on `~/.azd/config.json` are managed by azd core; no change.
 - The validator rejects non-`https` schemes and non-Foundry hostnames, preventing accidental persistence of arbitrary URLs.
 
-## 12. Open Questions
+## 11. Open Questions
 
 1. Should the inside-azd-project warning on `project set` be suppressible via a flag (e.g. `--quiet`) or always-on? Current proposal: always-on, auto-suppressed when `--output json` + `--no-prompt`.
 2. Should `project show` also accept `-p` as an override (useful for "what would I resolve to if I passed this flag?"), or is that semantically odd? Current proposal: yes, accept it — keeps the resolver pure and aids debugging via coding agents.
 
-## 13. Reference: Command Summary
+## 12. Reference: Command Summary
 
 ```bash
 azd ai agent project set <endpoint>     [--output table|json] [--no-prompt] [--debug]

--- a/cli/azd/docs/design/azure-ai-project-commands.md
+++ b/cli/azd/docs/design/azure-ai-project-commands.md
@@ -1,6 +1,6 @@
 <!-- cspell:ignore foundry huimiu exterrors -->
 
-# Design Spec: `azd ai project` Context Commands + Shared Endpoint Resolution
+# Design Spec: `azd ai agent project` Context Commands + Shared Endpoint Resolution
 
 - Feature spec: `azd ai` Direct Commands (CLI Surface for Foundry)
 - Tracking issue: [Azure/azure-dev#8124](https://github.com/Azure/azure-dev/issues/8124)
@@ -11,9 +11,9 @@
 
 This spec covers the workspace-level project-context commands:
 
-- `azd ai project set <endpoint>` — persist an active Foundry project endpoint in azd global config.
-- `azd ai project unset` — clear the persisted endpoint.
-- `azd ai project show` — display the currently resolved endpoint and the source that provided it.
+- `azd ai agent project set <endpoint>` — persist an active Foundry project endpoint in azd global config.
+- `azd ai agent project unset` — clear the persisted endpoint.
+- `azd ai agent project show` — display the currently resolved endpoint and the source that provided it.
 
 It also defines the endpoint-resolution behavior these commands rely on.
 
@@ -34,7 +34,7 @@ Out of scope:
 
 The `project` subtree is added under the existing `azure.ai.agents` extension, in clearly-separated files so it can later be lifted into a dedicated extension without rewrite. No new module and no change to `registry.json`.
 
-> **Command surface note.** The existing agents extension registers its root as `agent`, so commands surface as `azd ai agent …`. The feature spec uses the unprefixed form `azd ai project …`. Because we are not creating a new extension yet, the v1 implementation will surface as **`azd ai agent project set | unset | show`**. The command names and config layout are chosen so a future move to `azd ai project …` is a registration-only change with no behavior diff. See Open Question 1.
+> **Command surface.** The existing agents extension registers its root as `agent`, so the `project` commands surface as **`azd ai agent project set | unset | show`**. The command names and config layout are chosen so a future move to a standalone `azd ai project …` extension is a registration-only change with no behavior diff.
 
 ## 4. Endpoint Resolution
 
@@ -75,7 +75,7 @@ Suggestion: Run `azd ai agent project set <endpoint>` to set one,
             or set the FOUNDRY_PROJECT_ENDPOINT environment variable.
 ```
 
-> The suggestion text uses the v1 surface form (`azd ai agent project set`). When the command moves to `azd ai project set` (see Open Question 1), update the suggestion accordingly.
+
 
 With `--output json`, the same information is emitted as a structured error envelope so coding agents can parse it.
 
@@ -105,7 +105,7 @@ The persisted state lives in azd user config (`~/.azd/config.json`) under the pr
 
 ## 6. Command Behavior
 
-### 6.1 `azd ai project set <endpoint>`
+### 6.1 `azd ai agent project set <endpoint>`
 
 Flags:
 
@@ -134,7 +134,7 @@ Behavior:
 
 Exit code `0` on success.
 
-### 6.2 `azd ai project unset`
+### 6.2 `azd ai agent project unset`
 
 Flags: `--output`, `--no-prompt`, `--debug`.
 
@@ -146,7 +146,7 @@ Behavior:
    - Table: `Project endpoint cleared.`
    - JSON: `{ "cleared": true, "previousEndpoint": "..." }`
 
-### 6.3 `azd ai project show`
+### 6.3 `azd ai agent project show`
 
 Flags: `-p` / `--project-endpoint`, `--output`, `--no-prompt`, `--debug`.
 
@@ -256,16 +256,15 @@ No PII; endpoints are hashed.
 
 | #   | Question                                                                                                                                                                                                                                                                      | Owner   |
 | --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| 1   | Surface form: `azd ai agent project …` (v1, no new extension) vs. `azd ai project …` (requires either a top-level passthrough in azd core or a new `azure.ai.project` extension). Decision affects only command-tree registration; everything else in this spec is invariant. | TBD     |
-| 2   | Should the inside-azd-project warning on `project set` be suppressible via a flag (e.g. `--quiet`) or always-on? Current proposal: always-on, auto-suppressed when `--output json` + `--no-prompt`.                                                                           | @huimiu |
-| 3   | Should `project show` also accept `-p` as an override (useful for "what would I resolve to if I passed this flag?"), or is that semantically odd? Current proposal: yes, accept it — keeps the resolver pure and aids debugging via coding agents.                            | @huimiu |
+| 1   | Should the inside-azd-project warning on `project set` be suppressible via a flag (e.g. `--quiet`) or always-on? Current proposal: always-on, auto-suppressed when `--output json` + `--no-prompt`.                                                                           | @huimiu |
+| 2   | Should `project show` also accept `-p` as an override (useful for "what would I resolve to if I passed this flag?"), or is that semantically odd? Current proposal: yes, accept it — keeps the resolver pure and aids debugging via coding agents.                            | @huimiu |
 
 ## 13. Reference: Command Summary
 
 ```bash
-azd ai [agent] project set <endpoint>     [--output table|json] [--no-prompt] [--debug]
-azd ai [agent] project unset              [--output table|json] [--no-prompt] [--debug]
-azd ai [agent] project show               [-p <url>] [--output table|json] [--no-prompt] [--debug]
+azd ai agent project set <endpoint>     [--output table|json] [--no-prompt] [--debug]
+azd ai agent project unset              [--output table|json] [--no-prompt] [--debug]
+azd ai agent project show               [-p <url>] [--output table|json] [--no-prompt] [--debug]
 ```
 
 Resolution cascade: `-p` flag → azd env (`AZURE_AI_PROJECT_ENDPOINT`) → `~/.azd/config.json` (`extensions.ai-agents.context.endpoint`) → `FOUNDRY_PROJECT_ENDPOINT` → structured error.

--- a/cli/azd/docs/design/azure-ai-project-commands.md
+++ b/cli/azd/docs/design/azure-ai-project-commands.md
@@ -45,14 +45,16 @@ The 5-level cascade (matches feature spec § "AZD Environment Scoping"):
 
 Only `FOUNDRY_PROJECT_ENDPOINT` is honored as a host env var — no aliases. `AZURE_AI_PROJECT_ENDPOINT` is read **only** from the azd env, not from the host environment, to avoid silent precedence ambiguity.
 
-> **Flag scope.** `--project-endpoint` (short: `-p`) is only available on the `project` subcommands. Existing `agent` commands keep their own endpoint flags (`--account-name` / `--project-name`, `--agent-endpoint`) and pick up levels 2–5 automatically. The short form `-p` is already taken on `agent run` and `agent invoke`, so `--project-endpoint` is the canonical name.
+> **Flag scope.** `--project-endpoint` (short: `-p`) is added only on the new `project` subcommands. Existing `agent` commands are **not** given a new `--project-endpoint` flag in this change; they keep the per-command overrides they have today (e.g. `--agent-endpoint` on `agent invoke`) and pick up levels 2–5 automatically through the widened resolver. The short form `-p` is already taken on `agent run` (`--port`) and `agent invoke` (`--protocol`), so `--project-endpoint` is the canonical long name.
+
+> **Implementation note.** `FOUNDRY_PROJECT_ENDPOINT` already appears in the agents extension (`run.go` bridges `AZURE_AI_PROJECT_ENDPOINT` → `FOUNDRY_PROJECT_ENDPOINT` for the launched local-agent process), but it is not yet documented as an azd-recognized environment variable. The implementation PR must add it to [`cli/azd/docs/environment-variables.md`](../environment-variables.md) per the AGENTS.md guideline for new env vars.
 
 ### 4.2 Endpoint Validation
 
 All five sources go through the same validator:
 
 - Must parse as an absolute `https://` URL.
-- Hostname must end with the Foundry suffix `.services.ai.azure.com`.
+- Hostname must end with the recognized Foundry suffix `.services.ai.azure.com` — the shape produced by the existing `buildAgentEndpoint` in `agent_context.go` and used everywhere else in the codebase (CHANGELOG, `models`/`finetune` extensions, `AZURE_AI_PROJECT_ENDPOINT` value). The accepted-suffix list is kept centralized so additional canonical Foundry hostnames can be added in one place if Foundry ever introduces a new official surface.
 - Path is expected to look like `/api/projects/<proj>`. Absence is a warning, not a hard failure, to leave room for future host shapes.
 - Whitespace trimmed; trailing `/` stripped before persistence.
 
@@ -60,15 +62,18 @@ All five sources go through the same validator:
 
 ### 4.3 Error Shape
 
-When nothing resolves, the resolver returns a structured validation error. Human-readable form:
+When nothing resolves, the resolver returns a structured validation error. The human-readable form uses a suggestion list that does not reference per-command flags, so it is valid whether the caller exposes `--project-endpoint` or not:
 
 ```text
 Error: No Foundry project endpoint resolved.
 
-Suggestion: Run `azd ai agent project set <endpoint>` to set one,
-            or pass `--project-endpoint <url>` on this command,
-            or set the FOUNDRY_PROJECT_ENDPOINT environment variable.
+Suggestion:
+  • Persist a workspace default with `azd ai agent project set <endpoint>`.
+  • Set `AZURE_AI_PROJECT_ENDPOINT` in the active azd environment.
+  • Export `FOUNDRY_PROJECT_ENDPOINT` in your shell.
 ```
+
+When the calling command exposes `--project-endpoint` (the `project` subcommands), an extra leading bullet — `Pass --project-endpoint <url> on this command.` — is prepended by the command, not by the resolver. Existing `agent` commands, which do not have that flag, never produce that line.
 
 With `--output json`, the same information is emitted as a structured error envelope so coding agents can parse it.
 
@@ -78,21 +83,21 @@ Implementation: the structured error uses `exterrors.Dependency` with a new code
 
 The persisted state lives in azd user config (`~/.azd/config.json`) under the prefix `extensions.ai-agents.context`:
 
-```jsonc
+```json
 {
   "extensions": {
     "ai-agents": {
       "context": {
         "endpoint": "https://my-project.services.ai.azure.com/api/projects/my-project",
-        "setAt": "2026-05-12T10:23:00Z",
-      },
-    },
-  },
+        "setAt": "2026-05-12T10:23:00Z"
+      }
+    }
+  }
 }
 ```
 
 - `endpoint` — the normalized URL written by `project set`.
-- `setAt` — RFC3339 UTC timestamp, written for diagnostics. Surfaced only in `project show --output json`.
+- `setAt` — RFC3339 UTC timestamp, written for diagnostics. Surfaced by `project show` in both table (as a `Set at:` line) and JSON output when the resolved source is the global config; see §6.3.
 
 `project unset` removes the `context` subtree but leaves other sibling keys under `extensions.ai-agents` untouched.
 
@@ -123,7 +128,9 @@ Behavior:
 
 4. Confirmation:
    - Table: `Project endpoint set: <endpoint>`
-   - JSON: `{ "endpoint": "...", "source": "global config (~/.azd/config.json)", "setAt": "..." }`
+   - JSON: `{ "endpoint": "...", "source": "globalConfig", "sourceDetail": "~/.azd/config.json", "setAt": "..." }`
+
+   The `source` / `sourceDetail` shape matches `project show` (see §6.3) so consumers can parse a single contract.
 
 Exit code `0` on success.
 
@@ -153,9 +160,10 @@ Behavior:
      ```text
      Project endpoint:  https://my-project.services.ai.azure.com/api/projects/my-project
      Source:            global config (~/.azd/config.json)
+     Set at:            2026-05-12T10:23:00Z
      ```
 
-     When the source is the azd env, the source line includes the env name, e.g. `azd env (dev)`.
+     When the source is the azd env, the source line includes the env name, e.g. `azd env (dev)`, and the `Set at` line is omitted (it is only meaningful for the global-config source).
 
    - JSON:
 
@@ -164,11 +172,14 @@ Behavior:
        "endpoint": "https://...",
        "source": "globalConfig",
        "sourceDetail": "~/.azd/config.json",
-       "azdEnv": ""
+       "azdEnv": "",
+       "setAt": "2026-05-12T10:23:00Z"
      }
      ```
 
 > The JSON shapes above are part of the public contract and must not change without a deprecation.
+
+> **Diagnosing stale context.** Because `project set` is workspace-global, a user who switches between projects can silently resolve to the wrong endpoint until they re-run `project set`. `project show` is the documented debugging tool for this scenario: it prints both the resolved endpoint and the source, and surfaces `setAt` in the table output as a staleness hint. A time-based warning threshold (e.g., 30 days) is intentionally not added in v1 to keep the resolver behavior deterministic; revisit if user feedback indicates it is needed.
 
 ## 7. Test Plan
 
@@ -184,19 +195,21 @@ E2E:
 
 ## 8. Impact on Existing Commands
 
-Today, the agents extension already has a 2-level endpoint resolver (`resolveAgentEndpoint`): explicit `--account-name` + `--project-name` flags first, then the active azd env's `AZURE_AI_PROJECT_ENDPOINT`. This resolver is called by the existing commands:
+Today, the agents extension already has a 2-level endpoint resolver (`resolveAgentEndpoint`): explicit `accountName` + `projectName` parameters first (passed in by callers — note these are **not** exposed as cobra flags on `agent` today; the only call sites pass `"", ""`), then the active azd env's `AZURE_AI_PROJECT_ENDPOINT`. This resolver is called by the existing commands:
 
-- `azd ai agent show`
+- `azd ai agent show` (via `newAgentContext`)
 - `azd ai agent invoke`
-- `azd ai agent monitor`
+- `azd ai agent monitor` (via `newAgentContext`)
 - `azd ai agent files`
-- `azd ai agent session`
+- `azd ai agent sessions`
 
-The proposal: route this existing resolver through the new 5-level chain. The `--account-name` / `--project-name` path is unchanged (still wins, still validated together), and the azd-env path is unchanged. The new behavior is purely additive at the tail of the cascade:
+`azd ai agent run` does not call `resolveAgentEndpoint`; it reads `AZURE_AI_PROJECT_ENDPOINT` from the active azd env and bridges it to `FOUNDRY_PROJECT_ENDPOINT` for the spawned local-agent process. It is therefore *not* affected by this change.
+
+The proposal: route this existing resolver through the new 5-level chain. The flag-parameter path is unchanged (still wins, still validated together), and the azd-env path is unchanged. The new behavior is purely additive at the tail of the cascade:
 
 | Scenario                                                                      | Before              | After                                       |
 | ----------------------------------------------------------------------------- | ------------------- | ------------------------------------------- |
-| `--account-name` + `--project-name` provided                                  | Used                | Used (unchanged)                            |
+| Explicit `accountName` + `projectName` parameters provided                    | Used                | Used (unchanged)                            |
 | Only one of the two provided                                                  | Error               | Error (unchanged)                           |
 | Inside azd project, `AZURE_AI_PROJECT_ENDPOINT` set                           | Used                | Used (unchanged)                            |
 | Inside azd project, `AZURE_AI_PROJECT_ENDPOINT` unset, **`project set` done** | Error               | **Uses global config**                      |
@@ -208,13 +221,13 @@ Key points:
 
 - **Back-compat preserved.** Every input combination that resolved before produces the same endpoint after the change.
 - **Error message updated.** The "nothing resolved" message now uses the structured error from §4.3 instead of the old text.
-- **Existing commands gain fallback sources.** `show`, `monitor`, `files`, `session`, and `run` still require `azure.yaml`, so global config / env var alone won't make them standalone. `invoke` with a positional agent name *can* now work outside an azd project — this is intentional and consistent with the existing `--agent-endpoint` path.
+- **Existing commands gain fallback sources.** `show`, `monitor`, `files`, and `sessions` still call `resolveAgentServiceFromProject` *before* the endpoint resolver, which requires `azure.yaml` and a deployed agent, so widening the endpoint resolver alone does not make them standalone. `invoke` with a positional agent name *can* now work outside an azd project — this is intentional and consistent with the existing `--agent-endpoint` path.
 - **No call-site changes.** `resolveAgentEndpoint` keeps its current signature; the new levels are internal lookups (`UserConfig`, `os.Getenv`).
 
 Out of scope for this change (called out so they aren't surprised later):
 
 - `service_target_agent.go` still reads `AZURE_AI_PROJECT_ENDPOINT` directly from the azd env at deploy time. Reconciling that with the broader cascade is a separate decision tied to the orchestrated (`azd up`) model.
-- No flag deprecations. `--account-name` / `--project-name` remain supported on the agent commands that accept them today.
+- No new cobra flags on existing `agent` commands. The `accountName` / `projectName` parameter path through `resolveAgentEndpoint` remains as-is for callers that already pass them.
 
 ## 9. Telemetry
 

--- a/cli/azd/docs/design/azure-ai-project-commands.md
+++ b/cli/azd/docs/design/azure-ai-project-commands.md
@@ -2,11 +2,6 @@
 
 # Design Spec: `azd ai agent project` Context Commands + Shared Endpoint Resolution
 
-- Feature spec: `azd ai` Direct Commands (CLI Surface for Foundry)
-- Tracking issue: [Azure/azure-dev#8124](https://github.com/Azure/azure-dev/issues/8124)
-- Owner: @huimiu
-- Status: Draft
-
 ## 1. Summary
 
 This spec covers the workspace-level project-context commands:
@@ -50,7 +45,7 @@ The 5-level cascade (matches feature spec § "AZD Environment Scoping"):
 
 Only `FOUNDRY_PROJECT_ENDPOINT` is honored as a host env var — no aliases. `AZURE_AI_PROJECT_ENDPOINT` is read **only** from the azd env, not from the host environment, to avoid silent precedence ambiguity.
 
-> **Flag scope.** Level 1 (`-p` / `--project-endpoint`) applies to the new `project` subcommands and future resource commands (`connection`, `toolbox`, `skill`). It is **not** added to existing `agent` commands (`show`, `invoke`, `monitor`, `files`, `session`), which already have their own endpoint overrides (`--account-name` + `--project-name`, `--agent-endpoint`). The existing agent commands benefit from levels 2–5 via the widened `resolveAgentEndpoint` body. Note: `-p` as a short flag is already taken on `agent run` (`--port`) and `agent invoke` (`--protocol`), so the long form `--project-endpoint` is the stable cross-command flag name.
+> **Flag scope.** `--project-endpoint` (short: `-p`) is only available on the `project` subcommands. Existing `agent` commands keep their own endpoint flags (`--account-name` / `--project-name`, `--agent-endpoint`) and pick up levels 2–5 automatically. The short form `-p` is already taken on `agent run` and `agent invoke`, so `--project-endpoint` is the canonical name.
 
 ### 4.2 Endpoint Validation
 
@@ -216,15 +211,12 @@ The proposal: route this existing resolver through the new 5-level chain. The `-
 | `FOUNDRY_PROJECT_ENDPOINT` set, nothing else                                  | Error               | **Uses env var**                            |
 | Nothing resolvable                                                            | Error (old message) | Error (new structured message + suggestion) |
 
-Implications:
+Key points:
 
-- **Back-compat is preserved**: every input combination that produced a valid endpoint today produces the same endpoint after the change.
-- **Error message changes** when nothing resolves. The old text ("Provide `--account-name` and `--project-name` flags, or run `azd init`...") is replaced by the structured error in §4.3, which is the right surface for both `agent` commands and the new `project` commands.
-- **`azd ai agent` commands now work in more situations than before** — specifically, when only global config or `FOUNDRY_PROJECT_ENDPOINT` is set. This is a strict expansion, not a regression. The practical impact varies by command:
-  - **`show`, `monitor`, `files`, `session`** — these call `resolveAgentServiceFromProject` *before* the endpoint resolver, which requires `azure.yaml` and a deployed agent. Widening the endpoint resolver alone does not make them standalone; they still fail without an azd project.
-  - **`run`** — requires `azure.yaml` for the service source directory and startup command. Still not standalone.
-  - **`invoke`** (without `--agent-endpoint`) — when a positional agent name is provided, `resolveAgentServiceFromProject` failure is best-effort (the name comes from the argument). After this change, `azd ai agent invoke my-agent "hi"` can succeed outside an azd project if global config or `FOUNDRY_PROJECT_ENDPOINT` resolves. This is an intentional expansion, consistent with the existing `--agent-endpoint` standalone path, and acceptable because the feature spec's "agent commands require an azd project" constraint applies to `run | eval | optimize` (which need `azure.yaml` for service config), not to one-shot invocations where the user supplies both agent name and endpoint.
-- **No call-site signature change required.** `resolveAgentEndpoint(ctx, accountName, projectName)` keeps its current signature. The new global-config and env-var levels are self-contained lookups added to the function body (reading `UserConfig` and `os.Getenv`), so callers do not need to pass additional parameters. `newAgentContext` is similarly unchanged. Existing tests in `show_test.go` continue to pass for the explicit-flag and partial-flag cases; new tests cover the additive levels.
+- **Back-compat preserved.** Every input combination that resolved before produces the same endpoint after the change.
+- **Error message updated.** The "nothing resolved" message now uses the structured error from §4.3 instead of the old text.
+- **Existing commands gain fallback sources.** `show`, `monitor`, `files`, `session`, and `run` still require `azure.yaml`, so global config / env var alone won't make them standalone. `invoke` with a positional agent name *can* now work outside an azd project — this is intentional and consistent with the existing `--agent-endpoint` path.
+- **No call-site changes.** `resolveAgentEndpoint` keeps its current signature; the new levels are internal lookups (`UserConfig`, `os.Getenv`).
 
 Out of scope for this change (called out so they aren't surprised later):
 
@@ -254,10 +246,8 @@ No PII; endpoints are hashed.
 
 ## 12. Open Questions
 
-| #   | Question                                                                                                                                                                                                                                                                      | Owner   |
-| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| 1   | Should the inside-azd-project warning on `project set` be suppressible via a flag (e.g. `--quiet`) or always-on? Current proposal: always-on, auto-suppressed when `--output json` + `--no-prompt`.                                                                           | @huimiu |
-| 2   | Should `project show` also accept `-p` as an override (useful for "what would I resolve to if I passed this flag?"), or is that semantically odd? Current proposal: yes, accept it — keeps the resolver pure and aids debugging via coding agents.                            | @huimiu |
+1. Should the inside-azd-project warning on `project set` be suppressible via a flag (e.g. `--quiet`) or always-on? Current proposal: always-on, auto-suppressed when `--output json` + `--no-prompt`.
+2. Should `project show` also accept `-p` as an override (useful for "what would I resolve to if I passed this flag?"), or is that semantically odd? Current proposal: yes, accept it — keeps the resolver pure and aids debugging via coding agents.
 
 ## 13. Reference: Command Summary
 


### PR DESCRIPTION
## Summary

This PR adds the design spec for the `azd ai project set | unset | show` commands and the shared 5-level endpoint resolution chain. This is for design review only and contains no implementation code.

### What's in this spec

- **Three new `project` subcommands** that manage a workspace-level Foundry project endpoint in azd global config (`~/.azd/config.json`):
  - `project set <endpoint>`: save an active Foundry project endpoint.
  - `project unset`: clear the saved endpoint.
  - `project show`: display the currently resolved endpoint and where it comes from.

- **5-level endpoint resolution cascade**:
  1. `-p` / `--project-endpoint` flag
  2. Active azd env value (`AZURE_AI_PROJECT_ENDPOINT`)
  3. Global config (`extensions.ai-agents.context.endpoint`)
  4. Environment variable `FOUNDRY_PROJECT_ENDPOINT`
  5. Structured error with actionable suggestion

- **Impact on existing `azd ai agent` commands**: The existing 2-level resolver (`resolveAgentEndpoint`) is expanded to use the new 5-level chain. This is purely additive, meaning every input that worked before still produces the same result. After this change, `agent` commands also work when only global config or `FOUNDRY_PROJECT_ENDPOINT` is set.

- **Extension placement**: The `project` subtree lives inside the existing `azure.ai.agents` extension in separate files, so it can be moved into a future `azure.ai.project` extension without rewrite.

### Key design decisions for review

1. **Surface form** (Open Question 1): `azd ai agent project ...` (v1, no new extension) vs. `azd ai project ...` (requires new extension or core passthrough).
2. **Endpoint validation**: Must be `https://`, hostname must end with `.services.ai.azure.com`, path shape triggers a warning but not a hard failure.
3. **Back-compat**: Existing commands, flags, and config paths are unchanged. Error messages are upgraded to structured errors with suggestions.
4. **No secrets**: The endpoint URL is not a credential, so no sensitive data is stored.

### Related

- Feature spec: `azd ai` Direct Commands (CLI Surface for Foundry)
- Tracking issue: [#8124](https://github.com/Azure/azure-dev/issues/8124)
