### PR TITLE
refactor: decouple Foundry project selection from model configuration in agent init

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1170,14 +1170,14 @@ func (a *InitAction) configureModelChoice(
 			}
 
 			if selectedProject == nil {
-				return nil, fmt.Errorf("foundry project not found: %s", a.flags.projectResourceId)
+				return nil, fmt.Errorf("specified foundry project was not found or is not eligible for the current configuration: %s", a.flags.projectResourceId)
 			}
 
 			// Signal Bicep to skip project/role/connection provisioning for this existing project
 			if err := setEnvValue(
 				ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "true",
 			); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 			}
 		} else {
 			// Prompt user to pick an existing Foundry project or create new resources
@@ -1195,6 +1195,9 @@ func (a *InitAction) configureModelChoice(
 				},
 			})
 			if err != nil {
+				if exterrors.IsCancellation(err) {
+					return nil, exterrors.Cancelled("project selection was cancelled")
+				}
 				return nil, exterrors.FromPrompt(err, "failed to prompt for Foundry project configuration choice")
 			}
 
@@ -1226,7 +1229,7 @@ func (a *InitAction) configureModelChoice(
 					if err := setEnvValue(
 						ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false",
 					); err != nil {
-						return nil, err
+						return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 					}
 					if err := ensureLocation(ctx, a.azdClient, a.azureContext, a.environment.Name); err != nil {
 						return nil, err
@@ -1236,7 +1239,7 @@ func (a *InitAction) configureModelChoice(
 					if err := setEnvValue(
 						ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "true",
 					); err != nil {
-						return nil, err
+						return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 					}
 				}
 			default:
@@ -1253,7 +1256,7 @@ func (a *InitAction) configureModelChoice(
 				if err := setEnvValue(
 					ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false",
 				); err != nil {
-					return nil, err
+					return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 				}
 			}
 		}
@@ -1286,10 +1289,10 @@ func (a *InitAction) configureModelChoice(
 			if err := setEnvValue(
 				ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "true",
 			); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 			}
 		} else {
-			return nil, fmt.Errorf("foundry project not found: %s", a.flags.projectResourceId)
+			return nil, fmt.Errorf("specified foundry project was not found or is not eligible for the current configuration: %s", a.flags.projectResourceId)
 		}
 	} else {
 		// Prompt user to pick an existing Foundry project or create new resources
@@ -1307,6 +1310,9 @@ func (a *InitAction) configureModelChoice(
 			},
 		})
 		if err != nil {
+			if exterrors.IsCancellation(err) {
+				return nil, exterrors.Cancelled("project selection was cancelled")
+			}
 			return nil, exterrors.FromPrompt(err, "failed to prompt for Foundry project configuration choice")
 		}
 
