### PR TITLE
Add link-pr-issue Copilot skill

### DIFF
--- a/.github/skills/link-pr-issue/SKILL.md
+++ b/.github/skills/link-pr-issue/SKILL.md
@@ -36,4 +36,4 @@ the boilerplate of creating a matching issue and editing the PR body.
 
 - A new GitHub issue exists with a title and body derived from the PR.
 - The PR body contains `Fixes #<issue_number>`.
-- The user has confirmed both the issue content and the PR edit before changes were made.
+- The user has confirmed the issue content before creation and the PR body edit before linking.

--- a/.github/skills/link-pr-issue/SKILL.md
+++ b/.github/skills/link-pr-issue/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: link-pr-issue
+license: MIT
+metadata:
+  version: "1.0"
+description: >-
+  **WORKFLOW SKILL** — Creates a GitHub issue from a PR's title and description,
+  then links the PR to the new issue via the `Fixes #NNN` keyword.
+  Designed to satisfy CI governance gates that require PRs to reference an issue.
+
+  INVOKES: gh CLI, ask_user.
+
+  USE FOR: link PR to issue, create issue for PR, PR missing issue, fix CI governance,
+  create and link issue, PR needs issue, link issue to PR, pr issue gate,
+  create tracking issue for PR.
+
+  DO NOT USE FOR: changelog generation (use changelog-generation),
+  code review (use code-review), creating PRs from issues.
+---
+
+# link-pr-issue
+
+Creates a GitHub issue derived from a pull request and links the PR back to it.
+This satisfies CI governance gates that require every PR to reference an issue.
+
+## Overview
+
+Many PRs are created without a linked issue — quick fixes, dependency bumps,
+external contributions, or automated changes. The repo's CI gate checks for
+an issue reference and blocks merge when one is missing. This skill automates
+the boilerplate of creating a matching issue and editing the PR body.
+
+{{ references/workflow.md }}
+
+## Exit Criteria
+
+- A new GitHub issue exists with a title and body derived from the PR.
+- The PR body contains `Fixes #<issue_number>`.
+- The user has confirmed both the issue content and the PR edit before changes were made.

--- a/.github/skills/link-pr-issue/references/workflow.md
+++ b/.github/skills/link-pr-issue/references/workflow.md
@@ -10,12 +10,33 @@ Determine the target PR number. Use one of these sources (in priority order):
 
 If no PR can be identified, ask the user for the PR number.
 
-### Step 2 — Fetch PR Details
+### Step 2 — Fetch PR Details and Check for Existing Linked Issues
 
 Use `gh pr view <number> --json number,title,body,url` to retrieve the PR's
-title, body, and URL. Parse the body to check whether an issue is already linked
-(look for `Fixes #`, `Closes #`, or `Resolves #` patterns). If a link already
-exists, inform the user and stop — no action needed.
+title, body, and URL.
+
+Before creating an issue, check whether one is already linked using the same
+source the CI governance gate uses — the GraphQL `closingIssuesReferences` API:
+
+```bash
+gh api graphql -f query='query {
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: PR_NUMBER) {
+      closingIssuesReferences(first: 10) {
+        nodes { number title url }
+      }
+    }
+  }
+}'
+```
+
+This covers issues linked via:
+- Closing keywords in the PR body (`Fixes #`, `Closes #`, `Resolves #`)
+- The GitHub sidebar "Linked issues" UI
+- Commit messages with closing keywords
+
+If `closingIssuesReferences.nodes` is non-empty, an issue is already linked.
+Inform the user which issue(s) are linked and stop — no action needed.
 
 ### Step 3 — Draft the Issue
 

--- a/.github/skills/link-pr-issue/references/workflow.md
+++ b/.github/skills/link-pr-issue/references/workflow.md
@@ -62,16 +62,10 @@ Compose an issue with:
   - Any external issue references found in the PR body (e.g., links to
     upstream issues in other repos).
 
-### Step 4 — Confirm with User
+### Step 4 — Confirm Issue Draft with User
 
