### PR TITLE
[microsoft.azd.extensions] Fix azd x watch glob matching on Windows and enable CI tests

### DIFF
--- a/cli/azd/extensions/microsoft.azd.extensions/ci-test.ps1
+++ b/cli/azd/extensions/microsoft.azd.extensions/ci-test.ps1
@@ -1,0 +1,27 @@
+$gopath = go env GOPATH
+$gotestsumBinary = "gotestsum"
+if ($IsWindows) {
+    $gotestsumBinary += ".exe"
+}
+$gotestsum = Join-Path $gopath "bin" $gotestsumBinary
+
+Write-Host "Running unit tests..."
+
+if (Test-Path $gotestsum) {
+    # Use gotestsum for better output formatting and summary
+    & $gotestsum --format testname -- ./... -count=1
+} else {
+    # Fallback to go test if gotestsum is not installed
+    Write-Host "gotestsum not found, using go test..." -ForegroundColor Yellow
+    go test ./... -v -count=1
+}
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Host ""
+    Write-Host "Tests failed with exit code: $LASTEXITCODE" -ForegroundColor Red
+    exit $LASTEXITCODE
+}
+
+Write-Host ""
+Write-Host "All tests passed!" -ForegroundColor Green
+exit 0

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/watch.go
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/watch.go
@@ -218,8 +218,11 @@ func shouldIgnoreWatchEvent(
 	relPath := relativeWatchPath(root, eventName)
 
 	// Fast path: ignore events matching hardcoded glob patterns.
+	// relPath uses forward slashes (see relativeWatchPath), so use Match,
+	// which always splits on '/', instead of PathMatch, which would split on
+	// the OS separator (`\` on Windows) and break these patterns.
 	for _, pattern := range globIgnorePaths {
-		matched, _ := doublestar.PathMatch(pattern, relPath)
+		matched, _ := doublestar.Match(pattern, relPath)
 		if matched {
 			return true
 		}

--- a/eng/pipelines/release-ext-microsoft-azd-extensions.yml
+++ b/eng/pipelines/release-ext-microsoft-azd-extensions.yml
@@ -30,4 +30,3 @@ extends:
           AzdExtensionId: microsoft.azd.extensions
           SanitizedExtensionId: microsoft-azd-extensions
           AzdExtensionDirectory: cli/azd/extensions/microsoft.azd.extensions
-          SkipTests: true


### PR DESCRIPTION
## Summary

Follow-up to #8273. Two related changes:

1. **Fix glob matching on Windows.** The hardcoded ignore fast-path in `shouldIgnoreWatchEvent` was using `doublestar.PathMatch`, which splits patterns on the OS path separator. On Windows that separator is `\`, so multi-segment patterns like `bin/**/*` could never match the forward-slashed `relPath` produced by `filepath.ToSlash`. Switched to `doublestar.Match`, which always splits on `/` and matches the convention already in use for `relPath` and the hardcoded patterns. This is the [library's documented recommendation](https://pkg.go.dev/github.com/bmatcuk/doublestar/v4#PathMatch) when both inputs are forward-slashed.

2. **Enable unit tests in CI for `microsoft.azd.extensions`.** The pipeline had `SkipTests: true` and the extension was missing `ci-test.ps1`. Without these, the existing `TestShouldIgnoreWatchEvent*` tests (and any future tests) never run in CI, so Windows-only regressions like (1) can slip through. Mirrors the setup used by other extensions (e.g. `azure.ai.agents`).

## User impact of the matching bug

In practice on Windows the broken matcher was largely **dormant**:

- `watchRecursive` skips ignored folders by directory name at any depth via `filepath.SkipDir`, so `bin/`, `obj/`, `build/`, `node_modules/`, and `.git/` are never added to the watcher.
- fsnotify on Windows is non-recursive, so events for files inside non-added directories never surface to `shouldIgnoreWatchEvent`.
- Single-segment patterns (`bin`, `*.spec`, `package-lock.json`, ...) still matched correctly even with the OS-separator bug.

The fix removes a latent footgun and makes the existing `TestShouldIgnoreWatchEvent*` unit tests pass on Windows. Linux and macOS were unaffected.

## Verification

```pwsh
cd cli/azd/extensions/microsoft.azd.extensions
go test ./internal/cmd/...
# ok  github.com/azure/azure-dev/cli/azd/extensions/microsoft.azd.extensions/internal/cmd

pwsh ./ci-test.ps1
# All tests passed!
```