@@ -1338,7 +1344,7 @@ func (a *InitAction) configureModelChoice(
 				if err := setEnvValue(
 					ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false",
 				); err != nil {
-					return nil, err
+					return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 				}
 				if err := ensureLocation(ctx, a.azdClient, a.azureContext, a.environment.Name); err != nil {
 					return nil, err
@@ -1347,7 +1353,7 @@ func (a *InitAction) configureModelChoice(
 				if err := setEnvValue(
 					ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "true",
 				); err != nil {
-					return nil, err
+					return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 				}
 			}
 		default:
@@ -1364,7 +1370,7 @@ func (a *InitAction) configureModelChoice(
 			if err := setEnvValue(
 				ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false",
 			); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 			}
 		}
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1261,37 +1261,9 @@ func (a *InitAction) configureModelChoice(
 		return agentManifest, nil
 	}
 
-	modelConfigChoices := []*azdext.SelectChoice{
-		{Label: "Deploy new model(s) (with new Foundry project)", Value: "new"},
-		{Label: "Use an existing Foundry project", Value: "existing"},
-	}
-
-	var modelConfigChoice string
-
+	// Step 1: Foundry project selection
 	if a.flags.projectResourceId != "" {
 		// --project-id provided: auto-select "existing" path
-		modelConfigChoice = "existing"
-	} else {
-		defaultIndex := int32(0)
-		modelConfigResp, err := a.azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
-			Options: &azdext.SelectOptions{
-				Message:       "How would you like to configure model(s) for your agent?",
-				Choices:       modelConfigChoices,
-				SelectedIndex: &defaultIndex,
-			},
-		})
-		if err != nil {
-			if exterrors.IsCancellation(err) {
-				return nil, exterrors.Cancelled("model configuration choice was cancelled")
-			}
-			return nil, fmt.Errorf("failed to prompt for model configuration choice: %w", err)
-		}
-		modelConfigChoice = modelConfigChoices[*modelConfigResp.Value].Value
-	}
-
-	switch modelConfigChoice {
-	case "existing":
-		// Ensure subscription for project listing
 		newCred, err := ensureSubscription(
 			ctx, a.azdClient, a.azureContext, a.environment.Name,
 			"Select an Azure subscription to look up available models and provision your Foundry project resources.",
@@ -1301,7 +1273,6 @@ func (a *InitAction) configureModelChoice(
 		}
 		a.credential = newCred
 
-		// Select a Foundry project (sets AZURE_AI_PROJECT_ID, ACR, AppInsights env vars)
 		selectedProject, err := selectFoundryProject(
 			ctx, a.azdClient, a.credential, a.azureContext, a.environment.Name,
 			a.azureContext.Scope.SubscriptionId, a.flags.projectResourceId,
@@ -1312,44 +1283,89 @@ func (a *InitAction) configureModelChoice(
 		}
 
 		if selectedProject != nil {
-			// Signal Bicep to skip project/role/connection provisioning for this existing project
 			if err := setEnvValue(
 				ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "true",
 			); err != nil {
 				return nil, err
 			}
 		} else {
-			// No existing project selected (no projects found or user chose "Create new") → fall back to "deploy new" path
-			fmt.Println(output.WithGrayFormat(
-				"No existing Foundry project was selected. Falling back to deploying a new model.",
-			))
-			// Clear any stale existing-project flag from a previous init
+			return nil, fmt.Errorf("foundry project not found: %s", a.flags.projectResourceId)
+		}
+	} else {
+		// Prompt user to pick an existing Foundry project or create new resources
+		projectChoices := []*azdext.SelectChoice{
+			{Label: "Use an existing Foundry project", Value: "existing"},
+			{Label: "Create a new Foundry project", Value: "new"},
+		}
+
+		defaultIdx := int32(0)
+		projectResp, err := a.azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
+			Options: &azdext.SelectOptions{
+				Message:       "Select a Foundry project to host your agent and any models or tools it uses.",
+				Choices:       projectChoices,
+				SelectedIndex: &defaultIdx,
+			},
+		})
+		if err != nil {
+			return nil, exterrors.FromPrompt(err, "failed to prompt for Foundry project configuration choice")
+		}
+
+		switch projectChoices[*projectResp.Value].Value {
+		case "existing":
+			newCred, err := ensureSubscription(
+				ctx, a.azdClient, a.azureContext, a.environment.Name,
+				"Select an Azure subscription to find existing Foundry projects.",
+			)
+			if err != nil {
+				return nil, err
+			}
+			a.credential = newCred
+
+			selectedProject, err := selectFoundryProject(
+				ctx, a.azdClient, a.credential, a.azureContext, a.environment.Name,
+				a.azureContext.Scope.SubscriptionId, "",
+				a.isCodeDeploy,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			if selectedProject == nil {
+				// No existing project selected → fall back to "create new" path
+				fmt.Println(output.WithGrayFormat(
+					"No existing Foundry project was selected. Falling back to creating new resources.",
+				))
+				if err := setEnvValue(
+					ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false",
+				); err != nil {
+					return nil, err
+				}
+				if err := ensureLocation(ctx, a.azdClient, a.azureContext, a.environment.Name); err != nil {
+					return nil, err
+				}
+			} else {
+				if err := setEnvValue(
+					ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "true",
+				); err != nil {
+					return nil, err
+				}
+			}
+		default:
+			newCred, err := ensureSubscriptionAndLocation(
+				ctx, a.azdClient, a.azureContext, a.environment.Name,
+				"Select an Azure subscription to look up available models and provision your Foundry project resources.",
+			)
+			if err != nil {
+				return nil, err
+			}
+			a.credential = newCred
+
+			// Creating new resources — clear any stale existing-project flag
 			if err := setEnvValue(
 				ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false",
 			); err != nil {
 				return nil, err
 			}
-			if err := ensureLocation(ctx, a.azdClient, a.azureContext, a.environment.Name); err != nil {
-				return nil, err
-			}
-		}
-
-	case "new":
-		// Ensure subscription + location for model catalog
-		newCred, err := ensureSubscriptionAndLocation(
-			ctx, a.azdClient, a.azureContext, a.environment.Name,
-			"Select an Azure subscription to look up available models and provision your Foundry project resources.",
-		)
-		if err != nil {
-			return nil, err
-		}
-		a.credential = newCred
-
-		// Deploying new resources — clear any stale existing-project flag
-		if err := setEnvValue(
-			ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false",
-		); err != nil {
-			return nil, err
 		}
 	}
 
@@ -2022,7 +2038,7 @@ func (a *InitAction) addToProject(ctx context.Context, targetDir string, agentMa
 	if projectID, _ := a.azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
 		EnvName: a.environment.Name,
 		Key:     "AZURE_AI_PROJECT_ID",
-	}); projectID != nil && projectID.Value != "" {
+	}); projectID != nil && projectID.Value != "" && len(a.deploymentDetails) == 0 {
 		fmt.Printf("To deploy your agent, use %s.\n",
 			color.HiBlueString("azd deploy %s", a.serviceNameOverride))
 	} else {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1262,8 +1262,8 @@ func (a *InitAction) configureModelChoice(
 	}
 
 	modelConfigChoices := []*azdext.SelectChoice{
-		{Label: "Deploy new model(s) from the catalog", Value: "new"},
-		{Label: "Use existing model deployment(s) from a Foundry project", Value: "existing"},
+		{Label: "Deploy new model(s) (with new Foundry project)", Value: "new"},
+		{Label: "Use an existing Foundry project", Value: "existing"},
 	}
 
 	var modelConfigChoice string

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -494,7 +494,17 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 	// Step 1: Foundry project selection
 	var selectedProject *FoundryProjectInfo
 	if a.flags.projectResourceId != "" {
-		a.azureContext.Scope.SubscriptionId = extractSubscriptionId(a.flags.projectResourceId)
+		projectDetails, err := extractProjectDetails(a.flags.projectResourceId)
+		if err != nil {
+			return nil, exterrors.Validation(
+				exterrors.CodeInvalidProjectResourceId,
+				fmt.Sprintf("invalid --project-id value: %s", err),
+				"Provide a valid Foundry project resource ID in the format:\n"+
+					"/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP>/providers/"+
+					"Microsoft.CognitiveServices/accounts/<ACCOUNT_NAME>/projects/<PROJECT_NAME>",
+			)
+		}
+		a.azureContext.Scope.SubscriptionId = projectDetails.SubscriptionId
 
 		newCred, err := ensureSubscription(
 			ctx, a.azdClient, a.azureContext, a.environment.Name,
@@ -510,12 +520,12 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 			return nil, err
 		}
 		if proj == nil {
-			return nil, fmt.Errorf("foundry project not found: %s", a.flags.projectResourceId)
+			return nil, fmt.Errorf("specified foundry project was not found or is not eligible for the current configuration: %s", a.flags.projectResourceId)
 		}
 		selectedProject = proj
 
 		if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "true"); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 		}
 	} else {
 		projectChoices := []*azdext.SelectChoice{
@@ -532,6 +542,9 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 			},
 		})
 		if err != nil {
+			if exterrors.IsCancellation(err) {
+				return nil, exterrors.Cancelled("project selection was cancelled")
+			}
 			return nil, exterrors.FromPrompt(err, "failed to prompt for Foundry project configuration choice")
 		}
 
