### PR TITLE
feat(agents): skip ACR creation and startupCommand for code deploy

### DIFF
--- a/cli/azd/docs/environment-variables.md
+++ b/cli/azd/docs/environment-variables.md
@@ -157,6 +157,7 @@ specific version of the tool installed on the machine.
 | `AZURE_AI_PROJECT_ACR_CONNECTION_NAME` | The Azure Container Registry connection name used by the extension for hosted agents. |
 | `AI_PROJECT_DEPLOYMENTS` | JSON-encoded deployment metadata populated by the extension for agent workflows. |
 | `AI_PROJECT_DEPENDENT_RESOURCES` | JSON-encoded dependent resource metadata populated by the extension for agent workflows. |
+| `AZD_AGENT_SKIP_ACR` | If `true`, signals the Bicep template to skip Azure Container Registry creation during provisioning. Automatically set by `azd agent init` for code-deploy scenarios (where no container image is built). |
 | `ENABLE_HOSTED_AGENTS` | If set, indicates that hosted agents are enabled for the current azd environment. |
 | `ENABLE_CONTAINER_AGENTS` | If set, indicates that container agents are enabled for the current azd environment. |
 | `AGENT_DEFINITION_PATH` | Path to an agent definition file for AI agent workflows. |

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -412,6 +412,28 @@ func resolveConversationID(
 	return newConvID, nil
 }
 
+// setACREnvVar sets the AZD_AGENT_SKIP_ACR environment variable based on whether the
+// deployment is code-based (no container registry needed) or container-based.
+// This env var is consumed by the Bicep template in Azure-Samples/azd-ai-starter-basic
+// (infra/main.bicep) as `param skipAcr bool` to conditionally skip ACR resource creation.
+//
+// Cross-repo dependency: changes to this variable name must be coordinated with
+// the template parameter mapping in main.parameters.json of the starter template.
+func setACREnvVar(ctx context.Context, azdClient *azdext.AzdClient, envName string, isCodeDeploy bool) error {
+	value := "false"
+	if isCodeDeploy {
+		value = "true"
+	}
+
+	if err := setEnvValue(ctx, azdClient, envName, "AZD_AGENT_SKIP_ACR", value); err != nil {
+		if isCodeDeploy {
+			return fmt.Errorf("configuring ACR skip for code deploy: %w", err)
+		}
+		return fmt.Errorf("configuring ACR for container deploy: %w", err)
+	}
+	return nil
+}
+
 // detectProjectType detects the project type and suggests a start command.
 type ProjectType struct {
 	Language string // "python", "dotnet", "node", "unknown"

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDetectStartupCommand(t *testing.T) {
@@ -296,6 +299,45 @@ func TestProtocolFromAgentYaml(t *testing.T) {
 			if string(got) != tt.wantProto {
 				t.Errorf("protocol = %q, want %q", got, tt.wantProto)
 			}
+		})
+	}
+}
+
+func TestSetACREnvVar(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		isCodeDeploy bool
+		wantValue    string
+	}{
+		{
+			name:         "code deploy sets true",
+			isCodeDeploy: true,
+			wantValue:    "true",
+		},
+		{
+			name:         "container deploy sets false",
+			isCodeDeploy: false,
+			wantValue:    "false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			envServer := &testEnvironmentServiceServer{
+				environments: map[string]*azdext.Environment{
+					"test-env": {Name: "test-env"},
+				},
+			}
+			workflowServer := &testWorkflowServiceServer{}
+			azdClient := newTestAzdClient(t, envServer, workflowServer)
+
+			err := setACREnvVar(t.Context(), azdClient, "test-env", tt.isCodeDeploy)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantValue, envServer.values["test-env"]["AZD_AGENT_SKIP_ACR"])
 		})
 	}
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1033,6 +1033,12 @@ func (a *InitAction) configureModelChoice(
 		); err != nil {
 			return nil, err
 		}
+	} else {
+		if err := setEnvValue(
+			ctx, a.azdClient, a.environment.Name, "SKIP_ACR", "false",
+		); err != nil {
+			return nil, err
+		}
 	}
 
 	return agentManifest, nil

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1026,19 +1026,9 @@ func (a *InitAction) configureModelChoice(
 	}
 	a.deploymentDetails = deploymentDetails
 
