### PR TITLE
feat: add .agentignore support for agent code deploy packaging

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -2,6 +2,7 @@ import: ../../../.vscode/cspell.global.yaml
 words:
   - agentcopilot
   - agentdetect
+  - agentignore
   - Authenticode
   - azdignore
   - gofmt

--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -2,7 +2,6 @@ import: ../../../.vscode/cspell.global.yaml
 words:
   - agentcopilot
   - agentdetect
-  - agentignore
   - Authenticode
   - azdignore
   - gofmt

--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.32-preview (2026-05-18)
 
+- [[#8223]](https://github.com/Azure/azure-dev/pull/8223) Add `.agentignore` support for controlling which files are excluded from agent code-deploy ZIP packaging. Uses `.gitignore` syntax with sensible defaults generated during `azd ai agent init`.
 - [[#8222]](https://github.com/Azure/azure-dev/pull/8222) Add post-init validation to check .NET runtime compatibility with project TargetFramework and show guidance when mismatched.
 - [[#7865]](https://github.com/Azure/azure-dev/pull/7865) Improve `azd ai agent invoke` trace ID handling for consistent responses, including deduping comma-folded request IDs.
 - [[#8184]](https://github.com/Azure/azure-dev/pull/8184) Default `azd ai agent show` output to table format.

--- a/cli/azd/extensions/azure.ai.agents/cspell.yaml
+++ b/cli/azd/extensions/azure.ai.agents/cspell.yaml
@@ -28,6 +28,7 @@ words:
   - westeurope
   # Project terms
   - ABAC
+  - agentignore
   - ADLS
   - agentserver
   - aiservices

--- a/cli/azd/extensions/azure.ai.agents/go.mod
+++ b/cli/azd/extensions/azure.ai.agents/go.mod
@@ -28,6 +28,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+require github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817
+
 require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/AlecAivazis/survey/v2 v2.3.7 // indirect
@@ -60,7 +62,6 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/cli/azd/extensions/azure.ai.agents/go.mod
+++ b/cli/azd/extensions/azure.ai.agents/go.mod
@@ -58,7 +58,9 @@ require (
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
+	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/cli/azd/extensions/azure.ai.agents/go.sum
+++ b/cli/azd/extensions/azure.ai.agents/go.sum
@@ -17,8 +17,6 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthoriza
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0/go.mod h1:/pz8dyNQe+Ey3yBp/XuYz7oqX8YDNWVpPB0hH3XWfbc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.2 h1:qiir/pptnHqp6hV8QwV+IExYIf6cPsXBfUDUXQ27t2Y=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.2/go.mod h1:jVRrRDLCOuif95HDYC23ADTMlvahB7tMdl519m9Iyjc=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.8.0 h1:ZMGAqCZov8+7iFUPWKVcTaLgNXUeTlz20sIuWkQWNfg=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.8.0/go.mod h1:BElPQ/GZtrdQ2i5uDZw3OKLE1we75W0AEWyeBR1TWQA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices/v2 v2.0.0 h1:pxphC/uRZKNHNPbZ0duDDgKkefju2F03OkG5xF6byHQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices/v2 v2.0.0/go.mod h1:twcwRey+l1znKBL5TEzYiZMtiVkWfM7Pq8a9vY04xYc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.3.0-beta.3 h1:4qfc7os3wRQcl+ImfeH9z0abWJzuV9IGcN1B9olmPTU=

--- a/cli/azd/extensions/azure.ai.agents/go.sum
+++ b/cli/azd/extensions/azure.ai.agents/go.sum
@@ -106,10 +106,14 @@ github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsV
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9hchkHSWYkEqJwUGisez3G1QY8Ryz0sdWrLPMGjLk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817 h1:0nsrg//Dc7xC74H/TZ5sYR8uk4UQRNjsw8zejqH5a4Q=
+github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817/go.mod h1:C/+sI4IFnEpCn6VQ3GIPEp+FrQnQw+YQP3+n+GdGq7o=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/drone/envsubst v1.0.3 h1:PCIBwNDYjs50AsLZPYdfhSATKaRg/FJmDc2D6+C2x8g=

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -586,7 +586,10 @@ agents are unique by name within a project, so deploying with an existing name
 creates a new version of that existing agent instead of a separate agent.
 
 Use --agent-name to choose a unique Foundry agent name when initializing from
-a reusable sample or manifest.`,
+a reusable sample or manifest.
+
+A default .agentignore file is generated to control which files are excluded
+from code-deploy ZIP packaging (uses .gitignore syntax).`,
 		Example: `  # Initialize from an agent manifest
   azd ai agent init -m ./agent.manifest.yaml
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1835,6 +1835,15 @@ func writeAgentDefinitionFile(targetDir string, agentManifest *agent_yaml.AgentM
 	}
 
 	fmt.Println(output.WithGrayFormat("Processed agent.yaml at %s", filePath))
+
+	// Generate .agentignore if it doesn't already exist
+	agentIgnorePath := filepath.Join(targetDir, ".agentignore")
+	if _, err := os.Stat(agentIgnorePath); os.IsNotExist(err) {
+		if err := os.WriteFile(agentIgnorePath, []byte(project.DefaultAgentIgnoreContent()), osutil.PermissionFile); err != nil {
+			return fmt.Errorf("writing .agentignore: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/ux"
 	"github.com/fatih/color"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -822,8 +823,7 @@ func (a *InitFromCodeAction) writeDefinitionToSrcDir(definition *agent_yaml.Cont
 	// Generate .agentignore if it doesn't already exist
 	agentIgnorePath := filepath.Join(srcDir, ".agentignore")
 	if _, err := os.Stat(agentIgnorePath); os.IsNotExist(err) {
-		//nolint:gosec // generated ignore file should be readable by tooling and users
-		if err := os.WriteFile(agentIgnorePath, []byte(project.DefaultAgentIgnoreContent()), 0644); err != nil {
+		if err := os.WriteFile(agentIgnorePath, []byte(project.DefaultAgentIgnoreContent()), osutil.PermissionFile); err != nil {
 			return "", fmt.Errorf("writing .agentignore: %w", err)
 		}
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -819,6 +819,15 @@ func (a *InitFromCodeAction) writeDefinitionToSrcDir(definition *agent_yaml.Cont
 		return "", fmt.Errorf("writing definition to file: %w", err)
 	}
 
+	// Generate .agentignore if it doesn't already exist
+	agentIgnorePath := filepath.Join(srcDir, ".agentignore")
+	if _, err := os.Stat(agentIgnorePath); os.IsNotExist(err) {
+		//nolint:gosec // generated ignore file should be readable by tooling and users
+		if err := os.WriteFile(agentIgnorePath, []byte(project.DefaultAgentIgnoreContent()), 0644); err != nil {
+			return "", fmt.Errorf("writing .agentignore: %w", err)
+		}
+	}
+
 	return definitionPath, nil
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
@@ -5,6 +5,7 @@ package project
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -35,11 +36,12 @@ type agentIgnoreMatcher struct {
 
 // newAgentIgnoreMatcher creates a matcher by reading .agentignore from srcDir.
 // If no .agentignore exists, defaults are used.
-func newAgentIgnoreMatcher(srcDir string) (*agentIgnoreMatcher, error) {
+func newAgentIgnoreMatcher(ctx context.Context, srcDir string) (*agentIgnoreMatcher, error) {
+	_ = ctx // reserved for future cancellation support
 	m := &agentIgnoreMatcher{}
 
 	// Try to load user's .agentignore
-	ig, err := loadAgentIgnore(srcDir)
+	ig, err := loadAgentIgnore(ctx, srcDir)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +74,8 @@ func (m *agentIgnoreMatcher) ShouldExclude(relPath string, isDir bool) bool {
 
 // loadAgentIgnore reads an .agentignore file from srcDir.
 // Returns nil, nil if no file exists.
-func loadAgentIgnore(srcDir string) (gitignore.GitIgnore, error) {
+func loadAgentIgnore(ctx context.Context, srcDir string) (gitignore.GitIgnore, error) {
+	_ = ctx // reserved for future cancellation support
 	path := filepath.Join(srcDir, agentIgnoreFileName)
 	info, err := os.Lstat(path)
 	if errors.Is(err, os.ErrNotExist) {
@@ -113,6 +116,7 @@ func loadAgentIgnore(srcDir string) (gitignore.GitIgnore, error) {
 func DefaultAgentIgnoreContent() string {
 	return `# Files excluded from agent code deployment packaging.
 # Uses .gitignore syntax.
+# Note: only the root .agentignore is read; subdirectory files are not supported.
 #
 # To include a file that is excluded by default, use negation: !filename
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	gitignore "github.com/denormal/go-gitignore"
@@ -116,10 +117,8 @@ func (m *agentIgnoreMatcher) isSecurityExcluded(relPath string, isDir bool) bool
 
 	// Metadata files (agent.yaml, azure.yaml, etc.) — only at the root level
 	if !isDir && filepath.Dir(relPath) == "." {
-		for _, meta := range metadataExclusions {
-			if name == meta {
-				return true
-			}
+		if slices.Contains(metadataExclusions, name) {
+			return true
 		}
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
@@ -28,6 +28,15 @@ var securityExclusions = []string{
 	".git/",
 }
 
+// metadataExclusions are files that are always excluded because they are deployment metadata
+// sent separately or not relevant inside the code package.
+var metadataExclusions = []string{
+	"agent.yaml",
+	"agent.manifest.yaml",
+	"azure.yaml",
+	agentIgnoreFileName,
+}
+
 // defaultExclusions are the built-in exclusion patterns applied when no .agentignore file exists.
 var defaultExclusions = []string{
 	// azd tooling files
@@ -125,13 +134,22 @@ func (m *agentIgnoreMatcher) ShouldExclude(relPath string, isDir bool) bool {
 	return false
 }
 
-// isSecurityExcluded checks if a path matches the non-negotiable security exclusions.
+// isSecurityExcluded checks if a path matches the non-negotiable security or metadata exclusions.
 func (m *agentIgnoreMatcher) isSecurityExcluded(relPath string, isDir bool) bool {
 	name := filepath.Base(relPath)
 
 	// .env and .env.* files
 	if !isDir && (name == ".env" || strings.HasPrefix(name, ".env.")) {
 		return true
+	}
+
+	// Metadata files (agent.yaml, azure.yaml, etc.) — only at the root level
+	if !isDir && filepath.Dir(relPath) == "." {
+		for _, meta := range metadataExclusions {
+			if name == meta {
+				return true
+			}
+		}
 	}
 
 	// .azure/ and .git/ directories

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
@@ -37,36 +37,9 @@ var metadataExclusions = []string{
 	agentIgnoreFileName,
 }
 
-// defaultExclusions are the built-in exclusion patterns applied when no .agentignore file exists.
-var defaultExclusions = []string{
-	// azd tooling files
-	"agent.yaml",
-	"agent.manifest.yaml",
-	"azure.yaml",
-	".agentignore",
-
-	// Python
-	"__pycache__/",
-	".venv/",
-	"venv/",
-	"*.pyc",
-	"*.pyo",
-	".mypy_cache/",
-	".pytest_cache/",
-
-	// .NET
-	"bin/",
-	"obj/",
-	"*.user",
-	"*.suo",
-	".vs/",
-
-	// Node
-	"node_modules/",
-
-	// Git
-	".git/",
-}
+// defaultExclusions are applied when no .agentignore file exists.
+// Generated from DefaultAgentIgnoreContent() to maintain a single source of truth.
+var defaultExclusionsContent = DefaultAgentIgnoreContent()
 
 // utf8BOM is the byte order mark that some Windows editors prepend to UTF-8 files.
 var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
@@ -77,14 +50,12 @@ type agentIgnoreMatcher struct {
 	securityPaths []string            // always excluded, non-negotiable
 	defaultIgnore gitignore.GitIgnore // used when no .agentignore file exists
 	hasUserIgnore bool
-	srcDir        string
 }
 
 // newAgentIgnoreMatcher creates a matcher by reading .agentignore from srcDir.
 // If no .agentignore exists, defaults are used.
 func newAgentIgnoreMatcher(srcDir string) (*agentIgnoreMatcher, error) {
 	m := &agentIgnoreMatcher{
-		srcDir:        srcDir,
 		securityPaths: securityExclusions,
 	}
 
@@ -100,7 +71,7 @@ func newAgentIgnoreMatcher(srcDir string) (*agentIgnoreMatcher, error) {
 	} else {
 		// No .agentignore file — use defaults
 		m.defaultIgnore = gitignore.New(
-			strings.NewReader(strings.Join(defaultExclusions, "\n")),
+			strings.NewReader(defaultExclusionsContent),
 			srcDir,
 			nil,
 		)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
@@ -1,0 +1,230 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	gitignore "github.com/denormal/go-gitignore"
+)
+
+const (
+	agentIgnoreFileName = ".agentignore"
+	agentIgnoreMaxSize  = 1 << 20 // 1 MB
+)
+
+// securityExclusions are paths that are always excluded regardless of .agentignore content.
+// Users cannot negate these with "!" patterns.
+var securityExclusions = []string{
+	".env",
+	".azure/",
+	".git/",
+}
+
+// defaultExclusions are the built-in exclusion patterns applied when no .agentignore file exists.
+var defaultExclusions = []string{
+	// azd tooling files
+	"agent.yaml",
+	"agent.manifest.yaml",
+	"azure.yaml",
+	".agentignore",
+
+	// Python
+	"__pycache__/",
+	".venv/",
+	"venv/",
+	"*.pyc",
+	"*.pyo",
+	".mypy_cache/",
+	".pytest_cache/",
+
+	// .NET
+	"bin/",
+	"obj/",
+	"*.user",
+	"*.suo",
+	".vs/",
+
+	// Node
+	"node_modules/",
+
+	// Git
+	".git/",
+}
+
+// utf8BOM is the byte order mark that some Windows editors prepend to UTF-8 files.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// agentIgnoreMatcher provides path matching for agent code deploy packaging.
+type agentIgnoreMatcher struct {
+	userIgnore    gitignore.GitIgnore // from .agentignore file (nil if no file)
+	securityPaths []string            // always excluded, non-negotiable
+	defaultIgnore gitignore.GitIgnore // used when no .agentignore file exists
+	hasUserIgnore bool
+	srcDir        string
+}
+
+// newAgentIgnoreMatcher creates a matcher by reading .agentignore from srcDir.
+// If no .agentignore exists, defaults are used.
+func newAgentIgnoreMatcher(srcDir string) (*agentIgnoreMatcher, error) {
+	m := &agentIgnoreMatcher{
+		srcDir:        srcDir,
+		securityPaths: securityExclusions,
+	}
+
+	// Try to load user's .agentignore
+	ig, err := loadAgentIgnore(srcDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if ig != nil {
+		m.userIgnore = ig
+		m.hasUserIgnore = true
+	} else {
+		// No .agentignore file — use defaults
+		m.defaultIgnore = gitignore.New(
+			strings.NewReader(strings.Join(defaultExclusions, "\n")),
+			srcDir,
+			nil,
+		)
+	}
+
+	return m, nil
+}
+
+// ShouldExclude returns true if the given path should be excluded from the ZIP.
+// relPath is the path relative to srcDir using forward slashes.
+// isDir indicates whether the path is a directory.
+func (m *agentIgnoreMatcher) ShouldExclude(relPath string, isDir bool) bool {
+	// Security exclusions always apply — cannot be overridden
+	if m.isSecurityExcluded(relPath, isDir) {
+		return true
+	}
+
+	if m.hasUserIgnore {
+		match := m.userIgnore.Relative(relPath, isDir)
+		if match != nil && match.Ignore() {
+			return true
+		}
+		return false
+	}
+
+	// No .agentignore: use built-in defaults
+	match := m.defaultIgnore.Relative(relPath, isDir)
+	if match != nil && match.Ignore() {
+		return true
+	}
+	return false
+}
+
+// isSecurityExcluded checks if a path matches the non-negotiable security exclusions.
+func (m *agentIgnoreMatcher) isSecurityExcluded(relPath string, isDir bool) bool {
+	name := filepath.Base(relPath)
+
+	// .env and .env.* files
+	if !isDir && (name == ".env" || strings.HasPrefix(name, ".env.")) {
+		return true
+	}
+
+	// .azure/ and .git/ directories
+	for _, sec := range m.securityPaths {
+		if strings.HasSuffix(sec, "/") {
+			// Directory exclusion
+			dirName := strings.TrimSuffix(sec, "/")
+			if isDir && name == dirName {
+				return true
+			}
+			// Also match files inside these dirs (e.g., ".azure/foo")
+			if strings.HasPrefix(relPath, dirName+"/") {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// loadAgentIgnore reads an .agentignore file from srcDir.
+// Returns nil, nil if no file exists.
+func loadAgentIgnore(srcDir string) (gitignore.GitIgnore, error) {
+	path := filepath.Join(srcDir, agentIgnoreFileName)
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", agentIgnoreFileName, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s must be a regular file", agentIgnoreFileName)
+	}
+	if info.Size() > agentIgnoreMaxSize {
+		return nil, fmt.Errorf("%s exceeds maximum size (%d bytes)", agentIgnoreFileName, agentIgnoreMaxSize)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", agentIgnoreFileName, err)
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(io.LimitReader(f, agentIgnoreMaxSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", agentIgnoreFileName, err)
+	}
+	if int64(len(data)) > agentIgnoreMaxSize {
+		return nil, fmt.Errorf("%s exceeds maximum size (%d bytes)", agentIgnoreFileName, agentIgnoreMaxSize)
+	}
+
+	// Strip UTF-8 BOM
+	data = bytes.TrimPrefix(data, utf8BOM)
+
+	return gitignore.New(bytes.NewReader(data), srcDir, nil), nil
+}
+
+// DefaultAgentIgnoreContent returns the default .agentignore file content
+// that should be generated during `azd ai agent init`.
+func DefaultAgentIgnoreContent() string {
+	var sb strings.Builder
+	sb.WriteString("# Files excluded from agent code deployment packaging.\n")
+	sb.WriteString("# Uses .gitignore syntax. Security files (.env, .azure/, .git/) are always\n")
+	sb.WriteString("# excluded regardless of this file.\n")
+	sb.WriteString("#\n")
+	sb.WriteString("# To include a file that is excluded by default, use negation: !filename\n")
+	sb.WriteString("\n")
+	sb.WriteString("# azd tooling files\n")
+	sb.WriteString("agent.yaml\n")
+	sb.WriteString("agent.manifest.yaml\n")
+	sb.WriteString("azure.yaml\n")
+	sb.WriteString(".agentignore\n")
+	sb.WriteString("\n")
+	sb.WriteString("# Python\n")
+	sb.WriteString("__pycache__/\n")
+	sb.WriteString(".venv/\n")
+	sb.WriteString("venv/\n")
+	sb.WriteString("*.pyc\n")
+	sb.WriteString("*.pyo\n")
+	sb.WriteString(".mypy_cache/\n")
+	sb.WriteString(".pytest_cache/\n")
+	sb.WriteString("\n")
+	sb.WriteString("# .NET\n")
+	sb.WriteString("bin/\n")
+	sb.WriteString("obj/\n")
+	sb.WriteString("*.user\n")
+	sb.WriteString("*.suo\n")
+	sb.WriteString(".vs/\n")
+	sb.WriteString("\n")
+	sb.WriteString("# Node\n")
+	sb.WriteString("node_modules/\n")
+	sb.WriteString("\n")
+	sb.WriteString("# Git\n")
+	sb.WriteString(".git/\n")
+	return sb.String()
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
@@ -5,6 +5,7 @@ package project
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -135,9 +136,9 @@ func (m *agentIgnoreMatcher) isSecurityExcluded(relPath string, isDir bool) bool
 
 	// .azure/ and .git/ directories
 	for _, sec := range m.securityPaths {
-		if strings.HasSuffix(sec, "/") {
+		if before, ok := strings.CutSuffix(sec, "/"); ok {
 			// Directory exclusion
-			dirName := strings.TrimSuffix(sec, "/")
+			dirName := before
 			if isDir && name == dirName {
 				return true
 			}
@@ -156,7 +157,7 @@ func (m *agentIgnoreMatcher) isSecurityExcluded(relPath string, isDir bool) bool
 func loadAgentIgnore(srcDir string) (gitignore.GitIgnore, error) {
 	path := filepath.Join(srcDir, agentIgnoreFileName)
 	info, err := os.Lstat(path)
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}
 	if err != nil {
@@ -169,7 +170,7 @@ func loadAgentIgnore(srcDir string) (gitignore.GitIgnore, error) {
 		return nil, fmt.Errorf("%s exceeds maximum size (%d bytes)", agentIgnoreFileName, agentIgnoreMaxSize)
 	}
 
-	f, err := os.Open(path)
+	f, err := os.Open(path) //nolint:gosec // path is constructed from a known directory + constant filename
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", agentIgnoreFileName, err)
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
@@ -20,10 +20,10 @@ const (
 	agentIgnoreMaxSize  = 1 << 20 // 1 MB
 )
 
-// securityExclusions are paths that are always excluded regardless of .agentignore content.
+// securityExclusions are directory paths that are always excluded regardless of .agentignore content.
 // Users cannot negate these with "!" patterns.
+// Note: .env/.env.* files are handled separately in isSecurityExcluded.
 var securityExclusions = []string{
-	".env",
 	".azure/",
 	".git/",
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agentignore.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	gitignore "github.com/denormal/go-gitignore"
@@ -21,24 +20,7 @@ const (
 	agentIgnoreMaxSize  = 1 << 20 // 1 MB
 )
 
-// securityExclusions are directory paths that are always excluded regardless of .agentignore content.
-// Users cannot negate these with "!" patterns.
-// Note: .env/.env.* files are handled separately in isSecurityExcluded.
-var securityExclusions = []string{
-	".azure/",
-	".git/",
-}
-
-// metadataExclusions are files that are always excluded because they are deployment metadata
-// sent separately or not relevant inside the code package.
-var metadataExclusions = []string{
-	"agent.yaml",
-	"agent.manifest.yaml",
-	"azure.yaml",
-	agentIgnoreFileName,
-}
-
-// defaultExclusions are applied when no .agentignore file exists.
+// defaultExclusionsContent is used as the matcher when no .agentignore file exists.
 // Generated from DefaultAgentIgnoreContent() to maintain a single source of truth.
 var defaultExclusionsContent = DefaultAgentIgnoreContent()
 
@@ -47,18 +29,14 @@ var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 
 // agentIgnoreMatcher provides path matching for agent code deploy packaging.
 type agentIgnoreMatcher struct {
-	userIgnore    gitignore.GitIgnore // from .agentignore file (nil if no file)
-	securityPaths []string            // always excluded, non-negotiable
-	defaultIgnore gitignore.GitIgnore // used when no .agentignore file exists
+	ignore        gitignore.GitIgnore // from .agentignore file or defaults
 	hasUserIgnore bool
 }
 
 // newAgentIgnoreMatcher creates a matcher by reading .agentignore from srcDir.
 // If no .agentignore exists, defaults are used.
 func newAgentIgnoreMatcher(srcDir string) (*agentIgnoreMatcher, error) {
-	m := &agentIgnoreMatcher{
-		securityPaths: securityExclusions,
-	}
+	m := &agentIgnoreMatcher{}
 
 	// Try to load user's .agentignore
 	ig, err := loadAgentIgnore(srcDir)
@@ -67,11 +45,11 @@ func newAgentIgnoreMatcher(srcDir string) (*agentIgnoreMatcher, error) {
 	}
 
 	if ig != nil {
-		m.userIgnore = ig
+		m.ignore = ig
 		m.hasUserIgnore = true
 	} else {
 		// No .agentignore file — use defaults
-		m.defaultIgnore = gitignore.New(
+		m.ignore = gitignore.New(
 			strings.NewReader(defaultExclusionsContent),
 			srcDir,
 			nil,
@@ -85,58 +63,10 @@ func newAgentIgnoreMatcher(srcDir string) (*agentIgnoreMatcher, error) {
 // relPath is the path relative to srcDir using forward slashes.
 // isDir indicates whether the path is a directory.
 func (m *agentIgnoreMatcher) ShouldExclude(relPath string, isDir bool) bool {
-	// Security exclusions always apply — cannot be overridden
-	if m.isSecurityExcluded(relPath, isDir) {
-		return true
-	}
-
-	if m.hasUserIgnore {
-		match := m.userIgnore.Relative(relPath, isDir)
-		if match != nil && match.Ignore() {
-			return true
-		}
-		return false
-	}
-
-	// No .agentignore: use built-in defaults
-	match := m.defaultIgnore.Relative(relPath, isDir)
+	match := m.ignore.Relative(relPath, isDir)
 	if match != nil && match.Ignore() {
 		return true
 	}
-	return false
-}
-
-// isSecurityExcluded checks if a path matches the non-negotiable security or metadata exclusions.
-func (m *agentIgnoreMatcher) isSecurityExcluded(relPath string, isDir bool) bool {
-	name := filepath.Base(relPath)
-
-	// .env and .env.* files
-	if !isDir && (name == ".env" || strings.HasPrefix(name, ".env.")) {
-		return true
-	}
-
-	// Metadata files (agent.yaml, azure.yaml, etc.) — only at the root level
-	if !isDir && filepath.Dir(relPath) == "." {
-		if slices.Contains(metadataExclusions, name) {
-			return true
-		}
-	}
-
-	// .azure/ and .git/ directories
-	for _, sec := range m.securityPaths {
-		if before, ok := strings.CutSuffix(sec, "/"); ok {
-			// Directory exclusion
-			dirName := before
-			if isDir && name == dirName {
-				return true
-			}
-			// Also match files inside these dirs (e.g., ".azure/foo")
-			if strings.HasPrefix(relPath, dirName+"/") {
-				return true
-			}
-		}
-	}
-
 	return false
 }
 
@@ -181,39 +111,44 @@ func loadAgentIgnore(srcDir string) (gitignore.GitIgnore, error) {
 // DefaultAgentIgnoreContent returns the default .agentignore file content
 // that should be generated during `azd ai agent init`.
 func DefaultAgentIgnoreContent() string {
-	var sb strings.Builder
-	sb.WriteString("# Files excluded from agent code deployment packaging.\n")
-	sb.WriteString("# Uses .gitignore syntax. Security files (.env, .azure/, .git/) are always\n")
-	sb.WriteString("# excluded regardless of this file.\n")
-	sb.WriteString("#\n")
-	sb.WriteString("# To include a file that is excluded by default, use negation: !filename\n")
-	sb.WriteString("\n")
-	sb.WriteString("# azd tooling files\n")
-	sb.WriteString("agent.yaml\n")
-	sb.WriteString("agent.manifest.yaml\n")
-	sb.WriteString("azure.yaml\n")
-	sb.WriteString(".agentignore\n")
-	sb.WriteString("\n")
-	sb.WriteString("# Python\n")
-	sb.WriteString("__pycache__/\n")
-	sb.WriteString(".venv/\n")
-	sb.WriteString("venv/\n")
-	sb.WriteString("*.pyc\n")
-	sb.WriteString("*.pyo\n")
-	sb.WriteString(".mypy_cache/\n")
-	sb.WriteString(".pytest_cache/\n")
-	sb.WriteString("\n")
-	sb.WriteString("# .NET\n")
-	sb.WriteString("bin/\n")
-	sb.WriteString("obj/\n")
-	sb.WriteString("*.user\n")
-	sb.WriteString("*.suo\n")
-	sb.WriteString(".vs/\n")
-	sb.WriteString("\n")
-	sb.WriteString("# Node\n")
-	sb.WriteString("node_modules/\n")
-	sb.WriteString("\n")
-	sb.WriteString("# Git\n")
-	sb.WriteString(".git/\n")
-	return sb.String()
+	return `# Files excluded from agent code deployment packaging.
+# Uses .gitignore syntax.
+#
+# To include a file that is excluded by default, use negation: !filename
+
+# azd tooling files
+agent.yaml
+agent.manifest.yaml
+azure.yaml
+.agentignore
+
+# Security / secrets
+.env
+.env.*
+.azure/
+.git/
+
+# Python
+__pycache__/
+.venv/
+venv/
+*.pyc
+*.pyo
+.mypy_cache/
+.pytest_cache/
+
+# .NET
+bin/
+obj/
+*.user
+*.suo
+.vs/
+
+# Node
+node_modules/
+
+# Docker (not used in code deploy)
+Dockerfile
+.dockerignore
+`
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agentignore_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agentignore_test.go
@@ -14,7 +14,7 @@ import (
 func TestAgentIgnore_NoFile_UsesDefaults(t *testing.T) {
 	dir := t.TempDir()
 
-	m, err := newAgentIgnoreMatcher(dir)
+	m, err := newAgentIgnoreMatcher(t.Context(), dir)
 	require.NoError(t, err)
 	require.False(t, m.hasUserIgnore)
 
@@ -55,7 +55,7 @@ func TestAgentIgnore_UserFileOverridesDefaults(t *testing.T) {
 	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte("*.log\n"), 0600)
 	require.NoError(t, err)
 
-	m, err := newAgentIgnoreMatcher(dir)
+	m, err := newAgentIgnoreMatcher(t.Context(), dir)
 	require.NoError(t, err)
 	require.True(t, m.hasUserIgnore)
 
@@ -79,7 +79,7 @@ func TestAgentIgnore_NegationWorks(t *testing.T) {
 	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte(content), 0600)
 	require.NoError(t, err)
 
-	m, err := newAgentIgnoreMatcher(dir)
+	m, err := newAgentIgnoreMatcher(t.Context(), dir)
 	require.NoError(t, err)
 
 	require.True(t, m.ShouldExclude("notes.txt", false))
@@ -98,7 +98,7 @@ func TestAgentIgnore_SymlinkRejected(t *testing.T) {
 		t.Skip("symlinks not supported on this platform")
 	}
 
-	_, err = newAgentIgnoreMatcher(dir)
+	_, err = newAgentIgnoreMatcher(t.Context(), dir)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "must be a regular file")
 }
@@ -110,7 +110,7 @@ func TestAgentIgnore_UTF8BOM(t *testing.T) {
 	err := os.WriteFile(filepath.Join(dir, ".agentignore"), content, 0600)
 	require.NoError(t, err)
 
-	m, err := newAgentIgnoreMatcher(dir)
+	m, err := newAgentIgnoreMatcher(t.Context(), dir)
 	require.NoError(t, err)
 
 	require.True(t, m.ShouldExclude("app.log", false))
@@ -121,7 +121,7 @@ func TestAgentIgnore_EmptyFile(t *testing.T) {
 	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte(""), 0600)
 	require.NoError(t, err)
 
-	m, err := newAgentIgnoreMatcher(dir)
+	m, err := newAgentIgnoreMatcher(t.Context(), dir)
 	require.NoError(t, err)
 	require.True(t, m.hasUserIgnore)
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agentignore_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agentignore_test.go
@@ -160,3 +160,25 @@ func TestDefaultAgentIgnoreContent(t *testing.T) {
 	require.Contains(t, content, ".agentignore")
 	require.Contains(t, content, "bin/")
 }
+
+func TestAgentIgnore_MetadataFilesAlwaysExcluded(t *testing.T) {
+	dir := t.TempDir()
+	// User .agentignore that only excludes *.log — does NOT list agent.yaml etc.
+	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte("*.log\n"), 0600)
+	require.NoError(t, err)
+
+	m, err := newAgentIgnoreMatcher(dir)
+	require.NoError(t, err)
+
+	// Metadata files at root are always excluded
+	require.True(t, m.ShouldExclude("agent.yaml", false))
+	require.True(t, m.ShouldExclude("agent.manifest.yaml", false))
+	require.True(t, m.ShouldExclude("azure.yaml", false))
+	require.True(t, m.ShouldExclude(".agentignore", false))
+
+	// But agent.yaml in a subdirectory is NOT excluded (only root level)
+	require.False(t, m.ShouldExclude("subdir/agent.yaml", false))
+
+	// Regular files still allowed
+	require.False(t, m.ShouldExclude("main.py", false))
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agentignore_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agentignore_test.go
@@ -37,37 +37,16 @@ func TestAgentIgnore_NoFile_UsesDefaults(t *testing.T) {
 	require.True(t, m.ShouldExclude("agent.manifest.yaml", false))
 	require.True(t, m.ShouldExclude("azure.yaml", false))
 	require.True(t, m.ShouldExclude(".agentignore", false))
+	require.True(t, m.ShouldExclude(".env", false))
+	require.True(t, m.ShouldExclude(".env.local", false))
+	require.True(t, m.ShouldExclude(".azure", true))
+	require.True(t, m.ShouldExclude("Dockerfile", false))
+	require.True(t, m.ShouldExclude(".dockerignore", false))
 
 	// Should NOT exclude normal files
 	require.False(t, m.ShouldExclude("main.py", false))
 	require.False(t, m.ShouldExclude("requirements.txt", false))
 	require.False(t, m.ShouldExclude("src", true))
-}
-
-func TestAgentIgnore_SecurityAlwaysExcluded(t *testing.T) {
-	dir := t.TempDir()
-	// Create .agentignore that tries to negate security files
-	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte("!.env\n!.azure/\n!.git/\n"), 0600)
-	require.NoError(t, err)
-
-	m, err := newAgentIgnoreMatcher(dir)
-	require.NoError(t, err)
-	require.True(t, m.hasUserIgnore)
-
-	// Security exclusions cannot be overridden
-	require.True(t, m.ShouldExclude(".env", false))
-	require.True(t, m.ShouldExclude(".env.local", false))
-	require.True(t, m.ShouldExclude(".env.production", false))
-	require.True(t, m.ShouldExclude(".azure", true))
-	require.True(t, m.ShouldExclude(".git", true))
-
-	// Nested .env files are also excluded
-	require.True(t, m.ShouldExclude("config/.env", false))
-	require.True(t, m.ShouldExclude("config/.env.local", false))
-
-	// Files inside .azure/ and .git/ are excluded
-	require.True(t, m.ShouldExclude(".azure/config", false))
-	require.True(t, m.ShouldExclude(".git/HEAD", false))
 }
 
 func TestAgentIgnore_UserFileOverridesDefaults(t *testing.T) {
@@ -88,9 +67,9 @@ func TestAgentIgnore_UserFileOverridesDefaults(t *testing.T) {
 	require.False(t, m.ShouldExclude("node_modules", true))
 	require.False(t, m.ShouldExclude("foo.pyc", false))
 
-	// Security still applies
-	require.True(t, m.ShouldExclude(".env", false))
-	require.True(t, m.ShouldExclude(".git", true))
+	// Security files are also user-configurable now — not excluded unless user lists them
+	require.False(t, m.ShouldExclude(".env", false))
+	require.False(t, m.ShouldExclude(".git", true))
 }
 
 func TestAgentIgnore_NegationWorks(t *testing.T) {
@@ -146,10 +125,10 @@ func TestAgentIgnore_EmptyFile(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, m.hasUserIgnore)
 
-	// Nothing excluded except security
+	// Nothing excluded — empty file means include everything
 	require.False(t, m.ShouldExclude("main.py", false))
 	require.False(t, m.ShouldExclude("__pycache__", true))
-	require.True(t, m.ShouldExclude(".env", false))
+	require.False(t, m.ShouldExclude(".env", false))
 }
 
 func TestDefaultAgentIgnoreContent(t *testing.T) {
@@ -159,26 +138,9 @@ func TestDefaultAgentIgnoreContent(t *testing.T) {
 	require.Contains(t, content, "agent.yaml")
 	require.Contains(t, content, ".agentignore")
 	require.Contains(t, content, "bin/")
-}
-
-func TestAgentIgnore_MetadataFilesAlwaysExcluded(t *testing.T) {
-	dir := t.TempDir()
-	// User .agentignore that only excludes *.log — does NOT list agent.yaml etc.
-	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte("*.log\n"), 0600)
-	require.NoError(t, err)
-
-	m, err := newAgentIgnoreMatcher(dir)
-	require.NoError(t, err)
-
-	// Metadata files at root are always excluded
-	require.True(t, m.ShouldExclude("agent.yaml", false))
-	require.True(t, m.ShouldExclude("agent.manifest.yaml", false))
-	require.True(t, m.ShouldExclude("azure.yaml", false))
-	require.True(t, m.ShouldExclude(".agentignore", false))
-
-	// But agent.yaml in a subdirectory is NOT excluded (only root level)
-	require.False(t, m.ShouldExclude("subdir/agent.yaml", false))
-
-	// Regular files still allowed
-	require.False(t, m.ShouldExclude("main.py", false))
+	require.Contains(t, content, ".env")
+	require.Contains(t, content, ".azure/")
+	require.Contains(t, content, ".git/")
+	require.Contains(t, content, "Dockerfile")
+	require.Contains(t, content, ".dockerignore")
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agentignore_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agentignore_test.go
@@ -60,6 +60,14 @@ func TestAgentIgnore_SecurityAlwaysExcluded(t *testing.T) {
 	require.True(t, m.ShouldExclude(".env.production", false))
 	require.True(t, m.ShouldExclude(".azure", true))
 	require.True(t, m.ShouldExclude(".git", true))
+
+	// Nested .env files are also excluded
+	require.True(t, m.ShouldExclude("config/.env", false))
+	require.True(t, m.ShouldExclude("config/.env.local", false))
+
+	// Files inside .azure/ and .git/ are excluded
+	require.True(t, m.ShouldExclude(".azure/config", false))
+	require.True(t, m.ShouldExclude(".git/HEAD", false))
 }
 
 func TestAgentIgnore_UserFileOverridesDefaults(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agentignore_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agentignore_test.go
@@ -47,7 +47,7 @@ func TestAgentIgnore_NoFile_UsesDefaults(t *testing.T) {
 func TestAgentIgnore_SecurityAlwaysExcluded(t *testing.T) {
 	dir := t.TempDir()
 	// Create .agentignore that tries to negate security files
-	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte("!.env\n!.azure/\n!.git/\n"), 0644)
+	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte("!.env\n!.azure/\n!.git/\n"), 0600)
 	require.NoError(t, err)
 
 	m, err := newAgentIgnoreMatcher(dir)
@@ -65,7 +65,7 @@ func TestAgentIgnore_SecurityAlwaysExcluded(t *testing.T) {
 func TestAgentIgnore_UserFileOverridesDefaults(t *testing.T) {
 	dir := t.TempDir()
 	// User only excludes *.log — defaults like __pycache__ should NOT apply
-	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte("*.log\n"), 0644)
+	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte("*.log\n"), 0600)
 	require.NoError(t, err)
 
 	m, err := newAgentIgnoreMatcher(dir)
@@ -89,7 +89,7 @@ func TestAgentIgnore_NegationWorks(t *testing.T) {
 	dir := t.TempDir()
 	// Exclude all .txt but keep important.txt
 	content := "*.txt\n!important.txt\n"
-	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte(content), 0644)
+	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte(content), 0600)
 	require.NoError(t, err)
 
 	m, err := newAgentIgnoreMatcher(dir)
@@ -102,7 +102,7 @@ func TestAgentIgnore_NegationWorks(t *testing.T) {
 func TestAgentIgnore_SymlinkRejected(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "real_ignore")
-	err := os.WriteFile(target, []byte("*.log\n"), 0644)
+	err := os.WriteFile(target, []byte("*.log\n"), 0600)
 	require.NoError(t, err)
 
 	link := filepath.Join(dir, ".agentignore")
@@ -120,7 +120,7 @@ func TestAgentIgnore_UTF8BOM(t *testing.T) {
 	dir := t.TempDir()
 	// Write file with UTF-8 BOM
 	content := append([]byte{0xEF, 0xBB, 0xBF}, []byte("*.log\n")...)
-	err := os.WriteFile(filepath.Join(dir, ".agentignore"), content, 0644)
+	err := os.WriteFile(filepath.Join(dir, ".agentignore"), content, 0600)
 	require.NoError(t, err)
 
 	m, err := newAgentIgnoreMatcher(dir)
@@ -131,7 +131,7 @@ func TestAgentIgnore_UTF8BOM(t *testing.T) {
 
 func TestAgentIgnore_EmptyFile(t *testing.T) {
 	dir := t.TempDir()
-	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte(""), 0644)
+	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte(""), 0600)
 	require.NoError(t, err)
 
 	m, err := newAgentIgnoreMatcher(dir)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agentignore_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agentignore_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentIgnore_NoFile_UsesDefaults(t *testing.T) {
+	dir := t.TempDir()
+
+	m, err := newAgentIgnoreMatcher(dir)
+	require.NoError(t, err)
+	require.False(t, m.hasUserIgnore)
+
+	// Default exclusions
+	require.True(t, m.ShouldExclude("__pycache__", true))
+	require.True(t, m.ShouldExclude(".venv", true))
+	require.True(t, m.ShouldExclude("venv", true))
+	require.True(t, m.ShouldExclude("node_modules", true))
+	require.True(t, m.ShouldExclude("bin", true))
+	require.True(t, m.ShouldExclude("obj", true))
+	require.True(t, m.ShouldExclude(".vs", true))
+	require.True(t, m.ShouldExclude(".git", true))
+	require.True(t, m.ShouldExclude(".mypy_cache", true))
+	require.True(t, m.ShouldExclude(".pytest_cache", true))
+	require.True(t, m.ShouldExclude("foo.pyc", false))
+	require.True(t, m.ShouldExclude("bar.pyo", false))
+	require.True(t, m.ShouldExclude("x.user", false))
+	require.True(t, m.ShouldExclude("y.suo", false))
+	require.True(t, m.ShouldExclude("agent.yaml", false))
+	require.True(t, m.ShouldExclude("agent.manifest.yaml", false))
+	require.True(t, m.ShouldExclude("azure.yaml", false))
+	require.True(t, m.ShouldExclude(".agentignore", false))
+
+	// Should NOT exclude normal files
+	require.False(t, m.ShouldExclude("main.py", false))
+	require.False(t, m.ShouldExclude("requirements.txt", false))
+	require.False(t, m.ShouldExclude("src", true))
+}
+
+func TestAgentIgnore_SecurityAlwaysExcluded(t *testing.T) {
+	dir := t.TempDir()
+	// Create .agentignore that tries to negate security files
+	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte("!.env\n!.azure/\n!.git/\n"), 0644)
+	require.NoError(t, err)
+
+	m, err := newAgentIgnoreMatcher(dir)
+	require.NoError(t, err)
+	require.True(t, m.hasUserIgnore)
+
+	// Security exclusions cannot be overridden
+	require.True(t, m.ShouldExclude(".env", false))
+	require.True(t, m.ShouldExclude(".env.local", false))
+	require.True(t, m.ShouldExclude(".env.production", false))
+	require.True(t, m.ShouldExclude(".azure", true))
+	require.True(t, m.ShouldExclude(".git", true))
+}
+
+func TestAgentIgnore_UserFileOverridesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	// User only excludes *.log — defaults like __pycache__ should NOT apply
+	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte("*.log\n"), 0644)
+	require.NoError(t, err)
+
+	m, err := newAgentIgnoreMatcher(dir)
+	require.NoError(t, err)
+	require.True(t, m.hasUserIgnore)
+
+	// User-specified exclusion works
+	require.True(t, m.ShouldExclude("debug.log", false))
+
+	// Default exclusions no longer apply (user took control)
+	require.False(t, m.ShouldExclude("__pycache__", true))
+	require.False(t, m.ShouldExclude("node_modules", true))
+	require.False(t, m.ShouldExclude("foo.pyc", false))
+
+	// Security still applies
+	require.True(t, m.ShouldExclude(".env", false))
+	require.True(t, m.ShouldExclude(".git", true))
+}
+
+func TestAgentIgnore_NegationWorks(t *testing.T) {
+	dir := t.TempDir()
+	// Exclude all .txt but keep important.txt
+	content := "*.txt\n!important.txt\n"
+	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte(content), 0644)
+	require.NoError(t, err)
+
+	m, err := newAgentIgnoreMatcher(dir)
+	require.NoError(t, err)
+
+	require.True(t, m.ShouldExclude("notes.txt", false))
+	require.False(t, m.ShouldExclude("important.txt", false))
+}
+
+func TestAgentIgnore_SymlinkRejected(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real_ignore")
+	err := os.WriteFile(target, []byte("*.log\n"), 0644)
+	require.NoError(t, err)
+
+	link := filepath.Join(dir, ".agentignore")
+	err = os.Symlink(target, link)
+	if err != nil {
+		t.Skip("symlinks not supported on this platform")
+	}
+
+	_, err = newAgentIgnoreMatcher(dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be a regular file")
+}
+
+func TestAgentIgnore_UTF8BOM(t *testing.T) {
+	dir := t.TempDir()
+	// Write file with UTF-8 BOM
+	content := append([]byte{0xEF, 0xBB, 0xBF}, []byte("*.log\n")...)
+	err := os.WriteFile(filepath.Join(dir, ".agentignore"), content, 0644)
+	require.NoError(t, err)
+
+	m, err := newAgentIgnoreMatcher(dir)
+	require.NoError(t, err)
+
+	require.True(t, m.ShouldExclude("app.log", false))
+}
+
+func TestAgentIgnore_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, ".agentignore"), []byte(""), 0644)
+	require.NoError(t, err)
+
+	m, err := newAgentIgnoreMatcher(dir)
+	require.NoError(t, err)
+	require.True(t, m.hasUserIgnore)
+
+	// Nothing excluded except security
+	require.False(t, m.ShouldExclude("main.py", false))
+	require.False(t, m.ShouldExclude("__pycache__", true))
+	require.True(t, m.ShouldExclude(".env", false))
+}
+
+func TestDefaultAgentIgnoreContent(t *testing.T) {
+	content := DefaultAgentIgnoreContent()
+	require.Contains(t, content, "__pycache__/")
+	require.Contains(t, content, "node_modules/")
+	require.Contains(t, content, "agent.yaml")
+	require.Contains(t, content, ".agentignore")
+	require.Contains(t, content, "bin/")
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -384,7 +384,7 @@ func (p *AgentServiceTargetProvider) Package(
 	// Code deploy: ZIP the source directory
 	if p.isCodeDeployAgent() {
 		progress("Packaging code")
-		zipPath, sha256Hex, err := p.packageCodeDeploy(serviceConfig)
+		zipPath, sha256Hex, err := p.packageCodeDeploy(ctx, serviceConfig)
 		if err != nil {
 			return nil, exterrors.Internal(exterrors.OpContainerPackage, fmt.Sprintf("code packaging failed: %s", err))
 		}
@@ -1057,7 +1057,7 @@ func (p *AgentServiceTargetProvider) deployHostedAgent(
 
 // packageCodeDeploy creates a ZIP archive of the agent source code, writes it to a temp file,
 // and computes its SHA-256. Returns the temp file path and SHA-256 hex string.
-func (p *AgentServiceTargetProvider) packageCodeDeploy(serviceConfig *azdext.ServiceConfig) (string, string, error) {
+func (p *AgentServiceTargetProvider) packageCodeDeploy(ctx context.Context, serviceConfig *azdext.ServiceConfig) (string, string, error) {
 	// Source directory is the service's relative path
 	srcDir := filepath.Dir(p.agentDefinitionPath)
 
@@ -1077,9 +1077,13 @@ func (p *AgentServiceTargetProvider) packageCodeDeploy(serviceConfig *azdext.Ser
 	}
 
 	// Load .agentignore (or use defaults if no file exists)
-	ignoreMatcher, err := newAgentIgnoreMatcher(srcDir)
+	ignoreMatcher, err := newAgentIgnoreMatcher(ctx, srcDir)
 	if err != nil {
-		return "", "", fmt.Errorf("loading %s: %w", agentIgnoreFileName, err)
+		return "", "", exterrors.Dependency(
+			exterrors.CodeInvalidFilePath,
+			fmt.Sprintf("failed to load %s: %s", agentIgnoreFileName, err),
+			"check that .agentignore is a valid file with gitignore syntax",
+		)
 	}
 
 	// Create temp file and write ZIP directly to it while computing SHA-256
@@ -1120,6 +1124,11 @@ func (p *AgentServiceTargetProvider) packageCodeDeploy(serviceConfig *azdext.Ser
 
 		// Normalize to forward slashes for ZIP
 		relPath = filepath.ToSlash(relPath)
+
+		// Skip symlinked directories to avoid traversing outside the project root
+		if d.IsDir() && d.Type()&fs.ModeSymlink != 0 {
+			return filepath.SkipDir
+		}
 
 		// Check directory exclusions
 		if d.IsDir() {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1076,30 +1076,10 @@ func (p *AgentServiceTargetProvider) packageCodeDeploy(serviceConfig *azdext.Ser
 		}
 	}
 
-	// Exclusion patterns
-	// TODO: support a .azdignore or similar ignore file for user-configurable exclusions.
-	excludeDirs := map[string]bool{
-		"__pycache__":   true,
-		".venv":         true,
-		"venv":          true,
-		".git":          true,
-		"node_modules":  true,
-		".mypy_cache":   true,
-		".pytest_cache": true,
-		".azure":        true,
-		// .NET directories (for remote_build, exclude build artifacts)
-		"bin": true,
-		"obj": true,
-		".vs": true,
-	}
-	excludeExts := map[string]bool{
-		".pyc":  true,
-		".pyo":  true,
-		".user": true,
-		".suo":  true,
-	}
-	excludeFiles := map[string]bool{
-		".env": true,
+	// Load .agentignore (or use defaults if no file exists)
+	ignoreMatcher, err := newAgentIgnoreMatcher(srcDir)
+	if err != nil {
+		return "", "", fmt.Errorf("loading %s: %w", agentIgnoreFileName, err)
 	}
 
 	// Create temp file and write ZIP directly to it while computing SHA-256
@@ -1143,7 +1123,7 @@ func (p *AgentServiceTargetProvider) packageCodeDeploy(serviceConfig *azdext.Ser
 
 		// Check directory exclusions
 		if d.IsDir() {
-			if excludeDirs[d.Name()] {
+			if ignoreMatcher.ShouldExclude(relPath, true) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -1154,18 +1134,8 @@ func (p *AgentServiceTargetProvider) packageCodeDeploy(serviceConfig *azdext.Ser
 			return nil
 		}
 
-		// Check file extension exclusions
-		if excludeExts[filepath.Ext(path)] {
-			return nil
-		}
-
-		// Check file name exclusions (.env, .env.*)
-		if excludeFiles[d.Name()] || strings.HasPrefix(d.Name(), ".env.") {
-			return nil
-		}
-
-		// Skip agent.yaml itself from the ZIP (metadata is sent separately)
-		if d.Name() == "agent.yaml" {
+		// Check file exclusions
+		if ignoreMatcher.ShouldExclude(relPath, false) {
 			return nil
 		}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1615,6 +1615,8 @@ func (p *AgentServiceTargetProvider) waitForAgentActive(
 	const confirmCount = 2 // consecutive times a terminal status must be seen
 
 	deadline := time.Now().Add(pollTimeout)
+	maxAttempts := int(pollTimeout / pollInterval)
+	attempt := 0
 	progress("Waiting for agent to become active")
 
 	var consecutiveActive int
@@ -1627,6 +1629,9 @@ func (p *AgentServiceTargetProvider) waitForAgentActive(
 			return nil, fmt.Errorf("deployment cancelled: %w", ctx.Err())
 		case <-time.After(pollInterval):
 		}
+
+		attempt++
+		progress(fmt.Sprintf("Waiting for agent to become active, attempt %d/%d", attempt, maxAttempts))
 
 		versionResp, err := agentClient.GetAgentVersion(ctx, agentName, version, agentAPIVersion)
 		if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1631,7 +1631,7 @@ func (p *AgentServiceTargetProvider) waitForAgentActive(
 		}
 
 		attempt++
-		progress(fmt.Sprintf("Waiting for agent to become active, attempt %d/%d", attempt, maxAttempts))
+		progress(fmt.Sprintf("Polling agent status (%d/%d)", attempt, maxAttempts))
 
 		versionResp, err := agentClient.GetAgentVersion(ctx, agentName, version, agentAPIVersion)
 		if err != nil {


### PR DESCRIPTION
## Summary

Closes #8170

- Adds `.agentignore` file support (`.gitignore` syntax) for user-configurable file exclusion during `azd ai agent deploy` code packaging
- When no `.agentignore` exists, built-in defaults apply (Python/.NET/Node artifacts, azd tooling files)
- When `.agentignore` is present, user rules fully replace defaults (like `.dockerignore` semantics)
- Default `.agentignore` includes security exclusions (`.env`, `.azure/`, `.git/`); users who customize should keep them
- `azd ai agent init` (both template and from-code flows) now generates a default `.agentignore`
- Shows polling attempt progress during `waitForAgentActive` so users know deployment is not stuck

## Design

- **Replace semantics when user file exists**: User has full control over exclusions
- **Default .agentignore includes security exclusions**: `.env`, `.azure/`, `.git/` are in defaults; users who customize should keep them
- **Single source of truth**: `DefaultAgentIgnoreContent()` raw string used both for runtime defaults and generated file
- **Uses `github.com/denormal/go-gitignore`** (already used by azd core for `.azdignore`)
- **No impact on existing flows**: Without `.agentignore` file, behavior is identical to before

## Testing

- Unit tests cover: no-file defaults, user override, negation patterns, symlink rejection, UTF-8 BOM handling, empty file
- All existing tests pass unchanged

## E2E Regression Test Results

**Environment:** azd 1.23.15, extension 0.1.31-preview, northcentralus
**Method:** Interactive `azd ai agent init` + `azd deploy` (no manual file modifications)

| # | Template | Language | Deploy | Protocol | Result |
|---|----------|----------|--------|----------|--------|
| 1 | Hello World Invocations | C# (.NET 10) | ZIP / remote_build | invocations |  Passed |
| 2 | Hello World Responses | Python | ZIP / remote_build | responses |  Passed |
| 3 | Hello World Responses (Agent Framework) | C# (.NET 10) | ZIP / remote_build | responses |  Passed |
| 4 | From-code (vnext-responses-streaming) | Python | ZIP / remote_build | responses |  Passed |
| 5 | Hello World Responses (template) | Python | ZIP / remote_build | responses |  Passed |
| 6 | Hello World Invocations (template) | C# (.NET 10) | ZIP / remote_build | invocations |  Passed |
| 7 | Agent with MCP Tools (Docker/ACR) | Python | Docker / ACR | responses |  Passed |

All 7 tests passed: init → deploy → invoke (verified HTTP 200 with correct agent response).