### PR TITLE
chore(azure.ai.*): point `no azd project` guidance at `azd ai agent init`

### DIFF
--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/context.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/context.go
@@ -73,7 +73,7 @@ func newContextCommand() *cobra.Command {
 				fmt.Println()
 			} else {
 				color.Yellow("WARNING: No azd project found in current working directory")
-				fmt.Printf("Run %s to create a new project.\n", color.CyanString("azd init"))
+				fmt.Printf("Run %s to create a new project.\n", color.CyanString("azd ai agent init"))
 				return nil
 			}
 

--- a/cli/azd/extensions/azure.ai.projects/internal/cmd/context.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/cmd/context.go
@@ -73,7 +73,7 @@ func newContextCommand() *cobra.Command {
 				fmt.Println()
 			} else {
 				color.Yellow("WARNING: No azd project found in current working directory")
-				fmt.Printf("Run %s to create a new project.\n", color.CyanString("azd init"))
+				fmt.Printf("Run %s to create a new project.\n", color.CyanString("azd ai agent init"))
 				return nil
 			}
 

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/context.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/context.go
@@ -73,7 +73,7 @@ func newContextCommand() *cobra.Command {
 				fmt.Println()
 			} else {
 				color.Yellow("WARNING: No azd project found in current working directory")
-				fmt.Printf("Run %s to create a new project.\n", color.CyanString("azd init"))
+				fmt.Printf("Run %s to create a new project.\n", color.CyanString("azd ai agent init"))
 				return nil
 			}
 

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/context.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/context.go
@@ -73,7 +73,7 @@ func newContextCommand() *cobra.Command {
 				fmt.Println()
 			} else {
 				color.Yellow("WARNING: No azd project found in current working directory")
-				fmt.Printf("Run %s to create a new project.\n", color.CyanString("azd init"))
+				fmt.Printf("Run %s to create a new project.\n", color.CyanString("azd ai agent init"))
 				return nil
 			}
 


### PR DESCRIPTION
## What this fixes

When a developer runs `azd ai connection context`, `azd ai project context`, `azd ai routines context`, or `azd ai skills context` outside an azd project, the extensions print a warning that suggests `azd init`. Following that suggestion gets them a generic azd project that the rest of the `azure.ai.*` family can't actually operate on -- no agent service target, no Foundry endpoint wiring, no model deployment.

This PR points all four extensions at `azd ai agent init` instead, which scaffolds a project the family is actually designed to work with.

## Why it matters

A first-time `azure.ai.*` user is most likely to hit this message exactly when they're trying to set up a new project. The current suggestion sends them down a path that looks like it's working until much later, when they discover the project shape is wrong and they have to start over.

## Scope

One-line change per file (string only). No runtime behavior change beyond the printed suggestion.

Fixes #8379
