### PR TITLE
[fix] Adaptive changes for optimization request contract

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_helpers.go
@@ -337,6 +337,9 @@ func promptModelSelection(
 	if err != nil {
 		return "", fmt.Errorf("prompting for model: %w", err)
 	}
+	if resp.Value == nil || int(*resp.Value) >= len(choices) {
+		return "", fmt.Errorf("unexpected prompt response for model selection")
+	}
 	selected := choices[int(*resp.Value)].Value
 
 	if selected == selectOtherDeploymentValue {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_helpers.go
@@ -16,6 +16,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"azureaiagent/internal/pkg/agents/eval_api"
 	"azureaiagent/internal/pkg/agents/opt_eval"
@@ -304,4 +305,153 @@ func padColorizedStatus(status string) string {
 	label, colorFn := statusLabelAndColor(status)
 	padded := fmt.Sprintf("%-*s", statusWidth, label)
 	return colorFn(padded)
+}
+
+// ---------------------------------------------------------------------------
+// Shared prompt helpers (used by eval init and optimize)
+// ---------------------------------------------------------------------------
+
+// selectOtherDeploymentValue is the sentinel value for the "Select another
+// deployment" choice in the model picker.
+const selectOtherDeploymentValue = "__select_other_deployment__"
+
+// promptModelSelection presents an interactive model picker. It shows the
+// defaultModel (if non-empty) as the first choice, followed by a "Select
+// another deployment" option. If the user picks "Select another deployment",
+// it fetches all Foundry project deployments and prompts again.
+func promptModelSelection(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	message string,
+	defaultModel string,
+) (string, error) {
+	choices := buildModelSelectionChoices(defaultModel)
+	defaultIndex := int32(0)
+	resp, err := azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
+		Options: &azdext.SelectOptions{
+			Message:       message,
+			Choices:       choices,
+			SelectedIndex: &defaultIndex,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("prompting for model: %w", err)
+	}
+	selected := choices[int(*resp.Value)].Value
+
+	if selected == selectOtherDeploymentValue {
+		return promptAllDeployments(ctx, azdClient)
+	}
+
+	return selected, nil
+}
+
+// buildModelSelectionChoices builds the initial choices for the model picker.
+// When defaultModel is non-empty it appears first as the default.
+func buildModelSelectionChoices(defaultModel string) []*azdext.SelectChoice {
+	var choices []*azdext.SelectChoice
+	if defaultModel != "" {
+		choices = append(choices, &azdext.SelectChoice{
+			Label: defaultModel + " (deployed)",
+			Value: defaultModel,
+		})
+	}
+	choices = append(choices, &azdext.SelectChoice{
+		Label: "Select another deployment",
+		Value: selectOtherDeploymentValue,
+	})
+	return choices
+}
+
+// promptAllDeployments fetches all model deployments from the Foundry project
+// and prompts the user to select one.
+func promptAllDeployments(ctx context.Context, azdClient *azdext.AzdClient) (string, error) {
+	deployments := listDeploymentsFromEnv(ctx, azdClient)
+	if len(deployments) == 0 {
+		return "", fmt.Errorf("no model deployments found in the Foundry project")
+	}
+
+	choices := make([]*azdext.SelectChoice, len(deployments))
+	seen := make(map[string]bool)
+	i := 0
+	for _, d := range deployments {
+		if seen[d.Name] {
+			continue
+		}
+		label := d.Name
+		if d.ModelName != "" && d.ModelName != d.Name {
+			label = fmt.Sprintf("%s (%s)", d.Name, d.ModelName)
+		}
+		choices[i] = &azdext.SelectChoice{Label: label, Value: d.Name}
+		seen[d.Name] = true
+		i++
+	}
+	choices = choices[:i]
+
+	defaultIndex := int32(0)
+	resp, err := azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
+		Options: &azdext.SelectOptions{
+			Message:       "Select a model deployment",
+			Choices:       choices,
+			SelectedIndex: &defaultIndex,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("prompting for model deployment: %w", err)
+	}
+	return choices[int(*resp.Value)].Value, nil
+}
+
+// getDeployedModelFromEnv reads the AZURE_AI_MODEL_DEPLOYMENT_NAME from
+// the current azd environment. Returns empty string if not available.
+func getDeployedModelFromEnv(ctx context.Context, azdClient *azdext.AzdClient) string {
+	envResp, err := azdClient.Environment().GetCurrent(ctx, &azdext.EmptyRequest{})
+	if err != nil || envResp == nil || envResp.Environment == nil {
+		return ""
+	}
+	v, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+		EnvName: envResp.Environment.Name,
+		Key:     "AZURE_AI_MODEL_DEPLOYMENT_NAME",
+	})
+	if err != nil || v.Value == "" {
+		return ""
+	}
+	return v.Value
+}
+
+// promptDatasetSelection prompts the user to enter a dataset file path or
+// registered dataset name and resolves it. Returns the file path and dataset
+// reference (one will be set, the other empty/nil).
+func promptDatasetSelection(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	agentProject string,
+) (datasetFile string, datasetRef *opt_eval.DatasetRef, err error) {
+	resp, err := azdClient.Prompt().Prompt(ctx, &azdext.PromptRequest{
+		Options: &azdext.PromptOptions{
+			Message:        "Dataset file path or registered dataset name",
+			HelpMessage:    "Enter a local .jsonl file path or a registered dataset name",
+			IgnoreHintKeys: true,
+		},
+	})
+	if err != nil {
+		return "", nil, fmt.Errorf("prompting for dataset: %w", err)
+	}
+
+	value := strings.TrimSpace(resp.Value)
+	if value == "" {
+		return "", nil, fmt.Errorf(
+			"a dataset is required: use --dataset <file-or-name>, or provide dataset_file / dataset_reference " +
+				"in your config, or run 'azd ai agent eval init' to generate one")
+	}
+
+	if eval_api.IsDatasetName(value) {
+		return "", &opt_eval.DatasetRef{Name: value}, nil
+	}
+
+	resolved, err := resolveLocalDatasetFile(value, agentProject)
+	if err != nil {
+		return "", nil, err
+	}
+	return resolved, nil, nil
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_init_prompts.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_init_prompts.go
@@ -151,26 +151,9 @@ func promptEvalInitOptions(ctx context.Context, resolved *evalResolvedContext, f
 			}
 		}
 
-		choices := buildModelChoices(deployedModel)
-		defaultIndex := int32(0)
-		resp, err := azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
-			Options: &azdext.SelectOptions{
-				Message:       "Select the model for evaluation and generation",
-				Choices:       choices,
-				SelectedIndex: &defaultIndex,
-			},
-		})
+		selected, err := promptModelSelection(ctx, azdClient, "Select the model for evaluation and generation", deployedModel)
 		if err != nil {
-			return fmt.Errorf("prompting for evaluation model: %w", err)
-		}
-		selected := choices[int(*resp.Value)].Value
-
-		// User chose to pick from another deployment in the project.
-		if selected == selectOtherDeployment {
-			selected, err = promptProjectDeployment(ctx, resolved)
-			if err != nil {
-				return err
-			}
+			return err
 		}
 		flags.evalModel = selected
 	}
@@ -196,77 +179,6 @@ func promptEvalInitOptions(ctx context.Context, resolved *evalResolvedContext, f
 	}
 
 	return nil
