### PR TITLE
Reduce Fig spec size by pruning help and output noise

### DIFF
--- a/cli/azd/cmd/completion.go
+++ b/cli/azd/cmd/completion.go
@@ -131,13 +131,20 @@ func newCompletionPowerShellAction(cmd *cobra.Command) actions.Action {
 
 // Fig completion action and flags
 type completionFigFlags struct {
-	includeHidden bool
+	includeHidden          bool
+	includeHelpSubcommands bool
 }
 
 func newCompletionFigFlags(cmd *cobra.Command) *completionFigFlags {
 	flags := &completionFigFlags{}
 	cmd.Flags().BoolVar(&flags.includeHidden, "include-hidden", false, "Include hidden commands in the Fig spec")
 	_ = cmd.Flags().MarkHidden("include-hidden")
+	cmd.Flags().BoolVar(
+		&flags.includeHelpSubcommands,
+		"include-help-subcommands",
+		false,
+		"Include subcommands under the help command in the Fig spec",
+	)
 	return flags
 }
 
@@ -191,6 +198,7 @@ func (a *completionFigAction) Run(ctx context.Context) (*actions.ActionResult, e
 
 	// Generate the Fig spec
 	builder := figspec.NewSpecBuilder(a.flags.includeHidden).
+		WithHelpSubcommands(a.flags.includeHelpSubcommands).
 		WithExtensionMetadata(a.extensionManager)
 	spec := builder.BuildSpec(rootCmd)
 

--- a/cli/azd/cmd/completion_test.go
+++ b/cli/azd/cmd/completion_test.go
@@ -121,9 +121,12 @@ func TestCompletionFigFlags(t *testing.T) {
 
 	require.NotNil(t, flags)
 	require.False(t, flags.includeHidden)
+	require.False(t, flags.includeHelpSubcommands)
 
 	// Verify flag is registered
 	f := cmd.Flags().Lookup("include-hidden")
+	require.NotNil(t, f)
+	f = cmd.Flags().Lookup("include-help-subcommands")
 	require.NotNil(t, f)
 }
 

--- a/cli/azd/cmd/testdata/TestFigSpec.ts
+++ b/cli/azd/cmd/testdata/TestFigSpec.ts
@@ -231,15 +231,6 @@ const completionSpec: Fig.Spec = {
 									description: 'Skip remote (network-dependent) checks. Useful when offline, behind a proxy, or for a fast local triage.',
 								},
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--unredacted'],
 									description: 'Show raw principal IDs, scope ARNs, and UPNs in the report.',
 								},
@@ -252,28 +243,6 @@ const completionSpec: Fig.Spec = {
 								{
 									name: ['update'],
 									description: 'Update an agent\'s endpoint and card configuration without deploying a new version.',
-									options: [
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
-									],
-								},
-							],
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
 								},
 							],
 						},
@@ -372,15 +341,6 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
-										{
 											name: ['--project-endpoint', '-p'],
 											description: 'Microsoft Foundry project endpoint URL',
 											args: [
@@ -417,15 +377,6 @@ const completionSpec: Fig.Spec = {
 												},
 											],
 										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
 									],
 								},
 								{
@@ -453,15 +404,6 @@ const completionSpec: Fig.Spec = {
 										{
 											name: ['--no-wait'],
 											description: 'Start the run and return immediately without waiting for results',
-										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
 										},
 									],
 								},
@@ -496,15 +438,6 @@ const completionSpec: Fig.Spec = {
 												},
 											],
 										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
 									],
 								},
 								{
@@ -527,26 +460,6 @@ const completionSpec: Fig.Spec = {
 										{
 											name: ['--evaluator-only'],
 											description: 'Only update evaluators',
-										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
-									],
-								},
-							],
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
 										},
 									],
 								},
@@ -584,15 +497,6 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'file',
-												},
-											],
-										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
 												},
 											],
 										},
@@ -648,15 +552,6 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'file',
-												},
-											],
-										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
 												},
 											],
 										},
@@ -773,15 +668,6 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
-										{
 											name: ['--session-id', '-s'],
 											description: 'Session ID override (defaults to last invoke session)',
 											args: [
@@ -885,15 +771,6 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
-										{
 											name: ['--session-id', '-s'],
 											description: 'Session ID override (defaults to last invoke session)',
 											args: [
@@ -919,17 +796,6 @@ const completionSpec: Fig.Spec = {
 													name: 'user-isolation-key',
 												},
 											],
-										},
-									],
-								},
-							],
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
 										},
 									],
 								},
@@ -1004,15 +870,6 @@ const completionSpec: Fig.Spec = {
 									args: [
 										{
 											name: 'model-deployment',
-										},
-									],
-								},
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
 										},
 									],
 								},
@@ -1191,15 +1048,6 @@ const completionSpec: Fig.Spec = {
 									description: 'Stream logs in real-time',
 								},
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--raw'],
 									description: 'Print the raw SSE stream without formatting',
 								},
@@ -1281,15 +1129,6 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
-										{
 											name: ['--project-endpoint', '-p'],
 											description: 'Foundry project endpoint URL',
 											args: [
@@ -1310,15 +1149,6 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'endpoint',
-												},
-											],
-										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
 												},
 											],
 										},
@@ -1365,15 +1195,6 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
-										{
 											name: ['--project-endpoint', '-p'],
 											description: 'Foundry project endpoint URL',
 											args: [
@@ -1407,15 +1228,6 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
-										{
 											name: ['--project-endpoint', '-p'],
 											description: 'Foundry project endpoint URL',
 											args: [
@@ -1445,15 +1257,6 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'endpoint',
-												},
-											],
-										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
 												},
 											],
 										},
@@ -1551,15 +1354,6 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--poll-interval'],
 									description: 'Polling interval in seconds',
 									args: [
@@ -1586,15 +1380,6 @@ const completionSpec: Fig.Spec = {
 								{
 									name: ['--no-inspector'],
 									description: 'Do not open Agent Inspector',
-								},
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
 								},
 								{
 									name: ['--port', '-p'],
@@ -1655,17 +1440,6 @@ const completionSpec: Fig.Spec = {
 													name: 'type',
 												},
 											],
-										},
-									],
-								},
-							],
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
 										},
 									],
 								},
@@ -1773,15 +1547,6 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'isolation-key',
-												},
-											],
-										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
 												},
 											],
 										},
@@ -1901,17 +1666,6 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 							],
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-							],
 						},
 						{
 							name: ['show'],
@@ -1932,17 +1686,6 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['version'],
 							description: 'Prints the version of the application',
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-							],
 						},
 					],
 				},
@@ -1954,15 +1697,6 @@ const completionSpec: Fig.Spec = {
 							name: ['context'],
 							description: 'Get the context of the azd project & environment.',
 							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
 								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
@@ -2076,15 +1810,6 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
 									args: [
@@ -2140,15 +1865,6 @@ const completionSpec: Fig.Spec = {
 									name: ['--force'],
 									description: 'Skip confirmation prompt',
 									isDangerous: true,
-								},
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
 								},
 								{
 									name: ['--project-endpoint', '-p'],
@@ -2258,15 +1974,6 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
 									args: [
@@ -2290,15 +1997,6 @@ const completionSpec: Fig.Spec = {
 							name: ['version'],
 							description: 'Display the extension version',
 							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
 								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
@@ -2796,15 +2494,6 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--port'],
 									description: 'Localhost port of the agent the inspector targets (default: 8088)',
 									args: [
@@ -2827,17 +2516,6 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['version'],
 							description: 'Display the extension version',
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-							],
 						},
 					],
 				},
@@ -3647,17 +3325,6 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['context'],
 							description: 'Get the context of the azd project & environment.',
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-							],
 						},
 						{
 							name: ['set'],
@@ -3710,17 +3377,6 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['version'],
 							description: 'Display the extension version',
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-							],
 						},
 					],
 				},
