### PR TITLE
chore: add disk space cleanup steps to CI pipeline (Phase 3)

### DIFF
--- a/eng/pipelines/templates/jobs/build-cli.yml
+++ b/eng/pipelines/templates/jobs/build-cli.yml
@@ -173,7 +173,6 @@ jobs:
 
       - template: /eng/pipelines/templates/steps/cleanup-disk-space.yml
         parameters:
-          CleanGoCache: true
           CleanNuGet: true
           CleanDotNet: true
 
@@ -217,6 +216,7 @@ jobs:
       - template: /eng/pipelines/templates/steps/cleanup-disk-space.yml
         parameters:
           CleanDocker: true
+          Condition: and(succeeded(), eq(variables['BuildLinuxPackages'], 'true'))
 
       - pwsh: New-Item -ItemType Directory -Path $(Build.ArtifactStagingDirectory)/shield -Force
         condition: and(succeeded(), eq(variables['SetShieldInfo'], 'true'))

--- a/eng/pipelines/templates/jobs/build-cli.yml
+++ b/eng/pipelines/templates/jobs/build-cli.yml
@@ -171,6 +171,12 @@ jobs:
         displayName: Publish test results
         condition: succeededOrFailed()
 
+      - template: /eng/pipelines/templates/steps/cleanup-disk-space.yml
+        parameters:
+          CleanGoCache: true
+          CleanNuGet: true
+          CleanDotNet: true
+
       - task: PowerShell@2
         inputs:
           pwsh: true
@@ -200,9 +206,17 @@ jobs:
         workingDirectory: cli/azd
         displayName: Copy binary to artifact staging directory
 
+      - template: /eng/pipelines/templates/steps/cleanup-disk-space.yml
+        parameters:
+          CleanGoCache: true
+
       - template: /eng/pipelines/templates/steps/build-linux-packages.yml
         parameters:
           Condition: and(succeeded(), eq(variables['BuildLinuxPackages'], 'true'))
+
+      - template: /eng/pipelines/templates/steps/cleanup-disk-space.yml
+        parameters:
+          CleanDocker: true
 
       - pwsh: New-Item -ItemType Directory -Path $(Build.ArtifactStagingDirectory)/shield -Force
         condition: and(succeeded(), eq(variables['SetShieldInfo'], 'true'))

--- a/eng/pipelines/templates/jobs/build-cli.yml
+++ b/eng/pipelines/templates/jobs/build-cli.yml
@@ -173,6 +173,7 @@ jobs:
 
       - template: /eng/pipelines/templates/steps/cleanup-disk-space.yml
         parameters:
+          Condition: succeededOrFailed()
           CleanNuGet: true
           CleanDotNet: true
 

--- a/eng/pipelines/templates/jobs/build-cli.yml
+++ b/eng/pipelines/templates/jobs/build-cli.yml
@@ -208,6 +208,9 @@ jobs:
       - template: /eng/pipelines/templates/steps/cleanup-disk-space.yml
         parameters:
           CleanGoCache: true
+          CleanDocker: true
+          CleanSystemCaches: true
+          Condition: and(succeeded(), eq(variables['BuildLinuxPackages'], 'true'))
 
       - template: /eng/pipelines/templates/steps/build-linux-packages.yml
         parameters:

--- a/eng/pipelines/templates/jobs/cross-build-cli.yml
+++ b/eng/pipelines/templates/jobs/cross-build-cli.yml
@@ -102,6 +102,7 @@ jobs:
         parameters:
           CleanDocker: true
           CleanGoCache: true
+          Condition: and(succeeded(), eq(variables['BuildLinuxPackages'], 'true'))
     
     templateContext: 
       outputs: 

--- a/eng/pipelines/templates/jobs/cross-build-cli.yml
+++ b/eng/pipelines/templates/jobs/cross-build-cli.yml
@@ -93,6 +93,11 @@ jobs:
         workingDirectory: cli/azd
         displayName: Copy binary to artifact staging directory
 
+      - template: /eng/pipelines/templates/steps/cleanup-disk-space.yml
+        parameters:
+          CleanGoCache: true
+          Condition: and(succeeded(), eq(variables['BuildLinuxPackages'], 'true'))
+
       - template: /eng/pipelines/templates/steps/build-linux-packages.yml
         parameters:
           Architecture: arm64
@@ -101,7 +106,6 @@ jobs:
       - template: /eng/pipelines/templates/steps/cleanup-disk-space.yml
         parameters:
           CleanDocker: true
-          CleanGoCache: true
           Condition: and(succeeded(), eq(variables['BuildLinuxPackages'], 'true'))
     
     templateContext: 

