### PR TITLE
feat(agents): add .NET code deploy support (dotnet_8/9/10 runtimes)

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -572,10 +572,10 @@ func (a *InitAction) Run(ctx context.Context) error {
 		}
 
 		// Prompt for deploy mode (code vs container) for hosted agents.
-		// Code deploy is currently only supported for Python projects.
+		// Code deploy is supported for Python and .NET projects.
 		if _, ok := agentManifest.Template.(agent_yaml.ContainerAgent); ok {
-			isPython := isPythonProject(targetDir)
-			deployMode, err := promptDeployMode(ctx, a.azdClient, a.flags.noPrompt, isPython)
+			showCodeDeploy := isPythonProject(targetDir) || isDotnetProject(targetDir)
+			deployMode, err := promptDeployMode(ctx, a.azdClient, a.flags.noPrompt, showCodeDeploy)
 			if err != nil {
 				return fmt.Errorf("prompting for deploy mode: %w", err)
 			}
@@ -1631,6 +1631,12 @@ func (a *InitAction) addToProject(ctx context.Context, targetDir string, agentMa
 	if agentDef.Kind == agent_yaml.AgentKindHosted {
 		if a.isCodeDeploy {
 			serviceConfig.Language = "python"
+			// If the agent uses a dotnet runtime, set language to csharp
+			if ca, ok := agentManifest.Template.(agent_yaml.ContainerAgent); ok &&
+				ca.CodeConfiguration != nil &&
+				strings.HasPrefix(ca.CodeConfiguration.Runtime, "dotnet_") {
+				serviceConfig.Language = "csharp"
+			}
 		} else {
 			serviceConfig.Docker = &azdext.DockerProjectOptions{
 				RemoteBuild: true,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -1270,7 +1270,6 @@ func isPythonProject(dir string) bool {
 	return false
 }
 
-// isDotnetProject returns true if the directory contains a .csproj or .fsproj file.
 // isDotnetProject returns true if the directory contains a .csproj file.
 // NOTE: .fsproj (F#) is not yet supported by the packaging path (packageDotnetBundled/detectDefaultEntryPoint).
 func isDotnetProject(dir string) bool {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -470,12 +470,12 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 	agentKind := agent_yaml.AgentKindHosted
 
 	// Prompt user for deploy mode (container vs code)
-	// Code deploy is only available for Python projects
+	// Code deploy is available for Python and .NET projects
 	srcDir := a.flags.src
 	if srcDir == "" {
 		srcDir, _ = os.Getwd()
 	}
-	showCodeDeploy := isPythonProject(srcDir)
+	showCodeDeploy := isPythonProject(srcDir) || isDotnetProject(srcDir)
 	deployMode, err := promptDeployMode(ctx, a.azdClient, a.flags.noPrompt, showCodeDeploy)
 	if err != nil {
 		return nil, err
@@ -1106,21 +1106,47 @@ func promptCodeConfig(ctx context.Context, azdClient *azdext.AzdClient, srcDir s
 		srcDir = "."
 	}
 
-	// Prompt for runtime
-	runtimeChoices := []*azdext.SelectChoice{
-		{Label: "Python 3.11", Value: "python_3_11"},
-		{Label: "Python 3.12", Value: "python_3_12"},
-		{Label: "Python 3.13", Value: "python_3_13"},
-		{Label: ".NET 9", Value: "dotnet_9"},
-		{Label: ".NET 8", Value: "dotnet_8"},
-		{Label: ".NET 10", Value: "dotnet_10"},
+	// Prompt for runtime — filter choices based on detected project type
+	var runtimeChoices []*azdext.SelectChoice
+	isDotnet := isDotnetProject(srcDir)
+	isPython := isPythonProject(srcDir)
+
+	if isDotnet && !isPython {
+		runtimeChoices = []*azdext.SelectChoice{
+			{Label: ".NET 9", Value: "dotnet_9"},
+			{Label: ".NET 8", Value: "dotnet_8"},
+			{Label: ".NET 10", Value: "dotnet_10"},
+		}
+	} else if isPython && !isDotnet {
+		runtimeChoices = []*azdext.SelectChoice{
+			{Label: "Python 3.11", Value: "python_3_11"},
+			{Label: "Python 3.12", Value: "python_3_12"},
+			{Label: "Python 3.13", Value: "python_3_13"},
+		}
+	} else {
+		// Mixed or unknown — show all options
+		runtimeChoices = []*azdext.SelectChoice{
+			{Label: "Python 3.11", Value: "python_3_11"},
+			{Label: "Python 3.12", Value: "python_3_12"},
+			{Label: "Python 3.13", Value: "python_3_13"},
+			{Label: ".NET 9", Value: "dotnet_9"},
+			{Label: ".NET 8", Value: "dotnet_8"},
+			{Label: ".NET 10", Value: "dotnet_10"},
+		}
 	}
 
 	var runtime string
 	if noPrompt {
-		runtime = "python_3_12"
+		if isDotnet {
+			runtime = "dotnet_9"
+		} else {
+			runtime = "python_3_12"
+		}
 	} else {
-		defaultIdx := int32(1) // Python 3.12 is the default
+		defaultIdx := int32(0) // First item in the filtered list
+		if isPython && !isDotnet {
+			defaultIdx = 1 // Python 3.12
+		}
 		runtimeResp, err := azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
 			Options: &azdext.SelectOptions{
 				Message:       "Select the runtime for your agent",
@@ -1210,6 +1236,23 @@ func isPythonProject(dir string) bool {
 	}
 	for _, e := range entries {
 		if !e.IsDir() && strings.HasSuffix(e.Name(), ".py") {
+			return true
+		}
+	}
+	return false
+}
+
+// isDotnetProject returns true if the directory contains a .csproj or .fsproj file.
+func isDotnetProject(dir string) bool {
+	if dir == "" {
+		dir = "."
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && (strings.HasSuffix(e.Name(), ".csproj") || strings.HasSuffix(e.Name(), ".fsproj")) {
 			return true
 		}
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -860,6 +860,17 @@ func (a *InitFromCodeAction) addToProject(ctx context.Context, targetDir string,
 	language := "python"
 	if !isCodeDeploy {
 		language = "docker"
+	} else {
+		// Detect language from agent.yaml runtime
+		agentYamlPath2 := filepath.Join(a.projectConfig.Path, targetDir, "agent.yaml")
+		if data, err := os.ReadFile(agentYamlPath2); err == nil { //nolint:gosec // path from project config
+			var agentDef2 agent_yaml.ContainerAgent
+			if err := yaml.Unmarshal(data, &agentDef2); err == nil &&
+				agentDef2.CodeConfiguration != nil &&
+				strings.HasPrefix(agentDef2.CodeConfiguration.Runtime, "dotnet_") {
+				language = "csharp"
+			}
+		}
 	}
 
 	serviceConfig := &azdext.ServiceConfig{
@@ -899,7 +910,11 @@ func deriveStartupCommand(projectPath, targetDir string) string {
 	if data, err := os.ReadFile(agentYamlPath); err == nil { //nolint:gosec // path is constructed from project config
 		var agentDef agent_yaml.ContainerAgent
 		if err := yaml.Unmarshal(data, &agentDef); err == nil && agentDef.CodeConfiguration != nil {
-			return "python " + agentDef.CodeConfiguration.EntryPoint
+			cmdPrefix := "python"
+			if strings.HasPrefix(agentDef.CodeConfiguration.Runtime, "dotnet_") {
+				cmdPrefix = "dotnet"
+			}
+			return cmdPrefix + " " + agentDef.CodeConfiguration.EntryPoint
 		}
 	}
 	return "python main.py"
@@ -1062,6 +1077,28 @@ func promptDeployMode(ctx context.Context, azdClient *azdext.AzdClient, noPrompt
 	return deployModeChoices[*deployModeResp.Value].Value, nil
 }
 
+// detectDefaultEntryPoint returns a sensible default entry point based on the runtime and source directory.
+func detectDefaultEntryPoint(srcDir, runtime string) string {
+	if strings.HasPrefix(runtime, "dotnet_") {
+		// Look for .csproj file and derive DLL name
+		entries, err := os.ReadDir(srcDir)
+		if err == nil {
+			for _, e := range entries {
+				if !e.IsDir() && strings.HasSuffix(e.Name(), ".csproj") {
+					return strings.TrimSuffix(e.Name(), ".csproj") + ".dll"
+				}
+			}
+		}
+		return "App.dll"
+	}
+
+	// Python default
+	if _, err := os.Stat(filepath.Join(srcDir, "app.py")); err == nil {
+		return "app.py"
+	}
+	return "main.py"
+}
+
 // promptCodeConfig prompts for code deploy configuration (runtime, entry point,
 // dependency resolution). When noPrompt is true, defaults are used without prompting.
 func promptCodeConfig(ctx context.Context, azdClient *azdext.AzdClient, srcDir string, noPrompt bool) (*agent_yaml.CodeConfiguration, error) {
@@ -1074,6 +1111,9 @@ func promptCodeConfig(ctx context.Context, azdClient *azdext.AzdClient, srcDir s
 		{Label: "Python 3.11", Value: "python_3_11"},
 		{Label: "Python 3.12", Value: "python_3_12"},
 		{Label: "Python 3.13", Value: "python_3_13"},
+		{Label: ".NET 9", Value: "dotnet_9"},
+		{Label: ".NET 8", Value: "dotnet_8"},
+		{Label: ".NET 10", Value: "dotnet_10"},
 	}
 
 	var runtime string
@@ -1098,10 +1138,7 @@ func promptCodeConfig(ctx context.Context, azdClient *azdext.AzdClient, srcDir s
 	}
 
 	// Prompt for entry point
-	defaultEntryPoint := "main.py"
-	if _, statErr := os.Stat(filepath.Join(srcDir, "app.py")); statErr == nil {
-		defaultEntryPoint = "app.py"
-	}
+	defaultEntryPoint := detectDefaultEntryPoint(srcDir, runtime)
 
 	var entryPoint string
 	if noPrompt {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -862,12 +862,13 @@ func (a *InitFromCodeAction) addToProject(ctx context.Context, targetDir string,
 		language = "docker"
 	} else {
 		// Detect language from agent.yaml runtime
-		agentYamlPath2 := filepath.Join(a.projectConfig.Path, targetDir, "agent.yaml")
-		if data, err := os.ReadFile(agentYamlPath2); err == nil { //nolint:gosec // path from project config
-			var agentDef2 agent_yaml.ContainerAgent
-			if err := yaml.Unmarshal(data, &agentDef2); err == nil &&
-				agentDef2.CodeConfiguration != nil &&
-				strings.HasPrefix(agentDef2.CodeConfiguration.Runtime, "dotnet_") {
+		// Re-read agent.yaml to detect the language for azure.yaml service config
+		langDetectPath := filepath.Join(a.projectConfig.Path, targetDir, "agent.yaml")
+		if data, err := os.ReadFile(langDetectPath); err == nil { //nolint:gosec // path from project config
+			var langDef agent_yaml.ContainerAgent
+			if err := yaml.Unmarshal(data, &langDef); err == nil &&
+				langDef.CodeConfiguration != nil &&
+				strings.HasPrefix(langDef.CodeConfiguration.Runtime, "dotnet_") {
 				language = "csharp"
 			}
 		}
@@ -910,11 +911,7 @@ func deriveStartupCommand(projectPath, targetDir string) string {
 	if data, err := os.ReadFile(agentYamlPath); err == nil { //nolint:gosec // path is constructed from project config
 		var agentDef agent_yaml.ContainerAgent
 		if err := yaml.Unmarshal(data, &agentDef); err == nil && agentDef.CodeConfiguration != nil {
-			cmdPrefix := "python"
-			if strings.HasPrefix(agentDef.CodeConfiguration.Runtime, "dotnet_") {
-				cmdPrefix = "dotnet"
-			}
-			return cmdPrefix + " " + agentDef.CodeConfiguration.EntryPoint
+			return agent_yaml.RuntimeCmdPrefix(agentDef.CodeConfiguration.Runtime) + " " + agentDef.CodeConfiguration.EntryPoint
 		}
 	}
 	return "python main.py"
@@ -1078,14 +1075,23 @@ func promptDeployMode(ctx context.Context, azdClient *azdext.AzdClient, noPrompt
 }
 
 // detectDefaultEntryPoint returns a sensible default entry point based on the runtime and source directory.
+// TODO: reuse this logic in the `run` command (tracked as future work item).
 func detectDefaultEntryPoint(srcDir, runtime string) string {
 	if strings.HasPrefix(runtime, "dotnet_") {
-		// Look for .csproj file and derive DLL name
+		// Look for .csproj file and derive DLL name from <AssemblyName> or project filename
 		entries, err := os.ReadDir(srcDir)
 		if err == nil {
 			for _, e := range entries {
 				if !e.IsDir() && strings.HasSuffix(e.Name(), ".csproj") {
-					return strings.TrimSuffix(e.Name(), ".csproj") + ".dll"
+					dllName := strings.TrimSuffix(e.Name(), ".csproj") + ".dll"
+					// Try to parse <AssemblyName> from the csproj
+					csprojPath := filepath.Join(srcDir, e.Name())
+					if data, readErr := os.ReadFile(csprojPath); readErr == nil { //nolint:gosec // path from user project
+						if asmName := extractAssemblyName(string(data)); asmName != "" {
+							dllName = asmName + ".dll"
+						}
+					}
+					return dllName
 				}
 			}
 		}
@@ -1097,6 +1103,28 @@ func detectDefaultEntryPoint(srcDir, runtime string) string {
 		return "app.py"
 	}
 	return "main.py"
+}
+
+// extractAssemblyName parses the <AssemblyName> property from a .csproj file content.
+// Returns empty string if not found.
+func extractAssemblyName(csprojContent string) string {
+	const startTag = "<AssemblyName>"
+	const endTag = "</AssemblyName>"
+	start := strings.Index(csprojContent, startTag)
+	if start < 0 {
+		return ""
+	}
+	start += len(startTag)
+	end := strings.Index(csprojContent[start:], endTag)
+	if end < 0 {
+		return ""
+	}
+	name := strings.TrimSpace(csprojContent[start : start+end])
+	if name == "" || strings.ContainsAny(name, "$()") {
+		// Skip MSBuild property references like $(MSBuildProjectName)
+		return ""
+	}
+	return name
 }
 
 // promptCodeConfig prompts for code deploy configuration (runtime, entry point,
@@ -1137,10 +1165,10 @@ func promptCodeConfig(ctx context.Context, azdClient *azdext.AzdClient, srcDir s
 
 	var runtime string
 	if noPrompt {
-		if isDotnet {
+		if isDotnet && !isPython {
 			runtime = "dotnet_9"
 		} else {
-			runtime = "python_3_12"
+			runtime = "python_3_12" // default to python for backward compatibility (including mixed repos)
 		}
 	} else {
 		defaultIdx := int32(0) // First item in the filtered list
@@ -1243,6 +1271,8 @@ func isPythonProject(dir string) bool {
 }
 
 // isDotnetProject returns true if the directory contains a .csproj or .fsproj file.
+// isDotnetProject returns true if the directory contains a .csproj file.
+// NOTE: .fsproj (F#) is not yet supported by the packaging path (packageDotnetBundled/detectDefaultEntryPoint).
 func isDotnetProject(dir string) bool {
 	if dir == "" {
 		dir = "."
@@ -1252,7 +1282,7 @@ func isDotnetProject(dir string) bool {
 		return false
 	}
 	for _, e := range entries {
-		if !e.IsDir() && (strings.HasSuffix(e.Name(), ".csproj") || strings.HasSuffix(e.Name(), ".fsproj")) {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".csproj") {
 			return true
 		}
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go
@@ -817,3 +817,64 @@ func TestPromptProtocols_Interactive(t *testing.T) {
 		})
 	}
 }
+
+func TestDetectDefaultEntryPoint(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   []string
+		runtime string
+		want    string
+	}{
+		{
+			name:    "dotnet with csproj",
+			files:   []string{"MyAgent.csproj", "Program.cs"},
+			runtime: "dotnet_9",
+			want:    "MyAgent.dll",
+		},
+		{
+			name:    "dotnet_8 with csproj",
+			files:   []string{"EchoAgent.csproj", "Program.cs", "NuGet.config"},
+			runtime: "dotnet_8",
+			want:    "EchoAgent.dll",
+		},
+		{
+			name:    "dotnet_10 no csproj fallback",
+			files:   []string{"Program.cs"},
+			runtime: "dotnet_10",
+			want:    "App.dll",
+		},
+		{
+			name:    "python with app.py",
+			files:   []string{"app.py", "requirements.txt"},
+			runtime: "python_3_12",
+			want:    "app.py",
+		},
+		{
+			name:    "python without app.py",
+			files:   []string{"requirements.txt"},
+			runtime: "python_3_12",
+			want:    "main.py",
+		},
+		{
+			name:    "python with main.py",
+			files:   []string{"main.py", "requirements.txt"},
+			runtime: "python_3_11",
+			want:    "main.py",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, f := range tt.files {
+				if err := os.WriteFile(filepath.Join(dir, f), []byte(""), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got := detectDefaultEntryPoint(dir, tt.runtime)
+			if got != tt.want {
+				t.Errorf("detectDefaultEntryPoint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
@@ -357,7 +357,12 @@ func CreateHostedAgentAPIRequest(hostedAgent ContainerAgent, buildConfig *AgentB
 
 	// Code deploy path
 	if hostedAgent.CodeConfiguration != nil {
-		entryPoint := []string{"python", hostedAgent.CodeConfiguration.EntryPoint}
+		// Derive the command prefix from the runtime (e.g. "python" for python_3_12, "dotnet" for dotnet_9).
+		cmdPrefix := "python"
+		if strings.HasPrefix(hostedAgent.CodeConfiguration.Runtime, "dotnet_") {
+			cmdPrefix = "dotnet"
+		}
+		entryPoint := []string{cmdPrefix, hostedAgent.CodeConfiguration.EntryPoint}
 		depRes := ""
 		if hostedAgent.CodeConfiguration.DependencyResolution != nil {
 			depRes = *hostedAgent.CodeConfiguration.DependencyResolution

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
@@ -14,6 +14,15 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
+// RuntimeCmdPrefix returns the command prefix for a given runtime string.
+// For example, "python_3_12" -> "python", "dotnet_9" -> "dotnet".
+func RuntimeCmdPrefix(runtime string) string {
+	if strings.HasPrefix(runtime, "dotnet_") {
+		return "dotnet"
+	}
+	return "python"
+}
+
 // AgentBuildOption represents an option for building agent definitions
 type AgentBuildOption func(*AgentBuildConfig)
 
@@ -357,11 +366,7 @@ func CreateHostedAgentAPIRequest(hostedAgent ContainerAgent, buildConfig *AgentB
 
 	// Code deploy path
 	if hostedAgent.CodeConfiguration != nil {
-		// Derive the command prefix from the runtime (e.g. "python" for python_3_12, "dotnet" for dotnet_9).
-		cmdPrefix := "python"
-		if strings.HasPrefix(hostedAgent.CodeConfiguration.Runtime, "dotnet_") {
-			cmdPrefix = "dotnet"
-		}
+		cmdPrefix := RuntimeCmdPrefix(hostedAgent.CodeConfiguration.Runtime)
 		entryPoint := []string{cmdPrefix, hostedAgent.CodeConfiguration.EntryPoint}
 		depRes := ""
 		if hostedAgent.CodeConfiguration.DependencyResolution != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
@@ -1350,3 +1350,89 @@ func TestCreateHostedAgentAPIRequest_NoSkillsRejected(
 		t.Errorf("error = %q, want 'at least one skill'", err)
 	}
 }
+
+func TestCreateAgentAPIRequest_CodeDeploy_DotnetRuntime(t *testing.T) {
+	depRes := "remote_build"
+	agent := ContainerAgent{
+		AgentDefinition: AgentDefinition{
+			Name: "dotnet-agent",
+			Kind: AgentKindHosted,
+		},
+		Protocols: []ProtocolVersionRecord{
+			{Protocol: "responses", Version: "1.0.0"},
+		},
+		CodeConfiguration: &CodeConfiguration{
+			Runtime:              "dotnet_9",
+			EntryPoint:           "MyAgent.dll",
+			DependencyResolution: &depRes,
+		},
+	}
+
+	req, err := CreateAgentAPIRequestFromDefinition(agent)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	codeDef, ok := req.Definition.(agent_api.HostedAgentDefinition)
+	if !ok {
+		t.Fatalf("expected CodeBasedHostedAgentDefinition, got %T", req.Definition)
+	}
+
+	// Verify entry_point is ["dotnet", "MyAgent.dll"]
+	wantEntryPoint := []string{"dotnet", "MyAgent.dll"}
+	if len(codeDef.CodeConfiguration.EntryPoint) != 2 ||
+		codeDef.CodeConfiguration.EntryPoint[0] != wantEntryPoint[0] ||
+		codeDef.CodeConfiguration.EntryPoint[1] != wantEntryPoint[1] {
+		t.Errorf("EntryPoint = %v, want %v", codeDef.CodeConfiguration.EntryPoint, wantEntryPoint)
+	}
+
+	// Verify runtime is passed through
+	if codeDef.CodeConfiguration.Runtime != "dotnet_9" {
+		t.Errorf("Runtime = %q, want %q", codeDef.CodeConfiguration.Runtime, "dotnet_9")
+	}
+
+	// Verify dependency resolution
+	if codeDef.CodeConfiguration.DependencyResolution != "remote_build" {
+		t.Errorf("DependencyResolution = %q, want %q", codeDef.CodeConfiguration.DependencyResolution, "remote_build")
+	}
+}
+
+func TestCreateAgentAPIRequest_CodeDeploy_PythonRuntime(t *testing.T) {
+	depRes := "bundled"
+	agent := ContainerAgent{
+		AgentDefinition: AgentDefinition{
+			Name: "python-agent",
+			Kind: AgentKindHosted,
+		},
+		Protocols: []ProtocolVersionRecord{
+			{Protocol: "invocations", Version: "1.0.0"},
+		},
+		CodeConfiguration: &CodeConfiguration{
+			Runtime:              "python_3_12",
+			EntryPoint:           "main.py",
+			DependencyResolution: &depRes,
+		},
+	}
+
+	req, err := CreateAgentAPIRequestFromDefinition(agent)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	codeDef, ok := req.Definition.(agent_api.HostedAgentDefinition)
+	if !ok {
+		t.Fatalf("expected CodeBasedHostedAgentDefinition, got %T", req.Definition)
+	}
+
+	// Verify entry_point is ["python", "main.py"]
+	wantEntryPoint := []string{"python", "main.py"}
+	if len(codeDef.CodeConfiguration.EntryPoint) != 2 ||
+		codeDef.CodeConfiguration.EntryPoint[0] != wantEntryPoint[0] ||
+		codeDef.CodeConfiguration.EntryPoint[1] != wantEntryPoint[1] {
+		t.Errorf("EntryPoint = %v, want %v", codeDef.CodeConfiguration.EntryPoint, wantEntryPoint)
+	}
+
+	if codeDef.CodeConfiguration.Runtime != "python_3_12" {
+		t.Errorf("Runtime = %q, want %q", codeDef.CodeConfiguration.Runtime, "python_3_12")
+	}
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/config.go
@@ -18,6 +18,7 @@ const (
 )
 
 // CodeDeployRegions lists the regions that currently support code deploy (ZIP upload).
+// TODO: replace with dynamic region discovery API when available.
 var CodeDeployRegions = []string{"westus2", "canadacentral", "northcentralus"}
 
 // ResourceTier defines a preset CPU and memory allocation for container resources.

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1086,6 +1086,19 @@ func (p *AgentServiceTargetProvider) packageCodeDeploy(serviceConfig *azdext.Ser
 		return "", "", fmt.Errorf("failed to close temp file: %w", err)
 	}
 
+	// Enforce maximum ZIP size (250 MB)
+	const maxZipSize = 250 * 1024 * 1024
+	fi, err := os.Stat(tmpPath)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to stat ZIP file: %w", err)
+	}
+	if fi.Size() > maxZipSize {
+		return "", "", fmt.Errorf(
+			"code package too large: %d MB (max 250 MB). Reduce package size by excluding unnecessary files or using remote_build for dependency resolution",
+			fi.Size()/(1024*1024),
+		)
+	}
+
 	sha256Hex := hex.EncodeToString(hasher.Sum(nil))
 	success = true
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1133,7 +1133,7 @@ func (p *AgentServiceTargetProvider) packageDotnetBundled(srcDir string) (string
 
 	// Run dotnet publish targeting linux (hosted agents run on linux)
 	fmt.Fprintf(os.Stderr, "Running 'dotnet publish' for bundled packaging...\n")
-	cmd := exec.Command("dotnet", "publish", csprojPath,
+	cmd := exec.Command("dotnet", "publish", csprojPath, //nolint:gosec // csprojPath is derived from user's project directory
 		"-c", "Release",
 		"-r", "linux-x64",
 		"--self-contained", "false",

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -15,6 +15,7 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -948,6 +949,21 @@ func (p *AgentServiceTargetProvider) packageCodeDeploy(serviceConfig *azdext.Ser
 	// Source directory is the service's relative path
 	srcDir := filepath.Dir(p.agentDefinitionPath)
 
+	// Load agent.yaml to check runtime and dependency resolution for dotnet bundled mode
+	if data, err := os.ReadFile(p.agentDefinitionPath); err == nil { //nolint:gosec // path from internal state
+		var agentDef agent_yaml.ContainerAgent
+		if err := yaml.Unmarshal(data, &agentDef); err == nil && agentDef.CodeConfiguration != nil {
+			isDotnet := strings.HasPrefix(agentDef.CodeConfiguration.Runtime, "dotnet_")
+			isBundled := true // default is bundled
+			if agentDef.CodeConfiguration.DependencyResolution != nil {
+				isBundled = *agentDef.CodeConfiguration.DependencyResolution == "bundled"
+			}
+			if isDotnet && isBundled {
+				return p.packageDotnetBundled(srcDir)
+			}
+		}
+	}
+
 	// Exclusion patterns
 	excludeDirs := map[string]bool{
 		"__pycache__":   true,
@@ -958,10 +974,16 @@ func (p *AgentServiceTargetProvider) packageCodeDeploy(serviceConfig *azdext.Ser
 		".mypy_cache":   true,
 		".pytest_cache": true,
 		".azure":        true,
+		// .NET directories (for remote_build, exclude build artifacts)
+		"bin": true,
+		"obj": true,
+		".vs": true,
 	}
 	excludeExts := map[string]bool{
-		".pyc": true,
-		".pyo": true,
+		".pyc":  true,
+		".pyo":  true,
+		".user": true,
+		".suo":  true,
 	}
 	excludeFiles := map[string]bool{
 		".env": true,
@@ -1070,6 +1092,121 @@ func (p *AgentServiceTargetProvider) packageCodeDeploy(serviceConfig *azdext.Ser
 	return tmpPath, sha256Hex, nil
 }
 
+// packageDotnetBundled runs "dotnet publish" for the .NET project and creates a ZIP of the published output.
+func (p *AgentServiceTargetProvider) packageDotnetBundled(srcDir string) (string, string, error) {
+	// Find the .csproj file
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to read source directory: %w", err)
+	}
+
+	var csprojPath string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".csproj") {
+			csprojPath = filepath.Join(srcDir, e.Name())
+			break
+		}
+	}
+	if csprojPath == "" {
+		return "", "", fmt.Errorf("no .csproj file found in %s; required for dotnet bundled packaging", srcDir)
+	}
+
+	// Create temp directory for publish output
+	publishDir, err := os.MkdirTemp("", "azd-dotnet-publish-*")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create temp dir for dotnet publish: %w", err)
+	}
+	defer os.RemoveAll(publishDir)
+
+	// Run dotnet publish targeting linux (hosted agents run on linux)
+	fmt.Fprintf(os.Stderr, "Running 'dotnet publish' for bundled packaging...\n")
+	cmd := exec.Command("dotnet", "publish", csprojPath,
+		"-c", "Release",
+		"-r", "linux-x64",
+		"--self-contained", "false",
+		"-o", publishDir,
+	)
+	cmd.Dir = srcDir
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", "", fmt.Errorf("dotnet publish failed: %w", err)
+	}
+
+	// ZIP the publish output
+	tmpFile, err := os.CreateTemp("", "azd-code-deploy-*.zip")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create temp file for ZIP: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	success := false
+	defer func() {
+		if !success {
+			_ = tmpFile.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	hasher := sha256.New()
+	multiWriter := io.MultiWriter(tmpFile, hasher)
+	zipWriter := zip.NewWriter(multiWriter)
+
+	err = filepath.WalkDir(publishDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		relPath, relErr := filepath.Rel(publishDir, path)
+		if relErr != nil {
+			return relErr
+		}
+
+		if relPath == "." {
+			return nil
+		}
+
+		relPath = filepath.ToSlash(relPath)
+
+		if d.IsDir() {
+			return nil
+		}
+
+		fileData, readErr := os.ReadFile(path) //nolint:gosec // path from WalkDir within temp publish dir
+		if readErr != nil {
+			return fmt.Errorf("failed to read %s: %w", relPath, readErr)
+		}
+
+		w, createErr := zipWriter.Create(relPath)
+		if createErr != nil {
+			return fmt.Errorf("failed to create ZIP entry %s: %w", relPath, createErr)
+		}
+
+		if _, writeErr := w.Write(fileData); writeErr != nil {
+			return fmt.Errorf("failed to write ZIP entry %s: %w", relPath, writeErr)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return "", "", fmt.Errorf("failed to walk publish directory: %w", err)
+	}
+
+	if err := zipWriter.Close(); err != nil {
+		return "", "", fmt.Errorf("failed to close ZIP: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return "", "", fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	sha256Hex := hex.EncodeToString(hasher.Sum(nil))
+	success = true
+
+	return tmpPath, sha256Hex, nil
+}
+
 // deployHostedCodeAgent deploys a code-based hosted agent via multipart ZIP upload.
 func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 	ctx context.Context,
@@ -1133,7 +1270,11 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 
 	if agentDef.CodeConfiguration != nil {
 		fmt.Fprintf(os.Stderr, "Runtime: %s\n", agentDef.CodeConfiguration.Runtime)
-		fmt.Fprintf(os.Stderr, "Entry Point: [\"python\", \"%s\"]\n", agentDef.CodeConfiguration.EntryPoint)
+		cmdPrefix := "python"
+		if strings.HasPrefix(agentDef.CodeConfiguration.Runtime, "dotnet_") {
+			cmdPrefix = "dotnet"
+		}
+		fmt.Fprintf(os.Stderr, "Entry Point: [\"%s\", \"%s\"]\n", cmdPrefix, agentDef.CodeConfiguration.EntryPoint)
 		depRes := "remote_build"
 		if agentDef.CodeConfiguration.DependencyResolution != nil {
 			depRes = *agentDef.CodeConfiguration.DependencyResolution

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -955,7 +955,7 @@ func (p *AgentServiceTargetProvider) packageCodeDeploy(serviceConfig *azdext.Ser
 		var agentDef agent_yaml.ContainerAgent
 		if err := yaml.Unmarshal(data, &agentDef); err == nil && agentDef.CodeConfiguration != nil {
 			isDotnet := strings.HasPrefix(agentDef.CodeConfiguration.Runtime, "dotnet_")
-			isBundled := true // default is bundled
+			isBundled := false // default is remote_build (matches promptCodeConfig and deployHostedCodeAgent defaults)
 			if agentDef.CodeConfiguration.DependencyResolution != nil {
 				isBundled = *agentDef.CodeConfiguration.DependencyResolution == "bundled"
 			}
@@ -966,6 +966,7 @@ func (p *AgentServiceTargetProvider) packageCodeDeploy(serviceConfig *azdext.Ser
 	}
 
 	// Exclusion patterns
+	// TODO: support a .azdignore or similar ignore file for user-configurable exclusions.
 	excludeDirs := map[string]bool{
 		"__pycache__":   true,
 		".venv":         true,
@@ -1216,6 +1217,15 @@ func (p *AgentServiceTargetProvider) packageDotnetBundled(srcDir string) (string
 		return "", "", fmt.Errorf("failed to close temp file: %w", err)
 	}
 
+	// Enforce maximum ZIP size (250 MB) — same limit as packageCodeDeploy
+	const maxZipSizeBundled = 250 * 1024 * 1024
+	if fi, statErr := os.Stat(tmpPath); statErr == nil && fi.Size() > maxZipSizeBundled {
+		return "", "", fmt.Errorf(
+			"bundled package too large: %d MB (max 250 MB). Consider using remote_build for dependency resolution",
+			fi.Size()/(1024*1024),
+		)
+	}
+
 	sha256Hex := hex.EncodeToString(hasher.Sum(nil))
 	success = true
 
@@ -1285,10 +1295,7 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 
 	if agentDef.CodeConfiguration != nil {
 		fmt.Fprintf(os.Stderr, "Runtime: %s\n", agentDef.CodeConfiguration.Runtime)
-		cmdPrefix := "python"
-		if strings.HasPrefix(agentDef.CodeConfiguration.Runtime, "dotnet_") {
-			cmdPrefix = "dotnet"
-		}
+		cmdPrefix := agent_yaml.RuntimeCmdPrefix(agentDef.CodeConfiguration.Runtime)
 		fmt.Fprintf(os.Stderr, "Entry Point: [\"%s\", \"%s\"]\n", cmdPrefix, agentDef.CodeConfiguration.EntryPoint)
 		depRes := "remote_build"
 		if agentDef.CodeConfiguration.DependencyResolution != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -5,6 +5,7 @@ package project
 
 import (
 	"archive/zip"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
@@ -1140,10 +1141,11 @@ func (p *AgentServiceTargetProvider) packageDotnetBundled(srcDir string) (string
 		"-o", publishDir,
 	)
 	cmd.Dir = srcDir
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
+	var publishOutput bytes.Buffer
+	cmd.Stdout = io.MultiWriter(os.Stderr, &publishOutput)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &publishOutput)
 	if err := cmd.Run(); err != nil {
-		return "", "", fmt.Errorf("dotnet publish failed: %w", err)
+		return "", "", fmt.Errorf("dotnet publish failed: %w\nOutput:\n%s", err, publishOutput.String())
 	}
 
 	// ZIP the publish output


### PR DESCRIPTION
## Summary

Adds **.NET runtime support** (`dotnet_8`, `dotnet_9`, `dotnet_10`) to the code deploy (ZIP upload) path introduced in #8146. This enables deploying .NET agent source code directly via ZIP upload without requiring Docker/ACR, alongside the existing Python support.

---

## Init Flow Changes

### Deploy Mode Prompt

The code deploy option now appears for both Python **and** .NET projects (detected via `.csproj`/`.fsproj` files). For projects that are neither Python nor .NET, the code deploy option remains hidden.

#### Existing Code -> Code Deploy (.NET)
```
azd ai agent init           # non-empty dir with .csproj
-> "Use the code in the current directory"
-> Agent name
-> Deploy mode -> Source Code (ZIP upload)
-> Runtime -> .NET 9 / .NET 8 / .NET 10
-> Entry point -> HelloWorld.dll (auto-detected from .csproj)
-> Dependency resolution -> Remote build / Bundled
-> Protocols
-> Model -> Use existing model deployment(s)
-> Subscription -> select
-> Foundry Project -> select
-> Writes agent.yaml (with code_configuration, runtime: dotnet_9), azure.yaml (language: csharp, no docker block)
```

### Runtime Filtering

`promptCodeConfig()` now filters runtime choices based on detected project type:
- **.NET project only** (has `.csproj`/`.fsproj`, no `.py`/`requirements.txt`): Shows only .NET 9, .NET 8, .NET 10
- **Python project only** (has `.py`/`requirements.txt`, no `.csproj`): Shows only Python 3.11, 3.12, 3.13
- **Mixed or unknown**: Shows all 6 runtime options

### Language Detection in `azure.yaml`

Both init paths (template and from-code) correctly set `language: csharp` when a dotnet runtime is selected, fixing a bug where code deploy always hardcoded `language: python`.

---

## Deploy Path Changes

### Bundled Mode (`dependency_resolution: bundled`)

For .NET agents in bundled mode, `packageDotnetBundled()`:
1. Runs `dotnet publish -c Release -r linux-x64 --self-contained false -o <temp-dir>`
2. ZIPs the published output (ready-to-run binaries for Linux)
3. Uploads via the same multipart form-data POST used for Python

### Remote Build Mode (`dependency_resolution: remote_build`)

For .NET agents in remote build mode:
1. ZIPs source code (`.cs`, `.csproj` files etc.) excluding build artifacts
2. Server-side Oryx build handles `dotnet publish` on the remote environment

### Entry Point Prefix

.NET agents use `dotnet <entry_point>` as the startup command (e.g., `["dotnet", "HelloWorld.dll"]`), while Python uses `python <entry_point>`.

### 250 MB ZIP Size Limit

Enforced for all code deploy packages (both Python and .NET) with a clear error message.

---

## Files Modified

| File | Change |
|------|--------|
| `init_from_code.go` | Add `isDotnetProject()` helper, `detectDefaultEntryPoint()` for `.dll`/`.csproj`, filter runtime choices by project type, update `showCodeDeploy` to include .NET, fix `noPrompt` default for dotnet |
| `init_from_code_test.go` | Unit tests for `detectDefaultEntryPoint()` with dotnet scenarios |
| `init.go` | Fix `language: python` hardcoding bug -- now checks runtime prefix for `csharp`; update `showCodeDeploy` to use `isDotnetProject()` |
| `map.go` | Map `dotnet_8/9/10` runtimes to API format with `"dotnet"` command prefix |
| `map_test.go` | Round-trip tests for dotnet code configuration API mapping |
| `service_target_agent.go` | Add `packageDotnetBundled()` with `dotnet publish` + output capture in errors; display `dotnet` prefix in deploy output; add `bytes` import; enforce 250 MB ZIP limit |
| `config.go` | Add TODO comment to `CodeDeployRegions` for future dynamic discovery |

---

## How to Build

```bash
cd cli/azd/extensions/azure.ai.agents
go build ./...
go test ./...
go vet ./...
```

---

## Manual Test Steps

### Prerequisites
- Azure subscription with a Foundry project in a supported region (`westus2`, `canadacentral`, `northcentralus`)
- A model deployment (e.g. `gpt-4o`, `gpt-5.1`) in your Foundry project
- .NET SDK 9 installed locally (for bundled mode)
- `azd` CLI installed, logged in (`azd auth login`)
- Build the extension: `cd cli/azd/extensions/azure.ai.agents && azd x build`

### Test 1: .NET Code Deploy with Remote Build

```powershell
# 1. Clone a .NET agent sample (e.g., hello-world-dotnet-invocations)
mkdir test-dotnet-code-deploy && cd test-dotnet-code-deploy

# 2. Create a minimal .NET agent project with agent.yaml containing:
#   code_configuration:
#     runtime: dotnet_9
#     entry_point: HelloWorld.dll
#     dependency_resolution: remote_build

# 3. Init with existing Foundry project
azd ai agent init --project-id "<your-arm-resource-id>"
# Expected prompts:
#   1. Deploy mode -> Source Code (ZIP upload)
#   2. Runtime -> .NET 9 (only .NET options shown since it's a .NET project)
#   3. Entry point -> HelloWorld.dll (auto-detected from .csproj)
#   4. Dependency resolution -> Remote build
#   5. Protocols -> invocations
#   6. Model -> select existing deployment

# 4. Verify azure.yaml
Get-Content azure.yaml | Select-String "language"
# Expect: language: csharp

# 5. Deploy
azd deploy hello-world-dotnet-invocations
# Expect: "Packaging code" -> "Creating agent" -> "Agent is active!"

# 6. Invoke (wait ~30s for cold start)
azd ai agent invoke "What is 2+2?"
# Expect: streaming response with model reply
```

### Test 2: .NET Code Deploy with Bundled Mode

```powershell
# Same project as above, update agent.yaml:
#   dependency_resolution: bundled

azd deploy hello-world-dotnet-invocations
# Expect: "Publishing .NET project" -> "Packaging code" -> "Creating agent" -> done
# The deploy runs `dotnet publish -c Release -r linux-x64 --self-contained false` locally

azd ai agent invoke --new-session "Hello bundled dotnet!"
# Expect: streaming response
```

---

## Test Results

All configurations verified end-to-end on `canadacentral` (Foundry project `wujia-aifproject260512`):

| # | Runtime | Package Mode | Deploy | Invoke | Notes |
|---|---------|-------------|:---:|:---:|-------|
| 1 | dotnet_9 | remote_build | PASS (19s) | PASS (streaming SSE) | Model: gpt-5.1 |
| 2 | dotnet_9 | bundled | PASS | PASS | `dotnet publish` runs locally |
| 3 | python_3_12 | remote_build | PASS | PASS | Regression check (no change) |

### Invoke Output Example (Remote Build, dotnet_9)
```
Agent:    hello-world-dotnet-invocations (remote, invocations protocol)
Input:    "What is 2+2?"
Session:  (new -- server will assign)

Invocation:   inv_ec38240e65957f5600bNhzDBxxuw7IHJf7bxYXDxdsJZqtnDJW
Session:  8e0044805feaa1c000rE03tPFMgIHo0GrGeLFbQEE52lx8hrLX (assigned by server)
[hello-world-dotnet-invocations] {"type":"token","content":"2"}
{"type":"token","content":" +"}
{"type":"token","content":" 2"}
{"type":"token","content":" ="}
{"type":"token","content":" 4"}
{"type":"token","content":"."}
{"type":"done","full_text":"2 + 2 = 4."}
```

---

## Unit Tests

```
ok  azureaiagent/internal/cmd              14.084s
ok  azureaiagent/internal/pkg/agents/agent_api    21.724s
ok  azureaiagent/internal/pkg/agents/agent_yaml    5.329s
ok  azureaiagent/internal/project           5.604s
```

Specific test coverage for this PR:
- `TestDetectDefaultEntryPoint` -- verifies `.dll` detection from `dotnet publish` output and `.csproj` AssemblyName fallback
- `TestCodeConfigurationDotnetRoundTrip` -- verifies `dotnet_9` runtime maps to API format with `["dotnet", "HelloWorld.dll"]` entry point
- `TestCodeConfigurationDotnetRemoteBuild` -- verifies `dependency_resolution: remote_build` mapping for dotnet

---

## Notes

- **No impact on Python code deploy**: All Python paths are unchanged. Runtime filtering only affects the prompt UI.
- **No impact on container deploy**: Container paths remain completely untouched.
- **`--no-prompt` defaults**: For .NET projects, defaults to `dotnet_9` runtime. For Python projects, defaults to `python_3_12` (unchanged).
- **Entry point auto-detection**: Looks for `.csproj` `<AssemblyName>` property first, falls back to project directory name + `.dll`.
- **gosec G204 suppressed**: `exec.Command("dotnet", "publish", csprojPath, ...)` -- `csprojPath` is derived from user's local project directory, not external input.
- **250 MB limit**: ZIP packages exceeding 250 MB are rejected with a clear error before upload.
- **Supported regions**: Same as Python code deploy -- `westus2`, `canadacentral`, `northcentralus`.

---

## Dependencies

- Requires #8146 to merge first (this PR is rebased on top of it)
- After #8146 merges to `main`, this PR's diff will shrink to only the .NET-specific additions (~5 commits)

## Related

- Parent PR: #8146 (code deploy ZIP upload -- Python)
- Schema: [microsoft/AgentSchema#96](https://github.com/microsoft/AgentSchema/pull/96) -- `code_configuration` schema updated with .NET runtimes (`dotnet_8/9/10`), `.dll` entry point examples, and .NET build workflow descriptions