-	// Signal Bicep to skip ACR creation for code deploy (no container registry needed)
-	if a.isCodeDeploy {
-		if err := setEnvValue(
-			ctx, a.azdClient, a.environment.Name, "SKIP_ACR", "true",
-		); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := setEnvValue(
-			ctx, a.azdClient, a.environment.Name, "SKIP_ACR", "false",
-		); err != nil {
-			return nil, err
-		}
+	// Set AZD_AGENT_SKIP_ACR so Bicep knows whether to create a container registry.
+	if err := setACREnvVar(ctx, a.azdClient, a.environment.Name, a.isCodeDeploy); err != nil {
+		return nil, err
 	}
 
 	return agentManifest, nil

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1026,6 +1026,15 @@ func (a *InitAction) configureModelChoice(
 	}
 	a.deploymentDetails = deploymentDetails
 
+	// Signal Bicep to skip ACR creation for code deploy (no container registry needed)
+	if a.isCodeDeploy {
+		if err := setEnvValue(
+			ctx, a.azdClient, a.environment.Name, "SKIP_ACR", "true",
+		); err != nil {
+			return nil, err
+		}
+	}
+
 	return agentManifest, nil
 }
 
@@ -1607,11 +1616,8 @@ func (a *InitAction) addToProject(ctx context.Context, targetDir string, agentMa
 		}
 	}
 
-	// Detect startup command from the project source directory
-	if a.isCodeDeploy {
-		// For code deploy, auto-derive startupCommand from entry point in agent.yaml
-		agentConfig.StartupCommand = deriveStartupCommand(a.projectConfig.Path, targetDir)
-	} else {
+	// Detect startup command (container deploy only; code deploy does not use startupCommand)
+	if !a.isCodeDeploy {
 		startupCmd, err := resolveStartupCommandForInit(ctx, a.azdClient, a.projectConfig.Path, targetDir, a.flags.noPrompt)
 		if err != nil {
 			return err

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -889,21 +889,16 @@ func (a *InitFromCodeAction) addToProject(ctx context.Context, targetDir string,
 		}
 	}
 
+	// Set AZD_AGENT_SKIP_ACR so Bicep knows whether to create a container registry.
+	// Set before AddService so env state is consistent even if AddService fails.
+	if err := setACREnvVar(ctx, a.azdClient, a.environment.Name, isCodeDeploy); err != nil {
+		return err
+	}
+
 	req := &azdext.AddServiceRequest{Service: serviceConfig}
 
 	if _, err := a.azdClient.Project().AddService(ctx, req); err != nil {
 		return fmt.Errorf("adding agent service to project: %w", err)
-	}
-
-	// Signal Bicep to skip ACR creation for code deploy (no container registry needed)
-	if isCodeDeploy {
-		if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "SKIP_ACR", "true"); err != nil {
-			return err
-		}
-	} else {
-		if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "SKIP_ACR", "false"); err != nil {
-			return err
-		}
 	}
 
 	fmt.Printf("\nAdded your agent as a service entry named '%s' under the file azure.yaml.\n", agentName)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -900,6 +900,10 @@ func (a *InitFromCodeAction) addToProject(ctx context.Context, targetDir string,
 		if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "SKIP_ACR", "true"); err != nil {
 			return err
 		}
+	} else {
+		if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "SKIP_ACR", "false"); err != nil {
+			return err
+		}
 	}
 
 	fmt.Printf("\nAdded your agent as a service entry named '%s' under the file azure.yaml.\n", agentName)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -842,16 +842,13 @@ func (a *InitFromCodeAction) addToProject(ctx context.Context, targetDir string,
 
 	agentConfig.Deployments = a.deploymentDetails
 
-	// Detect startup command from the project source directory (container mode only for prompt)
+	// Detect startup command (container deploy only; code deploy does not use startupCommand)
 	if !isCodeDeploy {
 		startupCmd, err := resolveStartupCommandForInit(ctx, a.azdClient, a.projectConfig.Path, targetDir, a.flags.noPrompt)
 		if err != nil {
 			return err
 		}
 		agentConfig.StartupCommand = startupCmd
-	} else {
-		// For code deploy, auto-derive startupCommand from entry point in agent.yaml
-		agentConfig.StartupCommand = deriveStartupCommand(a.projectConfig.Path, targetDir)
 	}
 
 	var agentConfigStruct *structpb.Struct
@@ -898,6 +895,13 @@ func (a *InitFromCodeAction) addToProject(ctx context.Context, targetDir string,
 		return fmt.Errorf("adding agent service to project: %w", err)
 	}
 
+	// Signal Bicep to skip ACR creation for code deploy (no container registry needed)
+	if isCodeDeploy {
+		if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "SKIP_ACR", "true"); err != nil {
+			return err
+		}
+	}
+
 	fmt.Printf("\nAdded your agent as a service entry named '%s' under the file azure.yaml.\n", agentName)
 	return nil
 }