--- a/eng/pipelines/templates/jobs/cross-build-cli.yml
+++ b/eng/pipelines/templates/jobs/cross-build-cli.yml
@@ -96,6 +96,8 @@ jobs:
       - template: /eng/pipelines/templates/steps/cleanup-disk-space.yml
         parameters:
           CleanGoCache: true
+          CleanDocker: true
+          CleanSystemCaches: true
           Condition: and(succeeded(), eq(variables['BuildLinuxPackages'], 'true'))
 
       - template: /eng/pipelines/templates/steps/build-linux-packages.yml

--- a/eng/pipelines/templates/jobs/cross-build-cli.yml
+++ b/eng/pipelines/templates/jobs/cross-build-cli.yml
@@ -97,6 +97,11 @@ jobs:
         parameters:
           Architecture: arm64
           Condition: and(succeeded(), eq(variables['BuildLinuxPackages'], 'true'))
+
+      - template: /eng/pipelines/templates/steps/cleanup-disk-space.yml
+        parameters:
+          CleanDocker: true
+          CleanGoCache: true
     
     templateContext: 
       outputs: 

--- a/eng/pipelines/templates/stages/build-and-test.yml
+++ b/eng/pipelines/templates/stages/build-and-test.yml
@@ -27,6 +27,11 @@ parameters:
           GOOS: linux
           GOARCH: arm64
           BuildLinuxPackages: true
+          # Set special temp/cache directory overrides to avoid out of space
+          # issues on hosted agents
+          DOCKER_TMPDIR: $(Agent.TempDirectory)
+          TMPDIR: $(Agent.TempDirectory)
+          GOCACHE: $(Agent.TempDirectory)/go-cache
       MacARM64:
         Pool: Azure Pipelines
         OSVmImage: $(MACVMIMAGE)

--- a/eng/pipelines/templates/steps/cleanup-disk-space.yml
+++ b/eng/pipelines/templates/steps/cleanup-disk-space.yml
@@ -22,29 +22,29 @@ steps:
     continueOnError: true
 
   - ${{ if eq(parameters.CleanDocker, true) }}:
-    - bash: docker system prune -af --volumes 2>/dev/null || true
+    - bash: docker system prune -af --volumes
       displayName: Cleanup Docker
       condition: and(${{ parameters.Condition }}, eq(variables['Agent.OS'], 'Linux'))
       continueOnError: true
 
   - ${{ if eq(parameters.CleanGoCache, true) }}:
     - bash: |
-        go clean -cache 2>/dev/null || true
-        go clean -testcache 2>/dev/null || true
+        go clean -cache
+        go clean -testcache
       displayName: Cleanup Go cache
       condition: and(${{ parameters.Condition }}, eq(variables['Agent.OS'], 'Linux'))
       continueOnError: true
 
   - ${{ if eq(parameters.CleanNuGet, true) }}:
-    - bash: dotnet nuget locals all --clear 2>/dev/null || true
+    - bash: dotnet nuget locals all --clear
       displayName: Cleanup NuGet cache
       condition: and(${{ parameters.Condition }}, eq(variables['Agent.OS'], 'Linux'))
       continueOnError: true
 
   - ${{ if eq(parameters.CleanDotNet, true) }}:
     - bash: |
-        rm -rf /tmp/NuGetScratch 2>/dev/null || true
-        rm -rf /tmp/.dotnet 2>/dev/null || true
+        rm -rf /tmp/NuGetScratch
+        rm -rf /tmp/.dotnet
       displayName: Cleanup .NET temp artifacts
       condition: and(${{ parameters.Condition }}, eq(variables['Agent.OS'], 'Linux'))
       continueOnError: true

--- a/eng/pipelines/templates/steps/cleanup-disk-space.yml
+++ b/eng/pipelines/templates/steps/cleanup-disk-space.yml
@@ -1,0 +1,55 @@
+parameters:
+  - name: CleanDocker
+    type: boolean
+    default: false
+  - name: CleanGoCache
+    type: boolean
+    default: false
+  - name: CleanNuGet
+    type: boolean
+    default: false
+  - name: CleanDotNet
+    type: boolean
+    default: false
+  - name: Condition
+    type: string
+    default: succeeded()
+
+steps:
+  - bash: df -h /
+    displayName: Disk usage (before cleanup)
+    condition: and(${{ parameters.Condition }}, eq(variables['Agent.OS'], 'Linux'))
+    continueOnError: true
+
+  - ${{ if eq(parameters.CleanDocker, true) }}:
+    - bash: docker system prune -af --volumes 2>/dev/null || true
+      displayName: Cleanup Docker
+      condition: and(${{ parameters.Condition }}, eq(variables['Agent.OS'], 'Linux'))
+      continueOnError: true
+
+  - ${{ if eq(parameters.CleanGoCache, true) }}:
+    - bash: |
+        go clean -cache 2>/dev/null || true
+        go clean -testcache 2>/dev/null || true
+      displayName: Cleanup Go cache
+      condition: and(${{ parameters.Condition }}, eq(variables['Agent.OS'], 'Linux'))
+      continueOnError: true
+
+  - ${{ if eq(parameters.CleanNuGet, true) }}:
+    - bash: dotnet nuget locals all --clear 2>/dev/null || true
+      displayName: Cleanup NuGet cache
+      condition: and(${{ parameters.Condition }}, eq(variables['Agent.OS'], 'Linux'))
+      continueOnError: true
+
+  - ${{ if eq(parameters.CleanDotNet, true) }}:
+    - bash: |
+        rm -rf /tmp/NuGetScratch 2>/dev/null || true
+        rm -rf /tmp/.dotnet 2>/dev/null || true
+      displayName: Cleanup .NET temp artifacts
+      condition: and(${{ parameters.Condition }}, eq(variables['Agent.OS'], 'Linux'))
+      continueOnError: true
+
+  - bash: df -h /
+    displayName: Disk usage (after cleanup)
+    condition: and(${{ parameters.Condition }}, eq(variables['Agent.OS'], 'Linux'))
+    continueOnError: true

