### PR TITLE
fix: truncate progress widget lines to terminal width on narrow terminals

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -7,6 +7,7 @@ words:
   - gofmt
   - golangci
   - lightspeed
+  - runewidth
   - toplevel
   - azcloud
   - azdext

--- a/cli/azd/internal/agent/copilot_agent.go
+++ b/cli/azd/internal/agent/copilot_agent.go
@@ -147,7 +147,7 @@ func (a *CopilotAgent) Initialize(ctx context.Context, opts ...InitOption) (resu
 		HelpMessage:     "Higher reasoning uses more premium requests and may cost more. You can change this later.",
 		Choices:         effortChoices,
 		SelectedIndex:   new(1),
-		DisplayNumbers:  uxlib.Ptr(true),
+		DisplayNumbers:  new(true),
 		EnableFiltering: new(false),
 		DisplayCount:    3,
 	})
@@ -189,8 +189,8 @@ func (a *CopilotAgent) Initialize(ctx context.Context, opts ...InitOption) (resu
 		HelpMessage:     "Premium models may use more requests. You can change this later.",
 		Choices:         modelChoices,
 		SelectedIndex:   new(0),
-		DisplayNumbers:  uxlib.Ptr(true),
-		EnableFiltering: uxlib.Ptr(true),
+		DisplayNumbers:  new(true),
+		EnableFiltering: new(true),
 		DisplayCount:    min(len(modelChoices), 10),
 	})
 
@@ -263,8 +263,8 @@ func (a *CopilotAgent) SelectSession(ctx context.Context) (*SessionMetadata, err
 	selector := uxlib.NewSelect(&uxlib.SelectOptions{
 		Message:         "Previous sessions found",
 		Choices:         choices,
-		EnableFiltering: uxlib.Ptr(true),
-		DisplayNumbers:  uxlib.Ptr(true),
+		EnableFiltering: new(true),
+		DisplayNumbers:  new(true),
 		DisplayCount:    min(len(choices), 6),
 	})
 
@@ -985,7 +985,7 @@ func (a *CopilotAgent) createUserInputHandler(ctx context.Context) copilot.UserI
 				Message:         question,
 				Choices:         choices,
 				EnableFiltering: new(false),
-				DisplayNumbers:  uxlib.Ptr(true),
+				DisplayNumbers:  new(true),
 				DisplayCount:    min(len(choices), 10),
 			})
 
@@ -1060,7 +1060,7 @@ func (a *CopilotAgent) handleErrorWithRetryPrompt(ctx context.Context, err error
 
 	retryPrompt := uxlib.NewConfirm(&uxlib.ConfirmOptions{
 		Message:      "Want to try again?",
-		DefaultValue: uxlib.Ptr(true),
+		DefaultValue: new(true),
 	})
 
 	shouldRetry, promptErr := retryPrompt.Ask(ctx)
@@ -1099,7 +1099,7 @@ func (a *CopilotAgent) ensureAuthenticated(ctx context.Context) error {
 		HelpMessage: fmt.Sprintf(
 			"%s requires GitHub authentication to access AI models and agent capabilities.",
 			agentcopilot.DisplayTitle),
-		DefaultValue: uxlib.Ptr(true),
+		DefaultValue: new(true),
 	})
 
 	shouldLogin, err := confirm.Ask(ctx)

--- a/cli/azd/pkg/ux/formatting_test.go
+++ b/cli/azd/pkg/ux/formatting_test.go
@@ -40,14 +40,14 @@ func TestVisibleLength(t *testing.T) {
 			0,
 		},
 		{"unicode characters", "héllo", 5},
-		{"CJK characters", "日本語", 3},
+		{"CJK characters", "日本語", 6},
 		{"emoji single codepoint", "★", 1},
 		{
 			"mixed ANSI and unicode",
 			"\x1b[36m日本\x1b[0m",
-			2,
+			4,
 		},
