### PR TITLE
fix(azure.ai.agents): use snake_case yaml tags for agent_endpoint / gent_card

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse_test.go
@@ -130,6 +130,9 @@ template:
           kind: Header
   agent_card:
     description: image-agent card
+    skills:
+      - name: chat
+        description: Basic chat capability
 `)
 
 	agent, err := ExtractAgentDefinition(yamlContent)

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse_test.go
@@ -121,6 +121,15 @@ template:
   protocols:
     - protocol: invocations
       version: 1.0.0
+  agent_endpoint:
+    protocols:
+      - responses
+    authorization_schemes:
+      - type: Entra
+        isolation_key_source:
+          kind: Header
+  agent_card:
+    description: image-agent card
 `)
 
 	agent, err := ExtractAgentDefinition(yamlContent)
@@ -135,6 +144,19 @@ template:
 
 	if containerAgent.Image != "myregistry.azurecr.io/myimage:v1" {
 		t.Errorf("Expected image 'myregistry.azurecr.io/myimage:v1', got '%s'", containerAgent.Image)
+	}
+
+	if containerAgent.AgentEndpoint == nil {
+		t.Fatal("Expected AgentEndpoint to be set, got nil")
+	}
+	if len(containerAgent.AgentEndpoint.AuthorizationSchemes) != 1 ||
+		containerAgent.AgentEndpoint.AuthorizationSchemes[0].IsolationKeySource == nil ||
+		containerAgent.AgentEndpoint.AuthorizationSchemes[0].IsolationKeySource.Kind != "Header" {
+		t.Errorf("Expected isolation_key_source.kind 'Header', got %+v",
+			containerAgent.AgentEndpoint.AuthorizationSchemes)
+	}
+	if containerAgent.AgentCard == nil || containerAgent.AgentCard.Description != "image-agent card" {
+		t.Errorf("Expected agent_card.description 'image-agent card', got %+v", containerAgent.AgentCard)
 	}
 
 	marshaled, err := yaml.Marshal(containerAgent)

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
@@ -194,8 +194,8 @@ type ContainerAgent struct {
 	Protocols            []ProtocolVersionRecord `json:"protocols" yaml:"protocols"`
 	Resources            *ContainerResources     `json:"resources,omitempty" yaml:"resources,omitempty"`
 	EnvironmentVariables *[]EnvironmentVariable  `json:"environmentVariables,omitempty" yaml:"environment_variables,omitempty"`
-	AgentEndpoint        *AgentEndpoint          `json:"agentEndpoint,omitempty" yaml:"agentEndpoint,omitempty"`
-	AgentCard            *AgentCard              `json:"agentCard,omitempty" yaml:"agentCard,omitempty"`
+	AgentEndpoint        *AgentEndpoint          `json:"agentEndpoint,omitempty" yaml:"agent_endpoint,omitempty"`
+	AgentCard            *AgentCard              `json:"agentCard,omitempty" yaml:"agent_card,omitempty"`
 	CodeConfiguration    *CodeConfiguration      `json:"codeConfiguration,omitempty" yaml:"code_configuration,omitempty"`
 }
 


### PR DESCRIPTION
ContainerAgent's AgentEndpoint and AgentCard fields used yaml:"agentEndpoint" and yaml:"agentCard" (camelCase) while every other field in the same struct and every published agent.yaml uses snake_case (e.g. environment_variables, code_configuration). As a result, an `agent_endpoint:` block in the user's agent.yaml silently unmarshaled to nil, the deploy request omitted the block, and the Foundry service substituted default values - notably isolation_key_source.kind defaulting to `Entra` even when the user wrote `kind: Header` - discarding the user's intent without any warning.

Switch the yaml tags to agent_endpoint / agent_card and add a regression test that feeds a snake_case manifest with isolation_key_source.kind: Header and asserts the field round-trips correctly.