### PR TITLE
feat(azure.ai.agents): add full OAuth2 fields and connector-name support

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection.go
@@ -200,14 +200,14 @@ type connectionCreateFlags struct {
 	metadata         []string
 	force            bool
 	projectEndpoint  string
-	clientID         string // OAuth2 client ID
-	clientSecret     string // OAuth2 client secret
-	audience         string // Token audience for user-entra-token / agentic-identity / project-managed-identity
-	authorizationURL string // OAuth2 authorization endpoint
-	tokenURL         string // OAuth2 token endpoint
-	refreshURL       string // OAuth2 refresh endpoint
+	clientID         string   // OAuth2 client ID
+	clientSecret     string   // OAuth2 client secret
+	audience         string   // Token audience for user-entra-token / agentic-identity / project-managed-identity
+	authorizationURL string   // OAuth2 authorization endpoint
+	tokenURL         string   // OAuth2 token endpoint
+	refreshURL       string   // OAuth2 refresh endpoint
 	scopes           []string // OAuth2 scopes
-	connectorName    string // Managed connector name
+	connectorName    string   // Managed connector name
 }
 
 // ConnectionCreateAction implements connection creation.

--- a/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection.go
@@ -202,11 +202,11 @@ type connectionCreateFlags struct {
 	projectEndpoint  string
 	clientID         string // OAuth2 client ID
 	clientSecret     string // OAuth2 client secret
-	audience         string // Token audience for user-entra-token / agentic-identity
+	audience         string // Token audience for user-entra-token / agentic-identity / project-managed-identity
 	authorizationURL string // OAuth2 authorization endpoint
 	tokenURL         string // OAuth2 token endpoint
 	refreshURL       string // OAuth2 refresh endpoint
-	scopes           string // OAuth2 scopes (space-separated)
+	scopes           string // OAuth2 scopes (comma-separated)
 	connectorName    string // Managed connector name
 }
 
@@ -321,10 +321,10 @@ func (a *ConnectionCreateAction) Run(ctx context.Context) error {
 		}
 	}
 	if a.flags.audience != "" && a.flags.authType != "user-entra-token" &&
-		a.flags.authType != "agentic-identity" {
+		a.flags.authType != "agentic-identity" && a.flags.authType != "project-managed-identity" {
 		return exterrors.Validation(
 			exterrors.CodeConflictingArguments,
-			"--audience is only valid with --auth-type user-entra-token or agentic-identity.",
+			"--audience is only valid with --auth-type user-entra-token, agentic-identity, or project-managed-identity.",
 			"",
 		)
 	}
@@ -440,7 +440,7 @@ func newConnectionCreateCommand(extCtx *azdext.ExtensionContext) *cobra.Command 
 	cmd.Flags().StringVar(&flags.clientSecret, "client-secret", "",
 		"OAuth2 client secret (required for BYO OAuth2)")
 	cmd.Flags().StringVar(&flags.audience, "audience", "",
-		"Token audience for user-entra-token/agentic-identity auth")
+		"Token audience for user-entra-token/agentic-identity/project-managed-identity auth")
 	cmd.Flags().StringVar(&flags.authorizationURL, "authorization-url", "",
 		"OAuth2 authorization endpoint URL")
 	cmd.Flags().StringVar(&flags.tokenURL, "token-url", "",
@@ -448,7 +448,7 @@ func newConnectionCreateCommand(extCtx *azdext.ExtensionContext) *cobra.Command 
 	cmd.Flags().StringVar(&flags.refreshURL, "refresh-url", "",
 		"OAuth2 token refresh URL")
 	cmd.Flags().StringVar(&flags.scopes, "scopes", "",
-		"OAuth2 scopes (space-separated)")
+		"OAuth2 scopes (comma-separated)")
 	cmd.Flags().StringVar(&flags.connectorName, "connector-name", "",
 		"Managed connector name (for OAuth2 connectors)")
 	return cmd

--- a/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection.go
@@ -206,7 +206,7 @@ type connectionCreateFlags struct {
 	authorizationURL string // OAuth2 authorization endpoint
 	tokenURL         string // OAuth2 token endpoint
 	refreshURL       string // OAuth2 refresh endpoint
-	scopes           string // OAuth2 scopes (comma-separated)
+	scopes           []string // OAuth2 scopes
 	connectorName    string // Managed connector name
 }
 
@@ -255,7 +255,7 @@ func (a *ConnectionCreateAction) Run(ctx context.Context) error {
 			)
 		}
 		if a.flags.authorizationURL != "" || a.flags.tokenURL != "" ||
