### PR TITLE
Switch to using GitHubApp

### DIFF
--- a/eng/pipelines/templates/steps/publish-vscode.yml
+++ b/eng/pipelines/templates/steps/publish-vscode.yml
@@ -6,6 +6,12 @@ parameters:
 
 steps:
   - ${{ if eq('true', parameters.TagRepository) }}:
+
+    - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+      parameters:
+        TokenOwners:
+          - Azure
+
     # Perform tag verification before publishing anything
     - pwsh: |
         $existingTag = gh api /repos/$(Build.Repository.Name)/tags --paginate | ConvertFrom-Json | Where-Object { $_.name -eq $tag }
@@ -22,7 +28,7 @@ steps:
         exit 0
       displayName: Check for existing tag or release
       env:
-        GH_TOKEN: $(azuresdk-github-pat)
+        GH_TOKEN: $(GH_TOKEN)
 
 
   - pwsh: |
@@ -64,7 +70,7 @@ steps:
         gh release upload $(GH_RELEASE_TAG) release/* --repo $(Build.Repository.Name)
       displayName: Create GitHub Release and upload artifacts
       env:
-        GH_TOKEN: $(azuresdk-github-pat)
+        GH_TOKEN: $(GH_TOKEN)
 
   - ${{ if eq('true', parameters.PublishToMarketplace) }}:
     - task: AzureCLI@2


### PR DESCRIPTION
This pull request makes a minor update to the `eng/pipelines/templates/steps/publish-vscode.yml` pipeline template, changing the environment variable used for GitHub authentication from `azuresdk-github-pat` to `GH_TOKEN` in two steps. This ensures consistency in how the GitHub token is referenced throughout the pipeline.

- Pipeline authentication update:
  * Changed the environment variable for GitHub authentication from `azuresdk-github-pat` to `GH_TOKEN` in the steps that check for existing tags/releases and create GitHub releases. [[1]](diffhunk://#diff-7e917013ed0887889b07e9c910336ae3b51f67d6c15fb24861db4f08d1ed31deL25-R25) [[2]](diffhunk://#diff-7e917013ed0887889b07e9c910336ae3b51f67d6c15fb24861db4f08d1ed31deL67-R67)
  
Part of resolving https://github.com/Azure/azure-sdk-tools/issues/9842

Fixes #8408