@@ -556,7 +569,7 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 					"No existing Foundry project was selected. Falling back to creating new resources.",
 				))
 				if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false"); err != nil {
-					return nil, err
+					return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 				}
 				if err := ensureLocation(ctx, a.azdClient, a.azureContext, a.environment.Name); err != nil {
 					return nil, err
@@ -564,7 +577,7 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 			} else {
 				selectedProject = proj
 				if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "true"); err != nil {
-					return nil, err
+					return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 				}
 			}
 		default:
@@ -578,7 +591,7 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 			a.credential = newCred
 
 			if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false"); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 			}
 		}
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/ux"
 	"github.com/fatih/color"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -490,107 +491,165 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 		return nil, err
 	}
 
-	// Ask user how they want to configure a model
-	modelConfigChoices := []*azdext.SelectChoice{
-		{Label: "Deploy new model(s) (with new Foundry project)", Value: "new"},
-		{Label: "Use an existing Foundry project", Value: "existing"},
-		{Label: "Skip model configuration", Value: "skip"},
-	}
+	// Step 1: Foundry project selection
+	var selectedProject *FoundryProjectInfo
+	if a.flags.projectResourceId != "" {
+		a.azureContext.Scope.SubscriptionId = extractSubscriptionId(a.flags.projectResourceId)
 
-	var modelConfigChoice string
-	if a.flags.projectResourceId == "" {
-		defaultIndex := int32(0)
-		modelConfigResp, err := a.azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
+		newCred, err := ensureSubscription(
+			ctx, a.azdClient, a.azureContext, a.environment.Name,
+			"Select an Azure subscription to find existing Foundry projects.",
+		)
+		if err != nil {
+			return nil, err
+		}
+		a.credential = newCred
+
+		proj, err := selectFoundryProject(ctx, a.azdClient, a.credential, a.azureContext, a.environment.Name, a.azureContext.Scope.SubscriptionId, a.flags.projectResourceId, deployMode == "code")
+		if err != nil {
+			return nil, err
+		}
+		if proj == nil {
+			return nil, fmt.Errorf("foundry project not found: %s", a.flags.projectResourceId)
+		}
+		selectedProject = proj
+
+		if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "true"); err != nil {
+			return nil, err
+		}
+	} else {
+		projectChoices := []*azdext.SelectChoice{
+			{Label: "Use an existing Foundry project", Value: "existing"},
+			{Label: "Create a new Foundry project", Value: "new"},
+		}
+
+		defaultIdx := int32(0)
+		projectResp, err := a.azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
 			Options: &azdext.SelectOptions{
-				Message:       "How would you like to configure a model for your agent?",
-				Choices:       modelConfigChoices,
-				SelectedIndex: &defaultIndex,
+				Message:       "Select a Foundry project to host your agent and any models or tools it uses.",
+				Choices:       projectChoices,
+				SelectedIndex: &defaultIdx,
 			},
 		})
 		if err != nil {
-			if exterrors.IsCancellation(err) {
-				return nil, exterrors.Cancelled("model configuration choice was cancelled")
-			}
-			return nil, fmt.Errorf("failed to prompt for model configuration choice: %w", err)
+			return nil, exterrors.FromPrompt(err, "failed to prompt for Foundry project configuration choice")
 		}
