### PR TITLE
fix: remove extra shift in --no-telemetry flag parsing in install-azd.sh

### DIFF
--- a/cli/installer/install-azd.sh
+++ b/cli/installer/install-azd.sh
@@ -190,7 +190,6 @@ do
         symlink_folder="$1"
         ;;
     --no-telemetry)
-        shift
         no_telemetry=true
         ;;
     -v|--verbose)

--- a/cli/installer/install-azd.sh
+++ b/cli/installer/install-azd.sh
@@ -24,7 +24,7 @@ save_error_report_if_enabled() {
     collect_telemetry=$(echo "$env_collect_telemetry" | tr "[:upper:]" "[:lower:]")
 
     # If user has opted out of telemetry return immediately
-    if [ "$no_telemetry" = 1 ] || [ "$collect_telemetry" = "no" ]; then
+    if [ "$no_telemetry" = true ] || [ "$collect_telemetry" = "no" ]; then
         say_verbose "Telemetry disabled. No error report data stored."
         return
     fi
@@ -148,7 +148,7 @@ dry_run=false
 skip_verify=false
 symlink_folder="/usr/local/bin"
 install_folder="/opt/microsoft/azd"
-no_telemetry=0
+no_telemetry=false
 verbose=false
 
 while [[ $# -ne 0 ]];
@@ -189,7 +189,7 @@ do
         shift
         symlink_folder="$1"
         ;;
-    --no-telemetry)
+    -t|--no-telemetry)
         no_telemetry=true
         ;;
     -v|--verbose)


### PR DESCRIPTION
## Description

The `--no-telemetry` case branch in `install-azd.sh` had an erroneous `shift` before setting the variable. Since `--no-telemetry` is a boolean flag (no value argument), it should not shift inside its case branch — the loop's trailing `shift` already advances past the flag. The extra shift caused a failure under `set -e` when `--no-telemetry` was the last argument (or in any position without a following argument to consume), as shifting past an empty argument list returns non-zero.

## Fix

Removed the extra `shift` from the `--no-telemetry` case branch, matching the pattern used by other boolean flags (`--dry-run`, `--skip-verify`, `--verbose`).

## Verification

- Reproduced the failure before the fix (`ERROR: Unhandled error`)
- Confirmed the fix works with `--no-telemetry` in any argument position (`--dry-run --no-telemetry` and `--no-telemetry --dry-run`)

Fixes #8311