### PR TITLE
fix: remove hardcoded code deploy region restriction, use dynamic hosted-agent regions

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"azureaiagent/internal/exterrors"
 	"azureaiagent/internal/pkg/azure"
-	"azureaiagent/internal/project"
 	"context"
 	"fmt"
 	"log"
@@ -1234,11 +1233,17 @@ func selectFoundryProject(
 		return nil, fmt.Errorf("failed to list Foundry projects: %w", err)
 	}
 
-	// When code deploy is selected, restrict to regions that support it.
+	// When code deploy is selected, restrict to regions that support hosted agents.
+	// Code deploy is available in all hosted-agent regions (no separate allowlist).
 	if skipACR {
-		projects = slices.DeleteFunc(projects, func(p FoundryProjectInfo) bool {
-			return !locationAllowed(p.Location, project.CodeDeployRegions)
-		})
+		supportedRegions, regErr := supportedRegionsForInit(ctx)
+		if regErr != nil {
+			log.Printf("warning: failed to fetch supported regions, skipping code-deploy region filter: %v", regErr)
+		} else if len(supportedRegions) > 0 {
+			projects = slices.DeleteFunc(projects, func(p FoundryProjectInfo) bool {
+				return !locationAllowed(p.Location, supportedRegions)
+			})
+		}
 	}
 
 	if len(projects) == 0 {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -1238,6 +1238,10 @@ func selectFoundryProject(
 	if skipACR {
 		supportedRegions, regErr := supportedRegionsForInit(ctx)
 		if regErr != nil {
+			// Propagate context cancellation/timeout — these are not recoverable fetch failures.
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			log.Printf("warning: failed to fetch supported regions, skipping code-deploy region filter: %v", regErr)
 		} else if len(supportedRegions) > 0 {
 			projects = slices.DeleteFunc(projects, func(p FoundryProjectInfo) bool {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/config.go
@@ -17,10 +17,6 @@ const (
 	DefaultCpu    = "0.5"
 )
 
-// CodeDeployRegions lists the regions that currently support code deploy (ZIP upload).
-// TODO: replace with dynamic region discovery API when available.
-var CodeDeployRegions = []string{"westus2", "canadacentral", "northcentralus"}
-
 // ResourceTier defines a preset CPU and memory allocation for container resources.
 type ResourceTier struct {
 	Cpu    string

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -22,7 +22,6 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"strings"
 	"time"
 
@@ -1499,24 +1498,13 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 ) (*deployResult, error) {
 	progress("Deploying hosted agent (code deploy)")
 
-	// Validate that the Foundry project's region supports code deploy.
-	projectLocation := strings.ToLower(strings.TrimSpace(azdEnv["AZURE_LOCATION"]))
-	if projectLocation == "" {
+	// Validate that AZURE_LOCATION is set (region validation is handled server-side;
+	// code deploy is supported in all hosted-agent regions).
+	if strings.TrimSpace(azdEnv["AZURE_LOCATION"]) == "" {
 		return nil, exterrors.Dependency(
 			exterrors.CodeAgentCreateFailed,
 			"AZURE_LOCATION is not set; the Foundry project region is required for code deploy",
 			"run 'azd provision' or 'azd ai agent init' to set the project location",
-		)
-	}
-	if !slices.Contains(CodeDeployRegions, projectLocation) {
-		return nil, exterrors.Dependency(
-			exterrors.CodeAgentCreateFailed,
-			fmt.Sprintf(
-				"code deploy is not supported in region %q; supported regions: %s",
-				azdEnv["AZURE_LOCATION"],
-				strings.Join(CodeDeployRegions, ", "),
-			),
-			"select a Foundry project in a supported region or use container deploy instead",
 		)
 	}
 


### PR DESCRIPTION
Fixes #8427

## Summary

Code deploy is now supported in **all hosted-agent regions** (confirmed by service team). This PR removes the hardcoded 3-region allowlist and unifies code deploy region handling with the existing dynamic hosted-agent region mechanism.

## Background

- Previously, code deploy was gated to only `westus2`, `canadacentral`, `northcentralus` via a hardcoded `CodeDeployRegions` variable in `config.go`
- Service team (Pranav/Santhosh) confirmed: **code deploy is enabled in all regions of hosted agent**
- PR #8398 (`antrikshjain/add-region`) already added `canadaeast` and `germanywestcentral` to the hosted-agent fallback manifest -- but code deploy was still blocked by its own hardcoded list

## Changes

| File | Change |
|------|--------|
| `internal/project/config.go` | Remove `CodeDeployRegions` variable |
| `internal/cmd/init_foundry_resources_helpers.go` | Replace `project.CodeDeployRegions` with `supportedRegionsForInit(ctx)` (dynamic fetch with embedded fallback); propagate context cancellation instead of treating as recoverable |
| `internal/project/service_target_agent.go` | Remove client-side region validation at deploy time (server handles rejection for truly unsupported regions) |

## Behavior After This Change

1. **During `azd ai agent init`** (code deploy mode): Foundry projects are filtered using the same dynamic region list as container deploy
2. **During `azd deploy`**: No client-side region gate -- if a region is somehow unsupported, the server returns a clear error
3. **New regions**: Automatically picked up when `https://aka.ms/azd-ai-agents/regions` is updated (or when the embedded fallback JSON is refreshed)
4. **Context cancellation**: Properly propagated instead of being swallowed as a fetch warning

## Testing

- `go build ./...` -- PASS
- `go test ./internal/project/ ./internal/cmd/` -- PASS (all tests, no regressions)
