### PR TITLE
azd core - improve extension pack support

### DIFF
--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -790,6 +790,13 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 			Suggestion: "Install one extension at a time when using --version.",
 		}
 	}
+	if err := validateExactVersionFlag(a.flags.version); err != nil {
+		return nil, &internal.ErrorWithSuggestion{
+			Err: err,
+			Suggestion: "Use an exact extension version with --version. " +
+				"Dependency constraints belong in extension manifests.",
+		}
+	}
 
 	azdVersion := currentAzdSemver()
 
@@ -907,7 +914,11 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 			// Use upgrade logic for existing installations
 			a.console.ShowSpinner(ctx, stepMessage, input.Step)
 			extensionVersion, _, err = a.extensionManager.Upgrade(
-				ctx, compatibleExtension, extensions.DefaultUpgradeOptions(a.flags.version),
+				ctx, compatibleExtension, extensions.UpgradeOptions{
+					VersionPreference:   a.flags.version,
+					UpgradeDependencies: true,
+					AzdVersion:          azdVersion,
+				},
 			)
 			if err != nil {
 				a.console.StopSpinner(ctx, stepMessage, input.StepFailed)
@@ -920,7 +931,14 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 		} else {
 			// Extension not installed - proceed with fresh install
 			a.console.ShowSpinner(ctx, stepMessage, input.Step)
-			extensionVersion, err = a.extensionManager.Install(ctx, compatibleExtension, a.flags.version)
+			extensionVersion, err = a.extensionManager.InstallWithOptions(
+				ctx,
+				compatibleExtension,
+				extensions.InstallOptions{
+					VersionPreference: a.flags.version,
+					AzdVersion:        azdVersion,
+				},
+			)
 			if err != nil {
 				a.console.StopSpinner(ctx, stepMessage, input.StepFailed)
 				return nil, fmt.Errorf("failed to install extension: %w", err)
@@ -1126,6 +1144,13 @@ func (a *extensionUpgradeAction) Run(
 				internal.ErrInvalidFlagCombination),
 			Suggestion: "Upgrade one extension at a time when " +
 				"using --version.",
+		}
+	}
+	if err := validateExactVersionFlag(a.flags.version); err != nil {
+		return nil, &internal.ErrorWithSuggestion{
+			Err: err,
+			Suggestion: "Use an exact extension version with --version. " +
+				"Dependency constraints belong in extension manifests.",
 		}
 	}
 
@@ -1469,6 +1494,23 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 	}
 
 	if installedSemver.Equal(targetSemver) && !isPromotion {
+		reconciledVersion, depUpgrades, err := a.extensionManager.ReconcileDependencies(
+			ctx, compatExt, extensions.UpgradeOptions{
+				VersionPreference:   a.flags.version,
+				UpgradeDependencies: !a.flags.noDependencyUpgrades,
+				AzdVersion:          azdVersion,
+			},
+		)
+		if err != nil {
+			return fail(fmt.Errorf(
+				"failed to reconcile extension dependencies: %w", err,
+			))
+		}
+		baseResult.DependencyUpgrades = depUpgrades
+		if reconciledVersion != nil {
+			baseResult.ToSource = newSource
+		}
+
 		baseResult.Status = extensions.UpgradeStatusSkipped
 		baseResult.SkipReason = "already up to date"
 		if !isJsonOutput {
@@ -1478,6 +1520,7 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 			a.console.StopSpinner(
 				ctx, skipMsg, input.StepSkipped,
 			)
+			displayDependencyUpgradeResults(ctx, a.console, baseResult.DependencyUpgrades, "  ")
 		}
 		return baseResult
 	}
