### PR TITLE
feat(azure.ai.agents): display metadata in connection show output

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection.go
@@ -859,6 +859,12 @@ func printDetail(result connectionDetailResult, format string) error {
 	fmt.Printf("Kind:      %s\n", result.Kind)
 	fmt.Printf("Auth Type: %s\n", result.AuthType)
 	fmt.Printf("Target:    %s\n", result.Target)
+	if len(result.Metadata) > 0 {
+		fmt.Println("\nMetadata:")
+		for k, v := range result.Metadata {
+			fmt.Printf("  %s: %s\n", k, deref(v))
+		}
+	}
 	if len(result.Credentials) > 0 {
 		fmt.Println("\nCredentials:")
 		for k, v := range result.Credentials {

--- a/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection_test.go
@@ -4,7 +4,10 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -562,4 +565,96 @@ func TestBuildCredentialReferences(t *testing.T) {
 			require.Equal(t, tt.want, result)
 		})
 	}
+}
+
+func TestPrintDetail_IncludesMetadata(t *testing.T) {
+	v1 := "value1"
+	v2 := "value2"
+	result := connectionDetailResult{
+		Name:     "test-conn",
+		Kind:     "RemoteTool",
+		AuthType: "None",
+		Target:   "https://example.com",
+		Metadata: map[string]*string{
+			"key1": &v1,
+			"key2": &v2,
+		},
+	}
+
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := printDetail(result, "table")
+	require.NoError(t, err)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	output := buf.String()
+
+	require.Contains(t, output, "Metadata:")
+	require.Contains(t, output, "key1: value1")
+	require.Contains(t, output, "key2: value2")
+}
+
+func TestPrintDetail_OmitsEmptyMetadata(t *testing.T) {
+	result := connectionDetailResult{
+		Name:     "test-conn",
+		Kind:     "RemoteTool",
+		AuthType: "None",
+		Target:   "https://example.com",
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := printDetail(result, "table")
+	require.NoError(t, err)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	output := buf.String()
+
+	require.NotContains(t, output, "Metadata:")
+}
+
+func TestPrintDetail_JSON_IncludesMetadata(t *testing.T) {
+	v1 := "val1"
+	result := connectionDetailResult{
+		Name:     "test-conn",
+		Kind:     "RemoteTool",
+		AuthType: "None",
+		Target:   "https://example.com",
+		Metadata: map[string]*string{
+			"foo": &v1,
+		},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := printDetail(result, "json")
+	require.NoError(t, err)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &parsed))
+
+	meta, ok := parsed["metadata"].(map[string]any)
+	require.True(t, ok, "metadata should be present in JSON output")
+	require.Equal(t, "val1", meta["foo"])
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/connections/cmd/connection_test.go
@@ -589,7 +589,7 @@ func TestPrintDetail_IncludesMetadata(t *testing.T) {
 	err := printDetail(result, "table")
 	require.NoError(t, err)
 
-	w.Close()
+	require.NoError(t, w.Close())
 	os.Stdout = old
 
 	var buf bytes.Buffer
@@ -616,7 +616,7 @@ func TestPrintDetail_OmitsEmptyMetadata(t *testing.T) {
 	err := printDetail(result, "table")
 	require.NoError(t, err)
 
-	w.Close()
+	require.NoError(t, w.Close())
 	os.Stdout = old
 
 	var buf bytes.Buffer
@@ -645,7 +645,7 @@ func TestPrintDetail_JSON_IncludesMetadata(t *testing.T) {
 	err := printDetail(result, "json")
 	require.NoError(t, err)
 
-	w.Close()
+	require.NoError(t, w.Close())
 	os.Stdout = old
 
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary

Fixes #8351

The `connection show` command was not displaying metadata key-value pairs in its table output. The metadata was already being fetched from the API and included in JSON output, but the table formatter (`printDetail`) was not rendering it.

This PR adds a **Metadata** section to the table output of `azd ai agent connection show`, displayed between the Target and Credentials sections. When no metadata exists, the section is cleanly omitted.

## Changes

- **`connection.go`**: Added metadata rendering block in `printDetail()` — iterates `result.Metadata` and prints each key-value pair with proper indentation
- **`connection_test.go`**: Added 3 new tests:
  - `TestPrintDetail_Metadata_TableOutput` — verifies metadata appears in table format
  - `TestPrintDetail_Metadata_OmittedWhenEmpty` — verifies no metadata section when map is empty
  - `TestPrintDetail_Metadata_JsonOutput` — verifies metadata is included in JSON output

## Before

```
Name:      GitHubMCP
Kind:      RemoteTool
Auth Type: OAuth2
Target:    https://api.githubcopilot.com/mcp
```

## After

```
Name:      GitHubMCP
Kind:      RemoteTool
Auth Type: OAuth2
Target:    https://api.githubcopilot.com/mcp

Metadata:
  toolEntityId: azureml://...github-mcp-server/version/1
  type: catalog_MCP
```
