### PR TITLE
Honor .azdignore in azd ai agent init (#8384)

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 0.1.35-preview (Unreleased)
+
+- [[#8384]](https://github.com/Azure/azure-dev/issues/8384) Honor `.azdignore` in `azd ai agent init` across local manifest copy, GitHub URL download, and the interactive "from code" starter template flow. Matches the contract documented for core `azd init`: the root `.azdignore` is processed; ignored paths are filtered from the consumer's project; and every `.azdignore` (root and nested) is removed from the final output.
+
 ## 0.1.34-preview (2026-05-22)
 
 - [[#8264]](https://github.com/Azure/azure-dev/pull/8264) Launch Agent Inspector automatically on `azd ai agent run`. Use `--no-inspector` to opt out. Requires the `azure.ai.inspector` extension.

--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Release History
 
-## 0.1.35-preview (Unreleased)
-
-- [[#8384]](https://github.com/Azure/azure-dev/issues/8384) Honor `.azdignore` in `azd ai agent init` across local manifest copy, GitHub URL download, and the interactive "from code" starter template flow. Matches the contract documented for core `azd init`: the root `.azdignore` is processed; ignored paths are filtered from the consumer's project; and every `.azdignore` (root and nested) is removed from the final output.
-
 ## 0.1.34-preview (2026-05-22)
 
 - [[#8264]](https://github.com/Azure/azure-dev/pull/8264) Launch Agent Inspector automatically on `azd ai agent run`. Use `--no-inspector` to opt out. Requires the `azure.ai.inspector` extension.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -27,6 +27,7 @@ import (
 	"azureaiagent/internal/pkg/agents"
 	"azureaiagent/internal/pkg/agents/agent_api"
 	"azureaiagent/internal/pkg/agents/agent_yaml"
+	"azureaiagent/internal/pkg/azdignore"
 	"azureaiagent/internal/pkg/envkey"
 	"azureaiagent/internal/project"
 
@@ -2059,6 +2060,14 @@ func (a *InitAction) downloadAgentYaml(
 				if err != nil {
 					return nil, "", fmt.Errorf("copying parent directory: %w", err)
 				}
+				// Honor .azdignore in the copied template tree (parity
+				// with `azd init -t <template>`). This runs after the
+				// full copy so the matcher reads the root .azdignore
+				// from targetDir and prunes matches, then removes the
+				// root + any nested .azdignore files from the output.
+				if err := azdignore.Apply(targetDir); err != nil {
+					return nil, "", fmt.Errorf("applying %s rules: %w", azdignore.FileName, err)
+				}
 			}
 		}
 	} else if isGitHubUrl {
@@ -2075,6 +2084,14 @@ func (a *InitAction) downloadAgentYaml(
 					fmt.Sprintf("downloading parent directory: %s", err),
 					"verify the URL points to a valid repository and you have access",
 				)
+			}
+			// Honor .azdignore in the downloaded template tree. Apply
+			// matches core's "copy then prune" model: the recursive
+			// GitHub download intentionally fetches everything, then
+			// the ignore rules trim the result and the .azdignore
+			// files themselves are removed.
+			if err := azdignore.Apply(targetDir); err != nil {
+				return nil, "", fmt.Errorf("applying %s rules: %w", azdignore.FileName, err)
 			}
 		}
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_azdignore_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_azdignore_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"azureaiagent/internal/pkg/azdignore"
+)
+
+// TestCopyDirectoryThenAzdIgnoreApply verifies the integration used by
+// downloadAgentYaml for the local ContainerAgent path: copy a manifest
+// directory and then apply .azdignore rules in-place. This is the
+// observable behavior consumers depend on -- ignored files must not be
+// present and the .azdignore file itself must be removed.
+func TestCopyDirectoryThenAzdIgnoreApply(t *testing.T) {
+	t.Parallel()
+
+	src := t.TempDir()
+	// Files we expect to keep.
+	mustWriteFile(t, filepath.Join(src, "agent.yaml"), "name: test\n")
+	mustWriteFile(t, filepath.Join(src, "keep.txt"), "keep")
+	// Files we expect to be filtered.
+	mustWriteFile(t, filepath.Join(src, "secrets.env"), "TOKEN=abc")
+	mustWriteFile(t, filepath.Join(src, "ignored", "data.bin"), "x")
+	// Nested ignore file -- pruned regardless of content.
+	mustWriteFile(t, filepath.Join(src, "nested", azdignore.FileName), "noop\n")
+	// Root ignore file -- controls filtering and is also removed.
+	mustWriteFile(t, filepath.Join(src, azdignore.FileName),
+		"*.env\nignored/\n")
+
+	dst := filepath.Join(t.TempDir(), "out")
+	if err := copyDirectory(src, dst); err != nil {
+		t.Fatalf("copyDirectory: %v", err)
+	}
+	if err := azdignore.Apply(dst); err != nil {
+		t.Fatalf("azdignore.Apply: %v", err)
+	}
+
+	// Kept files must exist.
+	for _, rel := range []string{"agent.yaml", "keep.txt"} {
+		if _, err := os.Stat(filepath.Join(dst, rel)); err != nil {
+			t.Errorf("expected %s to be retained: %v", rel, err)
+		}
+	}
+	// Ignored files and ignore files must be gone.
+	for _, rel := range []string{
+		"secrets.env",
+		filepath.Join("ignored", "data.bin"),
+		"ignored",
+		azdignore.FileName,
+		filepath.Join("nested", azdignore.FileName),
+	} {
+		if _, err := os.Stat(filepath.Join(dst, rel)); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed, stat err: %v", rel, err)
+		}
+	}
+}
+
+// mustWriteFile writes a file (creating any parent dirs) or fails the
+// test. Tests own these paths so 0o600/0o750 modes are intentional.
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -7,6 +7,7 @@ import (
 	"azureaiagent/internal/cmd/nextstep"
 	"azureaiagent/internal/exterrors"
 	"azureaiagent/internal/pkg/agents/agent_yaml"
+	"azureaiagent/internal/pkg/azdignore"
 	"azureaiagent/internal/project"
 	"context"
 	"encoding/json"
@@ -26,6 +27,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/ux"
+	gitignore "github.com/denormal/go-gitignore"
 	"github.com/fatih/color"
 	"google.golang.org/protobuf/types/known/structpb"
 	"gopkg.in/yaml.v3"
@@ -232,6 +234,84 @@ func setGitHubAuthHeader(req *http.Request, token string) {
 	}
 }
 
+// treeEntry is the minimal shape of a single entry returned by the
+// GitHub Git Trees API. Declared here so helpers can accept the slice
+// without coupling to the anonymous struct declared inline in
+// scaffoldTemplate.
+type treeEntry struct {
+	Path string `json:"path"`
+	Type string `json:"type"`
+}
+
+// fetchAzdIgnoreMatcher fetches the root .azdignore from a GitHub repo
+// branch when the tree listing reports one, and returns a matcher
+// suitable for pre-filtering paths during the from-code starter
+// template flow. Returns nil when:
+//
+//   - the tree contains no root .azdignore,
+//   - the file exceeds azdignore.MaxSize,
+//   - the file is empty after BOM stripping, or
+//   - any HTTP/read error occurs (best-effort; the caller falls back
+//     to the unfiltered behavior).
+//
+// Errors are deliberately swallowed (logged at debug) because the
+// alternative -- failing init when an optional metadata file cannot be
+// read -- regresses users whose templates do not ship one.
+func fetchAzdIgnoreMatcher(
+	ctx context.Context,
+	httpClient *http.Client,
+	repoSlug, branch, ghToken string,
+	tree []treeEntry,
+) gitignore.GitIgnore {
+	hasRootIgnore := false
+	for _, entry := range tree {
+		if entry.Type == "blob" && entry.Path == azdignore.FileName {
+			hasRootIgnore = true
+			break
+		}
+	}
+	if !hasRootIgnore {
+		return nil
+	}
+
+	rawURL := fmt.Sprintf(
+		"https://raw.githubusercontent.com/%s/%s/%s",
+		repoSlug, branch, azdignore.FileName,
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		log.Printf("skipping %s: %v", azdignore.FileName, err)
+		return nil
+	}
+	setGitHubAuthHeader(req, ghToken)
+
+	//nolint:gosec // URL is constructed from validated repo slug + constant filename
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		log.Printf("skipping %s: fetch failed: %v", azdignore.FileName, err)
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("skipping %s: status %d", azdignore.FileName, resp.StatusCode)
+		return nil
+	}
+
+	// Cap reads at azdignore.MaxSize+1 so an oversized server response
+	// cannot exhaust memory and we still detect the overflow.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, azdignore.MaxSize+1))
+	if err != nil {
+		log.Printf("skipping %s: read failed: %v", azdignore.FileName, err)
+		return nil
+	}
+	if int64(len(data)) > azdignore.MaxSize {
+		log.Printf("skipping %s: exceeds maximum size (%d bytes)", azdignore.FileName, azdignore.MaxSize)
+		return nil
+	}
+
+	return azdignore.ParseBytes(data, ".")
+}
+
 // scaffoldTemplate downloads a GitHub template repo into the current directory,
 // checking for file collisions before writing. Files that don't collide are shown
 // in green; colliding files are shown in yellow and the user is prompted for how
@@ -272,14 +352,17 @@ func (a *InitFromCodeAction) scaffoldTemplate(ctx context.Context, azdClient *az
 	}
 
 	var treeResp struct {
-		Tree []struct {
-			Path string `json:"path"`
-			Type string `json:"type"` // "blob" or "tree"
-		} `json:"tree"`
+		Tree []treeEntry `json:"tree"`
 	}
 	if err := json.Unmarshal(body, &treeResp); err != nil {
 		return fmt.Errorf("parsing tree response: %w", err)
 	}
+
+	// Best-effort fetch of the root .azdignore from the same repo+branch.
+	// When present, it pre-filters the file list so ignored entries never
+	// appear in the displayed plan or get downloaded. Fetch errors are
+	// non-fatal: the legacy behavior (no filtering) is the safe fallback.
+	azdIgnoreMatcher := fetchAzdIgnoreMatcher(ctx, a.httpClient, repoSlug, branch, ghToken, treeResp.Tree)
 
 	// Collect only files (blobs) from the infra folder and azure.yaml
 	var files []templateFileInfo
@@ -296,6 +379,13 @@ func (a *InitFromCodeAction) scaffoldTemplate(ctx context.Context, azdClient *az
 		cleanPath := posixpath.Clean(entry.Path)
 		if posixpath.IsAbs(cleanPath) || strings.HasPrefix(cleanPath, "..") {
 			return fmt.Errorf("invalid path in repository tree: %s", entry.Path)
+		}
+		// Honor .azdignore from the template repo if one was published.
+		// Filtering happens before display/prompt/download so the user
+		// only ever sees the post-filter file plan.
+		if azdIgnoreMatcher != nil && azdignore.IsIgnored(azdIgnoreMatcher, cleanPath) {
+			log.Printf("Skipping %s due to .azdignore rule", cleanPath)
+			continue
 		}
 		downloadURL := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s", repoSlug, branch, cleanPath)
 		collides := false

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_azdignore_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_azdignore_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"azureaiagent/internal/pkg/azdignore"
+)
+
+// TestFetchAzdIgnoreMatcher_NotInTree returns nil without making any
+// HTTP request when the tree listing does not include .azdignore. This
+// is the common case and must not pay a network round-trip.
+func TestFetchAzdIgnoreMatcher_NotInTree(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	tree := []treeEntry{
+		{Type: "blob", Path: "infra/main.bicep"},
+		{Type: "blob", Path: "azure.yaml"},
+	}
+
+	got := fetchAzdIgnoreMatcher(t.Context(), srv.Client(), "owner/repo", "main", "", tree)
+	if got != nil {
+		t.Errorf("expected nil matcher when tree has no %s", azdignore.FileName)
+	}
+	if called {
+		t.Error("expected no HTTP call when tree has no .azdignore")
+	}
+}
+
+// TestFetchAzdIgnoreMatcher_RewriteToTestServer uses a custom RoundTripper
+// to redirect the raw.githubusercontent.com URL to a local test server
+// that serves a known .azdignore body, then verifies the returned
+// matcher correctly identifies ignored paths.
+func TestFetchAzdIgnoreMatcher_RewriteToTestServer(t *testing.T) {
+	t.Parallel()
+
+	body := "*.log\ninfra/secrets/\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/"+azdignore.FileName) {
+			http.Error(w, "unexpected path", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	httpClient := &http.Client{Transport: redirectTo(t, srv.URL)}
+	tree := []treeEntry{
+		{Type: "blob", Path: azdignore.FileName},
+		{Type: "blob", Path: "azure.yaml"},
+		{Type: "blob", Path: "infra/main.bicep"},
+		{Type: "blob", Path: "infra/secrets/password.txt"},
+		{Type: "blob", Path: "infra/debug.log"},
+	}
+
+	matcher := fetchAzdIgnoreMatcher(t.Context(), httpClient, "owner/repo", "main", "", tree)
+	if matcher == nil {
+		t.Fatal("expected non-nil matcher")
+	}
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"azure.yaml", false},
+		{"infra/main.bicep", false},
+		{"infra/secrets/password.txt", true},
+		{"infra/debug.log", true},
+	}
+	for _, tc := range tests {
+		ignored := azdignore.IsIgnored(matcher, tc.path)
+		if ignored != tc.want {
+			t.Errorf("path %s: ignored=%v, want %v", tc.path, ignored, tc.want)
+		}
+	}
+}
+
+// TestFetchAzdIgnoreMatcher_FetchErrorReturnsNil verifies that a server
+// error during the raw fetch is swallowed: the from-code flow must fall
+// back to the unfiltered behavior rather than failing.
+func TestFetchAzdIgnoreMatcher_FetchErrorReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	httpClient := &http.Client{Transport: redirectTo(t, srv.URL)}
+	tree := []treeEntry{{Type: "blob", Path: azdignore.FileName}}
+
+	got := fetchAzdIgnoreMatcher(t.Context(), httpClient, "owner/repo", "main", "", tree)
+	if got != nil {
+		t.Errorf("expected nil matcher on non-200 response")
+	}
+}
+
+// redirectTo returns a RoundTripper that rewrites every outbound
+// request to target the given base URL. Used to redirect the
+// hard-coded raw.githubusercontent.com URL to a test server.
+func redirectTo(t *testing.T, baseURL string) http.RoundTripper {
+	t.Helper()
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("parse %s: %v", baseURL, err)
+	}
+	return &rewriteTransport{base: u}
+}
+
+type rewriteTransport struct {
+	base *url.URL
+}
+
+func (rt *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	r := req.Clone(req.Context())
+	newURL := *rt.base
+	newURL.Path = req.URL.Path
+	r.URL = &newURL
+	r.Host = newURL.Host
+	return http.DefaultTransport.RoundTrip(r)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/azdignore/azdignore.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/azdignore/azdignore.go
@@ -137,20 +137,30 @@ func Apply(dir string) error {
 // .azdignore files the template might contain. Templates may not put
 // rules in nested .azdignore files, but the contract is that consumers
 // never see them in the output.
+//
+// Paths are collected during the walk and removed afterward so the
+// removal phase runs outside the WalkDir callback. This mirrors Apply
+// and avoids gosec's G122 race-prone-path warning for filesystem
+// mutations inside walk callbacks.
 func removeAllIgnoreFiles(dir string) error {
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
+	var toRemove []string
+	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
 		if !d.IsDir() && d.Name() == FileName {
-			if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-				return fmt.Errorf("removing %s file: %w", FileName, removeErr)
-			}
+			toRemove = append(toRemove, path)
 		}
 		return nil
 	})
