### PR TITLE
fix: correct end-of-init message logic for existing project + existing deployment

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -81,6 +81,7 @@ type InitAction struct {
 	models        *modelSelector
 
 	deploymentDetails   []project.Deployment
+	needsProvision      bool
 	containerSettings   *project.ContainerSettings
 	isCodeDeploy        bool // true when user selects code deploy mode; skips ACR config
 	httpClient          *http.Client
@@ -2089,7 +2090,7 @@ func (a *InitAction) addToProject(ctx context.Context, targetDir string, agentMa
 	if projectID, _ := a.azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
 		EnvName: a.environment.Name,
 		Key:     "AZURE_AI_PROJECT_ID",
-	}); projectID != nil && projectID.Value != "" && len(a.deploymentDetails) == 0 {
+	}); projectID != nil && projectID.Value != "" && !a.needsProvision {
 		fmt.Printf("To deploy your agent, use %s.\n",
 			color.HiBlueString("azd deploy %s", a.serviceNameOverride))
 	} else {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -2087,10 +2087,7 @@ func (a *InitAction) addToProject(ctx context.Context, targetDir string, agentMa
 		"\nAdded your agent as a service entry named '%s' under the file azure.yaml.\n",
 		a.serviceNameOverride,
 	)
-	if projectID, _ := a.azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
-		EnvName: a.environment.Name,
-		Key:     "AZURE_AI_PROJECT_ID",
-	}); projectID != nil && projectID.Value != "" && !a.needsProvision {
+	if a.initCompletionNeedsDeploy(ctx) {
 		fmt.Printf("To deploy your agent, use %s.\n",
 			color.HiBlueString("azd deploy %s", a.serviceNameOverride))
 	} else {
@@ -2100,6 +2097,21 @@ func (a *InitAction) addToProject(ctx context.Context, targetDir string, agentMa
 		)
 	}
 	return nil
+}
+
+// initCompletionNeedsDeploy returns true when the user only needs to run
+// "azd deploy <service>" (i.e. infrastructure is already provisioned and no
+// new model deployments were requested). When false, the user should run
+// "azd up" to provision and deploy.
+func (a *InitAction) initCompletionNeedsDeploy(ctx context.Context) bool {
+	if a.needsProvision {
+		return false
+	}
+	projectID, _ := a.azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+		EnvName: a.environment.Name,
+		Key:     "AZURE_AI_PROJECT_ID",
+	})
+	return projectID != nil && projectID.Value != ""
 }
 
 // resolveCollisions checks whether the auto-computed target directory or

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
@@ -291,6 +291,9 @@ func (a *InitAction) getModelDeploymentDetails(ctx context.Context, model agent_
 		return nil, fmt.Errorf("failed to get model details: %w", err)
 	}
 
+	// This path creates a new model deployment that needs provisioning
+	a.needsProvision = true
+
 	message := fmt.Sprintf("Enter model deployment name for model '%s' (defaults to model name)", modelDetails.ModelName)
 
 	modelDeploymentInput, err := a.azdClient.Prompt().Prompt(ctx, &azdext.PromptRequest{

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -2282,3 +2282,62 @@ func TestDownloadAgentYaml_NoPromptManifestInSrcWithoutForce(t *testing.T) {
 		t.Errorf("suggestion should mention --force, got: %s", localErr.Suggestion)
 	}
 }
+
+func TestInitCompletionNeedsDeploy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		needsProvision bool
+		projectID      string // empty means AZURE_AI_PROJECT_ID is not set
+		want           bool
+	}{
+		{
+			name:           "existing project, no new deployments → deploy only",
+			needsProvision: false,
+			projectID:      "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/acct/projects/proj",
+			want:           true,
+		},
+		{
+			name:           "existing project, new model deployed → needs provision",
+			needsProvision: true,
+			projectID:      "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/acct/projects/proj",
+			want:           false,
+		},
+		{
+			name:           "no project set → needs provision",
+			needsProvision: false,
+			projectID:      "",
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			envName := "test-env"
+			envServer := &testEnvironmentServiceServer{
+				values: map[string]map[string]string{},
+			}
+			if tt.projectID != "" {
+				envServer.values[envName] = map[string]string{
+					"AZURE_AI_PROJECT_ID": tt.projectID,
+				}
+			}
+
+			azdClient := newTestAzdClient(t, envServer, &testWorkflowServiceServer{})
+
+			action := &InitAction{
+				azdClient:      azdClient,
+				needsProvision: tt.needsProvision,
+				environment:    &azdext.Environment{Name: envName},
+			}
+
+			got := action.initCompletionNeedsDeploy(t.Context())
+			if got != tt.want {
+				t.Errorf("initCompletionNeedsDeploy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the end-of-init message incorrectly recommending `azd up` when the user selected an existing project with an existing deployment (no provisioning needed).

**Root cause**: `len(a.deploymentDetails) == 0` was used to detect whether new provisioning is needed, but existing deployments also populate this slice.

**Fix**: Replace with an explicit `needsProvision` boolean set only when a new model deployment is created (deploy-from-catalog path). This aligns `init.go` with the pattern already used in `init_from_code.go`.

### Truth table

| Project | Model config | Needs provision? | Message |
|---|---|---|---|
| Existing | Use existing deployment | No | `azd deploy` |
| Existing | Deploy from catalog | Yes | `azd up` |
| Existing | Skip | No | `azd deploy` |
| New | Deploy from catalog | Yes | `azd up` |
| New | Skip | Yes | `azd up` |

Follow-up to #8292 — identified by @wbreza in re-review.