### PR TITLE
fix: exempt Microsoft.Chaos/targets from reserved name preflight check

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -473,6 +473,9 @@ overrides:
     words:
       - extensionquery
       - bitmask
+  - filename: pkg/infra/provisioning/bicep/bicep_provider.go
+    words:
+      - azurekubernetesservicechaosmesh
 ignorePaths:
   - "**/*_test.go"
   - "**/mock*.go"

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -161,6 +161,9 @@ var azureReservedResourceNameExemptTypes = []string{
 	"Microsoft.Compute/virtualMachineScaleSets/extensions",
 	"Microsoft.Web/connections",                             // e.g. "office365", "sharepointonline"
 	"Microsoft.Network/virtualNetworks/subnets/delegations", // e.g. "Microsoft.Web/serverFarms"
+
+	// Service-mandated names (the resource name is fixed by the service, not user-chosen).
+	"Microsoft.Chaos/targets", // e.g. "microsoft-azurekubernetesservicechaosmesh"
 }
 
 // isReservedNameCheckExempt reports whether the reserved-word check should be

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_reserved_names_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_reserved_names_test.go
@@ -257,6 +257,13 @@ func TestCheckReservedResourceNames(t *testing.T) {
 				Type: "microsoft.network/privatednszones",
 				Name: "another.windows.net",
 			},
+			// Issue #8239: Chaos Studio target names are service-mandated
+			// (e.g. "microsoft-azurekubernetesservicechaosmesh") and cannot
+			// be renamed; the reserved-word check should be suppressed.
+			{
+				Type: "Microsoft.Chaos/targets",
+				Name: "microsoft-azurekubernetesservicechaosmesh",
+			},
 		},
 	})
 
@@ -421,6 +428,16 @@ func TestIsReservedNameCheckExempt(t *testing.T) {
 		{
 			name:         "subnet delegation exempt",
 			resourceType: "Microsoft.Network/virtualNetworks/subnets/delegations",
+			want:         true,
+		},
+		{
+			name:         "Chaos Studio targets exempt (service-mandated names)",
+			resourceType: "Microsoft.Chaos/targets",
+			want:         true,
+		},
+		{
+			name:         "Chaos Studio target capabilities exempt via prefix",
+			resourceType: "Microsoft.Chaos/targets/capabilities",
 			want:         true,
 		},
 		{

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_reserved_names_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_reserved_names_test.go
@@ -441,6 +441,11 @@ func TestIsReservedNameCheckExempt(t *testing.T) {
 			want:         true,
 		},
 		{
+			name:         "Chaos Studio targets exempt case-insensitive",
+			resourceType: "microsoft.chaos/targets",
+			want:         true,
+		},
+		{
 			// VM parent is NOT exempt — only the per-extension child names are.
 			name:         "VM parent NOT exempt",
 			resourceType: "Microsoft.Compute/virtualMachines",


### PR DESCRIPTION
## Summary

Fixes #8239

Azure Chaos Studio target names (e.g. `microsoft-azurekubernetesservicechaosmesh`) are service-mandated and cannot be renamed by users. ARM does not enforce the reserved-word rule on `Microsoft.Chaos/targets`, so the preflight warning was a false positive that misleadingly claimed "The deployment will fail."

## Changes

- Added `Microsoft.Chaos/targets` to `azureReservedResourceNameExemptTypes` in `bicep_provider.go`
- Added test coverage in `bicep_provider_reserved_names_test.go`:
  - `TestIsReservedNameCheckExempt`: exact type + child type (`capabilities`) via prefix match
  - `TestCheckReservedResourceNames`: end-to-end resource entry confirming no warning is emitted