### PR TITLE
fix: add missing azd exec (#7400) to 1.25.1 changelog + fix skill coverage gap

### DIFF
--- a/.github/skills/changelog-generation/SKILL.md
+++ b/.github/skills/changelog-generation/SKILL.md
@@ -85,8 +85,9 @@ Per [references/pr-processing.md](references/pr-processing.md):
 1. **Remove empty category sections** — scan the new release entry and delete any `### <Category>` heading that has no bullet entries beneath it (i.e., the next line is blank followed by another `###` heading or `##` heading or end of section). This is mandatory — never leave empty `### Breaking Changes`, `### Features Added`, `### Bugs Fixed`, or `### Other Changes` sections in the final output.
 2. For extensions using flat bullet lists (no category headings), match the existing style.
 3. **Validate PR links**: verify that every `- ` bullet under a category heading contains a `[[#NNNN]]` link. If any entry is missing a link, flag it and require either adding the PR reference or explicitly justifying the omission. When a single large PR warrants multiple changelog bullets, each must reference the same PR number.
-4. **Cross-reference commit range**: verify every `[[#NNNN]]` PR number against the commit list from Step 3. Flag any PR that does not appear in the commit range — it may be a duplicate from a prior release or an incorrectly attributed entry.
-5. Present the **complete changelog entry** to the user for review via `ask_user`.
+4. **Cross-reference commit range (forward)**: verify every `[[#NNNN]]` PR number against the commit list from Step 3. Flag any PR that does not appear in the commit range — it may be a duplicate from a prior release or an incorrectly attributed entry.
+5. **Reverse cross-reference (coverage check)**: for every commit in the Step 3 range, verify it is either (a) included in the changelog entry, or (b) excluded with a documented reason (test-only, docs-only, CI, extension-only, dependency bump, duplicate PR, alpha-gated, or cross-release dedup). Present a summary table to the user listing each commit's PR number, title, and disposition (included / excluded with reason). Flag any commit that is neither included nor has a clear exclusion reason — these are potential misses that require explicit user confirmation before proceeding.
+6. Present the **complete changelog entry** to the user for review via `ask_user`.
 
    Choices:
    - **Approve** — accept and proceed to spell check

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Features Added
 
+- [[#7400]](https://github.com/Azure/azure-dev/pull/7400) Add `azd exec` — a cross-platform command and script execution engine that runs programs with full azd environment context (environment variables, Key Vault secret resolution).
 - [[#8047]](https://github.com/Azure/azure-dev/pull/8047) Expose ARM deployment IDs via `AZD_DEPLOYMENT_ID_FILE` environment variable during provision, written in NDJSON format for programmatic consumption.
 - [[#8059]](https://github.com/Azure/azure-dev/pull/8059) Add actionable suggestions and links to preflight warnings with multi-line formatting for better readability.
 - [[#8083]](https://github.com/Azure/azure-dev/pull/8083) Add tenant picker before subscription prompt for multi-tenant users, scoping the subscription list to the selected tenant.


### PR DESCRIPTION
## Problem

The 1.25.1 release changelog (PR #8215) missed PR #7400 (`azd exec`). The PR was in the commit range (`af7011e09`) but was silently skipped during changelog generation.

The GitHub release notes have already been updated directly: https://github.com/Azure/azure-dev/releases/tag/azure-dev-cli_1.25.1

## Changes

### 1. CHANGELOG.md fix
- Add the missing `#7400` entry to the 1.25.1 `Features Added` section

### 2. Changelog generation skill fix
- Add **reverse cross-reference (coverage check)** as Step 5.5 in `.github/skills/changelog-generation/SKILL.md`
- The existing forward cross-reference (Step 5.4) verifies included PRs are in the commit range, but does NOT verify the reverse — that every commit in range is accounted for
- The new step requires the skill to present a summary table showing every commit's disposition (included / excluded with reason), flagging any commit without a clear classification

## Root Cause

The skill's Step 5 validation only checked that *included* entries were valid (forward check). It never verified that all commits in the range were *covered* — either included or explicitly excluded. This meant a PR could be silently dropped without anyone noticing.

PR #7400 was likely skipped due to a processing error (possibly the em dash in the commit subject or an MCP fetch failure) with no flag raised because no reverse coverage check existed.