### PR TITLE
Add authorization_schemes support to AgentEndpoint

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
@@ -79,9 +79,40 @@ type ProtocolVersionRecord struct {
 	Version  string        `json:"version"`
 }
 
-// AgentEndpoint describes the endpoint protocols an agent supports.
+// AgentEndpointAuthorizationSchemeType identifies the type of authorization scheme.
+type AgentEndpointAuthorizationSchemeType string
+
+const (
+	AgentEndpointAuthorizationSchemeTypeEntra          AgentEndpointAuthorizationSchemeType = "Entra"
+	AgentEndpointAuthorizationSchemeTypeBotService     AgentEndpointAuthorizationSchemeType = "BotService"
+	AgentEndpointAuthorizationSchemeTypeBotServiceRbac AgentEndpointAuthorizationSchemeType = "BotServiceRbac"
+)
+
+// IsolationKeySourceKind identifies the kind of isolation key source.
+type IsolationKeySourceKind string
+
+const (
+	IsolationKeySourceKindEntra  IsolationKeySourceKind = "Entra"
+	IsolationKeySourceKindHeader IsolationKeySourceKind = "Header"
+)
+
+// IsolationKeySource configures how the isolation key is derived for an agent endpoint.
+type IsolationKeySource struct {
+	Kind IsolationKeySourceKind `json:"kind"`
+}
+
+// AgentEndpointAuthorizationScheme describes an authorization scheme for an agent endpoint.
+// IsolationKeySource is only applicable when Type is "Entra".
+type AgentEndpointAuthorizationScheme struct {
+	Type               AgentEndpointAuthorizationSchemeType `json:"type"`
+	IsolationKeySource *IsolationKeySource                  `json:"isolation_key_source,omitempty"`
+}
+
+// AgentEndpoint describes the endpoint configuration an agent supports.
+// Corresponds to AgentEndpointConfig in the Foundry API.
 type AgentEndpoint struct {
-	Protocols []AgentProtocol `json:"protocols"`
+	Protocols            []AgentProtocol                    `json:"protocols,omitempty"`
+	AuthorizationSchemes []AgentEndpointAuthorizationScheme `json:"authorization_schemes,omitempty"`
 }
 
 // AgentCardSkill describes a single capability that an agent can perform.

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
@@ -997,6 +997,101 @@ func TestAgentEndpoint_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestAgentEndpoint_AuthorizationSchemes_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := AgentEndpoint{
+		Protocols: []AgentProtocol{AgentProtocolResponses},
+		AuthorizationSchemes: []AgentEndpointAuthorizationScheme{
+			{
+				Type: AgentEndpointAuthorizationSchemeTypeEntra,
+				IsolationKeySource: &IsolationKeySource{
+					Kind: IsolationKeySourceKindEntra,
+				},
+			},
+			{
+				Type: AgentEndpointAuthorizationSchemeTypeBotService,
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	s := string(data)
+	for _, field := range []string{
+		`"authorization_schemes"`,
+		`"type":"Entra"`,
+		`"type":"BotService"`,
+		`"isolation_key_source"`,
+		`"kind":"Entra"`,
+	} {
+		if !strings.Contains(s, field) {
+			t.Errorf("expected JSON to contain %s, got: %s", field, s)
+		}
+	}
+
+	// Ensure omitempty drops IsolationKeySource when nil (second scheme has no isolation key).
+	// The substring count for "isolation_key_source" should be exactly 1.
+	if c := strings.Count(s, `"isolation_key_source"`); c != 1 {
+		t.Errorf("expected exactly one isolation_key_source in JSON, got %d: %s", c, s)
+	}
+
+	var got AgentEndpoint
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(got.AuthorizationSchemes) != 2 {
+		t.Fatalf("AuthorizationSchemes length = %d, want 2", len(got.AuthorizationSchemes))
+	}
+	if got.AuthorizationSchemes[0].Type != AgentEndpointAuthorizationSchemeTypeEntra {
+		t.Errorf(
+			"AuthorizationSchemes[0].Type = %q, want %q",
+			got.AuthorizationSchemes[0].Type,
+			AgentEndpointAuthorizationSchemeTypeEntra,
+		)
+	}
+	if got.AuthorizationSchemes[0].IsolationKeySource == nil {
+		t.Fatal("AuthorizationSchemes[0].IsolationKeySource is nil")
+	}
+	if got.AuthorizationSchemes[0].IsolationKeySource.Kind != IsolationKeySourceKindEntra {
+		t.Errorf(
+			"AuthorizationSchemes[0].IsolationKeySource.Kind = %q, want %q",
+			got.AuthorizationSchemes[0].IsolationKeySource.Kind,
+			IsolationKeySourceKindEntra,
+		)
+	}
+	if got.AuthorizationSchemes[1].Type != AgentEndpointAuthorizationSchemeTypeBotService {
+		t.Errorf(
+			"AuthorizationSchemes[1].Type = %q, want %q",
+			got.AuthorizationSchemes[1].Type,
+			AgentEndpointAuthorizationSchemeTypeBotService,
+		)
+	}
+	if got.AuthorizationSchemes[1].IsolationKeySource != nil {
+		t.Errorf(
+			"AuthorizationSchemes[1].IsolationKeySource = %v, want nil",
+			got.AuthorizationSchemes[1].IsolationKeySource,
+		)
+	}
+}
+
+func TestAgentEndpoint_OmitEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Empty AgentEndpoint should marshal to {} (both Protocols and AuthorizationSchemes are omitempty).
+	data, err := json.Marshal(AgentEndpoint{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(data) != "{}" {
+		t.Errorf("expected empty AgentEndpoint to marshal to {}, got: %s", string(data))
+	}
+}
+
 func TestAgentCard_RoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
@@ -495,6 +495,14 @@ func createAgentAPIRequest(
 				Type: agent_api.AgentEndpointAuthorizationSchemeType(trimmedType),
 			}
 			if scheme.IsolationKeySource != nil {
+				if apiScheme.Type != agent_api.AgentEndpointAuthorizationSchemeTypeEntra {
+					return nil, fmt.Errorf(
+						"agentEndpoint authorization_schemes isolation_key_source is only "+
+							"allowed when type is %q (got %q)",
+						agent_api.AgentEndpointAuthorizationSchemeTypeEntra,
+						trimmedType,
+					)
+				}
 				trimmedKind := strings.TrimSpace(scheme.IsolationKeySource.Kind)
 				if trimmedKind == "" {
 					return nil, fmt.Errorf(

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
@@ -482,8 +482,35 @@ func createAgentAPIRequest(
 			}
 			protocols = append(protocols, agent_api.AgentProtocol(trimmed))
 		}
+
+		var authSchemes []agent_api.AgentEndpointAuthorizationScheme
+		for _, scheme := range agentEndpoint.AuthorizationSchemes {
+			trimmedType := strings.TrimSpace(scheme.Type)
+			if trimmedType == "" {
+				return nil, fmt.Errorf(
+					"agentEndpoint authorization_schemes contains an entry with empty type",
+				)
+			}
+			apiScheme := agent_api.AgentEndpointAuthorizationScheme{
+				Type: agent_api.AgentEndpointAuthorizationSchemeType(trimmedType),
+			}
+			if scheme.IsolationKeySource != nil {
+				trimmedKind := strings.TrimSpace(scheme.IsolationKeySource.Kind)
+				if trimmedKind == "" {
+					return nil, fmt.Errorf(
+						"agentEndpoint authorization_schemes isolation_key_source has empty kind",
+					)
+				}
+				apiScheme.IsolationKeySource = &agent_api.IsolationKeySource{
+					Kind: agent_api.IsolationKeySourceKind(trimmedKind),
+				}
+			}
+			authSchemes = append(authSchemes, apiScheme)
+		}
+
 		request.AgentEndpoint = &agent_api.AgentEndpoint{
-			Protocols: protocols,
+			Protocols:            protocols,
+			AuthorizationSchemes: authSchemes,
 		}
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
@@ -1571,3 +1571,35 @@ func TestCreateHostedAgentAPIRequest_EmptyIsolationKeyKindRejected(t *testing.T)
 		t.Errorf("error = %q, want it to mention 'empty kind'", err.Error())
 	}
 }
+
+func TestCreateHostedAgentAPIRequest_IsolationKeySourceOnlyAllowedForEntra(t *testing.T) {
+	t.Parallel()
+
+	hostedAgent := ContainerAgent{
+		AgentDefinition: AgentDefinition{
+			Kind: AgentKindHosted,
+			Name: "bad-agent",
+		},
+		Protocols: []ProtocolVersionRecord{
+			{Protocol: "responses", Version: "1.0.0"},
+		},
+		AgentEndpoint: &AgentEndpoint{
+			Protocols: []string{"responses"},
+			AuthorizationSchemes: []AgentEndpointAuthorizationScheme{
+				{
+					Type:               "BotService",
+					IsolationKeySource: &IsolationKeySource{Kind: "Entra"},
+				},
+			},
+		},
+	}
+
+	buildConfig := &AgentBuildConfig{ImageURL: "myregistry.azurecr.io/agent:latest"}
+	_, err := CreateHostedAgentAPIRequest(hostedAgent, buildConfig)
+	if err == nil {
+		t.Fatal("expected error for isolation_key_source on non-Entra scheme")
+	}
+	if !strings.Contains(err.Error(), "only allowed when type is") {
+		t.Errorf("error = %q, want it to mention 'only allowed when type is'", err.Error())
+	}
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
@@ -1436,3 +1436,138 @@ func TestCreateAgentAPIRequest_CodeDeploy_PythonRuntime(t *testing.T) {
 		t.Errorf("Runtime = %q, want %q", codeDef.CodeConfiguration.Runtime, "python_3_12")
 	}
 }
+
+func TestCreateHostedAgentAPIRequest_WithAuthorizationSchemes(t *testing.T) {
+	t.Parallel()
+
+	hostedAgent := ContainerAgent{
+		AgentDefinition: AgentDefinition{
+			Kind: AgentKindHosted,
+			Name: "auth-agent",
+		},
+		Protocols: []ProtocolVersionRecord{
+			{Protocol: "responses", Version: "1.0.0"},
+		},
+		AgentEndpoint: &AgentEndpoint{
+			Protocols: []string{"responses"},
+			AuthorizationSchemes: []AgentEndpointAuthorizationScheme{
+				{
+					Type: "Entra",
+					IsolationKeySource: &IsolationKeySource{
+						Kind: "Header",
+					},
+				},
+				{
+					Type: "BotService",
+				},
+				{
+					Type: "BotServiceRbac",
+				},
+			},
+		},
+	}
+
+	buildConfig := &AgentBuildConfig{ImageURL: "myregistry.azurecr.io/agent:latest"}
+	request, err := CreateHostedAgentAPIRequest(hostedAgent, buildConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if request.AgentEndpoint == nil {
+		t.Fatal("AgentEndpoint is nil")
+	}
+
+	schemes := request.AgentEndpoint.AuthorizationSchemes
+	if len(schemes) != 3 {
+		t.Fatalf("AuthorizationSchemes length = %d, want 3", len(schemes))
+	}
+
+	// Verify Entra scheme with isolation key source
+	if schemes[0].Type != agent_api.AgentEndpointAuthorizationSchemeTypeEntra {
+		t.Errorf("schemes[0].Type = %q, want %q",
+			schemes[0].Type, agent_api.AgentEndpointAuthorizationSchemeTypeEntra)
+	}
+	if schemes[0].IsolationKeySource == nil {
+		t.Fatal("schemes[0].IsolationKeySource is nil")
+	}
+	if schemes[0].IsolationKeySource.Kind != agent_api.IsolationKeySourceKindHeader {
+		t.Errorf("schemes[0].IsolationKeySource.Kind = %q, want %q",
+			schemes[0].IsolationKeySource.Kind, agent_api.IsolationKeySourceKindHeader)
+	}
+
+	// Verify BotService scheme (no isolation key source)
+	if schemes[1].Type != agent_api.AgentEndpointAuthorizationSchemeTypeBotService {
+		t.Errorf("schemes[1].Type = %q, want %q",
+			schemes[1].Type, agent_api.AgentEndpointAuthorizationSchemeTypeBotService)
+	}
+	if schemes[1].IsolationKeySource != nil {
+		t.Error("schemes[1].IsolationKeySource should be nil for BotService")
+	}
+
+	// Verify BotServiceRbac scheme
+	if schemes[2].Type != agent_api.AgentEndpointAuthorizationSchemeTypeBotServiceRbac {
+		t.Errorf("schemes[2].Type = %q, want %q",
+			schemes[2].Type, agent_api.AgentEndpointAuthorizationSchemeTypeBotServiceRbac)
+	}
+}
+
+func TestCreateHostedAgentAPIRequest_EmptyAuthSchemeTypeRejected(t *testing.T) {
+	t.Parallel()
+
+	hostedAgent := ContainerAgent{
+		AgentDefinition: AgentDefinition{
+			Kind: AgentKindHosted,
+			Name: "bad-agent",
+		},
+		Protocols: []ProtocolVersionRecord{
+			{Protocol: "responses", Version: "1.0.0"},
+		},
+		AgentEndpoint: &AgentEndpoint{
+			Protocols: []string{"responses"},
+			AuthorizationSchemes: []AgentEndpointAuthorizationScheme{
+				{Type: ""},
+			},
+		},
+	}
+
+	buildConfig := &AgentBuildConfig{ImageURL: "myregistry.azurecr.io/agent:latest"}
+	_, err := CreateHostedAgentAPIRequest(hostedAgent, buildConfig)
+	if err == nil {
+		t.Fatal("expected error for empty authorization scheme type")
+	}
+	if !strings.Contains(err.Error(), "empty type") {
+		t.Errorf("error = %q, want it to mention 'empty type'", err.Error())
+	}
+}
+
+func TestCreateHostedAgentAPIRequest_EmptyIsolationKeyKindRejected(t *testing.T) {
+	t.Parallel()
+
+	hostedAgent := ContainerAgent{
+		AgentDefinition: AgentDefinition{
+			Kind: AgentKindHosted,
+			Name: "bad-agent",
+		},
+		Protocols: []ProtocolVersionRecord{
+			{Protocol: "responses", Version: "1.0.0"},
+		},
+		AgentEndpoint: &AgentEndpoint{
+			Protocols: []string{"responses"},
+			AuthorizationSchemes: []AgentEndpointAuthorizationScheme{
+				{
+					Type:               "Entra",
+					IsolationKeySource: &IsolationKeySource{Kind: ""},
+				},
+			},
+		},
+	}
+
+	buildConfig := &AgentBuildConfig{ImageURL: "myregistry.azurecr.io/agent:latest"}
+	_, err := CreateHostedAgentAPIRequest(hostedAgent, buildConfig)
+	if err == nil {
+		t.Fatal("expected error for empty isolation key source kind")
+	}
+	if !strings.Contains(err.Error(), "empty kind") {
+		t.Errorf("error = %q, want it to mention 'empty kind'", err.Error())
+	}
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
@@ -617,9 +617,22 @@ type ProtocolVersionRecord struct {
 	Version  string `json:"version" yaml:"version"`
 }
 
-// AgentEndpoint describes the endpoint protocols an agent supports in agent.yaml.
+// IsolationKeySource configures how the isolation key is derived for an agent endpoint.
+type IsolationKeySource struct {
+	Kind string `json:"kind" yaml:"kind"`
+}
+
+// AgentEndpointAuthorizationScheme describes an authorization scheme for an agent endpoint.
+type AgentEndpointAuthorizationScheme struct {
+	Type               string              `json:"type" yaml:"type"`
+	IsolationKeySource *IsolationKeySource `json:"isolation_key_source,omitempty" yaml:"isolation_key_source,omitempty"`
+}
+
+// AgentEndpoint describes the endpoint configuration an agent supports in agent.yaml.
+// Corresponds to AgentEndpointConfig in the Foundry API.
 type AgentEndpoint struct {
-	Protocols []string `json:"protocols" yaml:"protocols"`
+	Protocols            []string                           `json:"protocols,omitempty" yaml:"protocols,omitempty"`
+	AuthorizationSchemes []AgentEndpointAuthorizationScheme `json:"authorization_schemes,omitempty" yaml:"authorization_schemes,omitempty"`
 }
 
 // AgentCardSkill describes a single capability that an agent can perform.


### PR DESCRIPTION
Adds support for the agent_endpoint.authorization_schemes field on hosted agents in the azure.ai.agents extension, matching the Foundry API spec.

New types in agent_api and agent_yaml:

- AgentEndpointAuthorizationScheme (Entra/BotService/BotServiceRbac)

- IsolationKeySource (Entra/Header) - applies to Entra schemes

Maps from agent.yaml to the Foundry CreateAgentRequest in createAgentAPIRequest with validation (empty type/kind rejected).