### PR TITLE
fix: resolve parallel dotnet publish race in Aspire deploys

### DIFF
--- a/cli/azd/internal/cmd/aspire_gate.go
+++ b/cli/azd/internal/cmd/aspire_gate.go
@@ -6,21 +6,25 @@ package cmd
 import "github.com/azure/azure-dev/cli/azd/pkg/project"
 
 // aspireBuildGateKey is the gate-key policy used by `azd deploy` and `azd up`
-// to serialize deploys for services that share a single .NET AppHost build.
+// to group Aspire services that share a single .NET AppHost build.
 //
 // It returns a constant non-empty key ("aspire") for every service whose
 // [project.ServiceConfig.DotNetContainerApp] is populated by the Aspire
 // importer, and "" for every other service.
 //
-// The effect: the first such service's deploy step acts as the build gate,
-// and every subsequent Aspire service's deploy depends on it, so the
-// AppHost's shared build runs exactly once while deploy-side work for other
-// services continues in parallel.
+// The effect: all Aspire services in the same gate group receive a shared
+// mutex via context. The deploy target
+// ([project.DotNetContainerAppTarget.Deploy]) uses this as a signal to
+// create a per-service --artifacts-path temp directory, so concurrent
+// dotnet publish invocations write to isolated intermediate output trees
+// and run fully in parallel. Only if the temp-dir creation fails does the
+// mutex act as a serialization fallback — the normal path is zero
+// serialization.
 //
 // This is the *only* Aspire-specific policy the execution graph layer
 // carries; the graph builder itself (see service_graph.go) is Aspire-
 // agnostic and consumes any opaque grouping key. Extensions that own their
-// own "first-wins" build lane can supply a different callback through
+// own sequential build lane can supply a different callback through
 // [serviceGraphOptions.buildGateKey] without touching the DAG code.
 //
 // When Aspire eventually moves into an extension, this function — and only

--- a/cli/azd/internal/cmd/deploy.go
+++ b/cli/azd/internal/cmd/deploy.go
@@ -272,10 +272,12 @@ func (da *DeployAction) Run(ctx context.Context) (*actions.ActionResult, error) 
 
 // deployServicesGraph builds an execution graph of service deployments and runs them in
 // parallel via the execution graph scheduler. Services that share a non-empty
