### PR TITLE
Increase AI agent invoke timeout

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -180,7 +180,7 @@ session automatically. Pass --new-session to force a reset.`,
 		"timeout",
 		"t",
 		defaultInvokeTimeoutSeconds,
-		fmt.Sprintf("Request timeout in seconds (0 for no timeout; default: %d)", defaultInvokeTimeoutSeconds),
+		"Request timeout in seconds (0 for no timeout)",
 	)
 	cmd.Flags().StringVarP(&flags.session, "session-id", "s", "", "Explicit session ID override")
 	cmd.Flags().BoolVar(&flags.newSession, "new-session", false, "Force a new session (discard saved one)")

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -41,6 +41,8 @@ type invokeFlags struct {
 	agentEndpoint   string
 }
 
+const defaultInvokeTimeoutSeconds = 30 * 60
+
 type InvokeAction struct {
 	flags    *invokeFlags
 	noPrompt bool
@@ -173,7 +175,13 @@ session automatically. Pass --new-session to force a reset.`,
 	cmd.Flags().StringVarP(&flags.inputFile, "input-file", "f", "", "Path to a file whose contents are sent as the request body")
 	cmd.Flags().StringVarP(&flags.protocol, "protocol", "p", "", "Protocol to use: responses (default) or invocations")
 	cmd.Flags().IntVar(&flags.port, "port", DefaultPort, "Local server port")
-	cmd.Flags().IntVarP(&flags.timeout, "timeout", "t", 120, "Request timeout in seconds (0 for no timeout)")
+	cmd.Flags().IntVarP(
+		&flags.timeout,
+		"timeout",
+		"t",
+		defaultInvokeTimeoutSeconds,
+		fmt.Sprintf("Request timeout in seconds (0 for no timeout; default: %d)", defaultInvokeTimeoutSeconds),
+	)
 	cmd.Flags().StringVarP(&flags.session, "session-id", "s", "", "Explicit session ID override")
 	cmd.Flags().BoolVar(&flags.newSession, "new-session", false, "Force a new session (discard saved one)")
 	cmd.Flags().StringVar(&flags.conversation, "conversation-id", "", "Explicit conversation ID override")

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
@@ -232,6 +232,7 @@ func TestHttpTimeout(t *testing.T) {
 		timeout int
 		want    time.Duration
 	}{
+		{name: "default value", timeout: defaultInvokeTimeoutSeconds, want: 30 * time.Minute},
 		{name: "positive value", timeout: 120, want: 120 * time.Second},
 		{name: "zero means no timeout", timeout: 0, want: 0},
 		{name: "negative means no timeout", timeout: -1, want: 0},
@@ -250,6 +251,24 @@ func TestHttpTimeout(t *testing.T) {
 				t.Errorf("httpTimeout() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestInvokeCommandTimeoutDefault(t *testing.T) {
+	t.Parallel()
+
+	cmd := newInvokeCommand(nil)
+	timeoutFlag := cmd.Flags().Lookup("timeout")
+	if timeoutFlag == nil {
+		t.Fatal("timeout flag not registered")
+	}
+
+	const want = "1800"
+	if timeoutFlag.DefValue != want {
+		t.Errorf("timeout default = %q, want %q", timeoutFlag.DefValue, want)
+	}
+	if timeoutFlag.Value.String() != want {
+		t.Errorf("timeout value = %q, want %q", timeoutFlag.Value.String(), want)
 	}
 }
 
@@ -823,6 +842,18 @@ func TestHandleInvocationLRO(t *testing.T) {
 			timeout:     100 * time.Millisecond,
 			wantErr:     true,
 			errContains: "timed out",
+		},
+		{
+			name:             "no timeout polls until completion",
+			initial202Header: "inv-009",
+			initial202Body:   `{}`,
+			pollResponses: []pollStep{
+				{status: 200, body: `{"status":"running"}`},
+				{status: 200, body: `{"status":"running"}`},
+				{status: 200, body: `{"status":"completed","result":"ok"}`},
+			},
+			timeout: 0,
+			wantErr: false,
 		},
 		{
 			name:             "retry-after header is respected",


### PR DESCRIPTION
## Summary
- Increase `azd ai agent invoke` default timeout from 2 minutes to 30 minutes.
- Keep `--timeout 0` as no overall timeout.
- Add tests for the timeout default and long-running invocation polling behavior.

Fixes #8131

## Validation
- `go test ./internal/cmd/... -run 'TestHttpTimeout|TestInvokeCommandTimeoutDefault|TestHandleInvocationLRO|TestAgentEndpointFlagValidation' -count=1`
- `go test ./internal/cmd/... -count=1`
- `go test ./... -count=1`