@@ -1487,6 +1530,7 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 		ctx, compatExt, extensions.UpgradeOptions{
 			VersionPreference:   a.flags.version,
 			UpgradeDependencies: !a.flags.noDependencyUpgrades,
+			AzdVersion:          azdVersion,
 		},
 	)
 	if err != nil {
@@ -1591,10 +1635,12 @@ func displayDependencyUpgradeResults(
 	for _, child := range results {
 		switch child.Status {
 		case extensions.UpgradeStatusUpgraded:
+			verb := dependencyChangeVerb(child.FromVersion, child.ToVersion)
 			console.Message(ctx, fmt.Sprintf(
-				"%s%s Upgraded %s dependency %s",
+				"%s%s %s %s dependency %s",
 				indent,
 				output.WithSuccessFormat("(\u2713) Done:"),
+				verb,
 				output.WithHighLightFormat(child.ExtensionId),
 				output.WithGrayFormat(
 					"(%s \u2192 %s)",
@@ -1635,6 +1681,18 @@ func displayDependencyUpgradeResults(
 	}
 }
 
+func dependencyChangeVerb(fromVersion, toVersion string) string {
+	from, fromErr := semver.NewVersion(fromVersion)
+	to, toErr := semver.NewVersion(toVersion)
+	if fromErr != nil || toErr != nil {
+		return "Updated"
+	}
+	if to.LessThan(from) {
+		return "Downgraded"
+	}
+	return "Upgraded"
+}
+
 // displayUpgradeSummary prints the batch summary line after all
 // extensions have been processed.
 func displayUpgradeSummary(
@@ -1657,7 +1715,7 @@ func displayUpgradeSummary(
 				noun = "dependencies"
 			}
 			upgradedPart += output.WithGrayFormat(
-				" (%d %s)", depUpgraded, noun,
+				" (%d %s updated)", depUpgraded, noun,
 			)
 		}
 		parts = append(parts, upgradedPart)
@@ -1667,7 +1725,7 @@ func displayUpgradeSummary(
 			noun = "dependencies"
 		}
 		parts = append(parts, output.WithSuccessFormat(
-			"%d %s upgraded", depUpgraded, noun,
+			"%d %s updated", depUpgraded, noun,
 		))
 	}
 	if summary.Skipped > 0 {
@@ -2282,6 +2340,27 @@ func validateVersionCompatibility(
 			break
 		}
 	}
+	return nil
+}
+
+func validateExactVersionFlag(version string) error {
+	if version == "" || strings.EqualFold(version, "latest") {
+		return nil
+	}
+
+	if _, err := semver.NewVersion(version); err == nil {
+		return nil
+	}
+
+	hasWildcardPart := slices.ContainsFunc(strings.Split(version, "."), func(part string) bool {
+		return part == "x" || part == "X" || part == "*"
+	})
+	if strings.ContainsAny(version, "<>=^~*, ") ||
+		strings.Contains(version, "||") ||
+		hasWildcardPart {
+		return fmt.Errorf("--version requires an exact version, not a version constraint: %s", version)
+	}
+
 	return nil
 }
 

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -809,12 +809,7 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 		}
 
 		installedExtension, alreadyInstalled := allInstalled[extensionId]
-		// Snapshot the set of installed ids BEFORE Install runs so we can
-		// later distinguish "freshly installed by this call" from "already
-		// installed before this call" when rendering the dep tree.
-		// Note: allInstalled is a live reference to the manager's in-memory
-		// installed map, which Install mutates — we cannot reuse it for the
-		// pre-install check after Install returns.
+		// Snapshot installed ids before Install mutates the manager cache.
 		preInstalledIds := make(map[string]struct{}, len(allInstalled))
 		for id := range allInstalled {
 			preInstalledIds[id] = struct{}{}
@@ -936,8 +931,7 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 		}
 
 		if len(extensionVersion.Dependencies) > 0 {
-			// Render child deps flat with the parent step rather than nested,
-			// using the same 2-space indent as the parent's "(✓) Done:" line.
+			// Render dependencies flat with the parent step.
 			displayInstalledDependencies(
 				ctx, a.console, a.extensionManager,
 				extensionVersion.Dependencies,
@@ -1587,10 +1581,7 @@ func (a *extensionUpgradeAction) displayPromotionWarning(
 	))
 }
 
-// displayDependencyUpgradeResults renders the dependency upgrade tree under
-// the parent at the configured indent. Recursion preserves the same indent
-// so nested entries render flat under the parent step, matching the
-// install-time dep display.
+// displayDependencyUpgradeResults renders dependency upgrades as flat rows.
 func displayDependencyUpgradeResults(
 	ctx context.Context,
 	console input.Console,
@@ -1986,11 +1977,7 @@ func (a *extensionSourceRemoveAction) Run(ctx context.Context) (*actions.ActionR
 	}, nil
 }
 
-// displayExtensionUsageAndExamples prints the Usage line and Examples block
-// for an installed extension, skipping each section when its content is
-// empty. Extension packs (which have no executable, only dependencies)
-// typically have no usage or examples, so omitting empty labels avoids
-// noisy blank rows in the install/upgrade output.
+// displayExtensionUsageAndExamples prints non-empty Usage and Examples sections.
 func displayExtensionUsageAndExamples(
 	ctx context.Context,
 	console input.Console,
@@ -2014,21 +2001,8 @@ func displayExtensionUsageAndExamples(
 	}
 }
 
-// displayInstalledDependencies renders the dependency tree of a freshly
-// installed extension as a flat list of rows aligned with the parent step.
-// Each entry is one of:
-//
-//   - `(✓) Installed: <id> (<version>)` — newly installed by this call,
-//     i.e., not present in preInstalledIds.
-//   - `(-) Skipped: <id> (<version>, already installed)` — already in
-//     preInstalledIds, so Install short-circuited via ErrExtensionInstalled.
-//
-// The helper recurses into nested packs by re-querying each child's
-// dependency list from the registry but keeps rendering flat at every
-// level, which avoids deep nesting noise for deeply-nested pack graphs.
-// The visited map guards against diamond/cycle shapes. Glyphs and color
-// helpers match those used by the TaskList primitive
-// (pkg/ux/task_list.go) so styling stays consistent across the CLI.
+// displayInstalledDependencies renders newly installed and skipped dependencies
+// as flat rows aligned with the parent step.
 func displayInstalledDependencies(
 	ctx context.Context,
 	console input.Console,

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -871,7 +871,7 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 
 		// Determine target version
 		targetVersion := a.flags.version
-		if targetVersion == "" || targetVersion == "latest" {
+		if targetVersion == "" || strings.EqualFold(targetVersion, "latest") {
 			targetVersion = extensions.LatestVersion(compatibleExtension.Versions).Version
 		}
 
@@ -887,20 +887,15 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 				continue
 			}
 
-			// Parse versions for semantic comparison
-			installedSemver, err := semver.NewVersion(installedExtension.Version)
-			if err != nil {
-				a.console.StopSpinner(ctx, stepMessage, input.StepFailed)
-				return nil, fmt.Errorf("failed to parse installed version '%s': %w", installedExtension.Version, err)
-			}
-
-			targetSemver, err := semver.NewVersion(targetVersion)
-			if err != nil {
-				a.console.StopSpinner(ctx, stepMessage, input.StepFailed)
-				return nil, fmt.Errorf("failed to parse target version '%s': %w", targetVersion, err)
-			}
-
-			if targetSemver.LessThan(installedSemver) && !a.flags.force {
+			// Parse versions for semantic comparison. Non-semver tags
+			// (e.g. "nightly", "dev") have no defined ordering, so when
+			// either side fails to parse we skip the downgrade guard and
+			// fall through to the upgrade path. The string equality check
+			// above already short-circuits the no-op case.
+			installedSemver, installedErr := semver.NewVersion(installedExtension.Version)
+			targetSemver, targetErr := semver.NewVersion(targetVersion)
+			if installedErr == nil && targetErr == nil &&
+				targetSemver.LessThan(installedSemver) && !a.flags.force {
 				// Would be a downgrade - require --force
 				stepMessage += output.WithGrayFormat(
 					" (would downgrade from %s to %s, use --force to override)",
@@ -1455,26 +1450,17 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 		targetVersionStr = latestVer.Version
 	}
 
-	installedSemver, err := semver.NewVersion(installed.Version)
-	if err != nil {
-		return fail(fmt.Errorf(
-			"failed to parse installed version '%s': %w",
-			installed.Version, err,
-		))
-	}
-
-	targetSemver, err := semver.NewVersion(targetVersionStr)
-	if err != nil {
-		return fail(fmt.Errorf(
-			"failed to parse target version '%s': %w",
-			targetVersionStr, err,
-		))
-	}
+	// Parse versions for semantic comparison. Non-semver tags
+	// (e.g. "nightly", "dev") have no defined ordering, so when either
+	// side fails to parse we skip the "installed is newer" guard and
+	// proceed with the upgrade attempt.
+	installedSemver, installedErr := semver.NewVersion(installed.Version)
+	targetSemver, targetErr := semver.NewVersion(targetVersionStr)
 
 	baseResult.ToSource = newSource
 
 	// Compare versions
-	if installedSemver.GreaterThan(targetSemver) {
+	if installedErr == nil && targetErr == nil && installedSemver.GreaterThan(targetSemver) {
 		baseResult.Status = extensions.UpgradeStatusSkipped
 		baseResult.SkipReason = fmt.Sprintf(
 			"installed %s is newer than %s",
@@ -1493,7 +1479,11 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 		return baseResult
 	}
 
-	if installedSemver.Equal(targetSemver) && !isPromotion {
+	versionsEqual := installed.Version == targetVersionStr
+	if installedErr == nil && targetErr == nil {
+		versionsEqual = installedSemver.Equal(targetSemver)
+	}
+	if versionsEqual && !isPromotion {
 		reconciledVersion, depUpgrades, err := a.extensionManager.ReconcileDependencies(
 			ctx, compatExt, extensions.UpgradeOptions{
 				VersionPreference:   a.flags.version,
@@ -1663,17 +1653,22 @@ func displayDependencyUpgradeResults(
 				}(),
 			))
 		case extensions.UpgradeStatusSkipped:
-			console.Message(ctx, fmt.Sprintf(
+			line := fmt.Sprintf(
 				"%s%s Upgrading %s dependency",
 				indent,
 				output.WithGrayFormat("(-) Skipped:"),
 				output.WithHighLightFormat(child.ExtensionId),
-			))
+			)
 			if child.SkipReason != "" {
+				line += output.WithGrayFormat(" (%s)", child.SkipReason)
+			}
+			console.Message(ctx, line)
+			if child.Suggestion != "" {
 				console.Message(ctx, fmt.Sprintf(
-					"%s  %s",
+					"%s%s%s",
 					indent,
-					output.WithGrayFormat("%s", child.SkipReason),
+					strings.Repeat(" ", len("(-) Skipped: ")),
+					child.Suggestion,
 				))
 			}
 		}

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -102,6 +102,12 @@ Use --source to explicitly override the registry source for the upgrade. Use
 --all to upgrade all installed extensions in a single batch; failures in one
 extension do not prevent the remaining extensions from being upgraded.
 
+When upgrading an extension that has dependencies, any installed
+dependencies are automatically upgraded too, to the highest version
+satisfying the extension's declared constraints. Use
+--no-dependency-upgrades to opt out and upgrade only the named
+extension.
+
 Use --output json for a structured report of all upgrade results.`,
 		},
 		OutputFormats:  []output.Format{output.JsonFormat, output.NoneFormat},
@@ -803,6 +809,16 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 		}
 
 		installedExtension, alreadyInstalled := allInstalled[extensionId]
+		// Snapshot the set of installed ids BEFORE Install runs so we can
+		// later distinguish "freshly installed by this call" from "already
+		// installed before this call" when rendering the dep tree.
+		// Note: allInstalled is a live reference to the manager's in-memory
+		// installed map, which Install mutates — we cannot reuse it for the
+		// pre-install check after Install returns.
+		preInstalledIds := make(map[string]struct{}, len(allInstalled))
+		for id := range allInstalled {
+			preInstalledIds[id] = struct{}{}
+		}
 
 		// Find the extension metadata first
 		filterOptions := &extensions.FilterOptions{
@@ -895,7 +911,9 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 
 			// Use upgrade logic for existing installations
 			a.console.ShowSpinner(ctx, stepMessage, input.Step)
-			extensionVersion, err = a.extensionManager.Upgrade(ctx, compatibleExtension, a.flags.version)
+			extensionVersion, _, err = a.extensionManager.Upgrade(
+				ctx, compatibleExtension, extensions.DefaultUpgradeOptions(a.flags.version),
+			)
 			if err != nil {
 				a.console.StopSpinner(ctx, stepMessage, input.StepFailed)
 				return nil, fmt.Errorf("failed to upgrade extension: %w", err)
@@ -915,6 +933,18 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 
 			stepMessage += output.WithGrayFormat(" (%s)", extensionVersion.Version)
 			a.console.StopSpinner(ctx, stepMessage, input.StepDone)
+		}
+
+		if len(extensionVersion.Dependencies) > 0 {
+			// Render child deps flat with the parent step rather than nested,
+			// using the same 2-space indent as the parent's "(✓) Done:" line.
+			displayInstalledDependencies(
+				ctx, a.console, a.extensionManager,
+				extensionVersion.Dependencies,
+				preInstalledIds,
+				"  ",
+				map[string]struct{}{compatibleExtension.Id: {}},
+			)
 		}
 
 		displayExtensionUsageAndExamples(ctx, a.console, extensionVersion)
@@ -1034,10 +1064,11 @@ func (a *extensionUninstallAction) Run(ctx context.Context) (*actions.ActionResu
 }
 
 type extensionUpgradeFlags struct {
-	version string
-	source  string
-	all     bool
-	global  *internal.GlobalCommandOptions
+	version              string
+	source               string
+	all                  bool
+	noDependencyUpgrades bool
+	global               *internal.GlobalCommandOptions
 }
 
 func newExtensionUpgradeFlags(cmd *cobra.Command, global *internal.GlobalCommandOptions) *extensionUpgradeFlags {
@@ -1047,6 +1078,8 @@ func newExtensionUpgradeFlags(cmd *cobra.Command, global *internal.GlobalCommand
 	cmd.Flags().StringVarP(&flags.version, "version", "v", "", "The version of the extension to upgrade to")
 	cmd.Flags().StringVarP(&flags.source, "source", "s", "", "The extension source to use for upgrades")
 	cmd.Flags().BoolVar(&flags.all, "all", false, "Upgrade all installed extensions")
+	cmd.Flags().BoolVar(&flags.noDependencyUpgrades, "no-dependency-upgrades", false,
+		"Do not upgrade dependencies when upgrading an extension that has dependencies")
 
 	return flags
 }
@@ -1229,6 +1262,9 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 			fields.ExtensionUpgradeDurationMs.Int64(elapsed),
 			fields.ExtensionUpgradeOutcome.String(
 				baseResult.Status.String(),
+			),
+			fields.ExtensionDependencyUpgradeCount.Int(
+				extensions.CountDependencyUpgrades(baseResult.DependencyUpgrades),
 			),
 		)
 		if baseResult.Status == extensions.UpgradeStatusFailed {
@@ -1453,8 +1489,11 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 	}
 
 	// Perform the upgrade
-	extVersion, err := a.extensionManager.Upgrade(
-		ctx, compatExt, a.flags.version,
+	extVersion, depUpgrades, err := a.extensionManager.Upgrade(
+		ctx, compatExt, extensions.UpgradeOptions{
+			VersionPreference:   a.flags.version,
+			UpgradeDependencies: !a.flags.noDependencyUpgrades,
+		},
 	)
 	if err != nil {
 		if isNetworkError(err) {
@@ -1469,6 +1508,7 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 		))
 	}
 	baseResult.ToVersion = extVersion.Version
+	baseResult.DependencyUpgrades = depUpgrades
 
 	// Handle promotion display and distinct telemetry
 	if isPromotion {
@@ -1499,6 +1539,7 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 			),
 		)
 		a.console.StopSpinner(ctx, doneMsg, input.StepDone)
+		displayDependencyUpgradeResults(ctx, a.console, baseResult.DependencyUpgrades, "  ")
 		displayExtensionUsageAndExamples(
 			ctx, a.console, extVersion,
 		)
@@ -1546,6 +1587,63 @@ func (a *extensionUpgradeAction) displayPromotionWarning(
 	))
 }
 
+// displayDependencyUpgradeResults renders the dependency upgrade tree under
+// the parent at the configured indent. Recursion preserves the same indent
+// so nested entries render flat under the parent step, matching the
+// install-time dep display.
+func displayDependencyUpgradeResults(
+	ctx context.Context,
+	console input.Console,
+	results []extensions.UpgradeResult,
+	indent string,
+) {
+	for _, child := range results {
+		switch child.Status {
+		case extensions.UpgradeStatusUpgraded:
+			console.Message(ctx, fmt.Sprintf(
+				"%s%s Upgraded %s dependency %s",
+				indent,
+				output.WithSuccessFormat("(\u2713) Done:"),
+				output.WithHighLightFormat(child.ExtensionId),
+				output.WithGrayFormat(
+					"(%s \u2192 %s)",
+					child.FromVersion, child.ToVersion,
+				),
+			))
+		case extensions.UpgradeStatusFailed:
+			console.Message(ctx, fmt.Sprintf(
+				"%s%s Upgrading %s dependency%s",
+				indent,
+				output.WithErrorFormat("(x) Failed:"),
+				output.WithHighLightFormat(child.ExtensionId),
+				func() string {
+					if child.Error == nil {
+						return ""
+					}
+					return ": " + output.WithGrayFormat(
+						"%s", child.Error.Error(),
+					)
+				}(),
+			))
+		case extensions.UpgradeStatusSkipped:
+			console.Message(ctx, fmt.Sprintf(
+				"%s%s Upgrading %s dependency",
+				indent,
+				output.WithGrayFormat("(-) Skipped:"),
+				output.WithHighLightFormat(child.ExtensionId),
+			))
+			if child.SkipReason != "" {
+				console.Message(ctx, fmt.Sprintf(
+					"%s  %s",
+					indent,
+					output.WithGrayFormat("%s", child.SkipReason),
+				))
+			}
+		}
+		displayDependencyUpgradeResults(ctx, console, child.DependencyUpgrades, indent)
+	}
+}
+
 // displayUpgradeSummary prints the batch summary line after all
 // extensions have been processed.
 func displayUpgradeSummary(
@@ -1556,10 +1654,28 @@ func displayUpgradeSummary(
 	summary := extensions.NewUpgradeSummary(results)
 	console.Message(ctx, "")
 
-	parts := make([]string, 0, 4)
+	parts := make([]string, 0, 5)
 	if summary.Upgraded > 0 {
-		parts = append(parts, output.WithSuccessFormat(
+		upgradedPart := output.WithSuccessFormat(
 			"%d upgraded", summary.Upgraded,
+		)
+		if summary.DependencyUpgrades > 0 {
+			noun := "dependency"
+			if summary.DependencyUpgrades != 1 {
+				noun = "dependencies"
+			}
+			upgradedPart += output.WithGrayFormat(
+				" (%d %s)", summary.DependencyUpgrades, noun,
+			)
+		}
+		parts = append(parts, upgradedPart)
+	} else if summary.DependencyUpgrades > 0 {
+		noun := "dependency"
+		if summary.DependencyUpgrades != 1 {
+			noun = "dependencies"
+		}
+		parts = append(parts, output.WithSuccessFormat(
+			"%d %s upgraded", summary.DependencyUpgrades, noun,
 		))
 	}
 	if summary.Skipped > 0 {
@@ -1869,16 +1985,103 @@ func (a *extensionSourceRemoveAction) Run(ctx context.Context) (*actions.ActionR
 	}, nil
 }
 
+// displayExtensionUsageAndExamples prints the Usage line and Examples block
+// for an installed extension, skipping each section when its content is
+// empty. Extension packs (which have no executable, only dependencies)
+// typically have no usage or examples, so omitting empty labels avoids
+// noisy blank rows in the install/upgrade output.
 func displayExtensionUsageAndExamples(
 	ctx context.Context,
 	console input.Console,
 	extensionVersion *extensions.ExtensionVersion,
 ) {
-	console.Message(ctx, fmt.Sprintf("      %s %s", output.WithBold("Usage: "), extensionVersion.Usage))
-	console.Message(ctx, output.WithBold("      Examples:"))
+	if extensionVersion == nil {
+		return
+	}
+	if strings.TrimSpace(extensionVersion.Usage) != "" {
+		console.Message(ctx, fmt.Sprintf(
+			"      %s %s",
+			output.WithBold("Usage:"),
+			extensionVersion.Usage,
+		))
+	}
+	if len(extensionVersion.Examples) > 0 {
+		console.Message(ctx, output.WithBold("      Examples:"))
+		for _, example := range extensionVersion.Examples {
+			console.Message(ctx, "        "+output.WithHighLightFormat(example.Usage))
+		}
+	}
+}
 
-	for _, example := range extensionVersion.Examples {
-		console.Message(ctx, "        "+output.WithHighLightFormat(example.Usage))
+// displayInstalledDependencies renders the dependency tree of a freshly
+// installed extension as a flat list of rows aligned with the parent step.
+// Each entry is one of:
+//
+//   - `(✓) Installed: <id> (<version>)` — newly installed by this call,
+//     i.e., not present in preInstalledIds.
+//   - `(-) Skipped: <id> (<version>, already installed)` — already in
+//     preInstalledIds, so Install short-circuited via ErrExtensionInstalled.
+//
+// The helper recurses into nested packs by re-querying each child's
+// dependency list from the registry but keeps rendering flat at every
+// level, which avoids deep nesting noise for deeply-nested pack graphs.
+// The visited map guards against diamond/cycle shapes. Glyphs and color
+// helpers match those used by the TaskList primitive
+// (pkg/ux/task_list.go) so styling stays consistent across the CLI.
+func displayInstalledDependencies(
+	ctx context.Context,
+	console input.Console,
+	manager *extensions.Manager,
+	deps []extensions.ExtensionDependency,
+	preInstalledIds map[string]struct{},
+	indent string,
+	visited map[string]struct{},
+) {
+	for _, dep := range deps {
+		if _, seen := visited[dep.Id]; seen {
+			continue
+		}
+		visited[dep.Id] = struct{}{}
+
+		installed, err := manager.GetInstalled(extensions.FilterOptions{Id: dep.Id})
+		if err != nil || installed == nil {
+			continue
+		}
+
+		if _, wasInstalledBefore := preInstalledIds[dep.Id]; wasInstalledBefore {
+			console.Message(ctx, fmt.Sprintf(
+				"%s%s Installing %s dependency %s",
+				indent,
+				output.WithGrayFormat("(-) Skipped:"),
+				output.WithHighLightFormat(installed.Id),
+				output.WithGrayFormat("(%s, already installed)", installed.Version),
+			))
+		} else {
+			console.Message(ctx, fmt.Sprintf(
+				"%s%s Installing %s dependency %s",
+				indent,
+				output.WithSuccessFormat("(\u2713) Done:"),
+				output.WithHighLightFormat(installed.Id),
+				output.WithGrayFormat("(%s)", installed.Version),
+			))
+		}
+
+		matches, ferr := manager.FindExtensions(ctx, &extensions.FilterOptions{
+			Id:     dep.Id,
+			Source: installed.Source,
+		})
+		if ferr != nil || len(matches) == 0 {
+			continue
+		}
+		for _, v := range matches[0].Versions {
+			if v.Version == installed.Version && len(v.Dependencies) > 0 {
+				displayInstalledDependencies(
+					ctx, console, manager, v.Dependencies,
+					preInstalledIds, indent, visited,
+				)
+				break
+			}
+		}
 	}
 }
 

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -2066,11 +2066,11 @@ func displayInstalledDependencies(
 			))
 		}
 
-		matches, ferr := manager.FindExtensions(ctx, &extensions.FilterOptions{
+		matches, findErr := manager.FindExtensions(ctx, &extensions.FilterOptions{
 			Id:     dep.Id,
 			Source: installed.Source,
 		})
-		if ferr != nil || len(matches) == 0 {
+		if findErr != nil || len(matches) == 0 {
 			continue
 		}
 		for _, v := range matches[0].Versions {

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -1655,27 +1655,28 @@ func displayUpgradeSummary(
 	console.Message(ctx, "")
 
 	parts := make([]string, 0, 5)
+	depUpgraded := summary.DependencyUpgradesByStatus[extensions.UpgradeStatusUpgraded]
 	if summary.Upgraded > 0 {
 		upgradedPart := output.WithSuccessFormat(
 			"%d upgraded", summary.Upgraded,
 		)
-		if summary.DependencyUpgrades > 0 {
+		if depUpgraded > 0 {
 			noun := "dependency"
-			if summary.DependencyUpgrades != 1 {
+			if depUpgraded != 1 {
 				noun = "dependencies"
 			}
 			upgradedPart += output.WithGrayFormat(
-				" (%d %s)", summary.DependencyUpgrades, noun,
+				" (%d %s)", depUpgraded, noun,
 			)
 		}
 		parts = append(parts, upgradedPart)
-	} else if summary.DependencyUpgrades > 0 {
+	} else if depUpgraded > 0 {
 		noun := "dependency"
-		if summary.DependencyUpgrades != 1 {
+		if depUpgraded != 1 {
 			noun = "dependencies"
 		}
 		parts = append(parts, output.WithSuccessFormat(
-			"%d %s upgraded", summary.DependencyUpgrades, noun,
+			"%d %s upgraded", depUpgraded, noun,
 		))
 	}
 	if summary.Skipped > 0 {

--- a/cli/azd/cmd/extension_test.go
+++ b/cli/azd/cmd/extension_test.go
@@ -211,6 +211,38 @@ func TestValidateVersionCompatibility(t *testing.T) {
 	})
 }
 
+func TestValidateExactVersionFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version string
+		wantErr bool
+	}{
+		{name: "empty", version: ""},
+		{name: "latest", version: "latest"},
+		{name: "semver", version: "1.2.3"},
+		{name: "prerelease", version: "1.2.3-preview.1"},
+		{name: "non_semver_version", version: "nightly"},
+		{name: "range", version: ">=1.2.3", wantErr: true},
+		{name: "tilde", version: "~1.2.0", wantErr: true},
+		{name: "wildcard", version: "1.x", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateExactVersionFlag(tt.version)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestResolveCompatibleExtension_NilAzdVersion(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/cmd/testdata/TestFigSpec.ts
+++ b/cli/azd/cmd/testdata/TestFigSpec.ts
@@ -3486,6 +3486,10 @@ const completionSpec: Fig.Spec = {
 							description: 'Upgrade all installed extensions',
 						},
 						{
+							name: ['--no-dependency-upgrades'],
+							description: 'Do not upgrade dependencies when upgrading an extension that has dependencies',
+						},
+						{
 							name: ['--source', '-s'],
 							description: 'The extension source to use for upgrades',
 							args: [

--- a/cli/azd/cmd/testdata/TestUsage-azd-extension-upgrade.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-extension-upgrade.snap
@@ -5,9 +5,10 @@ Usage
   azd extension upgrade [extension-id] [flags]
 
 Flags
-        --all            	: Upgrade all installed extensions
-    -s, --source string  	: The extension source to use for upgrades
-    -v, --version string 	: The version of the extension to upgrade to
+        --all                    	: Upgrade all installed extensions
+        --no-dependency-upgrades 	: Do not upgrade dependencies when upgrading an extension that has dependencies
+    -s, --source string          	: The extension source to use for upgrades
+    -v, --version string         	: The version of the extension to upgrade to
 
 Global Flags
     -C, --cwd string         	: Sets the current working directory.

--- a/cli/azd/docs/extensions/extension-framework.md
+++ b/cli/azd/docs/extensions/extension-framework.md
@@ -1112,6 +1112,10 @@ Dependencies support semantic versioning constraints:
 - `~1.2.0`: Compatible with version 1.2.x
 - `>=1.0.0 <2.0.0`: Range specification
 
+azd installs or upgrades to the highest published version that satisfies the dependency constraint.
+Pre-release versions follow standard semver constraint rules: a constraint must include a pre-release comparator to match pre-release versions.
+For example, `>=0.1.0` does not match `0.1.31-preview`; use `>=0.1.0-0` or a pre-release range such as `~0.1.0-preview` when preview versions should be eligible.
+
 #### Provider Registration
 
 When your extension provides custom service targets or framework services, declare them in the `providers` section:

--- a/cli/azd/docs/extensions/extension-framework.md
+++ b/cli/azd/docs/extensions/extension-framework.md
@@ -122,7 +122,7 @@ Shows detailed information for a specific extension, including description, tags
 
 Installs one or more extensions from any configured extension source.
 
-- `-v, --version` Specifies the version constraint to apply when installing extensions. Supports any semver constraint notation.
+- `-v, --version` Specifies the exact version to install.
 - `-s, --source` Specifies the extension source used for installations.
 
 #### `azd extension uninstall <extension-ids> [flags]`
@@ -136,7 +136,7 @@ Uninstalls one or more previously installed extensions.
 Upgrades one or more extensions to the latest versions.
 
 - `--all` Upgrades all previously installed extensions when specified.
-- `-v, --version` Upgrades a specified extension using a semver version constraint, if provided.
+- `-v, --version` Upgrades a specified extension to an exact version, if provided.
 - `-s, --source` Specifies the extension source used for installations.
 
 ## Developing Extensions
@@ -1115,6 +1115,29 @@ Dependencies support semantic versioning constraints:
 azd installs or upgrades to the highest published version that satisfies the dependency constraint.
 Pre-release versions follow standard semver constraint rules: a constraint must include a pre-release comparator to match pre-release versions.
 For example, `>=0.1.0` does not match `0.1.31-preview`; use `>=0.1.0-0` or a pre-release range such as `~0.1.0-preview` when preview versions should be eligible.
+
+#### Extension Packs
+
+An extension pack is an extension manifest that groups related extensions so users can install them with one command. Packs declare `dependencies` but do not provide an executable, command namespace, or runtime capabilities of their own. Use a pack when you want to publish a curated set of extensions, such as a product family or scenario bundle, without asking users to install each extension separately.
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/extension.schema.json
+
+id: contoso.ai
+displayName: Contoso AI Extension Pack
+description: Installs the Contoso AI azd extensions.
+version: 0.1.0
+
+dependencies:
+  - id: contoso.ai.agents
+    version: "~0.1.0-preview"
+  - id: contoso.ai.models
+    version: "~0.1.0-preview"
+```
+
+Pack manifests must include at least one dependency. They may omit `capabilities`, `namespace`, `entryPoint`, `usage`, and `examples` when the pack has no commands of its own. Installing a pack installs its dependencies recursively from the same extension source as the pack. Dependency versions in the manifest support semver constraints, but command-line `--version` values for `azd extension install` and `azd extension upgrade` are exact versions.
+
+Upgrading a pack upgrades the pack and, by default, reconciles installed dependencies to the highest published versions that satisfy the pack's declared dependency constraints. This dependency reconciliation still runs when the pack itself is already current, because an unchanged pack can point to a dependency range with newer matching versions. Users can disable automatic dependency upgrades with `azd extension upgrade <pack-id> --no-dependency-upgrades`.
 
 #### Provider Registration
 

--- a/cli/azd/docs/extensions/extension-framework.md
+++ b/cli/azd/docs/extensions/extension-framework.md
@@ -138,6 +138,7 @@ Upgrades one or more extensions to the latest versions.
 - `--all` Upgrades all previously installed extensions when specified.
 - `-v, --version` Upgrades a specified extension to an exact version, if provided.
 - `-s, --source` Specifies the extension source used for installations.
+- `--no-dependency-upgrades` Skips upgrading dependencies declared by extension packs.
 
 ## Developing Extensions
 

--- a/cli/azd/docs/extensions/extension-framework.md
+++ b/cli/azd/docs/extensions/extension-framework.md
@@ -1001,13 +1001,16 @@ A [JSON schema](../../extensions/extension.schema.json) is available to support 
 **Required Properties:**
 - `id`: Unique identifier for the extension
 - `version`: Semantic version following MAJOR.MINOR.PATCH format
-- `capabilities`: Array of extension capabilities (see below)
 - `displayName`: Human-readable name of the extension
 - `description`: Detailed description of the extension
+
+Each manifest must include either `capabilities` or `dependencies`. Extension packs may omit `capabilities`
+when they declare `dependencies` instead and have no executable.
 
 **Optional Properties:**
 - `namespace`: Command namespace for grouping extension commands
 - `entryPoint`: Executable or script that serves as the entry point
+- `capabilities`: Array of extension capabilities (see below)
 - `usage`: Instructions on how to use the extension
 - `examples`: Array of usage examples with name, description, and usage
 - `tags`: Keywords for categorization and filtering

--- a/cli/azd/extensions/extension.schema.json
+++ b/cli/azd/extensions/extension.schema.json
@@ -200,7 +200,8 @@
       "description": "List of other extensions that this extension depends on. These will be resolved and installed automatically.",
       "items": {
         "$ref": "#/definitions/ExtensionDependency"
-      }
+      },
+      "minItems": 1
     },
     "providers": {
       "type": "array",

--- a/cli/azd/extensions/extension.schema.json
+++ b/cli/azd/extensions/extension.schema.json
@@ -47,8 +47,7 @@
         }
       },
       "required": [
-        "id",
-        "version"
+        "id"
       ]
     },
     "Provider": {

--- a/cli/azd/extensions/extension.schema.json
+++ b/cli/azd/extensions/extension.schema.json
@@ -113,7 +113,7 @@
     "capabilities": {
       "type": "array",
       "title": "Capabilities",
-      "description": "List of capabilities provided by the extension. Supported values: custom-commands, lifecycle-events, mcp-server, service-target-provider, framework-service-provider, provisioning-provider, metadata. Select one or more from the allowed list. Each value must be unique.",
+      "description": "List of capabilities provided by the extension. Supported values: custom-commands, lifecycle-events, mcp-server, service-target-provider, framework-service-provider, provisioning-provider, metadata. Select one or more from the allowed list. Each value must be unique. Not required for extension packs, which declare dependencies instead and have no executable.",
       "minItems": 1,
       "uniqueItems": true,
       "items": {
@@ -259,8 +259,15 @@
   "required": [
     "id",
     "version",
-    "capabilities",
     "displayName",
     "description"
+  ],
+  "anyOf": [
+    {
+      "required": ["capabilities"]
+    },
+    {
+      "required": ["dependencies"]
+    }
   ]
 }

--- a/cli/azd/internal/tracing/fields/fields.go
+++ b/cli/azd/internal/tracing/fields/fields.go
@@ -922,6 +922,22 @@ var (
 		Classification: SystemMetadata,
 		Purpose:        FeatureInsight,
 	}
+	// ExtensionDependencyOf is the identifier of the parent extension that
+	// triggered this dependency upgrade. Present only on the child span.
+	ExtensionDependencyOf = AttributeKey{
+		Key:            attribute.Key("extension.dependency_of"),
+		Classification: SystemMetadata,
+		Purpose:        FeatureInsight,
+	}
+	// ExtensionDependencyUpgradeCount is the recursive count of dependency
+	// upgrades performed as part of upgrading this extension, including
+	// transitive dependencies of dependencies.
+	ExtensionDependencyUpgradeCount = AttributeKey{
+		Key:            attribute.Key("extension.dependency_upgrade_count"),
+		Classification: SystemMetadata,
+		Purpose:        FeatureInsight,
+		IsMeasurement:  true,
+	}
 )
 
 // Update related fields

--- a/cli/azd/internal/tracing/fields/fields.go
+++ b/cli/azd/internal/tracing/fields/fields.go
@@ -922,16 +922,13 @@ var (
 		Classification: SystemMetadata,
 		Purpose:        FeatureInsight,
 	}
-	// ExtensionDependencyOf is the identifier of the parent extension that
-	// triggered this dependency upgrade. Present only on the child span.
+	// ExtensionDependencyOf is the parent extension for a dependency upgrade.
 	ExtensionDependencyOf = AttributeKey{
 		Key:            attribute.Key("extension.dependency_of"),
 		Classification: SystemMetadata,
 		Purpose:        FeatureInsight,
 	}
-	// ExtensionDependencyUpgradeCount is the recursive count of dependency
-	// upgrades performed as part of upgrading this extension, including
-	// transitive dependencies of dependencies.
+	// ExtensionDependencyUpgradeCount is the recursive dependency upgrade count.
 	ExtensionDependencyUpgradeCount = AttributeKey{
 		Key:            attribute.Key("extension.dependency_upgrade_count"),
 		Classification: SystemMetadata,

--- a/cli/azd/pkg/extensions/manager.go
+++ b/cli/azd/pkg/extensions/manager.go
@@ -68,16 +68,7 @@ type sourceFilterPredicate func(config *SourceConfig) bool
 type extensionFilterPredicate func(extension *ExtensionMetadata) bool
 
 // matchesVersionConstraint reports whether candidate satisfies expr.
-//
-// expr may be:
-//   - An empty string or "latest", which matches any candidate.
-//   - A semver constraint expression (e.g. ">=0.1.0", "^0.1", "~0.1.0-preview",
-//     ">=1.0.0,<2.0.0"). When expr parses as a constraint and candidate parses
-//     as a semver version, the constraint check determines the result.
-//   - An exact version tag. If either expr fails to parse as a constraint or
-//     candidate fails to parse as a semver version, the function falls back to
-//     a case-insensitive string comparison so non-semver tags such as "dev" or
-//     "nightly" continue to work.
+// Empty, "latest", semver constraints, and exact non-semver tags are supported.
 func matchesVersionConstraint(expr, candidate string) bool {
 	if expr == "" || strings.EqualFold(expr, "latest") {
 		return true
@@ -96,12 +87,8 @@ func matchesVersionConstraint(expr, candidate string) bool {
 	return constraint.Check(parsedVersion)
 }
 
-// bestSatisfyingVersion returns the highest published version satisfying
-// expr from the provided versions slice, or nil when no published version
-// matches. Empty expr or "latest" returns LatestVersion. Constraint-shaped
-// expressions are evaluated via semver.NewConstraint; non-semver tags fall
-// back to a case-insensitive exact match. The caller treats a nil return
-// as "no acceptable version available".
+// bestSatisfyingVersion returns the highest published version satisfying expr.
+// Empty or "latest" selects the latest version; non-semver tags use exact match.
 func bestSatisfyingVersion(expr string, versions []ExtensionVersion) *ExtensionVersion {
 	if len(versions) == 0 {
 		return nil
@@ -113,8 +100,7 @@ func bestSatisfyingVersion(expr string, versions []ExtensionVersion) *ExtensionV
 
 	constraint, err := semver.NewConstraint(expr)
 	if err != nil {
-		// Non-semver expression: fall back to exact-match against any
-		// candidate tag.
+		// Non-semver expression: fall back to an exact tag match.
 		for i := range versions {
 			if strings.EqualFold(versions[i].Version, expr) {
 				return &versions[i]
@@ -161,9 +147,7 @@ func createExtensionFilter(options *FilterOptions) extensionFilterPredicate {
 			}
 		}
 
-		// Check Version filter - extension must have at least one version satisfying the expression.
-		// The expression may be an exact version, a semver constraint (e.g. ">=0.1.0", "^0.1",
-		// "~0.1.0-preview"), an empty string, or "latest". See matchesVersionConstraint for details.
+		// Check Version filter - extension must have at least one matching version.
 		if options.Version != "" && options.Version != "latest" {
 			hasVersion := slices.ContainsFunc(extension.Versions, func(version ExtensionVersion) bool {
 				return matchesVersionConstraint(options.Version, version.Version)
@@ -395,13 +379,8 @@ func (m *Manager) Install(
 	return m.installInternal(ctx, extension, versionPreference, map[string]struct{}{})
 }
 
-// installInternal performs the actual install work and recurses through the
-// dependency list. The visited map is shared across the recursive call chain
-// and contains every extension id currently in flight; this prevents
-// unbounded recursion when a registry declares a dependency cycle
-// (e.g. A → B → A) where the cycle would otherwise loop because the parent's
-// installed-config record is not written until after its dependencies have
-// finished installing.
+// installInternal installs an extension and its dependencies.
+// visited contains the ids currently in flight, which prevents dependency cycles.
 func (m *Manager) installInternal(
 	ctx context.Context,
 	extension *ExtensionMetadata,
@@ -434,11 +413,7 @@ func (m *Manager) installInternal(
 		return nil, fmt.Errorf("%s %w", extension.Id, ErrExtensionInstalled)
 	}
 
-	// Resolve the version to install. Empty or "latest" → latest published;
-	// otherwise pick the highest published version satisfying the
-	// (possibly semver-constraint-shaped) preference. bestSatisfyingVersion
-	// also handles non-semver exact-match tags ("dev", "nightly") so the
-	// behavior matches createExtensionFilter.
+	// Resolve to the latest published version that satisfies the preference.
 	selectedVersion := bestSatisfyingVersion(versionPreference, extension.Versions)
 	if selectedVersion == nil {
 		if versionPreference == "" || strings.EqualFold(versionPreference, "latest") {
@@ -678,15 +653,11 @@ type UpgradeOptions struct {
 	// VersionPreference is the version constraint or exact tag to install.
 	// Empty or "latest" selects the highest available version.
 	VersionPreference string
-	// UpgradeDependencies controls whether installed dependencies whose
-	// versions are behind the upgraded extension's declared constraints are
-	// also upgraded. Defaults to true when constructed via
-	// DefaultUpgradeOptions.
+	// UpgradeDependencies enables automatic upgrades for installed dependencies.
 	UpgradeDependencies bool
 }
 
-// DefaultUpgradeOptions returns UpgradeOptions with UpgradeDependencies
-// enabled and the supplied version preference.
+// DefaultUpgradeOptions returns UpgradeOptions with dependency upgrades enabled.
 func DefaultUpgradeOptions(versionPreference string) UpgradeOptions {
 	return UpgradeOptions{
 		VersionPreference:   versionPreference,
@@ -695,16 +666,8 @@ func DefaultUpgradeOptions(versionPreference string) UpgradeOptions {
 }
 
 // Upgrade upgrades the extension to the specified version.
-// This is a convenience method that uninstalls the existing extension and installs the new version.
-// If opts.VersionPreference is empty or "latest", the latest version is installed.
-//
-// When opts.UpgradeDependencies is true and the upgraded version declares
-// dependencies, any installed dependency that is not already at the highest
-// version satisfying the declared constraint is recursively upgraded. The
-// returned slice contains one entry per dependency upgrade attempt and is
-// ordered to match the parent's dependency list. Dependencies not installed,
-// at the highest matching version, or with an empty constraint are skipped
-// silently and do not appear in the returned slice.
+// Empty or "latest" selects the latest available version.
+// The returned slice contains dependency upgrade results.
 func (m *Manager) Upgrade(
 	ctx context.Context,
 	extension *ExtensionMetadata,
@@ -718,11 +681,8 @@ func (m *Manager) Upgrade(
 	return m.upgradeInternal(ctx, extension, opts, visited)
 }
 
-// upgradeInternal performs the uninstall+reinstall and, when
-// opts.UpgradeDependencies is true, recursively upgrades outdated
-// dependencies. visited prevents infinite recursion in the presence of
-// dependency cycles; an id present in visited is treated as
-// already-processed and is not upgraded again.
+// upgradeInternal performs the reinstall and any dependency upgrades.
+// visited prevents dependency cycles.
 func (m *Manager) upgradeInternal(
 	ctx context.Context,
 	extension *ExtensionMetadata,
@@ -746,22 +706,8 @@ func (m *Manager) upgradeInternal(
 	return extensionVersion, depUpgrades, nil
 }
 
-// evaluateDependencyChanges walks the upgraded parent's declared dependencies
-// and decides per child:
-//   - empty dep.Version, child not installed, or installed version is already
-//     the highest satisfying the constraint → no entry returned.
-//   - opts.UpgradeDependencies is true → recursively upgrade the child and
-//     append an UpgradeStatusUpgraded (or Failed) entry.
-//   - opts.UpgradeDependencies is false → append an UpgradeStatusSkipped
-//     entry with a SkipReason so the user sees what would have happened
-//     with automatic dependency upgrades enabled.
-//   - constraint not satisfied but another sibling has already pinned the
-//     child (id in visited) → append an UpgradeStatusFailed entry describing
-//     the constraint conflict, rather than silently leaving a child at a
-//     version the upgraded parent does not allow.
-//
-// Children already present in visited that DO satisfy the parent's constraint
-// are skipped silently — a sibling upgrade has already taken care of them.
+// evaluateDependencyChanges returns dependency upgrade work needed after a parent upgrade.
+// It selects the highest published version satisfying each dependency constraint.
 func (m *Manager) evaluateDependencyChanges(
 	ctx context.Context,
 	parentExtension *ExtensionMetadata,
@@ -778,13 +724,11 @@ func (m *Manager) evaluateDependencyChanges(
 
 		installed, err := m.GetInstalled(FilterOptions{Id: dep.Id})
 		if err != nil || installed == nil {
-			// Not installed — handled by the parent's Install dep loop.
+			// Not installed — handled by the parent's Install dependency loop.
 			continue
 		}
 
-		// If a sibling upgrade ran first and this child is already in the
-		// visited set, respect the sibling's choice when compatible.
-		// Otherwise surface a conflict — both parents can't both win.
+		// Respect a sibling's compatible choice; otherwise surface a conflict.
 		if _, seen := visited[dep.Id]; seen {
 			if matchesVersionConstraint(dep.Version, installed.Version) {
 				continue
@@ -804,17 +748,10 @@ func (m *Manager) evaluateDependencyChanges(
 			continue
 		}
 
-		// Resolve the highest published version satisfying the parent's
-		// constraint. Dependency upgrades use "upgrade-to-best-match"
-		// semantics (same as npm/yarn), not just "fix-if-violating", so a
-		// child whose installed version still satisfies the constraint but
-		// is behind a newer matching version is upgraded too.
+		// Dependency upgrades use upgrade-to-best-match semantics.
 		childMetadata, findErr := m.findDependencyChild(ctx, parentExtension, dep.Id)
 		if findErr != nil {
-			// Fall back to the constraint-only check: only flag a
-			// failure when the installed version actually violates the
-			// constraint. Otherwise leave the child alone — we can't
-			// improve on what's installed without the registry data.
+			// Without registry data, only fail if the installed version violates the constraint.
 			if matchesVersionConstraint(dep.Version, installed.Version) {
 				continue
 			}
@@ -830,9 +767,7 @@ func (m *Manager) evaluateDependencyChanges(
 
 		bestVersion := bestSatisfyingVersion(dep.Version, childMetadata.Versions)
 		if bestVersion == nil {
-			// Constraint matches no published version. If the installed
-			// version still satisfies the constraint there's nothing to
-			// do; otherwise surface as a failure.
+			// If no published version matches, keep a compatible installed version.
 			if matchesVersionConstraint(dep.Version, installed.Version) {
 				continue
 			}
@@ -854,8 +789,7 @@ func (m *Manager) evaluateDependencyChanges(
 			continue
 		}
 
-		// Dependency upgrades disabled — surface as a Skipped entry so the
-		// user sees which children would otherwise be upgraded.
+		// Surface disabled dependency upgrades as Skipped entries.
 		if !opts.UpgradeDependencies {
 			results = append(results, UpgradeResult{
 				ExtensionId: dep.Id,
@@ -878,8 +812,7 @@ func (m *Manager) evaluateDependencyChanges(
 			FromSource:  installed.Source,
 		}
 
-		// Emit a child span tagged with dependency_of so downstream telemetry
-		// can correlate this upgrade with its triggering parent.
+		// Correlate the child upgrade with its triggering parent.
 		childCtx, span := tracing.Start(ctx, events.ExtensionUpgradeEvent)
 		span.SetAttributes(
 			fields.ExtensionId.String(dep.Id),

--- a/cli/azd/pkg/extensions/manager.go
+++ b/cli/azd/pkg/extensions/manager.go
@@ -87,6 +87,20 @@ func matchesVersionConstraint(expr, candidate string) bool {
 	return constraint.Check(parsedVersion)
 }
 
+// isDowngrade reports whether moving from current to target is a version regression.
+// Returns false if either version is not valid semver.
+func isDowngrade(current, target string) bool {
+	currentSemver, err := semver.NewVersion(current)
+	if err != nil {
+		return false
+	}
+	targetSemver, err := semver.NewVersion(target)
+	if err != nil {
+		return false
+	}
+	return targetSemver.LessThan(currentSemver)
+}
+
 // bestSatisfyingVersion returns the highest published version satisfying expr.
 // Empty or "latest" selects the latest version; non-semver tags use exact match.
 func bestSatisfyingVersion(expr string, versions []ExtensionVersion) *ExtensionVersion {
@@ -892,6 +906,27 @@ func (m *Manager) evaluateDependencyChanges(
 
 		// Already at the highest matching version — nothing to do.
 		if bestVersion.Version == installed.Version {
+			continue
+		}
+
+		// Refuse to silently downgrade: a user (or sibling pack) may have moved the dependency
+		// past this pack's declared range deliberately.
+		if isDowngrade(installed.Version, bestVersion.Version) {
+			if matchesVersionConstraint(dep.Version, installed.Version) {
+				// Installed is newer but still satisfies the constraint — keep it, no-op.
+				continue
+			}
+			results = append(results, UpgradeResult{
+				ExtensionId: dep.Id,
+				Status:      UpgradeStatusSkipped,
+				FromVersion: installed.Version,
+				FromSource:  installed.Source,
+				SkipReason: fmt.Sprintf(
+					"installed version %s is outside %s's constraint %q; not downgrading. "+
+						"Run 'azd extension install %s --version %s' to align with the pack.",
+					installed.Version, parentExtension.Id, dep.Version, dep.Id, bestVersion.Version,
+				),
+			})
 			continue
 		}
 

--- a/cli/azd/pkg/extensions/manager.go
+++ b/cli/azd/pkg/extensions/manager.go
@@ -869,6 +869,12 @@ func (m *Manager) evaluateDependencyChanges(
 			continue
 		}
 
+		// Mark visited up front so that any sibling pack processed later in this
+		// run goes through the seen-branch above and validates against the
+		// currently installed version — regardless of whether this iteration
+		// upgrades, skips, or fails.
+		visited[dep.Id] = struct{}{}
+
 		// Dependency upgrades use upgrade-to-best-match semantics.
 		childMetadata, findErr := m.findDependencyChild(ctx, parentExtension, dep.Id)
 		if findErr != nil {
@@ -951,8 +957,6 @@ func (m *Manager) evaluateDependencyChanges(
 			})
 			continue
 		}
-
-		visited[dep.Id] = struct{}{}
 
 		childResult := UpgradeResult{
 			ExtensionId: dep.Id,

--- a/cli/azd/pkg/extensions/manager.go
+++ b/cli/azd/pkg/extensions/manager.go
@@ -130,6 +130,45 @@ func bestSatisfyingVersion(expr string, versions []ExtensionVersion) *ExtensionV
 	return &versions[bestIdx]
 }
 
+func bestSatisfyingVersionForAzd(
+	expr string,
+	versions []ExtensionVersion,
+	azdVersion *semver.Version,
+) *ExtensionVersion {
+	if azdVersion == nil {
+		return bestSatisfyingVersion(expr, versions)
+	}
+
+	compatible := make([]ExtensionVersion, 0, len(versions))
+	for i := range versions {
+		if VersionIsCompatible(&versions[i], azdVersion) {
+			compatible = append(compatible, versions[i])
+		}
+	}
+
+	return bestSatisfyingVersion(expr, compatible)
+}
+
+// resolveExtensionVersion selects the best published version of extension that satisfies
+// versionPreference and is compatible with azdVersion, or returns a descriptive error.
+func resolveExtensionVersion(
+	extension *ExtensionMetadata,
+	versionPreference string,
+	azdVersion *semver.Version,
+) (*ExtensionVersion, error) {
+	selected := bestSatisfyingVersionForAzd(versionPreference, extension.Versions, azdVersion)
+	if selected != nil {
+		return selected, nil
+	}
+	if versionPreference == "" || strings.EqualFold(versionPreference, "latest") {
+		return nil, fmt.Errorf("no compatible version found for extension: %s", extension.Id)
+	}
+	return nil, fmt.Errorf(
+		"no matching version found for extension: %s and constraint: %s",
+		extension.Id, versionPreference,
+	)
+}
+
 // createExtensionFilter creates a comprehensive filter that checks ALL criteria with AND logic
 func createExtensionFilter(options *FilterOptions) extensionFilterPredicate {
 	return func(extension *ExtensionMetadata) bool {
@@ -368,23 +407,48 @@ func (m *Manager) FindExtensions(ctx context.Context, options *FilterOptions) ([
 	return allExtensions, nil
 }
 
-// Install an extension from metadata with optional version preference
-// If no version is provided, the latest version is installed
-// Latest version is determined by semver comparison across all available versions
+// Install an extension from metadata with optional version preference.
 func (m *Manager) Install(
 	ctx context.Context,
 	extension *ExtensionMetadata,
 	versionPreference string,
 ) (*ExtensionVersion, error) {
-	return m.installInternal(ctx, extension, versionPreference, map[string]struct{}{})
+	return m.installInternal(
+		ctx,
+		extension,
+		InstallOptions{VersionPreference: versionPreference},
+		false,
+		map[string]struct{}{},
+	)
+}
+
+// InstallOptions controls how Manager.InstallWithOptions behaves.
+type InstallOptions struct {
+	// VersionPreference is the version constraint or exact tag to install.
+	// Empty or "latest" selects the highest available version.
+	VersionPreference string
+	// AzdVersion limits selected extension versions to those compatible with azd.
+	AzdVersion *semver.Version
+}
+
+// InstallWithOptions installs an extension using the supplied options.
+func (m *Manager) InstallWithOptions(
+	ctx context.Context,
+	extension *ExtensionMetadata,
+	opts InstallOptions,
+) (*ExtensionVersion, error) {
+	return m.installInternal(ctx, extension, opts, false, map[string]struct{}{})
 }
 
 // installInternal installs an extension and its dependencies.
+// skipDependencyValidation bypasses the installed-dependency constraint check; it is set by the
+// upgrade flow so dependency reconciliation can run after the parent has been reinstalled.
 // visited contains the ids currently in flight, which prevents dependency cycles.
 func (m *Manager) installInternal(
 	ctx context.Context,
 	extension *ExtensionMetadata,
-	versionPreference string,
+	opts InstallOptions,
+	skipDependencyValidation bool,
 	visited map[string]struct{},
 ) (extVersion *ExtensionVersion, err error) {
 	if extension == nil {
@@ -414,15 +478,9 @@ func (m *Manager) installInternal(
 	}
 
 	// Resolve to the latest published version that satisfies the preference.
-	selectedVersion := bestSatisfyingVersion(versionPreference, extension.Versions)
-	if selectedVersion == nil {
-		if versionPreference == "" || strings.EqualFold(versionPreference, "latest") {
-			return nil, fmt.Errorf("no compatible version found for extension: %s", extension.Id)
-		}
-		return nil, fmt.Errorf(
-			"no matching version found for extension: %s and constraint: %s",
-			extension.Id, versionPreference,
-		)
+	selectedVersion, err := resolveExtensionVersion(extension, opts.VersionPreference, opts.AzdVersion)
+	if err != nil {
+		return nil, err
 	}
 
 	// Record the resolved version on the span so failures during install
@@ -438,6 +496,19 @@ func (m *Manager) installInternal(
 	// Install dependencies
 	if len(selectedVersion.Dependencies) > 0 {
 		for _, dependency := range selectedVersion.Dependencies {
+			installedDependency, err := m.GetInstalled(FilterOptions{Id: dependency.Id})
+			if err == nil && installedDependency != nil {
+				if !skipDependencyValidation &&
+					dependency.Version != "" &&
+					!matchesVersionConstraint(dependency.Version, installedDependency.Version) {
+					return nil, fmt.Errorf(
+						"installed dependency %s version %s does not satisfy constraint %q",
+						dependency.Id, installedDependency.Version, dependency.Version,
+					)
+				}
+				continue
+			}
+
 			// Find the dependency extension metadata first
 			dependencyOptions := &FilterOptions{
 				Id:      dependency.Id,
@@ -460,7 +531,11 @@ func (m *Manager) installInternal(
 
 			dependencyMetadata := dependencyMatches[0]
 
-			if _, err := m.installInternal(ctx, dependencyMetadata, dependency.Version, visited); err != nil {
+			dependencyOpts := InstallOptions{
+				VersionPreference: dependency.Version,
+				AzdVersion:        opts.AzdVersion,
+			}
+			if _, err := m.installInternal(ctx, dependencyMetadata, dependencyOpts, false, visited); err != nil {
 				if !errors.Is(err, ErrExtensionInstalled) {
 					return nil, fmt.Errorf("failed to install dependency: %w", err)
 				}
@@ -655,6 +730,8 @@ type UpgradeOptions struct {
 	VersionPreference string
 	// UpgradeDependencies enables automatic upgrades for installed dependencies.
 	UpgradeDependencies bool
+	// AzdVersion limits selected extension versions to those compatible with azd.
+	AzdVersion *semver.Version
 }
 
 // DefaultUpgradeOptions returns UpgradeOptions with dependency upgrades enabled.
@@ -681,6 +758,30 @@ func (m *Manager) Upgrade(
 	return m.upgradeInternal(ctx, extension, opts, visited)
 }
 
+// ReconcileDependencies upgrades installed dependencies for the selected extension version.
+func (m *Manager) ReconcileDependencies(
+	ctx context.Context,
+	extension *ExtensionMetadata,
+	opts UpgradeOptions,
+) (*ExtensionVersion, []UpgradeResult, error) {
+	if extension == nil {
+		return nil, nil, fmt.Errorf("extension metadata cannot be nil")
+	}
+
+	selectedVersion, err := resolveExtensionVersion(extension, opts.VersionPreference, opts.AzdVersion)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(selectedVersion.Dependencies) == 0 {
+		return selectedVersion, nil, nil
+	}
+
+	visited := map[string]struct{}{extension.Id: {}}
+	results := m.evaluateDependencyChanges(ctx, extension, selectedVersion, opts, visited)
+	return selectedVersion, results, nil
+}
+
 // upgradeInternal performs the reinstall and any dependency upgrades.
 // visited prevents dependency cycles.
 func (m *Manager) upgradeInternal(
@@ -693,7 +794,12 @@ func (m *Manager) upgradeInternal(
 		return nil, nil, fmt.Errorf("failed to uninstall extension: %w", err)
 	}
 
-	extensionVersion, err := m.Install(ctx, extension, opts.VersionPreference)
+	// Skip the installed-dependency constraint check: the previous parent has just been
+	// uninstalled and any stale dependency will be reconciled by evaluateDependencyChanges below.
+	extensionVersion, err := m.installInternal(ctx, extension, InstallOptions{
+		VersionPreference: opts.VersionPreference,
+		AzdVersion:        opts.AzdVersion,
+	}, true, map[string]struct{}{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to install extension: %w", err)
 	}
@@ -765,7 +871,7 @@ func (m *Manager) evaluateDependencyChanges(
 			continue
 		}
 
-		bestVersion := bestSatisfyingVersion(dep.Version, childMetadata.Versions)
+		bestVersion := bestSatisfyingVersionForAzd(dep.Version, childMetadata.Versions, opts.AzdVersion)
 		if bestVersion == nil {
 			// If no published version matches, keep a compatible installed version.
 			if matchesVersionConstraint(dep.Version, installed.Version) {
@@ -777,7 +883,7 @@ func (m *Manager) evaluateDependencyChanges(
 				FromVersion: installed.Version,
 				FromSource:  installed.Source,
 				Error: fmt.Errorf(
-					"no published version of %s satisfies constraint %q",
+					"no compatible published version of %s satisfies constraint %q",
 					dep.Id, dep.Version,
 				),
 			})
@@ -797,7 +903,7 @@ func (m *Manager) evaluateDependencyChanges(
 				FromVersion: installed.Version,
 				FromSource:  installed.Source,
 				SkipReason: fmt.Sprintf(
-					"automatic dependency upgrade disabled (newer matching version %s available)",
+					"automatic dependency upgrade disabled (matching version %s available)",
 					bestVersion.Version,
 				),
 			})
@@ -822,6 +928,7 @@ func (m *Manager) evaluateDependencyChanges(
 		childOpts := UpgradeOptions{
 			VersionPreference:   dep.Version,
 			UpgradeDependencies: opts.UpgradeDependencies,
+			AzdVersion:          opts.AzdVersion,
 		}
 
 		childVersion, nested, upErr := m.upgradeInternal(childCtx, childMetadata, childOpts, visited)

--- a/cli/azd/pkg/extensions/manager.go
+++ b/cli/azd/pkg/extensions/manager.go
@@ -19,7 +19,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -68,6 +67,84 @@ type FilterOptions struct {
 type sourceFilterPredicate func(config *SourceConfig) bool
 type extensionFilterPredicate func(extension *ExtensionMetadata) bool
 
+// matchesVersionConstraint reports whether candidate satisfies expr.
+//
+// expr may be:
+//   - An empty string or "latest", which matches any candidate.
+//   - A semver constraint expression (e.g. ">=0.1.0", "^0.1", "~0.1.0-preview",
+//     ">=1.0.0,<2.0.0"). When expr parses as a constraint and candidate parses
+//     as a semver version, the constraint check determines the result.
+//   - An exact version tag. If either expr fails to parse as a constraint or
+//     candidate fails to parse as a semver version, the function falls back to
+//     a case-insensitive string comparison so non-semver tags such as "dev" or
+//     "nightly" continue to work.
+func matchesVersionConstraint(expr, candidate string) bool {
+	if expr == "" || strings.EqualFold(expr, "latest") {
+		return true
+	}
+
+	constraint, err := semver.NewConstraint(expr)
+	if err != nil {
+		return strings.EqualFold(expr, candidate)
+	}
+
+	parsedVersion, err := semver.NewVersion(candidate)
+	if err != nil {
+		return strings.EqualFold(expr, candidate)
+	}
+
+	return constraint.Check(parsedVersion)
+}
+
+// bestSatisfyingVersion returns the highest published version satisfying
+// expr from the provided versions slice. Returns (nil, nil) when no
+// published version satisfies the constraint. Returns (nil, err) only when
+// expr fails to parse as a semver constraint AND no candidate matches
+// expr literally — for non-semver tags this falls back to exact match.
+func bestSatisfyingVersion(expr string, versions []ExtensionVersion) (*ExtensionVersion, error) {
+	if len(versions) == 0 {
+		return nil, nil
+	}
+
+	// "" or "latest" → just return the LatestVersion (which already handles
+	// the semver-vs-non-semver ordering used elsewhere in the package).
+	if expr == "" || strings.EqualFold(expr, "latest") {
+		return LatestVersion(versions), nil
+	}
+
+	constraint, err := semver.NewConstraint(expr)
+	if err != nil {
+		// Non-semver expression: fall back to exact-match against any
+		// candidate tag.
+		for i := range versions {
+			if strings.EqualFold(versions[i].Version, expr) {
+				return &versions[i], nil
+			}
+		}
+		return nil, nil
+	}
+
+	var best *semver.Version
+	var bestIdx int
+	for i := range versions {
+		v, err := semver.NewVersion(versions[i].Version)
+		if err != nil {
+			continue
+		}
+		if !constraint.Check(v) {
+			continue
+		}
+		if best == nil || v.GreaterThan(best) {
+			best = v
+			bestIdx = i
+		}
+	}
+	if best == nil {
+		return nil, nil
+	}
+	return &versions[bestIdx], nil
+}
+
 // createExtensionFilter creates a comprehensive filter that checks ALL criteria with AND logic
 func createExtensionFilter(options *FilterOptions) extensionFilterPredicate {
 	return func(extension *ExtensionMetadata) bool {
@@ -85,10 +162,12 @@ func createExtensionFilter(options *FilterOptions) extensionFilterPredicate {
 			}
 		}
 
-		// Check Version filter - extension must have the specified version
+		// Check Version filter - extension must have at least one version satisfying the expression.
+		// The expression may be an exact version, a semver constraint (e.g. ">=0.1.0", "^0.1",
+		// "~0.1.0-preview"), an empty string, or "latest". See matchesVersionConstraint for details.
 		if options.Version != "" && options.Version != "latest" {
 			hasVersion := slices.ContainsFunc(extension.Versions, func(version ExtensionVersion) bool {
-				return strings.EqualFold(version.Version, options.Version)
+				return matchesVersionConstraint(options.Version, version.Version)
 			})
 			if !hasVersion {
 				return false
@@ -313,10 +392,35 @@ func (m *Manager) Install(
 	ctx context.Context,
 	extension *ExtensionMetadata,
 	versionPreference string,
+) (*ExtensionVersion, error) {
+	return m.installInternal(ctx, extension, versionPreference, map[string]struct{}{})
+}
+
+// installInternal performs the actual install work and recurses through the
+// dependency list. The visited map is shared across the recursive call chain
+// and contains every extension id currently in flight; this prevents
+// unbounded recursion when a registry declares a dependency cycle
+// (e.g. A → B → A) where the cycle would otherwise loop because the parent's
+// installed-config record is not written until after its dependencies have
+// finished installing.
+func (m *Manager) installInternal(
+	ctx context.Context,
+	extension *ExtensionMetadata,
+	versionPreference string,
+	visited map[string]struct{},
 ) (extVersion *ExtensionVersion, err error) {
 	if extension == nil {
 		return nil, fmt.Errorf("extension metadata cannot be nil")
 	}
+
+	if _, inFlight := visited[extension.Id]; inFlight {
+		return nil, fmt.Errorf(
+			"dependency cycle detected involving extension %s",
+			extension.Id,
+		)
+	}
+	visited[extension.Id] = struct{}{}
+	defer delete(visited, extension.Id)
 
 	ctx, span := tracing.Start(ctx, events.ExtensionInstallEvent)
 	// Set the extension id immediately so failure spans can be correlated to the
@@ -331,52 +435,23 @@ func (m *Manager) Install(
 		return nil, fmt.Errorf("%s %w", extension.Id, ErrExtensionInstalled)
 	}
 
-	// Step 1: Determine the version to install
-	var selectedVersion *ExtensionVersion
-
-	if versionPreference == "" || versionPreference == "latest" {
-		selectedVersion = LatestVersion(extension.Versions)
-	} else {
-		// Find the best match for the version constraint
-		availableVersions := []*semver.Version{}
-		availableVersionMap := map[*semver.Version]*ExtensionVersion{}
-
-		for i, extensionVersion := range extension.Versions {
-			version, err := semver.NewVersion(extensionVersion.Version)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse version: %w", err)
-			}
-
-			availableVersionMap[version] = &extension.Versions[i]
-			availableVersions = append(availableVersions, version)
-		}
-
-		sort.Sort(semver.Collection(availableVersions))
-
-		constraint, err := semver.NewConstraint(versionPreference)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse version constraint: %w", err)
-		}
-
-		var bestMatch *semver.Version
-		for _, v := range availableVersions {
-			if constraint.Check(v) {
-				bestMatch = v
-			}
-		}
-
-		if bestMatch == nil {
-			return nil, fmt.Errorf(
-				"no matching version found for extension: %s and constraint: %s",
-				extension.Id, versionPreference,
-			)
-		}
-
-		selectedVersion = availableVersionMap[bestMatch]
+	// Resolve the version to install. Empty or "latest" → latest published;
+	// otherwise pick the highest published version satisfying the
+	// (possibly semver-constraint-shaped) preference. bestSatisfyingVersion
+	// also handles non-semver exact-match tags ("dev", "nightly") so the
+	// behavior matches createExtensionFilter.
+	selectedVersion, err := bestSatisfyingVersion(versionPreference, extension.Versions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve version for %s: %w", extension.Id, err)
 	}
-
 	if selectedVersion == nil {
-		return nil, fmt.Errorf("no compatible version found for extension: %s", extension.Id)
+		if versionPreference == "" || strings.EqualFold(versionPreference, "latest") {
+			return nil, fmt.Errorf("no compatible version found for extension: %s", extension.Id)
+		}
+		return nil, fmt.Errorf(
+			"no matching version found for extension: %s and constraint: %s",
+			extension.Id, versionPreference,
+		)
 	}
 
 	// Record the resolved version on the span so failures during install
@@ -414,7 +489,7 @@ func (m *Manager) Install(
 
 			dependencyMetadata := dependencyMatches[0]
 
-			if _, err := m.Install(ctx, dependencyMetadata, dependency.Version); err != nil {
+			if _, err := m.installInternal(ctx, dependencyMetadata, dependency.Version, visited); err != nil {
 				if !errors.Is(err, ErrExtensionInstalled) {
 					return nil, fmt.Errorf("failed to install dependency: %w", err)
 				}
@@ -602,28 +677,280 @@ func (m *Manager) Uninstall(id string) error {
 	return nil
 }
 
-// Upgrade upgrades the extension to the specified version
-// This is a convenience method that uninstalls the existing extension and installs the new version
-// If the version is not specified, the latest version is installed
+// UpgradeOptions controls how Manager.Upgrade behaves.
+type UpgradeOptions struct {
+	// VersionPreference is the version constraint or exact tag to install.
+	// Empty or "latest" selects the highest available version.
+	VersionPreference string
+	// UpgradeDependencies controls whether installed dependencies whose
+	// versions are behind the upgraded extension's declared constraints are
+	// also upgraded. Defaults to true when constructed via
+	// DefaultUpgradeOptions.
+	UpgradeDependencies bool
+}
+
+// DefaultUpgradeOptions returns UpgradeOptions with UpgradeDependencies
+// enabled and the supplied version preference.
+func DefaultUpgradeOptions(versionPreference string) UpgradeOptions {
+	return UpgradeOptions{
+		VersionPreference:   versionPreference,
+		UpgradeDependencies: true,
+	}
+}
+
+// Upgrade upgrades the extension to the specified version.
+// This is a convenience method that uninstalls the existing extension and installs the new version.
+// If opts.VersionPreference is empty or "latest", the latest version is installed.
+//
+// When opts.UpgradeDependencies is true and the upgraded version declares
+// dependencies, any installed dependency that is not already at the highest
+// version satisfying the declared constraint is recursively upgraded. The
+// returned slice contains one entry per dependency upgrade attempt and is
+// ordered to match the parent's dependency list. Dependencies not installed,
+// at the highest matching version, or with an empty constraint are skipped
+// silently and do not appear in the returned slice.
 func (m *Manager) Upgrade(
 	ctx context.Context,
 	extension *ExtensionMetadata,
-	versionPreference string,
-) (*ExtensionVersion, error) {
+	opts UpgradeOptions,
+) (*ExtensionVersion, []UpgradeResult, error) {
 	if extension == nil {
-		return nil, fmt.Errorf("extension metadata cannot be nil")
+		return nil, nil, fmt.Errorf("extension metadata cannot be nil")
 	}
 
+	visited := map[string]struct{}{extension.Id: {}}
+	return m.upgradeInternal(ctx, extension, opts, visited)
+}
+
+// upgradeInternal performs the uninstall+reinstall and, when
+// opts.UpgradeDependencies is true, recursively upgrades outdated
+// dependencies. visited prevents infinite recursion in the presence of
+// dependency cycles; an id present in visited is treated as
+// already-processed and is not upgraded again.
+func (m *Manager) upgradeInternal(
+	ctx context.Context,
+	extension *ExtensionMetadata,
+	opts UpgradeOptions,
+	visited map[string]struct{},
+) (*ExtensionVersion, []UpgradeResult, error) {
 	if err := m.Uninstall(extension.Id); err != nil {
-		return nil, fmt.Errorf("failed to uninstall extension: %w", err)
+		return nil, nil, fmt.Errorf("failed to uninstall extension: %w", err)
 	}
 
-	extensionVersion, err := m.Install(ctx, extension, versionPreference)
+	extensionVersion, err := m.Install(ctx, extension, opts.VersionPreference)
 	if err != nil {
-		return nil, fmt.Errorf("failed to install extension: %w", err)
+		return nil, nil, fmt.Errorf("failed to install extension: %w", err)
 	}
 
-	return extensionVersion, nil
+	if extensionVersion == nil || len(extensionVersion.Dependencies) == 0 {
+		return extensionVersion, nil, nil
+	}
+
+	depUpgrades := m.evaluateDependencyChanges(ctx, extension, extensionVersion, opts, visited)
+	return extensionVersion, depUpgrades, nil
+}
+
+// evaluateDependencyChanges walks the upgraded parent's declared dependencies
+// and decides per child:
+//   - empty dep.Version, child not installed, or installed version is already
+//     the highest satisfying the constraint → no entry returned.
+//   - opts.UpgradeDependencies is true → recursively upgrade the child and
+//     append an UpgradeStatusUpgraded (or Failed) entry.
+//   - opts.UpgradeDependencies is false → append an UpgradeStatusSkipped
+//     entry with a SkipReason so the user sees what would have happened
+//     with automatic dependency upgrades enabled.
+//   - constraint not satisfied but another sibling has already pinned the
+//     child (id in visited) → append an UpgradeStatusFailed entry describing
+//     the constraint conflict, rather than silently leaving a child at a
+//     version the upgraded parent does not allow.
+//
+// Children already present in visited that DO satisfy the parent's constraint
+// are skipped silently — a sibling upgrade has already taken care of them.
+func (m *Manager) evaluateDependencyChanges(
+	ctx context.Context,
+	parentExtension *ExtensionMetadata,
+	parentVersion *ExtensionVersion,
+	opts UpgradeOptions,
+	visited map[string]struct{},
+) []UpgradeResult {
+	var results []UpgradeResult
+
+	for _, dep := range parentVersion.Dependencies {
+		if dep.Version == "" {
+			continue
+		}
+
+		installed, err := m.GetInstalled(FilterOptions{Id: dep.Id})
+		if err != nil || installed == nil {
+			// Not installed — handled by the parent's Install dep loop.
+			continue
+		}
+
+		// If a sibling upgrade ran first and this child is already in the
+		// visited set, respect the sibling's choice when compatible.
+		// Otherwise surface a conflict — both parents can't both win.
+		if _, seen := visited[dep.Id]; seen {
+			if matchesVersionConstraint(dep.Version, installed.Version) {
+				continue
+			}
+			conflictErr := fmt.Errorf(
+				"constraint conflict for %s: %s requires %q but another "+
+					"dependency already pinned it to %s",
+				dep.Id, parentExtension.Id, dep.Version, installed.Version,
+			)
+			results = append(results, UpgradeResult{
+				ExtensionId: dep.Id,
+				Status:      UpgradeStatusFailed,
+				FromVersion: installed.Version,
+				FromSource:  installed.Source,
+				Error:       conflictErr,
+			})
+			continue
+		}
+
+		// Resolve the highest published version satisfying the parent's
+		// constraint. Dependency upgrades use "upgrade-to-best-match"
+		// semantics (same as npm/yarn), not just "fix-if-violating", so a
+		// child whose installed version still satisfies the constraint but
+		// is behind a newer matching version is upgraded too.
+		childMetadata, findErr := m.findDependencyChild(ctx, parentExtension, dep.Id)
+		if findErr != nil {
+			// Fall back to the constraint-only check: only flag a
+			// failure when the installed version actually violates the
+			// constraint. Otherwise leave the child alone — we can't
+			// improve on what's installed without the registry data.
+			if matchesVersionConstraint(dep.Version, installed.Version) {
+				continue
+			}
+			results = append(results, UpgradeResult{
+				ExtensionId: dep.Id,
+				Status:      UpgradeStatusFailed,
+				FromVersion: installed.Version,
+				FromSource:  installed.Source,
+				Error:       findErr,
+			})
+			continue
+		}
+
+		bestVersion, bestErr := bestSatisfyingVersion(dep.Version, childMetadata.Versions)
+		if bestErr != nil || bestVersion == nil {
+			// Constraint matches no published version. If the installed
+			// version still satisfies the constraint there's nothing to
+			// do; otherwise surface as a failure.
+			if matchesVersionConstraint(dep.Version, installed.Version) {
+				continue
+			}
+			err := bestErr
+			if err == nil {
+				err = fmt.Errorf(
+					"no published version of %s satisfies constraint %q",
+					dep.Id, dep.Version,
+				)
+			}
+			results = append(results, UpgradeResult{
+				ExtensionId: dep.Id,
+				Status:      UpgradeStatusFailed,
+				FromVersion: installed.Version,
+				FromSource:  installed.Source,
+				Error:       err,
+			})
+			continue
+		}
+
+		// Already at the highest matching version — nothing to do.
+		if bestVersion.Version == installed.Version {
+			continue
+		}
+
+		// Dependency upgrades disabled — surface as a Skipped entry so the
+		// user sees which children would otherwise be upgraded.
+		if !opts.UpgradeDependencies {
+			results = append(results, UpgradeResult{
+				ExtensionId: dep.Id,
+				Status:      UpgradeStatusSkipped,
+				FromVersion: installed.Version,
+				FromSource:  installed.Source,
+				SkipReason: fmt.Sprintf(
+					"automatic dependency upgrade disabled (newer matching version %s available)",
+					bestVersion.Version,
+				),
+			})
+			continue
+		}
+
+		visited[dep.Id] = struct{}{}
+
+		childResult := UpgradeResult{
+			ExtensionId: dep.Id,
+			FromVersion: installed.Version,
+			FromSource:  installed.Source,
+		}
+
+		// Emit a child span tagged with dependency_of so downstream telemetry
+		// can correlate this upgrade with its triggering parent.
+		childCtx, span := tracing.Start(ctx, events.ExtensionUpgradeEvent)
+		span.SetAttributes(
+			fields.ExtensionId.String(dep.Id),
+			fields.ExtensionDependencyOf.String(parentExtension.Id),
+		)
+
+		childOpts := UpgradeOptions{
+			VersionPreference:   dep.Version,
+			UpgradeDependencies: opts.UpgradeDependencies,
+		}
+
+		childVersion, nested, upErr := m.upgradeInternal(childCtx, childMetadata, childOpts, visited)
+		if upErr != nil {
+			childResult.Status = UpgradeStatusFailed
+			childResult.Error = upErr
+			span.EndWithStatus(upErr)
+			results = append(results, childResult)
+			continue
+		}
+
+		childResult.Status = UpgradeStatusUpgraded
+		childResult.ToVersion = childVersion.Version
+		childResult.ToSource = childMetadata.Source
+		childResult.DependencyUpgrades = nested
+		span.SetAttributes(
+			fields.ExtensionVersionFrom.String(installed.Version),
+			fields.ExtensionVersionTo.String(childVersion.Version),
+			fields.ExtensionSource.String(childMetadata.Source),
+		)
+		span.EndWithStatus(nil)
+		results = append(results, childResult)
+	}
+
+	return results
+}
+
+// findDependencyChild locates the child extension metadata to use for a
+// dependency upgrade. It prefers the parent's source but falls back to any
+// source if the child is not present in the parent's source.
+func (m *Manager) findDependencyChild(
+	ctx context.Context,
+	parent *ExtensionMetadata,
+	childId string,
+) (*ExtensionMetadata, error) {
+	opts := &FilterOptions{Id: childId, Source: parent.Source}
+	matches, err := m.FindExtensions(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find dependency %s: %w", childId, err)
+	}
+	if len(matches) == 0 {
+		// Fall back to any source
+		matches, err = m.FindExtensions(ctx, &FilterOptions{Id: childId})
+		if err != nil {
+			return nil, fmt.Errorf("failed to find dependency %s: %w", childId, err)
+		}
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("dependency %s not found in any registry", childId)
+	}
+	if len(matches) > 1 {
+		return nil, fmt.Errorf("dependency %s found in multiple sources, specify exact source", childId)
+	}
+	return matches[0], nil
 }
 
 // Helper function to find the artifact for the current OS

--- a/cli/azd/pkg/extensions/manager.go
+++ b/cli/azd/pkg/extensions/manager.go
@@ -32,6 +32,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/errorhandler"
 	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/rzip"
 )
 
@@ -922,9 +923,15 @@ func (m *Manager) evaluateDependencyChanges(
 				FromVersion: installed.Version,
 				FromSource:  installed.Source,
 				SkipReason: fmt.Sprintf(
-					"installed version %s is outside %s's constraint %q; not downgrading. "+
-						"Run 'azd extension install %s --version %s' to align with the pack.",
-					installed.Version, parentExtension.Id, dep.Version, dep.Id, bestVersion.Version,
+					"current %s is outside %s's constraint %q",
+					installed.Version, parentExtension.Id, dep.Version,
+				),
+				Suggestion: fmt.Sprintf(
+					"Run %s to align with extension pack.",
+					output.WithHighLightFormat(
+						"azd ext install %s --version %s",
+						dep.Id, bestVersion.Version,
+					),
 				),
 			})
 			continue
@@ -938,7 +945,7 @@ func (m *Manager) evaluateDependencyChanges(
 				FromVersion: installed.Version,
 				FromSource:  installed.Source,
 				SkipReason: fmt.Sprintf(
-					"automatic dependency upgrade disabled (matching version %s available)",
+					"dependency upgrades disabled; %s available",
 					bestVersion.Version,
 				),
 			})

--- a/cli/azd/pkg/extensions/manager.go
+++ b/cli/azd/pkg/extensions/manager.go
@@ -97,19 +97,18 @@ func matchesVersionConstraint(expr, candidate string) bool {
 }
 
 // bestSatisfyingVersion returns the highest published version satisfying
-// expr from the provided versions slice. Returns (nil, nil) when no
-// published version satisfies the constraint. Returns (nil, err) only when
-// expr fails to parse as a semver constraint AND no candidate matches
-// expr literally — for non-semver tags this falls back to exact match.
-func bestSatisfyingVersion(expr string, versions []ExtensionVersion) (*ExtensionVersion, error) {
+// expr from the provided versions slice, or nil when no published version
+// matches. Empty expr or "latest" returns LatestVersion. Constraint-shaped
+// expressions are evaluated via semver.NewConstraint; non-semver tags fall
+// back to a case-insensitive exact match. The caller treats a nil return
+// as "no acceptable version available".
+func bestSatisfyingVersion(expr string, versions []ExtensionVersion) *ExtensionVersion {
 	if len(versions) == 0 {
-		return nil, nil
+		return nil
 	}
 
-	// "" or "latest" → just return the LatestVersion (which already handles
-	// the semver-vs-non-semver ordering used elsewhere in the package).
 	if expr == "" || strings.EqualFold(expr, "latest") {
-		return LatestVersion(versions), nil
+		return LatestVersion(versions)
 	}
 
 	constraint, err := semver.NewConstraint(expr)
@@ -118,10 +117,10 @@ func bestSatisfyingVersion(expr string, versions []ExtensionVersion) (*Extension
 		// candidate tag.
 		for i := range versions {
 			if strings.EqualFold(versions[i].Version, expr) {
-				return &versions[i], nil
+				return &versions[i]
 			}
 		}
-		return nil, nil
+		return nil
 	}
 
 	var best *semver.Version
@@ -140,9 +139,9 @@ func bestSatisfyingVersion(expr string, versions []ExtensionVersion) (*Extension
 		}
 	}
 	if best == nil {
-		return nil, nil
+		return nil
 	}
-	return &versions[bestIdx], nil
+	return &versions[bestIdx]
 }
 
 // createExtensionFilter creates a comprehensive filter that checks ALL criteria with AND logic
@@ -440,10 +439,7 @@ func (m *Manager) installInternal(
 	// (possibly semver-constraint-shaped) preference. bestSatisfyingVersion
 	// also handles non-semver exact-match tags ("dev", "nightly") so the
 	// behavior matches createExtensionFilter.
-	selectedVersion, err := bestSatisfyingVersion(versionPreference, extension.Versions)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve version for %s: %w", extension.Id, err)
-	}
+	selectedVersion := bestSatisfyingVersion(versionPreference, extension.Versions)
 	if selectedVersion == nil {
 		if versionPreference == "" || strings.EqualFold(versionPreference, "latest") {
 			return nil, fmt.Errorf("no compatible version found for extension: %s", extension.Id)
@@ -832,27 +828,23 @@ func (m *Manager) evaluateDependencyChanges(
 			continue
 		}
 
-		bestVersion, bestErr := bestSatisfyingVersion(dep.Version, childMetadata.Versions)
-		if bestErr != nil || bestVersion == nil {
+		bestVersion := bestSatisfyingVersion(dep.Version, childMetadata.Versions)
+		if bestVersion == nil {
 			// Constraint matches no published version. If the installed
 			// version still satisfies the constraint there's nothing to
 			// do; otherwise surface as a failure.
 			if matchesVersionConstraint(dep.Version, installed.Version) {
 				continue
 			}
-			err := bestErr
-			if err == nil {
-				err = fmt.Errorf(
-					"no published version of %s satisfies constraint %q",
-					dep.Id, dep.Version,
-				)
-			}
 			results = append(results, UpgradeResult{
 				ExtensionId: dep.Id,
 				Status:      UpgradeStatusFailed,
 				FromVersion: installed.Version,
 				FromSource:  installed.Source,
-				Error:       err,
+				Error: fmt.Errorf(
+					"no published version of %s satisfies constraint %q",
+					dep.Id, dep.Version,
+				),
 			})
 			continue
 		}

--- a/cli/azd/pkg/extensions/manager_test.go
+++ b/cli/azd/pkg/extensions/manager_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
@@ -447,6 +448,122 @@ func Test_Install_PackDependency_SemverConstraint(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, installed)
 	require.Equal(t, "0.1.31-preview", installed.Version)
+}
+
+func Test_Install_PackDependency_InstalledDependencyMustSatisfyConstraint(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: "test.pack",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "test.child", Version: ">=2.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "test.child",
+				Versions: []ExtensionVersion{
+					{Version: "1.0.0", Artifacts: sampleArtifacts},
+					{Version: "2.0.0", Artifacts: sampleArtifacts},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	children, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.child"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, children[0], "1.0.0")
+	require.NoError(t, err)
+
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.pack"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, packs[0], "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "installed dependency test.child version 1.0.0 does not satisfy constraint")
+}
+
+func Test_Install_PackDependency_UsesCompatibleDependencyVersion(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: "test.pack",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "test.child", Version: ">=1.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "test.child",
+				Versions: []ExtensionVersion{
+					{Version: "1.0.0", Artifacts: sampleArtifacts},
+					{Version: "2.0.0", RequiredAzdVersion: ">=99.0.0", Artifacts: sampleArtifacts},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	azdVersion, err := semver.NewVersion("1.0.0")
+	require.NoError(t, err)
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.pack"})
+	require.NoError(t, err)
+	_, err = manager.InstallWithOptions(*mockContext.Context, packs[0], InstallOptions{
+		AzdVersion: azdVersion,
+	})
+	require.NoError(t, err)
+
+	installed, err := manager.GetInstalled(FilterOptions{Id: "test.child"})
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", installed.Version)
 }
 
 func Test_DownloadArtifact_Remote(t *testing.T) {
@@ -1689,6 +1806,143 @@ func Test_Upgrade_DependencyUpgrade_ConstraintAlreadySatisfied(t *testing.T) {
 		*mockContext.Context,
 		packs[0],
 		DefaultUpgradeOptions(""),
+	)
+	require.NoError(t, err)
+	require.Empty(t, depUpgrades)
+}
+
+func Test_Upgrade_DependencyUpgrade_ReconcilesWhenParentCurrent(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: "test.pack",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "test.child", Version: ">=1.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "test.child",
+				Versions: []ExtensionVersion{
+					{Version: "1.0.0", Artifacts: sampleArtifacts},
+					{Version: "2.0.0", Artifacts: sampleArtifacts},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	children, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.child"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, children[0], "1.0.0")
+	require.NoError(t, err)
+
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.pack"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, packs[0], "")
+	require.NoError(t, err)
+
+	_, depUpgrades, err := manager.ReconcileDependencies(
+		*mockContext.Context,
+		packs[0],
+		DefaultUpgradeOptions(""),
+	)
+	require.NoError(t, err)
+	require.Len(t, depUpgrades, 1)
+	require.Equal(t, "test.child", depUpgrades[0].ExtensionId)
+	require.Equal(t, "1.0.0", depUpgrades[0].FromVersion)
+	require.Equal(t, "2.0.0", depUpgrades[0].ToVersion)
+}
+
+func Test_Upgrade_DependencyUpgrade_UsesCompatibleDependencyVersion(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: "test.pack",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "test.child", Version: ">=1.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "test.child",
+				Versions: []ExtensionVersion{
+					{Version: "1.0.0", Artifacts: sampleArtifacts},
+					{Version: "2.0.0", RequiredAzdVersion: ">=99.0.0", Artifacts: sampleArtifacts},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	children, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.child"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, children[0], "1.0.0")
+	require.NoError(t, err)
+
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.pack"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, packs[0], "")
+	require.NoError(t, err)
+
+	azdVersion, err := semver.NewVersion("1.0.0")
+	require.NoError(t, err)
+	_, depUpgrades, err := manager.ReconcileDependencies(
+		*mockContext.Context,
+		packs[0],
+		UpgradeOptions{
+			VersionPreference:   "",
+			UpgradeDependencies: true,
+			AzdVersion:          azdVersion,
+		},
 	)
 	require.NoError(t, err)
 	require.Empty(t, depUpgrades)

--- a/cli/azd/pkg/extensions/manager_test.go
+++ b/cli/azd/pkg/extensions/manager_test.go
@@ -296,6 +296,159 @@ func Test_Install_With_SemverConstraints(t *testing.T) {
 	}
 }
 
+func Test_MatchesVersionConstraint(t *testing.T) {
+	testCases := []struct {
+		Name      string
+		Expr      string
+		Candidate string
+		Want      bool
+	}{
+		{Name: "empty matches any", Expr: "", Candidate: "0.1.0", Want: true},
+		{Name: "latest matches any", Expr: "latest", Candidate: "0.1.0", Want: true},
+		{Name: "Latest case-insensitive", Expr: "Latest", Candidate: "9.9.9-rc1", Want: true},
+		{Name: "exact pin match", Expr: "0.1.31-preview", Candidate: "0.1.31-preview", Want: true},
+		{Name: "exact pin miss", Expr: "0.1.31-preview", Candidate: "0.1.32-preview", Want: false},
+		{Name: "ge matches base", Expr: ">=0.1.0", Candidate: "0.1.0", Want: true},
+		// Pre-release versions are only matched by constraints that explicitly include a
+		// pre-release tag on the lower bound (Masterminds/semver semantics).
+		{Name: "ge does not match pre-release", Expr: ">=0.1.0", Candidate: "0.1.31-preview", Want: false},
+		{
+			Name:      "ge with preview lower bound matches pre-release",
+			Expr:      ">=0.1.0-0",
+			Candidate: "0.1.31-preview",
+			Want:      true,
+		},
+		{Name: "ge matches higher major", Expr: ">=0.1.0", Candidate: "1.0.0", Want: true},
+		{Name: "range matches in-range", Expr: ">=1.0.0,<2.0.0", Candidate: "1.5.0", Want: true},
+		{Name: "range rejects below", Expr: ">=1.0.0,<2.0.0", Candidate: "0.9.0", Want: false},
+		{Name: "range rejects upper bound", Expr: ">=1.0.0,<2.0.0", Candidate: "2.0.0", Want: false},
+		{Name: "caret matches pre-release within range", Expr: "^0.1.0-0", Candidate: "0.1.31-preview", Want: true},
+		{Name: "caret rejects next minor", Expr: "^0.1", Candidate: "0.2.0", Want: false},
+		{Name: "tilde matches pre-release within range", Expr: "~0.1.0-preview", Candidate: "0.1.31-preview", Want: true},
+		{Name: "tilde rejects next minor", Expr: "~0.1.0-preview", Candidate: "0.2.0", Want: false},
+		{Name: "unparseable expr falls back to exact match", Expr: "dev", Candidate: "dev", Want: true},
+		{
+			Name:      "unparseable expr fallback case-insensitive",
+			Expr:      "Nightly",
+			Candidate: "nightly",
+			Want:      true,
+		},
+		{Name: "unparseable expr no match", Expr: "dev", Candidate: "0.1.0", Want: false},
+		{
+			Name:      "non-semver candidate falls back to exact",
+			Expr:      ">=0.1.0",
+			Candidate: "nightly",
+			Want:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			got := matchesVersionConstraint(tc.Expr, tc.Candidate)
+			require.Equal(t, tc.Want, got)
+		})
+	}
+}
+
+func Test_CreateExtensionFilter_VersionConstraints(t *testing.T) {
+	ext := &ExtensionMetadata{
+		Id: "test.constraints",
+		Versions: []ExtensionVersion{
+			{Version: "0.1.0"},
+			{Version: "0.1.31-preview"},
+			{Version: "1.0.0"},
+			{Version: "1.5.0"},
+			{Version: "2.0.0"},
+		},
+	}
+
+	testCases := []struct {
+		Name    string
+		Version string
+		Match   bool
+	}{
+		{Name: "empty matches", Version: "", Match: true},
+		{Name: "latest matches", Version: "latest", Match: true},
+		{Name: "exact pin", Version: "0.1.31-preview", Match: true},
+		{Name: "ge across versions", Version: ">=0.1.0", Match: true},
+		{Name: "range matches 1.5.0", Version: ">=1.0.0,<2.0.0", Match: true},
+		{Name: "caret 0.1 with preview lower bound", Version: "^0.1.0-0", Match: true},
+		{Name: "tilde preview", Version: "~0.1.0-preview", Match: true},
+		{Name: "unparseable matches none", Version: "dev", Match: false},
+		{Name: "constraint matches nothing", Version: ">=99.0.0", Match: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			filter := createExtensionFilter(&FilterOptions{Version: tc.Version})
+			require.Equal(t, tc.Match, filter(ext))
+		})
+	}
+}
+
+func Test_Install_PackDependency_SemverConstraint(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	packRegistry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id:          "test.pack",
+				Namespace:   "test",
+				DisplayName: "Test Pack",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "test.dependency", Version: ">=0.1.0-0"},
+						},
+					},
+				},
+			},
+			{
+				Id:          "test.dependency",
+				Namespace:   "test",
+				DisplayName: "Test Dependency",
+				Versions: []ExtensionVersion{
+					{Version: "0.1.0", Artifacts: sampleArtifacts},
+					{Version: "0.1.15-preview", Artifacts: sampleArtifacts},
+					{Version: "0.1.31-preview", Artifacts: sampleArtifacts},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, packRegistry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.pack"})
+	require.NoError(t, err)
+	require.Len(t, packs, 1)
+
+	_, err = manager.Install(*mockContext.Context, packs[0], "")
+	require.NoError(t, err)
+
+	installed, err := manager.GetInstalled(FilterOptions{Id: "test.dependency"})
+	require.NoError(t, err)
+	require.NotNil(t, installed)
+	require.Equal(t, "0.1.31-preview", installed.Version)
+}
+
 func Test_DownloadArtifact_Remote(t *testing.T) {
 	mockContext := mocks.NewMockContext(t.Context())
 
@@ -1385,4 +1538,688 @@ func Test_CopyFromLocalPath_PathTraversal_Blocked(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test_Upgrade_DependencyUpgrade verifies the dependency-upgrade decision matrix described in
+// the issue: parent upgrades trigger child upgrades only when the
+// declared dependency constraint is no longer satisfied by the installed
+// child version, and respect the UpgradeDependencies=false opt-out.
+func Test_Upgrade_DependencyUpgrade_TightenedConstraint(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id:          "test.pack",
+				Namespace:   "test",
+				DisplayName: "Test Pack",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "test.child", Version: "~1.0.0"},
+						},
+					},
+					{
+						Version: "2.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "test.child", Version: ">=2.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id:          "test.child",
+				Namespace:   "test",
+				DisplayName: "Test Child",
+				Versions: []ExtensionVersion{
+					{Version: "1.0.0", Artifacts: sampleArtifacts},
+					{Version: "2.0.0", Artifacts: sampleArtifacts},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	// Install pack v1, which pulls in child v1 (constrained to ~1.0.0).
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.pack"})
+	require.NoError(t, err)
+	require.Len(t, packs, 1)
+	_, err = manager.Install(*mockContext.Context, packs[0], "1.0.0")
+	require.NoError(t, err)
+
+	installed, err := manager.GetInstalled(FilterOptions{Id: "test.child"})
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", installed.Version)
+
+	// Upgrade pack to v2 — child constraint is now >=2.0.0 so child
+	// must cascade-upgrade from 1.0.0 to 2.0.0.
+	packsV2, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.pack"})
+	require.NoError(t, err)
+	require.Len(t, packsV2, 1)
+
+	_, depUpgrades, err := manager.Upgrade(
+		*mockContext.Context,
+		packsV2[0],
+		DefaultUpgradeOptions("2.0.0"),
+	)
+	require.NoError(t, err)
+	require.Len(t, depUpgrades, 1)
+	require.Equal(t, "test.child", depUpgrades[0].ExtensionId)
+	require.Equal(t, UpgradeStatusUpgraded, depUpgrades[0].Status)
+	require.Equal(t, "1.0.0", depUpgrades[0].FromVersion)
+	require.Equal(t, "2.0.0", depUpgrades[0].ToVersion)
+
+	child, err := manager.GetInstalled(FilterOptions{Id: "test.child"})
+	require.NoError(t, err)
+	require.Equal(t, "2.0.0", child.Version)
+}
+
+func Test_Upgrade_DependencyUpgrade_ConstraintAlreadySatisfied(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: "test.pack",
+				Versions: []ExtensionVersion{
+					{
+						Version: "2.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "test.child", Version: ">=1.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "test.child",
+				Versions: []ExtensionVersion{
+					{Version: "1.5.0", Artifacts: sampleArtifacts},
+					{Version: "2.0.0", Artifacts: sampleArtifacts},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.pack"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, packs[0], "")
+	require.NoError(t, err)
+
+	// Child should be at 2.0.0 (latest >=1.0.0).
+	child, err := manager.GetInstalled(FilterOptions{Id: "test.child"})
+	require.NoError(t, err)
+	require.Equal(t, "2.0.0", child.Version)
+
+	// Upgrading pack again with the same constraint should not cascade.
+	_, depUpgrades, err := manager.Upgrade(
+		*mockContext.Context,
+		packs[0],
+		DefaultUpgradeOptions(""),
+	)
+	require.NoError(t, err)
+	require.Empty(t, depUpgrades)
+}
+
+func Test_Upgrade_DependencyUpgrade_EmptyConstraint(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: "test.pack",
+				Versions: []ExtensionVersion{
+					{
+						Version: "2.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "test.child"}, // empty constraint
+						},
+					},
+				},
+			},
+			{
+				Id: "test.child",
+				Versions: []ExtensionVersion{
+					{Version: "1.0.0", Artifacts: sampleArtifacts},
+					{Version: "9.9.9", Artifacts: sampleArtifacts},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.pack"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, packs[0], "")
+	require.NoError(t, err)
+
+	// Force the child to an older version to confirm cascade does NOT
+	// run when the parent's dependency constraint is empty.
+	_ = manager.Uninstall("test.child")
+	childMeta, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.child"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, childMeta[0], "1.0.0")
+	require.NoError(t, err)
+
+	_, depUpgrades, err := manager.Upgrade(
+		*mockContext.Context,
+		packs[0],
+		DefaultUpgradeOptions(""),
+	)
+	require.NoError(t, err)
+	require.Empty(t, depUpgrades)
+
+	child, err := manager.GetInstalled(FilterOptions{Id: "test.child"})
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", child.Version)
+}
+
+func Test_Upgrade_DependencyUpgrade_DisabledByOpts(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: "test.pack",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "test.child", Version: "~1.0.0"},
+						},
+					},
+					{
+						Version: "2.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "test.child", Version: ">=2.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "test.child",
+				Versions: []ExtensionVersion{
+					{Version: "1.0.0", Artifacts: sampleArtifacts},
+					{Version: "2.0.0", Artifacts: sampleArtifacts},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.pack"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, packs[0], "1.0.0")
+	require.NoError(t, err)
+
+	_, depUpgrades, err := manager.Upgrade(
+		*mockContext.Context,
+		packs[0],
+		UpgradeOptions{VersionPreference: "2.0.0", UpgradeDependencies: false},
+	)
+	require.NoError(t, err)
+	// With cascade disabled, a child whose installed version no longer
+	// satisfies the new parent's constraint must surface as a Skipped
+	// entry so the user is not left with a silent constraint violation.
+	require.Len(t, depUpgrades, 1)
+	require.Equal(t, "test.child", depUpgrades[0].ExtensionId)
+	require.Equal(t, UpgradeStatusSkipped, depUpgrades[0].Status)
+	require.Equal(t, "1.0.0", depUpgrades[0].FromVersion)
+	require.Contains(t, depUpgrades[0].SkipReason, "automatic dependency upgrade disabled")
+
+	child, err := manager.GetInstalled(FilterOptions{Id: "test.child"})
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", child.Version, "child must remain at 1.0.0 when cascade disabled")
+}
+
+func Test_Upgrade_DependencyUpgrade_CycleGuard(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	// Registry shape avoids a cycle during initial Install (pack.b v1 has no
+	// dependency on pack.a) but introduces a cycle in the upgraded versions
+	// (pack.b v2 depends on pack.a). The cascade visited-set must prevent the
+	// upgraded pack.b from re-cascading back into pack.a.
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: "pack.a",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "pack.b", Version: "~1.0.0"},
+						},
+					},
+					{
+						Version: "2.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "pack.b", Version: ">=2.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "pack.b",
+				Versions: []ExtensionVersion{
+					{
+						Version:   "1.0.0",
+						Artifacts: sampleArtifacts,
+					},
+					{
+						Version:   "2.0.0",
+						Artifacts: sampleArtifacts,
+						Dependencies: []ExtensionDependency{
+							{Id: "pack.a", Version: ">=1.0.0"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	// Bootstrap: install pack.a v1 → pulls in pack.b v1 (no transitive deps).
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "pack.a"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, packs[0], "1.0.0")
+	require.NoError(t, err)
+
+	// Upgrade pack.a — pack.b cascade-upgrades to v2 (which now declares
+	// pack.a as a dep). The cascade visited-set must skip pack.a inside
+	// pack.b's nested cascade rather than recurse back into it.
+	_, depUpgrades, err := manager.Upgrade(
+		*mockContext.Context,
+		packs[0],
+		DefaultUpgradeOptions("2.0.0"),
+	)
+	require.NoError(t, err)
+	require.Len(t, depUpgrades, 1)
+	require.Equal(t, "pack.b", depUpgrades[0].ExtensionId)
+	require.Equal(t, UpgradeStatusUpgraded, depUpgrades[0].Status)
+	require.Equal(t, "2.0.0", depUpgrades[0].ToVersion)
+	// pack.a is in the visited set, so pack.b's nested cascade must not
+	// re-upgrade it.
+	require.Empty(t, depUpgrades[0].DependencyUpgrades, "nested cascade must respect visited set")
+}
+
+func Test_Upgrade_DependencyUpgrade_NestedPacks(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: "pack.a",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "pack.b", Version: "~1.0.0"},
+						},
+					},
+					{
+						Version: "2.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "pack.b", Version: ">=2.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "pack.b",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "leaf.c", Version: "~1.0.0"},
+						},
+					},
+					{
+						Version: "2.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "leaf.c", Version: ">=2.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "leaf.c",
+				Versions: []ExtensionVersion{
+					{Version: "1.0.0", Artifacts: sampleArtifacts},
+					{Version: "2.0.0", Artifacts: sampleArtifacts},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	// Bootstrap: install A v1 → B v1 → C v1 (constraints pin each step to ~1.0.0).
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "pack.a"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, packs[0], "1.0.0")
+	require.NoError(t, err)
+
+	bInstalled, err := manager.GetInstalled(FilterOptions{Id: "pack.b"})
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", bInstalled.Version)
+	cInstalled, err := manager.GetInstalled(FilterOptions{Id: "leaf.c"})
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", cInstalled.Version)
+
+	// Upgrade A to v2 — should cascade to B v2 → C v2.
+	_, depUpgrades, err := manager.Upgrade(
+		*mockContext.Context,
+		packs[0],
+		DefaultUpgradeOptions("2.0.0"),
+	)
+	require.NoError(t, err)
+	require.Len(t, depUpgrades, 1)
+	require.Equal(t, "pack.b", depUpgrades[0].ExtensionId)
+	require.Equal(t, UpgradeStatusUpgraded, depUpgrades[0].Status)
+	require.Equal(t, "2.0.0", depUpgrades[0].ToVersion)
+	require.Len(t, depUpgrades[0].DependencyUpgrades, 1)
+	require.Equal(t, "leaf.c", depUpgrades[0].DependencyUpgrades[0].ExtensionId)
+	require.Equal(t, "2.0.0", depUpgrades[0].DependencyUpgrades[0].ToVersion)
+
+	bFinal, err := manager.GetInstalled(FilterOptions{Id: "pack.b"})
+	require.NoError(t, err)
+	require.Equal(t, "2.0.0", bFinal.Version)
+	cFinal, err := manager.GetInstalled(FilterOptions{Id: "leaf.c"})
+	require.NoError(t, err)
+	require.Equal(t, "2.0.0", cFinal.Version)
+}
+
+func Test_Install_DependencyCycle_Bounded(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	// Registry defines a true install-time cycle: A → B → A. Without an
+	// in-flight visited set, Install would recurse without bound because the
+	// parent's installed-config record is only written after dependencies
+	// finish installing, so ErrExtensionInstalled cannot short-circuit
+	// the cycle during the initial install.
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: "pack.a",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "pack.b", Version: "1.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "pack.b",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "pack.a", Version: "1.0.0"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "pack.a"})
+	require.NoError(t, err)
+	require.Len(t, packs, 1)
+
+	// Install must terminate (not recurse forever) and surface a cycle error.
+	_, err = manager.Install(*mockContext.Context, packs[0], "1.0.0")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dependency cycle detected")
+}
+
+func Test_Upgrade_DependencyUpgrade_ConstraintConflict(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	// Pack A v2 depends on { B: ">=2.0.0", C: ">=2.0.0" }.
+	// B v2 depends on { C: "~1.0.0" } — mutually unsatisfiable with A's
+	// constraint on C. Iteration upgrades B first, B's cascade pins C to
+	// 1.x to satisfy its own constraint, then A's cascade reaches C: the
+	// installed C now violates A's >=2.0.0 and C is already in the visited
+	// set. The cascade must surface this as a Failed entry rather than
+	// silently leaving C at a version A does not allow.
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: "pack.a",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "pack.b", Version: "~1.0.0"},
+							{Id: "leaf.c", Version: "~0.9.0"},
+						},
+					},
+					{
+						Version: "2.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "pack.b", Version: ">=2.0.0"},
+							{Id: "leaf.c", Version: ">=2.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "pack.b",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "leaf.c", Version: "~0.9.0"},
+						},
+					},
+					{
+						Version: "2.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "leaf.c", Version: "~1.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "leaf.c",
+				Versions: []ExtensionVersion{
+					{Version: "0.9.0", Artifacts: sampleArtifacts},
+					{Version: "1.0.0", Artifacts: sampleArtifacts},
+					{Version: "2.0.0", Artifacts: sampleArtifacts},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	// Bootstrap: install A v1 → B v1 → C v0.9. After this, all three are
+	// installed and consistent with A v1's constraints.
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "pack.a"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, packs[0], "1.0.0")
+	require.NoError(t, err)
+
+	cInstalled, err := manager.GetInstalled(FilterOptions{Id: "leaf.c"})
+	require.NoError(t, err)
+	require.Equal(t, "0.9.0", cInstalled.Version)
+
+	// Upgrade A to v2 — iteration order processes B first (sibling pin to
+	// C ~1.0.0), then attempts to upgrade C to satisfy A's >=2.0.0.
+	_, depUpgrades, err := manager.Upgrade(
+		*mockContext.Context,
+		packs[0],
+		DefaultUpgradeOptions("2.0.0"),
+	)
+	require.NoError(t, err)
+
+	// Two top-level dependency-upgrade entries: B upgraded, C reported as a conflict.
+	require.Len(t, depUpgrades, 2)
+
+	var bEntry, cEntry *UpgradeResult
+	for i := range depUpgrades {
+		entry := &depUpgrades[i]
+		switch entry.ExtensionId {
+		case "pack.b":
+			bEntry = entry
+		case "leaf.c":
+			cEntry = entry
+		}
+	}
+	require.NotNil(t, bEntry, "pack.b dependency-upgrade entry expected")
+	require.NotNil(t, cEntry, "leaf.c dependency-upgrade entry expected")
+
+	require.Equal(t, UpgradeStatusUpgraded, bEntry.Status)
+	require.Equal(t, "2.0.0", bEntry.ToVersion)
+
+	require.Equal(t, UpgradeStatusFailed, cEntry.Status)
+	require.Error(t, cEntry.Error)
+	require.Contains(t, cEntry.Error.Error(), "constraint conflict")
+	require.Contains(t, cEntry.Error.Error(), "leaf.c")
 }

--- a/cli/azd/pkg/extensions/manager_test.go
+++ b/cli/azd/pkg/extensions/manager_test.go
@@ -1924,7 +1924,7 @@ func Test_Upgrade_DependencyUpgrade_RefusesToDowngradeOutsideConstraint(t *testi
 	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
 	require.NoError(t, err)
 
-	// Install pack first; it pulls in test.child at the highest version matching ~1.0.0 (1.1.0).
+	// Install pack first; it pulls in test.child at 1.0.0 (the only version matching ~1.0.0).
 	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.pack"})
 	require.NoError(t, err)
 	_, err = manager.Install(*mockContext.Context, packs[0], "")
@@ -2612,4 +2612,130 @@ func Test_Upgrade_DependencyUpgrade_ConstraintConflict(t *testing.T) {
 	require.Error(t, cEntry.Error)
 	require.Contains(t, cEntry.Error.Error(), "constraint conflict")
 	require.Contains(t, cEntry.Error.Error(), "leaf.c")
+}
+
+// Test_Upgrade_DependencyUpgrade_NoOpStillPinsForSiblings exercises the case
+// where the first parent processed for a dependency leaves it untouched (the
+// installed version already matches the highest satisfying version). A later
+// sibling upgrade chain whose constraint is incompatible with that installed
+// version must still surface a constraint conflict, rather than silently
+// picking its own preferred version and invalidating the first parent's
+// constraint.
+func Test_Upgrade_DependencyUpgrade_NoOpStillPinsForSiblings(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	// pack.a v2 lists leaf.c first (already at 1.0.0, satisfies ~1.0.0 → no-op)
+	// and pack.b second. pack.b v2 wants leaf.c >=2.0.0, which would normally
+	// trigger an upgrade of leaf.c — but pack.a's earlier no-op visit must
+	// have pinned leaf.c so that pack.b's recursive walk surfaces a conflict
+	// instead of silently upgrading leaf.c out of pack.a's range.
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: "pack.a",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "leaf.c", Version: "~1.0.0"},
+							{Id: "pack.b", Version: "~1.0.0"},
+						},
+					},
+					{
+						Version: "2.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "leaf.c", Version: "~1.0.0"},
+							{Id: "pack.b", Version: ">=2.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "pack.b",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "leaf.c", Version: "~1.0.0"},
+						},
+					},
+					{
+						Version: "2.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "leaf.c", Version: ">=2.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "leaf.c",
+				Versions: []ExtensionVersion{
+					{Version: "1.0.0", Artifacts: sampleArtifacts},
+					{Version: "2.0.0", Artifacts: sampleArtifacts},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	// Bootstrap: install pack.a v1 → pack.b v1 → leaf.c 1.0.0.
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "pack.a"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, packs[0], "1.0.0")
+	require.NoError(t, err)
+
+	cInstalled, err := manager.GetInstalled(FilterOptions{Id: "leaf.c"})
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", cInstalled.Version)
+
+	_, depUpgrades, err := manager.Upgrade(
+		*mockContext.Context,
+		packs[0],
+		DefaultUpgradeOptions("2.0.0"),
+	)
+	require.NoError(t, err)
+
+	var cEntry *UpgradeResult
+	var findInNested func(entries []UpgradeResult)
+	findInNested = func(entries []UpgradeResult) {
+		for i := range entries {
+			if entries[i].ExtensionId == "leaf.c" {
+				cEntry = &entries[i]
+				return
+			}
+			findInNested(entries[i].DependencyUpgrades)
+			if cEntry != nil {
+				return
+			}
+		}
+	}
+	findInNested(depUpgrades)
+
+	require.NotNil(t, cEntry, "leaf.c dependency-upgrade entry expected")
+	require.Equal(t, UpgradeStatusFailed, cEntry.Status)
+	require.Error(t, cEntry.Error)
+	require.Contains(t, cEntry.Error.Error(), "constraint conflict")
+
+	// leaf.c must remain at 1.0.0 — pack.a's earlier no-op visit pinned it.
+	cFinal, err := manager.GetInstalled(FilterOptions{Id: "leaf.c"})
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", cFinal.Version)
 }

--- a/cli/azd/pkg/extensions/manager_test.go
+++ b/cli/azd/pkg/extensions/manager_test.go
@@ -1878,6 +1878,162 @@ func Test_Upgrade_DependencyUpgrade_ReconcilesWhenParentCurrent(t *testing.T) {
 	require.Equal(t, "2.0.0", depUpgrades[0].ToVersion)
 }
 
+func Test_Upgrade_DependencyUpgrade_RefusesToDowngradeOutsideConstraint(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: "test.pack",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "test.child", Version: "~1.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "test.child",
+				Versions: []ExtensionVersion{
+					{Version: "1.0.0", Artifacts: sampleArtifacts},
+					{Version: "1.1.0", Artifacts: sampleArtifacts},
+					{Version: "2.0.0", Artifacts: sampleArtifacts},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	// Install pack first; it pulls in test.child at the highest version matching ~1.0.0 (1.1.0).
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.pack"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, packs[0], "")
+	require.NoError(t, err)
+
+	// Simulate the user upgrading the dependency standalone to a version outside the constraint.
+	require.NoError(t, manager.Uninstall("test.child"))
+	children, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.child"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, children[0], "2.0.0")
+	require.NoError(t, err)
+
+	_, depUpgrades, err := manager.ReconcileDependencies(
+		*mockContext.Context,
+		packs[0],
+		DefaultUpgradeOptions(""),
+	)
+	require.NoError(t, err)
+	require.Len(t, depUpgrades, 1)
+	require.Equal(t, "test.child", depUpgrades[0].ExtensionId)
+	require.Equal(t, UpgradeStatusSkipped, depUpgrades[0].Status)
+	require.Equal(t, "2.0.0", depUpgrades[0].FromVersion)
+	require.Contains(t, depUpgrades[0].SkipReason, "outside")
+	require.Contains(t, depUpgrades[0].SkipReason, "not downgrading")
+
+	// Installed version should still be 2.0.0 — no downgrade happened.
+	installed, err := manager.GetInstalled(FilterOptions{Id: "test.child"})
+	require.NoError(t, err)
+	require.Equal(t, "2.0.0", installed.Version)
+}
+
+func Test_Upgrade_DependencyUpgrade_KeepsNewerInstalledWhenInRange(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: "test.pack",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Dependencies: []ExtensionDependency{
+							{Id: "test.child", Version: ">=1.0.0"},
+						},
+					},
+				},
+			},
+			{
+				Id: "test.child",
+				Versions: []ExtensionVersion{
+					{Version: "1.0.0", Artifacts: sampleArtifacts},
+					{Version: "1.5.0", Artifacts: sampleArtifacts},
+					{Version: "2.0.0", RequiredAzdVersion: ">=99.0.0", Artifacts: sampleArtifacts},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	// Install the child at 2.0.0 first; it's outside the azd-compatible candidate set
+	// ({1.0.0, 1.5.0}) but still satisfies the pack's >=1.0.0 constraint, so reconciliation
+	// should keep it rather than downgrade to 1.5.0.
+	children, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.child"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, children[0], "2.0.0")
+	require.NoError(t, err)
+
+	packs, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.pack"})
+	require.NoError(t, err)
+	_, err = manager.Install(*mockContext.Context, packs[0], "")
+	require.NoError(t, err)
+
+	azdVersion, err := semver.NewVersion("1.0.0")
+	require.NoError(t, err)
+	_, depUpgrades, err := manager.ReconcileDependencies(
+		*mockContext.Context,
+		packs[0],
+		UpgradeOptions{
+			VersionPreference:   "",
+			UpgradeDependencies: true,
+			AzdVersion:          azdVersion,
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, depUpgrades)
+
+	installed, err := manager.GetInstalled(FilterOptions{Id: "test.child"})
+	require.NoError(t, err)
+	require.Equal(t, "2.0.0", installed.Version)
+}
+
 func Test_Upgrade_DependencyUpgrade_UsesCompatibleDependencyVersion(t *testing.T) {
 	mockContext := mocks.NewMockContext(t.Context())
 

--- a/cli/azd/pkg/extensions/manager_test.go
+++ b/cli/azd/pkg/extensions/manager_test.go
@@ -1540,11 +1540,7 @@ func Test_CopyFromLocalPath_PathTraversal_Blocked(t *testing.T) {
 	}
 }
 
-// Test_Upgrade_DependencyUpgrade verifies the dependency-upgrade decision
-// matrix: parent upgrades select the highest published version satisfying
-// each declared constraint (upgrade-to-best-match, same as npm/yarn), skip
-// dependencies already at that best version, and respect the
-// UpgradeDependencies=false opt-out.
+// Test_Upgrade_DependencyUpgrade verifies dependency upgrade decisions.
 func Test_Upgrade_DependencyUpgrade_TightenedConstraint(t *testing.T) {
 	mockContext := mocks.NewMockContext(t.Context())
 
@@ -1611,8 +1607,7 @@ func Test_Upgrade_DependencyUpgrade_TightenedConstraint(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "1.0.0", installed.Version)
 
-	// Upgrade pack to v2 — child constraint is now >=2.0.0 so child
-	// must cascade-upgrade from 1.0.0 to 2.0.0.
+	// Upgrade pack to v2; child must upgrade from 1.0.0 to 2.0.0.
 	packsV2, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.pack"})
 	require.NoError(t, err)
 	require.Len(t, packsV2, 1)
@@ -1689,7 +1684,7 @@ func Test_Upgrade_DependencyUpgrade_ConstraintAlreadySatisfied(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "2.0.0", child.Version)
 
-	// Upgrading pack again with the same constraint should not cascade.
+	// Upgrading pack again with the same constraint should not upgrade the child.
 	_, depUpgrades, err := manager.Upgrade(
 		*mockContext.Context,
 		packs[0],
@@ -1749,7 +1744,7 @@ func Test_Upgrade_DependencyUpgrade_EmptyConstraint(t *testing.T) {
 	_, err = manager.Install(*mockContext.Context, packs[0], "")
 	require.NoError(t, err)
 
-	// Force the child to an older version to confirm cascade does NOT
+	// Force the child to an older version to confirm dependency upgrade does NOT
 	// run when the parent's dependency constraint is empty.
 	_ = manager.Uninstall("test.child")
 	childMeta, err := manager.FindExtensions(*mockContext.Context, &FilterOptions{Id: "test.child"})
@@ -1832,9 +1827,7 @@ func Test_Upgrade_DependencyUpgrade_DisabledByOpts(t *testing.T) {
 		UpgradeOptions{VersionPreference: "2.0.0", UpgradeDependencies: false},
 	)
 	require.NoError(t, err)
-	// With cascade disabled, a child whose installed version no longer
-	// satisfies the new parent's constraint must surface as a Skipped
-	// entry so the user is not left with a silent constraint violation.
+	// Disabled dependency upgrades should surface as Skipped.
 	require.Len(t, depUpgrades, 1)
 	require.Equal(t, "test.child", depUpgrades[0].ExtensionId)
 	require.Equal(t, UpgradeStatusSkipped, depUpgrades[0].Status)
@@ -1843,16 +1836,13 @@ func Test_Upgrade_DependencyUpgrade_DisabledByOpts(t *testing.T) {
 
 	child, err := manager.GetInstalled(FilterOptions{Id: "test.child"})
 	require.NoError(t, err)
-	require.Equal(t, "1.0.0", child.Version, "child must remain at 1.0.0 when cascade disabled")
+	require.Equal(t, "1.0.0", child.Version, "child must remain at 1.0.0 when dependency upgrades are disabled")
 }
 
 func Test_Upgrade_DependencyUpgrade_CycleGuard(t *testing.T) {
 	mockContext := mocks.NewMockContext(t.Context())
 
-	// Registry shape avoids a cycle during initial Install (pack.b v1 has no
-	// dependency on pack.a) but introduces a cycle in the upgraded versions
-	// (pack.b v2 depends on pack.a). The cascade visited-set must prevent the
-	// upgraded pack.b from re-cascading back into pack.a.
+	// Registry shape avoids an install cycle but introduces one during upgrade.
 	registry := Registry{
 		Extensions: []*ExtensionMetadata{
 			{
@@ -1916,9 +1906,7 @@ func Test_Upgrade_DependencyUpgrade_CycleGuard(t *testing.T) {
 	_, err = manager.Install(*mockContext.Context, packs[0], "1.0.0")
 	require.NoError(t, err)
 
-	// Upgrade pack.a — pack.b cascade-upgrades to v2 (which now declares
-	// pack.a as a dep). The cascade visited-set must skip pack.a inside
-	// pack.b's nested cascade rather than recurse back into it.
+	// Upgrade pack.a; pack.b v2 depends back on pack.a.
 	_, depUpgrades, err := manager.Upgrade(
 		*mockContext.Context,
 		packs[0],
@@ -1929,9 +1917,8 @@ func Test_Upgrade_DependencyUpgrade_CycleGuard(t *testing.T) {
 	require.Equal(t, "pack.b", depUpgrades[0].ExtensionId)
 	require.Equal(t, UpgradeStatusUpgraded, depUpgrades[0].Status)
 	require.Equal(t, "2.0.0", depUpgrades[0].ToVersion)
-	// pack.a is in the visited set, so pack.b's nested cascade must not
-	// re-upgrade it.
-	require.Empty(t, depUpgrades[0].DependencyUpgrades, "nested cascade must respect visited set")
+	// pack.a is in the visited set, so pack.b's nested upgrade must skip it.
+	require.Empty(t, depUpgrades[0].DependencyUpgrades, "nested dependency upgrade must respect visited set")
 }
 
 func Test_Upgrade_DependencyUpgrade_NestedPacks(t *testing.T) {
@@ -2015,7 +2002,7 @@ func Test_Upgrade_DependencyUpgrade_NestedPacks(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "1.0.0", cInstalled.Version)
 
-	// Upgrade A to v2 — should cascade to B v2 → C v2.
+	// Upgrade A to v2; B and C should also upgrade to v2.
 	_, depUpgrades, err := manager.Upgrade(
 		*mockContext.Context,
 		packs[0],
@@ -2041,11 +2028,7 @@ func Test_Upgrade_DependencyUpgrade_NestedPacks(t *testing.T) {
 func Test_Install_DependencyCycle_Bounded(t *testing.T) {
 	mockContext := mocks.NewMockContext(t.Context())
 
-	// Registry defines a true install-time cycle: A → B → A. Without an
-	// in-flight visited set, Install would recurse without bound because the
-	// parent's installed-config record is only written after dependencies
-	// finish installing, so ErrExtensionInstalled cannot short-circuit
-	// the cycle during the initial install.
+	// Registry defines a true install-time cycle: A → B → A.
 	registry := Registry{
 		Extensions: []*ExtensionMetadata{
 			{
@@ -2106,12 +2089,7 @@ func Test_Upgrade_DependencyUpgrade_ConstraintConflict(t *testing.T) {
 	mockContext := mocks.NewMockContext(t.Context())
 
 	// Pack A v2 depends on { B: ">=2.0.0", C: ">=2.0.0" }.
-	// B v2 depends on { C: "~1.0.0" } — mutually unsatisfiable with A's
-	// constraint on C. Iteration upgrades B first, B's cascade pins C to
-	// 1.x to satisfy its own constraint, then A's cascade reaches C: the
-	// installed C now violates A's >=2.0.0 and C is already in the visited
-	// set. The cascade must surface this as a Failed entry rather than
-	// silently leaving C at a version A does not allow.
+	// B v2 pins C to 1.x, which conflicts with A v2's >=2.0.0 constraint on C.
 	registry := Registry{
 		Extensions: []*ExtensionMetadata{
 			{

--- a/cli/azd/pkg/extensions/manager_test.go
+++ b/cli/azd/pkg/extensions/manager_test.go
@@ -1947,8 +1947,9 @@ func Test_Upgrade_DependencyUpgrade_RefusesToDowngradeOutsideConstraint(t *testi
 	require.Equal(t, "test.child", depUpgrades[0].ExtensionId)
 	require.Equal(t, UpgradeStatusSkipped, depUpgrades[0].Status)
 	require.Equal(t, "2.0.0", depUpgrades[0].FromVersion)
+	require.Contains(t, depUpgrades[0].SkipReason, "current 2.0.0")
 	require.Contains(t, depUpgrades[0].SkipReason, "outside")
-	require.Contains(t, depUpgrades[0].SkipReason, "not downgrading")
+	require.Contains(t, depUpgrades[0].Suggestion, "azd ext install test.child --version 1.0.0")
 
 	// Installed version should still be 2.0.0 — no downgrade happened.
 	installed, err := manager.GetInstalled(FilterOptions{Id: "test.child"})
@@ -2242,7 +2243,7 @@ func Test_Upgrade_DependencyUpgrade_DisabledByOpts(t *testing.T) {
 	require.Equal(t, "test.child", depUpgrades[0].ExtensionId)
 	require.Equal(t, UpgradeStatusSkipped, depUpgrades[0].Status)
 	require.Equal(t, "1.0.0", depUpgrades[0].FromVersion)
-	require.Contains(t, depUpgrades[0].SkipReason, "automatic dependency upgrade disabled")
+	require.Contains(t, depUpgrades[0].SkipReason, "dependency upgrades disabled")
 
 	child, err := manager.GetInstalled(FilterOptions{Id: "test.child"})
 	require.NoError(t, err)

--- a/cli/azd/pkg/extensions/manager_test.go
+++ b/cli/azd/pkg/extensions/manager_test.go
@@ -1540,10 +1540,11 @@ func Test_CopyFromLocalPath_PathTraversal_Blocked(t *testing.T) {
 	}
 }
 
-// Test_Upgrade_DependencyUpgrade verifies the dependency-upgrade decision matrix described in
-// the issue: parent upgrades trigger child upgrades only when the
-// declared dependency constraint is no longer satisfied by the installed
-// child version, and respect the UpgradeDependencies=false opt-out.
+// Test_Upgrade_DependencyUpgrade verifies the dependency-upgrade decision
+// matrix: parent upgrades select the highest published version satisfying
+// each declared constraint (upgrade-to-best-match, same as npm/yarn), skip
+// dependencies already at that best version, and respect the
+// UpgradeDependencies=false opt-out.
 func Test_Upgrade_DependencyUpgrade_TightenedConstraint(t *testing.T) {
 	mockContext := mocks.NewMockContext(t.Context())
 

--- a/cli/azd/pkg/extensions/upgrade_result.go
+++ b/cli/azd/pkg/extensions/upgrade_result.go
@@ -57,6 +57,9 @@ type UpgradeResult struct {
 	Error error
 	// SkipReason describes why the extension was skipped (e.g., "already up to date").
 	SkipReason string
+	// Suggestion is an optional actionable hint shown alongside SkipReason or Error
+	// in interactive output. Not serialized to JSON; may contain ANSI formatting.
+	Suggestion string
 	// DependencyUpgrades captures upgrade results for dependent extensions
 	// that were upgraded as a side effect of upgrading this extension. Empty
 	// for leaf extensions or when --no-dependency-upgrades is set.

--- a/cli/azd/pkg/extensions/upgrade_result.go
+++ b/cli/azd/pkg/extensions/upgrade_result.go
@@ -57,20 +57,25 @@ type UpgradeResult struct {
 	Error error
 	// SkipReason describes why the extension was skipped (e.g., "already up to date").
 	SkipReason string
+	// DependencyUpgrades captures upgrade results for dependent extensions
+	// that were upgraded as a side effect of upgrading this extension. Empty
+	// for leaf extensions or when --no-dependency-upgrades is set.
+	DependencyUpgrades []UpgradeResult
 }
 
 // upgradeResultJSON is the JSON serialization format for UpgradeResult.
 // Field names are part of the public --output json contract.
 // Changes to field names or removal of fields is a breaking change.
 type upgradeResultJSON struct {
-	Name        string `json:"name"`
-	Status      string `json:"status"`
-	FromVersion string `json:"fromVersion,omitempty"`
-	ToVersion   string `json:"toVersion,omitempty"`
-	FromSource  string `json:"fromSource,omitempty"`
-	ToSource    string `json:"toSource,omitempty"`
-	SkipReason  string `json:"skipReason,omitempty"`
-	Error       string `json:"error,omitempty"`
+	Name               string          `json:"name"`
+	Status             string          `json:"status"`
+	FromVersion        string          `json:"fromVersion,omitempty"`
+	ToVersion          string          `json:"toVersion,omitempty"`
+	FromSource         string          `json:"fromSource,omitempty"`
+	ToSource           string          `json:"toSource,omitempty"`
+	SkipReason         string          `json:"skipReason,omitempty"`
+	Error              string          `json:"error,omitempty"`
+	DependencyUpgrades []UpgradeResult `json:"dependencyUpgrades,omitempty"`
 }
 
 // MarshalJSON serializes UpgradeResult to JSON for --output json.
@@ -78,13 +83,14 @@ type upgradeResultJSON struct {
 // by design (via ErrorWithSuggestion and error_suggestions.yaml pipeline).
 func (r UpgradeResult) MarshalJSON() ([]byte, error) {
 	j := upgradeResultJSON{
-		Name:        r.ExtensionId,
-		Status:      r.Status.String(),
-		FromVersion: r.FromVersion,
-		ToVersion:   r.ToVersion,
-		FromSource:  r.FromSource,
-		ToSource:    r.ToSource,
-		SkipReason:  r.SkipReason,
+		Name:               r.ExtensionId,
+		Status:             r.Status.String(),
+		FromVersion:        r.FromVersion,
+		ToVersion:          r.ToVersion,
+		FromSource:         r.FromSource,
+		ToSource:           r.ToSource,
+		SkipReason:         r.SkipReason,
+		DependencyUpgrades: r.DependencyUpgrades,
 	}
 	if r.Error != nil {
 		j.Error = r.Error.Error()
@@ -93,15 +99,23 @@ func (r UpgradeResult) MarshalJSON() ([]byte, error) {
 }
 
 // UpgradeSummary holds aggregate counts from a batch upgrade operation.
+// DependencyUpgrades is the recursive count of dependency-upgrade entries
+// and is reported as a separate counter so existing consumers continue
+// to see Upgraded as the top-level upgrade count.
 type UpgradeSummary struct {
-	Total    int `json:"total"`
-	Upgraded int `json:"upgraded"`
-	Skipped  int `json:"skipped"`
-	Promoted int `json:"promoted"`
-	Failed   int `json:"failed"`
+	Total              int `json:"total"`
+	Upgraded           int `json:"upgraded"`
+	Skipped            int `json:"skipped"`
+	Promoted           int `json:"promoted"`
+	Failed             int `json:"failed"`
+	DependencyUpgrades int `json:"dependencyUpgrades,omitempty"`
 }
 
 // NewUpgradeSummary computes aggregate counts from a slice of UpgradeResult.
+// Top-level Upgraded/Skipped/Promoted/Failed counters reflect only the
+// top-level entries. DependencyUpgrades counts every dependency-upgrade
+// entry recursively, regardless of its status, so callers can surface how
+// much extra work the dependency-upgrade flow performed.
 func NewUpgradeSummary(results []UpgradeResult) UpgradeSummary {
 	s := UpgradeSummary{Total: len(results)}
 	for i := range results {
@@ -115,8 +129,22 @@ func NewUpgradeSummary(results []UpgradeResult) UpgradeSummary {
 		case UpgradeStatusFailed:
 			s.Failed++
 		}
+		s.DependencyUpgrades += CountDependencyUpgrades(results[i].DependencyUpgrades)
 	}
 	return s
+}
+
+// CountDependencyUpgrades returns the recursive count of every entry in the
+// dependency-upgrade tree rooted at the supplied slice. Useful for telemetry
+// attributes and summary counters that should reflect total dependency work,
+// not just direct children.
+func CountDependencyUpgrades(results []UpgradeResult) int {
+	n := 0
+	for i := range results {
+		n++
+		n += CountDependencyUpgrades(results[i].DependencyUpgrades)
+	}
+	return n
 }
 
 // UpgradeReport is the top-level JSON structure for batch upgrade output.

--- a/cli/azd/pkg/extensions/upgrade_result.go
+++ b/cli/azd/pkg/extensions/upgrade_result.go
@@ -99,16 +99,18 @@ func (r UpgradeResult) MarshalJSON() ([]byte, error) {
 }
 
 // UpgradeSummary holds aggregate counts from a batch upgrade operation.
-// DependencyUpgrades is the recursive count of dependency-upgrade entries
-// and is reported as a separate counter so existing consumers continue
-// to see Upgraded as the top-level upgrade count.
+// DependencyUpgrades is the total recursive count of dependency-upgrade
+// entries regardless of status. DependencyUpgradesByStatus breaks that
+// total down per UpgradeStatus so callers (UI summary, telemetry) can
+// distinguish actually upgraded dependencies from skipped/failed ones.
 type UpgradeSummary struct {
-	Total              int `json:"total"`
-	Upgraded           int `json:"upgraded"`
-	Skipped            int `json:"skipped"`
-	Promoted           int `json:"promoted"`
-	Failed             int `json:"failed"`
-	DependencyUpgrades int `json:"dependencyUpgrades,omitempty"`
+	Total                      int                   `json:"total"`
+	Upgraded                   int                   `json:"upgraded"`
+	Skipped                    int                   `json:"skipped"`
+	Promoted                   int                   `json:"promoted"`
+	Failed                     int                   `json:"failed"`
+	DependencyUpgrades         int                   `json:"dependencyUpgrades,omitempty"`
+	DependencyUpgradesByStatus map[UpgradeStatus]int `json:"-"`
 }
 
 // NewUpgradeSummary computes aggregate counts from a slice of UpgradeResult.
@@ -117,7 +119,10 @@ type UpgradeSummary struct {
 // entry recursively, regardless of its status, so callers can surface how
 // much extra work the dependency-upgrade flow performed.
 func NewUpgradeSummary(results []UpgradeResult) UpgradeSummary {
-	s := UpgradeSummary{Total: len(results)}
+	s := UpgradeSummary{
+		Total:                      len(results),
+		DependencyUpgradesByStatus: map[UpgradeStatus]int{},
+	}
 	for i := range results {
 		switch results[i].Status {
 		case UpgradeStatusUpgraded:
@@ -130,8 +135,19 @@ func NewUpgradeSummary(results []UpgradeResult) UpgradeSummary {
 			s.Failed++
 		}
 		s.DependencyUpgrades += CountDependencyUpgrades(results[i].DependencyUpgrades)
+		countDependencyUpgradesByStatus(results[i].DependencyUpgrades, s.DependencyUpgradesByStatus)
 	}
 	return s
+}
+
+// countDependencyUpgradesByStatus accumulates per-status counts of every
+// dependency-upgrade entry in the tree (recursive). The map is mutated in
+// place so callers can share a single accumulator across a batch of results.
+func countDependencyUpgradesByStatus(results []UpgradeResult, counts map[UpgradeStatus]int) {
+	for i := range results {
+		counts[results[i].Status]++
+		countDependencyUpgradesByStatus(results[i].DependencyUpgrades, counts)
+	}
 }
 
 // CountDependencyUpgrades returns the recursive count of every entry in the

--- a/cli/azd/pkg/extensions/upgrade_result.go
+++ b/cli/azd/pkg/extensions/upgrade_result.go
@@ -99,10 +99,7 @@ func (r UpgradeResult) MarshalJSON() ([]byte, error) {
 }
 
 // UpgradeSummary holds aggregate counts from a batch upgrade operation.
-// DependencyUpgrades is the total recursive count of dependency-upgrade
-// entries regardless of status. DependencyUpgradesByStatus breaks that
-// total down per UpgradeStatus so callers (UI summary, telemetry) can
-// distinguish actually upgraded dependencies from skipped/failed ones.
+// DependencyUpgradesByStatus is for internal UI and telemetry counters.
 type UpgradeSummary struct {
 	Total                      int                   `json:"total"`
 	Upgraded                   int                   `json:"upgraded"`
@@ -114,10 +111,7 @@ type UpgradeSummary struct {
 }
 
 // NewUpgradeSummary computes aggregate counts from a slice of UpgradeResult.
-// Top-level Upgraded/Skipped/Promoted/Failed counters reflect only the
-// top-level entries. DependencyUpgrades counts every dependency-upgrade
-// entry recursively, regardless of its status, so callers can surface how
-// much extra work the dependency-upgrade flow performed.
+// Top-level status counters exclude dependency upgrades.
 func NewUpgradeSummary(results []UpgradeResult) UpgradeSummary {
 	s := UpgradeSummary{
 		Total:                      len(results),
@@ -140,9 +134,7 @@ func NewUpgradeSummary(results []UpgradeResult) UpgradeSummary {
 	return s
 }
 
-// countDependencyUpgradesByStatus accumulates per-status counts of every
-// dependency-upgrade entry in the tree (recursive). The map is mutated in
-// place so callers can share a single accumulator across a batch of results.
+// countDependencyUpgradesByStatus accumulates recursive dependency counts by status.
 func countDependencyUpgradesByStatus(results []UpgradeResult, counts map[UpgradeStatus]int) {
 	for i := range results {
 		counts[results[i].Status]++
@@ -150,10 +142,7 @@ func countDependencyUpgradesByStatus(results []UpgradeResult, counts map[Upgrade
 	}
 }
 
-// CountDependencyUpgrades returns the recursive count of every entry in the
-// dependency-upgrade tree rooted at the supplied slice. Useful for telemetry
-// attributes and summary counters that should reflect total dependency work,
-// not just direct children.
+// CountDependencyUpgrades returns the recursive count of dependency upgrade entries.
 func CountDependencyUpgrades(results []UpgradeResult) int {
 	n := 0
 	for i := range results {

--- a/cli/azd/pkg/extensions/upgrade_result_test.go
+++ b/cli/azd/pkg/extensions/upgrade_result_test.go
@@ -135,6 +135,57 @@ func TestUpgradeResult_MarshalJSON(t *testing.T) {
 		assert.Equal(t, "dev", parsed["fromSource"])
 		assert.Equal(t, "azd", parsed["toSource"])
 	})
+
+	t.Run("dependencyUpgrades_field_included", func(t *testing.T) {
+		t.Parallel()
+		child := UpgradeResult{
+			ExtensionId: "child.ext",
+			Status:      UpgradeStatusUpgraded,
+			FromVersion: "1.0.0",
+			ToVersion:   "2.0.0",
+		}
+		r := UpgradeResult{
+			ExtensionId:        "parent.pack",
+			Status:             UpgradeStatusUpgraded,
+			FromVersion:        "1.0.0",
+			ToVersion:          "2.0.0",
+			DependencyUpgrades: []UpgradeResult{child},
+		}
+
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(data, &parsed))
+
+		entries, ok := parsed["dependencyUpgrades"].([]any)
+		require.True(t, ok, "dependencyUpgrades field must be a JSON array")
+		require.Len(t, entries, 1)
+
+		childParsed, ok := entries[0].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "child.ext", childParsed["name"])
+		assert.Equal(t, "upgraded", childParsed["status"])
+		assert.Equal(t, "1.0.0", childParsed["fromVersion"])
+		assert.Equal(t, "2.0.0", childParsed["toVersion"])
+	})
+
+	t.Run("dependencyUpgrades_omitempty_when_nil", func(t *testing.T) {
+		t.Parallel()
+		r := UpgradeResult{
+			ExtensionId: "leaf.ext",
+			Status:      UpgradeStatusUpgraded,
+		}
+
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(data, &parsed))
+
+		_, present := parsed["dependencyUpgrades"]
+		assert.False(t, present, "dependencyUpgrades field must be omitted when empty")
+	})
 }
 
 func TestNewUpgradeSummary(t *testing.T) {
@@ -203,6 +254,26 @@ func TestNewUpgradeSummary(t *testing.T) {
 		assert.Equal(t, 2, s.Total)
 		assert.Equal(t, 2, s.Skipped)
 		assert.Equal(t, 0, s.Failed)
+	})
+
+	t.Run("dependencyUpgrades_counted_recursively", func(t *testing.T) {
+		t.Parallel()
+		grandchild := UpgradeResult{Status: UpgradeStatusUpgraded}
+		child := UpgradeResult{
+			Status:             UpgradeStatusUpgraded,
+			DependencyUpgrades: []UpgradeResult{grandchild},
+		}
+		results := []UpgradeResult{
+			{
+				Status:             UpgradeStatusUpgraded,
+				DependencyUpgrades: []UpgradeResult{child},
+			},
+			{Status: UpgradeStatusUpgraded},
+		}
+		s := NewUpgradeSummary(results)
+		assert.Equal(t, 2, s.Total)
+		assert.Equal(t, 2, s.Upgraded)
+		assert.Equal(t, 2, s.DependencyUpgrades, "dependency-upgrade count must include grandchildren")
 	})
 }
 


### PR DESCRIPTION
Fixes #8252
Fixes #8254
Fixes #8257

This PR closes the known gaps that prevent extension packs like `azure.ai.foundry` from working end-to-end. It also lets `azd extension upgrade` keep an extension's dependencies in sync, adds user-facing pack documentation, and tightens the install/upgrade output.

## What changed

**Extension pack manifests validate.** The schema no longer requires `capabilities` at the top level. A manifest can declare `capabilities`, `dependencies`, or both — so a pack that just bundles other extensions is now a valid manifest.

**Semver version constraints work (#8254).** Manifest `dependencies` now properly support semver ranges (e.g. `">=0.1.0"`, `"^0.1"`, `"~0.1.0-preview"`) and azd will resolve them to the highest published version that satisfies the range. Resolution also skips dependency versions that declare a `requiredAzdVersion` incompatible with the running azd, so packs never pull in a dependency that won't run on the user's CLI.

**`--version` is exact for users.** `azd extension install --version` and `azd extension upgrade --version` now require an exact version (or `latest`); constraint operators like `>=`, `^`, `~`, `*`, `||`, or wildcards are rejected with a clear error pointing users at manifest dependencies for ranges. Bare identifiers like `nightly` and `dev` are still accepted.

**Install cycles can no longer hang.** A registry that declares a true install-time dependency cycle (`A → B → A`) used to recurse forever; install now detects the cycle and returns a clear error.

**`azd extension upgrade` upgrades dependencies (#8257).** Upgrading an extension (or pack) now also reconciles its declared dependencies to the highest published version that satisfies the parent's constraint and is compatible with the running azd. This matches the behavior users expect from package managers like npm/yarn.

Reconciliation runs even when the parent itself is already current, so an unchanged pack can still move its dependencies forward when new matching versions are published:

<img width="709" height="136" alt="image" src="https://github.com/user-attachments/assets/9ba1248a-75a3-4dd0-8658-83edbfe6902b" />

The new `--no-dependency-upgrades` flag opts out and lists each outdated dependency as `Skipped` so users can see what's now out of sync.

**Install / upgrade output.** Dependencies are rendered under the parent step using the same `(✓) Done` / `(-) Skipped` pattern, with `Upgraded` / `Downgraded` / `Updated` labels picked based on the actual version movement. Empty `Usage:` and `Examples:` headers are no longer printed (the common case for packs), so the output isn't cluttered with blank rows.

**JSON output.** `azd extension upgrade --output json` now exposes a `dependencyUpgrades` array on each upgrade record and a recursive `dependencyUpgrades` counter on the summary. The pre-existing `upgraded` counter still reports parent extensions only, so existing consumers see the same semantics.

**Telemetry.** Dependency upgrade spans tag the parent extension id, and the parent upgrade span records the recursive dependency upgrade count, so dashboards can attribute the extra work to the triggering upgrade.

**Extension pack docs** The extension framework docs now describe extension packs: when to use them, what a pack manifest looks like, how install and upgrade behave (including reconciliation when the pack is unchanged), exact-`--version` semantics, and constraint guidance for preview versions.

## Validation

Tested with meta package changes from https://github.com/Azure/azure-dev/pull/8247:

<img width="602" height="135" alt="image" src="https://github.com/user-attachments/assets/b54bff0d-7e9b-45ee-872b-77457dee8efa" />

