### PR TITLE
fix(ext/toolboxes): unshadow `azd ai toolbox version` by renaming subgroup to `versions`

### DIFF
--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_version.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_version.go
@@ -8,11 +8,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// newToolboxVersionCommand returns the `azd ai toolbox version` parent.
+// newToolboxVersionCommand returns the `azd ai toolbox versions` parent.
 func newToolboxVersionCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 	extCtx = ensureExtensionContext(extCtx)
 	cmd := &cobra.Command{
-		Use:   "version",
+		Use:   "versions",
 		Short: "Inspect toolbox versions.",
 		Long: `Inspect toolbox versions.
 

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_version_list.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_version_list.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// newToolboxVersionListCommand returns `azd ai toolbox version list <toolbox>`.
+// newToolboxVersionListCommand returns `azd ai toolbox versions list <toolbox>`.
 func newToolboxVersionListCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 	extCtx = ensureExtensionContext(extCtx)
 
@@ -53,7 +53,7 @@ func runToolboxVersionList(ctx context.Context, toolboxName string, parent toolb
 	if err != nil {
 		return err
 	}
-	logResolvedEndpoint("toolbox version list", resolved)
+	logResolvedEndpoint("toolbox versions list", resolved)
 
 	return runToolboxVersionListWith(ctx, client, toolboxName, parent)
 }


### PR DESCRIPTION
## Summary

Fixes #8359. `azd ai toolbox version` was shadowed by a sibling subgroup registered with the same `Use: "version"`, so the standard extension version command (from `azdext.NewVersionCommand`) was unreachable and `--output json` silently fell into the subgroup help.

## Changes

- **`internal/cmd/toolbox_version.go`**: rename the toolbox-versions subgroup from `version` to `versions` so it no longer collides with the extension version command.
- **`internal/cmd/toolbox_version_list.go`**: update the `logResolvedEndpoint` label and doc comment to `toolbox versions list` to match the new path.
