### PR TITLE
Fix `azd x watch` output loop

### DIFF
--- a/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/watch.go
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/watch.go
@@ -142,36 +142,8 @@ func runWatchAction(ctx context.Context, flags *watchFlags) error {
 				return nil
 			}
 
-			// Fast path: ignore events matching hardcoded glob patterns.
-			shouldIgnore := false
-			for _, pattern := range globIgnorePaths {
-				matched, _ := doublestar.PathMatch(pattern, event.Name)
-				if matched {
-					shouldIgnore = true
-					break
-				}
-			}
-			if shouldIgnore {
+			if shouldIgnoreWatchEvent(cwd, event.Name, globIgnorePaths, ignoreMatcher) {
 				continue
-			}
-
-			// Check user-defined ignore patterns (.azdxignore / .gitignore).
-			// Use os.Stat once to determine if the path is a directory.
-			info, statErr := os.Stat(event.Name)
-			isDir := statErr == nil && info.IsDir()
-
-			if relPath, relErr := filepath.Rel(cwd, event.Name); relErr != nil {
-				log.Printf("debug: failed to compute relative path for %s: %v", event.Name, relErr)
-			} else {
-				if ignoreMatcher.IsIgnored(relPath, isDir) {
-					continue
-				}
-				// When the path no longer exists (e.g. Remove event), os.Stat fails
-				// and isDir defaults to false. Re-check as a directory so that
-				// directory-only patterns (trailing slash) still filter the event.
-				if statErr != nil && ignoreMatcher.IsIgnored(relPath, true) {
-					continue
-				}
 			}
 
 			// Collect unique changes
@@ -235,6 +207,47 @@ func watchRecursive(
 
 		return nil
 	})
+}
+
+func shouldIgnoreWatchEvent(
+	root string,
+	eventName string,
+	globIgnorePaths []string,
+	ignoreMatcher *ignore.Matcher,
+) bool {
+	relPath := relativeWatchPath(root, eventName)
+
+	// Fast path: ignore events matching hardcoded glob patterns.
+	for _, pattern := range globIgnorePaths {
+		matched, _ := doublestar.PathMatch(pattern, relPath)
+		if matched {
+			return true
+		}
+	}
+
+	// Check user-defined ignore patterns (.azdxignore / .gitignore).
+	// Use os.Stat once to determine if the path is a directory.
+	info, statErr := os.Stat(eventName)
+	isDir := statErr == nil && info.IsDir()
+
+	if ignoreMatcher.IsIgnored(relPath, isDir) {
+		return true
+	}
+
+	// When the path no longer exists (e.g. Remove event), os.Stat fails
+	// and isDir defaults to false. Re-check as a directory so that
+	// directory-only patterns (trailing slash) still filter the event.
+	return statErr != nil && ignoreMatcher.IsIgnored(relPath, true)
+}
+
+func relativeWatchPath(root string, eventName string) string {
+	relPath, err := filepath.Rel(root, eventName)
+	if err != nil {
+		log.Printf("debug: failed to compute relative path for %s: %v", eventName, err)
+		relPath = eventName
+	}
+
+	return filepath.ToSlash(relPath)
 }
 
 func rebuild(ctx context.Context, extensionPath string) {

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/watch_test.go
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/watch_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/ignore"
+)
+
+func TestShouldIgnoreWatchEventUsesRelativePathForHardcodedIgnores(t *testing.T) {
+	root := t.TempDir()
+	binPath := filepath.Join(root, "bin")
+	require.NoError(t, os.MkdirAll(binPath, 0755))
+
+	ignoreMatcher, err := ignore.NewMatcher(root)
+	require.NoError(t, err)
+
+	globIgnorePaths := []string{"bin", "bin/**/*"}
+
+	require.True(t, shouldIgnoreWatchEvent(root, binPath, globIgnorePaths, ignoreMatcher))
+	require.True(t, shouldIgnoreWatchEvent(root, filepath.Join(binPath, "extension.exe"), globIgnorePaths, ignoreMatcher))
+	require.True(t, shouldIgnoreWatchEvent(root, "bin", globIgnorePaths, ignoreMatcher))
+}
+
+func TestShouldIgnoreWatchEventUsesRelativePathForIgnoreMatcher(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, ignore.AzdxIgnoreFile), []byte("dist/\n"), 0600))
+
+	distPath := filepath.Join(root, "dist")
+	srcPath := filepath.Join(root, "src")
+	require.NoError(t, os.MkdirAll(distPath, 0755))
+	require.NoError(t, os.MkdirAll(srcPath, 0755))
+
+	ignoreMatcher, err := ignore.NewMatcher(root)
+	require.NoError(t, err)
+
+	require.True(t, shouldIgnoreWatchEvent(root, distPath, nil, ignoreMatcher))
+	require.False(t, shouldIgnoreWatchEvent(root, srcPath, nil, ignoreMatcher))
+}


### PR DESCRIPTION
Fixes #8274

This PR fixes a rebuild loop in `azd x watch` by normalizing file watcher event paths relative to the extension project root before applying hardcoded and user-defined ignore rules.

The bug was introduced in #7697 when the watcher root changed to an absolute path, causing absolute Windows events like `...\bin` to bypass relative ignore patterns such as `bin/**/*`, so rebuild output triggered another rebuild.

This PR also adds regression tests covering absolute output-directory events and `.azdxignore` matching.