-		{"tab and printable", "a\tb", 3},
+		{"tab and printable", "a\tb", 2},
 	}
 
 	for _, tt := range tests {

--- a/cli/azd/pkg/ux/printer.go
+++ b/cli/azd/pkg/ux/printer.go
@@ -36,6 +36,10 @@ type Printer interface {
 	CursorPosition() CursorPosition
 	SetCursorPosition(position CursorPosition)
 	Size() CanvasSize
+
+	// Width returns the terminal width in columns.
+	// Visuals can use this to truncate output and prevent line wrapping.
+	Width() int
 }
 
 // NewPrinter creates a new Printer instance.
@@ -75,6 +79,11 @@ type printer struct {
 
 func (p *printer) Size() CanvasSize {
 	return *p.size
+}
+
+// Width returns the terminal width in columns.
+func (p *printer) Width() int {
+	return p.consoleWidth
 }
 
 // CursorPosition represents the position of the cursor on the screen.

--- a/cli/azd/pkg/ux/printer.go
+++ b/cli/azd/pkg/ux/printer.go
@@ -60,7 +60,7 @@ func NewPrinter(writer io.Writer) Printer {
 		cursorPosition: nil,
 	}
 
-	printer.consoleWidth.Store(int32(width))
+	printer.consoleWidth.Store(int64(width))
 	printer.listenForResize()
 
 	return printer
@@ -70,7 +70,7 @@ type printer struct {
 	internal.Cursor
 
 	writer         io.Writer
-	consoleWidth   atomic.Int32
+	consoleWidth   atomic.Int64
 	currentLine    string
 	size           *CanvasSize
 	cursorPosition *CursorPosition
@@ -184,7 +184,7 @@ func (p *printer) listenForResize() {
 	go func() {
 		for range sigChan {
 			w, _ := consolesize.GetConsoleSize()
-			p.consoleWidth.Store(int32(w))
+			p.consoleWidth.Store(int64(w))
 		}
 	}()
 }

--- a/cli/azd/pkg/ux/printer.go
+++ b/cli/azd/pkg/ux/printer.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/ux/internal"
@@ -57,9 +58,9 @@ func NewPrinter(writer io.Writer) Printer {
 		currentLine:    "",
 		size:           newCanvasSize(),
 		cursorPosition: nil,
-		consoleWidth:   width,
 	}
 
+	printer.consoleWidth.Store(int32(width))
 	printer.listenForResize()
 
 	return printer
@@ -69,7 +70,7 @@ type printer struct {
 	internal.Cursor
 
 	writer         io.Writer
-	consoleWidth   int
+	consoleWidth   atomic.Int32
 	currentLine    string
 	size           *CanvasSize
 	cursorPosition *CursorPosition
@@ -83,7 +84,7 @@ func (p *printer) Size() CanvasSize {
 
 // Width returns the terminal width in columns.
 func (p *printer) Width() int {
-	return p.consoleWidth
+	return int(p.consoleWidth.Load())
 }
 
 // CursorPosition represents the position of the cursor on the screen.
@@ -144,8 +145,10 @@ func (p *printer) Fprintf(format string, a ...any) {
 	// Check if the content includes any line breaks
 	hasNewLines := strings.Count(content, "\n") > 0
 
+	width := int(p.consoleWidth.Load())
+
 	// Wrapping already counted for the current accumulated line
-	alreadyCounted := CountLineBreaks(p.currentLine, p.consoleWidth)
+	alreadyCounted := CountLineBreaks(p.currentLine, width)
 
 	var lastLine string
 	newLines := 0
@@ -158,14 +161,14 @@ func (p *printer) Fprintf(format string, a ...any) {
 
 		// Include accumulated currentLine for accurate wrapping of the first line
 		fullContent := p.currentLine + content
-		newLines = CountLineBreaks(fullContent, p.consoleWidth) - alreadyCounted
+		newLines = CountLineBreaks(fullContent, width) - alreadyCounted
 		p.currentLine = lastLine
 	} else {
 		// Need to see if appending content to the current line will cause wrapping
 		// (i.e. if the line is longer than the console width)
 		p.currentLine += content
 		// Only count NEW wrapping lines (delta from what was already tracked)
-		newLines = CountLineBreaks(p.currentLine, p.consoleWidth) - alreadyCounted
+		newLines = CountLineBreaks(p.currentLine, width) - alreadyCounted
 	}
 
 	fmt.Fprint(p.writer, content)
@@ -180,9 +183,8 @@ func (p *printer) listenForResize() {
 
 	go func() {
 		for range sigChan {
-			p.writeLock.Lock()
-			p.consoleWidth, _ = consolesize.GetConsoleSize()
-			p.writeLock.Unlock()
+			w, _ := consolesize.GetConsoleSize()
+			p.consoleWidth.Store(int32(w))
 		}
 	}()
 }

--- a/cli/azd/pkg/ux/spinner.go
+++ b/cli/azd/pkg/ux/spinner.go
@@ -5,6 +5,7 @@ package ux
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"time"
@@ -154,7 +155,10 @@ func (s *Spinner) Render(printer Printer) error {
 		return nil
 	}
 
-	printer.Fprintf("%s %s", output.WithHintFormat(s.options.Animation[s.animationIndex]), s.text)
+	// Truncate to terminal width to prevent line wrapping on narrow terminals
+	maxWidth := max(printer.Width()-1, 1)
+	line := fmt.Sprintf("%s %s", output.WithHintFormat(s.options.Animation[s.animationIndex]), s.text)
+	printer.Fprintf("%s", TruncateVisible(line, maxWidth))
 
 	if s.animationIndex == len(s.options.Animation)-1 {
 		s.animationIndex = 0

--- a/cli/azd/pkg/ux/task_list.go
+++ b/cli/azd/pkg/ux/task_list.go
@@ -220,6 +220,9 @@ func (t *TaskList) Render(printer Printer) error {
 	renderTasks = append(renderTasks, runningTasks...)
 	renderTasks = append(renderTasks, pendingTasks...)
 
+	// Use terminal width minus 1 to prevent cursor wrap on exact-width lines (Windows)
+	maxWidth := max(printer.Width()-1, 1)
+
 	printer.Fprintln()
 
 	for _, task := range renderTasks {
@@ -248,51 +251,54 @@ func (t *TaskList) Render(printer Printer) error {
 			progressText = fmt.Sprintf(" (%s)", task.progress)
 		}
 
+		var line string
 		switch task.State {
 		case Pending:
-			printer.Fprintf("%s %s\n", output.WithGrayFormat(t.options.PendingStyle), task.Title)
+			line = fmt.Sprintf("%s %s", output.WithGrayFormat(t.options.PendingStyle), task.Title)
 		case Running:
-			printer.Fprintf(
-				"%s %s%s %s\n",
+			line = fmt.Sprintf(
+				"%s %s%s %s",
 				output.WithHighLightFormat(t.options.RunningStyle),
 				task.Title,
 				progressText,
 				elapsedText,
 			)
 		case Warning:
-			printer.Fprintf(
-				"%s %s %s %s\n",
+			line = fmt.Sprintf(
+				"%s %s %s %s",
 				output.WithWarningFormat(t.options.WarningStyle),
 				task.Title,
 				elapsedText,
 				output.WithWarningFormat("(%s)", statusDescription),
 			)
 		case Error:
-			printer.Fprintf(
-				"%s %s %s %s\n",
+			line = fmt.Sprintf(
+				"%s %s %s %s",
 				output.WithErrorFormat(t.options.ErrorStyle),
 				task.Title,
 				elapsedText,
 				output.WithErrorFormat("(%s)", statusDescription),
 			)
 		case Success:
-			printer.Fprintf("%s %s  %s\n", output.WithSuccessFormat(t.options.SuccessStyle), task.Title, elapsedText)
+			line = fmt.Sprintf("%s %s  %s", output.WithSuccessFormat(t.options.SuccessStyle), task.Title, elapsedText)
 		case Skipped:
 			if statusDescription == "" {
-				printer.Fprintf(
-					"%s %s\n",
+				line = fmt.Sprintf(
+					"%s %s",
 					output.WithGrayFormat(t.options.SkippedStyle),
 					task.Title,
 				)
 			} else {
-				printer.Fprintf(
-					"%s %s %s\n",
+				line = fmt.Sprintf(
+					"%s %s %s",
 					output.WithGrayFormat(t.options.SkippedStyle),
 					task.Title,
 					output.WithErrorFormat("(%s)", statusDescription),
 				)
 			}
 		}
+
+		printer.Fprintf("%s\n", TruncateVisible(line, maxWidth))
 	}
 
 	printer.Fprintln()

--- a/cli/azd/pkg/ux/ux.go
+++ b/cli/azd/pkg/ux/ux.go
@@ -14,6 +14,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/internal/terminal"
 	"github.com/azure/azure-dev/cli/azd/pkg/ux/internal"
 	"github.com/fatih/color"
+	"github.com/mattn/go-runewidth"
 	"github.com/nathan-fiscaletti/consolesize-go"
 )
 
@@ -77,13 +78,12 @@ func CountLineBreaks(content string, width int) int {
 }
 
 // visibleLength calculates the number of visible characters in a string
-// by removing ANSI codes and counting the actual characters.
-// Cannot use len() as it counts bytes not runes
+// by removing ANSI codes and counting the display width (CJK/emoji = 2 columns).
 func VisibleLength(s string) int {
 	// Remove ANSI codes such as color, formatting, etc.
 	cleaned := specialTextRegex.ReplaceAllString(s, "")
-	// Count actual visible characters
-	return utf8.RuneCountInString(cleaned)
+	// Count display width (handles CJK/emoji as 2 columns)
+	return runewidth.StringWidth(cleaned)
 }
 
 // TruncateVisible truncates a string to fit within maxWidth visible characters,
@@ -133,15 +133,22 @@ func TruncateVisible(s string, maxWidth int) string {
 		}
 
 		// Regular character (may be multi-byte UTF-8)
-		_, size := utf8.DecodeRuneInString(s[i:])
+		r, size := utf8.DecodeRuneInString(s[i:])
+		w := runewidth.RuneWidth(r)
+		if visible+w > targetVisible {
+			break
+		}
 		result.WriteString(s[i : i+size])
 		i += size
-		visible++
+		visible += w
 	}
 
 	result.WriteString(ellipsis)
-	// Append a reset sequence to ensure no color bleeds past the truncation point
-	result.WriteString("\x1b[0m")
+	// Only append ANSI reset if the original string contained ANSI sequences,
+	// to avoid injecting escape codes into plain text (e.g., NO_COLOR mode).
+	if strings.Contains(s, "\x1b[") {
+		result.WriteString("\x1b[0m")
+	}
 
 	return result.String()
 }

--- a/cli/azd/pkg/ux/ux.go
+++ b/cli/azd/pkg/ux/ux.go
@@ -86,6 +86,66 @@ func VisibleLength(s string) int {
 	return utf8.RuneCountInString(cleaned)
 }
 
+// TruncateVisible truncates a string to fit within maxWidth visible characters,
+// preserving ANSI escape sequences (which don't consume terminal columns).
+// If the visible text exceeds maxWidth, it is truncated and "..." is appended.
+// Returns the original string unchanged if it fits within maxWidth.
+func TruncateVisible(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+
+	visLen := VisibleLength(s)
+	if visLen <= maxWidth {
+		return s
+	}
+
+	const ellipsis = "..."
+	ellipsisLen := len(ellipsis)
+
+	// Target visible length: leave room for ellipsis
+	targetVisible := maxWidth - ellipsisLen
+	if targetVisible <= 0 {
+		// Not enough room even for ellipsis; just return dots that fit
+		return ellipsis[:maxWidth]
+	}
+
+	// Walk the string, counting visible characters while preserving ANSI sequences
+	var result strings.Builder
+	result.Grow(len(s))
+	visible := 0
+	i := 0
+
+	for i < len(s) && visible < targetVisible {
+		// Check for ANSI escape sequence start
+		if i < len(s)-1 && s[i] == '\x1b' && s[i+1] == '[' {
+			// Read until the terminating letter (any byte in 0x40-0x7E)
+			j := i + 2
+			for j < len(s) && (s[j] < 0x40 || s[j] > 0x7E) {
+				j++
+			}
+			if j < len(s) {
+				j++ // include the terminating byte
+			}
+			result.WriteString(s[i:j])
+			i = j
+			continue
+		}
+
+		// Regular character (may be multi-byte UTF-8)
+		_, size := utf8.DecodeRuneInString(s[i:])
+		result.WriteString(s[i : i+size])
+		i += size
+		visible++
+	}
+
+	result.WriteString(ellipsis)
+	// Append a reset sequence to ensure no color bleeds past the truncation point
+	result.WriteString("\x1b[0m")
+
+	return result.String()
+}
+
 // ConsoleWidth returns the width of the console in characters.
 // It uses the consolesize package to get the size and falls back to check the COLUMNS environment variable
 // Defaults to 120 if the console size cannot be determined.

--- a/cli/azd/pkg/ux/ux_test.go
+++ b/cli/azd/pkg/ux/ux_test.go
@@ -153,3 +153,63 @@ func Test_VisibleLength(t *testing.T) {
 		})
 	}
 }
+
+func Test_TruncateVisible(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		maxWidth int
+		expected string
+	}{
+		// No truncation needed
+		{"Short plain text", "Hello", 10, "Hello"},
+		{"Exact fit", "Hello", 5, "Hello"},
+		{"Empty string", "", 10, ""},
+
+		// Basic truncation
+		{"Plain text truncated", "Hello World!", 8, "Hello...\x1b[0m"},
+		{"Truncated to minimum", "Hello", 3, "..."},
+
+		// Edge cases
+		{"Width 0", "Hello", 0, ""},
+		{"Width 1", "Hello", 1, "."},
+		{"Width 2", "Hello", 2, ".."},
+		{
+			"ANSI not counted in width",
+			"\x1b[31mHello World\x1b[0m",
+			8,
+			"\x1b[31mHello...\x1b[0m",
+		},
+		{
+			"ANSI fits within width",
+			"\x1b[31mHi\x1b[0m",
+			10,
+			"\x1b[31mHi\x1b[0m",
+		},
+		{
+			"Multiple ANSI sequences truncated",
+			"\x1b[1m\x1b[31mBold Red Text\x1b[0m",
+			10,
+			"\x1b[1m\x1b[31mBold Re...\x1b[0m",
+		},
+
+		// Unicode
+		{"Unicode truncated", "日本語テスト", 5, "日本...\x1b[0m"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := TruncateVisible(tc.input, tc.maxWidth)
+			if result != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, result)
+			}
+			// Verify the result doesn't exceed maxWidth visible chars
+			if tc.maxWidth > 0 {
+				visLen := VisibleLength(result)
+				if visLen > tc.maxWidth {
+					t.Errorf("visible length %d exceeds maxWidth %d", visLen, tc.maxWidth)
+				}
+			}
+		})
+	}
+}

--- a/cli/azd/pkg/ux/ux_test.go
+++ b/cli/azd/pkg/ux/ux_test.go
@@ -97,9 +97,9 @@ func Test_CountLineBreaks(t *testing.T) {
 		{"Mixed Short and Long Lines", "Short\nThis is a very long line that wraps.\nAnother short one", 30, 3},
 
 		// Unicode & special characters
-		{"Emoji Characters", "🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥", 10, 0},             // Should be 1 line
-		{"Emoji Line Wrap", "🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥", 10, 1},             // Should wrap to 2 lines
-		{"Mixing Emoji and Text", "🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥 Hello!", 10, 1}, // Wraps text correctly
+		{"Emoji Characters", "🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥", 10, 1},             // 10 emoji × 2 cols = 20 cols, wraps once
+		{"Emoji Line Wrap", "🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥", 10, 2},             // 11 emoji × 2 cols = 22 cols, wraps twice
+		{"Mixing Emoji and Text", "🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥 Hello!", 10, 2}, // 20 + 7 = 27 cols, wraps twice
 
 		// Trailing newlines shouldn't overcount
 		{"Two Printf calls (simulated)", "line 1\nline 2\n", 100, 2}, // Should be exactly 2 lines
@@ -135,8 +135,8 @@ func Test_VisibleLength(t *testing.T) {
 		{"Long ANSI Sequence", "\x1b[38;5;82mGreen Text\x1b[0m", 10},
 
 		// Unicode & special characters
-		{"Unicode Characters", "🔥🔥🔥", 3},
-		{"Mix of ANSI and Unicode", "\x1b[31m🔥🔥🔥\x1b[0m", 3},
+		{"Unicode Characters", "🔥🔥🔥", 6},
+		{"Mix of ANSI and Unicode", "\x1b[31m🔥🔥🔥\x1b[0m", 6},
 
 		// Edge Cases
 		{"Edge Case: Leading ANSI Code", "\x1b[31mRed\x1b[0mText", 7},

--- a/cli/azd/pkg/ux/ux_test.go
+++ b/cli/azd/pkg/ux/ux_test.go
@@ -167,7 +167,7 @@ func Test_TruncateVisible(t *testing.T) {
 		{"Empty string", "", 10, ""},
 
 		// Basic truncation
-		{"Plain text truncated", "Hello World!", 8, "Hello...\x1b[0m"},
+		{"Plain text truncated", "Hello World!", 8, "Hello..."},
 		{"Truncated to minimum", "Hello", 3, "..."},
 
 		// Edge cases
@@ -193,8 +193,8 @@ func Test_TruncateVisible(t *testing.T) {
 			"\x1b[1m\x1b[31mBold Re...\x1b[0m",
 		},
 
-		// Unicode
-		{"Unicode truncated", "日本語テスト", 5, "日本...\x1b[0m"},
+		// Unicode (CJK characters are 2 columns wide)
+		{"Unicode truncated", "日本語テスト", 7, "日本..."},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary

Fixes #8382. On narrow terminals (PowerShell, small panes), the progress widget (TaskList/Spinner) rendered lines that wrapped beyond terminal width. `ClearCanvas` couldn't clear enough rows, causing stale output to accumulate and print over itself.

## Changes

- **`TruncateVisible()`** — new ANSI-aware string truncation helper in `pkg/ux/ux.go`
- **`Printer.Width()`** — exposes terminal width on the Printer interface
- **`TaskList.Render()`** / **`Spinner.Render()`** — truncate each line to `consoleWidth - 1` visible characters before writing
- **Unit tests** for `TruncateVisible` covering ANSI sequences, unicode, and edge cases
- **Lint fix** — modernizes `uxlib.Ptr(true)` → `new(true)` in `copilot_agent.go` (pre-existing govet warnings)

## How it works

The `-1` prevents Windows' eager-wrap behavior (cursor wraps when a line fills exactly the terminal width). By keeping lines 1 char shorter than the terminal, wrapping never occurs and `ClearCanvas` row math stays correct.

## Testing

- All preflight checks pass (9/9 ✓)
- Manual test with 40-column terminal confirms correct in-place updates