### PR TITLE
azd ai agents: fix nextstep guidance for toolbox samples and unify invoke-local payload

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor.go
@@ -12,7 +12,6 @@ import (
 
 	"azureaiagent/internal/cmd/doctor"
 	"azureaiagent/internal/cmd/nextstep"
-	"azureaiagent/internal/pkg/paths"
 	"azureaiagent/internal/version"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -186,11 +185,11 @@ func resolveDoctorTrailing(ctx context.Context, azdClient *azdext.AzdClient) []n
 		return nextstep.ResolveAfterDeploy(
 			filterDeployedServices(state),
 			doctorCachedPayload(ctx, azdClient),
-			doctorReadmeExists(ctx, azdClient),
+			readmeExistsForProject(ctx, azdClient),
 		)
 	}
 
-	return nextstep.ResolveAfterInit(state)
+	return nextstep.ResolveAfterInit(state, readmeExistsForProject(ctx, azdClient))
 }
 
 func anyServiceDeployed(services []nextstep.ServiceState) bool {
@@ -261,19 +260,7 @@ func doctorCachedPayload(ctx context.Context, azdClient *azdext.AzdClient) func(
 	}
 }
 
-// doctorReadmeExists returns a readmeExists closure for ResolveAfterDeploy.
-// Only canonical "README.md" casing is checked to match rendered guidance.
-func doctorReadmeExists(ctx context.Context, azdClient *azdext.AzdClient) func(string) bool {
-	projectRoot := resolveProjectPath(ctx, azdClient)
-	return func(relativePath string) bool {
-		if projectRoot == "" {
-			return false
-		}
-		readmePath, err := paths.JoinAllowRoot(projectRoot, relativePath, "README.md")
-		if err != nil {
-			return false
-		}
-		_, err = os.Stat(readmePath)
-		return err == nil
-	}
-}
+// doctorReadmeExists has moved to helpers.go as readmeExistsForProject
+// so that ResolveAfterInit / ResolveAfterRun / ResolveAfterDeploy
+// callers (init.go, init_from_code.go, run.go, doctor.go) all share
+// the same README-detection contract.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor_format_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor_format_test.go
@@ -504,6 +504,6 @@ func TestFilterDeployedServices_ChainedIntoResolveAfterDeploy(t *testing.T) {
 	require.Len(t, out, 2, "filtered state has one deployed service → show + invoke")
 	assert.Equal(t, "azd ai agent show alpha", out[0].Command,
 		"command must be service-qualified even when filtered list has len==1")
-	assert.Equal(t, `azd ai agent invoke alpha "Hello!"`, out[1].Command,
+	assert.Equal(t, `azd ai agent invoke alpha '<payload>'`, out[1].Command,
 		"invoke command must also be service-qualified")
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -84,6 +84,32 @@ func resolveProjectPath(ctx context.Context, azdClient *azdext.AzdClient) string
 	return projectResponse.Project.Path
 }
 
+// readmeExistsForProject returns a closure suitable for passing to the
+// nextstep resolvers (e.g. ResolveAfterInit, ResolveAfterRun,
+// ResolveAfterDeploy). Given a service-relative path it checks for a
+// canonical "README.md" file inside the project root and returns true
+// when present. Only the canonical casing is checked to match the
+// rendered guidance ("see <relPath>/README.md").
+//
+// Behavior is nil-safe: if the project path cannot be resolved (e.g.
+// azdClient is nil or the gRPC call fails) the returned closure always
+// reports false, which causes the resolvers to fall back to the bare
+// placeholder payload — never a false-positive README pointer.
+func readmeExistsForProject(ctx context.Context, azdClient *azdext.AzdClient) func(string) bool {
+	projectRoot := resolveProjectPath(ctx, azdClient)
+	return func(relativePath string) bool {
+		if projectRoot == "" {
+			return false
+		}
+		readmePath, err := paths.JoinAllowRoot(projectRoot, relativePath, "README.md")
+		if err != nil {
+			return false
+		}
+		_, err = os.Stat(readmePath)
+		return err == nil
+	}
+}
+
 // loadLocalContext reads the legacy .foundry-agent.json state file.
 // Used only for migration. New code should use getContextValue/setContextValue.
 func loadLocalContext(configPath string) *AgentLocalContext {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -2311,7 +2311,7 @@ func (a *InitAction) addToProject(ctx context.Context, targetDir string, agentMa
 		stateOpts = append(stateOpts, nextstep.WithCreatedFolder(a.createdFolderDisplay))
 	}
 	state, _ := nextstep.AssembleState(ctx, a.azdClient, stateOpts...)
-	_ = printAllNextIfTerminal(os.Stdout, nextstep.ResolveAfterInit(state))
+	_ = printAllNextIfTerminal(os.Stdout, nextstep.ResolveAfterInit(state, readmeExistsForProject(ctx, a.azdClient)))
 	return nil
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -172,7 +172,7 @@ func (a *InitFromCodeAction) Run(ctx context.Context) error {
 		// intentionally ignored: the resolver degrades gracefully on
 		// partial state per the design spec.
 		state, _ := nextstep.AssembleState(ctx, a.azdClient)
-		_ = printAllNextIfTerminal(os.Stdout, nextstep.ResolveAfterInit(state))
+		_ = printAllNextIfTerminal(os.Stdout, nextstep.ResolveAfterInit(state, readmeExistsForProject(ctx, a.azdClient)))
 	}
 
 	return nil

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
@@ -43,12 +43,14 @@ const (
 // successful `azd ai agent init`. Pure function over *State.
 //
 // Decision tree:
+//
 //   - UnresolvedPlaceholders (always shown first when present, regardless
 //     of other branches) → one "edit agent.yaml: replace {{NAME}}" line
 //     per unresolved Mustache placeholder (up to maxFixupLines). These
 //     are deploy-time landmines: the literal `{{NAME}}` would otherwise
 //     land in the container. They never reach `azd env set` because the
 //     value lives in agent.yaml itself, not the azd environment.
+//
 //   - len(PendingProvisionReasons) > 0 OR !HasProjectEndpoint OR
 //     MissingInfraVars → `azd provision`
 //     The project endpoint is the canonical "provision finished"
@@ -70,13 +72,42 @@ const (
 //     sibling environment cannot mislead the resolver into
 //     suggesting `azd ai agent run`. See state.PendingProvisionReasons
 //     for the env-var contract.
-//   - MissingManualVars  → one `azd env set <KEY> <value>` per missing var
-//     (up to maxFixupLines) plus an `azd ai agent run` follow-up so
-//     the user knows what to do after supplying the values. Matches
+//
+//   - MissingToolboxEndpoints OR MissingManualVars (or BOTH) → a
+//     combined "fix things before you can run locally" branch. The two
+//     sub-branches are additive (not mutually exclusive) so a manifest
+//     that declares a toolbox AND references an unrelated manual var
+//     (e.g. an API key) surfaces guidance for both — otherwise the
+//     toolbox sub-branch would silently swallow the `azd env set` lines
+//     and still emit `azd ai agent run`, leaving the user to discover
+//     the unset manual var when the agent crashes.
+//
+//     Toolbox sub-branch: emits `azd provision` (with an
+//     `azd ai agent doctor` follow-up so the user can verify whether
+//     the toolbox already exists in their Foundry project before
+//     publishing a fresh version). Toolbox-derived endpoint vars
+//     (`TOOLBOX_<NAME>_MCP_ENDPOINT`) are azd-managed outputs of
+//     provision (see listen.go::registerToolboxEnvVars), not operator-
+//     supplied; suggesting `azd env set` for them would be misleading
+//     because the value is the URL of a Foundry resource that doesn't
+//     yet exist at this point in the lifecycle. The actual live
+//     existence check requires a Foundry API call and lives in
+//     `azd ai agent doctor`'s local.toolboxes check, not here —
+//     ResolveAfterInit is offline by contract.
+//
+//     Manual-vars sub-branch: one `azd env set <KEY> <value>` per
+//     missing operator-supplied var (up to maxFixupLines). Matches
 //     issue #7975's "Then run 'azd ai agent run' to start locally"
-//     manual-vars example. The run follow-up is suppressed when
-//     UnresolvedPlaceholders are also present, since literal
-//     `{{NAME}}` values would still break the local agent.
+//     manual-vars example.
+//
+//     A single `azd ai agent run` + invoke-local secondary follows
+//     both sub-branches, with a description that names the prerequisite
+//     ("once provision completes", "once the values above are set", or
+//     "once the steps above are complete" when both apply). The
+//     run/invoke pair is suppressed when UnresolvedPlaceholders are
+//     also present, since literal `{{NAME}}` values would still break
+//     the local agent.
+//
 //   - Otherwise          → `azd ai agent run` + `azd ai agent invoke
 //     --local <payload>` secondary
 //     Spec: issue #7975 lines 96-103. The invoke-local secondary
@@ -137,6 +168,9 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 		}
 	}
 
+	hasToolboxEndpoints := len(state.MissingToolboxEndpoints) > 0
+	hasManualVars := len(state.MissingManualVars) > 0
+
 	switch {
 	case len(state.PendingProvisionReasons) > 0 ||
 		!state.HasProjectEndpoint ||
@@ -146,40 +180,75 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 			Description: "set up your Foundry project, models, and connections",
 			Priority:    priority,
 		})
-	case len(state.MissingManualVars) > 0:
-		manual := slices.Clone(state.MissingManualVars)
-		slices.Sort(manual)
-		limit := min(len(manual), maxFixupLines)
-		for _, key := range manual[:limit] {
+	case hasToolboxEndpoints || hasManualVars:
+		// Combined branch for the two "things the user has to fix before
+		// running locally" categories. They are intentionally additive
+		// (not mutually exclusive) so a manifest that declares a
+		// toolbox AND references an unrelated manual var (e.g. an API
+		// key) surfaces guidance for BOTH — otherwise the toolbox
+		// branch would silently swallow the `azd env set` lines and
+		// still emit `azd ai agent run`, leaving the user to discover
+		// the unset manual var when the agent crashes.
+		//
+		// Toolbox sub-branch: manifest declares one or more toolboxes
+		// whose azd-injected TOOLBOX_<NAME>_MCP_ENDPOINT variable is
+		// not yet present in the azd environment. The variable is
+		// written by `azd provision` (listen.go::registerToolboxEnvVars)
+		// after the FoundryToolboxClient publishes the toolbox version,
+		// so the canonical fix is provision — NOT `azd env set`, which
+		// the generic manual-vars sub-branch below would otherwise
+		// suggest. We also surface `azd ai agent doctor` as a follow-up
+		// so the user can check whether the toolbox already exists in
+		// their Foundry project before running provision. The actual
+		// live existence check belongs in doctor's local.toolboxes (one
+		// HTTP GET per toolbox); ResolveAfterInit is offline by
+		// contract and must not initiate Foundry API calls.
+		if hasToolboxEndpoints {
 			out = append(out, Suggestion{
-				Command:     fmt.Sprintf("azd env set %s <value>", key),
-				Description: "referenced by agent.yaml but not set in azd env",
+				Command:     "azd provision",
+				Description: "create your toolbox(es) in Foundry",
+				Priority:    priority,
+			})
+			priority++
+			out = append(out, Suggestion{
+				Command:     "azd ai agent doctor",
+				Description: "(optional) verify whether your toolbox(es) already exist before provisioning",
 				Priority:    priority,
 			})
 			priority++
 		}
-		// Follow-up: once the user supplies the values above, the next
-		// productive command is `azd ai agent run`. Without this hint
-		// the post-init Next: block stops at the env-set lines and the
-		// user has to remember the run step themselves — that's the
-		// "Then run 'azd ai agent run' to start locally" line in
-		// issue #7975's manual-vars example output. Suppressed when
-		// placeholders are also unresolved — running locally with
-		// literal `{{NAME}}` values produces a broken agent, so the
-		// user must finish the placeholder fix-ups first; the
-		// trailing `azd deploy` reminder still applies.
+		// Manual-vars sub-branch: one `azd env set <KEY> <value>` per
+		// missing operator-supplied var (up to maxFixupLines). Matches
+		// issue #7975's "Then run 'azd ai agent run' to start locally"
+		// manual-vars example.
+		if hasManualVars {
+			manual := slices.Clone(state.MissingManualVars)
+			slices.Sort(manual)
+			limit := min(len(manual), maxFixupLines)
+			for _, key := range manual[:limit] {
+				out = append(out, Suggestion{
+					Command:     fmt.Sprintf("azd env set %s <value>", key),
+					Description: "referenced by agent.yaml but not set in azd env",
+					Priority:    priority,
+				})
+				priority++
+			}
+		}
+		// Follow-up: once the user finishes the steps above (provision
+		// for toolboxes, env-set for manual vars), the next productive
+		// command is `azd ai agent run` and the invoke-local secondary.
+		// Suppressed when placeholders are also unresolved because
+		// literal `{{NAME}}` values in agent.yaml still break the local
+		// agent — the user must finish the placeholder fix-ups first;
+		// the trailing `azd deploy` reminder still applies.
 		if !hasPlaceholders {
 			out = append(out, Suggestion{
 				Command:     "azd ai agent run",
-				Description: "start the agent locally once the values above are set",
+				Description: runFollowUpDescription(hasToolboxEndpoints, hasManualVars),
 				Priority:    priority,
 			})
 			priority++
-			// Tail with the invoke-local secondary so the user has a
-			// concrete "what to try once it's running" command. Without
-			// this the Next: block jumps from `run` straight to `deploy`
-			// and leaves the user to guess the invoke incantation.
-			out, priority = appendInvokeLocalSecondary(out, state, readmeExists, priority)
+			out, _ = appendInvokeLocalSecondary(out, state, readmeExists, priority)
 		}
 	case hasPlaceholders:
 		// Only unresolved placeholders remain — do not emit
@@ -208,6 +277,23 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 	})
 
 	return out
