### PR TITLE
fix: clarify model configuration prompt wording

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1259,8 +1259,8 @@ func (a *InitAction) configureModelChoice(
 	}
 
 	modelConfigChoices := []*azdext.SelectChoice{
-		{Label: "Deploy new model(s) from the catalog", Value: "new"},
-		{Label: "Use existing model deployment(s) from a Foundry project", Value: "existing"},
+		{Label: "Deploy new model(s) (with new Foundry project)", Value: "new"},
+		{Label: "Use an existing Foundry project", Value: "existing"},
 	}
 
 	var modelConfigChoice string

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -491,8 +491,8 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 
 	// Ask user how they want to configure a model
 	modelConfigChoices := []*azdext.SelectChoice{
-		{Label: "Deploy a new model from the catalog", Value: "new"},
-		{Label: "Select an existing model deployment from a Foundry project", Value: "existing"},
+		{Label: "Deploy new model(s) (with new Foundry project)", Value: "new"},
+		{Label: "Use an existing Foundry project", Value: "existing"},
 		{Label: "Skip model configuration", Value: "skip"},
 	}
 


### PR DESCRIPTION
## Summary

Clarifies the model configuration prompt options to reduce user confusion.

Relates to Azure/azure-dev#8155

### Before
```
? How would you like to configure model(s) for your agent?
  > Deploy new model(s) from the catalog
    Use existing model deployment(s) from a Foundry project
```

### After
```
? How would you like to configure model(s) for your agent?
  > Deploy new model(s) (with new Foundry project)
    Use an existing Foundry project
```

### Problems with the previous wording

1. **"Deploy new model(s) from the catalog"** — did not indicate that this path also creates a new Foundry project, misleading users who already have a project and just want to deploy a new model into it.
2. **"Use existing model deployment(s) from a Foundry project"** — implied only existing deployments could be used, but this path also allows creating new model deployments within the existing project.

The new wording accurately reflects that the choice is fundamentally about which Foundry project to use (new vs existing), not solely about the model deployment itself.

### Related
- Bicep fix for creating model deployments on existing projects: Azure-Samples/azd-ai-starter-basic#67