### PR TITLE
Default AI agent show output to table

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/show.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/show.go
@@ -54,8 +54,8 @@ configuration and the current azd environment. Optionally specify the service na
   # Show status for a specific agent service
   azd ai agent show my-agent
 
-  # Show status in table format
-  azd ai agent show --output table`,
+  # Show status as JSON
+  azd ai agent show --output json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
@@ -117,7 +117,7 @@ configuration and the current azd environment. Optionally specify the service na
 	azdext.RegisterFlagOptions(cmd, azdext.FlagOptions{
 		Name:          "output",
 		AllowedValues: []string{"json", "table"},
-		Default:       "json",
+		Default:       "table",
 	})
 
 	return cmd
@@ -152,11 +152,17 @@ func (a *ShowAction) Run(ctx context.Context) error {
 	// Resolve deployed endpoint URLs from env vars (best-effort)
 	result.Endpoints = a.resolveEndpointURLs(ctx)
 
-	switch a.flags.output {
-	case "table":
+	return printShowResult(result, a.flags.output)
+}
+
+func printShowResult(result *showResult, output string) error {
+	switch output {
+	case "", "table":
 		return printShowResultTable(result)
-	default:
+	case "json":
 		return printShowResultJSON(result)
+	default:
+		return fmt.Errorf("unsupported output format %q", output)
 	}
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/show_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/show_test.go
@@ -5,6 +5,8 @@ package cmd
 
 import (
 	"encoding/json"
+	"io"
+	"os"
 	"testing"
 
 	"azureaiagent/internal/pkg/agents/agent_api"
@@ -69,7 +71,46 @@ func TestNewAgentContext_PartialFlags(t *testing.T) {
 
 func TestShowCommand_DefaultOutputFormat(t *testing.T) {
 	cmd := newShowCommand(nil)
-	assertOutputFlagOptions(t, cmd, "json", []string{"json", "table"})
+	assertOutputFlagOptions(t, cmd, "table", []string{"json", "table"})
+}
+
+func TestPrintShowResult_DefaultsToTable(t *testing.T) {
+	output, err := captureStdout(t, func() error {
+		return printShowResult(sampleShowResult(), "")
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "FIELD")
+	assert.Contains(t, output, "VALUE")
+	assert.Contains(t, output, "sample-agent")
+	assert.NotContains(t, output, `"object"`)
+}
+
+func TestPrintShowResult_JSONOptIn(t *testing.T) {
+	output, err := captureStdout(t, func() error {
+		return printShowResult(sampleShowResult(), "json")
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, output, `"object": "agent.version"`)
+	assert.Contains(t, output, `"name": "sample-agent"`)
+}
+
+func TestPrintShowResult_ExplicitTable(t *testing.T) {
+	output, err := captureStdout(t, func() error {
+		return printShowResult(sampleShowResult(), "table")
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "FIELD")
+	assert.Contains(t, output, "VALUE")
+	assert.Contains(t, output, "sample-agent")
+	assert.NotContains(t, output, `"object"`)
+}
+
+func TestPrintShowResult_UnsupportedOutput(t *testing.T) {
+	err := printShowResult(sampleShowResult(), "yaml")
+	assert.EqualError(t, err, `unsupported output format "yaml"`)
 }
 
 func TestPrintAgentVersionJSON(t *testing.T) {
@@ -226,4 +267,36 @@ func TestPrintAgentVersionTable_MinimalFields(t *testing.T) {
 	result := &showResult{AgentVersionObject: version}
 	err := printShowResultTable(result)
 	require.NoError(t, err)
+}
+
+func sampleShowResult() *showResult {
+	return &showResult{
+		AgentVersionObject: &agent_api.AgentVersionObject{
+			Object:  "agent.version",
+			ID:      "ver-sample",
+			Name:    "sample-agent",
+			Version: "1",
+		},
+	}
+}
+
+func captureStdout(t *testing.T, run func() error) (string, error) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+	defer reader.Close()
+
+	os.Stdout = writer
+	runErr := run()
+	require.NoError(t, writer.Close())
+
+	output, err := io.ReadAll(reader)
+	require.NoError(t, err)
+
+	return string(output), runErr
 }


### PR DESCRIPTION
## Summary
- default azd ai agent show to table output
- keep JSON available with --output json
- update tests for default table and JSON opt-in behavior

Fixes #8156