### PR TITLE
fix(azure.ai.toolboxes): correct TOOLBOX_<NAME>_MCP_ENDPOINT in `toolbox show` help

### DIFF
--- a/cli/azd/extensions/azure.ai.toolboxes/cspell.yaml
+++ b/cli/azd/extensions/azure.ai.toolboxes/cspell.yaml
@@ -6,3 +6,4 @@ words:
     - retargets
     - subdocument
     - toolsets
+    - uppercased

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_show.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_show.go
@@ -35,7 +35,9 @@ func newToolboxShowCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 
 By default shows the default version. Use --version to inspect a specific
 version. The output includes the toolbox's runtime MCP endpoint, which agents
-consume via the TOOLBOX_<NAME>_MCP_ENDPOINT environment variable convention.`,
+consume via the TOOLBOX_<NORMALIZED_NAME>_MCP_ENDPOINT environment variable
+convention, where <NORMALIZED_NAME> is the toolbox name uppercased with
+non-alphanumeric character runs replaced by underscores.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runToolboxShow(cmd.Context(), args[0], *flags, readToolboxFlags(cmd, extCtx))

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_show.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_show.go
@@ -35,7 +35,7 @@ func newToolboxShowCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 
 By default shows the default version. Use --version to inspect a specific
 version. The output includes the toolbox's runtime MCP endpoint, which agents
-consume via the TOOLBOX_<NAME>_ENDPOINT environment variable convention.`,
+consume via the TOOLBOX_<NAME>_MCP_ENDPOINT environment variable convention.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runToolboxShow(cmd.Context(), args[0], *flags, readToolboxFlags(cmd, extCtx))


### PR DESCRIPTION
## What this fixes

The `azd ai toolbox show` help text told users to set `TOOLBOX_<NAME>_ENDPOINT` when wiring a toolbox into their agent. The actual variable name the agent runtime looks for is `TOOLBOX_<NAME>_MCP_ENDPOINT`. Users who followed the help text ended up with an agent that silently couldn't see the toolbox at runtime.

## Why it matters

This is a small string, but it sits on the critical path for anyone adding a toolbox to an agent for the first time. Getting the variable name wrong here turns a five-minute task into a confused debug session through Foundry logs.

## Scope

Documentation only -- no runtime behavior change.

Fixes #8380