-		modelConfigChoice = modelConfigChoices[*modelConfigResp.Value].Value
-	} else {
-		// If projectResourceId is provided, skip the prompt and default to existing deployment selection
-		modelConfigChoice = "existing"
 
-		a.azureContext.Scope.SubscriptionId = extractSubscriptionId(a.flags.projectResourceId)
+		switch projectChoices[*projectResp.Value].Value {
+		case "existing":
+			newCred, err := ensureSubscription(
+				ctx, a.azdClient, a.azureContext, a.environment.Name,
+				"Select an Azure subscription to find existing Foundry projects.",
+			)
+			if err != nil {
+				return nil, err
+			}
+			a.credential = newCred
+
+			proj, err := selectFoundryProject(ctx, a.azdClient, a.credential, a.azureContext, a.environment.Name, a.azureContext.Scope.SubscriptionId, "", deployMode == "code")
+			if err != nil {
+				return nil, err
+			}
+
+			if proj == nil {
+				fmt.Println(output.WithGrayFormat(
+					"No existing Foundry project was selected. Falling back to creating new resources.",
+				))
+				if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false"); err != nil {
+					return nil, err
+				}
+				if err := ensureLocation(ctx, a.azdClient, a.azureContext, a.environment.Name); err != nil {
+					return nil, err
+				}
+			} else {
+				selectedProject = proj
+				if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "true"); err != nil {
+					return nil, err
+				}
+			}
+		default:
+			newCred, err := ensureSubscriptionAndLocation(
+				ctx, a.azdClient, a.azureContext, a.environment.Name,
+				"Select an Azure subscription to look up available models and provision your Foundry project resources.",
+			)
+			if err != nil {
+				return nil, err
+			}
+			a.credential = newCred
+
+			if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false"); err != nil {
+				return nil, err
+			}
+		}
 	}
