### PR TITLE
ci(cspell-misc): declare contents: read

### DIFF
--- a/.github/workflows/cspell-misc.yml
+++ b/.github/workflows/cspell-misc.yml
@@ -12,6 +12,9 @@ on:
       - 'ext/devcontainer/**'
       - 'templates/**'
 
+permissions:
+  contents: read
+
 jobs:
   cspell-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Small follow-up to align cspell-misc.yml with its sibling cspell-ext.yml, which already declares `permissions: contents: read` at the top level. The workflow only checks out the tree and runs `cspell lint` - no GitHub API surface - so the same scope fits.

Confirmed with `yaml.safe_load` parse. No behavior change.

fix: https://github.com/Azure/azure-dev/issues/8231