-}
-
-// selectOtherDeployment is the sentinel value for the "Select another deployment"
-// choice in the model prompt.
-const selectOtherDeployment = "__select_other_deployment__"
-
-// buildModelChoices builds the initial model choices for the generation model
-// prompt. When deployedModel is non-empty it appears first as the default.
-// A "Select another deployment" option is always appended so the user can
-// browse all deployments in the Foundry project.
-func buildModelChoices(deployedModel string) []*azdext.SelectChoice {
-	var choices []*azdext.SelectChoice
-	if deployedModel != "" {
-		choices = append(choices, &azdext.SelectChoice{
-			Label: deployedModel + " (deployed)",
-			Value: deployedModel,
-		})
-	}
-	choices = append(choices, &azdext.SelectChoice{
-		Label: "Select another deployment",
-		Value: selectOtherDeployment,
-	})
-	return choices
-}
-
-// promptProjectDeployment fetches model deployments from the Foundry project
-// and prompts the user to select one.
-func promptProjectDeployment(ctx context.Context, resolved *evalResolvedContext) (string, error) {
-	var deployments []FoundryDeploymentInfo
-	if resolved.envName != "" {
-		if v, err := resolved.azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
-			EnvName: resolved.envName,
-			Key:     "AZURE_AI_PROJECT_ID",
-		}); err == nil && v.Value != "" {
-			if project, err := extractProjectDetails(v.Value); err == nil {
-				if cred, err := newAgentCredential(); err == nil {
-					deployments, _ = listProjectDeployments(
-						ctx, cred,
-						project.SubscriptionId,
-						project.ResourceGroupName,
-						project.AccountName,
-					)
-				}
-			}
-		}
-	}
-	if len(deployments) == 0 {
-		return "", fmt.Errorf("no model deployments found in the Foundry project")
-	}
-
-	choices := make([]*azdext.SelectChoice, len(deployments))
-	for i, d := range deployments {
-		label := d.Name
-		if d.ModelName != "" {
-			label = fmt.Sprintf("%s (%s)", d.Name, d.ModelName)
-		}
-		choices[i] = &azdext.SelectChoice{Label: label, Value: d.Name}
-	}
-
-	defaultIndex := int32(0)
-	resp, err := resolved.azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
-		Options: &azdext.SelectOptions{
-			Message:       "Select a model deployment",
-			Choices:       choices,
-			SelectedIndex: &defaultIndex,
-		},
-	})
-	if err != nil {
-		return "", fmt.Errorf("prompting for model deployment: %w", err)
-	}
-	return choices[int(*resp.Value)].Value, nil
 }
 
 // promptRegenerateChoices asks the user whether to regenerate the existing

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_init_test.go
@@ -276,27 +276,27 @@ func TestIsDatasetName(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// buildModelChoices
+// buildModelSelectionChoices (shared in model_prompt.go)
 // ---------------------------------------------------------------------------
 
-func TestBuildModelChoices(t *testing.T) {
+func TestBuildModelSelectionChoices(t *testing.T) {
 	t.Parallel()
 
 	t.Run("no deployed model has select-other only", func(t *testing.T) {
 		t.Parallel()
-		choices := buildModelChoices("")
+		choices := buildModelSelectionChoices("")
 		require.Len(t, choices, 1)
-		assert.Equal(t, selectOtherDeployment, choices[0].Value)
+		assert.Equal(t, selectOtherDeploymentValue, choices[0].Value)
 		assert.Equal(t, "Select another deployment", choices[0].Label)
 	})
 
 	t.Run("deployed model first then select-other", func(t *testing.T) {
 		t.Parallel()
-		choices := buildModelChoices("my-deployment")
+		choices := buildModelSelectionChoices("my-deployment")
 		require.Len(t, choices, 2)
 		assert.Equal(t, "my-deployment", choices[0].Value)
 		assert.Contains(t, choices[0].Label, "(deployed)")
-		assert.Equal(t, selectOtherDeployment, choices[1].Value)
+		assert.Equal(t, selectOtherDeploymentValue, choices[1].Value)
 	})
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize.go
@@ -320,16 +320,16 @@ func (a *OptimizeAction) applyOverrides(
 		}
 	}
 
-	// Resolve target_config.model: prompt user if not set.
-	if (cfg.Options.TargetConfig == nil || len(cfg.Options.TargetConfig.Model) == 0) && !a.noPrompt {
+	// Resolve optimization_config.model: prompt user if not set.
+	if !hasModelConfig(cfg.Options.OptimizationConfig) && !a.noPrompt {
 		if err := resolveOptimizeTargetModels(ctx, cfg); err != nil {
 			return err
 		}
 	}
 
-	// Resolve reflection_model: prompt user if not set.
-	if cfg.Options.ReflectionModel == "" && !a.noPrompt {
-		if err := resolveOptimizeReflectionModel(ctx, cfg); err != nil {
+	// Resolve optimization_model: prompt user if not set.
+	if cfg.Options.OptimizationModel == "" && !a.noPrompt {
+		if err := resolveOptimizeOptimizationModel(ctx, cfg); err != nil {
 			return err
 		}
 	}
@@ -382,7 +382,7 @@ func (a *OptimizeAction) submitJob(
 
 	client := optimize_api.NewOptimizeClient(endpoint, credential)
 
-	optimizeReq, err := cfg.ToRequest(endpoint)
+	optimizeReq, err := cfg.ToRequest()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build optimization request: %w", err)
 	}
@@ -395,8 +395,8 @@ func (a *OptimizeAction) submitJob(
 	hasProject := agentProject != ""
 	if hasProject {
 		if err := writeBaselineConfig(agentProject, baselineParams{
-			Model:       optimizeReq.Agent.Model,
-			Instruction: optimizeReq.Agent.SystemPrompt,
+			Model:       cfg.Agent.Model,
+			Instruction: cfg.Agent.ResolvedSystemPrompt(),
 			SkillDir:    cfg.SkillDir,
 			ToolsFile:   cfg.ToolsFile,
 		}); err != nil {
@@ -552,15 +552,15 @@ func printOptimizeResults(out io.Writer, status *optimize_api.OptimizeJobStatus,
 // formatOptimizeStatus returns a colorized string for the given job status.
 func formatOptimizeStatus(status string) string {
 	switch status {
-	case optimize_api.StatusCompleted:
+	case optimize_api.StatusCompleted, optimize_api.StatusSucceeded:
 		return color.GreenString(status)
 	case optimize_api.StatusFailed:
 		return color.RedString(status)
 	case optimize_api.StatusCancelled:
 		return color.YellowString(status)
-	case optimize_api.StatusRunning:
+	case optimize_api.StatusRunning, optimize_api.StatusInProgress:
 		return color.CyanString(status)
-	case optimize_api.StatusPending:
+	case optimize_api.StatusPending, optimize_api.StatusQueued:
 		return color.BlueString(status)
 	default:
 		return status

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"azureaiagent/internal/pkg/agents/eval_api"
 	"azureaiagent/internal/pkg/agents/opt_eval"
 	"azureaiagent/internal/pkg/agents/optimize_api"
 
@@ -79,12 +80,14 @@ func resolveOptimizeAgent(ctx context.Context, flagValue string, noPrompt bool) 
 
 // optimizeFlags holds CLI flags for the optimize (submit) command.
 type optimizeFlags struct {
-	configFile       string   // path to YAML config file
-	agent            string   // agent name override
-	evalModel        string   // model for evaluation
-	targetAttributes []string // optimization targets (instruction, skill)
-	noWait           bool     // return immediately after submission
-	pollInterval     int      // polling interval in seconds
+	configFile        string // path to YAML config file
+	agent             string // agent name override
+	dataset           string // existing dataset file or registered dataset name
+	evalModel         string // model for evaluation
+	optimizationModel string // model for optimization reasoning (gpt-5 family)
+	maxIterations     int    // max optimization iterations per strategy
+	noWait            bool   // return immediately after submission
+	pollInterval      int    // polling interval in seconds
 	optimizeConnectionFlags
 }
 
@@ -105,12 +108,6 @@ Use --config for a custom YAML spec, or just provide the agent name to use sensi
 
   # Optimize a specific agent
   azd ai agent optimize my-agent
-
-  # Optimize with skill target
-  azd ai agent optimize --target skill
-
-  # Optimize with multiple target attributes
-  azd ai agent optimize --target instruction --target skill
 
   # Full control via config file
   azd ai agent optimize --config spec.yaml
@@ -136,9 +133,11 @@ Use --config for a custom YAML spec, or just provide the agent name to use sensi
 
 	cmd.Flags().StringVarP(&flags.configFile, "config", "c", "", "Path to YAML config file (optional — uses defaults if omitted)")
 	cmd.Flags().StringVarP(&flags.agent, "agent", "a", "", "Agent name (auto-detected from azd project if omitted)")
-	cmd.Flags().StringVarP(&flags.evalModel, "eval-model", "m", defaultEvalModel, "Model for evaluation")
-	cmd.Flags().StringArrayVarP(&flags.targetAttributes, "target", "t", nil,
-		"Target attribute for optimization: instruction, skill (repeatable)")
+	cmd.Flags().StringVarP(&flags.dataset, "dataset", "d", "", "Existing local file or registered dataset name")
+	cmd.Flags().StringVarP(&flags.evalModel, "eval-model", "m", "", "Model for evaluation (required)")
+	cmd.Flags().StringVar(&flags.optimizationModel, "optimize-model", "",
+		"Model for optimization reasoning (must be gpt-5 family; falls back to eval model when not set)")
+	cmd.Flags().IntVar(&flags.maxIterations, "max-iterations", 5, "Maximum number of optimization iterations (must be >= 1)")
 	cmd.Flags().BoolVar(&flags.noWait, "no-wait", false, "Submit job and return immediately without waiting for completion")
 	cmd.Flags().IntVar(&flags.pollInterval, "poll-interval", 5, "Polling interval in seconds")
 	flags.optimizeConnectionFlags.register(cmd)
@@ -179,9 +178,7 @@ func (a *OptimizeAction) Run(ctx context.Context, cmd *cobra.Command) error {
 	bold := color.New(color.Bold)
 
 	_, _ = bold.Fprintf(out, "Optimizing agent %q...\n", cfg.Agent.Name)
-	if configSource == "" {
-		fmt.Fprintf(out, "  Dataset: built-in (3 tasks, 12 criteria)\n")
-	} else {
+	if configSource != "" {
 		fmt.Fprintf(out, "  Config: %s\n", configSource)
 	}
 
@@ -269,23 +266,52 @@ func (a *OptimizeAction) applyOverrides(
 	cfg *OptimizeConfig,
 	agentProject string,
 ) error {
-	if err := cfg.Validate(); err != nil {
-		return fmt.Errorf("invalid config: %w", err)
+	// Apply --dataset flag before anything else.
+	if a.flags.dataset != "" {
+		if eval_api.IsDatasetName(a.flags.dataset) {
+			cfg.DatasetReference = &opt_eval.DatasetRef{Name: a.flags.dataset}
+			cfg.DatasetFile = ""
+		} else {
+			resolved, err := resolveLocalDatasetFile(a.flags.dataset, agentProject)
+			if err != nil {
+				return err
+			}
+			cfg.DatasetFile = resolved
+			cfg.DatasetReference = nil
+		}
+	}
+
+	// Ensure Options is initialized.
+	if cfg.Options == nil {
+		cfg.Options = &opt_eval.Options{}
 	}
 
 	hasProject := agentProject != ""
 
-	// CLI flags override config values.
+	// CLI flags override config values (applied before prompts so prompts skip set values).
 	if a.flags.evalModel != "" {
 		cfg.Options.EvalModel = a.flags.evalModel
 	}
-	if len(a.flags.targetAttributes) > 0 {
-		cfg.Options.TargetAttributes = a.flags.targetAttributes
+	if a.flags.optimizationModel != "" {
+		cfg.Options.OptimizationModel = a.flags.optimizationModel
+	}
+	if a.flags.maxIterations > 0 {
+		cfg.Options.MaxIterations = &a.flags.maxIterations
 	}
 
 	// Resolve agent config: try existing config pointer, then default baseline.
 	if hasProject {
 		mergeAgentBaseline(cfg, agentProject)
+	}
+
+	// If the model is still unknown, try the azd environment (set during deploy).
+	if cfg.Agent.Model == "" {
+		if azdClient, clientErr := azdext.NewAzdClient(); clientErr == nil {
+			defer azdClient.Close()
+			if m := getDeployedModelFromEnv(ctx, azdClient); m != "" {
+				cfg.Agent.Model = m
+			}
+		}
 	}
 
 	// When baseline config is detected, show resolved values and let the user confirm.
@@ -320,6 +346,20 @@ func (a *OptimizeAction) applyOverrides(
 		}
 	}
 
+	// Resolve eval_model: prompt user if not set.
+	if cfg.Options.EvalModel == "" {
+		if err := resolveOptimizeEvalModel(ctx, cfg, a.noPrompt); err != nil {
+			return err
+		}
+	}
+
+	// Resolve dataset: prompt user if neither file nor reference is set.
+	if cfg.DatasetFile == "" && cfg.DatasetReference == nil {
+		if err := resolveOptimizeDataset(ctx, cfg, agentProject, a.noPrompt); err != nil {
+			return err
+		}
+	}
+
 	// Resolve optimization_config.model: prompt user if not set.
 	if !hasModelConfig(cfg.Options.OptimizationConfig) && !a.noPrompt {
 		if err := resolveOptimizeTargetModels(ctx, cfg); err != nil {
@@ -332,6 +372,11 @@ func (a *OptimizeAction) applyOverrides(
 		if err := resolveOptimizeOptimizationModel(ctx, cfg); err != nil {
 			return err
 		}
+	}
+
+	// Final validation after all overrides and prompts.
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
 	}
 
 	return nil
@@ -382,11 +427,16 @@ func (a *OptimizeAction) submitJob(
 
 	client := optimize_api.NewOptimizeClient(endpoint, credential)
 
-	optimizeReq, err := cfg.ToRequest()
+	optimizeReq, warnings, err := cfg.ToRequest()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build optimization request: %w", err)
 	}
 
+	for _, w := range warnings {
+		fmt.Fprintf(out, "  warning: %s\n", w)
+	}
+
+	// TODO: remove it
 	if body, jsonErr := json.MarshalIndent(optimizeReq, "", "  "); jsonErr == nil {
 		log.Printf("[debug] optimization request:\n%s", body)
 	}
@@ -489,10 +539,10 @@ func printOptimizeResults(out io.Writer, status *optimize_api.OptimizeJobStatus,
 	green := color.New(color.FgGreen)
 
 	_, _ = bold.Fprintln(out, "\nResults:")
-	fmt.Fprintf(out, "  %-20s %7s %7s %8s\n", "Candidate", "Score", "Pass", "Tokens")
-	fmt.Fprintf(out, "  %-20s %7s %7s %8s\n",
+	fmt.Fprintf(out, "  %-20s %7s %7s %8s  %s\n", "Candidate", "Score", "Pass", "Tokens", "Pareto optimal")
+	fmt.Fprintf(out, "  %-20s %7s %7s %8s  %s\n",
 		strings.Repeat("─", 20), strings.Repeat("─", 7),
-		strings.Repeat("─", 7), strings.Repeat("─", 8))
+		strings.Repeat("─", 7), strings.Repeat("─", 8), strings.Repeat("─", 13))
 
 	bestName := ""
 	if status.Best != nil {
@@ -506,7 +556,12 @@ func printOptimizeResults(out io.Writer, status *optimize_api.OptimizeJobStatus,
 			name += " ★"
 		}
 
-		line := fmt.Sprintf("  %-20s %7.2f %6.0f%% %8.0f", name, c.AvgScore, c.PassRate*100, c.AvgTokens)
+		pareto := "--"
+		if c.IsParetoOptimal {
+			pareto = color.New(color.FgGreen).Sprint("Pareto")
+		}
+
+		line := fmt.Sprintf("  %-20s %7.2f %6.0f%% %8.0f  %-6s", name, c.AvgScore, c.PassRate*100, c.AvgTokens, pareto)
 		if isBest {
 			_, _ = green.Fprintln(out, line)
 		} else {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize.go
@@ -12,10 +12,8 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -131,13 +129,13 @@ Use --config for a custom YAML spec, or just provide the agent name to use sensi
 		},
 	}
 
-	cmd.Flags().StringVarP(&flags.configFile, "config", "c", "", "Path to YAML config file (optional — uses defaults if omitted)")
+	cmd.Flags().StringVarP(&flags.configFile, "config", "c", "", "Path to YAML config file (optional — values are prompted interactively if omitted)")
 	cmd.Flags().StringVarP(&flags.agent, "agent", "a", "", "Agent name (auto-detected from azd project if omitted)")
 	cmd.Flags().StringVarP(&flags.dataset, "dataset", "d", "", "Existing local file or registered dataset name")
 	cmd.Flags().StringVarP(&flags.evalModel, "eval-model", "m", "", "Model for evaluation (required)")
 	cmd.Flags().StringVar(&flags.optimizationModel, "optimize-model", "",
-		"Model for optimization reasoning (must be gpt-5 family; falls back to eval model when not set)")
-	cmd.Flags().IntVar(&flags.maxIterations, "max-iterations", 5, "Maximum number of optimization iterations (must be >= 1)")
+		"Model for optimization reasoning (gpt-5 family recommended; falls back to eval model when not set)")
+	cmd.Flags().IntVar(&flags.maxIterations, "max-iterations", 0, "Maximum number of optimization iterations (must be >= 1; default: 5)")
 	cmd.Flags().BoolVar(&flags.noWait, "no-wait", false, "Submit job and return immediately without waiting for completion")
 	cmd.Flags().IntVar(&flags.pollInterval, "poll-interval", 5, "Polling interval in seconds")
 	flags.optimizeConnectionFlags.register(cmd)
@@ -434,11 +432,6 @@ func (a *OptimizeAction) submitJob(
 
 	for _, w := range warnings {
 		fmt.Fprintf(out, "  warning: %s\n", w)
-	}
-
-	// TODO: remove it
-	if body, jsonErr := json.MarshalIndent(optimizeReq, "", "  "); jsonErr == nil {
-		log.Printf("[debug] optimization request:\n%s", body)
 	}
 
 	// Save baseline config before starting optimization.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_apply.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_apply.go
@@ -132,9 +132,6 @@ func (a *OptimizeApplyAction) apply(
 		return fmt.Errorf("failed to create optimization directory: %w", err)
 	}
 
-	// Clean up other candidate directories, keeping only baseline and the current candidate.
-	cleanOtherCandidates(filepath.Join(serviceDir, agentConfigsDir), a.flags.candidate, out)
-
 	// Step 2: Download skill files into the candidate directory (before metadata.yaml
 	// so the skills/ dir exists when writeAgentConfigFromCandidate checks for it).
 	if n, dlErr := downloadSkillFilesToDir(ctx, optClient, a.flags.candidate, candidateDir, out); dlErr != nil {
@@ -401,31 +398,14 @@ func writeInlineSkills(candidateDir string, config map[string]any) error {
 	return nil
 }
 
-// writeToolsFile writes the candidate config as tools.json, preserving its
-// original structure (may be a list or an object).
+// writeToolsFile writes the "tools" array from the candidate config as tools.json.
 func writeToolsFile(candidateDir string, config map[string]any) error {
-	toolDefs, hasDefs := config["toolDefinitions"]
-	toolDescriptions, hasToolDescriptions := config["toolDescriptions"]
-	if !hasDefs && !hasToolDescriptions {
+	tools, ok := config["tools"]
+	if !ok {
 		return nil
 	}
 
-	// Write whichever is present. If only one key exists, write its value
-	// directly (preserves array or object). If both exist, wrap in an object.
-	var payload any
-	switch {
-	case hasDefs && hasToolDescriptions:
-		payload = map[string]any{
-			"toolDefinitions":  toolDefs,
-			"toolDescriptions": toolDescriptions,
-		}
-	case hasDefs:
-		payload = toolDefs
-	default:
-		payload = toolDescriptions
-	}
-
-	data, err := json.MarshalIndent(payload, "", "  ")
+	data, err := json.MarshalIndent(tools, "", "  ")
 	if err != nil {
 		return fmt.Errorf("serializing tools file: %w", err)
 	}
@@ -487,31 +467,6 @@ func downloadSkillFilesToDir(
 	}
 
 	return count, nil
-}
-
-// cleanOtherCandidates removes all subdirectories in the optimization folder
-// except the baseline and the candidate being applied.
-func cleanOtherCandidates(optimizeDir, currentCandidate string, out io.Writer) {
-	entries, err := os.ReadDir(optimizeDir)
-	if err != nil {
-		return
-	}
-
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		if name == opt_eval.BaselineDir || name == currentCandidate {
-			continue
-		}
-		dir := filepath.Join(optimizeDir, name)
-		if err := os.RemoveAll(dir); err != nil {
-			fmt.Fprintf(out, "  warning: failed to remove old candidate %s: %s\n", name, err)
-		} else {
-			fmt.Fprintf(out, "  Removed old candidate: %s\n", name)
-		}
-	}
 }
 
 // extractInstructions retrieves the system prompt string from a candidate config

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_apply_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_apply_test.go
@@ -358,26 +358,6 @@ func TestWriteAgentConfigFromCandidate(t *testing.T) {
 	})
 }
 
-// ---- cleanOtherCandidates ----
-
-func TestCleanOtherCandidates(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-
-	// Create baseline, current candidate, and old candidate directories.
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, opt_eval.BaselineDir), 0750))
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cand_current"), 0750))
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cand_old"), 0750))
-
-	var buf bytes.Buffer
-	cleanOtherCandidates(dir, "cand_current", &buf)
-
-	// baseline and cand_current should remain; cand_old should be removed.
-	assert.DirExists(t, filepath.Join(dir, opt_eval.BaselineDir))
-	assert.DirExists(t, filepath.Join(dir, "cand_current"))
-	assert.NoDirExists(t, filepath.Join(dir, "cand_old"))
-}
-
 // ---- isSkillFile ----
 
 func TestIsSkillFile(t *testing.T) {
@@ -424,7 +404,7 @@ func TestIsReservedEnvVarError(t *testing.T) {
 
 // ---- writeToolsFile ----
 
-func TestWriteToolsFile_NoKeys(t *testing.T) {
+func TestWriteToolsFile_NoTools(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	err := writeToolsFile(dir, map[string]any{"name": "agent"})
@@ -432,79 +412,30 @@ func TestWriteToolsFile_NoKeys(t *testing.T) {
 	assert.NoFileExists(t, filepath.Join(dir, opt_eval.ToolsFile))
 }
 
-func TestWriteToolsFile_OnlyToolDefinitions(t *testing.T) {
+func TestWriteToolsFile_WithTools(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	defs := []any{
+	tools := []any{
 		map[string]any{"type": "function", "function": map[string]any{"name": "search"}},
 	}
-	err := writeToolsFile(dir, map[string]any{"toolDefinitions": defs})
+	err := writeToolsFile(dir, map[string]any{"tools": tools})
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(filepath.Join(dir, opt_eval.ToolsFile)) //nolint:gosec // test file path
 	require.NoError(t, err)
 
-	// Should be written as a raw list (no wrapper object).
 	var parsed []any
 	require.NoError(t, json.Unmarshal(data, &parsed))
 	assert.Len(t, parsed, 1)
 }
 
-func TestWriteToolsFile_OnlyToolDescriptions(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	descs := map[string]any{
-		"lookup_policy": map[string]any{
-			"description": "Look up policy",
-			"parameters":  map[string]any{},
-		},
-	}
-	err := writeToolsFile(dir, map[string]any{"toolDescriptions": descs})
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(filepath.Join(dir, opt_eval.ToolsFile)) //nolint:gosec // test file path
-	require.NoError(t, err)
-
-	// Should be written as a raw object (no wrapper).
-	var parsed map[string]any
-	require.NoError(t, json.Unmarshal(data, &parsed))
-	assert.Contains(t, parsed, "lookup_policy")
-}
-
-func TestWriteToolsFile_BothKeys(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	defs := []any{
-		map[string]any{"type": "function", "function": map[string]any{"name": "search"}},
-	}
-	descs := map[string]any{
-		"search": map[string]any{"description": "Search stuff", "parameters": map[string]any{}},
-	}
-	err := writeToolsFile(dir, map[string]any{
-		"toolDefinitions":  defs,
-		"toolDescriptions": descs,
-	})
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(filepath.Join(dir, opt_eval.ToolsFile)) //nolint:gosec // test file path
-	require.NoError(t, err)
-
-	var parsed map[string]any
-	require.NoError(t, json.Unmarshal(data, &parsed))
-	assert.Contains(t, parsed, "toolDefinitions")
-	assert.Contains(t, parsed, "toolDescriptions")
-}
-
-func TestWriteAgentConfigFromCandidate_WithToolDescriptions(t *testing.T) {
+func TestWriteAgentConfigFromCandidate_WithTools(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	config := mustMarshal(t, map[string]any{
 		"systemPrompt": "prompt",
-		"toolDescriptions": map[string]any{
-			"check_budget": map[string]any{
-				"description": "Check the budget",
-				"parameters":  map[string]any{},
-			},
+		"tools": []any{
+			map[string]any{"type": "function", "function": map[string]any{"name": "lookup_travel_policy"}},
 		},
 	})
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_apply_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_apply_test.go
@@ -449,3 +449,125 @@ func TestWriteAgentConfigFromCandidate_WithTools(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(metaData), "tools_file")
 }
+
+// ---- writeToolsFile: ignores legacy keys ----
+
+func TestWriteToolsFile_IgnoresToolDefinitions(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// toolDefinitions is no longer supported — should not produce a file.
+	err := writeToolsFile(dir, map[string]any{
+		"toolDefinitions": []any{
+			map[string]any{"type": "function", "function": map[string]any{"name": "search"}},
+		},
+	})
+	require.NoError(t, err)
+	assert.NoFileExists(t, filepath.Join(dir, opt_eval.ToolsFile))
+}
+
+func TestWriteToolsFile_IgnoresToolDescriptions(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// toolDescriptions is no longer supported — should not produce a file.
+	err := writeToolsFile(dir, map[string]any{
+		"toolDescriptions": map[string]any{
+			"lookup": map[string]any{"description": "Look up stuff"},
+		},
+	})
+	require.NoError(t, err)
+	assert.NoFileExists(t, filepath.Join(dir, opt_eval.ToolsFile))
+}
+
+// ---- writeAgentConfigFromCandidate: model in metadata ----
+
+func TestWriteAgentConfigFromCandidate_ModelInMetadata(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	config := mustMarshal(t, map[string]any{
+		"name":         "travel-approver",
+		"model":        "gpt-4o",
+		"instructions": "Approve travel.",
+	})
+
+	err := writeAgentConfigFromCandidate(dir, config)
+	require.NoError(t, err)
+
+	metaData, err := os.ReadFile(filepath.Join(dir, opt_eval.MetadataFile)) //nolint:gosec // test file path
+	require.NoError(t, err)
+	assert.Contains(t, string(metaData), "model: gpt-4o")
+}
+
+func TestWriteAgentConfigFromCandidate_NoModel(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	config := mustMarshal(t, map[string]any{
+		"name":         "travel-approver",
+		"instructions": "Approve travel.",
+	})
+
+	err := writeAgentConfigFromCandidate(dir, config)
+	require.NoError(t, err)
+
+	metaData, err := os.ReadFile(filepath.Join(dir, opt_eval.MetadataFile)) //nolint:gosec // test file path
+	require.NoError(t, err)
+	// model is omitempty, so it should not appear when not set.
+	assert.NotContains(t, string(metaData), "model:")
+}
+
+// ---- writeAgentConfigFromCandidate: full candidate config ----
+
+func TestWriteAgentConfigFromCandidate_FullConfig(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	config := mustMarshal(t, map[string]any{
+		"name":         "travel-approver",
+		"model":        "gpt-4o",
+		"instructions": "Review and approve travel requests.",
+		"skills": []any{
+			map[string]any{
+				"name":        "policy-reviewer",
+				"description": "Reviews travel requests",
+				"body":        "# Policy Reviewer\nApprove everything.",
+			},
+		},
+		"tools": []any{
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":        "lookup_travel_policy",
+					"description": "Look up travel policy",
+				},
+			},
+		},
+	})
+
+	err := writeAgentConfigFromCandidate(dir, config)
+	require.NoError(t, err)
+
+	// Verify all files are created.
+	assert.FileExists(t, filepath.Join(dir, opt_eval.MetadataFile))
+	assert.FileExists(t, filepath.Join(dir, opt_eval.InstructionFile))
+	assert.FileExists(t, filepath.Join(dir, opt_eval.ToolsFile))
+	assert.FileExists(t, filepath.Join(dir, opt_eval.SkillsDir, "policy-reviewer", "SKILL.md"))
+
+	// Verify metadata has all fields.
+	metaData, err := os.ReadFile(filepath.Join(dir, opt_eval.MetadataFile)) //nolint:gosec // test file path
+	require.NoError(t, err)
+	metaStr := string(metaData)
+	assert.Contains(t, metaStr, "model: gpt-4o")
+	assert.Contains(t, metaStr, "instruction_file")
+	assert.Contains(t, metaStr, "skill_dir")
+	assert.Contains(t, metaStr, "tools_file")
+
+	// Verify instructions content.
+	instrData, err := os.ReadFile(filepath.Join(dir, opt_eval.InstructionFile)) //nolint:gosec // test file path
+	require.NoError(t, err)
+	assert.Equal(t, "Review and approve travel requests.", string(instrData))
+
+	// Verify tools.json is a list.
+	toolsData, err := os.ReadFile(filepath.Join(dir, opt_eval.ToolsFile)) //nolint:gosec // test file path
+	require.NoError(t, err)
+	var toolsParsed []any
+	require.NoError(t, json.Unmarshal(toolsData, &toolsParsed))
+	assert.Len(t, toolsParsed, 1)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
@@ -28,19 +28,12 @@ type OptimizeConfig struct {
 
 	// Optimize-specific YAML fields.
 	ValidationReference *opt_eval.DatasetRef       `yaml:"validation_reference,omitempty"`
-	Criteria            []OptimizeConfigCriterion  `yaml:"criteria,omitempty"`
 	Options             *opt_eval.Options          `yaml:"options"`
 	InlineDataset       []optimize_api.DatasetTask `yaml:"-"` // populated by defaultOptimizeConfig, not from YAML
 
 	// Runtime-only: resolved skill directory and tools file (not serialized to YAML).
 	SkillDir  string `yaml:"-"`
 	ToolsFile string `yaml:"-"`
-}
-
-// OptimizeConfigCriterion is a named evaluation criterion with a natural-language instruction.
-type OptimizeConfigCriterion struct {
-	Name        string `yaml:"name"`
-	Instruction string `yaml:"instruction"`
 }
 
 // LoadOptimizeConfig reads and parses a YAML optimization config file.
@@ -143,41 +136,26 @@ var defaultDataset = []optimize_api.DatasetTask{
 
 // ToRequest converts the YAML config into an API OptimizeRequest.
 // If DatasetFile is set, each line of the file is read as a JSON-encoded DatasetTask.
-func (c *OptimizeConfig) ToRequest(projectEndpoint string) (*optimize_api.OptimizeRequest, error) {
+func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, error) {
 	req := &optimize_api.OptimizeRequest{
-		Agent: optimize_api.AgentDefinition{
-			FoundryProjectURL: projectEndpoint,
-			AgentName:         c.Agent.Name,
-			AgentVersion:      c.Agent.Version,
-			Model:             c.Agent.Model,
-			SystemPrompt:      c.Agent.ResolvedSystemPrompt(),
+		Agent: optimize_api.AgentIdentifier{
+			AgentName:    c.Agent.Name,
+			AgentVersion: c.Agent.Version,
 		},
 		Evaluators: c.Evaluators.Names(),
 		Options: optimize_api.OptimizeOptions{
 			EvalModel:         c.Options.EvalModel,
 			MaxIterations:     c.Options.MaxIterations,
-			Strategies:        c.Options.TargetAttributes,
 			TargetAttributes:  c.Options.TargetAttributes,
 			KeepVersions:      c.Options.KeepVersions,
-			TasksPerIteration: c.Options.TasksPerIteration,
-			ReflectionModel:   c.Options.ReflectionModel,
+			OptimizationModel: c.Options.OptimizationModel,
 			EvaluationLevel:   c.Options.EvaluationLevel,
 		},
 	}
 
-	// Map target_config from YAML to API format.
-	if c.Options.TargetConfig != nil {
-		req.Options.TargetConfig = &optimize_api.TargetConfig{
-			Model: c.Options.TargetConfig.Model,
-		}
-	}
-
-	// Map criteria from config schema to API schema.
-	for _, crit := range c.Criteria {
-		req.Criteria = append(req.Criteria, optimize_api.Criterion{
-			Name:        crit.Name,
-			Instruction: crit.Instruction,
-		})
+	// Map optimization_config from YAML to API format.
+	if c.Options.OptimizationConfig != nil {
+		req.Options.OptimizationConfig = c.Options.OptimizationConfig
 	}
 
 	if c.DatasetReference != nil {
@@ -204,13 +182,34 @@ func (c *OptimizeConfig) ToRequest(projectEndpoint string) (*optimize_api.Optimi
 		req.Dataset = c.InlineDataset
 	}
 
+	// Populate optimization_config with baselineModel, systemPrompt, skills, tools.
+	ensureOptConfig := func() {
+		if req.Options.OptimizationConfig == nil {
+			req.Options.OptimizationConfig = make(map[string]json.RawMessage)
+		}
+	}
+
+	if model := c.Agent.Model; model != "" {
+		ensureOptConfig()
+		raw, _ := json.Marshal(model)
+		req.Options.OptimizationConfig["baselineModel"] = raw
+	}
+
+	if prompt := c.Agent.ResolvedSystemPrompt(); prompt != "" {
+		ensureOptConfig()
+		raw, _ := json.Marshal(prompt)
+		req.Options.OptimizationConfig["systemPrompt"] = raw
+	}
+
 	// Load skills from skill_dir if specified.
 	if c.SkillDir != "" {
 		skills, err := loadSkillsFromDir(c.SkillDir)
 		if err != nil {
 			return nil, fmt.Errorf("loading skills from %s: %w", c.SkillDir, err)
 		}
-		req.Agent.Skills = skills
+		ensureOptConfig()
+		raw, _ := json.Marshal(skills)
+		req.Options.OptimizationConfig["skills"] = raw
 	}
 
 	// Load tool definitions if a tools file is specified.
@@ -219,7 +218,9 @@ func (c *OptimizeConfig) ToRequest(projectEndpoint string) (*optimize_api.Optimi
 		if err != nil {
 			return nil, fmt.Errorf("loading tool definitions from %s: %w", c.ToolsFile, err)
 		}
-		req.Agent.ToolDefinitions = tools
+		ensureOptConfig()
+		raw, _ := json.Marshal(tools)
+		req.Options.OptimizationConfig["tools"] = raw
 	}
 
 	return req, nil

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
@@ -223,7 +223,7 @@ func loadJSONLRawFile(path string) ([]json.RawMessage, error) {
 	}
 
 	var result []json.RawMessage
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
@@ -76,8 +76,8 @@ func (c *OptimizeConfig) Validate() error {
 	return nil
 }
 
-// defaultOptimizeConfig returns a config with sensible defaults and a built-in
-// evaluation dataset.
+// defaultOptimizeConfig returns a minimal config skeleton with sensible defaults.
+// Dataset, eval model, and other values are resolved interactively or via flags.
 func defaultOptimizeConfig(agentName string) *OptimizeConfig {
 	return &OptimizeConfig{
 		Config: opt_eval.Config{
@@ -215,23 +215,31 @@ func loadToolDefinitions(path string) ([]optimize_api.ToolDefinition, []string, 
 }
 
 // loadJSONLRawFile reads a JSONL file and returns each non-empty line as
-// a json.RawMessage, preserving unknown fields.
+// a json.RawMessage, preserving unknown fields. Uses a streaming scanner
+// to avoid loading the entire file into memory at once.
 func loadJSONLRawFile(path string) ([]json.RawMessage, error) {
-	data, err := os.ReadFile(path) //nolint:gosec // path is provided by user for local config
+	f, err := os.Open(path) //nolint:gosec // path is provided by user for local config
 	if err != nil {
 		return nil, fmt.Errorf("failed to read JSONL file %s: %w", path, err)
 	}
+	defer f.Close()
 
 	var result []json.RawMessage
-	for line := range strings.SplitSeq(string(data), "\n") {
-		line = strings.TrimSpace(line)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
 			continue
 		}
-		if !json.Valid([]byte(line)) {
+		raw := make([]byte, len(line))
+		copy(raw, line)
+		if !json.Valid(raw) {
 			return nil, fmt.Errorf("invalid JSON line in %s: %s", path, line)
 		}
-		result = append(result, json.RawMessage(line))
+		result = append(result, json.RawMessage(raw))
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading JSONL file %s: %w", path, err)
 	}
 
 	if len(result) == 0 {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
@@ -102,7 +102,6 @@ func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, []string, e
 		Evaluators: c.Evaluators.Names(),
 		Options: optimize_api.OptimizeOptions{
 			EvalModel:         c.Options.EvalModel,
-			BaselineModel:     c.Agent.Model,
 			MaxIterations:     c.Options.MaxIterations,
 			OptimizationModel: c.Options.OptimizationModel,
 			EvaluationLevel:   c.Options.EvaluationLevel,
@@ -112,6 +111,15 @@ func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, []string, e
 	// Map optimization_config from YAML to API format.
 	if c.Options.OptimizationConfig != nil {
 		req.Options.OptimizationConfig = c.Options.OptimizationConfig
+	}
+
+	// Put baselineModel into optimizationConfig.
+	if c.Agent.Model != "" {
+		if req.Options.OptimizationConfig == nil {
+			req.Options.OptimizationConfig = make(map[string]json.RawMessage)
+		}
+		raw, _ := json.Marshal(c.Agent.Model)
+		req.Options.OptimizationConfig["baselineModel"] = raw
 	}
 
 	var warnings []string

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
@@ -27,9 +27,8 @@ type OptimizeConfig struct {
 	opt_eval.Config `yaml:",inline"`
 
 	// Optimize-specific YAML fields.
-	ValidationReference *opt_eval.DatasetRef       `yaml:"validation_reference,omitempty"`
-	Options             *opt_eval.Options          `yaml:"options"`
-	InlineDataset       []optimize_api.DatasetTask `yaml:"-"` // populated by defaultOptimizeConfig, not from YAML
+	ValidationReference *opt_eval.DatasetRef `yaml:"validation_reference,omitempty"`
+	Options             *opt_eval.Options    `yaml:"options"`
 
 	// Runtime-only: resolved skill directory and tools file (not serialized to YAML).
 	SkillDir  string `yaml:"-"`
@@ -63,14 +62,15 @@ func (c *OptimizeConfig) Validate() error {
 
 	hasFile := c.DatasetFile != ""
 	hasRef := c.DatasetReference != nil
-	hasInline := len(c.InlineDataset) > 0
 
 	if hasFile && hasRef {
 		return fmt.Errorf("dataset_file and dataset_reference are mutually exclusive; specify one, not both")
 	}
 
-	if !hasFile && !hasRef && !hasInline {
-		return fmt.Errorf("one of dataset_file or dataset_reference is required")
+	if !hasFile && !hasRef {
+		return fmt.Errorf(
+			"a dataset is required: provide dataset_file or dataset_reference in your config, " +
+				"or run 'azd ai agent eval init' to generate one")
 	}
 
 	return nil
@@ -84,59 +84,16 @@ func defaultOptimizeConfig(agentName string) *OptimizeConfig {
 			Agent:      opt_eval.AgentRef{Name: agentName},
 			Evaluators: opt_eval.EvaluatorList{{Name: "builtin.task_adherence"}},
 		},
-		InlineDataset: defaultDataset,
 		Options: &opt_eval.Options{
-			EvalModel:        defaultEvalModel,
-			TargetAttributes: []string{"instruction", "skill"},
+			MaxIterations: new(5),
 		},
 	}
 }
 
-var defaultDataset = []optimize_api.DatasetTask{
-	{
-		Name: "calculator_module",
-		Prompt: "Create a Python module calc.py with four functions: add, subtract, multiply, divide. " +
-			"Each takes two numbers and returns the result. Include a brief test at the bottom " +
-			"(if __name__ == '__main__') that exercises each function and prints the results. Then run it.",
-		Criteria: []optimize_api.Criterion{
-			{Name: "decimal_types", Instruction: "ALL functions MUST use and return Python's decimal.Decimal type, NOT float."},
-			{Name: "error_code_prefix", Instruction: "ALL error messages raised by any function MUST include a bracketed error code prefix [CALC-NNN]."},
-			{Name: "version_constant", Instruction: "The module MUST define VERSION = '0.1.0' and __version__ = VERSION near the top."},
-			{Name: "module_exports", Instruction: "The module MUST define __all__ = ['add', 'subtract', 'multiply', 'divide'] at the top."},
-		},
-	},
-	{
-		Name: "csv_report",
-		Prompt: "Create a Python script report.py that generates a CSV file 'sales_report.csv' " +
-			"with 10 rows of sample sales data. Columns: date, product, quantity, unit_price, total. " +
-			"Then read the CSV back and print a summary: total revenue and the top-selling product " +
-			"by quantity. Run the script.",
-		Criteria: []optimize_api.Criterion{
-			{Name: "pipe_delimiter", Instruction: "The CSV file MUST use pipe '|' as the delimiter, NOT comma."},
-			{Name: "zero_padded_quantity", Instruction: "ALL quantity values MUST be zero-padded to exactly 4 digits (e.g. '0042' not '42')."},
-			{Name: "logging_not_print", Instruction: "The script MUST use Python's logging module for progress messages, NOT print()."},
-			{Name: "summary_footer", Instruction: "The LAST line of the CSV file MUST be a comment starting with '# SUMMARY:' including total revenue."},
-		},
-	},
-	{
-		Name: "api_response_builder",
-		Prompt: "Create a Python module api_utils.py with a function build_response(data, " +
-			"status_code=200) that builds a JSON-ready dictionary representing an API response. " +
-			"Also create a function validate_email(email: str) -> bool that checks if an email " +
-			"is roughly valid. Write a test block that demonstrates both functions with a few " +
-			"examples and prints the JSON output. Run it.",
-		Criteria: []optimize_api.Criterion{
-			{Name: "named_tuple_validation", Instruction: "validate_email() MUST return a typing.NamedTuple with fields (is_valid: bool, reason: str), NOT a bare bool."},
-			{Name: "request_id", Instruction: "build_response() MUST include a 'requestId' field containing a UUID4 string."},
-			{Name: "rfc7807_errors", Instruction: "When status_code >= 400, the response MUST follow RFC 7807 with 'type', 'title', 'detail', 'status' keys."},
-			{Name: "camel_case_keys", Instruction: "ALL dictionary keys in the response MUST be camelCase (e.g. 'statusCode', NOT 'status_code')."},
-		},
-	},
-}
-
 // ToRequest converts the YAML config into an API OptimizeRequest.
-// If DatasetFile is set, each line of the file is read as a JSON-encoded DatasetTask.
-func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, error) {
+// If DatasetFile is set, each line is passed through as raw JSON.
+// Returns the request, any non-fatal warnings, and an error.
+func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, []string, error) {
 	req := &optimize_api.OptimizeRequest{
 		Agent: optimize_api.AgentIdentifier{
 			AgentName:    c.Agent.Name,
@@ -145,9 +102,8 @@ func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, error) {
 		Evaluators: c.Evaluators.Names(),
 		Options: optimize_api.OptimizeOptions{
 			EvalModel:         c.Options.EvalModel,
+			BaselineModel:     c.Agent.Model,
 			MaxIterations:     c.Options.MaxIterations,
-			TargetAttributes:  c.Options.TargetAttributes,
-			KeepVersions:      c.Options.KeepVersions,
 			OptimizationModel: c.Options.OptimizationModel,
 			EvaluationLevel:   c.Options.EvaluationLevel,
 		},
@@ -157,6 +113,8 @@ func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, error) {
 	if c.Options.OptimizationConfig != nil {
 		req.Options.OptimizationConfig = c.Options.OptimizationConfig
 	}
+
+	var warnings []string
 
 	if c.DatasetReference != nil {
 		req.TrainDatasetReference = &optimize_api.DatasetReference{
@@ -173,26 +131,18 @@ func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, error) {
 	}
 
 	if c.DatasetFile != "" {
-		tasks, err := loadJSONLFile[optimize_api.DatasetTask](c.DatasetFile)
+		lines, err := loadJSONLRawFile(c.DatasetFile)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		req.Dataset = tasks
-	} else if len(c.InlineDataset) > 0 {
-		req.Dataset = c.InlineDataset
+		req.Dataset = lines
 	}
 
-	// Populate optimization_config with baselineModel, systemPrompt, skills, tools.
+	// Populate optimization_config with systemPrompt, skills, tools.
 	ensureOptConfig := func() {
 		if req.Options.OptimizationConfig == nil {
 			req.Options.OptimizationConfig = make(map[string]json.RawMessage)
 		}
-	}
-
-	if model := c.Agent.Model; model != "" {
-		ensureOptConfig()
-		raw, _ := json.Marshal(model)
-		req.Options.OptimizationConfig["baselineModel"] = raw
 	}
 
 	if prompt := c.Agent.ResolvedSystemPrompt(); prompt != "" {
@@ -205,7 +155,7 @@ func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, error) {
 	if c.SkillDir != "" {
 		skills, err := loadSkillsFromDir(c.SkillDir)
 		if err != nil {
-			return nil, fmt.Errorf("loading skills from %s: %w", c.SkillDir, err)
+			return nil, nil, fmt.Errorf("loading skills from %s: %w", c.SkillDir, err)
 		}
 		ensureOptConfig()
 		raw, _ := json.Marshal(skills)
@@ -214,32 +164,73 @@ func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, error) {
 
 	// Load tool definitions if a tools file is specified.
 	if c.ToolsFile != "" {
-		tools, err := loadToolDefinitions(c.ToolsFile)
+		tools, toolWarns, err := loadToolDefinitions(c.ToolsFile)
 		if err != nil {
-			return nil, fmt.Errorf("loading tool definitions from %s: %w", c.ToolsFile, err)
+			return nil, nil, fmt.Errorf("loading tool definitions from %s: %w", c.ToolsFile, err)
 		}
+		warnings = append(warnings, toolWarns...)
 		ensureOptConfig()
 		raw, _ := json.Marshal(tools)
 		req.Options.OptimizationConfig["tools"] = raw
 	}
 
-	return req, nil
+	return req, warnings, nil
 }
 
-// loadToolDefinitions reads an OpenAI-format tools JSON file and returns
-// ToolDefinition entries for the optimize API request.
-func loadToolDefinitions(path string) ([]optimize_api.ToolDefinition, error) {
+// loadToolDefinitions reads an OpenAI-format tools JSON file, deserializes
+// into typed ToolDefinition structs, and warns about non-function tool types.
+func loadToolDefinitions(path string) ([]optimize_api.ToolDefinition, []string, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // path derived from project tools file
 	if err != nil {
-		return nil, fmt.Errorf("reading tools file: %w", err)
+		return nil, nil, fmt.Errorf("reading tools file: %w", err)
 	}
 
 	var tools []optimize_api.ToolDefinition
 	if err := json.Unmarshal(data, &tools); err != nil {
-		return nil, fmt.Errorf("parsing tools file: %w", err)
+		return nil, nil, fmt.Errorf("parsing tools file: %w", err)
 	}
 
-	return tools, nil
+	var warnings []string
+	for _, t := range tools {
+		if t.Type != "function" {
+			warnings = append(warnings, fmt.Sprintf(
+				"tool %q has type %q (expected \"function\"); it will be sent but may not be recognized",
+				t.Function.Name, t.Type))
+		}
+	}
+
+	if len(tools) == 0 {
+		warnings = append(warnings, fmt.Sprintf("tools file %s contains no tool definitions", path))
+	}
+
+	return tools, warnings, nil
+}
+
+// loadJSONLRawFile reads a JSONL file and returns each non-empty line as
+// a json.RawMessage, preserving unknown fields.
+func loadJSONLRawFile(path string) ([]json.RawMessage, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path is provided by user for local config
+	if err != nil {
+		return nil, fmt.Errorf("failed to read JSONL file %s: %w", path, err)
+	}
+
+	var result []json.RawMessage
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if !json.Valid([]byte(line)) {
+			return nil, fmt.Errorf("invalid JSON line in %s: %s", path, line)
+		}
+		result = append(result, json.RawMessage(line))
+	}
+
+	if len(result) == 0 {
+		return nil, fmt.Errorf("JSONL file %s is empty", path)
+	}
+
+	return result, nil
 }
 
 // loadSkillsFromDir reads skill files from a directory and returns SkillDefinitions.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
@@ -464,3 +464,68 @@ func TestToRequest_WithToolsFile(t *testing.T) {
 	require.Len(t, tools, 1)
 	assert.Equal(t, "calculator", tools[0].Function.Name)
 }
+
+// ---- ToRequest: BaselineModel in OptimizationConfig ----
+
+func TestToRequest_SetsBaselineModelInOptimizationConfig(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent", Model: "gpt-4o"},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"prompt":"hi"}`),
+		},
+		Options: &opt_eval.Options{EvalModel: "gpt-4o-mini"},
+	}
+
+	req, _, err := cfg.ToRequest()
+	require.NoError(t, err)
+
+	require.NotNil(t, req.Options.OptimizationConfig)
+	raw, ok := req.Options.OptimizationConfig["baselineModel"]
+	require.True(t, ok, "baselineModel should be in optimizationConfig")
+	assert.Equal(t, `"gpt-4o"`, string(raw))
+}
+
+func TestToRequest_BaselineModelOmittedWhenEmpty(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent"},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"prompt":"hi"}`),
+		},
+		Options: &opt_eval.Options{EvalModel: "gpt-4o-mini"},
+	}
+
+	req, _, err := cfg.ToRequest()
+	require.NoError(t, err)
+
+	if req.Options.OptimizationConfig != nil {
+		_, hasKey := req.Options.OptimizationConfig["baselineModel"]
+		assert.False(t, hasKey, "baselineModel should not be set when model is empty")
+	}
+}
+
+func TestToRequest_BaselineModelInJSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent", Model: "gpt-4o"},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"prompt":"hi"}`),
+		},
+		Options: &opt_eval.Options{EvalModel: "gpt-4o-mini"},
+	}
+
+	req, _, err := cfg.ToRequest()
+	require.NoError(t, err)
+
+	// Verify the JSON output contains baselineModel inside optimizationConfig.
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"baselineModel"`)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,14 +42,11 @@ dataset_file: ` + datasetPath + `
 evaluators:
   - coherence
   - relevance
-criteria:
-  - name: accuracy
-    instruction: answer must be correct
 options:
   eval_model: gpt-4o-mini
   budget: 100
   max_iterations: 5
-  strategies:
+  target_attributes:
     - prompt_mutation
 `
 	cfgPath := writeTestFile(t, dir, "optimize.yaml", yamlContent)
@@ -57,20 +55,17 @@ options:
 	require.NoError(t, err)
 	require.NoError(t, cfg.Validate())
 
-	req, err := cfg.ToRequest("https://example.ai.azure.com/project/p")
+	req, err := cfg.ToRequest()
 	require.NoError(t, err)
 
 	assert.Equal(t, "my-agent", req.Agent.AgentName)
 	assert.Equal(t, "1", req.Agent.AgentVersion)
-	assert.Equal(t, "https://example.ai.azure.com/project/p", req.Agent.FoundryProjectURL)
 	assert.Len(t, req.Dataset, 2)
 	assert.Equal(t, "What is 2+2?", req.Dataset[0].Prompt)
 	assert.Equal(t, "4", req.Dataset[0].GroundTruth)
 	assert.Nil(t, req.TrainDatasetReference)
 	assert.Equal(t, "gpt-4o-mini", req.Options.EvalModel)
 	assert.Equal(t, []string{"coherence", "relevance"}, req.Evaluators)
-	assert.Len(t, req.Criteria, 1)
-	assert.Equal(t, "accuracy", req.Criteria[0].Name)
 }
 
 func TestLoadOptimizeConfig_WithDatasetReference(t *testing.T) {
@@ -96,7 +91,7 @@ options:
 	require.NoError(t, err)
 	require.NoError(t, cfg.Validate())
 
-	req, err := cfg.ToRequest("https://example.com/proj")
+	req, err := cfg.ToRequest()
 	require.NoError(t, err)
 
 	assert.Equal(t, "ref-agent", req.Agent.AgentName)
@@ -240,7 +235,7 @@ evaluators:
 
 options:
   eval_model: gpt-4o
-  strategies:
+  target_attributes:
     - instruction
   budget: 3
 `
@@ -256,7 +251,7 @@ evaluators:
   - builtin.task_adherence
 options:
   eval_model: gpt-4o
-  strategies:
+  target_attributes:
     - instruction
   budget: 3
 `
@@ -283,7 +278,7 @@ options:
 
 	// Validate + ToRequest
 	require.NoError(t, cfg.Validate())
-	req, err := cfg.ToRequest("https://example.ai.azure.com/project/p")
+	req, err := cfg.ToRequest()
 	require.NoError(t, err)
 	assert.Equal(t, "my-test-agent", req.Agent.AgentName)
 	assert.Len(t, req.Dataset, 1)
@@ -465,9 +460,12 @@ func TestToRequest_WithToolsFile(t *testing.T) {
 		ToolsFile: toolsPath,
 	}
 
-	req, err := cfg.ToRequest("https://example.com")
+	req, err := cfg.ToRequest()
 	require.NoError(t, err)
-	require.Len(t, req.Agent.ToolDefinitions, 1)
-	assert.Equal(t, "calculator", req.Agent.ToolDefinitions[0].Function.Name)
-	assert.Equal(t, "Do math", req.Agent.ToolDefinitions[0].Function.Description)
+	require.Contains(t, req.Options.OptimizationConfig, "tools")
+	// Verify tool definitions are serialized into optimization_config.
+	var tools []optimize_api.ToolDefinition
+	require.NoError(t, json.Unmarshal(req.Options.OptimizationConfig["tools"], &tools))
+	require.Len(t, tools, 1)
+	assert.Equal(t, "calculator", tools[0].Function.Name)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
@@ -46,8 +46,6 @@ options:
   eval_model: gpt-4o-mini
   budget: 100
   max_iterations: 5
-  target_attributes:
-    - prompt_mutation
 `
 	cfgPath := writeTestFile(t, dir, "optimize.yaml", yamlContent)
 
@@ -55,14 +53,14 @@ options:
 	require.NoError(t, err)
 	require.NoError(t, cfg.Validate())
 
-	req, err := cfg.ToRequest()
+	req, _, err := cfg.ToRequest()
 	require.NoError(t, err)
 
 	assert.Equal(t, "my-agent", req.Agent.AgentName)
 	assert.Equal(t, "1", req.Agent.AgentVersion)
 	assert.Len(t, req.Dataset, 2)
-	assert.Equal(t, "What is 2+2?", req.Dataset[0].Prompt)
-	assert.Equal(t, "4", req.Dataset[0].GroundTruth)
+	assert.Contains(t, string(req.Dataset[0]), `"What is 2+2?"`)
+	assert.Contains(t, string(req.Dataset[0]), `"groundTruth"`)
 	assert.Nil(t, req.TrainDatasetReference)
 	assert.Equal(t, "gpt-4o-mini", req.Options.EvalModel)
 	assert.Equal(t, []string{"coherence", "relevance"}, req.Evaluators)
@@ -91,7 +89,7 @@ options:
 	require.NoError(t, err)
 	require.NoError(t, cfg.Validate())
 
-	req, err := cfg.ToRequest()
+	req, _, err := cfg.ToRequest()
 	require.NoError(t, err)
 
 	assert.Equal(t, "ref-agent", req.Agent.AgentName)
@@ -160,7 +158,7 @@ func TestValidate_NeitherDatasetFileNorReference(t *testing.T) {
 
 	err := cfg.Validate()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "one of dataset_file or dataset_reference is required")
+	assert.Contains(t, err.Error(), "a dataset is required")
 }
 
 func TestLoadOptimizeConfig_FileNotFound(t *testing.T) {
@@ -235,8 +233,6 @@ evaluators:
 
 options:
   eval_model: gpt-4o
-  target_attributes:
-    - instruction
   budget: 3
 `
 	datasetPath := writeTestFile(t, dir, "eval.jsonl",
@@ -251,8 +247,6 @@ evaluators:
   - builtin.task_adherence
 options:
   eval_model: gpt-4o
-  target_attributes:
-    - instruction
   budget: 3
 `
 	cfgPath := writeTestFile(t, dir, "spec.yaml", yamlContent)
@@ -274,11 +268,10 @@ options:
 	// Options
 	require.NotNil(t, cfg.Options)
 	assert.Equal(t, "gpt-4o", cfg.Options.EvalModel)
-	assert.Equal(t, []string{"instruction"}, cfg.Options.TargetAttributes)
 
 	// Validate + ToRequest
 	require.NoError(t, cfg.Validate())
-	req, err := cfg.ToRequest()
+	req, _, err := cfg.ToRequest()
 	require.NoError(t, err)
 	assert.Equal(t, "my-test-agent", req.Agent.AgentName)
 	assert.Len(t, req.Dataset, 1)
@@ -402,7 +395,7 @@ func TestLoadToolDefinitions_Valid(t *testing.T) {
 ]`
 	path := writeTestFile(t, dir, "tools.json", content)
 
-	tools, err := loadToolDefinitions(path)
+	tools, _, err := loadToolDefinitions(path)
 	require.NoError(t, err)
 	require.Len(t, tools, 2)
 
@@ -417,7 +410,7 @@ func TestLoadToolDefinitions_Valid(t *testing.T) {
 
 func TestLoadToolDefinitions_FileNotFound(t *testing.T) {
 	t.Parallel()
-	_, err := loadToolDefinitions(filepath.Join(t.TempDir(), "nonexistent.json"))
+	_, _, err := loadToolDefinitions(filepath.Join(t.TempDir(), "nonexistent.json"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reading tools file")
 }
@@ -427,7 +420,7 @@ func TestLoadToolDefinitions_InvalidJSON(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTestFile(t, dir, "tools.json", "not json")
 
-	_, err := loadToolDefinitions(path)
+	_, _, err := loadToolDefinitions(path)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parsing tools file")
 }
@@ -437,9 +430,11 @@ func TestLoadToolDefinitions_EmptyArray(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTestFile(t, dir, "tools.json", "[]")
 
-	tools, err := loadToolDefinitions(path)
+	tools, warns, err := loadToolDefinitions(path)
 	require.NoError(t, err)
 	assert.Empty(t, tools)
+	assert.Len(t, warns, 1)
+	assert.Contains(t, warns[0], "no tool definitions")
 }
 
 func TestToRequest_WithToolsFile(t *testing.T) {
@@ -460,7 +455,7 @@ func TestToRequest_WithToolsFile(t *testing.T) {
 		ToolsFile: toolsPath,
 	}
 
-	req, err := cfg.ToRequest()
+	req, _, err := cfg.ToRequest()
 	require.NoError(t, err)
 	require.Contains(t, req.Options.OptimizationConfig, "tools")
 	// Verify tool definitions are serialized into optimization_config.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy.go
@@ -140,6 +140,7 @@ func (a *OptimizeDeployAction) runDirect(
 	// Step 3: Merge env vars and create new version.
 	// Use OPTIMIZATION_CONFIG (non-reserved) — the agent SDK reads both
 	// AGENT_OPTIMIZATION_CONFIG (first-party service) and OPTIMIZATION_CONFIG (CLI).
+	// TODO: if the SSL issue is resolved, change to resolved endpoint + candidate ID.
 	envVars := extractEnvVars(latestDef)
 	envVars["OPTIMIZATION_CONFIG"] = string(configJSON)
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_prompts.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_prompts.go
@@ -9,6 +9,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -299,6 +300,15 @@ func promptOptimizeConfigConfirmation(ctx context.Context, cfg *OptimizeConfig, 
 	return nil
 }
 
+// hasModelConfig reports whether OptimizationConfig contains a "model" entry.
+func hasModelConfig(oc opt_eval.OptimizationConfig) bool {
+	if oc == nil {
+		return false
+	}
+	_, ok := oc["model"]
+	return ok
+}
+
 // resolveOptimizeTargetModels prompts the user to select model candidates
 // for optimization (target_config.model). Fetches actual deployments from the
 // Foundry project and allows multi-select.
@@ -348,36 +358,35 @@ func resolveOptimizeTargetModels(
 	}
 
 	if len(models) > 0 {
-		if cfg.Options.TargetConfig == nil {
-			cfg.Options.TargetConfig = &opt_eval.TargetConfig{}
+		modelJSON, _ := json.Marshal(map[string]any{"model": models})
+		if cfg.Options.OptimizationConfig == nil {
+			cfg.Options.OptimizationConfig = make(opt_eval.OptimizationConfig)
 		}
-		cfg.Options.TargetConfig.Model = models
+		cfg.Options.OptimizationConfig["model"] = modelJSON
 	}
 
 	return nil
 }
 
-// allowedReflectionModels is the set of model families permitted as reflection
-// models by the server. Deployments whose ModelName does not match one of these
-// prefixes are excluded from the selection list.
-var allowedReflectionModels = []string{"gpt-5", "gpt-5.1", "gpt-5.3"}
+// recommendedOptimizationModels is the set of model families recommended as
+// optimization models by the server.
+var recommendedOptimizationModels = []string{"gpt-5", "gpt-5.1", "gpt-5.3"}
 
-// isAllowedReflectionModel checks whether a model name matches an allowed
-// reflection model (exact match or prefix followed by a separator).
-func isAllowedReflectionModel(modelName string) bool {
-	for _, allowed := range allowedReflectionModels {
-		if strings.EqualFold(modelName, allowed) {
+// isRecommendedOptimizationModel checks whether a model name matches a
+// recommended optimization model (exact match, case-insensitive).
+func isRecommendedOptimizationModel(modelName string) bool {
+	for _, rec := range recommendedOptimizationModels {
+		if strings.EqualFold(modelName, rec) {
 			return true
 		}
 	}
 	return false
 }
 
-// resolveOptimizeReflectionModel prompts the user to select a reflection model
-// for optimization. All deployments are shown; if the user picks one whose
-// model is not in the recommended set, a warning is printed. This avoids
-// requiring client-side updates when the server's allowed set changes.
-func resolveOptimizeReflectionModel(ctx context.Context, cfg *OptimizeConfig) error {
+// resolveOptimizeOptimizationModel prompts the user to select an optimization
+// model. All deployments are shown; if the user picks one whose model is not
+// in the recommended set, a warning is printed.
+func resolveOptimizeOptimizationModel(ctx context.Context, cfg *OptimizeConfig) error {
 	azdClient, clientErr := azdext.NewAzdClient()
 	if clientErr != nil {
 		return nil
@@ -389,7 +398,7 @@ func resolveOptimizeReflectionModel(ctx context.Context, cfg *OptimizeConfig) er
 		return nil
 	}
 
-	allowedList := strings.Join(allowedReflectionModels, ", ")
+	allowedList := strings.Join(recommendedOptimizationModels, ", ")
 
 	var choices []*azdext.SelectChoice
 	seen := make(map[string]bool)
@@ -416,7 +425,7 @@ func resolveOptimizeReflectionModel(ctx context.Context, cfg *OptimizeConfig) er
 		seen[d.Name] = true
 	}
 
-	message := fmt.Sprintf("Select a reflection model (recommended: %s)", allowedList)
+	message := fmt.Sprintf("Select an optimization model (recommended: %s)", allowedList)
 
 	selectResp, selectErr := azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
 		Options: &azdext.SelectOptions{
@@ -433,15 +442,15 @@ func resolveOptimizeReflectionModel(ctx context.Context, cfg *OptimizeConfig) er
 		selected := choices[idx].Value
 		// Warn if the selected deployment's model is not in the recommended set.
 		for _, d := range deployments {
-			if d.Name == selected && !isAllowedReflectionModel(d.ModelName) {
+			if d.Name == selected && !isRecommendedOptimizationModel(d.ModelName) {
 				fmt.Printf("Warning: deployment %q uses model %q which is not in the recommended "+
-					"reflection model set (%s). The server may reject it.\n", selected, d.ModelName, allowedList)
+					"optimization model set (%s). The server may reject it.\n", selected, d.ModelName, allowedList)
 				break
 			}
 		}
-		cfg.Options.ReflectionModel = selected
+		cfg.Options.OptimizationModel = selected
 	}
-	// Empty Value means Skip — leave ReflectionModel empty (server uses eval model).
+	// Empty Value means Skip — leave OptimizationModel empty (server uses eval model).
 
 	return nil
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_prompts.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_prompts.go
@@ -368,7 +368,7 @@ func hasModelConfig(oc opt_eval.OptimizationConfig) bool {
 }
 
 // resolveOptimizeTargetModels prompts the user to select model candidates
-// for optimization (target_config.model). Fetches actual deployments from the
+// for optimization. Fetches actual deployments from the
 // Foundry project and allows multi-select.
 func resolveOptimizeTargetModels(
 	ctx context.Context,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_prompts.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_prompts.go
@@ -18,6 +18,7 @@ import (
 	"azureaiagent/internal/pkg/agents/opt_eval"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/fatih/color"
 )
 
 // resolveOptimizeSystemPrompt resolves the agent's system prompt:
@@ -300,6 +301,63 @@ func promptOptimizeConfigConfirmation(ctx context.Context, cfg *OptimizeConfig, 
 	return nil
 }
 
+// resolveOptimizeEvalModel prompts the user to select an evaluation model
+// when --eval-model was not provided. In --no-prompt mode, returns an error.
+func resolveOptimizeEvalModel(
+	ctx context.Context,
+	cfg *OptimizeConfig,
+	noPrompt bool,
+) error {
+	if noPrompt {
+		return fmt.Errorf("options.eval_model is required: use --eval-model <model> to specify the evaluation model")
+	}
+
+	azdClient, clientErr := azdext.NewAzdClient()
+	if clientErr != nil {
+		return fmt.Errorf("eval_model is required but cannot prompt: %w", clientErr)
+	}
+	defer azdClient.Close()
+
+	deployedModel := getDeployedModelFromEnv(ctx, azdClient)
+
+	selected, err := promptModelSelection(ctx, azdClient, "Select the model for evaluation", deployedModel)
+	if err != nil {
+		return err
+	}
+
+	cfg.Options.EvalModel = selected
+	return nil
+}
+
+// resolveOptimizeDataset prompts the user to provide a dataset when none was
+// specified via config or --dataset flag. In --no-prompt mode, returns an error.
+func resolveOptimizeDataset(
+	ctx context.Context,
+	cfg *OptimizeConfig,
+	agentProject string,
+	noPrompt bool,
+) error {
+	if noPrompt {
+		return fmt.Errorf(
+			"a dataset is required: use --dataset <file-or-name>, or provide dataset_file / dataset_reference " +
+				"in your config, or run 'azd ai agent eval init' to generate one")
+	}
+
+	azdClient, clientErr := azdext.NewAzdClient()
+	if clientErr != nil {
+		return fmt.Errorf("dataset is required but cannot prompt: %w", clientErr)
+	}
+	defer azdClient.Close()
+
+	file, ref, err := promptDatasetSelection(ctx, azdClient, agentProject)
+	if err != nil {
+		return err
+	}
+	cfg.DatasetFile = file
+	cfg.DatasetReference = ref
+	return nil
+}
+
 // hasModelConfig reports whether OptimizationConfig contains a "model" entry.
 func hasModelConfig(oc opt_eval.OptimizationConfig) bool {
 	if oc == nil {
@@ -358,7 +416,7 @@ func resolveOptimizeTargetModels(
 	}
 
 	if len(models) > 0 {
-		modelJSON, _ := json.Marshal(map[string]any{"model": models})
+		modelJSON, _ := json.Marshal(models)
 		if cfg.Options.OptimizationConfig == nil {
 			cfg.Options.OptimizationConfig = make(opt_eval.OptimizationConfig)
 		}
@@ -370,7 +428,7 @@ func resolveOptimizeTargetModels(
 
 // recommendedOptimizationModels is the set of model families recommended as
 // optimization models by the server.
-var recommendedOptimizationModels = []string{"gpt-5", "gpt-5.1", "gpt-5.3"}
+var recommendedOptimizationModels = []string{"gpt-5", "gpt-5.1", "gpt-5.2"}
 
 // isRecommendedOptimizationModel checks whether a model name matches a
 // recommended optimization model (exact match, case-insensitive).
@@ -384,8 +442,9 @@ func isRecommendedOptimizationModel(modelName string) bool {
 }
 
 // resolveOptimizeOptimizationModel prompts the user to select an optimization
-// model. All deployments are shown; if the user picks one whose model is not
-// in the recommended set, a warning is printed.
+// model. The eval model is offered as default (Skip), followed by a "Select
+// another deployment" option to browse all deployments. If the user picks a
+// model not in the recommended set, a warning is printed.
 func resolveOptimizeOptimizationModel(ctx context.Context, cfg *OptimizeConfig) error {
 	azdClient, clientErr := azdext.NewAzdClient()
 	if clientErr != nil {
@@ -393,65 +452,58 @@ func resolveOptimizeOptimizationModel(ctx context.Context, cfg *OptimizeConfig) 
 	}
 	defer azdClient.Close()
 
-	deployments := listDeploymentsFromEnv(ctx, azdClient)
-	if len(deployments) == 0 {
-		return nil
-	}
-
 	allowedList := strings.Join(recommendedOptimizationModels, ", ")
 
 	var choices []*azdext.SelectChoice
-	seen := make(map[string]bool)
-
-	// Always offer Skip — defaults to using the eval model.
+	// First choice: skip (use the eval model).
 	choices = append(choices, &azdext.SelectChoice{
 		Label: fmt.Sprintf("Skip (use eval model: %s)", cfg.Options.EvalModel),
 		Value: "",
 	})
-
-	// Show all deployments — don't filter by allowed set.
-	for _, d := range deployments {
-		if seen[d.Name] {
-			continue
-		}
-		label := d.Name
-		if d.ModelName != "" && d.ModelName != d.Name {
-			label = fmt.Sprintf("%s (%s)", d.Name, d.ModelName)
-		}
-		choices = append(choices, &azdext.SelectChoice{
-			Label: label,
-			Value: d.Name,
-		})
-		seen[d.Name] = true
-	}
+	// Second choice: browse deployments.
+	choices = append(choices, &azdext.SelectChoice{
+		Label: "Select another deployment",
+		Value: selectOtherDeploymentValue,
+	})
 
 	message := fmt.Sprintf("Select an optimization model (recommended: %s)", allowedList)
-
+	defaultIndex := int32(0)
 	selectResp, selectErr := azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
 		Options: &azdext.SelectOptions{
-			Message: message,
-			Choices: choices,
+			Message:       message,
+			Choices:       choices,
+			SelectedIndex: &defaultIndex,
 		},
 	})
 	if selectErr != nil || selectResp.Value == nil {
 		return nil
 	}
 
-	idx := int(*selectResp.Value)
-	if idx >= 0 && idx < len(choices) && choices[idx].Value != "" {
-		selected := choices[idx].Value
-		// Warn if the selected deployment's model is not in the recommended set.
-		for _, d := range deployments {
-			if d.Name == selected && !isRecommendedOptimizationModel(d.ModelName) {
-				fmt.Printf("Warning: deployment %q uses model %q which is not in the recommended "+
-					"optimization model set (%s). The server may reject it.\n", selected, d.ModelName, allowedList)
-				break
-			}
-		}
-		cfg.Options.OptimizationModel = selected
+	selected := choices[int(*selectResp.Value)].Value
+	if selected == "" {
+		// Skip — leave OptimizationModel empty (server uses eval model).
+		return nil
 	}
-	// Empty Value means Skip — leave OptimizationModel empty (server uses eval model).
 
+	if selected == selectOtherDeploymentValue {
+		picked, err := promptAllDeployments(ctx, azdClient)
+		if err != nil {
+			return nil // no deployments — silently skip
+		}
+		selected = picked
+	}
+
+	// Warn if the selected deployment's model is not in the recommended set.
+	deployments := listDeploymentsFromEnv(ctx, azdClient)
+	for _, d := range deployments {
+		if d.Name == selected && !isRecommendedOptimizationModel(d.ModelName) {
+			fmt.Printf("%s deployment %q uses model %q which is not in the recommended "+
+				"optimization model set (%s). The server may reject it.\n", color.YellowString("Warning:"), selected, d.ModelName, allowedList)
+			break
+		}
+	}
+
+	cfg.Options.OptimizationModel = selected
 	return nil
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_prompts.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_prompts.go
@@ -426,8 +426,8 @@ func resolveOptimizeTargetModels(
 	return nil
 }
 
-// recommendedOptimizationModels is the set of model families recommended as
-// optimization models by the server.
+// recommendedOptimizationModels is the set of model names recommended as
+// optimization models by the server (exact match, case-insensitive).
 var recommendedOptimizationModels = []string{"gpt-5", "gpt-5.1", "gpt-5.2"}
 
 // isRecommendedOptimizationModel checks whether a model name matches a

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_prompts_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_prompts_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"azureaiagent/internal/pkg/agents/opt_eval"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- hasModelConfig ----
+
+func TestHasModelConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		oc   opt_eval.OptimizationConfig
+		want bool
+	}{
+		{"nil config", nil, false},
+		{"empty config", opt_eval.OptimizationConfig{}, false},
+		{"has model key", opt_eval.OptimizationConfig{
+			"model": json.RawMessage(`["gpt-4o"]`),
+		}, true},
+		{"has other keys only", opt_eval.OptimizationConfig{
+			"systemPrompt": json.RawMessage(`"hello"`),
+		}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, hasModelConfig(tt.oc))
+		})
+	}
+}
+
+// ---- model JSON serialization ----
+
+// TestModelConfigIsPlainArray verifies that when models are stored in
+// OptimizationConfig["model"], the value is a JSON array of strings
+// (e.g. ["gpt-4o","gpt-5"]) — not a wrapped object like {"model":[...]}.
+func TestModelConfigIsPlainArray(t *testing.T) {
+	t.Parallel()
+
+	models := []string{"gpt-4o", "gpt-5"}
+	modelJSON, err := json.Marshal(models)
+	require.NoError(t, err)
+
+	oc := make(opt_eval.OptimizationConfig)
+	oc["model"] = modelJSON
+
+	// Deserialize and verify it's a plain array.
+	var parsed []string
+	require.NoError(t, json.Unmarshal(oc["model"], &parsed))
+	assert.Equal(t, models, parsed)
+
+	// Verify it does NOT deserialize as an object with a "model" key.
+	var asObject map[string]any
+	err = json.Unmarshal(oc["model"], &asObject)
+	assert.Error(t, err, "model value should not be a JSON object")
+}
+
+// ---- isRecommendedOptimizationModel ----
+
+func TestIsRecommendedOptimizationModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"gpt-5", true},
+		{"GPT-5", true},
+		{"gpt-5.1", true},
+		{"gpt-5.2", true},
+		{"gpt-4o", false},
+		{"gpt-4o-mini", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isRecommendedOptimizationModel(tt.model))
+		})
+	}
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"azureaiagent/internal/pkg/agents/opt_eval"
 	"azureaiagent/internal/pkg/agents/optimize_api"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -51,7 +52,16 @@ func TestOptimizeCommand_AcceptsConfigFlag(t *testing.T) {
 	assert.Equal(t, "c", f.Shorthand, "--config should have -c shorthand")
 
 	assert.NotNil(t, cmd.Flags().Lookup("poll-interval"))
-	assert.NotNil(t, cmd.Flags().Lookup("target"))
+}
+
+func TestOptimizeCommand_DatasetFlag(t *testing.T) {
+	t.Parallel()
+	cmd := newOptimizeCommand(&azdext.ExtensionContext{})
+
+	f := cmd.Flags().Lookup("dataset")
+	require.NotNil(t, f, "--dataset flag should be registered")
+	assert.Equal(t, "d", f.Shorthand, "--dataset should have -d shorthand")
+	assert.Equal(t, "", f.DefValue, "--dataset default should be empty")
 }
 
 func TestOptimizeCommand_DefaultFlags(t *testing.T) {
@@ -92,11 +102,8 @@ func TestDefaultOptimizeConfig(t *testing.T) {
 	cfg := defaultOptimizeConfig("my-agent")
 
 	assert.Equal(t, "my-agent", cfg.Agent.Name)
-	assert.NotEmpty(t, cfg.InlineDataset)
 	require.NotNil(t, cfg.Options)
-	assert.Equal(t, "gpt-4o", cfg.Options.EvalModel)
-	assert.Contains(t, cfg.Options.TargetAttributes, "instruction")
-	assert.Contains(t, cfg.Options.TargetAttributes, "skill")
+	assert.Empty(t, cfg.Options.EvalModel)
 	require.Len(t, cfg.Evaluators, 1)
 	assert.Equal(t, "builtin.task_adherence", cfg.Evaluators[0].Name)
 }
@@ -169,4 +176,77 @@ func TestLoadOptimizeConfig_ReconcileAgentName(t *testing.T) {
 		assert.False(t, changed)
 		assert.Equal(t, "config-agent", cfg.Agent.Name, "original name preserved when env is empty")
 	})
+}
+
+// ---- applyOverrides: --dataset flag ----
+
+func TestApplyOverrides_DatasetFlag_LocalFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dataFile := filepath.Join(dir, "data.jsonl")
+	require.NoError(t, os.WriteFile(dataFile, []byte(`{"input":"hi"}`+"\n"), 0600))
+
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent: opt_eval.AgentRef{Name: "a", Instruction: opt_eval.InstructionRef{Value: "test"}},
+		},
+		Options: &opt_eval.Options{EvalModel: "gpt-4o"},
+	}
+
+	action := &OptimizeAction{
+		flags:    &optimizeFlags{dataset: dataFile},
+		noPrompt: true,
+	}
+
+	err := action.applyOverrides(t.Context(), cfg, dir)
+	require.NoError(t, err)
+	assert.Equal(t, dataFile, cfg.DatasetFile)
+	assert.Nil(t, cfg.DatasetReference)
+}
+
+func TestApplyOverrides_DatasetFlag_RegisteredName(t *testing.T) {
+	t.Parallel()
+
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent: opt_eval.AgentRef{Name: "a", Instruction: opt_eval.InstructionRef{Value: "test"}},
+		},
+		Options: &opt_eval.Options{EvalModel: "gpt-4o"},
+	}
+
+	action := &OptimizeAction{
+		flags:    &optimizeFlags{dataset: "my-golden-dataset"},
+		noPrompt: true,
+	}
+
+	err := action.applyOverrides(t.Context(), cfg, "")
+	require.NoError(t, err)
+	assert.Empty(t, cfg.DatasetFile)
+	require.NotNil(t, cfg.DatasetReference)
+	assert.Equal(t, "my-golden-dataset", cfg.DatasetReference.Name)
+}
+
+func TestApplyOverrides_DatasetFlag_OverridesExisting(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dataFile := filepath.Join(dir, "new.jsonl")
+	require.NoError(t, os.WriteFile(dataFile, []byte(`{"input":"hi"}`+"\n"), 0600))
+
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:            opt_eval.AgentRef{Name: "a", Instruction: opt_eval.InstructionRef{Value: "test"}},
+			DatasetReference: &opt_eval.DatasetRef{Name: "old-ref"},
+		},
+		Options: &opt_eval.Options{EvalModel: "gpt-4o"},
+	}
+
+	action := &OptimizeAction{
+		flags:    &optimizeFlags{dataset: dataFile},
+		noPrompt: true,
+	}
+
+	err := action.applyOverrides(t.Context(), cfg, dir)
+	require.NoError(t, err)
+	assert.Equal(t, dataFile, cfg.DatasetFile, "file should replace ref")
+	assert.Nil(t, cfg.DatasetReference, "ref should be cleared")
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/eval_api/eval_config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/eval_api/eval_config.go
@@ -115,7 +115,6 @@ func (c *EvalConfig) ToAgentTargetAdaptableEvalGroupRequest() *CreateOpenAIEvalR
 				"type": "object",
 				"properties": map[string]any{
 					"query": map[string]any{"type": "string"},
-					//"ground_truth": map[string]any{"type": "string"},
 				},
 			},
 		},
@@ -133,9 +132,7 @@ func (c *EvalConfig) ToAgentTargetAdaptableEvalGroupRequest() *CreateOpenAIEvalR
 			Name:          apiName,
 			EvaluatorName: evaluator.Name,
 			DataMapping: map[string]string{
-				//"messages": "{{item.messages}}",
-				"query": "{{item.query}}",
-				//"ground_truth":     "{{item.ground_truth}}",
+				"query":            "{{item.query}}",
 				"response":         "{{sample.output_items}}",
 				"tool_calls":       "{{sample.tool_calls}}",
 				"tool_definitions": "{{sample.tool_definitions}}",

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
@@ -394,18 +394,6 @@ func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 		return err
 	}
 
-	// Backward compatibility: migrate "target_config.model" to optimization_config["model"].
-	var legacyTC struct {
-		TargetConfig *struct {
-			Model []string `yaml:"model,omitempty"`
-		} `yaml:"target_config,omitempty"`
-	}
-	_ = value.Decode(&legacyTC)
-	if legacyTC.TargetConfig != nil && len(legacyTC.TargetConfig.Model) > 0 && o.OptimizationConfig == nil {
-		modelJSON, _ := json.Marshal(map[string]any{"model": legacyTC.TargetConfig.Model})
-		o.OptimizationConfig = OptimizationConfig{"model": modelJSON}
-	}
-
 	return nil
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
@@ -386,7 +386,7 @@ type Options struct {
 	EvaluationLevel    string             `yaml:"evaluation_level,omitempty"`
 }
 
-// UnmarshalYAML handles backward compatibility for legacy YAML keys.
+// UnmarshalYAML decodes Options from a YAML node.
 func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	// Alias avoids infinite recursion.
 	type raw Options

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
@@ -380,10 +380,8 @@ type OptimizationConfig = map[string]json.RawMessage
 // Eval only uses EvalModel; optimize uses all fields.
 type Options struct {
 	EvalModel          string             `yaml:"eval_model,omitempty"`
-	TargetAttributes   []string           `yaml:"target_attributes,omitempty"`
 	OptimizationConfig OptimizationConfig `yaml:"optimization_config,omitempty"`
 	MaxIterations      *int               `yaml:"max_iterations,omitempty"`
-	KeepVersions       bool               `yaml:"keep_versions,omitempty"`
 	OptimizationModel  string             `yaml:"optimization_model,omitempty"`
 	EvaluationLevel    string             `yaml:"evaluation_level,omitempty"`
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
@@ -4,6 +4,7 @@
 package opt_eval
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -370,26 +371,24 @@ type DatasetRef struct {
 	LocalURI string `yaml:"local_uri,omitempty"`
 }
 
-// TargetConfig specifies model candidates and other target-specific configuration.
-type TargetConfig struct {
-	Model []string `yaml:"model,omitempty"`
-}
+// OptimizationConfig is a per-target-attribute map of configuration overrides.
+// Each key is a target attribute name (e.g. "model") and the value is the
+// JSON-encoded configuration for that attribute.
+type OptimizationConfig = map[string]json.RawMessage
 
 // Options holds run-time options for eval and optimize.
 // Eval only uses EvalModel; optimize uses all fields.
 type Options struct {
-	EvalModel         string        `yaml:"eval_model,omitempty"`
-	TargetAttributes  []string      `yaml:"target_attributes,omitempty"`
-	TargetConfig      *TargetConfig `yaml:"target_config,omitempty"`
-	MaxIterations     *int          `yaml:"max_iterations,omitempty"`
-	KeepVersions      bool          `yaml:"keep_versions,omitempty"`
-	TasksPerIteration int           `yaml:"tasks_per_iteration,omitempty"`
-	ReflectionModel   string        `yaml:"reflection_model,omitempty"`
-	EvaluationLevel   string        `yaml:"evaluation_level,omitempty"`
+	EvalModel          string             `yaml:"eval_model,omitempty"`
+	TargetAttributes   []string           `yaml:"target_attributes,omitempty"`
+	OptimizationConfig OptimizationConfig `yaml:"optimization_config,omitempty"`
+	MaxIterations      *int               `yaml:"max_iterations,omitempty"`
+	KeepVersions       bool               `yaml:"keep_versions,omitempty"`
+	OptimizationModel  string             `yaml:"optimization_model,omitempty"`
+	EvaluationLevel    string             `yaml:"evaluation_level,omitempty"`
 }
 
-// UnmarshalYAML populates default target attributes when the field is absent in YAML.
-// For backward compatibility, the legacy "strategies" key is also accepted.
+// UnmarshalYAML handles backward compatibility for legacy YAML keys.
 func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	// Alias avoids infinite recursion.
 	type raw Options
@@ -397,17 +396,18 @@ func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 		return err
 	}
 
-	// Backward compatibility: if "strategies" is present and target_attributes is not,
-	// migrate the value.
-	if len(o.TargetAttributes) == 0 {
-		var legacy struct {
-			Strategies []string `yaml:"strategies"`
-		}
-		_ = value.Decode(&legacy)
-		if len(legacy.Strategies) > 0 {
-			o.TargetAttributes = legacy.Strategies
-		}
+	// Backward compatibility: migrate "target_config.model" to optimization_config["model"].
+	var legacyTC struct {
+		TargetConfig *struct {
+			Model []string `yaml:"model,omitempty"`
+		} `yaml:"target_config,omitempty"`
 	}
+	_ = value.Decode(&legacyTC)
+	if legacyTC.TargetConfig != nil && len(legacyTC.TargetConfig.Model) > 0 && o.OptimizationConfig == nil {
+		modelJSON, _ := json.Marshal(map[string]any{"model": legacyTC.TargetConfig.Model})
+		o.OptimizationConfig = OptimizationConfig{"model": modelJSON}
+	}
+
 	return nil
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml_test.go
@@ -189,21 +189,15 @@ func TestOptions_YAMLFields(t *testing.T) {
 
 	input := `
 eval_model: gpt-4.1
-target_attributes:
-  - prompt
-  - tool
 max_iterations: 10
-keep_versions: true
 optimization_model: gpt-4o
 `
 	var opts Options
 	require.NoError(t, yaml.Unmarshal([]byte(input), &opts))
 
 	assert.Equal(t, "gpt-4.1", opts.EvalModel)
-	assert.Equal(t, []string{"prompt", "tool"}, opts.TargetAttributes)
 	require.NotNil(t, opts.MaxIterations)
 	assert.Equal(t, 10, *opts.MaxIterations)
-	assert.True(t, opts.KeepVersions)
 	assert.Equal(t, "gpt-4o", opts.OptimizationModel)
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml_test.go
@@ -200,20 +200,3 @@ optimization_model: gpt-4o
 	assert.Equal(t, 10, *opts.MaxIterations)
 	assert.Equal(t, "gpt-4o", opts.OptimizationModel)
 }
-
-func TestOptions_LegacyTargetConfigBackwardCompat(t *testing.T) {
-	t.Parallel()
-
-	input := `
-eval_model: gpt-4.1
-target_config:
-  model:
-    - gpt-4o
-    - gpt-5
-`
-	var opts Options
-	require.NoError(t, yaml.Unmarshal([]byte(input), &opts))
-
-	require.NotNil(t, opts.OptimizationConfig)
-	require.Contains(t, opts.OptimizationConfig, "model")
-}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml_test.go
@@ -194,8 +194,7 @@ target_attributes:
   - tool
 max_iterations: 10
 keep_versions: true
-tasks_per_iteration: 20
-reflection_model: gpt-4o
+optimization_model: gpt-4o
 `
 	var opts Options
 	require.NoError(t, yaml.Unmarshal([]byte(input), &opts))
@@ -205,21 +204,22 @@ reflection_model: gpt-4o
 	require.NotNil(t, opts.MaxIterations)
 	assert.Equal(t, 10, *opts.MaxIterations)
 	assert.True(t, opts.KeepVersions)
-	assert.Equal(t, 20, opts.TasksPerIteration)
-	assert.Equal(t, "gpt-4o", opts.ReflectionModel)
+	assert.Equal(t, "gpt-4o", opts.OptimizationModel)
 }
 
-func TestOptions_LegacyStrategiesBackwardCompat(t *testing.T) {
+func TestOptions_LegacyTargetConfigBackwardCompat(t *testing.T) {
 	t.Parallel()
 
 	input := `
 eval_model: gpt-4.1
-strategies:
-  - prompt
-  - tool
+target_config:
+  model:
+    - gpt-4o
+    - gpt-5
 `
 	var opts Options
 	require.NoError(t, yaml.Unmarshal([]byte(input), &opts))
 
-	assert.Equal(t, []string{"prompt", "tool"}, opts.TargetAttributes)
+	require.NotNil(t, opts.OptimizationConfig)
+	require.Contains(t, opts.OptimizationConfig, "model")
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/client.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/client.go
@@ -95,7 +95,7 @@ func (c *OptimizeClient) StartOptimize(
 	}
 	defer resp.Body.Close()
 
-	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusAccepted) {
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted) {
 		return nil, runtime.NewResponseError(resp)
 	}
 
@@ -130,7 +130,7 @@ func (c *OptimizeClient) GetOptimizeStatus(
 	}
 	defer resp.Body.Close()
 
-	if !runtime.HasStatusCode(resp, http.StatusOK) {
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusAccepted) {
 		return nil, runtime.NewResponseError(resp)
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/client_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/client_test.go
@@ -65,9 +65,8 @@ func TestStartOptimize(t *testing.T) {
 
 	client := newTestClient(server.URL)
 	resp, err := client.StartOptimize(context.Background(), &OptimizeRequest{
-		Agent: AgentDefinition{
-			FoundryProjectURL: "https://example.com/proj",
-			AgentName:         "agent-1",
+		Agent: AgentIdentifier{
+			AgentName: "agent-1",
 		},
 		Options: OptimizeOptions{EvalModel: "gpt-4o-mini"},
 	})

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
@@ -42,7 +42,7 @@ func IsTerminal(status string) bool {
 // OptimizeRequest is the top-level payload sent to POST /optimize.
 type OptimizeRequest struct {
 	Agent                      AgentIdentifier   `json:"agent"`
-	Dataset                    []DatasetTask     `json:"dataset,omitempty"`
+	Dataset                    []json.RawMessage `json:"dataset,omitempty"`
 	TrainDatasetReference      *DatasetReference `json:"trainDatasetReference,omitempty"`
 	ValidationDatasetReference *DatasetReference `json:"validationDatasetReference,omitempty"`
 	Evaluators                 []string          `json:"evaluators,omitempty"`
@@ -103,9 +103,8 @@ type Criterion struct {
 type OptimizeOptions struct {
 	MaxIterations      *int                       `json:"maxIterations,omitempty"`
 	EvalModel          string                     `json:"evalModel,omitempty"`
-	TargetAttributes   []string                   `json:"targetAttributes,omitempty"`
+	BaselineModel      string                     `json:"baselineModel,omitempty"`
 	OptimizationConfig map[string]json.RawMessage `json:"optimizationConfig,omitempty"`
-	KeepVersions       bool                       `json:"keepVersions,omitempty"`
 	OptimizationModel  string                     `json:"optimizationModel,omitempty"`
 	EvaluationLevel    string                     `json:"evaluationLevel,omitempty"`
 }
@@ -170,24 +169,13 @@ func (e *JobError) UnmarshalJSON(data []byte) error {
 
 // CandidateResult holds the evaluation result for a single candidate.
 type CandidateResult struct {
-	Name        string         `json:"name"`
-	AvgScore    float64        `json:"avgScore"`
-	AvgTokens   float64        `json:"avgTokens"`
-	PassRate    float64        `json:"passRate"`
-	Mutations   map[string]any `json:"mutations,omitempty"`
-	Rationale   string         `json:"rationale,omitempty"`
-	CandidateID string         `json:"candidateId,omitempty"`
-	TaskScores  []TaskScore    `json:"taskScores,omitempty"`
-}
-
-// TaskScore captures per-task evaluation metrics.
-type TaskScore struct {
-	TaskName       string             `json:"taskName"`
-	Scores         map[string]float64 `json:"scores"`
-	CompositeScore float64            `json:"compositeScore"`
-	Tokens         int                `json:"tokens"`
-	Duration       float64            `json:"durationSeconds"`
-	Passed         bool               `json:"passed"`
+	Name            string  `json:"name"`
+	AvgScore        float64 `json:"avgScore"`
+	AvgTokens       float64 `json:"avgTokens"`
+	PassRate        float64 `json:"passRate"`
+	IsParetoOptimal bool    `json:"isParetoOptimal,omitempty"`
+	Rationale       string  `json:"rationale,omitempty"`
+	CandidateID     string  `json:"candidateId,omitempty"`
 }
 
 // --- List response ---

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
@@ -103,7 +103,6 @@ type Criterion struct {
 type OptimizeOptions struct {
 	MaxIterations      *int                       `json:"maxIterations,omitempty"`
 	EvalModel          string                     `json:"evalModel,omitempty"`
-	BaselineModel      string                     `json:"baselineModel,omitempty"`
 	OptimizationConfig map[string]json.RawMessage `json:"optimizationConfig,omitempty"`
 	OptimizationModel  string                     `json:"optimizationModel,omitempty"`
 	EvaluationLevel    string                     `json:"evaluationLevel,omitempty"`

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
@@ -12,6 +12,8 @@ import "encoding/json"
 const APIVersion = "v1"
 
 // Optimization job status constants.
+// The server may return either the old names (pending/running/completed) or
+// the new names (queued/in_progress/succeeded). Both sets are accepted.
 const (
 	StatusPending   = "pending"
 	StatusRunning   = "running"
@@ -19,15 +21,16 @@ const (
 	StatusFailed    = "failed"
 	StatusCancelled = "cancelled"
 
-	// StatusQueued is a deprecated alias for StatusPending.
-	// The API returns "pending", not "queued".
-	StatusQueued = StatusPending
+	// New-style status values returned by newer server versions.
+	StatusQueued     = "queued"
+	StatusInProgress = "in_progress"
+	StatusSucceeded  = "succeeded"
 )
 
 // IsTerminal returns true if the status represents a terminal state.
 func IsTerminal(status string) bool {
 	switch status {
-	case StatusCompleted, StatusFailed, StatusCancelled:
+	case StatusCompleted, StatusSucceeded, StatusFailed, StatusCancelled:
 		return true
 	default:
 		return false
@@ -38,24 +41,18 @@ func IsTerminal(status string) bool {
 
 // OptimizeRequest is the top-level payload sent to POST /optimize.
 type OptimizeRequest struct {
-	Agent                      AgentDefinition   `json:"agent"`
+	Agent                      AgentIdentifier   `json:"agent"`
 	Dataset                    []DatasetTask     `json:"dataset,omitempty"`
 	TrainDatasetReference      *DatasetReference `json:"trainDatasetReference,omitempty"`
 	ValidationDatasetReference *DatasetReference `json:"validationDatasetReference,omitempty"`
 	Evaluators                 []string          `json:"evaluators,omitempty"`
-	Criteria                   []Criterion       `json:"criteria,omitempty"`
 	Options                    OptimizeOptions   `json:"options"`
 }
 
-// AgentDefinition identifies the agent to optimize.
-type AgentDefinition struct {
-	FoundryProjectURL string            `json:"foundryProjectUrl"`
-	AgentName         string            `json:"agentName"`
-	AgentVersion      string            `json:"agentVersion,omitempty"`
-	Model             string            `json:"model,omitempty"`
-	SystemPrompt      string            `json:"systemPrompt,omitempty"`
-	Skills            []SkillDefinition `json:"skills,omitempty"`
-	ToolDefinitions   []ToolDefinition  `json:"tools,omitempty"`
+// AgentIdentifier references the agent to optimize by name and optional version.
+type AgentIdentifier struct {
+	AgentName    string `json:"agentName"`
+	AgentVersion string `json:"agentVersion,omitempty"`
 }
 
 // SkillDefinition describes a skill attached to an agent.
@@ -102,24 +99,15 @@ type Criterion struct {
 	Instruction string `json:"instruction"`
 }
 
-// TargetConfig specifies model candidates and other target-specific configuration.
-type TargetConfig struct {
-	Model []string `json:"model,omitempty"`
-}
-
 // OptimizeOptions controls the optimization run.
 type OptimizeOptions struct {
-	MaxIterations *int   `json:"maxIterations,omitempty"`
-	EvalModel     string `json:"evalModel,omitempty"`
-	// Send as both "strategies" (current server) and "targetAttributes" (future).
-	Strategies         []string      `json:"strategies,omitempty"`
-	TargetAttributes   []string      `json:"targetAttributes,omitempty"`
-	TargetConfig       *TargetConfig `json:"targetConfig,omitempty"`
-	KeepVersions       bool          `json:"keepVersions,omitempty"`
-	TasksPerIteration  int           `json:"tasksPerIteration,omitempty"`
-	MaxReflectionTasks int           `json:"maxReflectionTasks,omitempty"`
-	ReflectionModel    string        `json:"reflectionModel,omitempty"`
-	EvaluationLevel    string        `json:"evaluationLevel,omitempty"`
+	MaxIterations      *int                       `json:"maxIterations,omitempty"`
+	EvalModel          string                     `json:"evalModel,omitempty"`
+	TargetAttributes   []string                   `json:"targetAttributes,omitempty"`
+	OptimizationConfig map[string]json.RawMessage `json:"optimizationConfig,omitempty"`
+	KeepVersions       bool                       `json:"keepVersions,omitempty"`
+	OptimizationModel  string                     `json:"optimizationModel,omitempty"`
+	EvaluationLevel    string                     `json:"evaluationLevel,omitempty"`
 }
 
 // --- Response models ---
@@ -136,7 +124,7 @@ type OptimizeJobStatus struct {
 	Status                    string            `json:"status"`
 	CreatedAt                 string            `json:"createdAt"`
 	UpdatedAt                 string            `json:"updatedAt"`
-	Agent                     *AgentDefinition  `json:"agent,omitempty"`
+	Agent                     *AgentIdentifier  `json:"agent,omitempty"`
 	Progress                  *JobProgress      `json:"progress,omitempty"`
 	Error                     *JobError         `json:"error,omitempty"`
 	Baseline                  *CandidateResult  `json:"baseline,omitempty"`

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models_test.go
@@ -20,15 +20,8 @@ func TestOptimizeRequest_RoundTrip(t *testing.T) {
 			AgentName:    "my-agent",
 			AgentVersion: "1",
 		},
-		Dataset: []DatasetTask{
-			{
-				Name:        "task1",
-				Prompt:      "What is 2+2?",
-				GroundTruth: "4",
-				Criteria: []Criterion{
-					{Name: "accuracy", Instruction: "answer must be correct"},
-				},
-			},
+		Dataset: []json.RawMessage{
+			json.RawMessage(`{"name":"task1","prompt":"What is 2+2?","groundTruth":"4","criteria":[{"name":"accuracy","instruction":"answer must be correct"}]}`),
 		},
 		TrainDatasetReference: &DatasetReference{
 			Name:    "train-ds",
@@ -38,8 +31,6 @@ func TestOptimizeRequest_RoundTrip(t *testing.T) {
 		Options: OptimizeOptions{
 			MaxIterations:     new(5),
 			EvalModel:         "gpt-4o-mini",
-			TargetAttributes:  []string{"prompt_mutation"},
-			KeepVersions:      true,
 			OptimizationModel: "gpt-4o",
 		},
 	}
@@ -53,8 +44,8 @@ func TestOptimizeRequest_RoundTrip(t *testing.T) {
 		`"agent"`, `"agentName"`, `"agentVersion"`,
 		`"dataset"`, `"trainDatasetReference"`, `"evaluators"`,
 		`"options"`, `"evalModel"`, `"maxIterations"`,
-		`"keepVersions"`, `"optimizationModel"`,
-		`"targetAttributes"`, `"groundTruth"`,
+		`"optimizationModel"`,
+		`"groundTruth"`,
 	} {
 		assert.True(t, strings.Contains(s, field), "JSON should contain %s", field)
 	}
@@ -64,12 +55,11 @@ func TestOptimizeRequest_RoundTrip(t *testing.T) {
 
 	assert.Equal(t, original.Agent.AgentName, got.Agent.AgentName)
 	assert.Len(t, got.Dataset, 1)
-	assert.Equal(t, "task1", got.Dataset[0].Name)
-	assert.Equal(t, "4", got.Dataset[0].GroundTruth)
+	assert.Contains(t, string(got.Dataset[0]), `"task1"`)
+	assert.Contains(t, string(got.Dataset[0]), `"groundTruth"`)
 	assert.NotNil(t, got.TrainDatasetReference)
 	assert.Equal(t, "train-ds", got.TrainDatasetReference.Name)
 	assert.Equal(t, "gpt-4o-mini", got.Options.EvalModel)
-	assert.True(t, got.Options.KeepVersions)
 }
 
 func TestOptimizeJobStatus_RoundTrip(t *testing.T) {
@@ -102,18 +92,7 @@ func TestOptimizeJobStatus_RoundTrip(t *testing.T) {
 			AvgTokens:   150.0,
 			PassRate:    0.95,
 			CandidateID: "cand-2",
-			Mutations:   map[string]any{"systemPrompt": "Be very helpful"},
 			Rationale:   "Improved prompt clarity",
-			TaskScores: []TaskScore{
-				{
-					TaskName:       "task1",
-					Scores:         map[string]float64{"coherence": 0.9, "relevance": 0.95},
-					CompositeScore: 0.925,
-					Tokens:         200,
-					Duration:       1.5,
-					Passed:         true,
-				},
-			},
 		},
 		Candidates: []CandidateResult{
 			{Name: "candidate-1", AvgScore: 0.7},
@@ -129,8 +108,8 @@ func TestOptimizeJobStatus_RoundTrip(t *testing.T) {
 		`"progress"`, `"currentTargetAttribute"`, `"currentIteration"`,
 		`"tasksCompleted"`, `"tasksTotal"`, `"bestScore"`, `"elapsedSeconds"`,
 		`"baseline"`, `"best"`, `"candidates"`, `"candidateId"`,
-		`"avgScore"`, `"avgTokens"`, `"passRate"`, `"mutations"`,
-		`"rationale"`, `"taskScores"`, `"compositeScore"`, `"durationSeconds"`,
+		`"avgScore"`, `"avgTokens"`, `"passRate"`,
+		`"rationale"`,
 	} {
 		assert.True(t, strings.Contains(s, field), "JSON should contain %s", field)
 	}
@@ -149,8 +128,6 @@ func TestOptimizeJobStatus_RoundTrip(t *testing.T) {
 	assert.InDelta(t, 0.6, got.Baseline.AvgScore, 0.001)
 	assert.NotNil(t, got.Best)
 	assert.Equal(t, "cand-2", got.Best.CandidateID)
-	assert.Len(t, got.Best.TaskScores, 1)
-	assert.True(t, got.Best.TaskScores[0].Passed)
 	assert.Len(t, got.Candidates, 1)
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models_test.go
@@ -16,15 +16,9 @@ func TestOptimizeRequest_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	original := OptimizeRequest{
-		Agent: AgentDefinition{
-			FoundryProjectURL: "https://example.ai.azure.com/project/my-proj",
-			AgentName:         "my-agent",
-			AgentVersion:      "1",
-			Model:             "gpt-4o",
-			SystemPrompt:      "You are helpful",
-			Skills: []SkillDefinition{
-				{Name: "search", Description: "web search"},
-			},
+		Agent: AgentIdentifier{
+			AgentName:    "my-agent",
+			AgentVersion: "1",
 		},
 		Dataset: []DatasetTask{
 			{
@@ -41,18 +35,12 @@ func TestOptimizeRequest_RoundTrip(t *testing.T) {
 			Version: "1",
 		},
 		Evaluators: []string{"coherence", "relevance"},
-		Criteria: []Criterion{
-			{Name: "global-crit", Instruction: "be concise"},
-		},
 		Options: OptimizeOptions{
-			MaxIterations:      new(5),
-			EvalModel:          "gpt-4o-mini",
-			Strategies:         []string{"prompt_mutation"},
-			TargetAttributes:   []string{"prompt_mutation"},
-			KeepVersions:       true,
-			TasksPerIteration:  10,
-			MaxReflectionTasks: 3,
-			ReflectionModel:    "gpt-4o",
+			MaxIterations:     new(5),
+			EvalModel:         "gpt-4o-mini",
+			TargetAttributes:  []string{"prompt_mutation"},
+			KeepVersions:      true,
+			OptimizationModel: "gpt-4o",
 		},
 	}
 
@@ -62,12 +50,11 @@ func TestOptimizeRequest_RoundTrip(t *testing.T) {
 	s := string(data)
 	// Verify camelCase JSON tags
 	for _, field := range []string{
-		`"agent"`, `"foundryProjectUrl"`, `"agentName"`, `"agentVersion"`,
-		`"dataset"`, `"trainDatasetReference"`, `"evaluators"`, `"criteria"`,
+		`"agent"`, `"agentName"`, `"agentVersion"`,
+		`"dataset"`, `"trainDatasetReference"`, `"evaluators"`,
 		`"options"`, `"evalModel"`, `"maxIterations"`,
-		`"keepVersions"`,
-		`"tasksPerIteration"`, `"maxReflectionTasks"`, `"reflectionModel"`,
-		`"strategies"`, `"targetAttributes"`, `"groundTruth"`, `"systemPrompt"`, `"skills"`,
+		`"keepVersions"`, `"optimizationModel"`,
+		`"targetAttributes"`, `"groundTruth"`,
 	} {
 		assert.True(t, strings.Contains(s, field), "JSON should contain %s", field)
 	}
@@ -76,8 +63,6 @@ func TestOptimizeRequest_RoundTrip(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &got), "unmarshal should succeed")
 
 	assert.Equal(t, original.Agent.AgentName, got.Agent.AgentName)
-	assert.Equal(t, original.Agent.FoundryProjectURL, got.Agent.FoundryProjectURL)
-	assert.Equal(t, original.Agent.Model, got.Agent.Model)
 	assert.Len(t, got.Dataset, 1)
 	assert.Equal(t, "task1", got.Dataset[0].Name)
 	assert.Equal(t, "4", got.Dataset[0].GroundTruth)
@@ -95,9 +80,8 @@ func TestOptimizeJobStatus_RoundTrip(t *testing.T) {
 		Status:      StatusRunning,
 		CreatedAt:   "2024-01-01T00:00:00Z",
 		UpdatedAt:   "2024-01-01T01:00:00Z",
-		Agent: &AgentDefinition{
-			FoundryProjectURL: "https://example.ai.azure.com/project/p",
-			AgentName:         "agent-1",
+		Agent: &AgentIdentifier{
+			AgentName: "agent-1",
 		},
 		Progress: &JobProgress{
 			CurrentTargetAttribute: "prompt_mutation",


### PR DESCRIPTION
## Summary

Adapts the `azure.ai.agents` extension's optimization flow to align with the updated Optimize service API contract.

## Changes

### API contract updates (`optimize_api/models.go`)
- Replace `AgentDefinition` (full agent payload with model, systemPrompt, skills, tools) with `AgentIdentifier` (name + version only) — agent content is now sent via `optimizationConfig`
- Replace typed `Dataset []DatasetTask` with `Dataset []json.RawMessage` for flexible pass-through
- Add new-style job status values (`queued`, `in_progress`, `succeeded`) alongside existing ones
- Replace `TargetConfig`, `Strategies`, `TargetAttributes`, `ReflectionModel`, `KeepVersions`, `TasksPerIteration`, `MaxReflectionTasks` with `OptimizationConfig map[string]json.RawMessage` and `OptimizationModel`
- Simplify `CandidateResult` — remove `TaskScores`, flatten structure
- Remove `Criterion` from request (now server-side)

### CLI command changes (`optimize.go`)
- Replace `--target` (repeatable target attributes) with `--dataset`, `--optimize-model`, `--max-iterations` flags
- Add interactive prompts for eval model, dataset, optimization model, and target model selection
- Move validation after all overrides and prompts (was before)
- Resolve baseline model from azd environment (`AZURE_AI_MODEL_DEPLOYMENT_NAME`) when not in config
- Add `baselineModel` to `optimizationConfig` map in the request

### Config changes (`optimize_config.go`, `opt_eval/yaml.go`)
- Remove `TargetAttributes`, `TargetConfig`, `Strategies` from `Options`; add `OptimizationModel` and `OptimizationConfig`
- Remove backward-compat migration for `strategies` and `target_config` YAML keys
- `ToRequest()` now builds `optimizationConfig` from system prompt, skills, tools, and baseline model
- Add `loadJSONLRawFile` for raw JSON line loading (dataset pass-through)

### Apply flow changes (`optimize_apply.go`)
- Simplify `writeToolsFile` to only support `tools` key (drop legacy `toolDefinitions`/`toolDescriptions`)
- Remove `cleanOtherCandidates` — no longer auto-deletes old candidate directories on apply

### Shared helpers (`eval_helpers.go`)
- Extract `promptModelSelection`, `buildModelSelectionChoices`, `promptDatasetSelection` for reuse across eval init and optimize flows

### Tests
- Add unit tests for `hasModelConfig`, `isRecommendedOptimizationModel`, model JSON serialization, `baselineModel` in `optimizationConfig`, tools-only `writeToolsFile`, and full candidate config apply
- Remove obsolete tests for `cleanOtherCandidates`, `LegacyTargetConfigBackwardCompat`, `Strategies` migration