+
+	// Step 2: Model configuration
+	var modelConfigChoices []*azdext.SelectChoice
+	if selectedProject != nil {
+		modelConfigChoices = []*azdext.SelectChoice{
+			{Label: "Use an existing model deployment", Value: "existing"},
+			{Label: "Deploy a new model from the catalog", Value: "new"},
+			{Label: "Skip model configuration", Value: "skip"},
+		}
+	} else {
+		modelConfigChoices = []*azdext.SelectChoice{
+			{Label: "Deploy a new model from the catalog", Value: "new"},
+			{Label: "Skip model configuration", Value: "skip"},
+		}
+	}
+
+	defaultIndex := int32(0)
+	modelConfigResp, err := a.azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
+		Options: &azdext.SelectOptions{
+			Message:       "How would you like to configure model(s) for your agent?",
+			Choices:       modelConfigChoices,
+			SelectedIndex: &defaultIndex,
+		},
+	})
+	if err != nil {
+		if exterrors.IsCancellation(err) {
+			return nil, exterrors.Cancelled("model configuration choice was cancelled")
+		}
+		return nil, fmt.Errorf("failed to prompt for model configuration choice: %w", err)
+	}
+	modelConfigChoice := modelConfigChoices[*modelConfigResp.Value].Value
 
 	var selectedModel *azdext.AiModel
 	var existingDeployment *FoundryDeploymentInfo
 
 	switch modelConfigChoice {
 	case "new":
-		// Path A: Deploy a new model from the catalog
-		// Need subscription + location for model catalog
-		newCred, err := ensureSubscriptionAndLocation(
-			ctx, a.azdClient, a.azureContext, a.environment.Name,
-			"Select an Azure subscription to look up available models and provision your Foundry project resources.",
-		)
-		if err != nil {
-			return nil, err
+		if a.azureContext.Scope.Location == "" {
+			if err := ensureLocation(ctx, a.azdClient, a.azureContext, a.environment.Name); err != nil {
+				return nil, err
+			}
 		}
-		a.credential = newCred
-
 		selectedModel, err = selectNewModel(ctx, a.azdClient, a.azureContext, a.flags.model)
 		if err != nil {
 			return nil, fmt.Errorf("failed to select new model: %w", err)
 		}
 
 	case "existing":
-		// Path B: Select an existing model deployment from a Foundry project
-		// Need subscription to enumerate projects
-		newCred, err := ensureSubscription(
-			ctx, a.azdClient, a.azureContext, a.environment.Name,
-			"Select an Azure subscription to look up available models and provision your Foundry project resources.",
-		)
-		if err != nil {
-			return nil, err
-		}
-		a.credential = newCred
-
-		// Select a Foundry project
-		selectedProject, err := selectFoundryProject(ctx, a.azdClient, a.credential, a.azureContext, a.environment.Name, a.azureContext.Scope.SubscriptionId, a.flags.projectResourceId, deployMode == "code")
-		if err != nil {
-			return nil, err
-		}
-
 		if selectedProject == nil {
-			// No projects found or user chose "Create new" → fall back to new model
-			if a.azureContext.Scope.Location == "" {
-				if err := ensureLocation(ctx, a.azdClient, a.azureContext, a.environment.Name); err != nil {
-					return nil, err
-				}
-			}
+			return nil, fmt.Errorf("cannot select existing deployment without a Foundry project")
+		}
+		deployment, err := selectModelDeployment(ctx, a.azdClient, a.credential, *selectedProject, a.flags.modelDeployment, "")
+		if err != nil {
+			return nil, err
+		}
+
+		if deployment != nil {
+			existingDeployment = deployment
+		} else {
+			// User wants to create a new deployment — region locked to the project's location
 			selectedModel, err = selectNewModel(ctx, a.azdClient, a.azureContext, a.flags.model)
 			if err != nil {
 				return nil, fmt.Errorf("failed to select new model: %w", err)
 			}
-		} else {
-			// Select a deployment from the project
-			deployment, err := selectModelDeployment(ctx, a.azdClient, a.credential, *selectedProject, a.flags.modelDeployment, "")
-			if err != nil {
-				return nil, err
-			}
-
-			if deployment != nil {
-				existingDeployment = deployment
-			} else {
-				// User wants to create a new deployment — region locked to the project's location
-				selectedModel, err = selectNewModel(ctx, a.azdClient, a.azureContext, a.flags.model)
-				if err != nil {
-					return nil, fmt.Errorf("failed to select new model: %w", err)
-				}
-			}
 		}
 
 	case "skip":
-		// Path C: Skip model configuration entirely
+		// Skip model configuration entirely
 	}
 
 	// Create a minimal Agent Definition

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -37,6 +37,7 @@ type InitFromCodeAction struct {
 	environment       *azdext.Environment
 	credential        azcore.TokenCredential
 	deploymentDetails []project.Deployment
+	needsProvision    bool
 	httpClient        *http.Client
 }
 
@@ -138,7 +139,7 @@ func (a *InitFromCodeAction) Run(ctx context.Context) error {
 		if projectID, _ := a.azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
 			EnvName: a.environment.Name,
 			Key:     "AZURE_AI_PROJECT_ID",
-		}); projectID != nil && projectID.Value != "" {
+		}); projectID != nil && projectID.Value != "" && !a.needsProvision {
 			fmt.Printf("Next steps: Run %s to deploy your agent to Microsoft Foundry.\n",
 				color.HiBlueString("azd deploy %s", localDefinition.Name))
 		} else {
@@ -721,6 +722,7 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 				Capacity: int(modelDetails.Capacity),
 			},
 		})