@@ -905,19 +909,6 @@ func (a *InitFromCodeAction) addToProject(ctx context.Context, targetDir string,
 // promptCodeConfiguration prompts the user for code deploy configuration settings.
 func (a *InitFromCodeAction) promptCodeConfiguration(ctx context.Context, srcDir string) (*agent_yaml.CodeConfiguration, error) {
 	return promptCodeConfig(ctx, a.azdClient, srcDir, a.flags.noPrompt)
-}
-
-// deriveStartupCommand derives the startup command for code deploy from the agent.yaml
-// entry point. Falls back to "python main.py" if the entry point cannot be determined.
-func deriveStartupCommand(projectPath, targetDir string) string {
-	agentYamlPath := filepath.Join(projectPath, targetDir, "agent.yaml")
-	if data, err := os.ReadFile(agentYamlPath); err == nil { //nolint:gosec // path is constructed from project config
-		var agentDef agent_yaml.ContainerAgent
-		if err := yaml.Unmarshal(data, &agentDef); err == nil && agentDef.CodeConfiguration != nil {
-			return agent_yaml.RuntimeCmdPrefix(agentDef.CodeConfiguration.Runtime) + " " + agentDef.CodeConfiguration.EntryPoint
-		}
-	}
-	return "python main.py"
 }
 
 // protocolInfo pairs a protocol name with the default version used when generating agent.yaml.


### PR DESCRIPTION
## Summary

Partial fix for #8232 (Bicep template change pending in separate PR).

- Sets `AZD_AGENT_SKIP_ACR=true` in `.azure/<env>/.env` when code deploy mode is selected during `azd agent init`, so Bicep can skip ACR creation during `azd provision`
- Sets `AZD_AGENT_SKIP_ACR=false` for container deploy to clear any stale state from a previous code-deploy init
- Removes `startupCommand` from azure.yaml service config for code deploy path (not applicable — code deploy uses agent.yaml's `code_configuration` directly)
- Removes dead `deriveStartupCommand` function
- Extracts shared `setACREnvVar` helper with cross-repo dependency documentation

## Design

- **AZD_AGENT_SKIP_ACR env var**: Written during init via `setACREnvVar()` helper (placed before `AddService` for atomicity). Bicep template reads this as a parameter to conditionally skip ACR resource creation. Defaults to `false` (existing behavior preserved).
- **startupCommand removal**: Code deploy agents don't use `startupCommand` in azure.yaml — the platform derives the command from `agent.yaml`'s `code_configuration.entry_point` and `runtime` fields.
- **Naming convention**: Uses `AZD_AGENT_` prefix consistent with other extension env vars (e.g. `AZD_AGENT_SKIP_ROLE_ASSIGNMENTS`).

## Cross-repo dependency

The `Azure-Samples/azd-ai-starter-basic` template needs a corresponding change to consume the new env var:
```bicep
param skipAcr bool = false
var shouldCreateAcr = !skipAcr && enableHostedAgents && !hasAcr && empty(existingContainerRegistryResourceId) && empty(existingAcrConnectionName)
```
With `main.parameters.json` mapping: `"skipAcr": { "value": "${AZD_AGENT_SKIP_ACR=false}" }`

**Bicep PR**: https://github.com/Azure-Samples/azd-ai-starter-basic/pull/66

## Testing

- All existing unit tests pass (`go test ./...` — 0 failures)
- New `TestSetACREnvVar` table-driven test covers both code-deploy and container-deploy cases
- No behavior change for container deploy flow (`AZD_AGENT_SKIP_ACR=false`)
- Build passes on all platforms (Linux/Mac/Windows x86_64 + ARM64)
- `AZD_AGENT_SKIP_ACR` documented in `cli/azd/docs/environment-variables.md`