-Present **both** planned changes to the user via `ask_user`:
-
-1. The drafted issue title and body.
-2. The exact PR body update — show the `Fixes #<issue_number>` line that will
-   be appended to the current PR body.
-
-Ask whether to proceed with both, modify, or cancel. Both the issue creation
-and the PR edit must be confirmed before any changes are made.
+Present the drafted issue title and body to the user via `ask_user`.
+Ask whether to proceed, modify, or cancel.
 
 ### Step 5 — Create the Issue
 
@@ -86,10 +80,17 @@ rm /tmp/issue-body.md
 
 Capture the new issue number from the output.
 
-### Step 6 — Link the PR
+### Step 6 — Confirm and Link the PR
 
-Write the updated PR body to a temporary file and use `--body-file` to avoid
-shell metacharacter issues with user-controlled markdown:
+Now that the issue number is known, show the user the exact PR body update:
+
+> The following line will be appended to the PR body:
+> `Fixes #<issue_number>`
+
+Ask the user to confirm via `ask_user` before editing the PR.
+
+Once confirmed, write the updated PR body to a temporary file and use
+`--body-file` to avoid shell metacharacter issues with user-controlled markdown:
 
 ```bash
 printf '%s\n\nFixes #%d\n' "$CURRENT_BODY" "$ISSUE_NUMBER" > /tmp/pr-body.md

--- a/.github/skills/link-pr-issue/references/workflow.md
+++ b/.github/skills/link-pr-issue/references/workflow.md
@@ -1,0 +1,62 @@
+## Workflow
+
+### Step 1 — Identify the PR
+
+Determine the target PR number. Use one of these sources (in priority order):
+
+1. **Explicit user input** — the user provides a PR number or URL.
+2. **Current branch** — run `gh pr view --json number` to find the PR for the
+   checked-out branch.
+
+If no PR can be identified, ask the user for the PR number.
+
+### Step 2 — Fetch PR Details
+
+Use `gh pr view <number> --json number,title,body,url` to retrieve the PR's
+title, body, and URL. Parse the body to check whether an issue is already linked
+(look for `Fixes #`, `Closes #`, or `Resolves #` patterns). If a link already
+exists, inform the user and stop — no action needed.
+
+### Step 3 — Draft the Issue
+
+Compose an issue with:
+
+- **Title**: Derived from the PR title. Keep it concise and action-oriented.
+  If the PR title is already descriptive, reuse it. Otherwise, summarize.
+- **Body**: Include:
+  - A one-paragraph summary of the change (derived from the PR body).
+  - A `## Linked PR` section referencing the PR number.
+  - Any external issue references found in the PR body (e.g., links to
+    upstream issues in other repos).
+
+### Step 4 — Confirm with User
+
+Present the drafted issue title and body to the user via `ask_user`.
+Ask whether to proceed, modify, or cancel.
+
+### Step 5 — Create the Issue
+
+Run `gh issue create --repo <owner/repo> --title "<title>" --body "<body>"`
+to create the issue. Capture the new issue number from the output.
+
+### Step 6 — Link the PR
+
+Append `\n\nFixes #<issue_number>` to the existing PR body using
+`gh pr edit <number> --body "<updated_body>"`.
+
+### Step 7 — Report Success
+
+Inform the user with:
+- The new issue URL.
+- Confirmation that the PR body was updated.
+- A reminder that the CI gate should now pass on the next check.
+
+## Error Handling
+
+- **PR not found**: Ask the user to verify the PR number and repository.
+- **Permission denied**: Inform the user they may not have write access to
+  the repository. Suggest they check their `gh auth status`.
+- **Issue already linked**: Do not create a duplicate. Inform the user which
+  issue is already linked and stop.
+- **PR body edit fails**: Show the error and suggest the user manually add
+  `Fixes #<number>` to the PR description.