-// [serviceGraphOptions.buildGateKey] serialize on the first one to act as a
-// shared build gate; today that policy only fires for Aspire services
-// (DotNetContainerApp != nil), which share a single .NET AppHost build. Every
-// other service runs fully in parallel with no inter-service edges.
+// [serviceGraphOptions.buildGateKey] share a runtime mutex that serializes only
+// their image-preparation phase (dotnet publish); the Azure deployment portion
+// runs fully in parallel. Today that policy only fires for Aspire services
+// (DotNetContainerApp != nil), which share .NET project references whose obj/
+// directories collide under parallel `dotnet publish`. Every other service runs
+// fully in parallel with no inter-service edges.
 func (da *DeployAction) deployServicesGraph(
 	ctx context.Context,
 	stableServices []*project.ServiceConfig,

--- a/cli/azd/internal/cmd/deploy_graph_test.go
+++ b/cli/azd/internal/cmd/deploy_graph_test.go
@@ -14,12 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestDeployServicesGraph_AspireOrdering verifies that the Aspire build-gate
-// policy (supplied by [aspireBuildGateKey]) produces the expected "first wins,
-// rest wait" serialization: the first Aspire service has no extra deps, every
-// subsequent Aspire service depends on that first step, and non-Aspire
-// services run with no inter-service edges.
-func TestDeployServicesGraph_AspireOrdering(t *testing.T) {
+// TestDeployServicesGraph_AspireParallel verifies that the Aspire build-gate
+// policy does NOT add graph-level dependency edges between Aspire deploy steps.
+// Serialization of the dotnet publish phase is handled at runtime via a mutex
+// (see build_gate.go), so all Aspire services deploy in parallel at the graph
+// level while only their image-preparation phases are serialized.
+func TestDeployServicesGraph_AspireParallel(t *testing.T) {
 	services := []*project.ServiceConfig{
 		{Name: "api", DotNetContainerApp: &project.DotNetContainerAppOptions{
 			Manifest: &apphost.Manifest{},
@@ -33,7 +33,7 @@ func TestDeployServicesGraph_AspireOrdering(t *testing.T) {
 		}},
 	}
 
-	g := buildDeployGraph(t, services, aspireBuildGateKey)
+	g := buildDeployGraph(t, services)
 
 	require.Equal(t, 4, g.Len())
 
@@ -43,23 +43,19 @@ func TestDeployServicesGraph_AspireOrdering(t *testing.T) {
 		stepMap[s.Name] = s
 	}
 
-	// First Aspire service — no dependencies.
+	// All Aspire services should have NO inter-service deploy edges.
+	// Build serialization is handled at runtime, not via graph topology.
 	require.Empty(t, stepMap["deploy-api"].DependsOn,
-		"first Aspire service should have no dependencies")
+		"Aspire service should have no graph-level deploy dependencies")
+	require.Empty(t, stepMap["deploy-worker"].DependsOn,
+		"Aspire service should have no graph-level deploy dependencies")
+	require.Empty(t, stepMap["deploy-backend"].DependsOn,
+		"Aspire service should have no graph-level deploy dependencies")
 
-	// Second Aspire service — depends on first.
-	require.Equal(t, []string{"deploy-api"}, stepMap["deploy-worker"].DependsOn,
-		"subsequent Aspire service should depend on the first Aspire service")
-
-	// Third Aspire service — also depends on first.
-	require.Equal(t, []string{"deploy-api"}, stepMap["deploy-backend"].DependsOn,
-		"subsequent Aspire service should depend on the first Aspire service")
-
-	// Non-Aspire service — no dependencies.
+	// Non-Aspire service — also no dependencies.
 	require.Empty(t, stepMap["deploy-web"].DependsOn,
 		"non-Aspire service should have no dependencies")
 
-	// The graph must be valid (no cycles, no missing refs).
 	require.NoError(t, g.Validate())
 }
 
@@ -72,7 +68,7 @@ func TestDeployServicesDAG_NoAspire(t *testing.T) {
 		{Name: "worker"},
 	}
 
-	g := buildDeployGraph(t, services, aspireBuildGateKey)
+	g := buildDeployGraph(t, services)
 
 	require.Equal(t, 3, g.Len())
 
@@ -94,7 +90,7 @@ func TestDeployServicesDAG_SingleAspireNoDeps(t *testing.T) {
 		{Name: "web"},
 	}
 
-	g := buildDeployGraph(t, services, aspireBuildGateKey)
+	g := buildDeployGraph(t, services)
 
 	require.Equal(t, 2, g.Len())
 
@@ -112,57 +108,6 @@ func TestDeployServicesDAG_SingleAspireNoDeps(t *testing.T) {
 	require.NoError(t, g.Validate())
 }
 
-// TestDeployServicesGraph_BuildGateKeyIsGeneric verifies that the build-gate
-// policy is opaque to the graph builder: multiple independent gate keys
-// coexist, each serializing only its own group, and services returning "" run
-// in full parallelism alongside both groups. No Aspire-specific knowledge is
-// required of the graph layer.
-func TestDeployServicesGraph_BuildGateKeyIsGeneric(t *testing.T) {
-	services := []*project.ServiceConfig{
-		{Name: "a1"},
-		{Name: "a2"},
-		{Name: "b1"},
-		{Name: "free"},
-		{Name: "a3"},
-		{Name: "b2"},
-	}
-
-	// Two disjoint gate groups plus an ungated service.
-	gate := func(s *project.ServiceConfig) string {
-		switch s.Name {
-		case "a1", "a2", "a3":
-			return "group-a"
-		case "b1", "b2":
-			return "group-b"
-		default:
-			return ""
-		}
-	}
-
-	g := buildDeployGraph(t, services, gate)
-	require.Equal(t, 6, g.Len())
-
-	steps := g.Steps()
-	stepMap := make(map[string]*exegraph.Step, len(steps))
-	for _, s := range steps {
-		stepMap[s.Name] = s
-	}
-
-	// group-a: a1 is the gate; a2 and a3 depend on a1 only.
-	require.Empty(t, stepMap["deploy-a1"].DependsOn)
-	require.Equal(t, []string{"deploy-a1"}, stepMap["deploy-a2"].DependsOn)
-	require.Equal(t, []string{"deploy-a1"}, stepMap["deploy-a3"].DependsOn)
-
-	// group-b: b1 is the gate; b2 depends on b1 — crucially, NOT on a1.
-	require.Empty(t, stepMap["deploy-b1"].DependsOn)
-	require.Equal(t, []string{"deploy-b1"}, stepMap["deploy-b2"].DependsOn)
-
-	// Ungated service has no cross-group edges.
-	require.Empty(t, stepMap["deploy-free"].DependsOn)
-
-	require.NoError(t, g.Validate())
-}
-
 // TestDeployServicesGraph_UsesDependencies verifies that declared
 // `services.<name>.uses:` entries that target other services produce
 // deploy-step edges, so hooks that pass values between services retain
@@ -176,7 +121,7 @@ func TestDeployServicesGraph_UsesDependencies(t *testing.T) {
 		{Name: "independent"},
 	}
 
-	g := buildDeployGraph(t, services, nil)
+	g := buildDeployGraph(t, services)
 
 	require.Equal(t, 4, g.Len())
 
@@ -187,20 +132,21 @@ func TestDeployServicesGraph_UsesDependencies(t *testing.T) {
 	}
 
 	require.Empty(t, stepMap["deploy-api"].DependsOn,
-		"api has no uses — no deps")
+		"api has no uses - no deps")
 	require.Equal(t, []string{"deploy-api"}, stepMap["deploy-web"].DependsOn,
 		"web uses api (service); cosmos (resource) must be ignored")
 	require.Equal(t, []string{"deploy-api"}, stepMap["deploy-worker"].DependsOn,
 		"worker uses api (service)")
 	require.Empty(t, stepMap["deploy-independent"].DependsOn,
-		"independent has no uses — no deps")
+		"independent has no uses - no deps")
 
 	require.NoError(t, g.Validate())
 }
 