@@ -3732,15 +3388,6 @@ const completionSpec: Fig.Spec = {
 							name: ['context'],
 							description: 'Get the context of the azd project & environment.',
 							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
 								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
@@ -4141,15 +3788,6 @@ const completionSpec: Fig.Spec = {
 							],
 							options: [
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
 									args: [
@@ -4359,15 +3997,6 @@ const completionSpec: Fig.Spec = {
 							description: 'Display the extension version',
 							options: [
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
 									args: [
@@ -4388,15 +4017,6 @@ const completionSpec: Fig.Spec = {
 							name: ['context'],
 							description: 'Get the context of the azd project & environment.',
 							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
 								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env vars and global config)',
@@ -4663,15 +4283,6 @@ const completionSpec: Fig.Spec = {
 							description: 'Print the extension version.',
 							options: [
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env vars and global config)',
 									args: [
@@ -4801,15 +4412,6 @@ const completionSpec: Fig.Spec = {
 								},
 							],
 							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
 								{
 									name: ['--project-endpoint'],
 									description: 'Foundry project endpoint URL. When unset, falls back to the active azd environment, azd user config, then FOUNDRY_PROJECT_ENDPOINT.',
@@ -5074,15 +4676,6 @@ const completionSpec: Fig.Spec = {
 							],
 							options: [
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--project-endpoint'],
 									description: 'Foundry project endpoint URL. When unset, falls back to the active azd environment, azd user config, then FOUNDRY_PROJECT_ENDPOINT.',
 									args: [
@@ -5097,15 +4690,6 @@ const completionSpec: Fig.Spec = {
 							name: ['version'],
 							description: 'Display the extension version',
 							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
 								{
 									name: ['--project-endpoint'],
 									description: 'Foundry project endpoint URL. When unset, falls back to the active azd environment, azd user config, then FOUNDRY_PROJECT_ENDPOINT.',
@@ -5148,15 +4732,6 @@ const completionSpec: Fig.Spec = {
 								},
 							],
 							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
 								{
 									name: ['--project-endpoint'],
 									description: 'Foundry project endpoint URL. When unset, falls back to the active azd environment, azd user config, then FOUNDRY_PROJECT_ENDPOINT.',
@@ -5375,6 +4950,12 @@ const completionSpec: Fig.Spec = {
 				{
 					name: ['fig'],
 					description: 'Generate Fig autocomplete spec.',
+					options: [
+						{
+							name: ['--include-help-subcommands'],
+							description: 'Include subcommands under the help command in the Fig spec',
+						},
+					],
 				},
 				{
 					name: ['fish'],
@@ -6808,15 +6389,6 @@ const completionSpec: Fig.Spec = {
 							],
 						},
 						{
-							name: ['--output', '-o'],
-							description: 'The output format',
-							args: [
-								{
-									name: 'output',
-								},
-							],
-						},
-						{
 							name: ['--registry', '-r'],
 							description: 'When set will create a local extension source registry.',
 						},
@@ -6871,15 +6443,6 @@ const completionSpec: Fig.Spec = {
 							args: [
 								{
 									name: 'artifacts',
-								},
-							],
-						},
-						{
-							name: ['--output', '-o'],
-							description: 'The output format',
-							args: [
-								{
-									name: 'output',
 								},
 							],
 						},
@@ -6953,15 +6516,6 @@ const completionSpec: Fig.Spec = {
 							],
 						},
 						{
-							name: ['--output', '-o'],
-							description: 'The output format',
-							args: [
-								{
-									name: 'output',
-								},
-							],
-						},
-						{
 							name: ['--prerelease'],
 							description: 'Create a pre-release version',
 						},
@@ -6997,1058 +6551,16 @@ const completionSpec: Fig.Spec = {
 				{
 					name: ['version'],
 					description: 'Prints the version of the application',
-					options: [
-						{
-							name: ['--output', '-o'],
-							description: 'The output format',
-							args: [
-								{
-									name: 'output',
-								},
-							],
-						},
-					],
 				},
 				{
 					name: ['watch'],
 					description: 'Watches the azd extension project for file changes and rebuilds it.',
-					options: [
-						{
-							name: ['--output', '-o'],
-							description: 'The output format',
-							args: [
-								{
-									name: 'output',
-								},
-							],
-						},
-					],
 				},
 			],
 		},
 		{
 			name: ['help'],
 			description: 'Help about any command',
-			subcommands: [
-				{
-					name: ['add'],
-					description: 'Add a component to your project.',
-				},
-				{
-					name: ['ai'],
-					description: 'Commands for the ai extension namespace.',
-					subcommands: [
-						{
-							name: ['agent'],
-							description: 'Ship agents with Microsoft Foundry from your terminal. (Preview)',
-							subcommands: [
-								{
-									name: ['doctor'],
-									description: 'Diagnose problems with an azd ai agent project.',
-								},
-								{
-									name: ['endpoint'],
-									description: 'Manage agent endpoint and card configuration.',
-									subcommands: [
-										{
-											name: ['update'],
-											description: 'Update an agent\'s endpoint and card configuration without deploying a new version.',
-										},
-									],
-								},
-								{
-									name: ['eval'],
-									description: 'Create and run quick evals for an agent.',
-									subcommands: [
-										{
-											name: ['init'],
-											description: 'Generate a local eval suite for a deployed agent.',
-										},
-										{
-											name: ['list'],
-											description: 'List evaluations for the current project.',
-										},
-										{
-											name: ['run'],
-											description: 'Execute an evaluation run from eval.yaml.',
-										},
-										{
-											name: ['show'],
-											description: 'Show an eval definition, run history, or run details.',
-										},
-										{
-											name: ['update'],
-											description: 'Update evaluators and datasets from local files.',
-										},
-									],
-								},
-								{
-									name: ['files'],
-									description: 'Manage files in a hosted agent session.',
-									subcommands: [
-										{
-											name: ['delete', 'remove', 'rm'],
-											description: 'Delete a file or directory from a hosted agent session.',
-										},
-										{
-											name: ['download'],
-											description: 'Download a file from a hosted agent session.',
-										},
-										{
-											name: ['list', 'ls'],
-											description: 'List files in a hosted agent session.',
-										},
-										{
-											name: ['mkdir'],
-											description: 'Create a directory in a hosted agent session.',
-										},
-										{
-											name: ['stat'],
-											description: 'Get file or directory metadata in a hosted agent session.',
-										},
-										{
-											name: ['upload'],
-											description: 'Upload a file to a hosted agent session.',
-										},
-									],
-								},
-								{
-									name: ['init'],
-									description: 'Initialize a new AI agent project. (Preview)',
-								},
-								{
-									name: ['invoke'],
-									description: 'Send a message to your agent.',
-								},
-								{
-									name: ['monitor'],
-									description: 'Monitor logs from a hosted agent.',
-								},
-								{
-									name: ['optimize'],
-									description: 'Evaluate and optimize AI agents.',
-									subcommands: [
-										{
-											name: ['apply'],
-											description: 'Apply optimized candidate configuration locally to your azd project.',
-										},
-										{
-											name: ['cancel'],
-											description: 'Cancel a running optimization job.',
-										},
-										{
-											name: ['deploy'],
-											description: 'Deploy a winning optimization candidate as a new agent version via the API.',
-										},
-										{
-											name: ['list'],
-											description: 'List recent optimization runs.',
-										},
-										{
-											name: ['status'],
-											description: 'Check the status of an optimization job.',
-										},
-									],
-								},
-								{
-									name: ['run'],
-									description: 'Run your agent locally for development.',
-								},
-								{
-									name: ['sample'],
-									description: 'Browse the curated catalog of agent samples and azd templates.',
-									subcommands: [
-										{
-											name: ['list', 'ls'],
-											description: 'List available agent samples that can be used with `azd ai agent init -m`.',
-										},
-									],
-								},
-								{
-									name: ['sessions'],
-									description: 'Manage sessions for a hosted agent endpoint.',
-									subcommands: [
-										{
-											name: ['create'],
-											description: 'Create a new session for a hosted agent.',
-										},
-										{
-											name: ['delete'],
-											description: 'Delete a session.',
-										},
-										{
-											name: ['list'],
-											description: 'List sessions for a hosted agent.',
-										},
-										{
-											name: ['show'],
-											description: 'Show details of a session.',
-										},
-									],
-								},
-								{
-									name: ['show'],
-									description: 'Show the status of a hosted agent.',
-								},
-								{
-									name: ['version'],
-									description: 'Prints the version of the application',
-								},
-							],
-						},
-						{
-							name: ['connection'],
-							description: 'Manage Microsoft Foundry Connections from your terminal. (Preview)',
-							subcommands: [
-								{
-									name: ['context'],
-									description: 'Get the context of the azd project & environment.',
-								},
-								{
-									name: ['create'],
-									description: 'Create a new Foundry project connection.',
-								},
-								{
-									name: ['delete'],
-									description: 'Delete a connection.',
-								},
-								{
-									name: ['list'],
-									description: 'List connections in the Foundry project.',
-								},
-								{
-									name: ['show'],
-									description: 'Show connection details.',
-								},
-								{
-									name: ['update'],
-									description: 'Update a connection\'s target, credentials, or metadata.',
-								},
-								{
-									name: ['version'],
-									description: 'Display the extension version',
-								},
-							],
-						},
-						{
-							name: ['finetuning'],
-							description: 'Extension for Foundry Fine Tuning. (Preview)',
-							subcommands: [
-								{
-									name: ['init'],
-									description: 'Initialize a new AI Fine-tuning project. (Preview)',
-								},
-								{
-									name: ['jobs'],
-									description: 'Manage fine-tuning jobs',
-									subcommands: [
-										{
-											name: ['cancel'],
-											description: 'Cancels a running or queued fine-tuning job.',
-										},
-										{
-											name: ['deploy'],
-											description: 'Deploy a fine-tuned model to Azure Cognitive Services',
-										},
-										{
-											name: ['list'],
-											description: 'List fine-tuning jobs.',
-										},
-										{
-											name: ['pause'],
-											description: 'Pauses a running fine-tuning job.',
-										},
-										{
-											name: ['resume'],
-											description: 'Resumes a paused fine-tuning job.',
-										},
-										{
-											name: ['show'],
-											description: 'Shows detailed information about a specific job.',
-										},
-										{
-											name: ['submit'],
-											description: 'Submit fine-tuning job.',
-										},
-									],
-								},
-								{
-									name: ['version'],
-									description: 'Prints the version of the application',
-								},
-							],
-						},
-						{
-							name: ['inspector'],
-							description: 'Browser-based inspector UI for locally running Foundry agents. (Preview)',
-							subcommands: [
-								{
-									name: ['launch'],
-									description: 'Launch the Agent Inspector UI in a browser, pointed at a local agent.',
-								},
-								{
-									name: ['version'],
-									description: 'Display the extension version',
-								},
-							],
-						},
-						{
-							name: ['models'],
-							description: 'Extension for managing custom models in Azure AI Foundry. (Preview)',
-							subcommands: [
-								{
-									name: ['create'],
-									description: 'Upload and register a custom model',
-								},
-								{
-									name: ['custom'],
-									description: 'Manage custom models in Azure AI Foundry',
-									subcommands: [
-										{
-											name: ['create'],
-											description: 'Upload and register a custom model',
-										},
-										{
-											name: ['delete'],
-											description: 'Delete a custom model',
-										},
-										{
-											name: ['list'],
-											description: 'List all custom models',
-										},
-										{
-											name: ['show'],
-											description: 'Show details of a custom model',
-										},
-										{
-											name: ['update'],
-											description: 'Update a custom model',
-										},
-									],
-								},
-								{
-									name: ['delete'],
-									description: 'Delete a custom model',
-								},
-								{
-									name: ['init'],
-									description: 'Initialize a new AI models project. (Preview)',
-								},
-								{
-									name: ['list'],
-									description: 'List all custom models',
-								},
-								{
-									name: ['show'],
-									description: 'Show details of a custom model',
-								},
-								{
-									name: ['update'],
-									description: 'Update a custom model',
-								},
-								{
-									name: ['version'],
-									description: 'Prints the version of the application',
-								},
-							],
-						},
-						{
-							name: ['project'],
-							description: 'Manage Microsoft Foundry Project resources from your terminal. (Preview)',
-							subcommands: [
-								{
-									name: ['context'],
-									description: 'Get the context of the azd project & environment.',
-								},
-								{
-									name: ['set'],
-									description: 'Persist a default Foundry project endpoint.',
-								},
-								{
-									name: ['show'],
-									description: 'Display the currently resolved Foundry project endpoint.',
-								},
-								{
-									name: ['unset'],
-									description: 'Clear the persisted Foundry project endpoint.',
-								},
-								{
-									name: ['version'],
-									description: 'Display the extension version',
-								},
-							],
-						},
-						{
-							name: ['routine'],
-							description: 'Manage Microsoft Foundry Routines from your terminal. (Preview)',
-							subcommands: [
-								{
-									name: ['context'],
-									description: 'Get the context of the azd project & environment.',
-								},
-								{
-									name: ['create'],
-									description: 'Create a new routine.',
-								},
-								{
-									name: ['delete'],
-									description: 'Delete a routine.',
-								},
-								{
-									name: ['disable'],
-									description: 'Disable a routine.',
-								},
-								{
-									name: ['dispatch'],
-									description: 'Manually trigger a routine.',
-								},
-								{
-									name: ['enable'],
-									description: 'Enable a routine.',
-								},
-								{
-									name: ['list'],
-									description: 'List all routines in the Foundry project.',
-								},
-								{
-									name: ['run'],
-									description: 'Manage routine run history.',
-									subcommands: [
-										{
-											name: ['list'],
-											description: 'List runs for a routine.',
-										},
-									],
-								},
-								{
-									name: ['show'],
-									description: 'Show details of a routine.',
-								},
-								{
-									name: ['update'],
-									description: 'Update an existing routine.',
-								},
-								{
-									name: ['version'],
-									description: 'Display the extension version',
-								},
-							],
-						},
-						{
-							name: ['skill'],
-							description: 'Manage Microsoft Foundry skills (reusable agent behavioral guidelines) from your terminal. (Preview)',
-							subcommands: [
-								{
-									name: ['context'],
-									description: 'Get the context of the azd project & environment.',
-								},
-								{
-									name: ['create'],
-									description: 'Create a new Foundry skill.',
-								},
-								{
-									name: ['delete'],
-									description: 'Delete a Foundry skill.',
-								},
-								{
-									name: ['download'],
-									description: 'Download a Foundry skill package.',
-								},
-								{
-									name: ['list'],
-									description: 'List Foundry skills in the project.',
-								},
-								{
-									name: ['show'],
-									description: 'Show metadata for a Foundry skill.',
-								},
-								{
-									name: ['update'],
-									description: 'Create a new default version for a Foundry skill.',
-								},
-								{
-									name: ['version'],
-									description: 'Print the extension version.',
-								},
-							],
-						},
-						{
-							name: ['toolbox'],
-							description: 'Manage Microsoft Foundry Toolboxes from your terminal. (Preview)',
-							subcommands: [
-								{
-									name: ['connection'],
-									description: 'Manage the connection-backed tools attached to a toolbox.',
-									subcommands: [
-										{
-											name: ['add'],
-											description: 'Attach one or more connections to a toolbox.',
-										},
-										{
-											name: ['list'],
-											description: 'List the connection-backed tools attached to a toolbox.',
-										},
-										{
-											name: ['remove'],
-											description: 'Detach one or more connections from a toolbox.',
-										},
-									],
-								},
-								{
-									name: ['create'],
-									description: 'Create a toolbox and its initial version from a file.',
-								},
-								{
-									name: ['delete'],
-									description: 'Delete a toolbox or a single version.',
-								},
-								{
-									name: ['list'],
-									description: 'List toolboxes on the project.',
-								},
-								{
-									name: ['publish'],
-									description: 'Set the default version for a toolbox.',
-								},
-								{
-									name: ['show'],
-									description: 'Show a toolbox version, including its computed MCP endpoint.',
-								},
-								{
-									name: ['skill'],
-									description: 'Manage skill references attached to a toolbox.',
-									subcommands: [
-										{
-											name: ['add'],
-											description: 'Attach one or more skill references to a toolbox.',
-										},
-										{
-											name: ['list'],
-											description: 'List the skill references attached to a toolbox.',
-										},
-										{
-											name: ['remove'],
-											description: 'Detach one or more skill references from a toolbox.',
-										},
-									],
-								},
-								{
-									name: ['version'],
-									description: 'Display the extension version',
-								},
-								{
-									name: ['versions'],
-									description: 'Inspect toolbox versions.',
-									subcommands: [
-										{
-											name: ['list'],
-											description: 'List published versions for a toolbox.',
-										},
-									],
-								},
-							],
-						},
-					],
-				},
-				{
-					name: ['appservice'],
-					description: 'Extension for managing Azure App Service resources.',
-					subcommands: [
-						{
-							name: ['swap'],
-							description: 'Swap deployment slots for an App Service.',
-						},
-						{
-							name: ['version'],
-							description: 'Display the version of the extension.',
-						},
-					],
-				},
-				{
-					name: ['auth'],
-					description: 'Authenticate with Azure.',
-					subcommands: [
-						{
-							name: ['login'],
-							description: 'Log in to Azure.',
-						},
-						{
-							name: ['logout'],
-							description: 'Log out of Azure.',
-						},
-						{
-							name: ['status'],
-							description: 'Show the current authentication status.',
-						},
-					],
-				},
-				{
-					name: ['coding-agent'],
-					description: 'This extension configures GitHub Copilot Coding Agent access to Azure',
-					subcommands: [
-						{
-							name: ['config'],
-							description: 'Configure the GitHub Copilot coding agent to access Azure resources via the Azure MCP',
-						},
-						{
-							name: ['version'],
-							description: 'Prints the version of the application',
-						},
-					],
-				},
-				{
-					name: ['completion'],
-					description: 'Generate shell completion scripts.',
-					subcommands: [
-						{
-							name: ['bash'],
-							description: 'Generate bash completion script.',
-						},
-						{
-							name: ['fig'],
-							description: 'Generate Fig autocomplete spec.',
-						},
-						{
-							name: ['fish'],
-							description: 'Generate fish completion script.',
-						},
-						{
-							name: ['powershell'],
-							description: 'Generate PowerShell completion script.',
-						},
-						{
-							name: ['zsh'],
-							description: 'Generate zsh completion script.',
-						},
-					],
-				},
-				{
-					name: ['concurx'],
-					description: 'Concurrent execution for azd deployment',
-					subcommands: [
-						{
-							name: ['up'],
-							description: 'Runs azd up in concurrent mode',
-						},
-						{
-							name: ['version'],
-							description: 'Prints the version of the application',
-						},
-					],
-				},
-				{
-					name: ['config'],
-					description: 'Manage azd configurations (ex: default Azure subscription, location).',
-					subcommands: [
-						{
-							name: ['get'],
-							description: 'Gets a configuration.',
-						},
-						{
-							name: ['list-alpha'],
-							description: 'Display the list of available features in alpha stage.',
-						},
-						{
-							name: ['options'],
-							description: 'List all available configuration settings.',
-						},
-						{
-							name: ['reset'],
-							description: 'Resets configuration to default.',
-						},
-						{
-							name: ['set'],
-							description: 'Sets a configuration.',
-						},
-						{
-							name: ['show'],
-							description: 'Show all the configuration values.',
-						},
-						{
-							name: ['unset'],
-							description: 'Unsets a configuration.',
-						},
-					],
-				},
-				{
-					name: ['copilot'],
-					description: 'Manage GitHub Copilot agent settings. (Preview)',
-					subcommands: [
-						{
-							name: ['consent'],
-							description: 'Manage tool consent.',
-							subcommands: [
-								{
-									name: ['grant'],
-									description: 'Grant consent trust rules.',
-								},
-								{
-									name: ['list'],
-									description: 'List consent rules.',
-								},
-								{
-									name: ['revoke'],
-									description: 'Revoke consent rules.',
-								},
-							],
-						},
-					],
-				},
-				{
-					name: ['demo'],
-					description: 'This extension provides examples of the azd extension framework.',
-					subcommands: [
-						{
-							name: ['ai'],
-							description: 'Interactive AI model discovery, deployment, and quota demos.',
-							subcommands: [
-								{
-									name: ['deployment'],
-									description: 'Select model/version/SKU/capacity and resolve a valid deployment configuration.',
-								},
-								{
-									name: ['models'],
-									description: 'Browse available AI models interactively.',
-								},
-								{
-									name: ['quota'],
-									description: 'View usage meters and limits for a selected location.',
-								},
-							],
-						},
-						{
-							name: ['colors', 'colours'],
-							description: 'Displays all ASCII colors with their standard and high-intensity variants.',
-						},
-						{
-							name: ['config'],
-							description: 'Set up monitoring configuration for the project and services',
-						},
-						{
-							name: ['context'],
-							description: 'Get the context of the azd project & environment.',
-						},
-						{
-							name: ['gh-url-parse'],
-							description: 'Parse a GitHub URL and extract repository information.',
-						},
-						{
-							name: ['listen'],
-							description: 'Starts the extension and listens for events.',
-						},
-						{
-							name: ['mcp'],
-							description: 'MCP server commands for demo extension',
-							subcommands: [
-								{
-									name: ['start'],
-									description: 'Start MCP server with demo tools',
-								},
-							],
-						},
-						{
-							name: ['prompt'],
-							description: 'Examples of prompting the user for input.',
-						},
-						{
-							name: ['version'],
-							description: 'Prints the version of the application',
-						},
-					],
-				},
-				{
-					name: ['deploy'],
-					description: 'Deploy your project code to Azure.',
-				},
-				{
-					name: ['down'],
-					description: 'Delete your project\'s Azure resources.',
-				},
-				{
-					name: ['env'],
-					description: 'Manage environments (ex: default environment, environment variables).',
-					subcommands: [
-						{
-							name: ['config'],
-							description: 'Manage environment configuration (ex: stored in .azure/<environment>/config.json).',
-							subcommands: [
-								{
-									name: ['get'],
-									description: 'Gets a configuration value from the environment.',
-								},
-								{
-									name: ['set'],
-									description: 'Sets a configuration value in the environment.',
-								},
-								{
-									name: ['unset'],
-									description: 'Unsets a configuration value in the environment.',
-								},
-							],
-						},
-						{
-							name: ['get-value'],
-							description: 'Get specific environment value.',
-						},
-						{
-							name: ['get-values'],
-							description: 'Get all environment values.',
-						},
-						{
-							name: ['list', 'ls'],
-							description: 'List environments.',
-						},
-						{
-							name: ['new'],
-							description: 'Create a new environment and set it as the default.',
-						},
-						{
-							name: ['refresh'],
-							description: 'Refresh environment values by using information from a previous infrastructure provision.',
-						},
-						{
-							name: ['remove', 'rm'],
-							description: 'Remove an environment.',
-						},
-						{
-							name: ['select'],
-							description: 'Set the default environment.',
-						},
-						{
-							name: ['set'],
-							description: 'Set one or more environment values.',
-						},
-						{
-							name: ['set-secret'],
-							description: 'Set a name as a reference to a Key Vault secret in the environment.',
-						},
-					],
-				},
-				{
-					name: ['exec'],
-					description: 'Execute commands and scripts with azd environment context.',
-				},
-				{
-					name: ['extension', 'ext'],
-					description: 'Manage azd extensions.',
-					subcommands: [
-						{
-							name: ['install'],
-							description: 'Installs specified extensions.',
-						},
-						{
-							name: ['list'],
-							description: 'List available extensions.',
-						},
-						{
-							name: ['show'],
-							description: 'Show details for a specific extension.',
-						},
-						{
-							name: ['source'],
-							description: 'View and manage extension sources',
-							subcommands: [
-								{
-									name: ['add'],
-									description: 'Add an extension source with the specified name',
-								},
-								{
-									name: ['list'],
-									description: 'List extension sources',
-								},
-								{
-									name: ['remove'],
-									description: 'Remove an extension source with the specified name',
-								},
-								{
-									name: ['validate'],
-									description: 'Validate an extension source\'s registry.json file.',
-								},
-							],
-						},
-						{
-							name: ['uninstall'],
-							description: 'Uninstall specified extensions.',
-						},
-						{
-							name: ['upgrade'],
-							description: 'Upgrade installed extensions to the latest version.',
-						},
-					],
-				},
-				{
-					name: ['hooks'],
-					description: 'Develop, test and run hooks for a project.',
-					subcommands: [
-						{
-							name: ['run'],
-							description: 'Runs the specified hook for the project, provisioning layers, and services',
-						},
-					],
-				},
-				{
-					name: ['infra'],
-					description: 'Manage your Infrastructure as Code (IaC).',
-					subcommands: [
-						{
-							name: ['generate', 'gen', 'synth'],
-							description: 'Write IaC for your project to disk, allowing you to manually manage it.',
-						},
-					],
-				},
-				{
-					name: ['init'],
-					description: 'Initialize a new application.',
-				},
-				{
-					name: ['mcp'],
-					description: 'Manage Model Context Protocol (MCP) server. (Alpha)',
-					subcommands: [
-						{
-							name: ['start'],
-							description: 'Starts the MCP server.',
-						},
-					],
-				},
-				{
-					name: ['monitor'],
-					description: 'Monitor a deployed project.',
-				},
-				{
-					name: ['package'],
-					description: 'Packages the project\'s code to be deployed to Azure.',
-				},
-				{
-					name: ['pipeline'],
-					description: 'Manage and configure your deployment pipelines.',
-					subcommands: [
-						{
-							name: ['config'],
-							description: 'Configure your deployment pipeline to connect securely to Azure. (Beta)',
-						},
-					],
-				},
-				{
-					name: ['provision'],
-					description: 'Provision Azure resources for your project.',
-				},
-				{
-					name: ['publish'],
-					description: 'Publish a service to a container registry.',
-				},
-				{
-					name: ['restore'],
-					description: 'Restores the project\'s dependencies.',
-				},
-				{
-					name: ['show'],
-					description: 'Display information about your project and its resources.',
-				},
-				{
-					name: ['template'],
-					description: 'Find and view template details.',
-					subcommands: [
-						{
-							name: ['list', 'ls'],
-							description: 'Show list of sample azd templates. (Beta)',
-						},
-						{
-							name: ['show'],
-							description: 'Show details for a given template. (Beta)',
-						},
-						{
-							name: ['source'],
-							description: 'View and manage template sources. (Beta)',
-							subcommands: [
-								{
-									name: ['add'],
-									description: 'Adds an azd template source with the specified key. (Beta)',
-								},
-								{
-									name: ['list', 'ls'],
-									description: 'Lists the configured azd template sources. (Beta)',
-								},
-								{
-									name: ['remove'],
-									description: 'Removes the specified azd template source (Beta)',
-								},
-							],
-						},
-					],
-				},
-				{
-					name: ['tool'],
-					description: 'Manage Azure development tools.',
-					subcommands: [
-						{
-							name: ['check'],
-							description: 'Check for tool updates.',
-						},
-						{
-							name: ['install'],
-							description: 'Install specified tools.',
-						},
-						{
-							name: ['list'],
-							description: 'List all tools with status.',
-						},
-						{
-							name: ['show'],
-							description: 'Show details for a specific tool.',
-						},
-						{
-							name: ['upgrade'],
-							description: 'Upgrade installed tools.',
-						},
-					],
-				},
-				{
-					name: ['up'],
-					description: 'Provision and deploy your project to Azure with a single command.',
-				},
-				{
-					name: ['update'],
-					description: 'Updates azd to the latest version.',
-				},
-				{
-					name: ['version'],
-					description: 'Print the version number of Azure Developer CLI.',
-				},
-				{
-					name: ['x'],
-					description: 'This extension provides a set of tools for azd extension developers to test and debug their extensions.',
-					subcommands: [
-						{
-							name: ['build'],
-							description: 'Build the azd extension project',
-						},
-						{
-							name: ['init'],
-							description: 'Initialize a new azd extension project',
-						},
-						{
-							name: ['pack'],
-							description: 'Build and pack extension artifacts',
-						},
-						{
-							name: ['publish'],
-							description: 'Publish the extension to the extension source',
-						},
-						{
-							name: ['release'],
-							description: 'Create a new extension release from the packaged artifacts',
-						},
-						{
-							name: ['version'],
-							description: 'Prints the version of the application',
-						},
-						{
-							name: ['watch'],
-							description: 'Watches the azd extension project for file changes and rebuilds it.',
-						},
-					],
-				},
-			],
 		},
 	],
 	options: [

--- a/cli/azd/cmd/testdata/TestUsage-azd-completion-fig.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-completion-fig.snap
@@ -4,6 +4,9 @@ Generate Fig autocomplete spec.
 Usage
   azd completion fig
 
+Flags
+        --include-help-subcommands 	: Include subcommands under the help command in the Fig spec
+
 Global Flags
     -C, --cwd string         	: Sets the current working directory.
         --debug              	: Enables debugging and diagnostics logging.

--- a/cli/azd/docs/fig-spec.md
+++ b/cli/azd/docs/fig-spec.md
@@ -20,6 +20,13 @@ A copy of it exists in this repo under `cli/azd/cmd/testdata/TestFigSpec.ts` for
 azd completion fig > azd.ts
 ```
 
+By default, the generated spec includes the top-level `azd help` command but omits its mirrored subcommand
+tree to keep the spec compact. To include the full `azd help <command>` tree, run:
+
+```bash
+azd completion fig --include-help-subcommands > azd.ts
+```
+
 ### Testing locally
 
 The generated spec is automatically tested via snapshot tests:

--- a/cli/azd/internal/figspec/extension_metadata.go
+++ b/cli/azd/internal/figspec/extension_metadata.go
@@ -7,6 +7,11 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
 )
 
+const (
+	defaultExtensionOutputFlagUsage = "The output format"
+	defaultExtensionOutputFlagValue = "default"
+)
+
 // ExtensionMetadataProvider provides extension metadata for generating figspec completions
 type ExtensionMetadataProvider interface {
 	// HasMetadataCapability checks if the extension has the metadata capability
@@ -40,6 +45,9 @@ func convertExtensionCommand(extCmd extensions.Command, includeHidden bool, glob
 			continue
 		}
 		if globalFlagNames[flag.Name] {
+			continue
+		}
+		if shouldSkipExtensionFlag(flag) {
 			continue
 		}
 
@@ -103,6 +111,14 @@ func convertExtensionFlag(flag extensions.Flag) Option {
 	option.IsRepeatable = isRepeatable
 
 	return option
+}
+
+func shouldSkipExtensionFlag(flag extensions.Flag) bool {
+	return flag.Name == "output" &&
+		flag.Shorthand == "o" &&
+		flag.Description == defaultExtensionOutputFlagUsage &&
+		flag.Default == defaultExtensionOutputFlagValue &&
+		len(flag.ValidValues) == 0
 }
 
 // convertExtensionArg converts an extension argument to a Fig arg

--- a/cli/azd/internal/figspec/extension_metadata_test.go
+++ b/cli/azd/internal/figspec/extension_metadata_test.go
@@ -368,6 +368,81 @@ func TestConvertExtensionFlag(t *testing.T) {
 	}
 }
 
+func TestShouldSkipExtensionFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		flag extensions.Flag
+		want bool
+	}{
+		{
+			name: "default inherited output flag",
+			flag: extensions.Flag{
+				Name:        "output",
+				Shorthand:   "o",
+				Description: defaultExtensionOutputFlagUsage,
+				Default:     defaultExtensionOutputFlagValue,
+			},
+			want: true,
+		},
+		{
+			name: "output flag with valid values",
+			flag: extensions.Flag{
+				Name:        "output",
+				Shorthand:   "o",
+				Description: defaultExtensionOutputFlagUsage,
+				Default:     defaultExtensionOutputFlagValue,
+				ValidValues: []string{"json", "table"},
+			},
+			want: false,
+		},
+		{
+			name: "output flag with custom description",
+			flag: extensions.Flag{
+				Name:        "output",
+				Shorthand:   "o",
+				Description: "Path to the output directory.",
+				Default:     defaultExtensionOutputFlagValue,
+			},
+			want: false,
+		},
+		{
+			name: "output flag with custom default",
+			flag: extensions.Flag{
+				Name:        "output",
+				Shorthand:   "o",
+				Description: defaultExtensionOutputFlagUsage,
+				Default:     "json",
+			},
+			want: false,
+		},
+		{
+			name: "output flag without shorthand",
+			flag: extensions.Flag{
+				Name:        "output",
+				Description: defaultExtensionOutputFlagUsage,
+				Default:     defaultExtensionOutputFlagValue,
+			},
+			want: false,
+		},
+		{
+			name: "different flag",
+			flag: extensions.Flag{
+				Name:        "format",
+				Shorthand:   "o",
+				Description: defaultExtensionOutputFlagUsage,
+				Default:     defaultExtensionOutputFlagValue,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shouldSkipExtensionFlag(tt.flag))
+		})
+	}
+}
+
 func TestConvertExtensionArg(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/cli/azd/internal/figspec/extension_metadata_test.go
+++ b/cli/azd/internal/figspec/extension_metadata_test.go
@@ -106,6 +106,75 @@ func TestConvertExtensionCommand(t *testing.T) {
 			wantArgs:      0,
 		},
 		{
+			name: "default inherited output flag is filtered out",
+			cmd: extensions.Command{
+				Name:  []string{"run"},
+				Short: "Run something",
+				Flags: []extensions.Flag{
+					{
+						Name:        "output",
+						Shorthand:   "o",
+						Description: defaultExtensionOutputFlagUsage,
+						Type:        "string",
+						Default:     defaultExtensionOutputFlagValue,
+					},
+				},
+			},
+			includeHidden: false,
+			wantNil:       false,
+			wantName:      []string{"run"},
+			wantDesc:      "Run something",
+			wantSubcmds:   0,
+			wantOptions:   0,
+			wantArgs:      0,
+		},
+		{
+			name: "registered output format flag is preserved",
+			cmd: extensions.Command{
+				Name:  []string{"list"},
+				Short: "List things",
+				Flags: []extensions.Flag{
+					{
+						Name:        "output",
+						Shorthand:   "o",
+						Description: defaultExtensionOutputFlagUsage,
+						Type:        "string",
+						Default:     "json",
+						ValidValues: []string{"json", "table"},
+					},
+				},
+			},
+			includeHidden: false,
+			wantNil:       false,
+			wantName:      []string{"list"},
+			wantDesc:      "List things",
+			wantSubcmds:   0,
+			wantOptions:   1,
+			wantArgs:      0,
+		},
+		{
+			name: "registered output path flag is preserved",
+			cmd: extensions.Command{
+				Name:  []string{"pack"},
+				Short: "Pack things",
+				Flags: []extensions.Flag{
+					{
+						Name:        "output",
+						Shorthand:   "o",
+						Description: "Path to the output directory.",
+						Type:        "string",
+					},
+				},
+			},
+			includeHidden: false,
+			wantNil:       false,
+			wantName:      []string{"pack"},
+			wantDesc:      "Pack things",
+			wantSubcmds:   0,
+			wantOptions:   1,
+			wantArgs:      0,
+		},
+		{
 			name: "global flags are filtered out",
 			cmd: extensions.Command{
 				Name:  []string{"test"},

--- a/cli/azd/internal/figspec/figspec_coverage_test.go
+++ b/cli/azd/internal/figspec/figspec_coverage_test.go
@@ -344,6 +344,7 @@ func TestNewSpecBuilder(t *testing.T) {
 		sb := NewSpecBuilder(false)
 		require.NotNil(t, sb)
 		require.False(t, sb.includeHidden)
+		require.False(t, sb.includeHelpSubcommands)
 		require.NotNil(t, sb.suggestionProvider)
 		require.NotNil(t, sb.generatorProvider)
 		require.NotNil(t, sb.argsProvider)
@@ -354,6 +355,16 @@ func TestNewSpecBuilder(t *testing.T) {
 		sb := NewSpecBuilder(true)
 		require.True(t, sb.includeHidden)
 	})
+}
+
+func TestWithHelpSubcommands(t *testing.T) {
+	sb := NewSpecBuilder(false)
+	require.False(t, sb.includeHelpSubcommands)
+
+	result := sb.WithHelpSubcommands(true)
+
+	require.Same(t, sb, result)
+	require.True(t, sb.includeHelpSubcommands)
 }
 
 func TestWithExtensionMetadata(t *testing.T) {
@@ -455,8 +466,7 @@ func TestBuildSpec_HelpCommandPresent(t *testing.T) {
 		if sub.Name[0] == "help" {
 			found = true
 			require.Equal(t, "Help about any command", sub.Description)
-			// Help subcommands should mirror the command tree
-			require.NotEmpty(t, sub.Subcommands)
+			require.Empty(t, sub.Subcommands)
 		}
 	}
 	require.True(t, found, "expected help subcommand")
@@ -1127,7 +1137,7 @@ func TestBuildSpec_GeneratesHelpTree(t *testing.T) {
 	env.AddCommand(&cobra.Command{Use: "list", Short: "List"})
 	root.AddCommand(env)
 
-	sb := newTestSpecBuilder(false)
+	sb := newTestSpecBuilder(false).WithHelpSubcommands(true)
 	spec := sb.BuildSpec(root)
 
 	var helpSub *Subcommand

--- a/cli/azd/internal/figspec/figspec_coverage_test.go
+++ b/cli/azd/internal/figspec/figspec_coverage_test.go
@@ -4,6 +4,7 @@
 package figspec
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -492,6 +493,19 @@ func TestBuildSpec_Aliases(t *testing.T) {
 	t.Fatal("expected environment subcommand with aliases")
 }
 
+func TestGenerateNonPersistentGlobalOptions(t *testing.T) {
+	root := &cobra.Command{Use: "azd", Short: "CLI"}
+	root.Flags().Bool("docs", false, "Open documentation")
+	root.Flags().Bool("local-only", false, "Local flag")
+
+	sb := newTestSpecBuilder(false)
+	opts := sb.generateNonPersistentGlobalOptions(root)
+
+	require.Len(t, opts, 1)
+	require.Equal(t, []string{"--docs"}, opts[0].Name)
+	require.True(t, opts[0].IsPersistent)
+}
+
 func TestGenerateOptions_FlagTypes(t *testing.T) {
 	t.Run("bool_flag_no_args", func(t *testing.T) {
 		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
@@ -957,6 +971,15 @@ func TestTryGenerateExtensionSubcommand(t *testing.T) {
 		require.Nil(t, result)
 	})
 
+	t.Run("load_error_returns_nil", func(t *testing.T) {
+		sb := newTestSpecBuilder(false)
+		sb.extensionMetadataProvider = &mockExtensionProvider{hasCapability: true, loadErr: errors.New("load failed")}
+		cmd := &cobra.Command{Use: "ext", Short: "Extension"}
+		cmd.Annotations = map[string]string{"extension.id": "test-ext"}
+		result := sb.tryGenerateExtensionSubcommand(cmd, []string{"ext"})
+		require.Nil(t, result)
+	})
+
 	t.Run("success_with_metadata", func(t *testing.T) {
 		sb := newTestSpecBuilder(false)
 		sb.globalFlagNames = map[string]bool{"help": true}
@@ -978,6 +1001,32 @@ func TestTryGenerateExtensionSubcommand(t *testing.T) {
 	})
 }
 
+func TestGenerateSubcommands_ExtensionMetadata(t *testing.T) {
+	root := &cobra.Command{Use: "azd", Short: "CLI"}
+	ext := &cobra.Command{Use: "ext", Short: "Extension"}
+	ext.Annotations = map[string]string{"extension.id": "test-ext"}
+	root.AddCommand(ext)
+
+	sb := newTestSpecBuilder(false)
+	sb.globalFlagNames = map[string]bool{}
+	sb.extensionMetadataProvider = &mockExtensionProvider{
+		hasCapability: true,
+		metadata: &extensions.ExtensionCommandMetadata{
+			Commands: []extensions.Command{
+				{Name: []string{"child"}, Short: "Child cmd"},
+			},
+		},
+	}
+
+	subs := sb.generateSubcommands(root, &CommandContext{Command: root, CommandPath: "azd"})
+
+	require.Len(t, subs, 2)
+	require.Equal(t, "ext", subs[0].Name[0])
+	require.Len(t, subs[0].Subcommands, 1)
+	require.Equal(t, "child", subs[0].Subcommands[0].Name[0])
+	require.Equal(t, "help", subs[1].Name[0])
+}
+
 func TestTryGenerateExtensionHelpSubcommand(t *testing.T) {
 	t.Run("nil_provider_returns_nil", func(t *testing.T) {
 		sb := newTestSpecBuilder(false)
@@ -993,6 +1042,33 @@ func TestTryGenerateExtensionHelpSubcommand(t *testing.T) {
 		sb.extensionMetadataProvider = &mockExtensionProvider{hasCapability: true}
 		cmd := &cobra.Command{Use: "plain"}
 		result := sb.tryGenerateExtensionHelpSubcommand(cmd, []string{"plain"})
+		require.Nil(t, result)
+	})
+
+	t.Run("no_capability_returns_nil", func(t *testing.T) {
+		sb := newTestSpecBuilder(false)
+		sb.extensionMetadataProvider = &mockExtensionProvider{hasCapability: false}
+		cmd := &cobra.Command{Use: "ext"}
+		cmd.Annotations = map[string]string{"extension.id": "test-ext"}
+		result := sb.tryGenerateExtensionHelpSubcommand(cmd, []string{"ext"})
+		require.Nil(t, result)
+	})
+
+	t.Run("load_error_returns_nil", func(t *testing.T) {
+		sb := newTestSpecBuilder(false)
+		sb.extensionMetadataProvider = &mockExtensionProvider{hasCapability: true, loadErr: errors.New("load failed")}
+		cmd := &cobra.Command{Use: "ext"}
+		cmd.Annotations = map[string]string{"extension.id": "test-ext"}
+		result := sb.tryGenerateExtensionHelpSubcommand(cmd, []string{"ext"})
+		require.Nil(t, result)
+	})
+
+	t.Run("nil_metadata_returns_nil", func(t *testing.T) {
+		sb := newTestSpecBuilder(false)
+		sb.extensionMetadataProvider = &mockExtensionProvider{hasCapability: true}
+		cmd := &cobra.Command{Use: "ext"}
+		cmd.Annotations = map[string]string{"extension.id": "test-ext"}
+		result := sb.tryGenerateExtensionHelpSubcommand(cmd, []string{"ext"})
 		require.Nil(t, result)
 	})
 
@@ -1056,6 +1132,18 @@ func TestGenerateHelpSubcommands_MirrorsTree(t *testing.T) {
 	require.Len(t, helpSubs[0].Subcommands, 2)
 }
 
+func TestGenerateHelpSubcommands_SkipsHelpCommand(t *testing.T) {
+	root := &cobra.Command{Use: "azd", Short: "CLI"}
+	root.AddCommand(&cobra.Command{Use: "init", Short: "Init"})
+	root.InitDefaultHelpCmd()
+
+	sb := newTestSpecBuilder(false)
+	helpSubs := sb.generateHelpSubcommands(root)
+
+	require.Len(t, helpSubs, 1)
+	require.Equal(t, "init", helpSubs[0].Name[0])
+}
+
 func TestGenerateHelpSubcommands_HiddenExcluded(t *testing.T) {
 	root := &cobra.Command{Use: "azd", Short: "CLI"}
 	visible := &cobra.Command{Use: "init", Short: "Init"}
@@ -1070,6 +1158,30 @@ func TestGenerateHelpSubcommands_HiddenExcluded(t *testing.T) {
 	for _, sub := range helpSubs {
 		require.NotEqual(t, "secret", sub.Name[0], "hidden command should not appear in help tree")
 	}
+}
+
+func TestGenerateHelpSubcommands_ExtensionMetadata(t *testing.T) {
+	root := &cobra.Command{Use: "azd", Short: "CLI"}
+	ext := &cobra.Command{Use: "ext", Short: "Extension"}
+	ext.Annotations = map[string]string{"extension.id": "test-ext"}
+	root.AddCommand(ext)
+
+	sb := newTestSpecBuilder(false)
+	sb.extensionMetadataProvider = &mockExtensionProvider{
+		hasCapability: true,
+		metadata: &extensions.ExtensionCommandMetadata{
+			Commands: []extensions.Command{
+				{Name: []string{"child"}, Short: "Child cmd"},
+			},
+		},
+	}
+
+	helpSubs := sb.generateHelpSubcommands(root)
+
+	require.Len(t, helpSubs, 1)
+	require.Equal(t, "ext", helpSubs[0].Name[0])
+	require.Len(t, helpSubs[0].Subcommands, 1)
+	require.Equal(t, "child", helpSubs[0].Subcommands[0].Name[0])
 }
 
 // ============================================================================

--- a/cli/azd/internal/figspec/spec_builder.go
+++ b/cli/azd/internal/figspec/spec_builder.go
@@ -22,6 +22,7 @@ type SpecBuilder struct {
 	flagArgsProvider          CustomFlagArgsProvider
 	extensionMetadataProvider ExtensionMetadataProvider
 	includeHidden             bool
+	includeHelpSubcommands    bool
 	globalFlagNames           map[string]bool // Flag names that are global (persistent + non-persistent)
 }
 
@@ -42,6 +43,12 @@ func NewSpecBuilder(includeHidden bool) *SpecBuilder {
 // for extensions that have the metadata capability.
 func (sb *SpecBuilder) WithExtensionMetadata(provider ExtensionMetadataProvider) *SpecBuilder {
 	sb.extensionMetadataProvider = provider
+	return sb
+}
+
+// WithHelpSubcommands controls whether the generated help command mirrors the full command tree.
+func (sb *SpecBuilder) WithHelpSubcommands(include bool) *SpecBuilder {
+	sb.includeHelpSubcommands = include
 	return sb
 }
 
@@ -317,11 +324,16 @@ func (sb *SpecBuilder) generateCommandArgs(cmd *cobra.Command, ctx *CommandConte
 }
 
 func (sb *SpecBuilder) generateHelpCommand(root *cobra.Command) Subcommand {
-	return Subcommand{
+	helpCommand := Subcommand{
 		Name:        []string{"help"},
 		Description: "Help about any command",
-		Subcommands: sb.generateHelpSubcommands(root),
 	}
+
+	if sb.includeHelpSubcommands {
+		helpCommand.Subcommands = sb.generateHelpSubcommands(root)
+	}
+
+	return helpCommand
 }
 
 func (sb *SpecBuilder) generateHelpSubcommands(cmd *cobra.Command) []Subcommand {

--- a/cli/azd/pkg/azdext/extension_commands.go
+++ b/cli/azd/pkg/azdext/extension_commands.go
@@ -63,7 +63,7 @@ func NewMetadataCommand(schemaVersion, extensionId string, rootCmdProvider func(
 // NewVersionCommand creates the standard "version" command.
 // outputFormat is a pointer to the output format string (for JSON support).
 func NewVersionCommand(extensionId, version string, outputFormat *string) *cobra.Command {
-	return &cobra.Command{
+	return RegisterFlagOptions(&cobra.Command{
 		Use:   "version",
 		Short: "Display the extension version",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -85,5 +85,5 @@ func NewVersionCommand(extensionId, version string, outputFormat *string) *cobra
 
 			return nil
 		},
-	}
+	}, FlagOptions{Name: "output", AllowedValues: []string{"json"}})
 }

--- a/cli/azd/pkg/azdext/metadata_generator.go
+++ b/cli/azd/pkg/azdext/metadata_generator.go
@@ -138,6 +138,11 @@ func generateFlags(cmd *cobra.Command) []extensions.Flag {
 	var flags []extensions.Flag
 
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		ov, hasOverride := overrides[flag.Name]
+		if !hasOverride && isDefaultInheritedOutputFlag(flag) {
+			return
+		}
+
 		flagMeta := extensions.Flag{
 			Name:        flag.Name,
 			Shorthand:   flag.Shorthand,
@@ -154,7 +159,7 @@ func generateFlags(cmd *cobra.Command) []extensions.Flag {
 			flagMeta.Deprecated = flag.Deprecated
 		}
 
-		if ov, ok := overrides[flag.Name]; ok {
+		if hasOverride {
 			if ov.Usage != "" {
 				flagMeta.Description = ov.Usage
 			}
@@ -172,6 +177,13 @@ func generateFlags(cmd *cobra.Command) []extensions.Flag {
 	})
 
 	return flags
+}
+
+func isDefaultInheritedOutputFlag(flag *pflag.Flag) bool {
+	return flag.Name == "output" &&
+		flag.Shorthand == "o" &&
+		flag.Usage == defaultOutputFlagUsage &&
+		flag.DefValue == "default"
 }
 
 // getFlagType maps Cobra/pflag types to metadata type strings

--- a/cli/azd/pkg/azdext/metadata_generator_test.go
+++ b/cli/azd/pkg/azdext/metadata_generator_test.go
@@ -381,10 +381,7 @@ func TestGenerateExtensionMetadata_FlagOptionsOverride(t *testing.T) {
 	plainMeta := findCommand(metadata.Commands, "plain")
 	require.NotNil(t, plainMeta)
 	plainOutput := findFlag(plainMeta.Flags, "output")
-	require.NotNil(t, plainOutput)
-	assert.Equal(t, defaultOutputFlagUsage, plainOutput.Description)
-	assert.Empty(t, plainOutput.ValidValues)
-	assert.Equal(t, "default", plainOutput.Default)
+	require.Nil(t, plainOutput)
 
 	pathMeta := findCommand(metadata.Commands, "pack")
 	require.NotNil(t, pathMeta)
@@ -392,4 +389,21 @@ func TestGenerateExtensionMetadata_FlagOptionsOverride(t *testing.T) {
 	require.NotNil(t, pathOutput)
 	assert.Equal(t, "Path to the output directory.", pathOutput.Description)
 	assert.Empty(t, pathOutput.Default)
+}
+
+func TestGenerateExtensionMetadata_VersionCommandOutputFormat(t *testing.T) {
+	rootCmd, _ := NewExtensionRootCommand(ExtensionCommandOptions{Name: "test-ext"})
+	outputFormat := ""
+
+	rootCmd.AddCommand(NewVersionCommand("test-ext", "1.0.0", &outputFormat))
+
+	metadata := GenerateExtensionMetadata("1.0", "test.extension", rootCmd)
+
+	versionMeta := findCommand(metadata.Commands, "version")
+	require.NotNil(t, versionMeta)
+
+	outputFlag := findFlag(versionMeta.Flags, "output")
+	require.NotNil(t, outputFlag)
+	assert.Equal(t, defaultOutputFlagUsage, outputFlag.Description)
+	assert.Equal(t, []string{"json"}, outputFlag.ValidValues)
 }


### PR DESCRIPTION
Fixes #8416

This PR reduces the generated Fig completion spec size by pruning low-value generated content. By default, `azd completion fig` now emits only the top-level `azd help` command instead of duplicating the full command tree beneath `help`, while a new `--include-help-subcommands` flag preserves the previous expanded output when needed.

It also removes redundant inherited extension `--output` options from generated extension metadata and Fig completions when the command has not registered any command-specific output behavior. Commands that use `RegisterFlagOptions` still keep meaningful `--output` metadata, including allowed-value suggestions such as `json`/`table` and custom path-oriented usage text. The standard extension `version` command now explicitly registers its JSON output support so it continues to appear with useful completion suggestions.

## Validation

From `cli/azd/`: `go test ./internal/figspec ./pkg/azdext`, `go build`, `UPDATE_SNAPSHOTS=true go test ./cmd -run TestFigSpec`, and `go test ./cmd -run 'TestCompletionFigFlags|TestCompletionFigAction_Run|TestFigSpec|TestUsage/azd/completion/fig$'`.