+		a.needsProvision = true
 
 		definition.EnvironmentVariables = appendEnvVar(definition.EnvironmentVariables, agent_yaml.EnvironmentVariable{
 			Name:  "AZURE_AI_MODEL_DEPLOYMENT_NAME",

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -492,8 +492,8 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 
 	// Ask user how they want to configure a model
 	modelConfigChoices := []*azdext.SelectChoice{
-		{Label: "Deploy a new model from the catalog", Value: "new"},
-		{Label: "Select an existing model deployment from a Foundry project", Value: "existing"},
+		{Label: "Deploy new model(s) (with new Foundry project)", Value: "new"},
+		{Label: "Use an existing Foundry project", Value: "existing"},
 		{Label: "Skip model configuration", Value: "skip"},
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
@@ -360,7 +360,7 @@ func (a *modelSelector) getModelDetails(ctx context.Context, modelName string) (
 		if choices[*resp.Value].Value == "change" {
 			selectedModel, err := a.promptModelFromCatalog(ctx)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to select alternative model: %w", err)
 			}
 			if selectedModel == nil {
 				return nil, fmt.Errorf("no model selected, exiting")

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
@@ -335,6 +335,38 @@ func (a *modelSelector) getModelDetails(ctx context.Context, modelName string) (
 			return nil, fmt.Errorf("no model selected, exiting")
 		}
 		model = selectedModel
+	} else if !a.flags.noPrompt {
+		// Model found in catalog — let user confirm or choose a different one
+		choices := []*azdext.SelectChoice{
+			{Label: fmt.Sprintf("Use '%s' (from manifest)", model.Name), Value: "keep"},
+			{Label: "Choose a different model", Value: "change"},
+		}
+
+		defaultIdx := int32(0)
+		resp, err := a.azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
+			Options: &azdext.SelectOptions{
+				Message:       fmt.Sprintf("Model '%s' is specified in the agent manifest.", model.Name),
+				Choices:       choices,
+				SelectedIndex: &defaultIdx,
+			},
+		})
+		if err != nil {
+			if exterrors.IsCancellation(err) {
+				return nil, exterrors.Cancelled("model selection was cancelled")
+			}
+			return nil, fmt.Errorf("failed to prompt for model choice: %w", err)
+		}
+
+		if choices[*resp.Value].Value == "change" {
+			selectedModel, err := a.promptModelFromCatalog(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if selectedModel == nil {
+				return nil, fmt.Errorf("no model selected, exiting")
+			}
+			model = selectedModel
+		}
 	}
 
 	currentLocation := a.azureContext.Scope.Location
@@ -553,6 +585,25 @@ func (a *modelSelector) promptForAlternativeModel(
 
 	if regionChoices[*regionResp.Value].Value == "region" {
 		promptReq.Filter = agentModelFilter([]string{a.azureContext.Scope.Location}, nil)
+	}
+
+	modelResp, err := a.azdClient.Prompt().PromptAiModel(ctx, promptReq)
+	if err != nil {
+		return nil, exterrors.FromPrompt(err, "failed to prompt for model selection")
+	}
+
+	return modelResp.Model, nil
+}
+
+// promptModelFromCatalog shows the model catalog list filtered to the current region,
+// allowing the user to pick any available model.
+func (a *modelSelector) promptModelFromCatalog(ctx context.Context) (*azdext.AiModel, error) {
+	promptReq := &azdext.PromptAiModelRequest{
+		AzureContext: a.azureContext,
+		Filter:       agentModelFilter([]string{a.azureContext.Scope.Location}, nil),
+		SelectOptions: &azdext.SelectOptions{
+			Message: "Select a model",
+		},
 	}
 
 	modelResp, err := a.azdClient.Prompt().PromptAiModel(ctx, promptReq)


### PR DESCRIPTION
## Summary

Splits the combined "Deploy new model(s) / Use existing Foundry project" prompt into two distinct sequential steps, making the `azd ai agent init` UX clearer and more flexible.

### Changes

- **Step 1: Project selection** — "Use an existing Foundry project" or "Create a new Foundry project"
- **Step 2: Model configuration** — Options adapt based on Step 1:
  - Existing project: "Use existing deployment / Deploy from catalog / Skip"
  - New project: "Deploy from catalog / Skip"
- **Bug fix**: `init_from_code.go` now properly sets `USE_EXISTING_AI_PROJECT` (was never set before)
- **Bug fix**: End message now recommends `azd up` instead of `azd deploy` when new model deployments need provisioning
- **Fix #8287**: When a manifest specifies a default model, the user can now confirm or choose a different model from the catalog before version/SKU selection

### No impact on downstream

The configuration values written to `.env` and `azure.yaml` are unchanged — this is purely a UX refactor. `azd provision` and `azd deploy` behavior is unaffected.

Addresses feedback from #8265.
Fixes #8287.