-// TestDeployServicesGraph_UsesWithBuildGate verifies that `uses:` edges
-// coexist with Aspire build-gate edges — the deploy step depends on both.
-func TestDeployServicesGraph_UsesWithBuildGate(t *testing.T) {
+// TestDeployServicesGraph_UsesWithAspire verifies that `uses:` edges
+// still work alongside Aspire services. The build gate no longer adds
+// graph edges, so only `uses:` produces deploy-step dependencies.
+func TestDeployServicesGraph_UsesWithAspire(t *testing.T) {
 	services := []*project.ServiceConfig{
 		{Name: "api", DotNetContainerApp: &project.DotNetContainerAppOptions{
 			Manifest: &apphost.Manifest{},
@@ -210,7 +156,7 @@ func TestDeployServicesGraph_UsesWithBuildGate(t *testing.T) {
 		}},
 	}
 
-	g := buildDeployGraph(t, services, aspireBuildGateKey)
+	g := buildDeployGraph(t, services)
 
 	steps := g.Steps()
 	stepMap := make(map[string]*exegraph.Step, len(steps))
@@ -219,30 +165,26 @@ func TestDeployServicesGraph_UsesWithBuildGate(t *testing.T) {
 	}
 
 	require.Empty(t, stepMap["deploy-api"].DependsOn)
-	// web depends on api — the build-gate and uses edges dedupe to a
-	// single entry.
+	// web depends on api via `uses:` only (build gate no longer adds edges).
 	require.Equal(t, []string{"deploy-api"},
 		stepMap["deploy-web"].DependsOn,
-		"web should depend on api exactly once (deduped across build-gate and uses)")
+		"web should depend on api via uses: edge")
 
 	require.NoError(t, g.Validate())
 }
 
 // buildDeployGraph mirrors the deploy-step wiring in
 // [addServiceStepsToGraph] without pulling in the full DeployAction wiring,
-// so tests can focus on graph topology. The gate policy is injected to match
-// the production contract on [serviceGraphOptions.buildGateKey]. Declared
-// `services.<name>.uses:` edges to other services in the set are wired too,
-// mirroring production so tests cover the use-edge path.
+// so tests can focus on graph topology. Only `uses:` edges between services
+// are wired; build-gate serialization is handled at runtime (not in the
+// graph), so it is not reflected here.
 func buildDeployGraph(
 	t *testing.T,
 	services []*project.ServiceConfig,
-	buildGateKey func(*project.ServiceConfig) string,
 ) *exegraph.Graph {
 	t.Helper()
 
 	g := exegraph.NewGraph()
-	firstByGate := map[string]string{}
 	serviceNames := make(map[string]struct{}, len(services))
 	for _, svc := range services {
 		serviceNames[svc.Name] = struct{}{}
@@ -252,15 +194,6 @@ func buildDeployGraph(
 		stepName := "deploy-" + svc.Name
 		var deps []string
 
-		if buildGateKey != nil {
-			if key := buildGateKey(svc); key != "" {
-				if first, ok := firstByGate[key]; ok {
-					deps = append(deps, first)
-				} else {
-					firstByGate[key] = stepName
-				}
-			}
-		}
 		for _, dep := range svc.Uses {
 			if dep == svc.Name {
 				continue

--- a/cli/azd/internal/cmd/service_graph.go
+++ b/cli/azd/internal/cmd/service_graph.go
@@ -156,20 +156,19 @@ type serviceGraphOptions struct {
 	// with hints) before the error bubbles up. Optional.
 	onDeployTimeout func(ctx context.Context, svc *project.ServiceConfig)
 
-	// buildGateKey groups services that must share a single sequential
-	// "first-wins" build lane: for each non-empty key, the first service
-	// encountered in slice order acts as the gate, and every later service
-	// returning the same key declares an edge to that first deploy step so
-	// their deploys wait for it. An empty key means "no gate" (full
-	// parallelism). Keys are opaque strings, so multiple independent gates
-	// can coexist (e.g. one group per shared build toolchain).
+	// buildGateKey groups services that share a concurrent-unsafe build
+	// phase: for each non-empty key, a shared mutex is created and injected
+	// into each gated deploy step's context. The service target acquires
+	// the mutex only during image preparation (dotnet publish) and releases
+	// it before the Azure deployment begins. An empty key means "no gate"
+	// (full parallelism). Keys are opaque strings, so multiple independent
+	// gates can coexist (e.g. one group per shared build toolchain).
 	//
 	// The graph builder itself is gate-agnostic: callers (including future
 	// extensions) inject the policy. `azd deploy` and `azd up` supply a
 	// callback that returns "aspire" for services owned by a .NET AppHost
-	// manifest, so the first Aspire deploy triggers the shared AppHost
-	// build and the rest wait — avoiding concurrent builds of the same
-	// AppHost. If nil, no gating is applied.
+	// manifest. The preferred approach is --artifacts-path (full
+	// parallelism); the mutex is a fallback. If nil, no gating is applied.
 	buildGateKey func(svc *project.ServiceConfig) string
 
 	// onPhaseProgress, if non-nil, is invoked with intra-phase progress
@@ -205,9 +204,9 @@ type serviceGraphHandles struct {
 //	opts.packageExtraDeps ──▶ package-<svc> ──▶ opts.publishExtraDeps ──▶ publish-<svc> ──▶ deploy-<svc>
 //	                                                                                            │
 //	                                                                     opts.buildGateKey:
-//	                                                             first service per non-empty key
-//	                                                           runs first; later services with the
-//	                                                            same key wait on that first step.
+//	                                                             services sharing a non-empty key
+//	                                                            get a runtime mutex in their context
+//	                                                              (no graph edges between deploys).
 //
 // Deploy ordering: when no service declares a `uses:` edge targeting
 // another service in this graph, deploy steps chain sequentially in the
@@ -246,12 +245,16 @@ func addServiceStepsToGraph(g *exegraph.Graph, opts serviceGraphOptions) (*servi
 		DeploySteps:  make([]string, 0, len(opts.services)),
 	}
 
-	// firstByGate records, per non-empty gate key produced by
-	// opts.buildGateKey, the first deploy step seen in iteration order.
-	// Later services that return the same key take a dependency on that
-	// first step. Services whose gate key is "" (or when buildGateKey is
-	// nil) are unconstrained and run in full parallelism.
-	firstByGate := make(map[string]string)
+	// buildGateMu holds a per-gate-key mutex used to serialize only the
+	// image-preparation phase (dotnet publish) inside Aspire deploy steps,
+	// while leaving the Azure deployment portion fully parallel. The mutex
+	// is injected into the deploy step's context so the service target can
+	// acquire it during the build-only window. See build_gate.go in the
+	// project package.
+	//
+	// Services whose gate key is "" (or when buildGateKey is nil) are
+	// unconstrained and run in full parallelism.
+	buildGateMu := make(map[string]*sync.Mutex)
 
 	// serviceNames is the set of service names in this graph, used to
 	// resolve service-to-service edges declared via `services.<name>.uses`
@@ -291,8 +294,8 @@ func addServiceStepsToGraph(g *exegraph.Graph, opts serviceGraphOptions) (*servi
 	}
 
 	// Check (b): buildGateKey policy — when any service produces a
-	// non-empty gate key, the gate itself provides the ordering constraint
-	// (first service builds, rest wait). The sequential fallback would be
+	// non-empty gate key, the gate provides runtime serialization of the
+	// build phase via a shared mutex. The sequential fallback would be
 	// redundant and would prevent parallelism for non-gated services.
 	if !hasExplicitOrdering && opts.buildGateKey != nil {
 		for _, svc := range opts.services {
@@ -452,16 +455,21 @@ func addServiceStepsToGraph(g *exegraph.Graph, opts serviceGraphOptions) (*servi
 			return nil, fmt.Errorf("building publish step %s: %w", publishStepName, err)
 		}
 
-		// ── deploy-<svc> ── publish + build gate (if any) + declared
-		// service-to-service `uses:` edges + any caller-supplied fan-in.
-		deployDeps := make([]string, 0, 1+1+len(svc.Uses)+len(opts.deployExtraDeps))
+		// ── deploy-<svc> ── publish + declared service-to-service `uses:`
+		// edges + any caller-supplied fan-in.
+		//
+		// Build-gate synchronization is handled at RUNTIME, not via graph
+		// topology: the deploy step's context carries a per-gate-key mutex
+		// that the service target acquires only during image preparation
+		// (dotnet publish) and releases before the Azure deployment begins.
+		// This serializes the race-prone build phase while keeping the slow
+		// Azure deployment portion fully parallel.
+		deployDeps := make([]string, 0, 1+len(svc.Uses)+len(opts.deployExtraDeps))
 		deployDeps = append(deployDeps, publishStepName)
 		if opts.buildGateKey != nil {
 			if key := opts.buildGateKey(svc); key != "" {
-				if first, ok := firstByGate[key]; ok {
-					deployDeps = append(deployDeps, first)
-				} else {
-					firstByGate[key] = deployStepName
+				if _, ok := buildGateMu[key]; !ok {
+					buildGateMu[key] = &sync.Mutex{}
 				}
 			}
 		}
@@ -522,6 +530,16 @@ func addServiceStepsToGraph(g *exegraph.Graph, opts serviceGraphOptions) (*servi
 
 				deployCtx, deployCancel := context.WithTimeout(stepCtx, opts.deployTimeout)
 				defer deployCancel()
+
+				// Inject the build gate mutex into the deploy context so the
+				// service target can serialize only the image-preparation phase.
+				if opts.buildGateKey != nil {
+					if key := opts.buildGateKey(depSvc); key != "" {
+						if mu, ok := buildGateMu[key]; ok {
+							deployCtx = project.ContextWithBuildGate(deployCtx, mu)
+						}
+					}
+				}
 
 				progress := newPhaseProgress(depSvc.Name, phaseDeploying)
 				defer progress.Wait()

--- a/cli/azd/internal/cmd/service_graph_test.go
+++ b/cli/azd/internal/cmd/service_graph_test.go
@@ -5,10 +5,12 @@ package cmd
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/apphost"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/exegraph"
@@ -237,4 +239,125 @@ func TestDeployGraphState_StoreLoadContext(t *testing.T) {
 	sc := project.NewServiceContext()
 	state.StoreContext("svc", sc)
 	require.Same(t, sc, state.LoadContext("svc"))
+}
+
+// TestBuildGateParallelWithArtifactsPath verifies that when a buildGateKey
+// is set, deploy steps still execute in PARALLEL at the graph level (no chain
+// edges). The build-race prevention is handled at runtime via --artifacts-path
+// and fallback mutex, not via graph topology. This is the fix for GitHub issue
+// #8177: full parallelism preserved while isolating intermediate build outputs.
+func TestBuildGateParallelWithArtifactsPath(t *testing.T) {
+	t.Parallel()
+
+	services := []*project.ServiceConfig{
+		{Name: "api", DotNetContainerApp: &project.DotNetContainerAppOptions{
+			Manifest: &apphost.Manifest{},
+		}},
+		{Name: "worker", DotNetContainerApp: &project.DotNetContainerAppOptions{
+			Manifest: &apphost.Manifest{},
+		}},
+		{Name: "web", DotNetContainerApp: &project.DotNetContainerAppOptions{
+			Manifest: &apphost.Manifest{},
+		}},
+		{Name: "free"}, // non-Aspire, should not be gated
+	}
+
+	opts, g := newGraphOpts(services)
+	opts.buildGateKey = aspireBuildGateKey
+	handles, err := addServiceStepsToGraph(g, opts)
+	require.NoError(t, err)
+	require.Len(t, handles.DeploySteps, 4)
+	require.NoError(t, g.Validate())
+
+	// Run the graph to confirm it completes without deadlock.
+	var order []string
+	var mu sync.Mutex
+	err = exegraph.Run(t.Context(), g, exegraph.RunOptions{
+		OnStepDone: func(name string, stepErr error) {
+			if stepErr == nil && strings.HasPrefix(name, "deploy-") {
+				mu.Lock()
+				order = append(order, name)
+				mu.Unlock()
+			}
+		},
+	})
+	require.NoError(t, err)
+
+	// All 4 services should have completed.
+	require.Len(t, order, 4, "all deploy steps should complete")
+	require.Contains(t, order, "deploy-api")
+	require.Contains(t, order, "deploy-worker")
+	require.Contains(t, order, "deploy-web")
+	require.Contains(t, order, "deploy-free")
+
+	// Verify graph topology: no Aspire deploy step should depend on another.
+	steps := g.Steps()
+	for _, s := range steps {
+		if !strings.HasPrefix(s.Name, "deploy-") {
+			continue
+		}
+		for _, dep := range s.DependsOn {
+			if strings.HasPrefix(dep, "deploy-") {
+				t.Errorf("deploy step %q has graph-level dependency on %q; "+
+					"build gate should NOT produce graph edges", s.Name, dep)
+			}
+		}
+	}
+}
+
+// TestBuildGateMultipleKeys verifies that multiple independent gate keys
+// produce distinct mutexes per key and no graph-level deploy edges. This
+// ensures services in different gate groups are isolated from each other
+// (e.g. two different Aspire app hosts in the same project).
+func TestBuildGateMultipleKeys(t *testing.T) {
+	t.Parallel()
+
+	services := []*project.ServiceConfig{
+		{Name: "groupA-1", DotNetContainerApp: &project.DotNetContainerAppOptions{
+			Manifest: &apphost.Manifest{},
+		}},
+		{Name: "groupA-2", DotNetContainerApp: &project.DotNetContainerAppOptions{
+			Manifest: &apphost.Manifest{},
+		}},
+		{Name: "groupB-1", DotNetContainerApp: &project.DotNetContainerAppOptions{
+			Manifest: &apphost.Manifest{},
+		}},
+		{Name: "groupB-2", DotNetContainerApp: &project.DotNetContainerAppOptions{
+			Manifest: &apphost.Manifest{},
+		}},
+	}
+
+	opts, g := newGraphOpts(services)
+	// Two distinct gate keys: "gate-A" and "gate-B".
+	opts.buildGateKey = func(svc *project.ServiceConfig) string {
+		if strings.HasPrefix(svc.Name, "groupA") {
+			return "gate-A"
+		}
+		if strings.HasPrefix(svc.Name, "groupB") {
+			return "gate-B"
+		}
+		return ""
+	}
+
+	handles, err := addServiceStepsToGraph(g, opts)
+	require.NoError(t, err)
+	require.Len(t, handles.DeploySteps, 4)
+	require.NoError(t, g.Validate())
+
+	// Run the graph to verify no deadlock (which would occur if independent
+	// gate groups accidentally shared a mutex with blocking semantics).
+	err = exegraph.Run(t.Context(), g, exegraph.RunOptions{})
+	require.NoError(t, err)
+
+	// Verify no deploy→deploy edges exist for any gate group.
+	for _, s := range g.Steps() {
+		if !strings.HasPrefix(s.Name, "deploy-") {
+			continue
+		}
+		for _, dep := range s.DependsOn {
+			if strings.HasPrefix(dep, "deploy-") {
+				t.Errorf("deploy step %q depends on %q; multi-key gates should NOT produce edges", s.Name, dep)
+			}
+		}
+	}
 }

--- a/cli/azd/pkg/project/build_gate.go
+++ b/cli/azd/pkg/project/build_gate.go
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"context"
+	"strings"
+	"sync"
+)
+
+type buildGateContextKey struct{}
+
+// ContextWithBuildGate returns a new context carrying the given mutex as a
+// build gate. Deploy targets that perform concurrent-unsafe build operations
+// (e.g. dotnet publish on Aspire projects that share <ProjectReference>
+// dependencies) should acquire this mutex for the duration of the build and
+// release it before proceeding to the Azure deployment portion.
+//
+// This is a FALLBACK mechanism. The preferred approach is to use
+// [dotnet.ContextWithArtifactsPath] to isolate intermediate outputs, which
+// allows full parallelism without serialization.
+func ContextWithBuildGate(ctx context.Context, mu *sync.Mutex) context.Context {
+	return context.WithValue(ctx, buildGateContextKey{}, mu)
+}
+
+// BuildGateFromContext retrieves the build gate mutex from the context, or nil
+// if none was set. Callers should check for nil before locking.
+func BuildGateFromContext(ctx context.Context) *sync.Mutex {
+	if mu, ok := ctx.Value(buildGateContextKey{}).(*sync.Mutex); ok {
+		return mu
+	}
+	return nil
+}
+
+// sanitizeTempDirName replaces characters outside [A-Za-z0-9_-] with
+// underscores so the result is safe for use as a temp-directory prefix on all
+// platforms.
+func sanitizeTempDirName(name string) string {
+	return strings.Map(func(r rune) rune {
+		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			return r
+		}
+		return '_'
+	}, name)
+}

--- a/cli/azd/pkg/project/build_gate_test.go
+++ b/cli/azd/pkg/project/build_gate_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildGateRoundTrip(t *testing.T) {
+	mu := &sync.Mutex{}
+	ctx := ContextWithBuildGate(context.Background(), mu)
+	got := BuildGateFromContext(ctx)
+	require.Same(t, mu, got)
+}
+
+func TestBuildGateFromContext_NilWhenAbsent(t *testing.T) {
+	require.Nil(t, BuildGateFromContext(context.Background()))
+}
+
+func TestSanitizeTempDirName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"alphanumeric passthrough", "webfrontend", "webfrontend"},
+		{"hyphens preserved", "my-api-service", "my-api-service"},
+		{"underscores preserved", "my_api", "my_api"},
+		{"dots replaced", "my.service", "my_service"},
+		{"slashes replaced", "path/to/svc", "path_to_svc"},
+		{"spaces replaced", "my service", "my_service"},
+		{"mixed unsafe chars", "svc@1.0/beta", "svc_1_0_beta"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, sanitizeTempDirName(tt.in))
+		})
+	}
+}

--- a/cli/azd/pkg/project/service_target_dotnet_containerapp.go
+++ b/cli/azd/pkg/project/service_target_dotnet_containerapp.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"text/template"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -149,9 +150,51 @@ func (at *dotnetContainerAppTarget) Deploy(
 	var bicepDeploymentResult *azapi.ResourceDeployment
 	var yamlDeploymentError error
 
-	// Prepare the container image based on service type and configuration
-	// This handles all four Aspire resource types (dockerfile.v0, container.v0, project.v0, container.v1)
-	imageResult, err := at.prepareContainerImage(ctx, serviceConfig, serviceContext, targetResource, progress)
+	// Prepare the container image based on service type and configuration.
+	// This handles all four Aspire resource types (dockerfile.v0, container.v0, project.v0, container.v1).
+	//
+	// When multiple Aspire services are deployed in parallel, their dotnet publish
+	// invocations race on shared <ProjectReference> obj/ directories, producing
+	// MSB4018 / System.IO.IOException. We resolve this by giving each service its
+	// own artifacts directory (--artifacts-path), so intermediate build outputs
+	// are isolated and concurrent publishes cannot interfere with each other.
+	//
+	// If a build gate mutex is present in ctx, we first try to create a per-service
+	// temp dir for --artifacts-path. If that fails (e.g. disk full, permissions),
+	// we fall back to acquiring the mutex during image preparation only.
+	imageCtx := ctx
+	var buildGateMu *sync.Mutex // non-nil only in the mutex fallback path
+	if BuildGateFromContext(ctx) != nil {
+		// Create a per-service temp directory for isolated intermediate outputs.
+		// Sanitize the service name to safe filesystem characters and keep the
+		// prefix short to avoid MAX_PATH issues on Windows when MSBuild nests
+		// obj/<config>/<tfm>/... underneath.
+		safeName := sanitizeTempDirName(serviceConfig.Name)
+		artifactsDir, mkdirErr := os.MkdirTemp("", "azd-"+safeName+"-")
+		if mkdirErr == nil {
+			defer func() {
+				if rmErr := os.RemoveAll(artifactsDir); rmErr != nil {
+					log.Printf("warning: failed to remove artifacts temp dir %s: %v", artifactsDir, rmErr)
+				}
+			}()
+			imageCtx = dotnet.ContextWithArtifactsPath(ctx, artifactsDir)
+		} else {
+			// Fallback: use the mutex to serialize image preparation only.
+			// We lock/unlock explicitly (not defer) so the Azure deployment
+			// portion that follows runs in parallel.
+			log.Printf("warning: failed to create artifacts temp dir for %s: %v; falling back to serial build",
+				serviceConfig.Name, mkdirErr)
+			buildGateMu = BuildGateFromContext(ctx)
+		}
+	}
+
+	if buildGateMu != nil {
+		buildGateMu.Lock()
+	}
+	imageResult, err := at.prepareContainerImage(imageCtx, serviceConfig, serviceContext, targetResource, progress)
+	if buildGateMu != nil {
+		buildGateMu.Unlock()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/cli/azd/pkg/tools/dotnet/dotnet.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet.go
@@ -258,6 +258,8 @@ func (cli *Cli) BuildContainerLocal(
 		"--getProperty:GeneratedContainerConfiguration",
 	)
 
+	runArgs = appendArtifactsPath(ctx, runArgs)
+
 	result, err := cli.commandRunner.Run(ctx, runArgs)
 	if err != nil {
 		return 0, "", fmt.Errorf("dotnet publish on project '%s' failed: %w", project, err)
@@ -302,6 +304,8 @@ func (cli *Cli) PublishContainer(
 		"--getProperty:GeneratedContainerConfiguration",
 	)
 
+	runArgs = appendArtifactsPath(ctx, runArgs)
+
 	runArgs = runArgs.WithEnv([]string{
 		fmt.Sprintf("DOTNET_CONTAINER_REGISTRY_UNAME=%s", username),
 		fmt.Sprintf("DOTNET_CONTAINER_REGISTRY_PWORD=%s", password),
@@ -321,6 +325,40 @@ func (cli *Cli) PublishContainer(
 	}
 
 	return port, nil
+}
+
+// appendArtifactsPath checks the context for a per-service artifacts path
+// (set by [ContextWithArtifactsPath]) and, if present, appends
+// --artifacts-path to the dotnet publish command. This redirects all
+// intermediate build outputs (obj/, bin/) to a service-specific directory,
+// preventing file races when multiple services that share <ProjectReference>
+// dependencies are published in parallel.
+func appendArtifactsPath(ctx context.Context, runArgs exec.RunArgs) exec.RunArgs {
+	if ap := ArtifactsPathFromContext(ctx); ap != "" {
+		runArgs = runArgs.AppendParams("--artifacts-path", ap)
+	}
+	return runArgs
+}
+
+type artifactsPathContextKey struct{}
+
+// ContextWithArtifactsPath returns a new context carrying a per-service
+// artifacts path. When set, dotnet publish commands append
+// `--artifacts-path <path>` to redirect all intermediate build outputs
+// (obj/, bin/) to a service-specific directory, preventing file races when
+// multiple services sharing <ProjectReference> dependencies are published
+// in parallel.
+func ContextWithArtifactsPath(ctx context.Context, path string) context.Context {
+	return context.WithValue(ctx, artifactsPathContextKey{}, path)
+}
+
+// ArtifactsPathFromContext retrieves the per-service artifacts path from
+// the context, or "" if none was set.
+func ArtifactsPathFromContext(ctx context.Context) string {
+	if p, ok := ctx.Value(artifactsPathContextKey{}).(string); ok {
+		return p
+	}
+	return ""
 }
 
 // getTargetPort parses the output of `dotnet publish` with `/t:PublishContainer` to get the port the container exposes.

--- a/cli/azd/pkg/tools/dotnet/dotnet_commands_test.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet_commands_test.go
@@ -532,6 +532,62 @@ func Test_Cli_PublishContainer(t *testing.T) {
 	})
 }
 
+func Test_Cli_ArtifactsPathContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("PublishContainer appends --artifacts-path from context", func(t *testing.T) {
+		t.Parallel()
+		cli, runner := newCliWithMock(t)
+		var captured exec.RunArgs
+		runner.When(matchDotnetArg0("publish")).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				captured = args
+				return exec.NewRunResult(0, successContainerOutput, ""), nil
+			})
+
+		ctx := ContextWithArtifactsPath(t.Context(), "/tmp/artifacts-svc1")
+		_, err := cli.PublishContainer(ctx, "p.csproj", "Release", "img", "r", "u", "p")
+		require.NoError(t, err)
+		joined := strings.Join(captured.Args, " ")
+		require.Contains(t, joined, "--artifacts-path")
+		require.Contains(t, joined, "/tmp/artifacts-svc1")
+	})
+
+	t.Run("BuildContainerLocal appends --artifacts-path from context", func(t *testing.T) {
+		t.Parallel()
+		cli, runner := newCliWithMock(t)
+		var captured exec.RunArgs
+		runner.When(matchDotnetArg0("publish")).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				captured = args
+				return exec.NewRunResult(0, successContainerOutput, ""), nil
+			})
+
+		ctx := ContextWithArtifactsPath(t.Context(), "/tmp/artifacts-svc2")
+		_, _, err := cli.BuildContainerLocal(ctx, "p.csproj", "Release", "img")
+		require.NoError(t, err)
+		joined := strings.Join(captured.Args, " ")
+		require.Contains(t, joined, "--artifacts-path")
+		require.Contains(t, joined, "/tmp/artifacts-svc2")
+	})
+
+	t.Run("no artifacts-path when context has none", func(t *testing.T) {
+		t.Parallel()
+		cli, runner := newCliWithMock(t)
+		var captured exec.RunArgs
+		runner.When(matchDotnetArg0("publish")).
+			RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+				captured = args
+				return exec.NewRunResult(0, successContainerOutput, ""), nil
+			})
+
+		_, err := cli.PublishContainer(t.Context(), "p.csproj", "Release", "img", "r", "u", "p")
+		require.NoError(t, err)
+		joined := strings.Join(captured.Args, " ")
+		require.NotContains(t, joined, "--artifacts-path")
+	})
+}
+
 func Test_Cli_getTargetPort_Branches(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #8177

## Problem

When multiple Aspire services sharing `<ProjectReference>` dependencies are deployed in parallel, their concurrent `dotnet publish` invocations race on shared `obj/` directories, producing MSB4018/IOException errors.

## Approach

Pass `--artifacts-path <per-service-temp-dir>` to `dotnet publish`, redirecting ALL intermediate build outputs (obj/, bin/) to an isolated directory per service. This eliminates the file race entirely while preserving full deploy parallelism.

**Why --artifacts-path?**
- First-class .NET 8+ SDK feature designed for exactly this isolation scenario
- Aspire requires .NET 8+, so the flag is always available
- Zero serialization — all services deploy fully in parallel including the dotnet publish phase
- Trade-off: shared project references get compiled once per service (redundant but fast vs the Azure deployment that follows)

**Fallback**: If temp dir creation fails (disk full, permissions), a mutex serializes only the `dotnet publish` phase while the Azure deployment portion remains parallel.

## Changes

- `dotnet.go` — `appendArtifactsPath()` + context helpers (`ContextWithArtifactsPath`/`ArtifactsPathFromContext`)
- `service_target_dotnet_containerapp.go` — Deploy() creates per-service temp dir, injects via context; explicit lock/enable for mutex fallback (not defer, to avoid holding across Azure deployment)
- `build_gate.go` (new) — Context helpers for build gate mutex
- `service_graph.go` — Injects mutex via context instead of graph edges; deploy steps remain parallel at graph level
- Tests rewritten to verify parallel topology

## Non-Aspire impact

None. The artifacts path and build gate are only injected when the service has a `DotNetContainerApp` configuration. Non-Aspire services get vanilla context with no behavioral change.

## Future optimization

A `dotnet build --artifacts-path` pass once upfront, followed by `dotnet publish --no-build`, would eliminate redundant shared-library compilation. Left for a follow-up since the current approach is correct and the redundant compilation is fast relative to the Azure deployment step.