### PR TITLE
doc: design spec for azd ai agent init reuse of existing agent.yaml

### DIFF
--- a/cli/azd/docs/design/azure-ai-agent-init-reuse-agent-yaml.md
+++ b/cli/azd/docs/design/azure-ai-agent-init-reuse-agent-yaml.md
@@ -10,7 +10,7 @@ The from-code path of `azd ai agent init` today treats a pre-existing `agent.yam
 
 This change adds **definition reuse**: when the user has a bare `agent.yaml` (a YAML file without a top-level `template:` wrapper) in the target directory and runs `azd ai agent init`, the command treats that file as the source of truth, skips the from-code prompts, and writes only the `azure.yaml` service entry, matching the issue's wording: *"if it's a definition, then we have less to ask and just setup azure.yaml."*
 
-Manifest reuse (the other half of the issue) is already handled by upstream `detectLocalManifest` in `init.go`, which intercepts valid local manifests (regardless of filename) and routes them through `runInitFromManifest`. This spec does **not** touch that path; it only fills the bare-definition gap.
+Manifest reuse (the other half of the issue) is already handled by upstream `detectLocalManifest` in `init.go`, which scans the four candidate filenames (`agent.manifest.yaml`, `agent.manifest.yml`, `agent.yaml`, `agent.yml`) and accepts whichever one parses as a valid manifest. This spec does **not** touch that path; it only fills the bare-definition gap.
 
 ## 2. Scope and Non-Goals
 
@@ -37,11 +37,11 @@ All paths inside `cli/azd/extensions/azure.ai.agents/internal/`.
 | --- | --- | --- |
 | Top-level dispatch | `cmd/init.go` `RunE` | **Modified**: a new detection+reuse block is inserted alongside the existing `detectLocalManifest` block. Triggers before the init-mode prompt, so users with a local `agent.yaml` skip both the mode prompt and the from-code scaffolding sequence. |
 | Existing in-action overwrite guard | `cmd/init_from_code.go` (`InitFromCodeAction.Run`) | **Modified**: the "agent.yaml already exists" guard at the top of the action is removed. By the time `InitFromCodeAction.Run` is reached, the RunE-level dispatch has already handled (or declined) the reuse. |
-| Upstream manifest detection | `cmd/init.go` (`detectLocalManifest`) | **Unchanged**. |
+| Upstream manifest detection | `cmd/init_from_templates_helpers.go` (`detectLocalManifest`, called from `cmd/init.go` `RunE`) | **Unchanged**. |
 | Manifest pipeline | `cmd/init.go` (`runInitFromManifest`) | **Unchanged**. |
 | Definition reuse helpers | `cmd/init_from_code_reuse.go` (new file) | `findExistingAgentYaml`, `runReuseDefinition`, `loadAgentDefinitionFile`. |
 | `azure.yaml` writer | `cmd/init_from_code.go` (`addToProject`) | **Reused as-is** by `runReuseDefinition`. |
-| Project / environment bootstrap | `cmd/init.go` (`ensureProject`, `getExistingEnvironment`, `createNewEnvironment`) | **Reused as-is**: the reuse path runs the same setup `runInitFromManifest` does. |
+| Project / environment bootstrap | `cmd/init.go` (`ensureProject`, `getExistingEnvironment`); `cmd/init_foundry_resources_helpers.go` (`createNewEnvironment`) | **Reused as-is**: the reuse path runs the same setup `runInitFromManifest` does. |
 | Definition types | `pkg/agents/agent_yaml/yaml.go` (`ContainerAgent`, `CodeConfiguration`) | Unchanged. |
 | Name validation | `pkg/agents/agent_yaml/parse.go` (`ValidateAgentName`) | Reused. |
 
@@ -54,7 +54,8 @@ The feature is primarily wiring. No new exported APIs.
 After auth and project resolution, when no `-m` was passed:
 
 1. `detectLocalManifest(srcDir)`: existing helper, runs first. If it returns a valid manifest path, `flags.manifestPointer` is set (with an optional confirmation prompt in interactive mode) and the manifest pipeline runs as today.
-2. **If `flags.manifestPointer` is still empty**, the new step runs: `findExistingAgentYaml(srcDir)` does a shallow `os.Stat` against the four candidate filenames. Any hit at this point is guaranteed to either be a bare definition (rejected by `detectLocalManifest` for lacking `template:`) or a malformed manifest (rejected for failing manifest validation).
+2. **If `detectLocalManifest` returned no valid manifest at all** (not merely "user declined the prompt"), the new step runs: `findExistingAgentYaml(srcDir)` does a shallow `os.Stat` against the four candidate filenames. Any hit at this point is either a bare definition (rejected by `detectLocalManifest` for lacking `template:`) or a malformed manifest (rejected for failing manifest validation).
+   - **Edge case**: when `detectLocalManifest` found a *valid* manifest but the user declined the reuse prompt, the reuse scan is skipped. Otherwise we would mis-classify the declined manifest as an "invalid definition" and block init with `CodeInvalidAgentManifest`, contradicting the user's choice to start fresh. The implementation tracks this with a `manifestDetectedButDeclined` flag set in the `detectLocalManifest` branch.
 3. On a hit, a confirmation prompt ("An existing agent definition was found at ... Use it?") is shown; in `--no-prompt` mode the answer auto-defaults to yes.
 4. On confirmation, `runReuseDefinition(ctx, flags, azdClient, httpClient, srcDir, existingPath)` is called and the command returns. The init-mode prompt and the from-code scaffolding sequence are both skipped.
 
@@ -64,7 +65,7 @@ The new free function lives in `init_from_code_reuse.go`. It performs:
 
 1. `loadAgentDefinitionFile(path)`: reads the file, rejects anything with a top-level `template:` (manifest-shaped but invalid, produces a targeted error), unmarshals to `agent_yaml.ContainerAgent` so `CodeConfiguration` is preserved, and validates the name via `agent_yaml.ValidateAgentName`.
 2. Prints `Detected existing agent definition: <relative-path> (name: <def.Name>).`
-3. Bootstraps project + env using the same helpers `runInitFromManifest` uses: `ensureProject`, then `getExistingEnvironment` / `createNewEnvironment` (the env is named `<def.Name>-dev` when none was supplied via `-e`).
+3. Bootstraps project + env using the same helpers `runInitFromManifest` uses: `ensureProject`, then `getExistingEnvironment` / `createNewEnvironment` (the env is named `sanitizeAgentName(<def.Name> + "-dev")` when none was supplied via `-e`, matching the existing from-code path).
 4. Builds a thin `*InitFromCodeAction` with the bootstrapped pieces and calls `action.addToProject(ctx, srcDir, def.Name, def.CodeConfiguration != nil)`, the existing from-code service-entry writer.
 5. Prints `Reusing existing agent.yaml (name: <def.Name>).`
 6. Calls `validatePostInit(srcDir, def.CodeConfiguration)` for the same advisory warnings the scaffold path emits.
@@ -119,7 +120,7 @@ Per the extension's error-handling rule, the structured error is created at the 
 
 ## 7. Test Plan
 
-- **Pre-existing unit tests** in `cli/azd/extensions/azure.ai.agents/internal/cmd/*_test.go` continue to pass. The no-yaml regression is covered by today's `init_from_code_test.go`.
+- **Pre-existing unit tests** in `cli/azd/extensions/azure.ai.agents/internal/cmd/*_test.go` continue to pass. They cover helpers (`sanitizeAgentName`, `writeDefinitionToSrcDir`, etc.) that this change does not modify; we are not adding new unit tests because the new code paths are exercised end-to-end below.
 - **Manual e2e** against the locally-built `azd` + extension. Three scenarios:
   - **Definition reuse**: write a bare `agent.yaml`, run `azd ai agent init --no-prompt`; assert no init-mode prompt, `Detected existing agent definition: ...` printed, `azure.yaml` contains the agent's `name:`, on-disk `agent.yaml` byte-identical to input.
   - **Manifest reuse**: write `agent.manifest.yaml`, run with `AZURE_SUBSCRIPTION_ID` and `AZURE_AI_PROJECT_ID` set; assert the existing upstream manifest path runs unchanged and `azure.yaml` ends up with the manifest's `template.name`.

--- a/cli/azd/docs/design/azure-ai-agent-init-reuse-agent-yaml.md
+++ b/cli/azd/docs/design/azure-ai-agent-init-reuse-agent-yaml.md
@@ -1,0 +1,172 @@
+<!-- cspell:ignore foundry exterrors -->
+
+# Design Spec: `azd ai agent init` Reuse of Existing `agent.yaml`
+
+## 1. Summary
+
+`azd ai agent init` today has two main paths into the existing `azure.ai.agents` extension:
+
+- `-m <manifest>` — pull a manifest pointer and scaffold from it (clones a remote repo when the pointer is remote).
+- From existing code — assume the target directory is a blank slate, prompt for model / instructions / entry point, then synthesize an `agent.yaml` and wire `azure.yaml`.
+
+When a user already has an `agent.yaml` (or `agent.manifest.yaml`) sitting in the target directory and runs `azd ai agent init`, the file is treated as a write conflict to overwrite rather than as a source of truth to reuse. The from-code path immediately prompts to overwrite the file (`init_from_code.go:84-104`) and then runs the full interactive scaffold regardless of its contents.
+
+This spec adds detection and reuse so the command short-circuits when an `agent.yaml` is already present:
+
+- If the file is an agent **manifest** (has a top-level `template:`), route through the existing `runInitFromManifest` flow using the local file directly — no clone.
+- If the file is an agent **definition** (no `template:`), skip the model/instruction prompts and only wire `azure.yaml`.
+
+Issue: [Azure/azure-dev#7268](https://github.com/Azure/azure-dev/issues/7268).
+
+## 2. Scope and Non-Goals
+
+In scope:
+
+- Detection of `agent.manifest.yaml` / `agent.manifest.yml` / `agent.yaml` / `agent.yml` in the resolved `srcDir` at the start of the from-code action.
+- Reuse via the existing manifest pipeline when classified as a manifest.
+- Reuse via the existing `addToProject` path when classified as a definition.
+- Preserving today's overwrite confirmation when the user explicitly intends to discard the file (covered by the same prompt that already exists today, with a new "reuse" option as the default).
+- Behavior under `--no-prompt`.
+
+Out of scope:
+
+- Schema migration of older `agent.yaml` files to the current shape.
+- Editing or rewriting the existing file's contents.
+- Walking parent directories or sibling dirs to discover `agent.yaml` (only the resolved `srcDir` is scanned).
+- Changes to the `-m` remote-clone behavior.
+- Changes to the scaffolded-template branches (`init.go:451-484`) — those already call `findAgentManifest` post-scaffold and are unaffected.
+
+## 3. Code Touch Points
+
+All paths are inside `cli/azd/extensions/azure.ai.agents/internal/`.
+
+| Concern | Location | Disposition |
+| --- | --- | --- |
+| From-code action entry | `cmd/init_from_code.go:49` (`InitFromCodeAction.Run`) | **Modified** — new detect-and-reuse step inserted at the top, replacing the current "overwrite?" branch at `:84-104`. |
+| Existing-file overwrite prompt | `cmd/init_from_code.go:84-104` | **Removed** — superseded by the new branching logic. |
+| Manifest-vs-definition detection | `cmd/init.go:1057` (`findAgentManifest`), `cmd/init.go:1084` (`looksLikeManifest`) | **Reused as-is**, made package-visible to `init_from_code.go` (they are already in the same package). |
+| Manifest path runner | `cmd/init.go:212` (`runInitFromManifest`) | **Reused as-is** — already handles a local file path via `downloadAgentYaml` at `init.go:1213-1215`. |
+| Initial flags struct | `cmd/init.go:49` (`initFlags`) | **Reused as-is** — `manifestPointer` is set in-process for the reuse path. |
+| Definition load + validate | `pkg/agents/agent_yaml/parse.go:51` (`ExtractAgentDefinition`), `parse.go:361` (`ValidateAgentDefinition`), `parse.go:419` (`ValidateAgentName`) | **Reused as-is**. |
+| `azure.yaml` writer (from-code) | `cmd/init_from_code.go:822` (`addToProject`) | **Reused as-is** for the definition path. |
+| `azure.yaml` writer (manifest) | `cmd/init.go:1495` (`InitAction.addToProject`) | **Reused as-is** for the manifest path. |
+| Definition types | `pkg/agents/agent_yaml/yaml.go:142` (`AgentDefinition`), `yaml.go:211` (`AgentManifest`) | Unchanged. |
+
+The feature is primarily wiring — no new exported APIs.
+
+## 4. Behavior
+
+### 4.1 Detection
+
+When `InitFromCodeAction.Run` starts, immediately after `srcDir` is resolved (currently lines `:76-79`):
+
+1. Call `findAgentManifest(srcDir)` (already iterates `agent.manifest.yaml`, `agent.manifest.yml`, `agent.yaml`, `agent.yml` in that order).
+2. If nothing is found → continue with today's from-code scaffold flow (no behavior change).
+3. If a file is found → call `looksLikeManifest(path)` to classify and dispatch.
+
+The `os.Stat(filepath.Join(srcDir, "agent.yaml"))` block at `init_from_code.go:84-104` is replaced by this detection step — the same on-disk file that today triggers the "Overwrite?" prompt is now classified and reused.
+
+### 4.2 Manifest classification → reuse `runInitFromManifest`
+
+When `looksLikeManifest` returns `true`:
+
+1. Inform the user: `Detected local agent manifest: <relative-path>. Using local manifest (no clone required).`
+2. Set `a.flags.manifestPointer = <absolute-path-to-file>`.
+3. Delegate to `runInitFromManifest(ctx, a.flags, a.azdClient, a.httpClient)`.
+
+`downloadAgentYaml` (called inside `runInitFromManifest`) already detects a local filesystem path at `init.go:1213-1215` and reads the bytes directly instead of issuing an HTTP request, so the clone step is automatically skipped. No new branch is needed inside `runInitFromManifest`.
+
+Resources, toolboxes, and connections declared in the manifest are projected into `azure.yaml` by the existing `InitAction.addToProject` (`init.go:1495`).
+
+### 4.3 Definition classification → reuse `addToProject` only
+
+When `looksLikeManifest` returns `false`:
+
+1. Read the file bytes.
+2. Unmarshal into `agent_yaml.AgentDefinition` (the same shape parsed by `ExtractAgentDefinition` on the bare-definition fallback branch).
+3. Validate via `agent_yaml.ValidateAgentDefinition` and `agent_yaml.ValidateAgentName`.
+4. Inform the user: `Detected existing agent definition: <relative-path> (name: <def.Name>).`
+5. Skip the entire `createDefinitionFromLocalAgent` prompt sequence (model / instructions / entry-point detection that today runs at `init_from_code.go:108`).
+6. Call `a.addToProject(ctx, srcDir, def.Name, def.CodeConfiguration != nil)` — the same call the from-code path makes today at `init_from_code.go:123`.
+7. Run `validatePostInit(srcDir, def.CodeConfiguration)` for the same advisory warnings the from-code path emits today.
+
+The reuse path **does not rewrite** the existing `agent.yaml`. The "+ agent.yaml" green-add line printed at `init_from_code.go:128-131` is replaced with a single info line: `Reusing existing agent.yaml (name: <def.Name>).`
+
+### 4.4 Service-name collision in `azure.yaml`
+
+Handled by the existing collision logic inside `addToProject` (manifest path: `init.go:1830`; from-code path: `init_from_code.go:822` and downstream). No new behavior — if `def.Name` (definition path) or the manifest-derived name collides with an existing service entry in `azure.yaml`, the user is prompted today and is still prompted under this change.
+
+### 4.5 `--no-prompt`
+
+The new path is fully non-interactive — detection + classification + reuse require no prompts. Therefore:
+
+- `--no-prompt` + detected manifest → succeeds, runs `runInitFromManifest` with the local path. `runInitFromManifest` itself already honors `--no-prompt` (no new contract).
+- `--no-prompt` + detected definition → succeeds, runs `addToProject` and exits with the same "Next steps" message the from-code path prints today (`init_from_code.go:141-146`).
+- `--no-prompt` + invalid `agent.yaml` → returns the validation error as a structured `exterrors.Validation(CodeInvalidAgentManifest, ...)` (see § 6).
+
+The current "overwrite declined in no-prompt mode" branch at `init_from_code.go:85-87` is removed — there is no overwrite to decline anymore.
+
+## 5. Interactions with Existing Flags
+
+| Scenario | Behavior |
+| --- | --- |
+| `-m <pointer>` provided **and** local `agent.yaml` exists | `-m` wins. The from-code action does not run at all when `flags.manifestPointer != ""` (see the routing at `init.go:373-380`). No change to that routing. |
+| `--src <dir>` set to a directory that contains `agent.yaml` | Detection runs against that directory (same `srcDir` already used by the from-code flow). |
+| Positional arg resolved to a manifest pointer | Same as `-m` — does not enter the from-code action. |
+| Scaffolded-template branches (`init.go:451-484`) | Unchanged. Those branches already call `findAgentManifest` post-scaffold and run `runInitFromManifest`. |
+| `detectLocalManifest` at `init.go:340` | Unchanged. That helper runs **before** the user picks an init mode and is independent of the from-code action. |
+
+## 6. Errors
+
+No new error codes. The reuse path uses existing codes from `internal/exterrors/codes.go`:
+
+| Failure | Code |
+| --- | --- |
+| `agent.yaml` exists but parses as neither valid manifest nor valid definition | `exterrors.Validation(CodeInvalidAgentManifest, "<path>: <yaml error>", "Fix the file or remove it to start a fresh init.")` |
+| Manifest classification but downstream `LoadAndValidateAgentManifest` fails | Already handled inside `runInitFromManifest` — same code as today. |
+| Definition classification but `ValidateAgentDefinition` / `ValidateAgentName` fails | `exterrors.Validation(CodeInvalidAgentManifest, ..., "Fix the agent.yaml and retry.")` (the existing manifest-invalid code is reused for definition validation because the user-facing surface — "your agent.yaml is wrong" — is the same; the `Op` is unchanged). |
+
+Per the extension's error-handling rule, the structured error is created at the from-code action boundary (where category, code, and suggestion are known). Lower-level helpers (`findAgentManifest`, `looksLikeManifest`, the YAML unmarshal) return plain `fmt.Errorf` wraps.
+
+## 7. Test Plan
+
+Unit tests (table-driven, no network) added to `cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go`:
+
+- **Manifest detected** — `srcDir` contains an `agent.manifest.yaml` with a `template:` block. Asserts `runInitFromManifest` is invoked with `flags.manifestPointer` set to the absolute local path; no HTTP client calls observed (via a fake `httpClient`).
+- **Definition detected** — `srcDir` contains an `agent.yaml` without `template:`. Asserts `createDefinitionFromLocalAgent` is **not** called (today's prompt sequence is skipped), `addToProject` is called once with `agentName == def.Name`, the existing file on disk is byte-identical after the run.
+- **No agent yaml** — `srcDir` is empty. Asserts today's path still runs (i.e. `createDefinitionFromLocalAgent` is called) — regression guard.
+- **Invalid agent yaml** — `srcDir` contains a syntactically broken `agent.yaml`. Asserts the returned error has code `CodeInvalidAgentManifest` and a non-empty `Suggestion`.
+- **Filename precedence** — both `agent.manifest.yaml` and `agent.yaml` present in `srcDir`. Asserts the manifest file wins (matches existing `findAgentManifest` order); a debug log records which file was chosen.
+- **`--no-prompt` + definition** — no prompts issued (the fake prompt client errors if any call is made), action returns successfully.
+
+Snapshot regression (existing): `UPDATE_SNAPSHOTS=true go test ./cmd -run 'TestFigSpec|TestUsage'` — no `--help` changes expected because no new flags are added; this run is purely a verification step.
+
+End-to-end coverage is not in scope for this change — the from-code action has no functional E2E test today, and adding one solely for this branch would be a larger investment than the feature warrants.
+
+## 8. Impact on Existing Commands
+
+Only `azd ai agent init` changes. The change is additive on a path that today either prompts to overwrite the file or proceeds with redundant prompts that discard the user's existing work. No flag is added or removed. `--help` snapshots do not change.
+
+## 9. Decisions
+
+1. **The existing "Overwrite agent.yaml?" prompt at `init_from_code.go:84-104` is removed, not extended.** Reuse is the new default behavior whenever a parseable `agent.yaml` is present. An overwrite escape hatch via `--force` was considered and rejected: a user who wants to start over can delete the file (one command) rather than learn a flag. Re-running with `-m <pointer>` also bypasses the from-code action entirely.
+2. **No new error code.** `CodeInvalidAgentManifest` covers both shapes (manifest and definition) from the user's perspective — they edited `agent.yaml` and got the file wrong. Splitting the code would add telemetry noise without distinguishing actionable user remedies.
+3. **No recursion into subdirectories.** Discovery is limited to `srcDir`. A nested `agent.yaml` (e.g. `./src/agent.yaml` when `srcDir == "."`) is invisible to detection; the user must point `--src` at the right directory. Walking would conflict with how `findAgentManifest` is used elsewhere in the codebase and is out of scope.
+4. **Definition path does not re-write the file.** The existing on-disk `agent.yaml` is treated as authoritative. If `def.Name` happens to collide with an existing service entry in `azure.yaml`, the collision is resolved by renaming the service entry, not the file.
+
+## 10. Reference: Decision Tree
+
+```text
+azd ai agent init (no -m, no positional manifest)
+  └── resolve srcDir
+        └── findAgentManifest(srcDir)
+              ├── not found
+              │     └── existing from-code scaffold flow (unchanged)
+              ├── found, looksLikeManifest == true
+              │     └── flags.manifestPointer = <local path>
+              │           └── runInitFromManifest  (no clone; existing path)
+              └── found, looksLikeManifest == false
+                    └── ValidateAgentDefinition
+                          ├── invalid → exterrors.Validation(CodeInvalidAgentManifest, ...)
+                          └── valid   → addToProject(srcDir, def.Name, def.CodeConfiguration != nil)
+```

--- a/cli/azd/docs/design/azure-ai-agent-init-reuse-agent-yaml.md
+++ b/cli/azd/docs/design/azure-ai-agent-init-reuse-agent-yaml.md
@@ -2,119 +2,110 @@
 
 # Design Spec: `azd ai agent init` Reuse of Existing `agent.yaml`
 
+Issue: [Azure/azure-dev#7268](https://github.com/Azure/azure-dev/issues/7268).
+
 ## 1. Summary
 
-`azd ai agent init` today has two main paths into the existing `azure.ai.agents` extension:
+The from-code path of `azd ai agent init` today treats a pre-existing `agent.yaml` in the target directory as a write conflict: interactively it prompts the user to overwrite, and in `--no-prompt` mode it fails fast with `CodeInvalidAgentManifest: "agent.yaml already exists at ..."` (added in #8266).
 
-- `-m <manifest>` — pull a manifest pointer and scaffold from it (clones a remote repo when the pointer is remote).
-- From existing code — assume the target directory is a blank slate, prompt for model / instructions / entry point, then synthesize an `agent.yaml` and wire `azure.yaml`.
+This change adds **definition reuse**: when the user has a bare `agent.yaml` (a YAML file without a top-level `template:` wrapper) in the target directory and runs `azd ai agent init`, the command treats that file as the source of truth, skips the from-code prompts, and writes only the `azure.yaml` service entry, matching the issue's wording: *"if it's a definition, then we have less to ask and just setup azure.yaml."*
 
-When a user already has an `agent.yaml` (or `agent.manifest.yaml`) sitting in the target directory and runs `azd ai agent init`, the file is treated as a write conflict to overwrite rather than as a source of truth to reuse. The from-code path immediately prompts to overwrite the file (`init_from_code.go:84-104`) and then runs the full interactive scaffold regardless of its contents.
-
-This spec adds detection and reuse so the command short-circuits when an `agent.yaml` is already present:
-
-- If the file is an agent **manifest** (has a top-level `template:`), route through the existing `runInitFromManifest` flow using the local file directly — no clone.
-- If the file is an agent **definition** (no `template:`), skip the model/instruction prompts and only wire `azure.yaml`.
-
-Issue: [Azure/azure-dev#7268](https://github.com/Azure/azure-dev/issues/7268).
+Manifest reuse (the other half of the issue) is already handled by upstream `detectLocalManifest` in `init.go`, which intercepts valid local manifests (regardless of filename) and routes them through `runInitFromManifest`. This spec does **not** touch that path; it only fills the bare-definition gap.
 
 ## 2. Scope and Non-Goals
 
 In scope:
 
-- Detection of `agent.manifest.yaml` / `agent.manifest.yml` / `agent.yaml` / `agent.yml` in the resolved `srcDir` at the start of the from-code action.
-- Reuse via the existing manifest pipeline when classified as a manifest.
-- Reuse via the existing `addToProject` path when classified as a definition.
-- Preserving today's overwrite confirmation when the user explicitly intends to discard the file (covered by the same prompt that already exists today, with a new "reuse" option as the default).
-- Behavior under `--no-prompt`.
+- Detection of `agent.manifest.yaml` / `agent.manifest.yml` / `agent.yaml` / `agent.yml` in the resolved source directory at the top of `RunE`, *after* `detectLocalManifest` has had the first chance to claim the file.
+- A new reuse path that validates the file as a bare `AgentDefinition`, ensures an azd environment exists, and calls the existing from-code `addToProject` helper to write the `azure.yaml` service entry.
+- Structured error when the file is present but does not parse as a valid bare definition (covers malformed YAML and manifest-shaped files that failed upstream validation).
+- Confirmation prompt symmetric to `detectLocalManifest` ("An existing agent definition was found at ... Use it?") that auto-confirms under `--no-prompt`.
 
 Out of scope:
 
-- Schema migration of older `agent.yaml` files to the current shape.
-- Editing or rewriting the existing file's contents.
-- Walking parent directories or sibling dirs to discover `agent.yaml` (only the resolved `srcDir` is scanned).
-- Changes to the `-m` remote-clone behavior.
-- Changes to the scaffolded-template branches (`init.go:451-484`) — those already call `findAgentManifest` post-scaffold and are unaffected.
+- **Manifest reuse.** Already covered by upstream `detectLocalManifest`.
+- **Foundry project resolution.** The issue limits the definition path to "just setup azure.yaml". Users who need a Foundry project bound for `azd deploy` must either delete the definition and rerun init interactively, set `AZURE_AI_PROJECT_ID` in their azd environment by hand, or use the manifest pipeline instead. Project resolution for definitions is tracked as a follow-up.
+- **Model deployment selection** (same reason).
+- **Editing or rewriting the existing file.** The on-disk `agent.yaml` is authoritative.
+- Schema migration, recursion into subdirectories, changes to `-m` semantics, or changes to the scaffolded-template branches.
 
 ## 3. Code Touch Points
 
-All paths are inside `cli/azd/extensions/azure.ai.agents/internal/`.
+All paths inside `cli/azd/extensions/azure.ai.agents/internal/`.
 
 | Concern | Location | Disposition |
 | --- | --- | --- |
-| From-code action entry | `cmd/init_from_code.go:49` (`InitFromCodeAction.Run`) | **Modified** — new detect-and-reuse step inserted at the top, replacing the current "overwrite?" branch at `:84-104`. |
-| Existing-file overwrite prompt | `cmd/init_from_code.go:84-104` | **Removed** — superseded by the new branching logic. |
-| Manifest-vs-definition detection | `cmd/init.go:1057` (`findAgentManifest`), `cmd/init.go:1084` (`looksLikeManifest`) | **Reused as-is**, made package-visible to `init_from_code.go` (they are already in the same package). |
-| Manifest path runner | `cmd/init.go:212` (`runInitFromManifest`) | **Reused as-is** — already handles a local file path via `downloadAgentYaml` at `init.go:1213-1215`. |
-| Initial flags struct | `cmd/init.go:49` (`initFlags`) | **Reused as-is** — `manifestPointer` is set in-process for the reuse path. |
-| Definition load + validate | `pkg/agents/agent_yaml/parse.go:51` (`ExtractAgentDefinition`), `parse.go:361` (`ValidateAgentDefinition`), `parse.go:419` (`ValidateAgentName`) | **Reused as-is**. |
-| `azure.yaml` writer (from-code) | `cmd/init_from_code.go:822` (`addToProject`) | **Reused as-is** for the definition path. |
-| `azure.yaml` writer (manifest) | `cmd/init.go:1495` (`InitAction.addToProject`) | **Reused as-is** for the manifest path. |
-| Definition types | `pkg/agents/agent_yaml/yaml.go:142` (`AgentDefinition`), `yaml.go:211` (`AgentManifest`) | Unchanged. |
+| Top-level dispatch | `cmd/init.go` `RunE` | **Modified**: a new detection+reuse block is inserted alongside the existing `detectLocalManifest` block. Triggers before the init-mode prompt, so users with a local `agent.yaml` skip both the mode prompt and the from-code scaffolding sequence. |
+| Existing in-action overwrite guard | `cmd/init_from_code.go` (`InitFromCodeAction.Run`) | **Modified**: the "agent.yaml already exists" guard at the top of the action is removed. By the time `InitFromCodeAction.Run` is reached, the RunE-level dispatch has already handled (or declined) the reuse. |
+| Upstream manifest detection | `cmd/init.go` (`detectLocalManifest`) | **Unchanged**. |
+| Manifest pipeline | `cmd/init.go` (`runInitFromManifest`) | **Unchanged**. |
+| Definition reuse helpers | `cmd/init_from_code_reuse.go` (new file) | `findExistingAgentYaml`, `runReuseDefinition`, `loadAgentDefinitionFile`. |
+| `azure.yaml` writer | `cmd/init_from_code.go` (`addToProject`) | **Reused as-is** by `runReuseDefinition`. |
+| Project / environment bootstrap | `cmd/init.go` (`ensureProject`, `getExistingEnvironment`, `createNewEnvironment`) | **Reused as-is**: the reuse path runs the same setup `runInitFromManifest` does. |
+| Definition types | `pkg/agents/agent_yaml/yaml.go` (`ContainerAgent`, `CodeConfiguration`) | Unchanged. |
+| Name validation | `pkg/agents/agent_yaml/parse.go` (`ValidateAgentName`) | Reused. |
 
-The feature is primarily wiring — no new exported APIs.
+The feature is primarily wiring. No new exported APIs.
 
 ## 4. Behavior
 
-### 4.1 Detection
+### 4.1 Top-level dispatch order in `RunE`
 
-When `InitFromCodeAction.Run` starts, immediately after `srcDir` is resolved (currently lines `:76-79`):
+After auth and project resolution, when no `-m` was passed:
 
-1. Call `findAgentManifest(srcDir)` (already iterates `agent.manifest.yaml`, `agent.manifest.yml`, `agent.yaml`, `agent.yml` in that order).
-2. If nothing is found → continue with today's from-code scaffold flow (no behavior change).
-3. If a file is found → call `looksLikeManifest(path)` to classify and dispatch.
+1. `detectLocalManifest(srcDir)`: existing helper, runs first. If it returns a valid manifest path, `flags.manifestPointer` is set (with an optional confirmation prompt in interactive mode) and the manifest pipeline runs as today.
+2. **If `flags.manifestPointer` is still empty**, the new step runs: `findExistingAgentYaml(srcDir)` does a shallow `os.Stat` against the four candidate filenames. Any hit at this point is guaranteed to either be a bare definition (rejected by `detectLocalManifest` for lacking `template:`) or a malformed manifest (rejected for failing manifest validation).
+3. On a hit, a confirmation prompt ("An existing agent definition was found at ... Use it?") is shown; in `--no-prompt` mode the answer auto-defaults to yes.
+4. On confirmation, `runReuseDefinition(ctx, flags, azdClient, httpClient, srcDir, existingPath)` is called and the command returns. The init-mode prompt and the from-code scaffolding sequence are both skipped.
 
-The `os.Stat(filepath.Join(srcDir, "agent.yaml"))` block at `init_from_code.go:84-104` is replaced by this detection step — the same on-disk file that today triggers the "Overwrite?" prompt is now classified and reused.
+### 4.2 `runReuseDefinition`
 
-### 4.2 Manifest classification → reuse `runInitFromManifest`
+The new free function lives in `init_from_code_reuse.go`. It performs:
 
-When `looksLikeManifest` returns `true`:
+1. `loadAgentDefinitionFile(path)`: reads the file, rejects anything with a top-level `template:` (manifest-shaped but invalid, produces a targeted error), unmarshals to `agent_yaml.ContainerAgent` so `CodeConfiguration` is preserved, and validates the name via `agent_yaml.ValidateAgentName`.
+2. Prints `Detected existing agent definition: <relative-path> (name: <def.Name>).`
+3. Bootstraps project + env using the same helpers `runInitFromManifest` uses: `ensureProject`, then `getExistingEnvironment` / `createNewEnvironment` (the env is named `<def.Name>-dev` when none was supplied via `-e`).
+4. Builds a thin `*InitFromCodeAction` with the bootstrapped pieces and calls `action.addToProject(ctx, srcDir, def.Name, def.CodeConfiguration != nil)`, the existing from-code service-entry writer.
+5. Prints `Reusing existing agent.yaml (name: <def.Name>).`
+6. Calls `validatePostInit(srcDir, def.CodeConfiguration)` for the same advisory warnings the scaffold path emits.
 
-1. Inform the user: `Detected local agent manifest: <relative-path>. Using local manifest (no clone required).`
-2. Set `a.flags.manifestPointer = <absolute-path-to-file>`.
-3. Delegate to `runInitFromManifest(ctx, a.flags, a.azdClient, a.httpClient)`.
+The function deliberately does **not** call `configureModelChoice` or any Foundry resource resolution. The on-disk `agent.yaml` is never rewritten.
 
-`downloadAgentYaml` (called inside `runInitFromManifest`) already detects a local filesystem path at `init.go:1213-1215` and reads the bytes directly instead of issuing an HTTP request, so the clone step is automatically skipped. No new branch is needed inside `runInitFromManifest`.
+### 4.3 Invalid file
 
-Resources, toolboxes, and connections declared in the manifest are projected into `azure.yaml` by the existing `InitAction.addToProject` (`init.go:1495`).
+When `loadAgentDefinitionFile` returns any error (broken YAML, manifest-shaped file that did not route upstream, missing/invalid name), `runReuseDefinition` wraps it in a structured error:
 
-### 4.3 Definition classification → reuse `addToProject` only
+```go
+exterrors.Validation(
+    exterrors.CodeInvalidAgentManifest,
+    fmt.Sprintf("agent definition in %s is invalid: %s", displayPath, err),
+    "Fix the agent.yaml and retry, or remove the file to start a fresh init.",
+)
+```
 
-When `looksLikeManifest` returns `false`:
-
-1. Read the file bytes.
-2. Unmarshal into `agent_yaml.AgentDefinition` (the same shape parsed by `ExtractAgentDefinition` on the bare-definition fallback branch).
-3. Validate via `agent_yaml.ValidateAgentDefinition` and `agent_yaml.ValidateAgentName`.
-4. Inform the user: `Detected existing agent definition: <relative-path> (name: <def.Name>).`
-5. Skip the entire `createDefinitionFromLocalAgent` prompt sequence (model / instructions / entry-point detection that today runs at `init_from_code.go:108`).
-6. Call `a.addToProject(ctx, srcDir, def.Name, def.CodeConfiguration != nil)` — the same call the from-code path makes today at `init_from_code.go:123`.
-7. Run `validatePostInit(srcDir, def.CodeConfiguration)` for the same advisory warnings the from-code path emits today.
-
-The reuse path **does not rewrite** the existing `agent.yaml`. The "+ agent.yaml" green-add line printed at `init_from_code.go:128-131` is replaced with a single info line: `Reusing existing agent.yaml (name: <def.Name>).`
+`azure.yaml` is **not** mutated.
 
 ### 4.4 Service-name collision in `azure.yaml`
 
-Handled by the existing collision logic inside `addToProject` (manifest path: `init.go:1830`; from-code path: `init_from_code.go:822` and downstream). No new behavior — if `def.Name` (definition path) or the manifest-derived name collides with an existing service entry in `azure.yaml`, the user is prompted today and is still prompted under this change.
+Handled by the existing collision logic inside `addToProject`. No new behavior.
 
 ### 4.5 `--no-prompt`
 
-The new path is fully non-interactive — detection + classification + reuse require no prompts. Therefore:
+- `--no-prompt` + valid bare `agent.yaml` -> succeeds, runs `addToProject`. The confirmation prompt auto-defaults to yes (matches `detectLocalManifest` behavior).
+- `--no-prompt` + invalid file -> returns the structured `exterrors.Validation` above.
+- `--no-prompt` + no `agent.yaml` -> unchanged.
 
-- `--no-prompt` + detected manifest → succeeds, runs `runInitFromManifest` with the local path. `runInitFromManifest` itself already honors `--no-prompt` (no new contract).
-- `--no-prompt` + detected definition → succeeds, runs `addToProject` and exits with the same "Next steps" message the from-code path prints today (`init_from_code.go:141-146`).
-- `--no-prompt` + invalid `agent.yaml` → returns the validation error as a structured `exterrors.Validation(CodeInvalidAgentManifest, ...)` (see § 6).
-
-The current "overwrite declined in no-prompt mode" branch at `init_from_code.go:85-87` is removed — there is no overwrite to decline anymore.
+The pre-existing fail-fast guard for "agent.yaml already exists" in `--no-prompt` mode (added in #8266) is removed: there is no overwrite to fail.
 
 ## 5. Interactions with Existing Flags
 
 | Scenario | Behavior |
 | --- | --- |
-| `-m <pointer>` provided **and** local `agent.yaml` exists | `-m` wins. The from-code action does not run at all when `flags.manifestPointer != ""` (see the routing at `init.go:373-380`). No change to that routing. |
-| `--src <dir>` set to a directory that contains `agent.yaml` | Detection runs against that directory (same `srcDir` already used by the from-code flow). |
-| Positional arg resolved to a manifest pointer | Same as `-m` — does not enter the from-code action. |
-| Scaffolded-template branches (`init.go:451-484`) | Unchanged. Those branches already call `findAgentManifest` post-scaffold and run `runInitFromManifest`. |
-| `detectLocalManifest` at `init.go:340` | Unchanged. That helper runs **before** the user picks an init mode and is independent of the from-code action. |
+| `-m <pointer>` provided **and** local `agent.yaml` exists | `-m` wins. The new reuse block runs only when `flags.manifestPointer == ""`. |
+| Local `agent.manifest.yaml` (or any agent yaml that parses as a valid manifest) exists, no `-m` | Caught by upstream `detectLocalManifest`. The reuse block in this spec is not entered. |
+| Local bare `agent.yaml` (no `template:`) exists, no `-m` | This spec's reuse block runs. |
+| `--src <dir>` set | Detection runs against that directory. |
+| `--no-prompt` + bare `agent.yaml` | Auto-yes on the confirmation, proceeds with reuse. |
 
 ## 6. Errors
 
@@ -122,51 +113,60 @@ No new error codes. The reuse path uses existing codes from `internal/exterrors/
 
 | Failure | Code |
 | --- | --- |
-| `agent.yaml` exists but parses as neither valid manifest nor valid definition | `exterrors.Validation(CodeInvalidAgentManifest, "<path>: <yaml error>", "Fix the file or remove it to start a fresh init.")` |
-| Manifest classification but downstream `LoadAndValidateAgentManifest` fails | Already handled inside `runInitFromManifest` — same code as today. |
-| Definition classification but `ValidateAgentDefinition` / `ValidateAgentName` fails | `exterrors.Validation(CodeInvalidAgentManifest, ..., "Fix the agent.yaml and retry.")` (the existing manifest-invalid code is reused for definition validation because the user-facing surface — "your agent.yaml is wrong" — is the same; the `Op` is unchanged). |
+| File present but unparseable as a bare definition (broken YAML, manifest-shaped, invalid name) | `exterrors.Validation(CodeInvalidAgentManifest, "agent definition in <path> is invalid: <err>", "Fix the agent.yaml and retry, or remove the file to start a fresh init.")` |
 
-Per the extension's error-handling rule, the structured error is created at the from-code action boundary (where category, code, and suggestion are known). Lower-level helpers (`findAgentManifest`, `looksLikeManifest`, the YAML unmarshal) return plain `fmt.Errorf` wraps.
+Per the extension's error-handling rule, the structured error is created at the boundary inside `runReuseDefinition` (where category, code, and suggestion are known). Lower-level helpers (`findExistingAgentYaml`, `loadAgentDefinitionFile`) return plain `fmt.Errorf` wraps.
 
 ## 7. Test Plan
 
-Unit tests (table-driven, no network) added to `cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go`:
-
-- **Manifest detected** — `srcDir` contains an `agent.manifest.yaml` with a `template:` block. Asserts `runInitFromManifest` is invoked with `flags.manifestPointer` set to the absolute local path; no HTTP client calls observed (via a fake `httpClient`).
-- **Definition detected** — `srcDir` contains an `agent.yaml` without `template:`. Asserts `createDefinitionFromLocalAgent` is **not** called (today's prompt sequence is skipped), `addToProject` is called once with `agentName == def.Name`, the existing file on disk is byte-identical after the run.
-- **No agent yaml** — `srcDir` is empty. Asserts today's path still runs (i.e. `createDefinitionFromLocalAgent` is called) — regression guard.
-- **Invalid agent yaml** — `srcDir` contains a syntactically broken `agent.yaml`. Asserts the returned error has code `CodeInvalidAgentManifest` and a non-empty `Suggestion`.
-- **Filename precedence** — both `agent.manifest.yaml` and `agent.yaml` present in `srcDir`. Asserts the manifest file wins (matches existing `findAgentManifest` order); a debug log records which file was chosen.
-- **`--no-prompt` + definition** — no prompts issued (the fake prompt client errors if any call is made), action returns successfully.
-
-Snapshot regression (existing): `UPDATE_SNAPSHOTS=true go test ./cmd -run 'TestFigSpec|TestUsage'` — no `--help` changes expected because no new flags are added; this run is purely a verification step.
-
-End-to-end coverage is not in scope for this change — the from-code action has no functional E2E test today, and adding one solely for this branch would be a larger investment than the feature warrants.
+- **Pre-existing unit tests** in `cli/azd/extensions/azure.ai.agents/internal/cmd/*_test.go` continue to pass. The no-yaml regression is covered by today's `init_from_code_test.go`.
+- **Manual e2e** against the locally-built `azd` + extension. Three scenarios:
+  - **Definition reuse**: write a bare `agent.yaml`, run `azd ai agent init --no-prompt`; assert no init-mode prompt, `Detected existing agent definition: ...` printed, `azure.yaml` contains the agent's `name:`, on-disk `agent.yaml` byte-identical to input.
+  - **Manifest reuse**: write `agent.manifest.yaml`, run with `AZURE_SUBSCRIPTION_ID` and `AZURE_AI_PROJECT_ID` set; assert the existing upstream manifest path runs unchanged and `azure.yaml` ends up with the manifest's `template.name`.
+  - **Invalid yaml**: write broken YAML; assert non-zero exit, error references `agent.yaml`, `azure.yaml` not mutated.
 
 ## 8. Impact on Existing Commands
 
-Only `azd ai agent init` changes. The change is additive on a path that today either prompts to overwrite the file or proceeds with redundant prompts that discard the user's existing work. No flag is added or removed. `--help` snapshots do not change.
+Only `azd ai agent init` changes:
+
+- Users with a bare `agent.yaml` no longer see the init-mode prompt or the from-code prompt sequence.
+- Users in `--no-prompt` mode with a bare `agent.yaml` no longer get the `agent.yaml already exists at ...` failure from #8266.
+- Users with a valid manifest are unaffected (upstream `detectLocalManifest` handles them as before).
+- Users with no `agent.yaml` are unaffected.
+
+No flags added or removed; no `--help` snapshot changes.
 
 ## 9. Decisions
 
-1. **The existing "Overwrite agent.yaml?" prompt at `init_from_code.go:84-104` is removed, not extended.** Reuse is the new default behavior whenever a parseable `agent.yaml` is present. An overwrite escape hatch via `--force` was considered and rejected: a user who wants to start over can delete the file (one command) rather than learn a flag. Re-running with `-m <pointer>` also bypasses the from-code action entirely.
-2. **No new error code.** `CodeInvalidAgentManifest` covers both shapes (manifest and definition) from the user's perspective — they edited `agent.yaml` and got the file wrong. Splitting the code would add telemetry noise without distinguishing actionable user remedies.
-3. **No recursion into subdirectories.** Discovery is limited to `srcDir`. A nested `agent.yaml` (e.g. `./src/agent.yaml` when `srcDir == "."`) is invisible to detection; the user must point `--src` at the right directory. Walking would conflict with how `findAgentManifest` is used elsewhere in the codebase and is out of scope.
-4. **Definition path does not re-write the file.** The existing on-disk `agent.yaml` is treated as authoritative. If `def.Name` happens to collide with an existing service entry in `azure.yaml`, the collision is resolved by renaming the service entry, not the file.
+1. **Dispatch at `RunE`, not inside `InitFromCodeAction.Run`.** Placing the detection alongside `detectLocalManifest` keeps the manifest and definition reuse paths symmetric, and means users with a local `agent.yaml` are not asked to pick an init mode first. An earlier draft placed the dispatch inside `InitFromCodeAction.Run`, which forced users through the mode prompt before the reuse could fire.
+2. **No Foundry project resolution in the definition path.** The issue explicitly limits this case to "just setup azure.yaml". Adding project resolution would either duplicate the manifest pipeline's logic or require a non-trivial refactor of `runInitFromManifest` to support an in-memory manifest input; it is tracked as a follow-up.
+3. **No new error code.** `CodeInvalidAgentManifest` covers both shapes from the user's perspective. Splitting the code would add telemetry noise without distinguishing actionable user remedies.
+4. **No recursion into subdirectories.** Discovery is limited to the resolved source directory.
+5. **Definition path does not re-write the file.** The on-disk `agent.yaml` is authoritative. If `def.Name` collides with an existing service entry in `azure.yaml`, the existing collision logic resolves it by renaming the service entry, not the file.
+6. **Manifest reuse is left to upstream `detectLocalManifest`.** Discovered during implementation: valid local manifests are already intercepted upstream and routed through `runInitFromManifest`. A duplicate dispatch would be dead code. `findExistingAgentYaml` still includes the manifest filenames in its scan so a malformed manifest-shaped file produces a targeted error instead of silently scaffolding.
 
 ## 10. Reference: Decision Tree
 
 ```text
 azd ai agent init (no -m, no positional manifest)
-  └── resolve srcDir
-        └── findAgentManifest(srcDir)
-              ├── not found
-              │     └── existing from-code scaffold flow (unchanged)
-              ├── found, looksLikeManifest == true
-              │     └── flags.manifestPointer = <local path>
-              │           └── runInitFromManifest  (no clone; existing path)
-              └── found, looksLikeManifest == false
-                    └── ValidateAgentDefinition
-                          ├── invalid → exterrors.Validation(CodeInvalidAgentManifest, ...)
-                          └── valid   → addToProject(srcDir, def.Name, def.CodeConfiguration != nil)
+  |
+  +-- detectLocalManifest(srcDir)                                  [unchanged]
+  |     |
+  |     +-- valid manifest found
+  |     |     +-- flags.manifestPointer = <local path>
+  |     |           +-- runInitFromManifest                        [existing path]
+  |     |
+  |     +-- nothing valid -> fall through
+  |
+  +-- findExistingAgentYaml(srcDir)                                [new]
+        |
+        +-- not found -> existing init-mode prompt / scaffold flow
+        |
+        +-- found -> runReuseDefinition
+              |
+              +-- loadAgentDefinitionFile
+                    |
+                    +-- invalid -> exterrors.Validation(CodeInvalidAgentManifest, ...)
+                    |
+                    +-- valid   -> ensureProject + env -> addToProject(srcDir, def.Name, isCodeDeploy)
 ```

--- a/cli/azd/docs/design/azure-ai-agent-init-reuse-agent-yaml.md
+++ b/cli/azd/docs/design/azure-ai-agent-init-reuse-agent-yaml.md
@@ -36,14 +36,14 @@ All paths inside `cli/azd/extensions/azure.ai.agents/internal/`.
 | Concern | Location | Disposition |
 | --- | --- | --- |
 | Top-level dispatch | `cmd/init.go` `RunE` | **Modified**: a new detection+reuse block is inserted alongside the existing `detectLocalManifest` block. Triggers before the init-mode prompt, so users with a local `agent.yaml` skip both the mode prompt and the from-code scaffolding sequence. |
-| Existing in-action overwrite guard | `cmd/init_from_code.go` (`InitFromCodeAction.Run`) | **Modified**: the "agent.yaml already exists" guard at the top of the action is removed. By the time `InitFromCodeAction.Run` is reached, the RunE-level dispatch has already handled (or declined) the reuse. |
+| In-action overwrite guard | `cmd/init_from_code.go` (`InitFromCodeAction.Run`) | **Modified**: the original "agent.yaml already exists" guard (#8266) is retained but uses `findExistingAgentYaml` so it covers all four candidate filenames. The guard now only fires when the scaffold path was entered despite a definition being on disk — e.g. when the user declined the reuse prompt and then picked "Use the code in the current directory". |
 | Upstream manifest detection | `cmd/init_from_templates_helpers.go` (`detectLocalManifest`, called from `cmd/init.go` `RunE`) | **Unchanged**. |
 | Manifest pipeline | `cmd/init.go` (`runInitFromManifest`) | **Unchanged**. |
 | Definition reuse helpers | `cmd/init_from_code_reuse.go` (new file) | `findExistingAgentYaml`, `runReuseDefinition`, `loadAgentDefinitionFile`. |
-| `azure.yaml` writer | `cmd/init_from_code.go` (`addToProject`) | **Reused as-is** by `runReuseDefinition`. |
+| `azure.yaml` writer | `cmd/init_from_code.go` (`addToProject`) | **Reused as-is** by `runReuseDefinition`. Language detection inside it is limited to the bare-definition filenames so a leftover manifest cannot short-circuit detection. |
 | Project / environment bootstrap | `cmd/init.go` (`ensureProject`, `getExistingEnvironment`); `cmd/init_foundry_resources_helpers.go` (`createNewEnvironment`) | **Reused as-is**: the reuse path runs the same setup `runInitFromManifest` does. |
 | Definition types | `pkg/agents/agent_yaml/yaml.go` (`ContainerAgent`, `CodeConfiguration`) | Unchanged. |
-| Name validation | `pkg/agents/agent_yaml/parse.go` (`ValidateAgentName`) | Reused. |
+| Definition validation | `pkg/agents/agent_yaml/parse.go` (`ValidateAgentDefinition`) | Reused. Catches missing/invalid `kind`, name format, and kind-specific structural checks. |
 
 The feature is primarily wiring. No new exported APIs.
 
@@ -63,24 +63,25 @@ After auth and project resolution, when no `-m` was passed:
 
 The new free function lives in `init_from_code_reuse.go`. It performs:
 
-1. `loadAgentDefinitionFile(path)`: reads the file, rejects anything with a top-level `template:` (manifest-shaped but invalid, produces a targeted error), unmarshals to `agent_yaml.ContainerAgent` so `CodeConfiguration` is preserved, and validates the name via `agent_yaml.ValidateAgentName`.
+1. `loadAgentDefinitionFile(path)`: reads the file, rejects anything with a top-level `template:` (manifest-shaped but invalid, produces a targeted error), runs `agent_yaml.ValidateAgentDefinition` on the bytes (catches missing/invalid `kind`, name format, kind-specific structural checks), then unmarshals to `agent_yaml.ContainerAgent` so `CodeConfiguration` is preserved.
 2. Prints `Detected existing agent definition: <relative-path> (name: <def.Name>).`
-3. Bootstraps project + env using the same helpers `runInitFromManifest` uses: `ensureProject`, then `getExistingEnvironment` / `createNewEnvironment` (the env is named `sanitizeAgentName(<def.Name> + "-dev")` when none was supplied via `-e`, matching the existing from-code path).
-4. Builds a thin `*InitFromCodeAction` with the bootstrapped pieces and calls `action.addToProject(ctx, srcDir, def.Name, def.CodeConfiguration != nil)`, the existing from-code service-entry writer.
-5. Prints `Reusing existing agent.yaml (name: <def.Name>).`
-6. Calls `validatePostInit(srcDir, def.CodeConfiguration)` for the same advisory warnings the scaffold path emits.
+3. Bootstraps project + env using the same helpers `runInitFromManifest` uses: `ensureProject`, then `getExistingEnvironment` / `createNewEnvironment` (the env is named `sanitizeAgentName(<def.Name> + "-dev")` when none was supplied via `-e`).
+4. Mirrors `InitFromCodeAction.Run`'s absolute-`--src` handling: when `flags.src` is absolute, converts it to a path relative to the azd project root so `azure.yaml`'s `RelativePath` stays portable.
+5. Builds a thin `*InitFromCodeAction` with the bootstrapped pieces and calls `action.addToProject(ctx, srcDir, def.Name, def.CodeConfiguration != nil)`.
+6. Prints `Reusing existing <displayPath> (name: <def.Name>).` where `displayPath` is the actual detected filename (so users with `agent.yml` see `agent.yml`, not a hardcoded `agent.yaml`).
+7. Calls `validatePostInit(srcDir, def.CodeConfiguration)` for the same advisory warnings the scaffold path emits.
 
-The function deliberately does **not** call `configureModelChoice` or any Foundry resource resolution. The on-disk `agent.yaml` is never rewritten.
+The function deliberately does **not** call `configureModelChoice` or any Foundry resource resolution. The on-disk file is never rewritten.
 
 ### 4.3 Invalid file
 
-When `loadAgentDefinitionFile` returns any error (broken YAML, manifest-shaped file that did not route upstream, missing/invalid name), `runReuseDefinition` wraps it in a structured error:
+When `loadAgentDefinitionFile` returns any error (broken YAML, manifest-shaped file that did not route upstream, missing/invalid kind or name), `runReuseDefinition` wraps it in a structured error:
 
 ```go
 exterrors.Validation(
     exterrors.CodeInvalidAgentManifest,
     fmt.Sprintf("agent definition in %s is invalid: %s", displayPath, err),
-    "Fix the agent.yaml and retry, or remove the file to start a fresh init.",
+    fmt.Sprintf("Fix %s and retry, or remove the file to start a fresh init.", displayPath),
 )
 ```
 
@@ -96,7 +97,18 @@ Handled by the existing collision logic inside `addToProject`. No new behavior.
 - `--no-prompt` + invalid file -> returns the structured `exterrors.Validation` above.
 - `--no-prompt` + no `agent.yaml` -> unchanged.
 
-The pre-existing fail-fast guard for "agent.yaml already exists" in `--no-prompt` mode (added in #8266) is removed: there is no overwrite to fail.
+The original `#8266` fail-fast guard inside `InitFromCodeAction.Run` is retained as a safety net for paths that bypass the `RunE`-level reuse dispatch (see § 4.6).
+
+### 4.6 Decline-reuse fallback into the from-code scaffold
+
+When the user declines the `RunE` reuse prompt and then picks "Use the code in the current directory" from the init-mode prompt, `InitFromCodeAction.Run` is entered with the existing `agent.yaml` still on disk. Without a guard, the from-code scaffold would silently overwrite it.
+
+The guard inside `InitFromCodeAction.Run` therefore:
+
+- In `--no-prompt` mode (defensive — not normally reached because `--no-prompt` auto-accepts the reuse upstream): returns `exterrors.Validation(CodeInvalidAgentManifest, "<displayPath> already exists at \"<path>\"", "delete or move the existing <displayPath>, or run interactively to confirm overwrite")`.
+- Interactively: prompts `An agent definition already exists at "<displayPath>". Overwrite?` with default-no. Declining returns `exterrors.Cancelled`.
+
+This restores the safety invariant from #8266 while keeping the happy path (file gets reused) lossless.
 
 ## 5. Interactions with Existing Flags
 
@@ -105,8 +117,9 @@ The pre-existing fail-fast guard for "agent.yaml already exists" in `--no-prompt
 | `-m <pointer>` provided **and** local `agent.yaml` exists | `-m` wins. The new reuse block runs only when `flags.manifestPointer == ""`. |
 | Local `agent.manifest.yaml` (or any agent yaml that parses as a valid manifest) exists, no `-m` | Caught by upstream `detectLocalManifest`. The reuse block in this spec is not entered. |
 | Local bare `agent.yaml` (no `template:`) exists, no `-m` | This spec's reuse block runs. |
-| `--src <dir>` set | Detection runs against that directory. |
+| `--src <dir>` set | Detection runs against that directory. Absolute paths are normalized to project-relative before `addToProject` is called. |
 | `--no-prompt` + bare `agent.yaml` | Auto-yes on the confirmation, proceeds with reuse. |
+| User declines reuse prompt, then picks "Use the code in the current directory" | Hits the `InitFromCodeAction.Run` overwrite guard (§ 4.6); interactive overwrite prompt defaults no, `--no-prompt` returns `CodeInvalidAgentManifest`. |
 
 ## 6. Errors
 
@@ -114,26 +127,33 @@ No new error codes. The reuse path uses existing codes from `internal/exterrors/
 
 | Failure | Code |
 | --- | --- |
-| File present but unparseable as a bare definition (broken YAML, manifest-shaped, invalid name) | `exterrors.Validation(CodeInvalidAgentManifest, "agent definition in <path> is invalid: <err>", "Fix the agent.yaml and retry, or remove the file to start a fresh init.")` |
+| File present but unparseable as a bare definition (broken YAML, manifest-shaped, missing/invalid kind, invalid name) | `exterrors.Validation(CodeInvalidAgentManifest, "agent definition in <displayPath> is invalid: <err>", "Fix <displayPath> and retry, or remove the file to start a fresh init.")` |
+| Existing definition present when the scaffold path is entered, `--no-prompt` mode (§ 4.6 fallback) | `exterrors.Validation(CodeInvalidAgentManifest, "<displayPath> already exists at \"<path>\"", "delete or move the existing <displayPath>, or run interactively to confirm overwrite")` |
+| User declines the interactive overwrite prompt (§ 4.6) | `exterrors.Cancelled("<displayPath> already exists; overwrite declined")` |
 
 Per the extension's error-handling rule, the structured error is created at the boundary inside `runReuseDefinition` (where category, code, and suggestion are known). Lower-level helpers (`findExistingAgentYaml`, `loadAgentDefinitionFile`) return plain `fmt.Errorf` wraps.
 
 ## 7. Test Plan
 
-- **Pre-existing unit tests** in `cli/azd/extensions/azure.ai.agents/internal/cmd/*_test.go` continue to pass. They cover helpers (`sanitizeAgentName`, `writeDefinitionToSrcDir`, etc.) that this change does not modify; we are not adding new unit tests because the new code paths are exercised end-to-end below.
+- **Unit tests** in `cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_reuse_test.go`:
+  - `TestFindExistingAgentYaml`: filename precedence (manifest before definition), empty dir, directory-entries-ignored, shallow-scan.
+  - `TestLoadAgentDefinitionFile`: happy path (bare definition + `CodeConfiguration` preserved), rejects manifest-shaped file, rejects missing `kind`, rejects invalid name, rejects broken YAML.
+  - `TestRunReuseDefinition_InvalidFileReturnsStructuredError` and `TestRunReuseDefinition_RejectsManifestShapedFile`: cover the failure paths that short-circuit before any azd gRPC calls and so don't need a full client mock.
+- **Pre-existing unit tests** in the same package continue to pass; they cover helpers (`sanitizeAgentName`, `writeDefinitionToSrcDir`, etc.) that this change does not modify.
 - **Manual e2e** against the locally-built `azd` + extension. Three scenarios:
   - **Definition reuse**: write a bare `agent.yaml`, run `azd ai agent init --no-prompt`; assert no init-mode prompt, `Detected existing agent definition: ...` printed, `azure.yaml` contains the agent's `name:`, on-disk `agent.yaml` byte-identical to input.
   - **Manifest reuse**: write `agent.manifest.yaml`, run with `AZURE_SUBSCRIPTION_ID` and `AZURE_AI_PROJECT_ID` set; assert the existing upstream manifest path runs unchanged and `azure.yaml` ends up with the manifest's `template.name`.
-  - **Invalid yaml**: write broken YAML; assert non-zero exit, error references `agent.yaml`, `azure.yaml` not mutated.
+  - **Invalid yaml**: write broken YAML; assert non-zero exit, error references the actual filename, `azure.yaml` not mutated.
 
 ## 8. Impact on Existing Commands
 
 Only `azd ai agent init` changes:
 
 - Users with a bare `agent.yaml` no longer see the init-mode prompt or the from-code prompt sequence.
-- Users in `--no-prompt` mode with a bare `agent.yaml` no longer get the `agent.yaml already exists at ...` failure from #8266.
+- Users in `--no-prompt` mode with a bare `agent.yaml` no longer get the `agent.yaml already exists at ...` failure from #8266 (the reuse path auto-accepts and proceeds).
 - Users with a valid manifest are unaffected (upstream `detectLocalManifest` handles them as before).
 - Users with no `agent.yaml` are unaffected.
+- The #8266 safety guard inside `InitFromCodeAction.Run` is preserved as a fallback for the decline-reuse path (§ 4.6).
 
 No flags added or removed; no `--help` snapshot changes.
 
@@ -145,6 +165,8 @@ No flags added or removed; no `--help` snapshot changes.
 4. **No recursion into subdirectories.** Discovery is limited to the resolved source directory.
 5. **Definition path does not re-write the file.** The on-disk `agent.yaml` is authoritative. If `def.Name` collides with an existing service entry in `azure.yaml`, the existing collision logic resolves it by renaming the service entry, not the file.
 6. **Manifest reuse is left to upstream `detectLocalManifest`.** Discovered during implementation: valid local manifests are already intercepted upstream and routed through `runInitFromManifest`. A duplicate dispatch would be dead code. `findExistingAgentYaml` still includes the manifest filenames in its scan so a malformed manifest-shaped file produces a targeted error instead of silently scaffolding.
+7. **Full schema validation, not just name validation.** `loadAgentDefinitionFile` calls `agent_yaml.ValidateAgentDefinition` (not just `ValidateAgentName`) so missing/invalid `kind`, name format, and kind-specific structural checks fail fast with the same error the manifest pipeline produces.
+8. **Retain the #8266 fail-fast guard inside `InitFromCodeAction.Run`.** An earlier draft removed it on the assumption that the `RunE`-level dispatch would always handle the reuse case. That assumption fails when the user declines the reuse prompt and then explicitly picks "Use the code in the current directory" — without the guard, the from-code scaffold would silently overwrite the user's file. The guard now uses `findExistingAgentYaml` so it covers all four candidate filenames.
 
 ## 10. Reference: Decision Tree
 
@@ -154,20 +176,28 @@ azd ai agent init (no -m, no positional manifest)
   +-- detectLocalManifest(srcDir)                                  [unchanged]
   |     |
   |     +-- valid manifest found
-  |     |     +-- flags.manifestPointer = <local path>
-  |     |           +-- runInitFromManifest                        [existing path]
-  |     |
+  |     |     +-- user accepts (or --no-prompt)
+  |     |     |     +-- flags.manifestPointer = <local path>
+  |     |     |           +-- runInitFromManifest                  [existing path]
+  |     |     +-- user declines (interactive only)
+  |     |           +-- set manifestDetectedButDeclined; fall through
   |     +-- nothing valid -> fall through
   |
-  +-- findExistingAgentYaml(srcDir)                                [new]
+  +-- findExistingAgentYaml(srcDir)                                [new, skipped if manifestDetectedButDeclined]
         |
-        +-- not found -> existing init-mode prompt / scaffold flow
+        +-- not found -> init-mode prompt
+        |                  |
+        |                  +-- "Use the code in the current directory"
+        |                  |     +-- InitFromCodeAction.Run
+        |                  |           +-- agent.yaml exists? -> overwrite guard (§ 4.6)
+        |                  |           +-- no -> scaffold prompts -> writeDefinitionToSrcDir -> addToProject
+        |                  +-- "Start new from a template" -> existing scaffold flow
         |
-        +-- found -> runReuseDefinition
+        +-- found -> reuse prompt ("Use it?", auto-yes under --no-prompt)
               |
-              +-- loadAgentDefinitionFile
-                    |
-                    +-- invalid -> exterrors.Validation(CodeInvalidAgentManifest, ...)
-                    |
-                    +-- valid   -> ensureProject + env -> addToProject(srcDir, def.Name, isCodeDeploy)
+              +-- accepted -> runReuseDefinition
+              |     +-- loadAgentDefinitionFile (ValidateAgentDefinition)
+              |           +-- invalid -> exterrors.Validation(CodeInvalidAgentManifest, ...)
+              |           +-- valid   -> ensureProject + env -> normalize abs --src -> addToProject
+              +-- declined -> init-mode prompt (same as "not found" branch)
 ```


### PR DESCRIPTION
Adds the design spec for #7268: when `azd ai agent init` runs in a directory that already contains a bare `agent.yaml` definition, reuse it instead of prompting to overwrite (interactive) or failing fast (`--no-prompt`, behavior added in #8266).

The manifest half of the issue is documented as already handled by upstream `detectLocalManifest`; this work fills only the bare-definition gap.

## Highlights for review

- **§3 / §9 decision 1**: detection lives at `RunE` next to `detectLocalManifest`, not inside `InitFromCodeAction.Run` (avoids forcing users through the init-mode prompt before reuse fires).
- **§2 / §9 decision 2**: Foundry project resolution is intentionally out of scope, matching the issue's *"less to ask and just setup azure.yaml"* wording. Tracked as a follow-up.
- **§4.6 / §9 decision 8**: the original #8266 fail-fast guard inside `InitFromCodeAction.Run` is retained as a safety net for the decline-reuse fallback path (user declines the reuse prompt and then picks "Use the code in the current directory").
- **§4.2 / §9 decision 7**: `loadAgentDefinitionFile` runs full `ValidateAgentDefinition` (kind + name + structural checks), not just name validation.
- **§9 decision 6**: documents the implementation discovery that the manifest case is already covered upstream, so our helper only handles bare definitions and malformed manifests.

## Related

- Implementation PR: #8326
- Issue: #7268
