### PR TITLE
fix: Recognize Copilot CLI

### DIFF
--- a/cli/azd/cmd/auto_install_integration_test.go
+++ b/cli/azd/cmd/auto_install_integration_test.go
@@ -205,6 +205,13 @@ func TestAgentDetectionIntegration(t *testing.T) {
 			description:      "When running under GitHub Copilot CLI, --no-prompt should be auto-enabled",
 		},
 		{
+			name:             "GitHub Copilot CLI via COPILOT_CLI enables no-prompt automatically",
+			args:             []string{"deploy"},
+			envVars:          map[string]string{"COPILOT_CLI": "true"},
+			expectedNoPrompt: true,
+			description:      "When running under GitHub Copilot CLI (COPILOT_CLI), --no-prompt should be auto-enabled",
+		},
+		{
 			name:             "Gemini agent enables no-prompt automatically",
 			args:             []string{"init"},
 			envVars:          map[string]string{"GEMINI_CLI": "1"},
@@ -297,7 +304,7 @@ func clearAgentEnvVarsForTest(t *testing.T) {
 		// Claude Code
 		"CLAUDE_CODE", "CLAUDE_CODE_ENTRYPOINT",
 		// GitHub Copilot CLI
-		"GITHUB_COPILOT_CLI", "GH_COPILOT",
+		"GITHUB_COPILOT_CLI", "GH_COPILOT", "COPILOT_CLI",
 		// Gemini CLI
 		"GEMINI_CLI", "GEMINI_CLI_NO_RELAUNCH",
 		// OpenCode

--- a/cli/azd/cmd/auto_install_test.go
+++ b/cli/azd/cmd/auto_install_test.go
@@ -388,6 +388,12 @@ func TestParseGlobalFlags_AgentDetection(t *testing.T) {
 			expectedNoPrompt: true,
 		},
 		{
+			name:             "GitHub Copilot CLI agent detected via COPILOT_CLI",
+			args:             []string{"deploy"},
+			envVars:          map[string]string{"COPILOT_CLI": "true"},
+			expectedNoPrompt: true,
+		},
+		{
 			name:             "OpenCode agent detected",
 			args:             []string{"provision"},
 			envVars:          map[string]string{"OPENCODE": "1"},

--- a/cli/azd/internal/runcontext/agentdetect/detect_env.go
+++ b/cli/azd/internal/runcontext/agentdetect/detect_env.go
@@ -26,6 +26,7 @@ var knownEnvVarPatterns = []envVarPattern{
 	// GitHub Copilot CLI
 	{envVar: "GITHUB_COPILOT_CLI", agentType: AgentTypeGitHubCopilotCLI},
 	{envVar: "GH_COPILOT", agentType: AgentTypeGitHubCopilotCLI},
+	{envVar: "COPILOT_CLI", agentType: AgentTypeGitHubCopilotCLI},
 
 	// Google Gemini CLI
 	{envVar: "GEMINI_CLI", agentType: AgentTypeGemini},

--- a/cli/azd/internal/runcontext/agentdetect/detect_test.go
+++ b/cli/azd/internal/runcontext/agentdetect/detect_test.go
@@ -78,6 +78,12 @@ func TestDetectFromEnvVars(t *testing.T) {
 			detected:      true,
 		},
 		{
+			name:          "GitHub Copilot CLI via COPILOT_CLI",
+			envVars:       map[string]string{"COPILOT_CLI": "1"},
+			expectedAgent: AgentTypeGitHubCopilotCLI,
+			detected:      true,
+		},
+		{
 			name:          "Gemini CLI via GEMINI_CLI",
 			envVars:       map[string]string{"GEMINI_CLI": "1"},
 			expectedAgent: AgentTypeGemini,
@@ -324,7 +330,7 @@ func clearAgentEnvVars(t *testing.T) {
 		// Claude Code
 		"CLAUDE_CODE", "CLAUDE_CODE_ENTRYPOINT",
 		// GitHub Copilot CLI
-		"GITHUB_COPILOT_CLI", "GH_COPILOT",
+		"GITHUB_COPILOT_CLI", "GH_COPILOT", "COPILOT_CLI",
 		// Gemini CLI
 		"GEMINI_CLI", "GEMINI_CLI_NO_RELAUNCH",
 		// OpenCode

--- a/cli/azd/internal/terminal/terminal_test.go
+++ b/cli/azd/internal/terminal/terminal_test.go
@@ -41,6 +41,11 @@ func TestIsTerminal_AgentDetection(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "GitHub Copilot CLI via COPILOT_CLI disables TTY",
+			envVars:  map[string]string{"COPILOT_CLI": "true"},
+			expected: false,
+		},
+		{
 			name:     "Gemini CLI disables TTY",
 			envVars:  map[string]string{"GEMINI_CLI": "1"},
 			expected: false,
@@ -88,7 +93,7 @@ func clearTestEnvVars(t *testing.T) {
 		"AZD_FORCE_TTY",
 		// Agent env vars
 		"CLAUDE_CODE", "CLAUDE_CODE_ENTRYPOINT",
-		"GITHUB_COPILOT_CLI", "GH_COPILOT",
+		"GITHUB_COPILOT_CLI", "GH_COPILOT", "COPILOT_CLI",
 		"GEMINI_CLI", "GEMINI_CLI_NO_RELAUNCH",
 		"OPENCODE",
 		// CI env vars


### PR DESCRIPTION
Fixes #8234.

`azd` attempts to determine if it is being invoked by an AI agent (e.g. Claude, Gemini, Copilot, etc.) and alter its behavior to be more "AI friendly". This includes setting the --`no-prompt` parameter by default, and reducing the console output from spinners, progress bars, and the like.

The most reliable way of doing this is by checking for certain environment variables set by the AI agent process. However, `azd` does not check for the variable currently used by Copilot CLI and VS Code: `COPILOT_CLI`.

Here we add a check for this specific environment variable and update the tests accordingly.