--- a/.github/skills/link-pr-issue/references/workflow.md
+++ b/.github/skills/link-pr-issue/references/workflow.md
@@ -40,15 +40,19 @@ and stop — no issue is needed.
 governance gate uses — the GraphQL `closingIssuesReferences` API:
 
 ```bash
-gh api graphql -f query='query {
-  repository(owner: "OWNER", name: "REPO") {
-    pullRequest(number: PR_NUMBER) {
-      closingIssuesReferences(first: 10) {
-        nodes { number title url }
+gh api graphql \
+  -f owner="$OWNER" \
+  -f repo="$REPO" \
+  -F number="$PR_NUMBER" \
+  -f query='query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        closingIssuesReferences(first: 10) {
+          nodes { number title url }
+        }
       }
     }
-  }
-}'
+  }'
 ```
 
 This covers issues linked via:

--- a/.github/skills/link-pr-issue/references/workflow.md
+++ b/.github/skills/link-pr-issue/references/workflow.md
@@ -2,18 +2,27 @@
 
 ### Step 1 — Identify the PR
 
-Determine the target PR number. Use one of these sources (in priority order):
+Determine the target PR number **and repository**. Use one of these sources
+(in priority order):
 
-1. **Explicit user input** — the user provides a PR number or URL.
-2. **Current branch** — run `gh pr view --json number` to find the PR for the
-   checked-out branch.
+1. **Explicit user input** — the user provides a PR URL (e.g.,
+   `https://github.com/OWNER/REPO/pull/123`). Extract the owner, repo, and
+   number from the URL.
+2. **Explicit PR number** — the user provides just a number. Resolve the
+   repository from the current checkout: `gh repo view --json owner,name`.
+3. **Current branch** — run `gh pr view --json number,url` to find the PR
+   for the checked-out branch. Extract owner/repo from the URL.
 
-If no PR can be identified, ask the user for the PR number.
+If no PR can be identified, ask the user for the PR number or URL.
+
+**Carry the resolved `OWNER`, `REPO`, and `PR_NUMBER` through all subsequent
+steps.** Always pass `--repo OWNER/REPO` to `gh` commands so they work
+regardless of the current working directory.
 
 ### Step 2 — Fetch PR Details and Check Skip Conditions
 
-Use `gh pr view <number> --json number,title,body,url,isDraft,author,labels` to
-retrieve the PR metadata.
+Use `gh pr view <PR_NUMBER> --repo OWNER/REPO --json number,title,body,url,isDraft,author,labels`
+to retrieve the PR metadata.
 
 **Before creating an issue, check whether the PR is exempt from governance.**
 The CI governance gate (`.github/scripts/pr-governance-issue-check.js`) skips
@@ -73,9 +82,10 @@ Write the issue body to a temporary file and use `--body-file` to avoid
 shell injection from PR-derived content:
 
 ```bash
-echo "$ISSUE_BODY" > /tmp/issue-body.md
-gh issue create --repo <owner/repo> --title "$TITLE" --body-file /tmp/issue-body.md
-rm /tmp/issue-body.md
+TMPFILE=$(mktemp)
+printf '%s' "$ISSUE_BODY" > "$TMPFILE"
+gh issue create --repo OWNER/REPO --title "$TITLE" --body-file "$TMPFILE"
+rm "$TMPFILE"
 ```
 
 Capture the new issue number from the output.
@@ -93,9 +103,10 @@ Once confirmed, write the updated PR body to a temporary file and use
 `--body-file` to avoid shell metacharacter issues with user-controlled markdown:
 
 ```bash
-printf '%s\n\nFixes #%d\n' "$CURRENT_BODY" "$ISSUE_NUMBER" > /tmp/pr-body.md
-gh pr edit <number> --body-file /tmp/pr-body.md
-rm /tmp/pr-body.md
+TMPFILE=$(mktemp)
+printf '%s\n\nFixes #%d\n' "$CURRENT_BODY" "$ISSUE_NUMBER" > "$TMPFILE"
+gh pr edit "$PR_NUMBER" --repo OWNER/REPO --body-file "$TMPFILE"
+rm "$TMPFILE"
 ```
 
 ### Step 7 — Report Success

--- a/.github/skills/link-pr-issue/references/workflow.md
+++ b/.github/skills/link-pr-issue/references/workflow.md
@@ -10,13 +10,25 @@ Determine the target PR number. Use one of these sources (in priority order):
 
 If no PR can be identified, ask the user for the PR number.
 