--- a/eng/pipelines/templates/steps/cleanup-disk-space.yml
+++ b/eng/pipelines/templates/steps/cleanup-disk-space.yml
@@ -11,6 +11,9 @@ parameters:
   - name: CleanDotNet
     type: boolean
     default: false
+  - name: CleanSystemCaches
+    type: boolean
+    default: false
   - name: Condition
     type: string
     default: succeeded()
@@ -46,6 +49,16 @@ steps:
         rm -rf /tmp/NuGetScratch
         rm -rf /tmp/.dotnet
       displayName: Cleanup .NET temp artifacts
+      condition: and(${{ parameters.Condition }}, eq(variables['Agent.OS'], 'Linux'))
+      continueOnError: true
+
+  - ${{ if eq(parameters.CleanSystemCaches, true) }}:
+    - bash: |
+        sudo apt-get clean
+        sudo rm -rf /var/lib/apt/lists/*
+        sudo rm -rf /var/cache/apt/archives/*
+        rm -rf /tmp/go-build*
+      displayName: Cleanup system caches
       condition: and(${{ parameters.Condition }}, eq(variables['Agent.OS'], 'Linux'))
       continueOnError: true
 


### PR DESCRIPTION
## Phase 3: Reduce disk space warnings from Linux CI agents

Resolves #7783

### Problem
The 1ES Pipeline Template checks disk space between every task and emits `Free disk space on / is lower than 5%` warnings when usage exceeds 95%. Linux agents in the ADO pipeline were generating 71+ such warnings per build.

### Solution
Created a reusable disk cleanup step template and inserted it at strategic points in the CI pipeline to keep disk usage below the 95% warning threshold.

#### Changes
1. **`eng/pipelines/templates/steps/cleanup-disk-space.yml`** (new) — Reusable cleanup template with parameterized targets:
   - `CleanDocker`: `docker system prune -af --volumes`
   - `CleanGoCache`: `go clean -cache && go clean -testcache`
   - `CleanNuGet`: `dotnet nuget locals all --clear`
   - `CleanDotNet`: Remove temp NuGet/dotnet artifacts
   - `CleanSystemCaches`: Clean apt cache, apt lists, temp Go build files
   - All steps Linux-only, `continueOnError: true`, with `df -h` diagnostics

2. **`eng/pipelines/templates/jobs/build-cli.yml`** — 3 cleanup insertions:
   - After tests: NuGet + .NET temp cleanup
   - Before Linux packages: Go cache + Docker + system caches cleanup (proactive)
   - After Linux packages: Docker cleanup (reactive)

3. **`eng/pipelines/templates/jobs/cross-build-cli.yml`** — 2 cleanup insertions:
   - Before Linux packages: Go cache + Docker + system caches cleanup
   - After Linux packages: Docker cleanup

4. **`eng/pipelines/templates/stages/build-and-test.yml`** — Added `DOCKER_TMPDIR`, `TMPDIR`, `GOCACHE` overrides to LinuxARM64 cross-build matrix (matching BuildCLI_Linux)

### Key Design Decisions
- **Pre-build Docker cleanup**: The 1ES `BuildContainerImage` + Copacetic security scan consumes ~4GB. Cleaning Docker images and system caches BEFORE the build keeps disk under the 95% threshold during Copacetic scanning
- **Post-test cleanup excludes Go cache**: Go cache is needed for the release build; cleaning it after tests would force a full rebuild
- **Docker cleanup conditioned on `BuildLinuxPackages`**: Only runs when the fpm Docker container is actually built
- **`continueOnError: true`**: Cleanup failures should never block the build