-			a.flags.refreshURL != "" || a.flags.scopes != "" || a.flags.connectorName != "" {
+			a.flags.refreshURL != "" || len(a.flags.scopes) > 0 || a.flags.connectorName != "" {
 			return exterrors.Validation(
 				exterrors.CodeConflictingArguments,
 				"--authorization-url, --token-url, --refresh-url, --scopes, and --connector-name "+
@@ -269,7 +269,7 @@ func (a *ConnectionCreateAction) Run(ctx context.Context) error {
 	if a.flags.authType == "oauth2" {
 		hasConnector := a.flags.connectorName != ""
 		hasBYO := a.flags.authorizationURL != "" || a.flags.tokenURL != "" ||
-			a.flags.refreshURL != "" || a.flags.scopes != "" ||
+			a.flags.refreshURL != "" || len(a.flags.scopes) > 0 ||
 			a.flags.clientID != "" || a.flags.clientSecret != ""
 
 		if hasConnector && hasBYO {
@@ -284,25 +284,21 @@ func (a *ConnectionCreateAction) Run(ctx context.Context) error {
 		if !hasConnector && !hasBYO {
 			return exterrors.Validation(
 				exterrors.CodeMissingConnectionField,
-				"OAuth2 auth requires either --connector-name (managed connector) or all of "+
-					"--authorization-url, --token-url, --refresh-url, --scopes, --client-id, --client-secret.",
+				"OAuth2 auth requires either --connector-name (managed connector) or "+
+					"--authorization-url, --token-url, --client-id, --client-secret "+
+					"(and optionally --refresh-url, --scopes).",
 				"",
 			)
 		}
 		if !hasConnector {
-			// BYO mode — all six fields are required.
+			// BYO mode — required: authorization-url, token-url, client-id, client-secret.
+			// Optional: refresh-url, scopes.
 			missing := []string{}
 			if a.flags.authorizationURL == "" {
 				missing = append(missing, "--authorization-url")
 			}
 			if a.flags.tokenURL == "" {
 				missing = append(missing, "--token-url")
-			}
-			if a.flags.refreshURL == "" {
-				missing = append(missing, "--refresh-url")
-			}
-			if a.flags.scopes == "" {
-				missing = append(missing, "--scopes")
 			}
 			if a.flags.clientID == "" {
 				missing = append(missing, "--client-id")
@@ -313,8 +309,8 @@ func (a *ConnectionCreateAction) Run(ctx context.Context) error {
 			if len(missing) > 0 {
 				return exterrors.Validation(
 					exterrors.CodeMissingConnectionField,
-					"BYO OAuth2 requires all of: --authorization-url, --token-url, --refresh-url, "+
-						"--scopes, --client-id, --client-secret. Missing: "+strings.Join(missing, ", "),
+					"BYO OAuth2 requires: --authorization-url, --token-url, --client-id, "+
+						"--client-secret. Missing: "+strings.Join(missing, ", "),
 					"",
 				)
 			}
@@ -447,8 +443,8 @@ func newConnectionCreateCommand(extCtx *azdext.ExtensionContext) *cobra.Command 
 		"OAuth2 token endpoint URL")
 	cmd.Flags().StringVar(&flags.refreshURL, "refresh-url", "",
 		"OAuth2 token refresh URL")
-	cmd.Flags().StringVar(&flags.scopes, "scopes", "",
-		"OAuth2 scopes (comma-separated)")
+	cmd.Flags().StringSliceVar(&flags.scopes, "scopes", nil,
+		"OAuth2 scopes (repeatable or comma-separated, e.g. --scopes read:user,user:email)")
 	cmd.Flags().StringVar(&flags.connectorName, "connector-name", "",
 		"Managed connector name (for OAuth2 connectors)")
 	return cmd

--- a/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"maps"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"azureaiagent/internal/connections/exterrors"
@@ -244,28 +245,80 @@ func (a *ConnectionCreateAction) Run(ctx context.Context) error {
 			"Specify at least one custom key (e.g., --custom-key x-api-key=value).",
 		)
 	}
-	if a.flags.authType == "oauth2" && (a.flags.clientID == "" || a.flags.clientSecret == "") {
-		return exterrors.Validation(
-			exterrors.CodeMissingConnectionField,
-			"Missing required flags --client-id and --client-secret for oauth2 auth.",
-			"Specify both OAuth2 client credentials.",
-		)
+	// OAuth2-only flags must not be used with other auth types.
+	if a.flags.authType != "oauth2" {
+		if a.flags.clientID != "" || a.flags.clientSecret != "" {
+			return exterrors.Validation(
+				exterrors.CodeConflictingArguments,
+				"--client-id and --client-secret are only valid with --auth-type oauth2.",
+				"",
+			)
+		}
+		if a.flags.authorizationURL != "" || a.flags.tokenURL != "" ||
+			a.flags.refreshURL != "" || a.flags.scopes != "" || a.flags.connectorName != "" {
+			return exterrors.Validation(
+				exterrors.CodeConflictingArguments,
+				"--authorization-url, --token-url, --refresh-url, --scopes, and --connector-name "+
+					"are only valid with --auth-type oauth2.",
+				"",
+			)
+		}
 	}
-	if a.flags.authType != "oauth2" && (a.flags.clientID != "" || a.flags.clientSecret != "") {
-		return exterrors.Validation(
-			exterrors.CodeConflictingArguments,
-			"--client-id and --client-secret are only valid with --auth-type oauth2.",
-			"",
-		)
-	}
-	if a.flags.authType != "oauth2" && (a.flags.authorizationURL != "" || a.flags.tokenURL != "" ||
-		a.flags.refreshURL != "" || a.flags.scopes != "" || a.flags.connectorName != "") {
-		return exterrors.Validation(
-			exterrors.CodeConflictingArguments,
-			"--authorization-url, --token-url, --refresh-url, --scopes, and --connector-name "+
-				"are only valid with --auth-type oauth2.",
-			"",
-		)
+	// OAuth2 validation: either --connector-name alone (managed connector) or all of
+	// --authorization-url, --token-url, --refresh-url, --scopes, --client-id, --client-secret.
+	if a.flags.authType == "oauth2" {
+		hasConnector := a.flags.connectorName != ""
+		hasBYO := a.flags.authorizationURL != "" || a.flags.tokenURL != "" ||
+			a.flags.refreshURL != "" || a.flags.scopes != "" ||
+			a.flags.clientID != "" || a.flags.clientSecret != ""
+
+		if hasConnector && hasBYO {
+			return exterrors.Validation(
+				exterrors.CodeConflictingArguments,
+				"--connector-name cannot be combined with --authorization-url, --token-url, "+
+					"--refresh-url, --scopes, --client-id, or --client-secret. "+
+					"Use --connector-name alone for managed connectors, or provide the other flags for BYO OAuth2.",
+				"",
+			)
+		}
+		if !hasConnector && !hasBYO {
+			return exterrors.Validation(
+				exterrors.CodeMissingConnectionField,
+				"OAuth2 auth requires either --connector-name (managed connector) or all of "+
+					"--authorization-url, --token-url, --refresh-url, --scopes, --client-id, --client-secret.",
+				"",
+			)
+		}
+		if !hasConnector {
+			// BYO mode — all six fields are required.
+			missing := []string{}
+			if a.flags.authorizationURL == "" {
+				missing = append(missing, "--authorization-url")
+			}
+			if a.flags.tokenURL == "" {
+				missing = append(missing, "--token-url")
+			}
+			if a.flags.refreshURL == "" {
+				missing = append(missing, "--refresh-url")
+			}
+			if a.flags.scopes == "" {
+				missing = append(missing, "--scopes")
+			}
+			if a.flags.clientID == "" {
+				missing = append(missing, "--client-id")
+			}
+			if a.flags.clientSecret == "" {
+				missing = append(missing, "--client-secret")
+			}
+			if len(missing) > 0 {
+				return exterrors.Validation(
+					exterrors.CodeMissingConnectionField,
+					"BYO OAuth2 requires all of: --authorization-url, --token-url, --refresh-url, "+
+						"--scopes, --client-id, --client-secret. Missing: "+strings.Join(missing, ", "),
+					"",
+				)
+			}
+		}
 	}
 	if a.flags.audience != "" && a.flags.authType != "user-entra-token" &&
 		a.flags.authType != "agentic-identity" {
@@ -383,9 +436,9 @@ func newConnectionCreateCommand(extCtx *azdext.ExtensionContext) *cobra.Command 
 	cmd.Flags().BoolVar(&flags.force, "force", false,
 		"Replace existing connection (upsert)")
 	cmd.Flags().StringVar(&flags.clientID, "client-id", "",
-		"OAuth2 client ID (required for oauth2 auth)")
+		"OAuth2 client ID (required for BYO OAuth2)")
 	cmd.Flags().StringVar(&flags.clientSecret, "client-secret", "",
-		"OAuth2 client secret (required for oauth2 auth)")
+		"OAuth2 client secret (required for BYO OAuth2)")
 	cmd.Flags().StringVar(&flags.audience, "audience", "",
 		"Token audience for user-entra-token/agentic-identity auth")
 	cmd.Flags().StringVar(&flags.authorizationURL, "authorization-url", "",

--- a/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection.go
@@ -190,18 +190,23 @@ func newConnectionShowCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 
 // connectionCreateFlags holds validated input for ConnectionCreateAction.
 type connectionCreateFlags struct {
-	name            string
-	kind            string
-	target          string
-	authType        string
-	key             string
-	customKeys      []string
-	metadata        []string
-	force           bool
-	projectEndpoint string
-	clientID        string // OAuth2 client ID
-	clientSecret    string // OAuth2 client secret
-	audience        string // Token audience for user-entra-token / agentic-identity
+	name             string
+	kind             string
+	target           string
+	authType         string
+	key              string
+	customKeys       []string
+	metadata         []string
+	force            bool
+	projectEndpoint  string
+	clientID         string // OAuth2 client ID
+	clientSecret     string // OAuth2 client secret
+	audience         string // Token audience for user-entra-token / agentic-identity
+	authorizationURL string // OAuth2 authorization endpoint
+	tokenURL         string // OAuth2 token endpoint
+	refreshURL       string // OAuth2 refresh endpoint
+	scopes           string // OAuth2 scopes (space-separated)
+	connectorName    string // Managed connector name
 }
 
 // ConnectionCreateAction implements connection creation.
@@ -253,6 +258,15 @@ func (a *ConnectionCreateAction) Run(ctx context.Context) error {
 			"",
 		)
 	}
+	if a.flags.authType != "oauth2" && (a.flags.authorizationURL != "" || a.flags.tokenURL != "" ||
+		a.flags.refreshURL != "" || a.flags.scopes != "" || a.flags.connectorName != "") {
+		return exterrors.Validation(
+			exterrors.CodeConflictingArguments,
+			"--authorization-url, --token-url, --refresh-url, --scopes, and --connector-name "+
+				"are only valid with --auth-type oauth2.",
+			"",
+		)
+	}
 	if a.flags.audience != "" && a.flags.authType != "user-entra-token" &&
 		a.flags.authType != "agentic-identity" {
 		return exterrors.Validation(
@@ -283,18 +297,26 @@ func (a *ConnectionCreateAction) Run(ctx context.Context) error {
 
 	// Route to raw REST or typed SDK based on auth type
 	switch a.flags.authType {
-	case "user-entra-token", "project-managed-identity", "agentic-identity":
-		err = rawCreateConnection(
-			ctx, connCtx,
-			a.flags.name,
-			rawConnectionProperties{
-				AuthType: normalizeAuthTypeToARM(a.flags.authType),
-				Category: normalizeKind(a.flags.kind),
-				Target:   a.flags.target,
-				Audience: a.flags.audience,
-				Metadata: parseKVMap(a.flags.metadata),
-			},
-		)
+	case "oauth2", "user-entra-token", "project-managed-identity", "agentic-identity":
+		props := rawConnectionProperties{
+			AuthType:         normalizeAuthTypeToARM(a.flags.authType),
+			Category:         normalizeKind(a.flags.kind),
+			Target:           a.flags.target,
+			Audience:         a.flags.audience,
+			Metadata:         parseKVMap(a.flags.metadata),
+			AuthorizationURL: a.flags.authorizationURL,
+			TokenURL:         a.flags.tokenURL,
+			RefreshURL:       a.flags.refreshURL,
+			Scopes:           a.flags.scopes,
+			ConnectorName:    a.flags.connectorName,
+		}
+		if a.flags.clientID != "" || a.flags.clientSecret != "" {
+			props.Credentials = &rawCredentials{
+				ClientID:     a.flags.clientID,
+				ClientSecret: a.flags.clientSecret,
+			}
+		}
+		err = rawCreateConnection(ctx, connCtx, a.flags.name, props)
 	default:
 		body, buildErr := buildConnectionBody(
 			a.flags.kind, a.flags.target, a.flags.authType,
@@ -366,6 +388,16 @@ func newConnectionCreateCommand(extCtx *azdext.ExtensionContext) *cobra.Command 
 		"OAuth2 client secret (required for oauth2 auth)")
 	cmd.Flags().StringVar(&flags.audience, "audience", "",
 		"Token audience for user-entra-token/agentic-identity auth")
+	cmd.Flags().StringVar(&flags.authorizationURL, "authorization-url", "",
+		"OAuth2 authorization endpoint URL")
+	cmd.Flags().StringVar(&flags.tokenURL, "token-url", "",
+		"OAuth2 token endpoint URL")
+	cmd.Flags().StringVar(&flags.refreshURL, "refresh-url", "",
+		"OAuth2 token refresh URL")
+	cmd.Flags().StringVar(&flags.scopes, "scopes", "",
+		"OAuth2 scopes (space-separated)")
+	cmd.Flags().StringVar(&flags.connectorName, "connector-name", "",
+		"Managed connector name (for OAuth2 connectors)")
 	return cmd
 }
 
@@ -471,8 +503,8 @@ func (a *ConnectionUpdateAction) Run(ctx context.Context) error {
 
 	// Route to raw REST or typed SDK based on auth type
 	switch normalizedAuth {
-	case "user-entra-token", "project-managed-identity", "agentic-identity":
-		// Identity auth types lack ARM SDK structs — update via raw REST
+	case "oauth2", "user-entra-token", "project-managed-identity", "agentic-identity":
+		// Auth types that lack full ARM SDK support — update via raw REST
 		err = rawCreateConnection(
 			ctx, connCtx,
 			a.flags.name,
@@ -736,31 +768,12 @@ func buildConnectionBody(
 			},
 		}, nil
 
-	case "oauth2":
-		at := armcognitiveservices.ConnectionAuthTypeOAuth2
-		creds := &armcognitiveservices.ConnectionOAuth2{}
-		if clientID != "" {
-			creds.ClientID = &clientID
-		}
-		if clientSecret != "" {
-			creds.ClientSecret = &clientSecret
-		}
-		return &armcognitiveservices.ConnectionPropertiesV2BasicResource{
-			Properties: &armcognitiveservices.OAuth2AuthTypeConnectionProperties{
-				AuthType:    &at,
-				Category:    &cat,
-				Target:      &target,
-				Credentials: creds,
-				Metadata:    metaMap,
-			},
-		}, nil
-
 	default:
 		return nil, exterrors.Validation(
 			exterrors.CodeInvalidAuthType,
 			fmt.Sprintf("Unsupported auth type %q.", authType),
-			"Supported: api-key, custom-keys, none, oauth2. "+
-				"For identity-based auth types (user-entra-token, project-managed-identity, "+
+			"Supported: api-key, custom-keys, none. "+
+				"For oauth2 and identity-based auth types (user-entra-token, project-managed-identity, "+
 				"agentic-identity), use 'connection create' directly.",
 		)
 	}
@@ -899,6 +912,8 @@ func normalizeAuthType(armAuthType string) string {
 // Used for auth types that lack ARM SDK structs and require raw REST.
 func normalizeAuthTypeToARM(cliAuthType string) string {
 	switch cliAuthType {
+	case "oauth2":
+		return "OAuth2"
 	case "user-entra-token":
 		return "UserEntraToken"
 	case "project-managed-identity":

--- a/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection_test.go
@@ -9,7 +9,6 @@ import (
 
 	"azureaiagent/internal/connections/pkg/connections"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -169,6 +168,7 @@ func TestNormalizeAuthTypeToARM(t *testing.T) {
 		input string
 		want  string
 	}{
+		{"oauth2", "OAuth2"},
 		{"user-entra-token", "UserEntraToken"},
 		{"project-managed-identity", "ProjectManagedIdentity"},
 		{"agentic-identity", "AgenticIdentityToken"},
@@ -183,20 +183,14 @@ func TestNormalizeAuthTypeToARM(t *testing.T) {
 	}
 }
 
-func TestBuildConnectionBody_OAuth2(t *testing.T) {
-	body, err := buildConnectionBody(
+func TestBuildConnectionBody_OAuth2_NowUnsupported(t *testing.T) {
+	// OAuth2 is now handled via raw REST, so buildConnectionBody should reject it
+	_, err := buildConnectionBody(
 		"RemoteTool", "https://example.com", "oauth2",
-		"", nil, nil,
-		"test-client-id", "test-client-secret",
+		"", nil, nil, "", "",
 	)
-	require.NoError(t, err)
-
-	props, ok := body.Properties.(*armcognitiveservices.OAuth2AuthTypeConnectionProperties)
-	require.True(t, ok, "expected OAuth2AuthTypeConnectionProperties")
-	require.Equal(t, armcognitiveservices.ConnectionAuthTypeOAuth2, *props.AuthType)
-	require.Equal(t, "https://example.com", *props.Target)
-	require.Equal(t, "test-client-id", *props.Credentials.ClientID)
-	require.Equal(t, "test-client-secret", *props.Credentials.ClientSecret)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Unsupported auth type")
 }
 
 func TestBuildConnectionBody_UnsupportedAuthType(t *testing.T) {
@@ -206,6 +200,41 @@ func TestBuildConnectionBody_UnsupportedAuthType(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Unsupported auth type")
+}
+
+func TestRawConnectionBody_OAuth2_FullFields(t *testing.T) {
+	props := rawConnectionProperties{
+		AuthType:         "OAuth2",
+		Category:         "RemoteTool",
+		Target:           "https://api.githubcopilot.com/mcp/",
+		AuthorizationURL: "https://github.com/login/oauth/authorize",
+		TokenURL:         "https://github.com/login/oauth/access_token",
+		RefreshURL:       "https://github.com/login/oauth/access_token",
+		Scopes:           "read:user user:email",
+		ConnectorName:    "github",
+		Credentials: &rawCredentials{
+			ClientID:     "test-cid",
+			ClientSecret: "test-csec",
+		},
+	}
+	body := rawConnectionBody{Properties: props}
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(data, &parsed))
+
+	p := parsed["properties"].(map[string]any)
+	require.Equal(t, "OAuth2", p["authType"])
+	require.Equal(t, "https://github.com/login/oauth/authorize", p["authorizationUrl"])
+	require.Equal(t, "https://github.com/login/oauth/access_token", p["tokenUrl"])
+	require.Equal(t, "https://github.com/login/oauth/access_token", p["refreshUrl"])
+	require.Equal(t, "read:user user:email", p["scopes"])
+	require.Equal(t, "github", p["connectorName"])
+
+	creds := p["credentials"].(map[string]any)
+	require.Equal(t, "test-cid", creds["clientId"])
+	require.Equal(t, "test-csec", creds["clientSecret"])
 }
 
 func TestRawConnectionBody_MarshalJSON(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection_test.go
@@ -356,6 +356,30 @@ func TestParseKVPtrMap(t *testing.T) {
 	}
 }
 
+func TestRawConnectionBody_OAuth2_ConnectorNameOnly(t *testing.T) {
+	// When using a managed connector, only connectorName is set — no credentials.
+	props := rawConnectionProperties{
+		AuthType:      "OAuth2",
+		Category:      "RemoteTool",
+		Target:        "https://example.com",
+		ConnectorName: "github",
+	}
+	body := rawConnectionBody{Properties: props}
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(data, &parsed))
+
+	p := parsed["properties"].(map[string]any)
+	require.Equal(t, "OAuth2", p["authType"])
+	require.Equal(t, "github", p["connectorName"])
+	_, hasCreds := p["credentials"]
+	require.False(t, hasCreds, "credentials should be omitted for connector-name-only")
+	_, hasAuthURL := p["authorizationUrl"]
+	require.False(t, hasAuthURL, "authorizationUrl should be omitted for connector-name-only")
+}
+
 func TestBuildCredentialReferences(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection_test.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"azureaiagent/internal/connections/pkg/connections"
@@ -202,7 +203,115 @@ func TestBuildConnectionBody_UnsupportedAuthType(t *testing.T) {
 	require.Contains(t, err.Error(), "Unsupported auth type")
 }
 
+func TestOAuth2Validation(t *testing.T) {
+	runValidation := func(flags *connectionCreateFlags) error {
+		action := &ConnectionCreateAction{flags: flags}
+		// Run calls resolveConnectionContext which needs real infra, so we only
+		// test the validation prefix by calling Run and checking for validation errors.
+		// Any error that is NOT a validation error means we passed validation.
+		err := action.Run(t.Context())
+		return err
+	}
+
+	isValidationError := func(err error, substr string) bool {
+		return err != nil && strings.Contains(err.Error(), substr)
+	}
+
+	t.Run("reject connector-name combined with BYO flags", func(t *testing.T) {
+		flags := &connectionCreateFlags{
+			kind:             "remote-tool",
+			target:           "https://example.com",
+			authType:         "oauth2",
+			connectorName:    "github",
+			authorizationURL: "https://example.com/auth",
+		}
+		err := runValidation(flags)
+		require.True(t, isValidationError(err, "--connector-name cannot be combined with"))
+	})
+
+	t.Run("reject empty oauth2 - neither connector nor BYO", func(t *testing.T) {
+		flags := &connectionCreateFlags{
+			kind:     "remote-tool",
+			target:   "https://example.com",
+			authType: "oauth2",
+		}
+		err := runValidation(flags)
+		require.True(t, isValidationError(err, "OAuth2 auth requires either"))
+	})
+
+	t.Run("reject partial BYO - missing required fields", func(t *testing.T) {
+		flags := &connectionCreateFlags{
+			kind:             "remote-tool",
+			target:           "https://example.com",
+			authType:         "oauth2",
+			authorizationURL: "https://example.com/auth",
+			// missing token-url, client-id, client-secret
+		}
+		err := runValidation(flags)
+		require.True(t, isValidationError(err, "Missing: --token-url"))
+	})
+
+	t.Run("accept connector-name only", func(t *testing.T) {
+		flags := &connectionCreateFlags{
+			kind:          "remote-tool",
+			target:        "https://example.com",
+			authType:      "oauth2",
+			connectorName: "github",
+		}
+		err := runValidation(flags)
+		// Should pass validation — any error here is from resolveConnectionContext, not validation
+		require.False(t, isValidationError(err, "connector-name"))
+		require.False(t, isValidationError(err, "Missing"))
+	})
+
+	t.Run("accept full BYO without optional refresh-url", func(t *testing.T) {
+		flags := &connectionCreateFlags{
+			kind:             "remote-tool",
+			target:           "https://example.com",
+			authType:         "oauth2",
+			authorizationURL: "https://example.com/auth",
+			tokenURL:         "https://example.com/token",
+			clientID:         "cid",
+			clientSecret:     "csec",
+		}
+		err := runValidation(flags)
+		// Should pass validation — any error here is from resolveConnectionContext, not validation
+		require.False(t, isValidationError(err, "Missing"))
+		require.False(t, isValidationError(err, "requires"))
+	})
+
+	t.Run("accept full BYO with all fields", func(t *testing.T) {
+		flags := &connectionCreateFlags{
+			kind:             "remote-tool",
+			target:           "https://example.com",
+			authType:         "oauth2",
+			authorizationURL: "https://example.com/auth",
+			tokenURL:         "https://example.com/token",
+			refreshURL:       "https://example.com/refresh",
+			scopes:           []string{"read", "write"},
+			clientID:         "cid",
+			clientSecret:     "csec",
+		}
+		err := runValidation(flags)
+		require.False(t, isValidationError(err, "Missing"))
+		require.False(t, isValidationError(err, "requires"))
+	})
+
+	t.Run("reject oauth2 flags with non-oauth2 auth type", func(t *testing.T) {
+		flags := &connectionCreateFlags{
+			kind:     "remote-tool",
+			target:   "https://example.com",
+			authType: "api-key",
+			key:      "abc",
+			scopes:   []string{"read"},
+		}
+		err := runValidation(flags)
+		require.True(t, isValidationError(err, "only valid with --auth-type oauth2"))
+	})
+}
+
 func TestRawConnectionBody_OAuth2_FullFields(t *testing.T) {
+	// BYO OAuth2 — no ConnectorName (CLI makes connector-name and BYO mutually exclusive).
 	props := rawConnectionProperties{
 		AuthType:         "OAuth2",
 		Category:         "RemoteTool",
@@ -210,8 +319,7 @@ func TestRawConnectionBody_OAuth2_FullFields(t *testing.T) {
 		AuthorizationURL: "https://github.com/login/oauth/authorize",
 		TokenURL:         "https://github.com/login/oauth/access_token",
 		RefreshURL:       "https://github.com/login/oauth/access_token",
-		Scopes:           "read:user user:email",
-		ConnectorName:    "github",
+		Scopes:           []string{"read:user", "user:email"},
 		Credentials: &rawCredentials{
 			ClientID:     "test-cid",
 			ClientSecret: "test-csec",
@@ -229,8 +337,15 @@ func TestRawConnectionBody_OAuth2_FullFields(t *testing.T) {
 	require.Equal(t, "https://github.com/login/oauth/authorize", p["authorizationUrl"])
 	require.Equal(t, "https://github.com/login/oauth/access_token", p["tokenUrl"])
 	require.Equal(t, "https://github.com/login/oauth/access_token", p["refreshUrl"])
-	require.Equal(t, "read:user user:email", p["scopes"])
-	require.Equal(t, "github", p["connectorName"])
+
+	// scopes must be a JSON array
+	scopesList, ok := p["scopes"].([]any)
+	require.True(t, ok, "scopes should be a JSON array")
+	require.Equal(t, []any{"read:user", "user:email"}, scopesList)
+
+	// No connectorName in BYO mode
+	_, hasConnector := p["connectorName"]
+	require.False(t, hasConnector, "connectorName should be omitted in BYO mode")
 
 	creds := p["credentials"].(map[string]any)
 	require.Equal(t, "test-cid", creds["clientId"])

--- a/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection_test.go
@@ -265,7 +265,7 @@ func TestOAuth2Validation(t *testing.T) {
 	})
 
 	t.Run("accept full BYO without optional refresh-url", func(t *testing.T) {
-		flags := &connectionCreateFlags{
+		flags := &connectionCreateFlags{ //nolint:gosec // test credentials, not real
 			kind:             "remote-tool",
 			target:           "https://example.com",
 			authType:         "oauth2",
@@ -281,7 +281,7 @@ func TestOAuth2Validation(t *testing.T) {
 	})
 
 	t.Run("accept full BYO with all fields", func(t *testing.T) {
-		flags := &connectionCreateFlags{
+		flags := &connectionCreateFlags{ //nolint:gosec // test credentials, not real
 			kind:             "remote-tool",
 			target:           "https://example.com",
 			authType:         "oauth2",
@@ -312,7 +312,7 @@ func TestOAuth2Validation(t *testing.T) {
 
 func TestRawConnectionBody_OAuth2_FullFields(t *testing.T) {
 	// BYO OAuth2 — no ConnectorName (CLI makes connector-name and BYO mutually exclusive).
-	props := rawConnectionProperties{
+	props := rawConnectionProperties{ //nolint:gosec // test credentials, not real
 		AuthType:         "OAuth2",
 		Category:         "RemoteTool",
 		Target:           "https://api.githubcopilot.com/mcp/",

--- a/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/raw_connection.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/raw_connection.go
@@ -18,14 +18,26 @@ import (
 )
 
 // rawConnectionProperties represents the JSON body for connection PUT requests
-// that use auth types not covered by the ARM Go SDK (e.g., UserEntraToken,
-// ProjectManagedIdentity, AgenticIdentityToken).
+// that use auth types not covered by the ARM Go SDK (e.g., OAuth2 with full fields,
+// UserEntraToken, ProjectManagedIdentity, AgenticIdentityToken).
 type rawConnectionProperties struct {
-	AuthType string            `json:"authType"`
-	Category string            `json:"category"`
-	Target   string            `json:"target"`
-	Metadata map[string]string `json:"metadata,omitempty"`
-	Audience string            `json:"audience,omitempty"`
+	AuthType         string            `json:"authType"`
+	Category         string            `json:"category"`
+	Target           string            `json:"target"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+	Audience         string            `json:"audience,omitempty"`
+	AuthorizationURL string            `json:"authorizationUrl,omitempty"`
+	TokenURL         string            `json:"tokenUrl,omitempty"`
+	RefreshURL       string            `json:"refreshUrl,omitempty"`
+	Scopes           string            `json:"scopes,omitempty"`
+	ConnectorName    string            `json:"connectorName,omitempty"`
+	Credentials      *rawCredentials   `json:"credentials,omitempty"`
+}
+
+// rawCredentials represents OAuth2 credentials in the raw REST body.
+type rawCredentials struct {
+	ClientID     string `json:"clientId,omitempty"`
+	ClientSecret string `json:"clientSecret,omitempty"`
 }
 
 type rawConnectionBody struct {

--- a/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/raw_connection.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/raw_connection.go
@@ -29,7 +29,7 @@ type rawConnectionProperties struct {
 	AuthorizationURL string            `json:"authorizationUrl,omitempty"`
 	TokenURL         string            `json:"tokenUrl,omitempty"`
 	RefreshURL       string            `json:"refreshUrl,omitempty"`
-	Scopes           string            `json:"scopes,omitempty"`
+	Scopes           []string          `json:"scopes,omitempty"`
 	ConnectorName    string            `json:"connectorName,omitempty"`
 	Credentials      *rawCredentials   `json:"credentials,omitempty"`
 }


### PR DESCRIPTION
## Summary

Fixes #8355

Adds missing OAuth2 connection fields (`--authorization-url`, `--token-url`, `--refresh-url`, `--scopes`, `--connector-name`) and implements either/or validation for managed connector vs BYO OAuth2 flows.

## Problem

The ARM Go SDK `ConnectionOAuth2` struct only exposes `AuthURL`, `ClientID`, and `ClientSecret`. It does not model `tokenUrl`, `refreshUrl`, `scopes`, or `connectorName` — all top-level ARM connection properties required for full OAuth2 support.

## Changes

### OAuth2 moved to raw REST path
- OAuth2 connections now use the same raw REST pipeline as identity auth types
- Bypasses SDK struct limitations — all fields serialize directly to the ARM wire format
- `buildConnectionBody` rejects OAuth2 with a clear error if accidentally called

### New flags
| Flag | Description |
|------|------------|
| `--authorization-url` | OAuth2 authorization endpoint |
| `--token-url` | OAuth2 token endpoint |
| `--refresh-url` | OAuth2 token refresh endpoint |
| `--scopes` | OAuth2 scopes (space-separated) |
| `--connector-name` | Managed connector name (e.g., github, slack) |

### Either/or validation
Two mutually exclusive modes for `--auth-type oauth2`:
1. **Managed connector**: `--connector-name` alone
2. **BYO OAuth2**: all of `--authorization-url`, `--token-url`, `--refresh-url`, `--scopes`, `--client-id`, `--client-secret`

Partial combinations are rejected with a clear error listing exactly which flags are missing.

### Tests
- 33 tests passing
- Added: connector-name-only body serialization test
- Added: OAuth2 full fields raw REST marshaling test

## Files changed
- `connection.go` — moved OAuth2 to raw REST switch, added flags, either/or validation
- `raw_connection.go` — added OAuth2 fields, `rawCredentials` struct
- `connection_test.go` — updated/added OAuth2 tests