-### Step 2 — Fetch PR Details and Check for Existing Linked Issues
+### Step 2 — Fetch PR Details and Check Skip Conditions
 
-Use `gh pr view <number> --json number,title,body,url` to retrieve the PR's
-title, body, and URL.
+Use `gh pr view <number> --json number,title,body,url,isDraft,author,labels` to
+retrieve the PR metadata.
 
-Before creating an issue, check whether one is already linked using the same
-source the CI governance gate uses — the GraphQL `closingIssuesReferences` API:
+**Before creating an issue, check whether the PR is exempt from governance.**
+The CI governance gate (`.github/scripts/pr-governance-issue-check.js`) skips
+PRs that match any of these conditions:
+
+1. **Draft PRs** — `isDraft` is `true`.
+2. **Automated authors** — author login is `dependabot[bot]`, `dependabot`,
+   `app/dependabot`, or `azure-sdk`.
+3. **Skip label** — the PR carries the `skip-governance` label.
+
+If any skip condition applies, inform the user the PR is exempt from governance
+and stop — no issue is needed.
+
+**Then check whether an issue is already linked** using the same source the CI
+governance gate uses — the GraphQL `closingIssuesReferences` API:
 
 ```bash
 gh api graphql -f query='query {
@@ -52,18 +64,38 @@ Compose an issue with:
 
 ### Step 4 — Confirm with User
 
-Present the drafted issue title and body to the user via `ask_user`.
-Ask whether to proceed, modify, or cancel.
+Present **both** planned changes to the user via `ask_user`:
+
+1. The drafted issue title and body.
+2. The exact PR body update — show the `Fixes #<issue_number>` line that will
+   be appended to the current PR body.
+
+Ask whether to proceed with both, modify, or cancel. Both the issue creation
+and the PR edit must be confirmed before any changes are made.
 
 ### Step 5 — Create the Issue
 
-Run `gh issue create --repo <owner/repo> --title "<title>" --body "<body>"`
-to create the issue. Capture the new issue number from the output.
+Write the issue body to a temporary file and use `--body-file` to avoid
+shell injection from PR-derived content:
+
+```bash
+echo "$ISSUE_BODY" > /tmp/issue-body.md
+gh issue create --repo <owner/repo> --title "$TITLE" --body-file /tmp/issue-body.md
+rm /tmp/issue-body.md
+```
+
+Capture the new issue number from the output.
 
 ### Step 6 — Link the PR
 
-Append `\n\nFixes #<issue_number>` to the existing PR body using
-`gh pr edit <number> --body "<updated_body>"`.
+Write the updated PR body to a temporary file and use `--body-file` to avoid
+shell metacharacter issues with user-controlled markdown:
+
+```bash
+printf '%s\n\nFixes #%d\n' "$CURRENT_BODY" "$ISSUE_NUMBER" > /tmp/pr-body.md
+gh pr edit <number> --body-file /tmp/pr-body.md
+rm /tmp/pr-body.md
+```
 
 ### Step 7 — Report Success
 


### PR DESCRIPTION
## Summary

Adds a new Copilot CLI skill (`link-pr-issue`) that creates a GitHub issue from a PR's title and description, then links the PR to the new issue via `Fixes #NNN`.

## Motivation

The repo has a CI governance gate requiring PRs to reference an issue. When PRs are created without one (quick fixes, dependency bumps, external contributions), contributors must manually create an issue and edit the PR — tedious busywork. This skill automates it.

## What's Included

- `.github/skills/link-pr-issue/SKILL.md` — Skill definition with frontmatter, overview, and exit criteria
- `.github/skills/link-pr-issue/references/workflow.md` — Step-by-step workflow (identify PR → fetch details → draft issue → confirm → create → link → report)

## How It Works

1. Identifies the target PR (from user input or current branch)
2. Checks if an issue is already linked (skips if so)
3. Drafts an issue from the PR title/body
4. Confirms with the user before making changes
5. Creates the issue via `gh issue create`
6. Appends `Fixes #NNN` to the PR body

Fixes #8409