+}
+
+// runFollowUpDescription picks the description for the
+// `azd ai agent run` follow-up emitted after the toolbox / manual-vars
+// branch, so the suffix reflects which categories of work the user
+// still has to complete first.
+func runFollowUpDescription(hasToolboxEndpoints, hasManualVars bool) string {
+	switch {
+	case hasToolboxEndpoints && hasManualVars:
+		return "start the agent locally once the steps above are complete"
+	case hasToolboxEndpoints:
+		return "start the agent locally once provision completes"
+	case hasManualVars:
+		return "start the agent locally once the values above are set"
+	default:
+		return "start the agent locally"
+	}
 }
 
 // ResolveAfterRun produces the Next: block printed when the running

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
@@ -10,9 +10,6 @@ import (
 	"strings"
 )
 
-// Default-payload literals used when the resolver cannot derive a sample
-// payload from the agent's OpenAPI spec. Two protocols are recognized;
-// anything else falls back to ProtocolDefaultPayload.
 const (
 	// ProtocolInvocations is the value of `agent.yaml#protocol` for
 	// JSON-body /invocations agents.
@@ -21,8 +18,19 @@ const (
 	// text /responses agents.
 	ProtocolResponses = "responses"
 
-	invokeInvocationsPayload = `'{"message": "Hello!"}'`
-	invokeResponsesPayload   = `"Hello!"`
+	// placeholderPayload is the single-quoted literal the resolver
+	// emits as the body argument when no concrete payload is known —
+	// either because no OpenAPI sample has been extracted yet, or
+	// because the agent's schema is genuinely opaque to azd. It
+	// replaces the legacy `'{"message": "Hello!"}'` (invocations) and
+	// `"Hello!"` (responses) fallbacks: those literals only matched
+	// the basic sample's schema and silently 400'd on every other
+	// agent shape. `'<payload>'` is honest — it signals "substitute
+	// your own body here" instead of pretending we know the right
+	// one. When the service has a sibling README on disk, the resolver
+	// pairs the placeholder with a `see <relPath>/README.md` pointer
+	// so the user has somewhere concrete to look for the real shape.
+	placeholderPayload = `'<payload>'`
 
 	// maxFixupLines caps the number of `azd env set` / `edit agent.yaml`
 	// hints emitted by ResolveAfterInit per missing-input category so the
@@ -73,19 +81,25 @@ const (
 //     --local <payload>` secondary
 //     Spec: issue #7975 lines 96-103. The invoke-local secondary
 //     lets the user test the agent in another terminal once it's
-//     running. Payload is protocol-aware when the project has
-//     exactly one service in state (the unqualified `invoke --local`
-//     resolves to that service). For multi-agent projects the
-//     payload defaults to the responses-style `"Hello!"` and the
-//     command is left unqualified — the user picks the target at
-//     runtime via the interactive prompt or `--service` flag, the
-//     same shape the spec example uses.
+//     running. Single-agent projects route through resolveInvokeArg,
+//     which prefers a sibling README pointer + `'<payload>'`
+//     placeholder over a hardcoded sample that could mismatch the
+//     agent's schema. Multi-agent projects emit a single unqualified
+//     invoke line with a bare placeholder — the user picks the
+//     target at runtime via the interactive prompt or `--service`
+//     flag, the same shape the spec example uses, and no per-service
+//     README hint can be picked deterministically at this layer.
 //     Both lines are skipped when only UnresolvedPlaceholders are
 //     present, because running locally with literal `{{NAME}}`
 //     values is broken.
 //
+// readmeExists is consulted by resolveInvokeArg to decide whether
+// to emit a sibling `see <relPath>/README.md` hint immediately before
+// the invoke line. A nil callback disables README detection (tests
+// and dry-run callers can pass nil safely).
+//
 // All paths append the static "When ready to deploy to Azure…" tail.
-func ResolveAfterInit(state *State) []Suggestion {
+func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool) []Suggestion {
 	if state == nil {
 		return nil
 	}
@@ -176,20 +190,24 @@ func ResolveAfterInit(state *State) []Suggestion {
 		// Invoke-local secondary (issue #7975 lines 99-100). The
 		// spec's "everything ready" example shows the user a second
 		// command to try once the agent is running:
-		//   azd ai agent invoke --local "Hello!"  -- test it in another terminal
-		// Single-agent projects get a protocol-aware payload (matches
-		// the protocol the agent's `/invocations` or `/responses`
-		// endpoint expects). Multi-agent projects fall back to the
-		// responses-style "Hello!" literal because the unqualified
-		// command shape doesn't know which service the user will
-		// pick at runtime — mirroring the spec example which also
-		// uses the unqualified form.
-		invokePayload := invokeResponsesPayload
+		//   azd ai agent invoke --local '<payload>'  -- test it in another terminal
+		// Single-agent projects route through resolveInvokeArg so
+		// they get a README pointer + placeholder pair when a
+		// sibling README is present; multi-agent projects emit a
+		// bare placeholder with no per-service README hint (we
+		// cannot pick one deterministically without knowing which
+		// service the user will target).
+		var svc *ServiceState
 		if len(state.Services) == 1 {
-			invokePayload = defaultInvokePayload(&state.Services[0])
+			svc = &state.Services[0]
+		}
+		invokeArg, readmeHint := resolveInvokeArg(svc, "", readmeExists, priority)
+		if readmeHint != nil {
+			out = append(out, *readmeHint)
+			priority++
 		}
 		out = append(out, Suggestion{
-			Command:     fmt.Sprintf("azd ai agent invoke --local %s", invokePayload),
+			Command:     fmt.Sprintf("azd ai agent invoke --local %s", invokeArg),
 			Description: "test it in another terminal",
 			Priority:    priority,
 		})
@@ -210,30 +228,45 @@ func ResolveAfterInit(state *State) []Suggestion {
 //
 // Decision tree:
 //   - HasOpenAPI + OpenAPIPayload non-empty → invoke with extracted payload
-//   - ServiceState.Protocol == ProtocolInvocations → invoke with {"message"…}
-//   - Otherwise (ProtocolResponses or unknown) → invoke with "Hello!"
+//   - No cached payload, sibling README on disk → README pointer +
+//     invoke with '<payload>' placeholder. The README pointer is
+//     preferred over the generic curl hint when both could fire,
+//     because a project-local README is usually the more concrete
+//     guide than the live spec URL.
+//   - Otherwise → invoke with '<payload>' placeholder + the
+//     curl-the-spec tip, so the user has somewhere to look when no
+//     README is available.
 //
-// When the resolver wanted a richer payload but could not extract one
-// (HasOpenAPI=false), the Tip suggestion is appended so the user knows
-// where to look up the agent's exact contract.
-func ResolveAfterRun(state *State, serviceName string) []Suggestion {
+// readmeExists is consulted by resolveInvokeArg to decide whether to
+// surface the README pointer. A nil callback disables README
+// detection (tests can pass nil safely).
+func ResolveAfterRun(state *State, serviceName string, readmeExists func(relativePath string) bool) []Suggestion {
 	if state == nil {
 		return nil
 	}
 
 	svc := findService(state, serviceName)
-	payload := defaultInvokePayload(svc)
+
+	cachedPayload := ""
 	if state.HasOpenAPI && state.OpenAPIPayload != "" {
-		payload = shellEscapeSingleQuoted(state.OpenAPIPayload)
+		cachedPayload = state.OpenAPIPayload
 	}
 
-	out := []Suggestion{{
-		Command:     fmt.Sprintf("azd ai agent invoke --local %s", payload),
+	invokeArg, readmeHint := resolveInvokeArg(svc, cachedPayload, readmeExists, 5)
+
+	out := make([]Suggestion, 0, 3)
+	if readmeHint != nil {
+		out = append(out, *readmeHint)
+	}
+	out = append(out, Suggestion{
+		Command:     fmt.Sprintf("azd ai agent invoke --local %s", invokeArg),
 		Description: "send a sample request to the running agent",
 		Priority:    10,
-	}}
+	})
 
-	if !state.HasOpenAPI {
+	// Tip suppressed when a README pointer is already shown: the README
+	// is the more concrete reference and the tip would just add noise.
+	if !state.HasOpenAPI && readmeHint == nil {
 		out = append(out, Suggestion{
 			Command:     "curl http://localhost:<port>/invocations/docs/openapi.json",
 			Description: "tip: inspect the spec to learn the agent's exact payload",
@@ -458,9 +491,10 @@ type AfterDeployOpts struct {
 // artifact note. Issue #7975 fix B9 spec (lines 228-242):
 //
 //   - Single-agent project: emit one `azd ai agent show <name>` line
-//     followed by one `azd ai agent invoke <name> '<payload>'` line
-//     or, when no cached payload is available but a README exists, a
-//     README pointer followed by a placeholder invoke command.
+//     followed by one `azd ai agent invoke <name> '<payload>'` line.
+//     When no cached payload is available but a sibling README exists,
+//     resolveInvokeArg inserts a README pointer immediately before the
+//     invoke line so the user has somewhere concrete to look first.
 //   - Multi-agent project: emit all `show <name>` lines first (one
 //     per service, in declaration order), then all `invoke <name>`
 //     lines. Descriptions include the agent name —
@@ -476,21 +510,16 @@ type AfterDeployOpts struct {
 //
 // cachedPayload is injected by the caller (typically a closure over
 // ReadCachedOpenAPISpec + ExtractInvokeExample) so the resolver itself
-// stays pure and unit-testable. The cached sample is used verbatim
-// (POSIX-escaped) when present. When no cached payload is available,
-// services with a README get a README pointer first and an explicit
-// '<payload>' placeholder instead of a concrete generic payload that
-// may not match the agent's schema.
+// stays pure and unit-testable. Per-service routing is delegated to
+// resolveInvokeArg, which decides between (a) the POSIX-escaped real
+// payload, (b) a README pointer + `'<payload>'` placeholder, or
+// (c) a bare `'<payload>'` placeholder.
 //
-// readmeExists, also injected, controls whether the
-// "See <relPath>/README.md for a sample payload" line is emitted
-// for a given service. The hint is emitted only when:
-// (1) no cached payload was available for that service,
-// (2) the service has a RelativePath, and
-// (3) readmeExists reports a README on disk at that path.
+// readmeExists, also injected, controls whether resolveInvokeArg
+// surfaces a `see <relPath>/README.md` pointer for a given service.
 // In the multi-agent layout each service's README hint is rendered
 // immediately before that service's placeholder invoke line so users
-// can find the sample-specific payload before running the command.
+// can scan rows top-to-bottom and find each agent's hint in context.
 //
 // opts is variadic for backward compatibility but is no longer
 // consulted — every field of AfterDeployOpts is now a no-op post-B9.
@@ -526,44 +555,28 @@ func ResolveAfterDeploy(
 	// Pass 2: all `azd ai agent invoke <name> <payload>` lines, each
 	// preceded by its README hint when applicable. Grouping invokes
 	// after shows matches the spec example output (lines 238-241).
-	for _, svc := range state.Services {
-		payload := ""
-		if cachedPayload != nil {
-			payload = cachedPayload(svc.Name)
-		}
-		hasReadme := payload == "" &&
-			readmeExists != nil &&
-			readmeExists(svc.RelativePath)
+	for i := range state.Services {
+		svc := &state.Services[i]
 
-		invokeArg := defaultInvokePayload(&svc)
-		if payload != "" {
-			invokeArg = shellEscapeSingleQuoted(payload)
-		} else if hasReadme {
-			invokeArg = "'<payload>'"
+		cached := ""
+		if cachedPayload != nil {
+			cached = cachedPayload(svc.Name)
 		}
+
+		invokeArg, readmeHint := resolveInvokeArg(svc, cached, readmeExists, priority)
 
 		desc := fmt.Sprintf("test %s", svc.Name)
 		if singleAgent {
 			desc = "test the deployment"
 		}
-
-		if payload == "" {
-			if hasReadme {
+		if cached == "" {
+			if readmeHint != nil {
 				desc = fmt.Sprintf("test %s with the sample-specific payload", svc.Name)
 				if singleAgent {
 					desc = "test with the sample-specific payload"
 				}
-				out = append(out, Suggestion{
-					Command:     readmeCommand(svc.RelativePath),
-					Description: "find the sample-specific payload",
-					Priority:    priority,
-				})
+				out = append(out, *readmeHint)
 				priority++
-			} else {
-				desc = fmt.Sprintf("test %s with a generic payload", svc.Name)
-				if singleAgent {
-					desc = "test with a generic payload"
-				}
 			}
 		}
 
@@ -608,14 +621,44 @@ func findService(state *State, serviceName string) *ServiceState {
 	return nil
 }
 
-// defaultInvokePayload returns the protocol-appropriate fallback payload
-// string (already quoted) for a service. Unknown protocols and a nil
-// service fall back to the /responses-style "Hello!" literal.
-func defaultInvokePayload(svc *ServiceState) string {
-	if svc != nil && svc.Protocol == ProtocolInvocations {
-		return invokeInvocationsPayload
+// resolveInvokeArg returns the payload argument to use in an
+// `azd ai agent invoke ...` command for svc, and an optional
+// README-pointer Suggestion that should be emitted immediately before
+// the invoke suggestion. Centralizing this logic keeps ResolveAfterInit,
+// ResolveAfterRun, and ResolveAfterDeploy in sync — all three need the
+// same "real payload > README hint + placeholder > placeholder" chain,
+// and prior to extraction each had its own slightly different copy.
+//
+// Priority:
+//  1. cachedPayload non-empty → POSIX-escaped real payload, no hint.
+//     The caller is responsible for sourcing this (e.g. the run-time
+//     OpenAPI extractor in ResolveAfterRun, or the doctor's spec
+//     cache in ResolveAfterDeploy).
+//  2. svc has a README on disk → placeholderPayload + README hint.
+//     The hint points the user at the sibling README so they can
+//     copy the real payload before running the command.
+//  3. Otherwise → placeholderPayload, no hint.
+//
+// When a hint is returned, callers should append it to the output
+// slice first (so it renders before the invoke line) and use
+// hintPriority as the next priority counter value.
+func resolveInvokeArg(
+	svc *ServiceState,
+	cachedPayload string,
+	readmeExists func(string) bool,
+	hintPriority int,
+) (invokeArg string, readmeHint *Suggestion) {
+	if cachedPayload != "" {
+		return shellEscapeSingleQuoted(cachedPayload), nil
 	}
-	return invokeResponsesPayload
+	if svc != nil && readmeExists != nil && readmeExists(svc.RelativePath) {
+		return placeholderPayload, &Suggestion{
+			Command:     readmeCommand(svc.RelativePath),
+			Description: "find the sample-specific payload",
+			Priority:    hintPriority,
+		}
+	}
+	return placeholderPayload, nil
 }
 
 // shellEscapeSingleQuoted wraps s in single quotes for POSIX shells.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
@@ -174,6 +174,12 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 				Description: "start the agent locally once the values above are set",
 				Priority:    priority,
 			})
+			priority++
+			// Tail with the invoke-local secondary so the user has a
+			// concrete "what to try once it's running" command. Without
+			// this the Next: block jumps from `run` straight to `deploy`
+			// and leaves the user to guess the invoke incantation.
+			out, priority = appendInvokeLocalSecondary(out, state, readmeExists, priority)
 		}
 	case hasPlaceholders:
 		// Only unresolved placeholders remain — do not emit
@@ -191,26 +197,7 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 		// spec's "everything ready" example shows the user a second
 		// command to try once the agent is running:
 		//   azd ai agent invoke --local '<payload>'  -- test it in another terminal
-		// Single-agent projects route through resolveInvokeArg so
-		// they get a README pointer + placeholder pair when a
-		// sibling README is present; multi-agent projects emit a
-		// bare placeholder with no per-service README hint (we
-		// cannot pick one deterministically without knowing which
-		// service the user will target).
-		var svc *ServiceState
-		if len(state.Services) == 1 {
-			svc = &state.Services[0]
-		}
-		invokeArg, readmeHint := resolveInvokeArg(svc, "", readmeExists, priority)
-		if readmeHint != nil {
-			out = append(out, *readmeHint)
-			priority++
-		}
-		out = append(out, Suggestion{
-			Command:     fmt.Sprintf("azd ai agent invoke --local %s", invokeArg),
-			Description: "test it in another terminal",
-			Priority:    priority,
-		})
+		out, _ = appendInvokeLocalSecondary(out, state, readmeExists, priority)
 	}
 
 	out = append(out, Suggestion{
@@ -659,6 +646,44 @@ func resolveInvokeArg(
 		}
 	}
 	return placeholderPayload, nil
+}
+
+// appendInvokeLocalSecondary appends the post-`azd ai agent run`
+// invoke-local Suggestion (and its optional README hint) to out. It is
+// shared by ResolveAfterInit's "everything ready" and "manual vars
+// missing" branches so both paths give the user a concrete "what to try
+// once it's running" command instead of bottoming out at `azd deploy`.
+//
+// Service selection: when state has exactly one service we route it
+// through resolveInvokeArg so the user gets a per-service README pointer
+// when applicable. With zero or multiple services we pass nil — the
+// resolver cannot pick deterministically which service the user will
+// target with an unqualified `azd ai agent invoke --local`, so it emits
+// the bare placeholderPayload without a README hint.
+//
+// Returns the updated slice and the next priority counter value so
+// callers can continue numbering subsequent suggestions.
+func appendInvokeLocalSecondary(
+	out []Suggestion,
+	state *State,
+	readmeExists func(string) bool,
+	priority int,
+) ([]Suggestion, int) {
+	var svc *ServiceState
+	if len(state.Services) == 1 {
+		svc = &state.Services[0]
+	}
+	invokeArg, readmeHint := resolveInvokeArg(svc, "", readmeExists, priority)
+	if readmeHint != nil {
+		out = append(out, *readmeHint)
+		priority++
+	}
+	out = append(out, Suggestion{
+		Command:     fmt.Sprintf("azd ai agent invoke --local %s", invokeArg),
+		Description: "test it in another terminal",
+		Priority:    priority,
+	})
+	return out, priority + 1
 }
 
 // shellEscapeSingleQuoted wraps s in single quotes for POSIX shells.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
@@ -199,10 +199,10 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 		// the generic manual-vars sub-branch below would otherwise
 		// suggest. We also surface `azd ai agent doctor` as a follow-up
 		// so the user can check whether the toolbox already exists in
-		// their Foundry project before running provision. The actual
-		// live existence check belongs in doctor's local.toolboxes (one
-		// HTTP GET per toolbox); ResolveAfterInit is offline by
-		// contract and must not initiate Foundry API calls.
+		// their Foundry project. The actual live existence check
+		// belongs in doctor's local.toolboxes (one HTTP GET per
+		// toolbox); ResolveAfterInit is offline by contract and must
+		// not initiate Foundry API calls.
 		if hasToolboxEndpoints {
 			out = append(out, Suggestion{
 				Command:     "azd provision",
@@ -212,7 +212,7 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 			priority++
 			out = append(out, Suggestion{
 				Command:     "azd ai agent doctor",
-				Description: "(optional) verify whether your toolbox(es) already exist before provisioning",
+				Description: "(optional) check whether your toolbox(es) already exist in Foundry",
 				Priority:    priority,
 			})
 			priority++

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
@@ -360,18 +360,25 @@ func TestResolveAfterInit_EverythingReady_EmitsInvokeLocalSecondary(t *testing.T
 
 // TestResolveAfterInit_ToolboxReproRendersAllCategories locks the full
 // regression for the toolbox-sample bug end-to-end: the state contains
-// BOTH an unresolved manifest placeholder AND a missing manual env var,
-// and the rendered "Next:" block must surface both fix-up categories
-// plus the trailing `azd deploy` reminder. PrintNext would silently
-// drop one category here because of its 2-line cap; PrintAllNext must
-// not.
+// BOTH an unresolved manifest placeholder AND a manifest-declared
+// toolbox whose azd-injected endpoint env var is unset. The rendered
+// "Next:" block must surface the placeholder fix-up AND route the
+// missing toolbox endpoint to `azd provision` (NOT to `azd env set`),
+// plus the trailing `azd deploy` reminder.
+//
+// Before #8198's toolbox-endpoint partition this would have rendered
+// "azd env set TOOLBOX_WEB_SEARCH_TOOLS_MCP_ENDPOINT <value>" — see
+// the test body's NotContains assertion below for the historical bug
+// shape we're locking out.
 func TestResolveAfterInit_ToolboxReproRendersAllCategories(t *testing.T) {
 	t.Parallel()
 
 	state := &State{
 		HasProjectEndpoint:     true,
 		UnresolvedPlaceholders: []string{"TOOLBOX_ENDPOINT"},
-		MissingManualVars:      []string{"TOOLBOX_WEB_SEARCH_TOOLS_MCP_ENDPOINT"},
+		MissingToolboxEndpoints: []ResourceRef{
+			{Name: "web-search-tools", ServiceName: "agent"},
+		},
 	}
 
 	var buf strings.Builder
@@ -381,17 +388,203 @@ func TestResolveAfterInit_ToolboxReproRendersAllCategories(t *testing.T) {
 	assert.Contains(t, rendered,
 		"edit agent.yaml: replace {{TOOLBOX_ENDPOINT}} with the actual value",
 		"placeholder fix-up missing")
-	assert.Contains(t, rendered,
-		"azd env set TOOLBOX_WEB_SEARCH_TOOLS_MCP_ENDPOINT <value>",
-		"manual-var fix-up missing — this is the original toolbox-sample regression")
-	// `azd ai agent run` follow-up is intentionally suppressed when
-	// UnresolvedPlaceholders are also present: running locally with
-	// literal `{{NAME}}` values produces a broken agent. The user
-	// must fix the placeholder first; the trailing `azd deploy`
-	// still applies.
-	assert.NotContains(t, rendered, "start the agent locally once the values above are set",
-		"run follow-up should be suppressed while placeholders are unresolved")
+	assert.Contains(t, rendered, "azd provision",
+		"toolbox-endpoint branch should route to azd provision")
+	assert.Contains(t, rendered, "azd ai agent doctor",
+		"toolbox-endpoint branch should surface doctor as an existence-check follow-up")
+	// Historical bug: the resolver used to emit `azd env set` for
+	// toolbox-derived endpoint vars. Those vars are azd-managed
+	// outputs of `azd provision`, not operator-supplied, so the
+	// `azd env set` shape is wrong here regardless of the user's
+	// `<value>` placeholder gripe.
+	assert.NotContains(t, rendered,
+		"azd env set TOOLBOX_WEB_SEARCH_TOOLS_MCP_ENDPOINT",
+		"toolbox endpoint var must not be routed through `azd env set`")
 	assert.Contains(t, rendered, "azd deploy", "trailing deploy reminder missing")
+}
+
+// TestResolveAfterInit_ToolboxEndpointsEmitsRunAndInvokeLocal locks the
+// "happy path" for the toolbox-endpoint branch: when the only thing
+// blocking the user is a manifest-declared toolbox whose
+// TOOLBOX_<NAME>_MCP_ENDPOINT var is unset (no placeholders, no
+// pending provision reasons), the resolver must render the full
+// post-init sequence:
+//
+//  1. `azd provision`               — create the toolbox in Foundry
+//  2. `azd ai agent doctor`         — optional existence-check follow-up
+//  3. `azd ai agent run`            — start locally once provision completes
+//  4. `azd ai agent invoke --local` — secondary; test the running agent
+//  5. `azd deploy`                  — trailing reminder
+//
+// Steps 3 and 4 are crucial: once provision finishes, main.py's
+// runtime fallback (constructed from FOUNDRY_PROJECT_ENDPOINT +
+// TOOLBOX_NAME) satisfies the agent even without the user setting
+// the azd-injected endpoint var, so the local-test commands MUST
+// appear here just as they do in the MissingManualVars branch.
+// Dropping them was the regression this test guards against.
+func TestResolveAfterInit_ToolboxEndpointsEmitsRunAndInvokeLocal(t *testing.T) {
+	t.Parallel()
+
+	state := &State{
+		HasProjectEndpoint: true,
+		MissingToolboxEndpoints: []ResourceRef{
+			{Name: "web-search-tools", ServiceName: "agent"},
+		},
+	}
+
+	var buf strings.Builder
+	require.NoError(t, PrintAllNext(&buf, ResolveAfterInit(state, nil)))
+	rendered := buf.String()
+
+	assert.Contains(t, rendered, "azd provision",
+		"toolbox-endpoint branch should route to azd provision")
+	assert.Contains(t, rendered, "azd ai agent doctor",
+		"toolbox-endpoint branch should surface doctor as an existence-check follow-up")
+	assert.Contains(t, rendered, "azd ai agent run",
+		"toolbox-endpoint branch should emit local run follow-up once provision completes")
+	assert.Contains(t, rendered, "once provision completes",
+		"toolbox-only run description must name provision as the prerequisite")
+	assert.Contains(t, rendered, "azd ai agent invoke --local",
+		"toolbox-endpoint branch should emit invoke-local secondary")
+	assert.NotContains(t, rendered,
+		"azd env set TOOLBOX_WEB_SEARCH_TOOLS_MCP_ENDPOINT",
+		"toolbox endpoint var must not be routed through `azd env set`")
+	assert.Contains(t, rendered, "azd deploy", "trailing deploy reminder missing")
+}
+
+// TestResolveAfterInit_ToolboxAndManualVarsCoexist locks the bug both
+// reviewers caught: when MissingToolboxEndpoints AND MissingManualVars
+// are populated, the previously-exclusive switch hid the manual
+// `azd env set` lines while still emitting `azd ai agent run` — so
+// the user was directed to run locally with required manual vars
+// still unset.
+//
+// Expected output for state with one toolbox + one unrelated manual
+// var (e.g. an API key):
+//
+//  1. `azd provision`              — create the toolbox in Foundry
+//  2. `azd ai agent doctor`        — optional existence-check follow-up
+//  3. `azd env set MY_API_KEY …`   — surface the manual var
+//  4. `azd ai agent run`           — start locally once the steps above are complete
+//  5. `azd ai agent invoke --local` — secondary
+//  6. `azd deploy`                 — trailing
+//
+// The `azd env set TOOLBOX_…` line must still NOT appear — that's the
+// original (separate) bug Commit A locked out.
+func TestResolveAfterInit_ToolboxAndManualVarsCoexist(t *testing.T) {
+	t.Parallel()
+
+	state := &State{
+		HasProjectEndpoint: true,
+		MissingToolboxEndpoints: []ResourceRef{
+			{Name: "web-search-tools", ServiceName: "agent"},
+		},
+		MissingManualVars: []string{"MY_API_KEY"},
+	}
+
+	var buf strings.Builder
+	require.NoError(t, PrintAllNext(&buf, ResolveAfterInit(state, nil)))
+	rendered := buf.String()
+
+	assert.Contains(t, rendered, "azd provision",
+		"coexistence: toolbox sub-branch must still emit provision")
+	assert.Contains(t, rendered, "azd ai agent doctor",
+		"coexistence: toolbox sub-branch must still emit doctor follow-up")
+	assert.Contains(t, rendered, "azd env set MY_API_KEY <value>",
+		"coexistence: manual sub-branch must surface the unrelated env-set line")
+	assert.Contains(t, rendered, "azd ai agent run",
+		"coexistence: run follow-up must be emitted (no placeholders blocking)")
+	assert.Contains(t, rendered, "once the steps above are complete",
+		"coexistence: run description must reflect that both provision and env-set are prerequisites")
+	assert.Contains(t, rendered, "azd ai agent invoke --local",
+		"coexistence: invoke-local secondary must be emitted")
+	assert.NotContains(t, rendered,
+		"azd env set TOOLBOX_WEB_SEARCH_TOOLS_MCP_ENDPOINT",
+		"coexistence: toolbox endpoint var must not be routed through `azd env set`")
+	assert.Contains(t, rendered, "azd deploy", "trailing deploy reminder missing")
+}
+
+// TestResolveAfterInit_ToolboxAndManualVarsCoexistWithPlaceholders
+// verifies the run/invoke suppression also fires for the coexistence
+// case: when placeholders are also unresolved, the run + invoke-local
+// pair must be suppressed regardless of which sub-branches contributed
+// guidance above them.
+func TestResolveAfterInit_ToolboxAndManualVarsCoexistWithPlaceholders(t *testing.T) {
+	t.Parallel()
+
+	state := &State{
+		HasProjectEndpoint:     true,
+		UnresolvedPlaceholders: []string{"AGENT_NAME"},
+		MissingToolboxEndpoints: []ResourceRef{
+			{Name: "web-search-tools", ServiceName: "agent"},
+		},
+		MissingManualVars: []string{"MY_API_KEY"},
+	}
+
+	var buf strings.Builder
+	require.NoError(t, PrintAllNext(&buf, ResolveAfterInit(state, nil)))
+	rendered := buf.String()
+
+	assert.Contains(t, rendered,
+		"edit agent.yaml: replace {{AGENT_NAME}} with the actual value",
+		"placeholder fix-up missing")
+	assert.Contains(t, rendered, "azd provision",
+		"coexistence+placeholders: toolbox sub-branch must still emit provision")
+	assert.Contains(t, rendered, "azd ai agent doctor",
+		"coexistence+placeholders: toolbox sub-branch must still emit doctor follow-up")
+	assert.Contains(t, rendered, "azd env set MY_API_KEY <value>",
+		"coexistence+placeholders: manual sub-branch must still surface env-set")
+	assert.NotContains(t, rendered, "azd ai agent run",
+		"coexistence+placeholders: run must be suppressed while placeholders are unresolved")
+	assert.NotContains(t, rendered, "azd ai agent invoke --local",
+		"coexistence+placeholders: invoke-local must be suppressed while placeholders are unresolved")
+	assert.Contains(t, rendered, "azd deploy", "trailing deploy reminder missing")
+}
+
+// TestRunFollowUpDescription exercises the helper directly so future
+// changes to the description text (or a regression in the conditional
+// branching) get caught even when the higher-level resolver tests
+// happen to overlap on substrings.
+func TestRunFollowUpDescription(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		hasToolboxEndpoint bool
+		hasManualVars      bool
+		want               string
+	}{
+		{
+			name:               "both",
+			hasToolboxEndpoint: true,
+			hasManualVars:      true,
+			want:               "start the agent locally once the steps above are complete",
+		},
+		{
+			name:               "toolbox only",
+			hasToolboxEndpoint: true,
+			want:               "start the agent locally once provision completes",
+		},
+		{
+			name:          "manual only",
+			hasManualVars: true,
+			want:          "start the agent locally once the values above are set",
+		},
+		{
+			// Defensive fallthrough — unreachable from ResolveAfterInit's
+			// combined case (guarded by `hasToolboxEndpoints ||
+			// hasManualVars`) but the helper is total over its inputs.
+			name: "neither",
+			want: "start the agent locally",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := runFollowUpDescription(tc.hasToolboxEndpoint, tc.hasManualVars)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }
 
 func TestResolveAfterInit_UnresolvedPlaceholders(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
@@ -132,9 +132,9 @@ func TestResolveAfterInit(t *testing.T) {
 			assert.True(t, last.Trailing, "last suggestion must be flagged Trailing")
 
 			if len(tt.wantManualVarKeys) > 0 {
-				// N env-set lines + 1 `azd ai agent run` follow-up + 1
-				// trailing `azd deploy`.
-				assert.Len(t, out, len(tt.wantManualVarKeys)+2)
+				// N env-set lines + 1 `azd ai agent run` follow-up +
+				// 1 invoke-local secondary + 1 trailing `azd deploy`.
+				assert.Len(t, out, len(tt.wantManualVarKeys)+3)
 				for i, key := range tt.wantManualVarKeys {
 					assert.True(t,
 						strings.HasPrefix(out[i].Command, "azd env set "+key+" "),
@@ -148,6 +148,16 @@ func TestResolveAfterInit(t *testing.T) {
 					"expected `azd ai agent run` follow-up after env-set lines")
 				assert.False(t, followUp.Trailing,
 					"run follow-up must be a primary suggestion, not Trailing")
+				// The slot after the run follow-up is the invoke-local
+				// secondary that tells the user how to test the agent
+				// once it's running.
+				invokeLocal := out[len(tt.wantManualVarKeys)+1]
+				assert.True(t,
+					strings.HasPrefix(invokeLocal.Command, "azd ai agent invoke --local "),
+					"expected invoke-local secondary after run follow-up, got %q",
+					invokeLocal.Command)
+				assert.False(t, invokeLocal.Trailing,
+					"invoke-local secondary must be a primary suggestion, not Trailing")
 			} else {
 				assert.Contains(t, out[0].Command, tt.wantPrimaryHas)
 			}
@@ -163,17 +173,19 @@ func TestResolveAfterInit_ManualVarsCapAtThree(t *testing.T) {
 		MissingManualVars:  []string{"V1", "V2", "V3", "V4", "V5"},
 	}
 	out := ResolveAfterInit(state, nil)
-	// 3 env-set lines (capped) + 1 `azd ai agent run` follow-up + 1
-	// trailing `azd deploy`.
-	require.Len(t, out, 5)
+	// 3 env-set lines (capped) + 1 `azd ai agent run` follow-up +
+	// 1 `azd ai agent invoke --local` secondary + 1 trailing `azd deploy`.
+	require.Len(t, out, 6)
 	for i := range 3 {
 		assert.True(t, strings.HasPrefix(out[i].Command, "azd env set "),
 			"slot %d should be an env-set line, got %q", i, out[i].Command)
 	}
 	assert.Equal(t, "azd ai agent run", out[3].Command,
 		"slot 3 should be the run follow-up")
-	assert.Equal(t, "azd deploy", out[4].Command)
-	assert.True(t, out[4].Trailing, "deploy footer must be Trailing")
+	assert.True(t, strings.HasPrefix(out[4].Command, "azd ai agent invoke --local "),
+		"slot 4 should be the invoke-local secondary, got %q", out[4].Command)
+	assert.Equal(t, "azd deploy", out[5].Command)
+	assert.True(t, out[5].Trailing, "deploy footer must be Trailing")
 }
 
 func TestResolveAfterInit_NilState(t *testing.T) {
@@ -238,8 +250,8 @@ func TestResolveAfterInit_ManualVarsSingleEmitsEnrichedShape(t *testing.T) {
 		MissingManualVars:  []string{"MY_API_KEY"},
 	}
 	out := ResolveAfterInit(state, nil)
-	// 1 env-set + 1 run follow-up + 1 trailing.
-	require.Len(t, out, 3)
+	// 1 env-set + 1 run follow-up + 1 invoke-local secondary + 1 trailing.
+	require.Len(t, out, 4)
 
 	assert.Equal(t, "azd env set MY_API_KEY <value>", out[0].Command)
 	assert.Equal(t, "referenced by agent.yaml but not set in azd env", out[0].Description,
@@ -250,8 +262,12 @@ func TestResolveAfterInit_ManualVarsSingleEmitsEnrichedShape(t *testing.T) {
 	assert.Equal(t, "start the agent locally once the values above are set", out[1].Description)
 	assert.False(t, out[1].Trailing, "run follow-up must be a primary suggestion")
 
-	assert.Equal(t, "azd deploy", out[2].Command)
-	assert.True(t, out[2].Trailing)
+	assert.Equal(t, `azd ai agent invoke --local '<payload>'`, out[2].Command)
+	assert.Equal(t, "test it in another terminal", out[2].Description)
+	assert.False(t, out[2].Trailing, "invoke-local secondary must be a primary suggestion")
+
+	assert.Equal(t, "azd deploy", out[3].Command)
+	assert.True(t, out[3].Trailing)
 }
 
 // TestResolveAfterInit_EverythingReady_EmitsInvokeLocalSecondary locks

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
@@ -122,7 +122,7 @@ func TestResolveAfterInit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			out := ResolveAfterInit(tt.state)
+			out := ResolveAfterInit(tt.state, nil)
 			require.NotEmpty(t, out)
 
 			// The trailing line is always present and flagged Trailing so
@@ -162,7 +162,7 @@ func TestResolveAfterInit_ManualVarsCapAtThree(t *testing.T) {
 		HasProjectEndpoint: true,
 		MissingManualVars:  []string{"V1", "V2", "V3", "V4", "V5"},
 	}
-	out := ResolveAfterInit(state)
+	out := ResolveAfterInit(state, nil)
 	// 3 env-set lines (capped) + 1 `azd ai agent run` follow-up + 1
 	// trailing `azd deploy`.
 	require.Len(t, out, 5)
@@ -178,7 +178,7 @@ func TestResolveAfterInit_ManualVarsCapAtThree(t *testing.T) {
 
 func TestResolveAfterInit_NilState(t *testing.T) {
 	t.Parallel()
-	assert.Nil(t, ResolveAfterInit(nil))
+	assert.Nil(t, ResolveAfterInit(nil, nil))
 }
 
 func TestResolveAfterInit_CreatedFolder(t *testing.T) {
@@ -190,7 +190,7 @@ func TestResolveAfterInit_CreatedFolder(t *testing.T) {
 			HasProjectEndpoint:   true,
 			CreatedFolderDisplay: "my-agent",
 		}
-		out := ResolveAfterInit(state)
+		out := ResolveAfterInit(state, nil)
 		require.NotEmpty(t, out)
 		assert.Equal(t, "cd my-agent", out[0].Command)
 		assert.Equal(t, "enter your new project folder", out[0].Description)
@@ -203,7 +203,7 @@ func TestResolveAfterInit_CreatedFolder(t *testing.T) {
 	t.Run("no cd suggestion when no folder created", func(t *testing.T) {
 		t.Parallel()
 		state := &State{HasProjectEndpoint: true}
-		out := ResolveAfterInit(state)
+		out := ResolveAfterInit(state, nil)
 		require.NotEmpty(t, out)
 		for _, s := range out {
 			assert.False(t, strings.HasPrefix(s.Command, "cd "),
@@ -216,7 +216,7 @@ func TestResolveAfterInit_CreatedFolder(t *testing.T) {
 		state := &State{
 			CreatedFolderDisplay: "hello-world",
 		}
-		out := ResolveAfterInit(state)
+		out := ResolveAfterInit(state, nil)
 		require.True(t, len(out) >= 2)
 		assert.Equal(t, "cd hello-world", out[0].Command)
 		assert.Equal(t, "azd provision", out[1].Command)
@@ -237,7 +237,7 @@ func TestResolveAfterInit_ManualVarsSingleEmitsEnrichedShape(t *testing.T) {
 		HasProjectEndpoint: true,
 		MissingManualVars:  []string{"MY_API_KEY"},
 	}
-	out := ResolveAfterInit(state)
+	out := ResolveAfterInit(state, nil)
 	// 1 env-set + 1 run follow-up + 1 trailing.
 	require.Len(t, out, 3)
 
@@ -263,15 +263,15 @@ func TestResolveAfterInit_ManualVarsSingleEmitsEnrichedShape(t *testing.T) {
 func TestResolveAfterInit_EverythingReady_EmitsInvokeLocalSecondary(t *testing.T) {
 	t.Parallel()
 
-	t.Run("zero services → unqualified invoke with responses payload", func(t *testing.T) {
+	t.Run("zero services → unqualified invoke with placeholder payload", func(t *testing.T) {
 		t.Parallel()
 		state := &State{HasProjectEndpoint: true}
-		out := ResolveAfterInit(state)
+		out := ResolveAfterInit(state, nil)
 		// run + invoke --local + trailing.
 		require.Len(t, out, 3)
 		assert.Equal(t, "azd ai agent run", out[0].Command)
 		assert.Equal(t, "start the agent locally", out[0].Description)
-		assert.Equal(t, `azd ai agent invoke --local "Hello!"`, out[1].Command)
+		assert.Equal(t, `azd ai agent invoke --local '<payload>'`, out[1].Command)
 		assert.Equal(t, "test it in another terminal", out[1].Description)
 		assert.Less(t, out[0].Priority, out[1].Priority,
 			"run must precede invoke --local; the renderer sorts by Priority")
@@ -279,31 +279,31 @@ func TestResolveAfterInit_EverythingReady_EmitsInvokeLocalSecondary(t *testing.T
 		assert.True(t, out[2].Trailing)
 	})
 
-	t.Run("single-agent responses protocol → invoke uses \"Hello!\"", func(t *testing.T) {
+	t.Run("single-agent responses protocol → invoke uses placeholder", func(t *testing.T) {
 		t.Parallel()
 		state := &State{
 			HasProjectEndpoint: true,
 			Services:           []ServiceState{{Name: "echo", Protocol: ProtocolResponses}},
 		}
-		out := ResolveAfterInit(state)
+		out := ResolveAfterInit(state, nil)
 		require.Len(t, out, 3)
 		assert.Equal(t, "azd ai agent run", out[0].Command)
-		assert.Equal(t, `azd ai agent invoke --local "Hello!"`, out[1].Command)
+		assert.Equal(t, `azd ai agent invoke --local '<payload>'`, out[1].Command)
 	})
 
-	t.Run("single-agent invocations protocol → invoke uses JSON envelope", func(t *testing.T) {
+	t.Run("single-agent invocations protocol → invoke uses placeholder", func(t *testing.T) {
 		t.Parallel()
 		state := &State{
 			HasProjectEndpoint: true,
 			Services:           []ServiceState{{Name: "echo", Protocol: ProtocolInvocations}},
 		}
-		out := ResolveAfterInit(state)
+		out := ResolveAfterInit(state, nil)
 		require.Len(t, out, 3)
 		assert.Equal(t, "azd ai agent run", out[0].Command)
-		assert.Equal(t, `azd ai agent invoke --local '{"message": "Hello!"}'`, out[1].Command)
+		assert.Equal(t, `azd ai agent invoke --local '<payload>'`, out[1].Command)
 	})
 
-	t.Run("multi-agent → invoke stays unqualified, defaults to responses payload", func(t *testing.T) {
+	t.Run("multi-agent → invoke stays unqualified, uses placeholder payload", func(t *testing.T) {
 		t.Parallel()
 		state := &State{
 			HasProjectEndpoint: true,
@@ -312,14 +312,14 @@ func TestResolveAfterInit_EverythingReady_EmitsInvokeLocalSecondary(t *testing.T
 				{Name: "beta", Protocol: ProtocolResponses},
 			},
 		}
-		out := ResolveAfterInit(state)
+		out := ResolveAfterInit(state, nil)
 		require.Len(t, out, 3)
 		assert.Equal(t, "azd ai agent run", out[0].Command)
 		// Multi-agent: the unqualified `invoke --local` doesn't know
-		// which service the user will pick at runtime, so use the
-		// safest generic payload (responses-style "Hello!") instead
-		// of picking one service's protocol arbitrarily.
-		assert.Equal(t, `azd ai agent invoke --local "Hello!"`, out[1].Command)
+		// which service the user will pick at runtime, so emit the
+		// bare '<payload>' placeholder rather than a per-protocol
+		// payload that may not match the user's chosen service.
+		assert.Equal(t, `azd ai agent invoke --local '<payload>'`, out[1].Command)
 	})
 
 	t.Run("placeholders present → invoke-local secondary suppressed (with run)", func(t *testing.T) {
@@ -332,7 +332,7 @@ func TestResolveAfterInit_EverythingReady_EmitsInvokeLocalSecondary(t *testing.T
 			HasProjectEndpoint:     true,
 			UnresolvedPlaceholders: []string{"FOO"},
 		}
-		out := ResolveAfterInit(state)
+		out := ResolveAfterInit(state, nil)
 		for _, s := range out {
 			assert.NotContains(t, s.Command, "azd ai agent invoke --local",
 				"invoke --local must not be emitted while placeholders are unresolved")
@@ -359,7 +359,7 @@ func TestResolveAfterInit_ToolboxReproRendersAllCategories(t *testing.T) {
 	}
 
 	var buf strings.Builder
-	require.NoError(t, PrintAllNext(&buf, ResolveAfterInit(state)))
+	require.NoError(t, PrintAllNext(&buf, ResolveAfterInit(state, nil)))
 	rendered := buf.String()
 
 	assert.Contains(t, rendered,
@@ -447,7 +447,7 @@ func TestResolveAfterInit_UnresolvedPlaceholders(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			out := ResolveAfterInit(tt.state)
+			out := ResolveAfterInit(tt.state, nil)
 			require.NotEmpty(t, out)
 
 			// Walk the output:
@@ -514,35 +514,35 @@ func TestResolveAfterRun(t *testing.T) {
 			},
 		},
 		{
-			name: "invocations protocol, no spec → default JSON payload + tip",
+			name: "invocations protocol, no spec, no README → placeholder + tip",
 			state: &State{
 				Services: []ServiceState{{Name: "echo", Protocol: ProtocolInvocations}},
 			},
 			serviceName: "echo",
 			want: []string{
-				`azd ai agent invoke --local '{"message": "Hello!"}'`,
+				`azd ai agent invoke --local '<payload>'`,
 				`curl http://localhost:<port>/invocations/docs/openapi.json`,
 			},
 		},
 		{
-			name: "responses protocol, no spec → Hello! string + tip",
+			name: "responses protocol, no spec, no README → placeholder + tip",
 			state: &State{
 				Services: []ServiceState{{Name: "echo", Protocol: ProtocolResponses}},
 			},
 			serviceName: "echo",
 			want: []string{
-				`azd ai agent invoke --local "Hello!"`,
+				`azd ai agent invoke --local '<payload>'`,
 				`curl http://localhost:<port>/invocations/docs/openapi.json`,
 			},
 		},
 		{
-			name: "unknown protocol falls back to responses default",
+			name: "unknown protocol, no README → placeholder + tip",
 			state: &State{
 				Services: []ServiceState{{Name: "echo", Protocol: ""}},
 			},
 			serviceName: "echo",
 			want: []string{
-				`azd ai agent invoke --local "Hello!"`,
+				`azd ai agent invoke --local '<payload>'`,
 				`curl http://localhost:<port>/invocations/docs/openapi.json`,
 			},
 		},
@@ -553,7 +553,7 @@ func TestResolveAfterRun(t *testing.T) {
 			},
 			serviceName: "",
 			want: []string{
-				`azd ai agent invoke --local '{"message": "Hello!"}'`,
+				`azd ai agent invoke --local '<payload>'`,
 				`curl http://localhost:<port>/invocations/docs/openapi.json`,
 			},
 		},
@@ -574,7 +574,7 @@ func TestResolveAfterRun(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			out := ResolveAfterRun(tt.state, tt.serviceName)
+			out := ResolveAfterRun(tt.state, tt.serviceName, nil)
 			require.Len(t, out, len(tt.want))
 			for i, snippet := range tt.want {
 				assert.Contains(t, out[i].Command, snippet)
@@ -585,7 +585,7 @@ func TestResolveAfterRun(t *testing.T) {
 
 func TestResolveAfterRun_NilState(t *testing.T) {
 	t.Parallel()
-	assert.Nil(t, ResolveAfterRun(nil, ""))
+	assert.Nil(t, ResolveAfterRun(nil, "", nil))
 }
 
 func TestResolveAfterInvoke_Success(t *testing.T) {
@@ -820,10 +820,10 @@ func TestResolveAfterDeploy(t *testing.T) {
 		assert.Equal(t, "verify alpha is running", out[0].Description)
 		assert.Equal(t, "azd ai agent show beta", out[1].Command)
 		assert.Equal(t, "verify beta is running", out[1].Description)
-		assert.Equal(t, `azd ai agent invoke alpha '{"message": "Hello!"}'`, out[2].Command)
-		assert.Equal(t, "test alpha with a generic payload", out[2].Description)
-		assert.Equal(t, `azd ai agent invoke beta "Hello!"`, out[3].Command)
-		assert.Equal(t, "test beta with a generic payload", out[3].Description)
+		assert.Equal(t, `azd ai agent invoke alpha '<payload>'`, out[2].Command)
+		assert.Equal(t, "test alpha", out[2].Description)
+		assert.Equal(t, `azd ai agent invoke beta '<payload>'`, out[3].Command)
+		assert.Equal(t, "test beta", out[3].Description)
 	})
 
 	t.Run("multi-agent README hint placement → before the corresponding placeholder invoke", func(t *testing.T) {
@@ -842,8 +842,8 @@ func TestResolveAfterDeploy(t *testing.T) {
 		assert.Equal(t, "find the sample-specific payload", out[2].Description)
 		assert.Equal(t, `azd ai agent invoke alpha '<payload>'`, out[3].Command)
 		assert.Equal(t, "test alpha with the sample-specific payload", out[3].Description)
-		assert.Equal(t, `azd ai agent invoke beta "Hello!"`, out[4].Command)
-		assert.Equal(t, "test beta with a generic payload", out[4].Description)
+		assert.Equal(t, `azd ai agent invoke beta '<payload>'`, out[4].Command)
+		assert.Equal(t, "test beta", out[4].Description)
 	})
 
 	t.Run("README hint skipped when cached payload is present", func(t *testing.T) {
@@ -888,7 +888,7 @@ func TestResolveAfterDeploy(t *testing.T) {
 		require.Equal(t, baseline, out)
 		require.Len(t, out, 2)
 		assert.Equal(t, "azd ai agent show echo", out[0].Command)
-		assert.Equal(t, `azd ai agent invoke echo '{"message": "Hello!"}'`, out[1].Command)
+		assert.Equal(t, `azd ai agent invoke echo '<payload>'`, out[1].Command)
 	})
 
 	t.Run("ForceQualified=false on len==1 → no-op, also qualified", func(t *testing.T) {
@@ -899,7 +899,7 @@ func TestResolveAfterDeploy(t *testing.T) {
 		out := ResolveAfterDeploy(state, nil, nil, AfterDeployOpts{ForceQualified: false})
 		require.Len(t, out, 2)
 		assert.Equal(t, "azd ai agent show echo", out[0].Command)
-		assert.Equal(t, `azd ai agent invoke echo '{"message": "Hello!"}'`, out[1].Command)
+		assert.Equal(t, `azd ai agent invoke echo '<payload>'`, out[1].Command)
 	})
 
 	t.Run("ForceQualified=true with cached payload → qualified invoke uses payload", func(t *testing.T) {
@@ -922,8 +922,8 @@ func TestResolveAfterDeploy(t *testing.T) {
 		require.Len(t, out, 4)
 		assert.Equal(t, "azd ai agent show alpha", out[0].Command)
 		assert.Equal(t, "azd ai agent show beta", out[1].Command)
-		assert.Equal(t, `azd ai agent invoke alpha '{"message": "Hello!"}'`, out[2].Command)
-		assert.Equal(t, `azd ai agent invoke beta "Hello!"`, out[3].Command)
+		assert.Equal(t, `azd ai agent invoke alpha '<payload>'`, out[2].Command)
+		assert.Equal(t, `azd ai agent invoke beta '<payload>'`, out[3].Command)
 	})
 
 	t.Run("extra opts elements beyond [0] are ignored", func(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state.go
@@ -307,8 +307,11 @@ func assembleState(ctx context.Context, src Source, opts ...Option) (*State, []e
 // entry in MissingManualVars without a corresponding manifest toolbox
 // is a generic user variable and stays where it is.
 //
-// Order is preserved in both buckets so the resolver's existing
-// "first sorted entry → paste-ready command" logic still works.
+// state.MissingManualVars order is preserved (caller-visible sorting
+// happens in the resolver). The matched ResourceRefs are then sorted
+// by (Name, ServiceName) before being written to MissingToolboxEndpoints
+// so callers see a stable ordering that matches state.Toolboxes regardless
+// of how MissingManualVars happens to be ordered.
 func partitionToolboxEndpointVars(state *State) {
 	if len(state.MissingManualVars) == 0 || len(state.Toolboxes) == 0 {
 		return

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"azureaiagent/internal/pkg/agents/agent_yaml"
+	"azureaiagent/internal/pkg/envkey"
 	"azureaiagent/internal/pkg/paths"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -286,7 +287,70 @@ func assembleState(ctx context.Context, src Source, opts ...Option) (*State, []e
 		populateManifestResources(project.Path, state)
 	}
 
+	// Partition toolbox-derived endpoint vars out of MissingManualVars
+	// into MissingToolboxEndpoints. This must run AFTER
+	// populateManifestResources because it depends on state.Toolboxes
+	// being populated — without the manifest's toolbox list we cannot
+	// tell a toolbox-derived var ("TOOLBOX_WEB_SEARCH_TOOLS_MCP_ENDPOINT"
+	// for a manifest-declared `web-search-tools` toolbox) apart from a
+	// generic user-named variable that happens to start with TOOLBOX_.
+	// See MissingToolboxEndpoints docs (types.go) for the rationale.
+	partitionToolboxEndpointVars(state)
+
 	return state, errs
+}
+
+// partitionToolboxEndpointVars moves any entry in state.MissingManualVars
+// whose name is the canonical TOOLBOX_<NAME>_MCP_ENDPOINT key for a
+// manifest-declared toolbox into state.MissingToolboxEndpoints. The
+// partition is a no-op when state.Toolboxes is empty: any TOOLBOX_*
+// entry in MissingManualVars without a corresponding manifest toolbox
+// is a generic user variable and stays where it is.
+//
+// Order is preserved in both buckets so the resolver's existing
+// "first sorted entry → paste-ready command" logic still works.
+func partitionToolboxEndpointVars(state *State) {
+	if len(state.MissingManualVars) == 0 || len(state.Toolboxes) == 0 {
+		return
+	}
+
+	// keyToToolbox maps each declared toolbox's canonical endpoint key
+	// to its ResourceRef. envkey.ToolboxMCPEndpoint is the single
+	// source of truth for the key normalization (sanitize → upper →
+	// "TOOLBOX_<X>_MCP_ENDPOINT") shared with the provisioner and the
+	// local.toolboxes doctor check; computing the lookup here ensures
+	// any future normalization change ripples consistently.
+	keyToToolbox := make(map[string]ResourceRef, len(state.Toolboxes))
+	for _, tb := range state.Toolboxes {
+		keyToToolbox[envkey.ToolboxMCPEndpoint(tb.Name)] = tb
+	}
+
+	remaining := make([]string, 0, len(state.MissingManualVars))
+	var matched []ResourceRef
+	for _, name := range state.MissingManualVars {
+		if tb, ok := keyToToolbox[name]; ok {
+			matched = append(matched, tb)
+			continue
+		}
+		remaining = append(remaining, name)
+	}
+	if len(matched) == 0 {
+		return
+	}
+
+	state.MissingManualVars = remaining
+	// Sort matched by (Name, ServiceName) for deterministic rendering;
+	// state.Toolboxes is already sorted but `matched` was built by
+	// MissingManualVars iteration order, which is sorted by var name
+	// rather than toolbox name. Re-sort so callers see the same
+	// ordering they'd see if they iterated state.Toolboxes directly.
+	slices.SortFunc(matched, func(a, b ResourceRef) int {
+		if c := strings.Compare(a.Name, b.Name); c != 0 {
+			return c
+		}
+		return strings.Compare(a.ServiceName, b.ServiceName)
+	})
+	state.MissingToolboxEndpoints = matched
 }
 
 // populateOpenAPIPayload locates a sample invoke payload for the

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state_test.go
@@ -1193,6 +1193,101 @@ environment_variables:
 	assert.Equal(t, []string{"TOOLBOX_ENDPOINT"}, state.UnresolvedPlaceholders)
 }
 
+// TestAssembleState_PartitionsToolboxEndpointVars locks the partition
+// behavior added for the toolbox-sample post-init UX: when a service
+// has a manifest-declared toolbox AND agent.yaml references the
+// canonical TOOLBOX_<NAME>_MCP_ENDPOINT env var, the missing-var
+// classifier must route the entry into MissingToolboxEndpoints
+// (provision-managed) rather than MissingManualVars (operator-supplied).
+// Non-toolbox manual vars in the same agent.yaml must still appear in
+// MissingManualVars.
+func TestAssembleState_PartitionsToolboxEndpointVars(t *testing.T) {
+	t.Parallel()
+
+	projectRoot := t.TempDir()
+	// agent.manifest.yaml declares the toolbox by name; envkey derives
+	// "TOOLBOX_WEB_SEARCH_TOOLS_MCP_ENDPOINT" from "web-search-tools",
+	// matching the ${...} ref in agent.yaml below.
+	writeManifest(t, projectRoot, "echo", `
+template:
+  kind: containerAgent
+  name: hello
+resources:
+  - name: web-search-tools
+    kind: toolbox
+    tools:
+      - id: tool-1
+`)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectRoot, "echo", "agent.yaml"),
+		[]byte(`kind: hostedAgent
+environment_variables:
+  - name: MCP_ENDPOINT
+    value: ${TOOLBOX_WEB_SEARCH_TOOLS_MCP_ENDPOINT}
+  - name: API_KEY
+    value: ${MY_API_KEY}
+`),
+		0o600,
+	))
+
+	src := &fakeSource{
+		envName: "dev",
+		project: &azdext.ProjectConfig{
+			Path: projectRoot,
+			Services: map[string]*azdext.ServiceConfig{
+				"echo": {Name: "echo", Host: agentHost, RelativePath: "echo"},
+			},
+		},
+	}
+
+	state, errs := assembleState(context.Background(), src)
+	require.Empty(t, errs)
+	assert.Empty(t, state.MissingInfraVars)
+	// Toolbox endpoint var moved into the dedicated bucket; the
+	// generic manual-var bucket only carries the truly user-supplied
+	// API key.
+	assert.Equal(t, []string{"MY_API_KEY"}, state.MissingManualVars)
+	require.Len(t, state.MissingToolboxEndpoints, 1)
+	assert.Equal(t, "web-search-tools", state.MissingToolboxEndpoints[0].Name)
+	assert.Equal(t, "echo", state.MissingToolboxEndpoints[0].ServiceName)
+}
+
+// TestAssembleState_ToolboxEndpointWithoutManifestStaysManual locks
+// the partition's guard: a TOOLBOX_*_MCP_ENDPOINT-shaped variable
+// whose name does NOT match a manifest-declared toolbox is treated
+// as a generic user variable and stays in MissingManualVars. The
+// partition is a no-op when no manifest toolbox claims the key.
+func TestAssembleState_ToolboxEndpointWithoutManifestStaysManual(t *testing.T) {
+	t.Parallel()
+
+	projectRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, "echo"), 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectRoot, "echo", "agent.yaml"),
+		[]byte(`kind: hostedAgent
+environment_variables:
+  - name: MCP_ENDPOINT
+    value: ${TOOLBOX_WEB_SEARCH_TOOLS_MCP_ENDPOINT}
+`),
+		0o600,
+	))
+
+	src := &fakeSource{
+		envName: "dev",
+		project: &azdext.ProjectConfig{
+			Path: projectRoot,
+			Services: map[string]*azdext.ServiceConfig{
+				"echo": {Name: "echo", Host: agentHost, RelativePath: "echo"},
+			},
+		},
+	}
+
+	state, errs := assembleState(context.Background(), src)
+	require.Empty(t, errs)
+	assert.Equal(t, []string{"TOOLBOX_WEB_SEARCH_TOOLS_MCP_ENDPOINT"}, state.MissingManualVars)
+	assert.Empty(t, state.MissingToolboxEndpoints)
+}
+
 func TestAssembleState_PlaceholdersDedupedAcrossServices(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/types.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/types.go
@@ -78,7 +78,30 @@ type State struct {
 
 	// MissingManualVars names ${...} references that map to user-supplied
 	// variables which are not set in the azd environment.
+	//
+	// Toolbox-derived endpoint variables (`TOOLBOX_<NAME>_MCP_ENDPOINT`
+	// keys that correspond to a manifest-declared toolbox) are
+	// partitioned out into MissingToolboxEndpoints — they are
+	// azd-managed outputs of `azd provision`, not operator-supplied,
+	// and routing them to `azd env set` is misleading.
 	MissingManualVars []string
+
+	// MissingToolboxEndpoints lists manifest-declared toolboxes whose
+	// azd-injected TOOLBOX_<NAME>_MCP_ENDPOINT variable is unset in the
+	// active azd environment. AssembleState partitions these out of
+	// MissingManualVars because they are produced by
+	// `azd provision` (listen.go::registerToolboxEnvVars), not by the
+	// user — the right remediation is `azd provision` (which creates
+	// the toolbox in the Foundry project on first run and sets the
+	// derived env var), not `azd env set`.
+	//
+	// Each entry carries the manifest's resource Name and the owning
+	// ServiceName so the resolver and doctor checks can render
+	// per-service guidance. The Detail field is unused (toolbox
+	// endpoints have no kind-specific identifier beyond Name) but the
+	// shared ResourceRef shape keeps the renderer code uniform with
+	// state.Toolboxes / state.ModelRefs / state.Connections.
+	MissingToolboxEndpoints []ResourceRef
 
 	// UnresolvedPlaceholders names {{NAME}} Mustache-style placeholders
 	// still present (literally) inside agent.yaml's environment_variables

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
@@ -855,7 +855,7 @@ func emitNextAfterBind(
 		return
 	}
 	fmt.Println("\nAgent ready. In another terminal, try:")
-	_ = printNextIfTerminal(os.Stdout, nextstep.ResolveAfterRun(state, serviceName))
+	_ = printNextIfTerminal(os.Stdout, nextstep.ResolveAfterRun(state, serviceName, readmeExistsForProject(ctx, azdClient)))
 }
 
 // portReadyBudget is the wall-clock ceiling for waitForPortReady;


### PR DESCRIPTION
Three independent rough-edge fixes to the `Next:` block printed by the `azure.ai.agents` extension after `azd ai agent init` / `azd ai agent run`.

## Toolbox samples: route through `azd provision`, not `azd env set`

`TOOLBOX_<NAME>_MCP_ENDPOINT` is an azd-managed output of `azd provision` (written by `listen.go::registerToolboxEnvVars` after the toolbox version is published), not operator-supplied — telling the user to `azd env set <value>` is misleading because there is no value to supply.

**Before** (toolbox sample after `azd ai agent init`):

```text
Next:  azd env set TOOLBOX_WEB_SEARCH_TOOLS_MCP_ENDPOINT <value>  -- referenced by agent.yaml but not set in azd env
       azd ai agent run                                           -- start the agent locally once the values above are set
       azd deploy                                                 -- when ready to deploy to Azure
```

**After:**

```text
Next:  azd provision                            -- create your toolbox(es) in Foundry
       azd ai agent doctor                      -- (optional) verify whether your toolbox(es) already exist before provisioning
       azd ai agent run                         -- start the agent locally once provision completes
       azd ai agent invoke --local '<payload>'  -- test it in another terminal
       azd deploy                               -- when ready to deploy to Azure
```

The toolbox + manual-vars coexistence case is handled additively, so a manifest that declares a toolbox AND references an unrelated manual var (e.g. an API key) surfaces guidance for both.

## Invoke-local payload: uniform `'<payload>'` placeholder

When no OpenAPI spec exists yet, single-agent samples used to omit the invoke secondary entirely while multi-agent samples emitted a hard-coded sample that often mismatched the agent's actual schema. Both shapes now emit one `azd ai agent invoke --local '<payload>'` line, with a sibling `see <path>/README.md` hint when a README is present.

## Manual-vars branch: invoke-local follow-up

The `MissingManualVars` branch emitted `azd ai agent run` after the `azd env set` lines but stopped there. Adding the invoke-local secondary so the user has a concrete "what to try once it's running" command — same shape as the default branch.

---

The live "does this toolbox exist in Foundry?" check lands in a follow-up — `ResolveAfterInit` is offline by contract and must not initiate Foundry API calls.
