### PR TITLE
fix(hooks): restore lifecycle hook output visibility during azd up

### DIFF
--- a/cli/azd/internal/cmd/up_graph.go
+++ b/cli/azd/internal/cmd/up_graph.go
@@ -337,13 +337,6 @@ func (u *UpGraphAction) Run(
 			serviceNames[i] = svc.Name
 		}
 		deployTracker = newDeployProgressTracker(w, u.console.IsSpinnerInteractive(), serviceNames)
-		// Suppress previewer output at the shared console level so that
-		// DI-injected consumers (e.g. ContainerHelper's Docker output)
-		// don't corrupt the progress table display.
-		if ps, ok := u.console.(input.PreviewerPauser); ok {
-			ps.PausePreviewer()
-			defer ps.ResumePreviewer()
-		}
 	}
 
 	updateDeployProgress := func(svcName string, phase deployPhase, detail string) {
@@ -490,6 +483,28 @@ func (u *UpGraphAction) Run(
 		stopTicker = func() {} // no-op until started
 	}
 
+	// startDeployTicker is called once (via tickerOnce) when the first publish or deploy
+	// step begins. It starts the progress table ticker and suppresses the console previewer
+	// so that DI-injected ShowPreviewer callers (e.g. ContainerHelper's Docker output)
+	// don't corrupt the progress table display.
+	// Previewer is not paused during the earlier provision + hook phases so that
+	// preprovision/postprovision hook output remains visible (fixes #8237).
+	startDeployTicker := func() {
+		if deployTracker == nil {
+			return
+		}
+		stop := deployTracker.StartTicker(ctx)
+		if ps, ok := u.console.(input.PreviewerPauser); ok {
+			ps.PausePreviewer()
+			stopTicker = func() {
+				stop()
+				ps.ResumePreviewer()
+			}
+		} else {
+			stopTicker = stop
+		}
+	}
+
 	opts := u.runOptions()
 	baseOnStepStart := opts.OnStepStart
 	baseOnStepDone := opts.OnStepDone
@@ -506,18 +521,10 @@ func (u *UpGraphAction) Run(
 		if svc, ok := strings.CutPrefix(stepName, "package-"); ok {
 			updateDeployProgress(svc, phasePackaging, "")
 		} else if svc, ok := strings.CutPrefix(stepName, "publish-"); ok {
-			tickerOnce.Do(func() {
-				if deployTracker != nil {
-					stopTicker = deployTracker.StartTicker(ctx)
-				}
-			})
+			tickerOnce.Do(startDeployTicker)
 			updateDeployProgress(svc, phasePublish, "")
 		} else if svc, ok := strings.CutPrefix(stepName, "deploy-"); ok {
-			tickerOnce.Do(func() {
-				if deployTracker != nil {
-					stopTicker = deployTracker.StartTicker(ctx)
-				}
-			})
+			tickerOnce.Do(startDeployTicker)
 			updateDeployProgress(svc, phaseDeploying, "")
 		}
 	}

--- a/cli/azd/internal/cmd/up_graph.go
+++ b/cli/azd/internal/cmd/up_graph.go
@@ -493,15 +493,17 @@ func (u *UpGraphAction) Run(
 		if deployTracker == nil {
 			return
 		}
-		stop := deployTracker.StartTicker(ctx)
+		// Pause the previewer before starting the ticker to avoid a window where
+		// the progress table renders while ShowPreviewer is still active.
 		if ps, ok := u.console.(input.PreviewerPauser); ok {
 			ps.PausePreviewer()
+			stop := deployTracker.StartTicker(ctx)
 			stopTicker = func() {
 				stop()
 				ps.ResumePreviewer()
 			}
 		} else {
-			stopTicker = stop
+			stopTicker = deployTracker.StartTicker(ctx)
 		}
 	}
 

--- a/cli/azd/pkg/input/console_test.go
+++ b/cli/azd/pkg/input/console_test.go
@@ -588,15 +588,16 @@ func TestAskerConsole_PausePreviewer_DiscardsHookOutput(t *testing.T) {
 	require.True(t, ok, "AskerConsole must implement PreviewerPauser")
 	ps.PausePreviewer()
 
-	// Bug: ShowPreviewer now returns io.Discard, silencing all hook output
-	// (preprovision, postprovision, predeploy, postdeploy hooks that call ShowPreviewer
-	// will have their stdout set to io.Discard, so their output is never seen).
+	// PausePreviewer is designed to suppress previewer output — ShowPreviewer returns
+	// io.Discard while paused. This is expected behavior. The actual bug (#8237) was that
+	// azd up called PausePreviewer too early (before hooks), not that PausePreviewer
+	// suppresses output.
 	writerWhilePaused := c.ShowPreviewer(ctx, &ShowPreviewerOptions{
 		Title:        "preprovision Hook Output",
 		MaxLineCount: 8,
 	})
 	require.Equal(t, io.Discard, writerWhilePaused,
-		"ShowPreviewer returns io.Discard when previewer is paused — this is the bug: hook output is silenced")
+		"ShowPreviewer returns io.Discard when previewer is paused (expected PausePreviewer behavior)")
 
 	// After ResumePreviewer, ShowPreviewer should work again.
 	ps.ResumePreviewer()

--- a/cli/azd/pkg/input/console_test.go
+++ b/cli/azd/pkg/input/console_test.go
@@ -542,14 +542,14 @@ func TestAskerConsole_Previewer_ConcurrentWriteStress(t *testing.T) {
 }
 
 // TestAskerConsole_PausePreviewer_DiscardsHookOutput reproduces the bug from GitHub issue #8237:
-// in azd 1.25.0+, azd up calls PausePreviewer() early in the execution graph setup (up_graph.go),
-// which causes ShowPreviewer to return io.Discard for the entire duration of the run. This means
-// lifecycle hook output (preprovision, postprovision, predeploy, postdeploy) is silently thrown away.
+// in azd 1.25.0+, azd up called PausePreviewer() early in the execution graph setup (up_graph.go),
+// which caused ShowPreviewer to return io.Discard for the entire duration of the run. This meant
+// lifecycle hook output (preprovision, postprovision, predeploy, postdeploy) was silently thrown away.
 //
 // Before 1.25.0, azd up used a workflow runner that invoked azd provision + azd deploy as
 // sub-commands. Each ran independently and hooks used ShowPreviewer normally — output was visible.
 //
-// The fix is to move PausePreviewer() to only be called when the deploy progress table ticker
+// The fix moved PausePreviewer() to only be called when the deploy progress table ticker
 // actually starts (publish/deploy phase), not upfront before any graph steps execute.
 func TestAskerConsole_PausePreviewer_DiscardsHookOutput(t *testing.T) {
 	formatter, err := output.NewFormatter(string(output.NoneFormat))
@@ -582,8 +582,8 @@ func TestAskerConsole_PausePreviewer_DiscardsHookOutput(t *testing.T) {
 		"ShowPreviewer should return a real writer when previewer is not paused")
 	c.StopPreviewer(ctx, false)
 
-	// Simulate what azd 1.25.0 up_graph.go does: PausePreviewer() is called early,
-	// before any graph steps execute (before preprovision/postprovision hooks run).
+	// Simulate what azd 1.25.0 up_graph.go did: PausePreviewer() was called early,
+	// before any graph steps executed (before preprovision/postprovision hooks ran).
 	ps, ok := c.(PreviewerPauser)
 	require.True(t, ok, "AskerConsole must implement PreviewerPauser")
 	ps.PausePreviewer()

--- a/cli/azd/pkg/input/console_test.go
+++ b/cli/azd/pkg/input/console_test.go
@@ -541,6 +541,74 @@ func TestAskerConsole_Previewer_ConcurrentWriteStress(t *testing.T) {
 	}
 }
 
+// TestAskerConsole_PausePreviewer_DiscardsHookOutput reproduces the bug from GitHub issue #8237:
+// in azd 1.25.0+, azd up calls PausePreviewer() early in the execution graph setup (up_graph.go),
+// which causes ShowPreviewer to return io.Discard for the entire duration of the run. This means
+// lifecycle hook output (preprovision, postprovision, predeploy, postdeploy) is silently thrown away.
+//
+// Before 1.25.0, azd up used a workflow runner that invoked azd provision + azd deploy as
+// sub-commands. Each ran independently and hooks used ShowPreviewer normally — output was visible.
+//
+// The fix is to move PausePreviewer() to only be called when the deploy progress table ticker
+// actually starts (publish/deploy phase), not upfront before any graph steps execute.
+func TestAskerConsole_PausePreviewer_DiscardsHookOutput(t *testing.T) {
+	formatter, err := output.NewFormatter(string(output.NoneFormat))
+	require.NoError(t, err)
+
+	lines := &lineCapturer{}
+	c := NewConsole(
+		false,
+		false,
+		Writers{Output: lines},
+		ConsoleHandles{
+			Stderr: os.Stderr,
+			Stdin:  os.Stdin,
+			Stdout: lines,
+		},
+		formatter,
+		nil,
+	)
+
+	ctx := t.Context()
+
+	// Regression: ShowPreviewer should return a real writer before PausePreviewer is called.
+	// This simulates the pre-1.25.0 behavior where hooks ran via normal sequential sub-commands
+	// (no PausePreviewer call), so hook output was visible.
+	writerBeforePause := c.ShowPreviewer(ctx, &ShowPreviewerOptions{
+		Title:        "preprovision Hook Output",
+		MaxLineCount: 8,
+	})
+	require.NotEqual(t, io.Discard, writerBeforePause,
+		"ShowPreviewer should return a real writer when previewer is not paused")
+	c.StopPreviewer(ctx, false)
+
+	// Simulate what azd 1.25.0 up_graph.go does: PausePreviewer() is called early,
+	// before any graph steps execute (before preprovision/postprovision hooks run).
+	ps, ok := c.(PreviewerPauser)
+	require.True(t, ok, "AskerConsole must implement PreviewerPauser")
+	ps.PausePreviewer()
+
+	// Bug: ShowPreviewer now returns io.Discard, silencing all hook output
+	// (preprovision, postprovision, predeploy, postdeploy hooks that call ShowPreviewer
+	// will have their stdout set to io.Discard, so their output is never seen).
+	writerWhilePaused := c.ShowPreviewer(ctx, &ShowPreviewerOptions{
+		Title:        "preprovision Hook Output",
+		MaxLineCount: 8,
+	})
+	require.Equal(t, io.Discard, writerWhilePaused,
+		"ShowPreviewer returns io.Discard when previewer is paused — this is the bug: hook output is silenced")
+
+	// After ResumePreviewer, ShowPreviewer should work again.
+	ps.ResumePreviewer()
+	writerAfterResume := c.ShowPreviewer(ctx, &ShowPreviewerOptions{
+		Title:        "postprovision Hook Output",
+		MaxLineCount: 8,
+	})
+	require.NotEqual(t, io.Discard, writerAfterResume,
+		"ShowPreviewer should return a real writer after ResumePreviewer")
+	c.StopPreviewer(ctx, false)
+}
+
 // writerAdapter wraps *strings.Builder to satisfy io.Writer for test purposes.
 type writerAdapter struct {
 	*strings.Builder


### PR DESCRIPTION
## Summary

Fixes #8237 — lifecycle hook output (`preprovision`, `postprovision`, `predeploy`) is restored during `azd up`.

**Note:** `postdeploy` hook output is still suppressed because `postdeploy` runs as a graph step before `RunWithResult` returns (while the deploy progress ticker is still active). Restoring `postdeploy` output requires adding a dedicated graph step to stop the ticker between deploy and postdeploy — tracked as a follow-up.

## Root Cause

Introduced in 1.25.0 by PR #7776 (the exegraph rewrite). In `up_graph.go`, `PausePreviewer()` was called at **graph build time**, before any steps execute:

```go
// Before: called here — before any hooks run
if ps, ok := u.console.(input.PreviewerPauser); ok {
    ps.PausePreviewer()
    defer ps.ResumePreviewer()
}
```

This set `previewerSuppressed = true` for the entire `Run()` duration. When lifecycle hooks later called `ShowPreviewer()` in `hooks_runner.go`, they received `io.Discard` — silently discarding all hook stdout.

**Pre-1.25.0**: `azd up` used a `workflow.Runner` spawning `azd provision` + `azd deploy` as sub-processes. `PausePreviewer` did not exist — hooks always got real writers.

## Fix

Move `PausePreviewer()` into `startDeployTicker`, which is called via `tickerOnce.Do` only when the **first publish or deploy step begins** (i.e., when the deploy progress table is actually rendering). The previewer is no longer suppressed during the provision + hook phases.

```go
startDeployTicker := func() {
    if ps, ok := u.console.(input.PreviewerPauser); ok {
        ps.PausePreviewer()           // ← pause before starting ticker
    }
    stop := deployTracker.StartTicker(ctx)
    // ...
}
// ...
tickerOnce.Do(startDeployTicker)  // called on first publish-* or deploy-* step
```

## Testing

- Added `TestAskerConsole_PausePreviewer_DiscardsHookOutput` to `pkg/input/console_test.go` documenting the `PreviewerPauser` mechanism and the window during which hooks must not be suppressed.
- All existing previewer concurrency tests continue to pass.