-	if err != nil {
-		return fmt.Errorf("cleaning nested %s files: %w", FileName, err)
+	if walkErr != nil {
+		return fmt.Errorf("cleaning nested %s files: %w", FileName, walkErr)
+	}
+
+	for _, p := range toRemove {
+		if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("removing %s file: %w", FileName, err)
+		}
 	}
 	return nil
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/azdignore/azdignore.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/azdignore/azdignore.go
@@ -1,0 +1,227 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Package azdignore applies .azdignore rules inside the azure.ai.agents
+// extension. It mirrors the contract documented for core azd
+// (cli/azd/docs/azdignore.md): the root .azdignore file uses gitignore
+// syntax, only the root file is read for rules, and every .azdignore
+// (root + nested) is removed from the consumer output after processing.
+//
+// The extension cannot import cli/azd/internal/repository, so this
+// package duplicates the relevant logic. Keep behavior in sync with
+// loadAzdIgnore / removeAzdIgnoredFiles in
+// cli/azd/internal/repository/initializer.go.
+package azdignore
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	gitignore "github.com/denormal/go-gitignore"
+)
+
+// FileName is the file template authors place at the root of a template
+// to exclude files from being copied when consumers run `azd ai agent init`.
+const FileName = ".azdignore"
+
+// MaxSize caps the size of a .azdignore file at 1 MB to mirror core azd.
+const MaxSize = 1 << 20
+
+// utf8BOM is the byte order mark that some Windows editors prepend to UTF-8 files.
+// It is stripped before parsing so the invisible bytes do not become part of
+// the first ignore pattern.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// Load reads .azdignore from the root of dir and returns a gitignore-syntax
+// matcher. Returns (nil, nil) when no .azdignore file exists. Symlinks are
+// rejected to prevent reading files outside dir, and oversized files are
+// rejected up front.
+func Load(dir string) (gitignore.GitIgnore, error) {
+	path := filepath.Join(dir, FileName)
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", FileName, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s must be a regular file", FileName)
+	}
+	if info.Size() > MaxSize {
+		return nil, fmt.Errorf("%s exceeds maximum size (%d bytes)", FileName, MaxSize)
+	}
+
+	f, err := os.Open(path) //nolint:gosec // path is dir + constant filename, lstat-checked above
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", FileName, err)
+	}
+	defer f.Close()
+
+	// LimitReader enforces the size cap on actual bytes read, guarding
+	// against TOCTOU between Lstat and Open.
+	data, err := io.ReadAll(io.LimitReader(f, MaxSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", FileName, err)
+	}
+	if int64(len(data)) > MaxSize {
+		return nil, fmt.Errorf("%s exceeds maximum size (%d bytes)", FileName, MaxSize)
+	}
+
+	data = bytes.TrimPrefix(data, utf8BOM)
+	return gitignore.New(bytes.NewReader(data), dir, nil), nil
+}
+
+// Apply reads .azdignore from dir, removes every matching file or
+// directory, and then strips every .azdignore file (root + nested) so
+// the consumer never sees them. It is a no-op when no .azdignore is
+// present at the root, except for the nested-cleanup pass which always
+// runs to honor the documented contract.
+func Apply(dir string) error {
+	ig, err := Load(dir)
+	if err != nil {
+		return err
+	}
+	if ig == nil {
+		// No root .azdignore -> still scrub any nested .azdignore files
+		// to keep behavior identical to core's removeAzdIgnoredFiles
+		// post-condition: consumers never see .azdignore files.
+		return removeAllIgnoreFiles(dir)
+	}
+
+	// Collect paths to remove before mutating the tree so the walk and
+	// the removal phases stay independent.
+	var toRemove []string
+	scanErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		if rel == "." {
+			return nil
+		}
+
+		match := ig.Relative(filepath.ToSlash(rel), d.IsDir())
+		if match != nil && match.Ignore() {
+			toRemove = append(toRemove, path)
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+		}
+		return nil
+	})
+	if scanErr != nil {
+		return fmt.Errorf("scanning for %s matches: %w", FileName, scanErr)
+	}
+
+	for _, p := range toRemove {
+		if err := os.RemoveAll(p); err != nil {
+			return fmt.Errorf("removing %s-ignored path: %w", FileName, err)
+		}
+	}
+
+	return removeAllIgnoreFiles(dir)
+}
+
+// removeAllIgnoreFiles walks dir and deletes every .azdignore file.
+// This includes the root file that Apply just processed and any nested
+// .azdignore files the template might contain. Templates may not put
+// rules in nested .azdignore files, but the contract is that consumers
+// never see them in the output.
+func removeAllIgnoreFiles(dir string) error {
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !d.IsDir() && d.Name() == FileName {
+			if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+				return fmt.Errorf("removing %s file: %w", FileName, removeErr)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("cleaning nested %s files: %w", FileName, err)
+	}
+	return nil
+}
+
+// ParseBytes builds a matcher from raw .azdignore bytes anchored at base.
+// Useful for paths that have a file listing in hand (e.g., the from-code
+// flow that fetches the GitHub repo tree before downloading) and need to
+// pre-filter without writing the file to disk.
+//
+// Returns nil when data is empty after BOM stripping.
+func ParseBytes(data []byte, base string) gitignore.GitIgnore {
+	data = bytes.TrimPrefix(data, utf8BOM)
+	if len(data) == 0 {
+		return nil
+	}
+	return gitignore.New(bytes.NewReader(data), base, nil)
+}
+
+// Filter returns the subset of relPaths that are NOT ignored by ig. The
+// .azdignore file itself is always excluded so callers do not display or
+// download it. Paths must use forward slashes (the GitHub Contents API
+// returns paths in that form). When ig is nil, the input is returned
+// with only .azdignore stripped out.
+//
+// Each path is checked both as a file and against every ancestor
+// directory path. This is necessary because we only have a flat file
+// listing -- in a directory walk, a directory-pattern match would skip
+// descendants, but here we have to detect "inside an ignored directory"
+// explicitly.
+func Filter(relPaths []string, ig gitignore.GitIgnore) []string {
+	out := make([]string, 0, len(relPaths))
+	for _, p := range relPaths {
+		if isIgnoreFile(p) {
+			continue
+		}
+		if ig != nil && IsIgnored(ig, p) {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// IsIgnored reports whether p is ignored by ig. The check considers the
+// file itself and every ancestor directory so that patterns like
+// `infra/secrets/` correctly exclude `infra/secrets/password.txt`.
+// Paths must use forward slashes.
+func IsIgnored(ig gitignore.GitIgnore, p string) bool {
+	if ig == nil {
+		return false
+	}
+	if match := ig.Relative(p, false); match != nil && match.Ignore() {
+		return true
+	}
+	parts := strings.Split(p, "/")
+	for i := 1; i < len(parts); i++ {
+		ancestor := strings.Join(parts[:i], "/")
+		if ancestor == "" {
+			continue
+		}
+		if match := ig.Relative(ancestor, true); match != nil && match.Ignore() {
+			return true
+		}
+	}
+	return false
+}
+
+// isIgnoreFile reports whether p is the .azdignore file at any depth.
+func isIgnoreFile(p string) bool {
+	if p == FileName {
+		return true
+	}
+	return strings.HasSuffix(p, "/"+FileName)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/azdignore/azdignore_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/azdignore/azdignore_test.go
@@ -1,0 +1,289 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azdignore
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestLoad_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	ig, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ig != nil {
+		t.Fatalf("expected nil matcher when no .azdignore exists")
+	}
+}
+
+func TestLoad_RejectsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Windows requires SeCreateSymbolicLinkPrivilege for non-admin
+		// users; skip rather than special-case the test environment.
+		t.Skip("symlink creation requires elevation on Windows")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.txt")
+	if err := os.WriteFile(target, []byte("ignored"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, FileName)
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("expected regular-file rejection, got: %v", err)
+	}
+}
+
+func TestLoad_RejectsOversize(t *testing.T) {
+	dir := t.TempDir()
+	// Write MaxSize+1 bytes so Lstat sees an over-cap file immediately.
+	data := make([]byte, MaxSize+1)
+	for i := range data {
+		data[i] = '#'
+	}
+	if err := os.WriteFile(filepath.Join(dir, FileName), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Fatalf("expected oversize rejection, got: %v", err)
+	}
+}
+
+func TestLoad_StripsBOM(t *testing.T) {
+	dir := t.TempDir()
+	// BOM followed by a single ignore pattern.
+	content := append([]byte{0xEF, 0xBB, 0xBF}, []byte("ignored.txt\n")...)
+	if err := os.WriteFile(filepath.Join(dir, FileName), content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ig, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ig == nil {
+		t.Fatal("expected non-nil matcher")
+	}
+	// If the BOM had not been stripped, the first pattern would be
+	// "\ufeffignored.txt" and would not match "ignored.txt".
+	m := ig.Relative("ignored.txt", false)
+	if m == nil || !m.Ignore() {
+		t.Fatalf("expected BOM-stripped pattern to match ignored.txt")
+	}
+}
+
+func TestApply_NoFile_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	keep := filepath.Join(dir, "keep.txt")
+	if err := os.WriteFile(keep, []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(dir); err != nil {
+		t.Fatalf("Apply returned error with no .azdignore: %v", err)
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Fatalf("file should still exist: %v", err)
+	}
+}
+
+func TestApply_RemovesMatchesAndIgnoreFile(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, dir, "keep.txt", "k")
+	mustWrite(t, dir, "drop.txt", "d")
+	mustWrite(t, dir, "docs/internal/secret.md", "s")
+	mustWrite(t, dir, "docs/public/readme.md", "r")
+	mustWrite(t, dir, FileName, "drop.txt\ndocs/internal/\n")
+
+	if err := Apply(dir); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	got := walkRel(t, dir)
+	want := []string{
+		"docs",
+		"docs/public",
+		"docs/public/readme.md",
+		"keep.txt",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("unexpected tree.\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestApply_RemovesNestedIgnoreFilesEvenWithoutRoot(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, dir, "keep.txt", "k")
+	mustWrite(t, dir, "docs/.azdignore", "# nested - never processed but always removed\n")
+
+	if err := Apply(dir); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	got := walkRel(t, dir)
+	want := []string{
+		"docs",
+		"keep.txt",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("unexpected tree.\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestApply_RemovesRootAndNestedIgnoreFiles(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, dir, "keep.txt", "k")
+	mustWrite(t, dir, "docs/.azdignore", "# nested\n")
+	mustWrite(t, dir, FileName, "# empty rules, just cleanup\n")
+
+	if err := Apply(dir); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	got := walkRel(t, dir)
+	want := []string{
+		"docs",
+		"keep.txt",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("unexpected tree.\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestApply_NegationPattern(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, dir, "README.md", "r")
+	mustWrite(t, dir, "NOTES.md", "n")
+	mustWrite(t, dir, FileName, "*.md\n!README.md\n")
+
+	if err := Apply(dir); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	got := walkRel(t, dir)
+	want := []string{"README.md"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("unexpected tree.\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestFilter(t *testing.T) {
+	rules := []byte("infra/keyvault.bicep\nazure.manifest.yaml\ninfra/secrets/\n")
+	ig := ParseBytes(rules, ".")
+
+	in := []string{
+		"azure.yaml",
+		"azure.manifest.yaml",
+		"infra/main.bicep",
+		"infra/keyvault.bicep",
+		"infra/secrets/password.txt",
+		"infra/secrets/nested/cert.pem",
+		".azdignore",
+		"docs/.azdignore",
+	}
+	got := Filter(in, ig)
+	want := []string{
+		"azure.yaml",
+		"infra/main.bicep",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("Filter unexpected.\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestIsIgnored(t *testing.T) {
+	ig := ParseBytes([]byte("*.log\nvendor/\n!keep.log\n"), ".")
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"src/main.go", false},
+		{"src/debug.log", true},
+		{"keep.log", false},
+		{"vendor/lib.go", true},
+		{"vendor/nested/lib.go", true},
+		{"not-vendor.go", false},
+	}
+	for _, tc := range tests {
+		if got := IsIgnored(ig, tc.path); got != tc.want {
+			t.Errorf("IsIgnored(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestIsIgnored_NilMatcher(t *testing.T) {
+	if IsIgnored(nil, "anything") {
+		t.Fatal("nil matcher must not ignore anything")
+	}
+}
+
+func TestFilter_NilMatcher_StripsIgnoreFilesOnly(t *testing.T) {
+	in := []string{"a.txt", ".azdignore", "sub/.azdignore", "b.txt"}
+	got := Filter(in, nil)
+	want := []string{"a.txt", "b.txt"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("Filter(nil) unexpected.\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestParseBytes_Empty(t *testing.T) {
+	if got := ParseBytes(nil, "."); got != nil {
+		t.Fatalf("expected nil matcher for empty input")
+	}
+	// BOM-only input collapses to empty.
+	if got := ParseBytes([]byte{0xEF, 0xBB, 0xBF}, "."); got != nil {
+		t.Fatalf("expected nil matcher for BOM-only input")
+	}
+}
+
+// mustWrite creates a file (including parent directories) inside dir
+// using forward-slash relative paths for cross-platform test fixtures.
+func mustWrite(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	full := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// walkRel returns the sorted list of paths under dir, relative to dir,
+// using forward slashes so assertions are stable across platforms.
+func walkRel(t *testing.T, dir string) []string {
+	t.Helper()
+	var out []string
+	if err := filepath.WalkDir(dir, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		if path == dir {
+			return nil
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		out = append(out, filepath.ToSlash(rel))
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	slices.Sort(out)
+	return out
+}


### PR DESCRIPTION
The agents extension owns its own init pipeline (local manifest copy, GitHub URL download, and the interactive 'from code' starter template flow) and was not running the .azdignore filtering that core azd init performs. Templates could not exclude files like azure.manifest.yaml from the consumer project.

Add an internal azdignore package that mirrors the documented contract from cli/azd/internal/repository/initializer.go (root file only is parsed, 1 MB cap, UTF-8 BOM stripping, symlink rejection, every .azdignore -- root and nested -- removed from the output), then wire it into the three init paths:

* Local manifest copy and GitHub parent-directory download: run azdignore.Apply on the populated target directory after the copy/download completes, matching core's 'fetch then prune' model.
* From-code starter download: best-effort fetch the root .azdignore via raw.githubusercontent.com using the existing http client, then pre-filter the tree listing with azdignore.IsIgnored before classifying files for the user prompt. Fetch errors fall back to the legacy unfiltered behavior so this never regresses templates that do not ship one.

The extension cannot import cli/azd/internal/repository so the package is intentionally duplicated for this single-PR rollout. Follow-up issue #8388 tracks providing a core extensibility hook so extensions can share the init pipeline.

Tests cover Load, Apply, ParseBytes, Filter, IsIgnored, the copy + Apply integration, and the from-code fetch helper (success, absent, and HTTP error cases).

Fixes #8384
Refs #8369