### PR TITLE
ai.agents: add invocations_ws as a displayable agent protocol

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## Unreleased
+
+- Add `invocations_ws` as a displayable agent protocol. `azd deploy` now registers the callable Foundry data-plane WebSocket URL (`wss://<account>.services.ai.azure.com/api/projects/agents/endpoint/protocols/invocations_ws?api-version=v1&project_name=<project>&agent_name=<agent>`) as `AGENT_{KEY}_INVOCATIONS_WS_ENDPOINT`, and `azd ai agent show` displays it as `Endpoint (invocations_ws)`. Previously, `invocations_ws` agents fell back to the legacy resource URL labeled `Endpoint (Agent)`.
+
 ## 0.1.34-preview (2026-05-22)
 
 - [[#8264]](https://github.com/Azure/azure-dev/pull/8264) Launch Agent Inspector automatically on `azd ai agent run`. Use `--no-inspector` to opt out. Requires the `azure.ai.inspector` extension.

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
@@ -16,6 +16,7 @@ type AgentProtocol string
 const (
 	AgentProtocolActivityProtocol AgentProtocol = "activity_protocol"
 	AgentProtocolInvocations      AgentProtocol = "invocations"
+	AgentProtocolInvocationsWS    AgentProtocol = "invocations_ws"
 	AgentProtocolResponses        AgentProtocol = "responses"
 	AgentProtocolA2A              AgentProtocol = "a2a"
 )

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -16,8 +16,10 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -53,15 +55,80 @@ const agentAPIVersion = "2025-11-15-preview"
 // displayableProtocolEntry defines a protocol that produces user-visible invocation endpoints.
 type displayableProtocolEntry struct {
 	Protocol  agent_api.AgentProtocol
-	URLPath   string // path suffix in the invocation URL
 	EnvSuffix string // suffix used in AGENT_{KEY}_{SUFFIX}_ENDPOINT env vars
+	// BuildURL builds the invocation URL for this protocol.
+	// projectEndpoint is the Foundry project root
+	// (https://<account>.services.ai.azure.com/api/projects/<project>).
+	BuildURL func(projectEndpoint, agentName string) string
 }
 
 // displayableProtocols is the single source of truth for protocols that produce
 // user-facing invocation endpoints and env vars.
 var displayableProtocols = []displayableProtocolEntry{
-	{Protocol: agent_api.AgentProtocolResponses, URLPath: "openai/responses", EnvSuffix: "RESPONSES"},
-	{Protocol: agent_api.AgentProtocolInvocations, URLPath: "invocations", EnvSuffix: "INVOCATIONS"},
+	{
+		Protocol:  agent_api.AgentProtocolResponses,
+		EnvSuffix: "RESPONSES",
+		BuildURL:  buildResponsesProtocolURL,
+	},
+	{
+		Protocol:  agent_api.AgentProtocolInvocations,
+		EnvSuffix: "INVOCATIONS",
+		BuildURL:  buildInvocationsProtocolURL,
+	},
+	{
+		Protocol:  agent_api.AgentProtocolInvocationsWS,
+		EnvSuffix: "INVOCATIONS_WS",
+		BuildURL:  buildInvocationsWSProtocolURL,
+	},
+}
+
+// buildResponsesProtocolURL builds the per-agent HTTPS URL for the "responses" protocol.
+func buildResponsesProtocolURL(projectEndpoint, agentName string) string {
+	return fmt.Sprintf(
+		"%s/agents/%s/endpoint/protocols/openai/responses?api-version=%s",
+		projectEndpoint, agentName, agentAPIVersion,
+	)
+}
+
+// buildInvocationsProtocolURL builds the per-agent HTTPS URL for the "invocations" protocol.
+func buildInvocationsProtocolURL(projectEndpoint, agentName string) string {
+	return fmt.Sprintf(
+		"%s/agents/%s/endpoint/protocols/invocations?api-version=%s",
+		projectEndpoint, agentName, agentAPIVersion,
+	)
+}
+
+// invocationsWebSocketAPIVersion is the Foundry data-plane api-version for the invocations_ws
+// dispatcher route. It is intentionally separate from agentAPIVersion (the agent control-plane
+// version) because the dispatcher route only accepts the v1 query parameter.
+const invocationsWebSocketAPIVersion = "v1"
+
+// buildInvocationsWSProtocolURL builds the Foundry dispatcher-form WebSocket URL for the
+// "invocations_ws" protocol. Unlike the per-agent HTTP protocols, invocations_ws uses a
+// fixed data-plane route under /api/projects/agents/endpoint/protocols/invocations_ws and
+// selects the agent via the project_name and agent_name query parameters. Callers must add
+// their own agent_session_id query parameter when establishing a session.
+//
+// Returns "" if projectEndpoint cannot be parsed into a URL with a host: the dispatcher route
+// requires both a host (for the wss:// authority) and a project name (derived from the URL
+// path) to be callable, so emitting a partial URL would only register a non-callable endpoint.
+// Callers (agentInvocationEndpoints) filter out empty results.
+func buildInvocationsWSProtocolURL(projectEndpoint, agentName string) string {
+	projectEndpoint = strings.TrimSpace(projectEndpoint)
+	u, err := url.Parse(projectEndpoint)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+
+	projectName := path.Base(u.Path)
+	q := url.Values{}
+	q.Set("api-version", invocationsWebSocketAPIVersion)
+	q.Set("project_name", projectName)
+	q.Set("agent_name", agentName)
+	return fmt.Sprintf(
+		"wss://%s/api/projects/agents/endpoint/protocols/invocations_ws?%s",
+		u.Host, q.Encode(),
+	)
 }
 
 // ProtocolEnvSuffix pairs a user-facing label with the env var suffix
@@ -1743,15 +1810,15 @@ type protocolEndpointInfo struct {
 	URL      string
 }
 
-// protocolPath maps an agent protocol to its URL path suffix.
-// Returns empty string for protocols that should not be displayed.
-func protocolPath(protocol string) string {
-	for _, dp := range displayableProtocols {
+// displayableProtocolFor returns the displayable protocol entry matching the given
+// protocol string, or nil if the protocol does not produce a user-visible endpoint.
+func displayableProtocolFor(protocol string) *displayableProtocolEntry {
+	for i, dp := range displayableProtocols {
 		if agent_api.AgentProtocol(protocol) == dp.Protocol {
-			return dp.URLPath
+			return &displayableProtocols[i]
 		}
 	}
-	return ""
+	return nil
 }
 
 // agentInvocationEndpoints builds the list of displayable invocation endpoints
@@ -1763,15 +1830,21 @@ func agentInvocationEndpoints(
 ) []protocolEndpointInfo {
 	var endpoints []protocolEndpointInfo
 	for _, p := range protocols {
-		path := protocolPath(p.Protocol)
-		if path == "" {
+		dp := displayableProtocolFor(p.Protocol)
+		if dp == nil {
+			continue
+		}
+		url := dp.BuildURL(projectEndpoint, agentName)
+		if url == "" {
+			// A protocol builder may decline to produce a URL when its inputs
+			// cannot yield a callable endpoint (e.g. a malformed projectEndpoint
+			// that fails to parse, for invocations_ws). Skip rather than
+			// registering a broken URL.
 			continue
 		}
 		endpoints = append(endpoints, protocolEndpointInfo{
 			Protocol: p.Protocol,
-			URL: fmt.Sprintf(
-				"%s/agents/%s/endpoint/protocols/%s?api-version=%s",
-				projectEndpoint, agentName, path, agentAPIVersion),
+			URL:      url,
 		})
 	}
 	return endpoints

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -64,13 +64,36 @@ type displayableProtocolEntry struct {
 // displayableProtocols is the single source of truth for protocols that produce
 // user-facing invocation endpoints and env vars.
 var displayableProtocols = []displayableProtocolEntry{
-	{Protocol: agent_api.AgentProtocolResponses, URLPath: "openai/v1/responses", EnvSuffix: "RESPONSES"},
-	{Protocol: agent_api.AgentProtocolInvocations, URLPath: "invocations", EnvSuffix: "INVOCATIONS"},
+	{
+		Protocol:  agent_api.AgentProtocolResponses,
+		EnvSuffix: "RESPONSES",
+		BuildURL:  buildResponsesProtocolURL,
+	},
+	{
+		Protocol:  agent_api.AgentProtocolInvocations,
+		EnvSuffix: "INVOCATIONS",
+		BuildURL:  buildInvocationsProtocolURL,
+	},
 	{
 		Protocol:  agent_api.AgentProtocolInvocationsWS,
 		EnvSuffix: "INVOCATIONS_WS",
 		BuildURL:  buildInvocationsWSProtocolURL,
 	},
+}
+
+// buildResponsesProtocolURL builds the per-agent HTTPS URL for the "responses" protocol.
+func buildResponsesProtocolURL(projectEndpoint, agentName string) string {
+	return fmt.Sprintf(
+		"%s/agents/%s/endpoint/protocols/openai/v1/responses", projectEndpoint, agentName,
+	)
+}
+
+// buildInvocationsProtocolURL builds the per-agent HTTPS URL for the "invocations" protocol.
+func buildInvocationsProtocolURL(projectEndpoint, agentName string) string {
+	return fmt.Sprintf(
+		"%s/agents/%s/endpoint/protocols/invocations?api-version=%s",
+		projectEndpoint, agentName, agent_api.AgentEndpointAPIVersion,
+	)
 }
 
 // buildInvocationsWSProtocolURL builds the Foundry dispatcher-form WebSocket URL for the

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -547,24 +547,72 @@ func TestRegisterAgentEnvironmentVariables_EmptyVersion(t *testing.T) {
 	require.Contains(t, err.Error(), "agent version is empty")
 }
 
-func TestProtocolPath(t *testing.T) {
+func TestDisplayableProtocolFor(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		protocol string
-		expected string
+		name             string
+		protocol         string
+		wantNil          bool
+		wantProtocol     agent_api.AgentProtocol
+		wantEnvSuffix    string
+		wantURLContains  string
+		wantURLScheme    string // "https" or "wss"
+		wantURLOmitAgent bool   // true when the protocol does not embed the agent name in the path
 	}{
-		{"responses", "responses", "openai/responses"},
-		{"invocations", "invocations", "invocations"},
-		{"activity_protocol excluded", "activity_protocol", ""},
-		{"unknown excluded", "unknown_proto", ""},
+		{
+			name:            "responses",
+			protocol:        "responses",
+			wantProtocol:    agent_api.AgentProtocolResponses,
+			wantEnvSuffix:   "RESPONSES",
+			wantURLContains: "/agents/my-agent/endpoint/protocols/openai/responses",
+			wantURLScheme:   "https",
+		},
+		{
+			name:            "invocations",
+			protocol:        "invocations",
+			wantProtocol:    agent_api.AgentProtocolInvocations,
+			wantEnvSuffix:   "INVOCATIONS",
+			wantURLContains: "/agents/my-agent/endpoint/protocols/invocations",
+			wantURLScheme:   "https",
+		},
+		{
+			name:             "invocations_ws",
+			protocol:         "invocations_ws",
+			wantProtocol:     agent_api.AgentProtocolInvocationsWS,
+			wantEnvSuffix:    "INVOCATIONS_WS",
+			wantURLContains:  "/api/projects/agents/endpoint/protocols/invocations_ws",
+			wantURLScheme:    "wss",
+			wantURLOmitAgent: true,
+		},
+		{name: "activity_protocol excluded", protocol: "activity_protocol", wantNil: true},
+		{name: "unknown excluded", protocol: "unknown_proto", wantNil: true},
 	}
+
+	const projectEndpoint = "https://acct.services.ai.azure.com/api/projects/proj"
+	const agentName = "my-agent"
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := protocolPath(tt.protocol)
-			require.Equal(t, tt.expected, got)
+			got := displayableProtocolFor(tt.protocol)
+			if tt.wantNil {
+				require.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			require.Equal(t, tt.wantProtocol, got.Protocol)
+			require.Equal(t, tt.wantEnvSuffix, got.EnvSuffix)
+			require.NotNil(t, got.BuildURL)
+
+			url := got.BuildURL(projectEndpoint, agentName)
+			require.True(t, strings.HasPrefix(url, tt.wantURLScheme+"://"),
+				"url %q should use %s scheme", url, tt.wantURLScheme)
+			require.Contains(t, url, tt.wantURLContains)
+			if tt.wantURLOmitAgent {
+				require.NotContains(t, url, "/agents/"+agentName+"/")
+				require.Contains(t, url, "agent_name="+agentName)
+				require.Contains(t, url, "project_name=proj")
+			}
 		})
 	}
 }
@@ -572,9 +620,15 @@ func TestProtocolPath(t *testing.T) {
 func TestAgentInvocationEndpoints(t *testing.T) {
 	t.Parallel()
 
-	const endpoint = "https://myproject.services.ai.azure.com"
+	const endpoint = "https://myproject.services.ai.azure.com/api/projects/proj"
 	const agentName = "my-agent"
 	baseURL := endpoint + "/agents/" + agentName + "/endpoint/protocols/"
+
+	const wsBase = "wss://myproject.services.ai.azure.com" +
+		"/api/projects/agents/endpoint/protocols/invocations_ws"
+	const wsQuery = "agent_name=" + agentName +
+		"&api-version=" + invocationsWebSocketAPIVersion +
+		"&project_name=proj"
 
 	tests := []struct {
 		name      string
@@ -606,11 +660,24 @@ func TestAgentInvocationEndpoints(t *testing.T) {
 			},
 		},
 		{
+			name: "single invocations_ws protocol uses dispatcher form",
+			protocols: []agent_yaml.ProtocolVersionRecord{
+				{Protocol: "invocations_ws", Version: "1.0.0"},
+			},
+			expected: []protocolEndpointInfo{
+				{
+					Protocol: "invocations_ws",
+					URL:      wsBase + "?" + wsQuery,
+				},
+			},
+		},
+		{
 			name: "multiple protocols with activity_protocol excluded",
 			protocols: []agent_yaml.ProtocolVersionRecord{
 				{Protocol: "responses", Version: "1.0.0"},
 				{Protocol: "activity_protocol", Version: "1.0.0"},
 				{Protocol: "invocations", Version: "1.0.0"},
+				{Protocol: "invocations_ws", Version: "1.0.0"},
 			},
 			expected: []protocolEndpointInfo{
 				{
@@ -620,6 +687,10 @@ func TestAgentInvocationEndpoints(t *testing.T) {
 				{
 					Protocol: "invocations",
 					URL:      baseURL + "invocations?api-version=" + agentAPIVersion,
+				},
+				{
+					Protocol: "invocations_ws",
+					URL:      wsBase + "?" + wsQuery,
 				},
 			},
 		},
@@ -643,6 +714,56 @@ func TestAgentInvocationEndpoints(t *testing.T) {
 			require.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+func TestBuildInvocationsWSProtocolURL_MalformedEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		projectEndpoint string
+	}{
+		{name: "empty", projectEndpoint: ""},
+		{name: "missing scheme", projectEndpoint: "myproject.services.ai.azure.com/api/projects/proj"},
+		{name: "leading whitespace only", projectEndpoint: "   "},
+		{name: "control characters", projectEndpoint: "https://%zz/api/projects/proj"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Empty(t, buildInvocationsWSProtocolURL(tt.projectEndpoint, "my-agent"),
+				"expected empty result for malformed projectEndpoint %q", tt.projectEndpoint)
+		})
+	}
+}
+
+func TestBuildInvocationsWSProtocolURL_TrimsWhitespace(t *testing.T) {
+	t.Parallel()
+
+	got := buildInvocationsWSProtocolURL(
+		"  https://myproject.services.ai.azure.com/api/projects/proj  ",
+		"my-agent",
+	)
+	require.NotEmpty(t, got)
+	require.Contains(t, got, "wss://myproject.services.ai.azure.com")
+	require.Contains(t, got, "project_name=proj")
+	require.Contains(t, got, "agent_name=my-agent")
+}
+
+func TestAgentInvocationEndpoints_SkipsInvocationsWSWithMalformedEndpoint(t *testing.T) {
+	t.Parallel()
+
+	const malformed = "not-a-url"
+	const agentName = "my-agent"
+
+	protocols := []agent_yaml.ProtocolVersionRecord{
+		{Protocol: "responses", Version: "1.0.0"},
+		{Protocol: "invocations_ws", Version: "1.0.0"},
+	}
+
+	got := agentInvocationEndpoints(malformed, agentName, protocols)
+	require.Len(t, got, 1, "invocations_ws entry should be filtered when builder returns empty")
+	require.Equal(t, "responses", got[0].Protocol)
 }
 
 func TestDeployArtifacts_HostedAgent_ProtocolEndpoints(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds `invocations_ws` as a recognized agent protocol in the `azd ai agent` extension, so hosted agents that expose a WebSocket invocation surface (e.g. Voice Live) get a usable endpoint after `azd deploy` and `azd ai agent show`.

## Repro

Deploy the C# Voice Live `invocations_ws` hello-world sample from [microsoft/foundry-samples](https://github.com/microsoft/foundry-samples) (PR #381), then:

```
azd ai agent show
```

### Before

```
Endpoint (Agent)         https://<account>.services.ai.azure.com/api/projects/<project>/agents/hello-world-dotnet-invocations-ws/versions/3
```

That URL is the agent **resource** URL — it is not a WebSocket and is not what clients connect to. It is also the only endpoint variable that `azd deploy` registered (`AGENT_HELLO_WORLD_DOTNET_INVOCATIONS_WS_ENDPOINT`), so users hooking the agent into other services were getting a non-callable URL.

### After

```
Endpoint (invocations_ws)  wss://<account>.services.ai.azure.com/api/projects/agents/endpoint/protocols/invocations_ws?agent_name=hello-world-dotnet-invocations-ws&api-version=v1&project_name=<project>
```

`azd deploy` also registers the new per-protocol variable `AGENT_HELLO_WORLD_DOTNET_INVOCATIONS_WS_INVOCATIONS_WS_ENDPOINT` so other services (e.g. a frontend Container App) can consume the callable URL directly.

## Why this URL shape

The Foundry data-plane WebSocket dispatcher is documented in the sample README and is the only `invocations_ws` shape that accepts WebSocket upgrades today:

```
wss://<account>.services.ai.azure.com
  /api/projects/agents/endpoint/protocols/invocations_ws
  ?api-version=v1
  &project_name=<project>
  &agent_name=<agent>
```

Notes:
* The path segments `agents` and `endpoint` are literal — the agent is selected via the `agent_name` query parameter, not via the path.
* `api-version=v1` is the WS-specific API version (separate from the existing `agentAPIVersion = "2025-11-15-preview"` used by the agent control plane).
* `agent_session_id` is intentionally omitted; the calling client generates it per session.

## Changes

* `internal/pkg/agents/agent_api/models.go` — add `AgentProtocolInvocationsWS = "invocations_ws"` to the `AgentProtocol` const block.
* `internal/project/service_target_agent.go`
  * Replace `displayableProtocolEntry.URLPath` (string) with a `BuildURL func(projectEndpoint, agentName string) string` closure so protocols whose URL doesn't fit the per-agent path shape can build their own URL.
  * Keep `responses` and `invocations` behavior unchanged — they continue to produce the existing HTTPS per-agent URLs.
  * Add `buildInvocationsWSProtocolURL` (dispatcher form, `wss://` scheme, `api-version=v1`).
  * Rename `protocolPath` → `displayableProtocolFor` (returns `*displayableProtocolEntry`); update call sites accordingly.
* `CHANGELOG.md` — add an `## Unreleased` entry.
* Tests:
  * `service_target_agent_test.go` — `TestProtocolPath` → `TestDisplayableProtocolFor`, table-driven covering all three displayable protocols (asserts scheme, path/query, env-var suffix; verifies `invocations_ws` omits the agent name from the path and adds it as a query param). Extends `TestAgentInvocationEndpoints` with a single-protocol invocations_ws case and a multi-protocol case.

## Verification

* `go build ./...`, `go vet ./...`, `gofmt -l .` clean.
* `go test ./...` passes.
* End-to-end against a live `hvattcac-foundry` deployment of the sample: redeployed with the patched binary, `azd ai agent show` shows the new `Endpoint (invocations_ws)` row with the dispatcher WSS URL, the new `AGENT_*_INVOCATIONS_WS_ENDPOINT` variable is set in the azd env, and the bundled local E2E client streams audio + reaches `response_done` against that URL.

## Out of scope

* The legacy `Endpoint (Agent)` row (resource URL fallback for protocols not in `displayableProtocols`) still exists for backward compatibility.
* The `agent_endpoint.go` regex used by `azd ai agent invoke --agent-endpoint` does not accept `invocations_ws` URLs. `invocations_ws` isn't invocable through that command anyway, so no `IsInvocable` change is needed here.
* No version bump / `extension.yaml` change per the extension release process (handled in a separate release PR).

Closes #8404