### PR TITLE
Auto-update extension registry after release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ bin/
 node_modules/
 test-results/
 
+# Downloaded by extension-set-metadata-variables.yml during the release
+# pipeline; must not be committed by automation jobs (e.g. Update_Registry).
+/release-metadata/
+
 # terraform .tfstate files
 **/.terraform
 *.tfstate*

--- a/cli/azd/test/snapshot/snapshot.go
+++ b/cli/azd/test/snapshot/snapshot.go
@@ -43,6 +43,12 @@ func NewDefaultConfig() *cupaloy.Config {
 	isCi := os.Getenv("GITHUB_ACTIONS") == "true" ||
 		os.Getenv("TF_BUILD") == "True"
 
+	// On CI, fail the test if a snapshot was regenerated to guard against
+	// drift being silently accepted. UPDATE_SNAPSHOTS=true is an explicit
+	// opt-in (e.g. an automation job intentionally refreshing snapshots), so
+	// honor it on CI as well.
+	explicitUpdate := os.Getenv("UPDATE_SNAPSHOTS") == "true"
+
 	return cupaloy.NewDefaultConfig().
 		// Always use testdata
 		WithOptions(cupaloy.SnapshotSubdirectory("testdata")).
@@ -50,8 +56,9 @@ func NewDefaultConfig() *cupaloy.Config {
 		WithOptions(cupaloy.SnapshotFileExtension(".snap")).
 		// Use go-spew instead of String() and Error() outputs
 		WithOptions(cupaloy.UseStringerMethods(false)).
-		// Fail update on CI, but allow local to succeed
-		WithOptions(cupaloy.FailOnUpdate(isCi))
+		// Fail update on CI unless the caller explicitly asked to refresh
+		// snapshots; allow local runs to succeed.
+		WithOptions(cupaloy.FailOnUpdate(isCi && !explicitUpdate))
 }
 
 // SnapshotT creates a snapshot with the global config, and the current testing.T.

--- a/eng/pipelines/templates/stages/publish-extension.yml
+++ b/eng/pipelines/templates/stages/publish-extension.yml
@@ -1,4 +1,8 @@
 parameters:
+  - name: AzdExtensionId
+    type: string
+  - name: AzdExtensionDirectory
+    type: string
   - name: SanitizedExtensionId
     type: string
 
@@ -69,3 +73,67 @@ stages:
                     PublishUploadLocations: $(StorageUploadLocations)
                     TagPrefix: azd-ext-${{ parameters.SanitizedExtensionId }}
                     TagVersion: $(EXT_VERSION)
+
+      # Updates cli/azd/extensions/registry.json (and snapshots) after the
+      # GitHub Release exists. Mirrors Increment_Version in
+      # eng/pipelines/templates/stages/publish.yml.
+      - job: Update_Registry
+        dependsOn: Publish_Release
+        condition: >-
+          and(
+            succeeded(),
+            ne('true', variables['Skip.RegistryUpdate'])
+          )
+
+        pool:
+          name: $(LINUXPOOL)
+          image: $(LINUXVMIMAGE)
+          os: linux
+
+        steps:
+          - checkout: self
+
+          - template: /eng/pipelines/templates/steps/extension-set-metadata-variables.yml
+
+          - template: /eng/pipelines/templates/steps/setup-go.yml
+
+          - bash: |
+              set -euo pipefail
+              curl -fsSL https://aka.ms/install-azd.sh | bash -s -- --verbose
+              azd version
+            displayName: Install azd
+
+          - bash: |
+              set -euo pipefail
+              azd ext install microsoft.azd.extensions --source azd
+            displayName: Install microsoft.azd.extensions
+
+          - bash: |
+              set -euo pipefail
+              cd "${{ parameters.AzdExtensionDirectory }}"
+              azd x publish \
+                --registry ../registry.json \
+                --repo "$(Build.Repository.Name)" \
+                --version "$(EXT_VERSION)"
+            displayName: Update registry.json (azd x publish)
+            env:
+              GH_TOKEN: $(azuresdk-github-pat)
+
+          - bash: |
+              set -euo pipefail
+              cd cli/azd
+              go build .
+              go test ./cmd -run 'TestFigSpec|TestUsage'
+            displayName: Refresh Fig/Usage snapshots
+            env:
+              UPDATE_SNAPSHOTS: "true"
+
+          - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
+            parameters:
+              PRBranchName: ext-registry-update/${{ parameters.SanitizedExtensionId }}/$(EXT_VERSION)-$(Build.BuildId)
+              CommitMsg: "[${{ parameters.AzdExtensionId }}] Registry update for $(EXT_VERSION)"
+              PRTitle: "[${{ parameters.AzdExtensionId }}] Registry update for $(EXT_VERSION)"
+              PRBody: >-
+                Registry update for the
+                [azd-ext-${{ parameters.SanitizedExtensionId }}_$(EXT_VERSION)](https://github.com/$(Build.Repository.Name)/releases/tag/azd-ext-${{ parameters.SanitizedExtensionId }}_$(EXT_VERSION))
+                release.

--- a/eng/pipelines/templates/stages/release-azd-extension.yml
+++ b/eng/pipelines/templates/stages/release-azd-extension.yml
@@ -83,4 +83,6 @@ stages:
 
     - template: /eng/pipelines/templates/stages/publish-extension.yml
       parameters:
+        AzdExtensionId: ${{ parameters.AzdExtensionId }}
+        AzdExtensionDirectory: ${{ parameters.AzdExtensionDirectory }}
         SanitizedExtensionId: ${{ parameters.SanitizedExtensionId }}


### PR DESCRIPTION
Resolves #8179

This PR automates the registry update step that is currently done by hand after every azd extension release. It adds an `Update_Registry` job to the extension `publish-extension` stage that runs after the GitHub Release has been created, mirroring the existing `Increment_Version` job in the CLI publish pipeline.

The job also regenerates the Fig/Usage test snapshots so PRs reflect any help-text changes shipped with the extension bump. Previously, snapshot tests failed in CI if there were snapshot changes even if `UPDATE_SNAPSHOTS` was set. This PR loosens the condition it's allowed when set in CI.

The job can be skipped per-run by setting the pipeline variable `Skip.RegistryUpdate=true` at queue time, matching the pattern used by `Skip.IncrementVersion` and `Skip.Publish`.

## Validation

Tested pipeline on https://github.com/Azure/azure-dev/tree/ext-registry-update-automation branch with `Skip.Publish=true` and Figspec and registry.json entries removed and confirmed `azure-sdk` bot auto-submitted PR with expected changes: #8178 

<img width="662" height="796" alt="image" src="https://github.com/user-attachments/assets/14ec3899-7509-4493-a3ea-069e3874ebc4" />
