### PR TITLE
Add support for updating dev registry in extension release pipelines

### DIFF
--- a/cli/azd/pkg/extensions/registry_files_test.go
+++ b/cli/azd/pkg/extensions/registry_files_test.go
@@ -20,6 +20,7 @@ func TestDevRegistryFileIsValid(t *testing.T) {
 	var registry Registry
 	require.NoError(t, json.Unmarshal(data, &registry))
 	require.Equal(t, CurrentRegistrySchemaVersion, registry.SchemaVersion)
+	require.Empty(t, registry.Extensions)
 
 	result := ValidateRegistry(&registry, false)
 	require.True(t, result.Valid, "registry.dev.json failed validation: %+v", result)

--- a/eng/pipelines/release-ext-azure-ai-agents.yml
+++ b/eng/pipelines/release-ext-azure-ai-agents.yml
@@ -22,6 +22,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -31,3 +37,4 @@ extends:
           AzdExtensionId: azure.ai.agents
           SanitizedExtensionId: azure-ai-agents
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.agents
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/release-ext-azure-ai-connections.yml
+++ b/eng/pipelines/release-ext-azure-ai-connections.yml
@@ -22,6 +22,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -31,3 +37,4 @@ extends:
           AzdExtensionId: azure.ai.connections
           SanitizedExtensionId: azure-ai-connections
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.connections
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/release-ext-azure-ai-finetune.yml
+++ b/eng/pipelines/release-ext-azure-ai-finetune.yml
@@ -22,6 +22,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -31,3 +37,4 @@ extends:
           AzdExtensionId: azure.ai.finetune
           SanitizedExtensionId: azure-ai-finetune
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.finetune
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/release-ext-azure-ai-inspector.yml
+++ b/eng/pipelines/release-ext-azure-ai-inspector.yml
@@ -22,6 +22,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -31,3 +37,4 @@ extends:
           AzdExtensionId: azure.ai.inspector
           SanitizedExtensionId: azure-ai-inspector
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.inspector
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/release-ext-azure-ai-models.yml
+++ b/eng/pipelines/release-ext-azure-ai-models.yml
@@ -22,6 +22,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -32,3 +38,4 @@ extends:
           SanitizedExtensionId: azure-ai-models
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.models
           SkipTests: true
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/release-ext-azure-ai-projects.yml
+++ b/eng/pipelines/release-ext-azure-ai-projects.yml
@@ -22,6 +22,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -31,3 +37,4 @@ extends:
           AzdExtensionId: azure.ai.projects
           SanitizedExtensionId: azure-ai-projects
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.projects
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/release-ext-azure-ai-routines.yml
+++ b/eng/pipelines/release-ext-azure-ai-routines.yml
@@ -22,6 +22,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -31,3 +37,4 @@ extends:
           AzdExtensionId: azure.ai.routines
           SanitizedExtensionId: azure-ai-routines
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.routines
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/release-ext-azure-ai-skills.yml
+++ b/eng/pipelines/release-ext-azure-ai-skills.yml
@@ -22,6 +22,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -31,3 +37,4 @@ extends:
           AzdExtensionId: azure.ai.skills
           SanitizedExtensionId: azure-ai-skills
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.skills
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/release-ext-azure-ai-toolboxes.yml
+++ b/eng/pipelines/release-ext-azure-ai-toolboxes.yml
@@ -22,6 +22,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -31,3 +37,4 @@ extends:
           AzdExtensionId: azure.ai.toolboxes
           SanitizedExtensionId: azure-ai-toolboxes
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.toolboxes
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/release-ext-azure-ai-training.yml
+++ b/eng/pipelines/release-ext-azure-ai-training.yml
@@ -22,6 +22,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -31,3 +37,4 @@ extends:
           AzdExtensionId: azure.ai.training
           SanitizedExtensionId: azure-ai-training
           AzdExtensionDirectory: cli/azd/extensions/azure.ai.training
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/release-ext-azure-appservice.yml
+++ b/eng/pipelines/release-ext-azure-appservice.yml
@@ -22,6 +22,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -31,3 +37,4 @@ extends:
           AzdExtensionId: azure.appservice
           SanitizedExtensionId: azure-appservice
           AzdExtensionDirectory: cli/azd/extensions/azure.appservice
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/release-ext-azure-coding-agent.yml
+++ b/eng/pipelines/release-ext-azure-coding-agent.yml
@@ -21,6 +21,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -31,3 +37,4 @@ extends:
           SanitizedExtensionId: azure-coding-agent
           AzdExtensionDirectory: cli/azd/extensions/azure.coding-agent
           SkipTests: true
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/release-ext-microsoft-azd-ai-builder.yml
+++ b/eng/pipelines/release-ext-microsoft-azd-ai-builder.yml
@@ -23,6 +23,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -33,3 +39,4 @@ extends:
           SanitizedExtensionId: microsoft-azd-ai-builder
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.ai.builder
           SkipTests: true
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/release-ext-microsoft-azd-concurx.yml
+++ b/eng/pipelines/release-ext-microsoft-azd-concurx.yml
@@ -21,6 +21,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -31,3 +37,4 @@ extends:
           SanitizedExtensionId: microsoft-azd-concurx
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.concurx
           SkipTests: true
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/release-ext-microsoft-azd-demo.yml
+++ b/eng/pipelines/release-ext-microsoft-azd-demo.yml
@@ -23,6 +23,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -32,3 +38,4 @@ extends:
           AzdExtensionId: microsoft.azd.demo
           SanitizedExtensionId: microsoft-azd-demo
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.demo
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/release-ext-microsoft-azd-extensions.yml
+++ b/eng/pipelines/release-ext-microsoft-azd-extensions.yml
@@ -21,6 +21,12 @@ pr:
     exclude:
       - cli/azd/docs/**
 
+parameters:
+  - name: PublishToDevRegistry
+    displayName: Publish to dev registry
+    type: boolean
+    default: false
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -30,3 +36,4 @@ extends:
           AzdExtensionId: microsoft.azd.extensions
           SanitizedExtensionId: microsoft-azd-extensions
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.extensions
+          PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}

--- a/eng/pipelines/templates/stages/publish-extension.yml
+++ b/eng/pipelines/templates/stages/publish-extension.yml
@@ -91,9 +91,9 @@ stages:
                     TagPrefix: azd-ext-${{ parameters.SanitizedExtensionId }}
                     TagVersion: $(EXT_VERSION)
 
-      # Updates the selected extension registry (and snapshots) after the
-      # GitHub Release exists. Mirrors Increment_Version in
-      # eng/pipelines/templates/stages/publish.yml.
+      # Updates the selected extension registry after the GitHub Release exists.
+      # Production registry updates also refresh global command snapshots.
+      # Mirrors Increment_Version in eng/pipelines/templates/stages/publish.yml.
       - job: Update_Registry
         dependsOn: Publish_Release
         condition: >-
@@ -136,14 +136,15 @@ stages:
             env:
               GH_TOKEN: $(azuresdk-github-pat)
 
-          - bash: |
-              set -euo pipefail
-              cd cli/azd
-              go build .
-              go test ./cmd -run 'TestFigSpec|TestUsage'
-            displayName: Refresh Fig/Usage snapshots
-            env:
-              UPDATE_SNAPSHOTS: "true"
+          - ${{ if ne(parameters.PublishToDevRegistry, true) }}:
+            - bash: |
+                set -euo pipefail
+                cd cli/azd
+                go build .
+                go test ./cmd -run 'TestFigSpec|TestUsage'
+              displayName: Refresh Fig/Usage snapshots
+              env:
+                UPDATE_SNAPSHOTS: "true"
 
           - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
             parameters:

--- a/eng/pipelines/templates/stages/publish-extension.yml
+++ b/eng/pipelines/templates/stages/publish-extension.yml
@@ -5,6 +5,9 @@ parameters:
     type: string
   - name: SanitizedExtensionId
     type: string
+  - name: PublishToDevRegistry
+    type: boolean
+    default: false
 
 stages:
   - stage: PublishExtension
@@ -25,6 +28,20 @@ stages:
     variables:
       - template: /eng/pipelines/templates/variables/image.yml
       - template: /eng/pipelines/templates/variables/globals.yml
+      - ${{ if eq(parameters.PublishToDevRegistry, true) }}:
+        - name: ExtensionRegistryFile
+          value: registry.dev.json
+        - name: ExtensionRegistryPullRequestPrefix
+          value: ext-dev-registry-update
+        - name: ExtensionRegistryPullRequestTitle
+          value: Dev registry update
+      - ${{ else }}:
+        - name: ExtensionRegistryFile
+          value: registry.json
+        - name: ExtensionRegistryPullRequestPrefix
+          value: ext-registry-update
+        - name: ExtensionRegistryPullRequestTitle
+          value: Registry update
 
     jobs:
       - deployment: Publish_Release
@@ -74,7 +91,7 @@ stages:
                     TagPrefix: azd-ext-${{ parameters.SanitizedExtensionId }}
                     TagVersion: $(EXT_VERSION)
 
-      # Updates cli/azd/extensions/registry.json (and snapshots) after the
+      # Updates the selected extension registry (and snapshots) after the
       # GitHub Release exists. Mirrors Increment_Version in
       # eng/pipelines/templates/stages/publish.yml.
       - job: Update_Registry
@@ -112,10 +129,10 @@ stages:
               set -euo pipefail
               cd "${{ parameters.AzdExtensionDirectory }}"
               azd x publish \
-                --registry ../registry.json \
+                --registry "../$(ExtensionRegistryFile)" \
                 --repo "$(Build.Repository.Name)" \
                 --version "$(EXT_VERSION)"
-            displayName: Update registry.json (azd x publish)
+            displayName: Update $(ExtensionRegistryFile) (azd x publish)
             env:
               GH_TOKEN: $(azuresdk-github-pat)
 
@@ -130,10 +147,10 @@ stages:
 
           - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
             parameters:
-              PRBranchName: ext-registry-update/${{ parameters.SanitizedExtensionId }}/$(EXT_VERSION)-$(Build.BuildId)
-              CommitMsg: "[${{ parameters.AzdExtensionId }}] Registry update for $(EXT_VERSION)"
-              PRTitle: "[${{ parameters.AzdExtensionId }}] Registry update for $(EXT_VERSION)"
+              PRBranchName: $(ExtensionRegistryPullRequestPrefix)/${{ parameters.SanitizedExtensionId }}/$(EXT_VERSION)-$(Build.BuildId)
+              CommitMsg: "[${{ parameters.AzdExtensionId }}] $(ExtensionRegistryPullRequestTitle) for $(EXT_VERSION)"
+              PRTitle: "[${{ parameters.AzdExtensionId }}] $(ExtensionRegistryPullRequestTitle) for $(EXT_VERSION)"
               PRBody: >-
-                Registry update for the
+                $(ExtensionRegistryPullRequestTitle) for the
                 [azd-ext-${{ parameters.SanitizedExtensionId }}_$(EXT_VERSION)](https://github.com/$(Build.Repository.Name)/releases/tag/azd-ext-${{ parameters.SanitizedExtensionId }}_$(EXT_VERSION))
                 release.

--- a/eng/pipelines/templates/stages/release-azd-extension.yml
+++ b/eng/pipelines/templates/stages/release-azd-extension.yml
@@ -8,6 +8,9 @@ parameters:
   - name: SkipTests
     type: boolean
     default: false
+  - name: PublishToDevRegistry
+    type: boolean
+    default: false
 
 stages: 
   - template: /eng/pipelines/templates/stages/build-and-test-azd-extension.yml
@@ -86,3 +89,4 @@ stages:
         AzdExtensionId: ${{ parameters.AzdExtensionId }}
         AzdExtensionDirectory: ${{ parameters.AzdExtensionDirectory }}
         SanitizedExtensionId: ${{ parameters.SanitizedExtensionId }}
+        PublishToDevRegistry: ${{ parameters.PublishToDevRegistry }}


### PR DESCRIPTION
Addresses #8179

Follow-up to #8167 to be able to automatically publish to and update the dev registry (`registry.dev.json`) instead of `registry.json`.

Note: Publishing to the dev registry still creates the same public GitHub release tag and storage artifacts as a production registry publish. Use a prerelease/dev version for dev-registry publishes to avoid colliding with a later production publish of the same version.

### Validation

Tested pipeline on [ext-dev-registry](https://github.com/Azure/azure-dev/tree/ext-dev-registry) branch with Skip.Publish=true confirmed azure-sdk bot auto-submitted PR with expected changes: https://github.com/Azure/azure-dev/pull/8253

<img width="1055" height="699" alt="image" src="https://github.com/user-attachments/assets/2fd7e873-7d68-45c9-bd4e-e552fdb9bbe2" />
