### PR TITLE
Add private ACR deploy guidance

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
@@ -58,6 +58,11 @@ const (
 	CodePromptFailed              = "prompt_failed"
 )
 
+// Error codes for ACR dependency errors.
+const (
+	CodePrivateACRNetworkAccessFailed = "private_acr_network_access_failed"
+)
+
 // Error codes commonly used for auth errors.
 //
 // These are usually paired with [Auth] for authentication/authorization failures.

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -511,12 +511,84 @@ func (p *AgentServiceTargetProvider) Publish(
 		})
 
 	if err != nil {
-		return nil, exterrors.Internal(exterrors.OpContainerPublish, fmt.Sprintf("container publish failed: %s", err))
+		return nil, classifyContainerPublishError(err)
 	}
 
 	return &azdext.ServicePublishResult{
 		Artifacts: publishResponse.Result.Artifacts,
 	}, nil
+}
+
+func classifyContainerPublishError(err error) error {
+	if isPrivateACRNetworkAccessError(err) {
+		return exterrors.Dependency(
+			exterrors.CodePrivateACRNetworkAccessFailed,
+			fmt.Sprintf(
+				"container publish failed because the Azure Container Registry may be blocking network access: %s",
+				err,
+			),
+			"allowlist the public outbound IP/CIDR of the dev environment running `azd deploy` in the ACR "+
+				"firewall/network settings. If `docker.remoteBuild: true` is enabled, first set "+
+				"`docker.remoteBuild: false` for this service because remote build worker IPs are not predictable. "+
+				"Ensure Docker or Podman is installed and running, then run `azd deploy` again.",
+		)
+	}
+
+	if actionable := azdext.ActionableErrorDetailFromError(err); actionable != nil && actionable.GetSuggestion() != "" {
+		return err
+	}
+
+	return exterrors.Internal(exterrors.OpContainerPublish, fmt.Sprintf("container publish failed: %s", err))
+}
+
+func isPrivateACRNetworkAccessError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	message := strings.ToLower(err.Error())
+	acrContext := []string{
+		".azurecr.io",
+		"azure container registry",
+		"container registry",
+	}
+	hasACRContext := containsAny(message, acrContext...)
+
+	networkSignals := []string{
+		"public network access",
+		"private endpoint",
+		"network rule",
+		"firewall",
+		"not allowed access",
+		"forbidden",
+		"i/o timeout",
+		"connection timed out",
+		"tls handshake timeout",
+		"connection refused",
+		"no such host",
+	}
+	hasNetworkSignal := containsAny(message, networkSignals...)
+
+	if strings.Contains(message, "client with ip address") &&
+		strings.Contains(message, "not allowed access") {
+		return true
+	}
+
+	if strings.Contains(message, "remote build failed") &&
+		strings.Contains(message, "local fallback unavailable") {
+		return hasNetworkSignal || hasACRContext
+	}
+
+	return hasACRContext && hasNetworkSignal
+}
+
+func containsAny(s string, values ...string) bool {
+	for _, value := range values {
+		if strings.Contains(s, value) {
+			return true
+		}
+	}
+	return false
 }
 
 func preBuiltImageArtifact(imageURL string) *azdext.Artifact {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -5,6 +5,7 @@ package project
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -12,12 +13,15 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"azureaiagent/internal/exterrors"
 	"azureaiagent/internal/pkg/agents/agent_api"
 	"azureaiagent/internal/pkg/agents/agent_yaml"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestApplyAgentMetadata(t *testing.T) {
@@ -106,6 +110,7 @@ type stubContainerServer struct {
 	buildCalls   atomic.Int32
 	packageCalls atomic.Int32
 	publishCalls atomic.Int32
+	publishErr   error
 }
 
 func (s *stubContainerServer) Build(
@@ -143,6 +148,10 @@ func (s *stubContainerServer) Publish(
 	_ *azdext.ContainerPublishRequest,
 ) (*azdext.ContainerPublishResponse, error) {
 	s.publishCalls.Add(1)
+	if s.publishErr != nil {
+		return nil, s.publishErr
+	}
+
 	return &azdext.ContainerPublishResponse{
 		Result: &azdext.ServicePublishResult{
 			Artifacts: []*azdext.Artifact{{
@@ -889,4 +898,145 @@ func TestPublish_PublishesWhenPackageBuiltFromDockerfile(t *testing.T) {
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.Artifacts, "expected published container artifacts")
 	require.Equal(t, int32(1), containerStub.publishCalls.Load())
+}
+
+func TestPublish_PrivateACRNetworkAccessGuidance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "remote build failed and local fallback unavailable",
+			err: errors.New(
+				"remote build failed: registry firewall blocked source upload\n\n" +
+					"Local fallback unavailable: Docker is not installed",
+			),
+		},
+		{
+			name: "acr client ip denied",
+			err: errors.New(
+				"pushing image: denied: client with IP address '203.0.113.10' " +
+					"is not allowed access to registry myregistry.azurecr.io",
+			),
+		},
+		{
+			name: "generic host docker login suggestion is overridden",
+			err: actionableStatusError(
+				t,
+				"pushing image to myregistry.azurecr.io failed: Forbidden",
+				"When pushing to an external registry, run 'docker login' and try again",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := publishWithContainerError(t, tt.err)
+
+			localErr, ok := errors.AsType[*azdext.LocalError](err)
+			require.True(t, ok, "expected LocalError, got %T: %v", err, err)
+			require.Equal(t, exterrors.CodePrivateACRNetworkAccessFailed, localErr.Code)
+			require.Equal(t, azdext.LocalErrorCategoryDependency, localErr.Category)
+			require.Contains(t, localErr.Message, tt.err.Error())
+			require.Contains(t, localErr.Suggestion, "allowlist the public outbound IP/CIDR")
+			require.Contains(t, localErr.Suggestion, "docker.remoteBuild: false")
+			require.Contains(t, localErr.Suggestion, "Docker or Podman")
+			require.NotContains(t, localErr.Suggestion, "docker login")
+		})
+	}
+}
+
+func TestPublish_GenericPublishErrorsAreNotClassifiedAsPrivateACR(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "generic publish failure",
+			err:  errors.New("registry returned unexpected 500"),
+		},
+		{
+			name: "non-acr denied failure",
+			err:  errors.New("denied: requested access to the resource is denied"),
+		},
+		{
+			name: "remote build dockerfile failure without acr network signal",
+			err: errors.New(
+				"remote build failed: Dockerfile parse error\n\n" +
+					"Local fallback unavailable: Docker is not installed",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := publishWithContainerError(t, tt.err)
+
+			localErr, ok := errors.AsType[*azdext.LocalError](err)
+			require.True(t, ok, "expected LocalError, got %T: %v", err, err)
+			require.Equal(t, exterrors.OpContainerPublish, localErr.Code)
+			require.Equal(t, azdext.LocalErrorCategoryInternal, localErr.Category)
+			require.Contains(t, localErr.Message, "container publish failed")
+		})
+	}
+}
+
+func TestPublish_PreservesNonACRHostActionableGuidance(t *testing.T) {
+	t.Parallel()
+
+	const suggestion = "run the custom remediation and try again"
+	err := publishWithContainerError(t, actionableStatusError(t, "publish failed", suggestion))
+
+	actionable := azdext.ActionableErrorDetailFromError(err)
+	require.NotNil(t, actionable)
+	require.Equal(t, suggestion, actionable.GetSuggestion())
+}
+
+func publishWithContainerError(t *testing.T, publishErr error) error {
+	t.Helper()
+
+	dir := t.TempDir()
+	agentPath := writeHostedAgentYAMLWithImage(t, dir, "myregistry.azurecr.io/myimage:v1")
+	containerStub := &stubContainerServer{publishErr: publishErr}
+	client := newContainerTestClient(t, containerStub)
+
+	provider := &AgentServiceTargetProvider{
+		azdClient:           client,
+		agentDefinitionPath: agentPath,
+		env:                 &azdext.Environment{Name: "test-env"},
+	}
+
+	_, err := provider.Publish(
+		t.Context(),
+		&azdext.ServiceConfig{Name: "test-svc"},
+		&azdext.ServiceContext{Package: []*azdext.Artifact{{
+			Kind:         azdext.ArtifactKind_ARTIFACT_KIND_CONTAINER,
+			Location:     "test-image:latest",
+			LocationKind: azdext.LocationKind_LOCATION_KIND_LOCAL,
+		}}},
+		&azdext.TargetResource{},
+		&azdext.PublishOptions{},
+		func(string) {},
+	)
+	require.Error(t, err)
+	require.Equal(t, int32(1), containerStub.publishCalls.Load())
+
+	return err
+}
+
+func actionableStatusError(t *testing.T, message, suggestion string) error {
+	t.Helper()
+
+	st := status.New(codes.Unknown, message)
+	stWithDetails, err := st.WithDetails(&azdext.ActionableErrorDetail{Suggestion: suggestion})
+	require.NoError(t, err)
+	return stWithDetails.Err()
 }


### PR DESCRIPTION
## Summary
- Detect private ACR network/firewall failures during Azure AI Agents container publish.
- Return structured dependency guidance to allowlist the dev environment outbound IP/CIDR and use local build for private ACR scenarios.
- Preserve original publish diagnostics and avoid surfacing misleading generic Docker-login guidance for private ACR failures.

Fixes #8132

## Validation
- `go test ./internal/project/... -count=1`
- `go test ./... -count=1`