### PR TITLE
feat: subscription filter commands and prompt integration

### DIFF
--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -184,6 +184,8 @@ $ azd config set defaults.location eastus`,
 		DefaultFormat:  output.NoneFormat,
 	})
 
+	subFilterActions(group)
+
 	return group
 }
 

--- a/cli/azd/cmd/config_sub_filter.go
+++ b/cli/azd/cmd/config_sub_filter.go
@@ -1,0 +1,397 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/azure/azure-dev/cli/azd/cmd/actions"
+	"github.com/azure/azure-dev/cli/azd/pkg/account"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
+	"github.com/azure/azure-dev/cli/azd/pkg/ux"
+	"github.com/spf13/cobra"
+)
+
+// subFilterActions registers the "azd config sub-filter" command group.
+func subFilterActions(
+	configGroup *actions.ActionDescriptor,
+) *actions.ActionDescriptor {
+	group := configGroup.Add("sub-filter", &actions.ActionDescriptorOptions{
+		Command: &cobra.Command{
+			Use:   "sub-filter",
+			Short: "Manage subscription filters for tenant-scoped subscription prompts.",
+			Long: "Manage per-tenant subscription filters that control which " +
+				"subscriptions are shown during interactive prompts.\n" +
+				"Filters are stored locally in your user configuration " +
+				"and apply per-device.",
+		},
+	})
+
+	group.Add("set", &actions.ActionDescriptorOptions{
+		Command: &cobra.Command{
+			Short: "Set a subscription filter for a tenant.",
+			Long: "Select which subscriptions to include when prompted " +
+				"for a subscription under a specific tenant.\n" +
+				"If a filter already exists, the previously selected " +
+				"subscriptions are pre-checked.",
+		},
+		ActionResolver: newSubFilterSetAction,
+	})
+
+	group.Add("remove", &actions.ActionDescriptorOptions{
+		Command: &cobra.Command{
+			Short: "Remove a saved subscription filter for a tenant.",
+			Long: "Remove the subscription filter for a tenant so that " +
+				"all subscriptions are shown during prompts.",
+		},
+		ActionResolver: newSubFilterRemoveAction,
+	})
+
+	return group
+}
+
+// azd config sub-filter set
+
+type subFilterSetAction struct {
+	accountManager    account.Manager
+	userConfigManager config.UserConfigManager
+	console           input.Console
+}
+
+func newSubFilterSetAction(
+	accountManager account.Manager,
+	userConfigManager config.UserConfigManager,
+	console input.Console,
+) actions.Action {
+	return &subFilterSetAction{
+		accountManager:    accountManager,
+		userConfigManager: userConfigManager,
+		console:           console,
+	}
+}
+
+func (a *subFilterSetAction) Run(
+	ctx context.Context,
+) (*actions.ActionResult, error) {
+	// Load subscriptions
+	var subscriptions []account.Subscription
+	loadingSpinner := ux.NewSpinner(&ux.SpinnerOptions{
+		Text: "Loading subscriptions...",
+	})
+
+	err := loadingSpinner.Run(ctx, func(ctx context.Context) error {
+		var loadErr error
+		subscriptions, loadErr = a.accountManager.GetSubscriptions(ctx)
+		return loadErr
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing subscriptions: %w", err)
+	}
+
+	if len(subscriptions) == 0 {
+		return nil, fmt.Errorf("no subscriptions found")
+	}
+
+	// Resolve tenant
+	tenantId, tenantName, err := a.resolveTenant(
+		ctx, subscriptions,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter subscriptions to the selected tenant
+	tenantSubs := prompt.FilterSubscriptionsByTenantId(
+		subscriptions, tenantId,
+	)
+	if len(tenantSubs) == 0 {
+		return nil, fmt.Errorf(
+			"no subscriptions found for tenant %s", tenantId,
+		)
+	}
+
+	// Build options for multi-select
+	hideId := prompt.IsDemoModeEnabled()
+	displayFn := func(sub *account.Subscription) string {
+		return prompt.FormatSubscriptionDisplay(sub, hideId)
+	}
+
+	options := make([]string, len(tenantSubs))
+	for i := range tenantSubs {
+		options[i] = displayFn(&tenantSubs[i])
+	}
+
+	// Load existing filter to pre-check items
+	cfg, err := a.userConfigManager.Load()
+	if err != nil {
+		return nil, fmt.Errorf("loading user config: %w", err)
+	}
+
+	existingFilter, _ := prompt.LoadSubscriptionFilter(cfg, tenantId)
+	preSelected := prompt.SubscriptionsMatchingFilter(
+		tenantSubs, existingFilter, displayFn,
+	)
+
+	// Prompt multi-select
+	selected, err := a.console.MultiSelect(ctx, input.ConsoleOptions{
+		Message:      "Select subscriptions to include in the filter",
+		Options:      options,
+		DefaultValue: preSelected,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("selecting subscriptions: %w", err)
+	}
+
+	if len(selected) == 0 {
+		a.console.Message(
+			ctx,
+			"No subscriptions selected. Filter not updated.",
+		)
+		return nil, nil
+	}
+
+	// Map selected display strings back to subscription IDs
+	selectedIds := subscriptionIdsByDisplayName(
+		tenantSubs, displayFn, selected,
+	)
+
+	// Save filter
+	if err := prompt.SaveSubscriptionFilter(
+		cfg, tenantId, selectedIds,
+	); err != nil {
+		return nil, fmt.Errorf("saving subscription filter: %w", err)
+	}
+
+	if err := a.userConfigManager.Save(cfg); err != nil {
+		return nil, fmt.Errorf("saving user config: %w", err)
+	}
+
+	displayTenant := tenantName
+	if displayTenant == "" {
+		displayTenant = tenantId
+	}
+
+	return &actions.ActionResult{
+		Message: &actions.ResultMessage{
+			Header: fmt.Sprintf(
+				"Saved subscription filter for tenant %s"+
+					" (%d subscription(s))",
+				displayTenant,
+				len(selectedIds),
+			),
+		},
+	}, nil
+}
+
+func (a *subFilterSetAction) resolveTenant(
+	ctx context.Context,
+	subscriptions []account.Subscription,
+) (string, string, error) {
+	tenantNames, err := a.accountManager.GetTenantDisplayNames(ctx)
+	if err != nil {
+		tenantNames = nil
+	}
+
+	tenants := prompt.ExtractUniqueTenants(subscriptions, tenantNames)
+	if len(tenants) == 0 {
+		return "", "", fmt.Errorf("no tenants found")
+	}
+
+	if len(tenants) == 1 {
+		return tenants[0].Id, tenants[0].DisplayName, nil
+	}
+
+	// Build options without "All tenants" — filter must be per-tenant
+	options := make([]string, len(tenants))
+	for i, t := range tenants {
+		options[i] = prompt.FormatTenantDisplay(i+1, t)
+	}
+
+	selectedIndex, err := a.console.Select(ctx, input.ConsoleOptions{
+		Message: "Select a tenant to set a subscription filter for",
+		Options: options,
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("selecting tenant: %w", err)
+	}
+
+	return tenants[selectedIndex].Id,
+		tenants[selectedIndex].DisplayName, nil
+}
+
+// azd config sub-filter remove
+
+type subFilterRemoveAction struct {
+	accountManager    account.Manager
+	userConfigManager config.UserConfigManager
+	console           input.Console
+}
+
+func newSubFilterRemoveAction(
+	accountManager account.Manager,
+	userConfigManager config.UserConfigManager,
+	console input.Console,
+) actions.Action {
+	return &subFilterRemoveAction{
+		accountManager:    accountManager,
+		userConfigManager: userConfigManager,
+		console:           console,
+	}
+}
+
+func (a *subFilterRemoveAction) Run(
+	ctx context.Context,
+) (*actions.ActionResult, error) {
+	// Load subscriptions for tenant resolution
+	var subscriptions []account.Subscription
+	loadingSpinner := ux.NewSpinner(&ux.SpinnerOptions{
+		Text: "Loading subscriptions...",
+	})
+
+	err := loadingSpinner.Run(ctx, func(ctx context.Context) error {
+		var loadErr error
+		subscriptions, loadErr = a.accountManager.GetSubscriptions(ctx)
+		return loadErr
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing subscriptions: %w", err)
+	}
+
+	if len(subscriptions) == 0 {
+		return nil, fmt.Errorf("no subscriptions found")
+	}
+
+	// Resolve tenant
+	tenantId, tenantName, err := a.resolveTenant(
+		ctx, subscriptions,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if filter exists
+	cfg, err := a.userConfigManager.Load()
+	if err != nil {
+		return nil, fmt.Errorf("loading user config: %w", err)
+	}
+
+	_, exists := prompt.LoadSubscriptionFilter(cfg, tenantId)
+	if !exists {
+		displayTenant := tenantName
+		if displayTenant == "" {
+			displayTenant = tenantId
+		}
+		a.console.Message(
+			ctx,
+			fmt.Sprintf(
+				"No saved filter to remove for tenant %s.",
+				displayTenant,
+			),
+		)
+		return nil, nil
+	}
+
+	// Confirm removal
+	displayTenant := tenantName
+	if displayTenant == "" {
+		displayTenant = tenantId
+	}
+
+	confirmed, err := a.console.Confirm(ctx, input.ConsoleOptions{
+		Message: fmt.Sprintf(
+			"Remove subscription filter for tenant %s?",
+			displayTenant,
+		),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("confirming removal: %w", err)
+	}
+
+	if !confirmed {
+		a.console.Message(ctx, "Filter removal cancelled.")
+		return nil, nil
+	}
+
+	// Remove filter
+	if err := prompt.RemoveSubscriptionFilter(cfg, tenantId); err != nil {
+		return nil, fmt.Errorf(
+			"removing subscription filter: %w", err,
+		)
+	}
+
+	if err := a.userConfigManager.Save(cfg); err != nil {
+		return nil, fmt.Errorf("saving user config: %w", err)
+	}
+
+	return &actions.ActionResult{
+		Message: &actions.ResultMessage{
+			Header: fmt.Sprintf(
+				"Removed subscription filter for tenant %s",
+				displayTenant,
+			),
+		},
+	}, nil
+}
+
+func (a *subFilterRemoveAction) resolveTenant(
+	ctx context.Context,
+	subscriptions []account.Subscription,
+) (string, string, error) {
+	tenantNames, err := a.accountManager.GetTenantDisplayNames(ctx)
+	if err != nil {
+		tenantNames = nil
+	}
+
+	tenants := prompt.ExtractUniqueTenants(subscriptions, tenantNames)
+	if len(tenants) == 0 {
+		return "", "", fmt.Errorf("no tenants found")
+	}
+
+	if len(tenants) == 1 {
+		return tenants[0].Id, tenants[0].DisplayName, nil
+	}
+
+	options := make([]string, len(tenants))
+	for i, t := range tenants {
+		options[i] = prompt.FormatTenantDisplay(i+1, t)
+	}
+
+	selectedIndex, err := a.console.Select(ctx, input.ConsoleOptions{
+		Message: "Select a tenant to remove the subscription filter for",
+		Options: options,
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("selecting tenant: %w", err)
+	}
+
+	return tenants[selectedIndex].Id,
+		tenants[selectedIndex].DisplayName, nil
+}
+
+// subscriptionIdsByDisplayName maps selected display strings back
+// to subscription IDs.
+func subscriptionIdsByDisplayName(
+	subscriptions []account.Subscription,
+	displayFn func(*account.Subscription) string,
+	selected []string,
+) []string {
+	optToId := make(map[string]string, len(subscriptions))
+	for i := range subscriptions {
+		optToId[displayFn(&subscriptions[i])] = subscriptions[i].Id
+	}
+
+	ids := make([]string, 0, len(selected))
+	for _, opt := range selected {
+		if id, ok := optToId[opt]; ok {
+			ids = append(ids, id)
+		}
+	}
+
+	slices.Sort(ids)
+	return ids
+}

--- a/cli/azd/cmd/config_sub_filter.go
+++ b/cli/azd/cmd/config_sub_filter.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
@@ -115,15 +116,24 @@ func (a *subFilterSetAction) Run(
 		)
 	}
 
-	// Build options for multi-select
+	// Build options for multi-select with unique index prefixes
+	// to avoid ambiguity when display names collide (e.g. demo mode).
 	hideId := prompt.IsDemoModeEnabled()
-	displayFn := func(sub *account.Subscription) string {
-		return prompt.FormatSubscriptionDisplay(sub, hideId)
-	}
 
 	options := make([]string, len(tenantSubs))
 	for i := range tenantSubs {
-		options[i] = displayFn(&tenantSubs[i])
+		label := prompt.FormatSubscriptionDisplay(
+			&tenantSubs[i], hideId,
+		)
+		options[i] = fmt.Sprintf("%d. %s", i+1, label)
+	}
+
+	// displayFn must match the indexed option format for preSelected matching
+	indexedDisplayFn := func(
+		sub *account.Subscription, idx int,
+	) string {
+		label := prompt.FormatSubscriptionDisplay(sub, hideId)
+		return fmt.Sprintf("%d. %s", idx+1, label)
 	}
 
 	// Load existing filter to pre-check items
@@ -133,9 +143,23 @@ func (a *subFilterSetAction) Run(
 	}
 
 	existingFilter, _ := prompt.LoadSubscriptionFilter(cfg, tenantId)
-	preSelected := prompt.SubscriptionsMatchingFilter(
-		tenantSubs, existingFilter, displayFn,
-	)
+
+	// Build preSelected with indexed labels
+	var preSelected []string
+	if len(existingFilter) > 0 {
+		filterSet := make(map[string]bool, len(existingFilter))
+		for _, id := range existingFilter {
+			filterSet[strings.ToLower(id)] = true
+		}
+		for i := range tenantSubs {
+			if filterSet[strings.ToLower(tenantSubs[i].Id)] {
+				preSelected = append(
+					preSelected,
+					indexedDisplayFn(&tenantSubs[i], i),
+				)
+			}
+		}
+	}
 
 	// Prompt multi-select
 	selected, err := a.console.MultiSelect(ctx, input.ConsoleOptions{
@@ -155,21 +179,17 @@ func (a *subFilterSetAction) Run(
 		return nil, nil
 	}
 
-	// Map selected display strings back to subscription IDs.
-	// Use a set for O(1) lookup; this handles duplicate display
-	// labels (e.g. demo-mode collisions) by matching all subs
-	// whose display string was selected.
-	selectedSet := make(map[string]bool, len(selected))
-	for _, s := range selected {
-		selectedSet[s] = true
+	// Map selected indexed options back to subscription IDs.
+	// Each option string is unique due to the index prefix.
+	optionToId := make(map[string]string, len(tenantSubs))
+	for i := range tenantSubs {
+		optionToId[options[i]] = tenantSubs[i].Id
 	}
 
 	selectedIds := make([]string, 0, len(selected))
-	for i := range tenantSubs {
-		if selectedSet[displayFn(&tenantSubs[i])] {
-			selectedIds = append(
-				selectedIds, tenantSubs[i].Id,
-			)
+	for _, opt := range selected {
+		if id, ok := optionToId[opt]; ok {
+			selectedIds = append(selectedIds, id)
 		}
 	}
 	slices.Sort(selectedIds)

--- a/cli/azd/cmd/config_sub_filter.go
+++ b/cli/azd/cmd/config_sub_filter.go
@@ -80,6 +80,13 @@ func newSubFilterSetAction(
 func (a *subFilterSetAction) Run(
 	ctx context.Context,
 ) (*actions.ActionResult, error) {
+	if a.console.IsNoPromptMode() {
+		return nil, fmt.Errorf(
+			"subscription filter set requires interactive mode" +
+				" (cannot run with --no-prompt)",
+		)
+	}
+
 	// Load subscriptions
 	var subscriptions []account.Subscription
 	loadingSpinner := ux.NewSpinner(&ux.SpinnerOptions{
@@ -269,6 +276,13 @@ func newSubFilterRemoveAction(
 func (a *subFilterRemoveAction) Run(
 	ctx context.Context,
 ) (*actions.ActionResult, error) {
+	if a.console.IsNoPromptMode() {
+		return nil, fmt.Errorf(
+			"subscription filter remove requires interactive mode" +
+				" (cannot run with --no-prompt)",
+		)
+	}
+
 	// Load subscriptions for tenant resolution
 	var subscriptions []account.Subscription
 	loadingSpinner := ux.NewSpinner(&ux.SpinnerOptions{

--- a/cli/azd/cmd/config_sub_filter.go
+++ b/cli/azd/cmd/config_sub_filter.go
@@ -155,10 +155,24 @@ func (a *subFilterSetAction) Run(
 		return nil, nil
 	}
 
-	// Map selected display strings back to subscription IDs
-	selectedIds := subscriptionIdsByDisplayName(
-		tenantSubs, displayFn, selected,
-	)
+	// Map selected display strings back to subscription IDs.
+	// Use a set for O(1) lookup; this handles duplicate display
+	// labels (e.g. demo-mode collisions) by matching all subs
+	// whose display string was selected.
+	selectedSet := make(map[string]bool, len(selected))
+	for _, s := range selected {
+		selectedSet[s] = true
+	}
+
+	selectedIds := make([]string, 0, len(selected))
+	for i := range tenantSubs {
+		if selectedSet[displayFn(&tenantSubs[i])] {
+			selectedIds = append(
+				selectedIds, tenantSubs[i].Id,
+			)
+		}
+	}
+	slices.Sort(selectedIds)
 
 	// Save filter
 	if err := prompt.SaveSubscriptionFilter(
@@ -371,27 +385,4 @@ func (a *subFilterRemoveAction) resolveTenant(
 
 	return tenants[selectedIndex].Id,
 		tenants[selectedIndex].DisplayName, nil
-}
-
-// subscriptionIdsByDisplayName maps selected display strings back
-// to subscription IDs.
-func subscriptionIdsByDisplayName(
-	subscriptions []account.Subscription,
-	displayFn func(*account.Subscription) string,
-	selected []string,
-) []string {
-	optToId := make(map[string]string, len(subscriptions))
-	for i := range subscriptions {
-		optToId[displayFn(&subscriptions[i])] = subscriptions[i].Id
-	}
-
-	ids := make([]string, 0, len(selected))
-	for _, opt := range selected {
-		if id, ok := optToId[opt]; ok {
-			ids = append(ids, id)
-		}
-	}
-
-	slices.Sort(ids)
-	return ids
 }

--- a/cli/azd/cmd/config_sub_filter.go
+++ b/cli/azd/cmd/config_sub_filter.go
@@ -210,13 +210,19 @@ func (a *subFilterSetAction) Run(
 		displayTenant = tenantId
 	}
 
+	subWord := "subscription"
+	if len(selectedIds) != 1 {
+		subWord = "subscriptions"
+	}
+
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
 			Header: fmt.Sprintf(
 				"Saved subscription filter for tenant %s"+
-					" (%d subscription(s))",
+					" (%d %s)",
 				displayTenant,
 				len(selectedIds),
+				subWord,
 			),
 		},
 	}, nil

--- a/cli/azd/cmd/config_sub_filter.go
+++ b/cli/azd/cmd/config_sub_filter.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
@@ -115,6 +116,13 @@ func (a *subFilterSetAction) Run(
 			"no subscriptions found for tenant %s", tenantId,
 		)
 	}
+
+	// Sort subscriptions by name for a stable, scannable list
+	slices.SortFunc(tenantSubs, func(a, b account.Subscription) int {
+		return cmp.Compare(
+			strings.ToLower(a.Name), strings.ToLower(b.Name),
+		)
+	})
 
 	// Build options for multi-select with unique index prefixes
 	// to avoid ambiguity when display names collide (e.g. demo mode).
@@ -232,12 +240,9 @@ func (a *subFilterSetAction) resolveTenant(
 	ctx context.Context,
 	subscriptions []account.Subscription,
 ) (string, string, error) {
-	tenantNames, err := a.accountManager.GetTenantDisplayNames(ctx)
-	if err != nil {
-		tenantNames = nil
-	}
-
-	tenants := prompt.ExtractUniqueTenants(subscriptions, tenantNames)
+	// Extract tenants without display names first to avoid an unnecessary
+	// API call when only a single tenant exists.
+	tenants := prompt.ExtractUniqueTenants(subscriptions, nil)
 	if len(tenants) == 0 {
 		return "", "", fmt.Errorf("no tenants found")
 	}
@@ -245,6 +250,14 @@ func (a *subFilterSetAction) resolveTenant(
 	if len(tenants) == 1 {
 		return tenants[0].Id, tenants[0].DisplayName, nil
 	}
+
+	// Multiple tenants — fetch display names for the prompt
+	tenantNames, err := a.accountManager.GetTenantDisplayNames(ctx)
+	if err != nil {
+		tenantNames = nil
+	}
+
+	tenants = prompt.ExtractUniqueTenants(subscriptions, tenantNames)
 
 	// Build options without "All tenants" — filter must be per-tenant
 	options := make([]string, len(tenants))
@@ -382,12 +395,9 @@ func (a *subFilterRemoveAction) resolveTenant(
 	ctx context.Context,
 	subscriptions []account.Subscription,
 ) (string, string, error) {
-	tenantNames, err := a.accountManager.GetTenantDisplayNames(ctx)
-	if err != nil {
-		tenantNames = nil
-	}
-
-	tenants := prompt.ExtractUniqueTenants(subscriptions, tenantNames)
+	// Extract tenants without display names first to avoid an unnecessary
+	// API call when only a single tenant exists.
+	tenants := prompt.ExtractUniqueTenants(subscriptions, nil)
 	if len(tenants) == 0 {
 		return "", "", fmt.Errorf("no tenants found")
 	}
@@ -395,6 +405,14 @@ func (a *subFilterRemoveAction) resolveTenant(
 	if len(tenants) == 1 {
 		return tenants[0].Id, tenants[0].DisplayName, nil
 	}
+
+	// Multiple tenants — fetch display names for the prompt
+	tenantNames, err := a.accountManager.GetTenantDisplayNames(ctx)
+	if err != nil {
+		tenantNames = nil
+	}
+
+	tenants = prompt.ExtractUniqueTenants(subscriptions, tenantNames)
 
 	options := make([]string, len(tenants))
 	for i, t := range tenants {

--- a/cli/azd/cmd/config_sub_filter.go
+++ b/cli/azd/cmd/config_sub_filter.go
@@ -240,41 +240,10 @@ func (a *subFilterSetAction) resolveTenant(
 	ctx context.Context,
 	subscriptions []account.Subscription,
 ) (string, string, error) {
-	// Extract tenants without display names first to avoid an unnecessary
-	// API call when only a single tenant exists.
-	tenants := prompt.ExtractUniqueTenants(subscriptions, nil)
-	if len(tenants) == 0 {
-		return "", "", fmt.Errorf("no tenants found")
-	}
-
-	if len(tenants) == 1 {
-		return tenants[0].Id, tenants[0].DisplayName, nil
-	}
-
-	// Multiple tenants — fetch display names for the prompt
-	tenantNames, err := a.accountManager.GetTenantDisplayNames(ctx)
-	if err != nil {
-		tenantNames = nil
-	}
-
-	tenants = prompt.ExtractUniqueTenants(subscriptions, tenantNames)
-
-	// Build options without "All tenants" — filter must be per-tenant
-	options := make([]string, len(tenants))
-	for i, t := range tenants {
-		options[i] = prompt.FormatTenantDisplay(i+1, t)
-	}
-
-	selectedIndex, err := a.console.Select(ctx, input.ConsoleOptions{
-		Message: "Select a tenant to set a subscription filter for",
-		Options: options,
-	})
-	if err != nil {
-		return "", "", fmt.Errorf("selecting tenant: %w", err)
-	}
-
-	return tenants[selectedIndex].Id,
-		tenants[selectedIndex].DisplayName, nil
+	return resolveTenantForFilter(
+		ctx, subscriptions, a.console, a.accountManager,
+		"Select a tenant to set a subscription filter for",
+	)
 }
 
 // azd config sub-filter remove
@@ -395,6 +364,22 @@ func (a *subFilterRemoveAction) resolveTenant(
 	ctx context.Context,
 	subscriptions []account.Subscription,
 ) (string, string, error) {
+	return resolveTenantForFilter(
+		ctx, subscriptions, a.console, a.accountManager,
+		"Select a tenant to remove the subscription filter for",
+	)
+}
+
+// resolveTenantForFilter resolves the tenant to use for a sub-filter
+// operation. If only one tenant exists, it is returned directly without
+// an API call for display names. Otherwise the user is prompted.
+func resolveTenantForFilter(
+	ctx context.Context,
+	subscriptions []account.Subscription,
+	console input.Console,
+	accountManager account.Manager,
+	promptMessage string,
+) (string, string, error) {
 	// Extract tenants without display names first to avoid an unnecessary
 	// API call when only a single tenant exists.
 	tenants := prompt.ExtractUniqueTenants(subscriptions, nil)
@@ -407,7 +392,7 @@ func (a *subFilterRemoveAction) resolveTenant(
 	}
 
 	// Multiple tenants — fetch display names for the prompt
-	tenantNames, err := a.accountManager.GetTenantDisplayNames(ctx)
+	tenantNames, err := accountManager.GetTenantDisplayNames(ctx)
 	if err != nil {
 		tenantNames = nil
 	}
@@ -419,8 +404,8 @@ func (a *subFilterRemoveAction) resolveTenant(
 		options[i] = prompt.FormatTenantDisplay(i+1, t)
 	}
 
-	selectedIndex, err := a.console.Select(ctx, input.ConsoleOptions{
-		Message: "Select a tenant to remove the subscription filter for",
+	selectedIndex, err := console.Select(ctx, input.ConsoleOptions{
+		Message: promptMessage,
 		Options: options,
 	})
 	if err != nil {

--- a/cli/azd/cmd/config_sub_filter.go
+++ b/cli/azd/cmd/config_sub_filter.go
@@ -7,6 +7,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 
@@ -90,7 +91,8 @@ func (a *subFilterSetAction) Run(
 	// Load subscriptions
 	var subscriptions []account.Subscription
 	loadingSpinner := ux.NewSpinner(&ux.SpinnerOptions{
-		Text: "Loading subscriptions...",
+		Text:   "Loading subscriptions...",
+		Writer: spinnerWriter(a.console),
 	})
 
 	err := loadingSpinner.Run(ctx, func(ctx context.Context) error {
@@ -286,7 +288,8 @@ func (a *subFilterRemoveAction) Run(
 	// Load subscriptions for tenant resolution
 	var subscriptions []account.Subscription
 	loadingSpinner := ux.NewSpinner(&ux.SpinnerOptions{
-		Text: "Loading subscriptions...",
+		Text:   "Loading subscriptions...",
+		Writer: spinnerWriter(a.console),
 	})
 
 	err := loadingSpinner.Run(ctx, func(ctx context.Context) error {
@@ -428,4 +431,13 @@ func resolveTenantForFilter(
 
 	return tenants[selectedIndex].Id,
 		tenants[selectedIndex].DisplayName, nil
+}
+
+// spinnerWriter returns the console's writer for spinner output,
+// falling back to io.Discard when nil (e.g. in tests).
+func spinnerWriter(console input.Console) io.Writer {
+	if w := console.GetWriter(); w != nil {
+		return w
+	}
+	return io.Discard
 }

--- a/cli/azd/cmd/config_sub_filter.go
+++ b/cli/azd/cmd/config_sub_filter.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
+	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -83,8 +84,8 @@ func (a *subFilterSetAction) Run(
 ) (*actions.ActionResult, error) {
 	if a.console.IsNoPromptMode() {
 		return nil, fmt.Errorf(
-			"subscription filter set requires interactive mode" +
-				" (cannot run with --no-prompt)",
+			"subscription filter set requires interactive mode (cannot run with --no-prompt): %w",
+			internal.ErrInteractiveRequired,
 		)
 	}
 
@@ -105,7 +106,10 @@ func (a *subFilterSetAction) Run(
 	}
 
 	if len(subscriptions) == 0 {
-		return nil, fmt.Errorf("no subscriptions found")
+		return nil, fmt.Errorf(
+			"no subscriptions found: %w",
+			internal.ErrNoSubscriptionsFound,
+		)
 	}
 
 	// Resolve tenant
@@ -122,7 +126,8 @@ func (a *subFilterSetAction) Run(
 	)
 	if len(tenantSubs) == 0 {
 		return nil, fmt.Errorf(
-			"no subscriptions found for tenant %s", tenantId,
+			"no subscriptions found for tenant %s: %w",
+			tenantId, internal.ErrNoSubscriptionsFound,
 		)
 	}
 
@@ -280,8 +285,8 @@ func (a *subFilterRemoveAction) Run(
 ) (*actions.ActionResult, error) {
 	if a.console.IsNoPromptMode() {
 		return nil, fmt.Errorf(
-			"subscription filter remove requires interactive mode" +
-				" (cannot run with --no-prompt)",
+			"subscription filter remove requires interactive mode (cannot run with --no-prompt): %w",
+			internal.ErrInteractiveRequired,
 		)
 	}
 
@@ -302,7 +307,10 @@ func (a *subFilterRemoveAction) Run(
 	}
 
 	if len(subscriptions) == 0 {
-		return nil, fmt.Errorf("no subscriptions found")
+		return nil, fmt.Errorf(
+			"no subscriptions found: %w",
+			internal.ErrNoSubscriptionsFound,
+		)
 	}
 
 	// Resolve tenant
@@ -401,7 +409,9 @@ func resolveTenantForFilter(
 	// API call when only a single tenant exists.
 	tenants := prompt.ExtractUniqueTenants(subscriptions, nil)
 	if len(tenants) == 0 {
-		return "", "", fmt.Errorf("no tenants found")
+		return "", "", fmt.Errorf(
+			"no tenants found: %w", internal.ErrNoTenantsFound,
+		)
 	}
 
 	if len(tenants) == 1 {

--- a/cli/azd/cmd/config_sub_filter_test.go
+++ b/cli/azd/cmd/config_sub_filter_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/account"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockaccount"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubFilterSetAction_SingleTenant_SavesFilter(t *testing.T) {
+	mockConsole := mockinput.NewMockConsole()
+	ucm := newTestUserConfigManager(t)
+
+	mockAccount := &mockaccount.MockAccountManager{
+		Subscriptions: []account.Subscription{
+			{Id: "sub-1", Name: "Alpha", TenantId: "t1", UserAccessTenantId: "t1"},
+			{Id: "sub-2", Name: "Bravo", TenantId: "t1", UserAccessTenantId: "t1"},
+		},
+	}
+
+	action := &subFilterSetAction{
+		accountManager:    mockAccount,
+		userConfigManager: ucm,
+		console:           mockConsole,
+	}
+
+	// Register MultiSelect response — pick the first option by label
+	mockConsole.WhenMultiSelect(func(opts input.ConsoleOptions) bool {
+		return strings.Contains(opts.Message, "subscription")
+	}).RespondFn(func(opts input.ConsoleOptions) (any, error) {
+		if len(opts.Options) > 0 {
+			return []string{opts.Options[0]}, nil
+		}
+		return []string{}, nil
+	})
+
+	result, err := action.Run(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Contains(t, result.Message.Header, "Saved subscription filter")
+
+	// Verify filter was persisted
+	cfg, err := ucm.Load()
+	require.NoError(t, err)
+	ids, exists := prompt.LoadSubscriptionFilter(cfg, "t1")
+	require.True(t, exists)
+	require.Len(t, ids, 1)
+}
+
+func TestSubFilterSetAction_EmptySelection_NoOp(t *testing.T) {
+	mockConsole := mockinput.NewMockConsole()
+	ucm := newTestUserConfigManager(t)
+
+	mockAccount := &mockaccount.MockAccountManager{
+		Subscriptions: []account.Subscription{
+			{Id: "sub-1", Name: "Alpha", TenantId: "t1", UserAccessTenantId: "t1"},
+		},
+	}
+
+	action := &subFilterSetAction{
+		accountManager:    mockAccount,
+		userConfigManager: ucm,
+		console:           mockConsole,
+	}
+
+	// Register MultiSelect response — empty selection
+	mockConsole.WhenMultiSelect(func(opts input.ConsoleOptions) bool {
+		return true
+	}).Respond([]string{})
+
+	result, err := action.Run(t.Context())
+	require.NoError(t, err)
+	require.Nil(t, result)
+
+	// Verify no filter was saved
+	cfg, err := ucm.Load()
+	require.NoError(t, err)
+	_, exists := prompt.LoadSubscriptionFilter(cfg, "t1")
+	require.False(t, exists)
+}
+
+func TestSubFilterRemoveAction_NoExistingFilter_NoOp(t *testing.T) {
+	mockConsole := mockinput.NewMockConsole()
+	ucm := newTestUserConfigManager(t)
+
+	mockAccount := &mockaccount.MockAccountManager{
+		Subscriptions: []account.Subscription{
+			{Id: "sub-1", Name: "Alpha", TenantId: "t1", UserAccessTenantId: "t1"},
+		},
+	}
+
+	action := &subFilterRemoveAction{
+		accountManager:    mockAccount,
+		userConfigManager: ucm,
+		console:           mockConsole,
+	}
+
+	result, err := action.Run(t.Context())
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+func TestSubFilterRemoveAction_ConfirmedRemoval(t *testing.T) {
+	mockConsole := mockinput.NewMockConsole()
+	ucm := newTestUserConfigManager(t)
+
+	// Pre-save a filter
+	cfg, err := ucm.Load()
+	require.NoError(t, err)
+	err = prompt.SaveSubscriptionFilter(cfg, "t1", []string{"sub-1"})
+	require.NoError(t, err)
+	err = ucm.Save(cfg)
+	require.NoError(t, err)
+
+	mockAccount := &mockaccount.MockAccountManager{
+		Subscriptions: []account.Subscription{
+			{Id: "sub-1", Name: "Alpha", TenantId: "t1", UserAccessTenantId: "t1"},
+		},
+	}
+
+	action := &subFilterRemoveAction{
+		accountManager:    mockAccount,
+		userConfigManager: ucm,
+		console:           mockConsole,
+	}
+
+	// Confirm removal
+	mockConsole.WhenConfirm(func(opts input.ConsoleOptions) bool {
+		return strings.Contains(opts.Message, "Remove subscription filter")
+	}).Respond(true)
+
+	result, err := action.Run(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Contains(t, result.Message.Header, "Removed subscription filter")
+
+	// Verify filter was removed
+	cfg, err = ucm.Load()
+	require.NoError(t, err)
+	_, exists := prompt.LoadSubscriptionFilter(cfg, "t1")
+	require.False(t, exists)
+}
+
+func TestSubFilterRemoveAction_CancelledRemoval(t *testing.T) {
+	mockConsole := mockinput.NewMockConsole()
+	ucm := newTestUserConfigManager(t)
+
+	// Pre-save a filter
+	cfg, err := ucm.Load()
+	require.NoError(t, err)
+	err = prompt.SaveSubscriptionFilter(cfg, "t1", []string{"sub-1"})
+	require.NoError(t, err)
+	err = ucm.Save(cfg)
+	require.NoError(t, err)
+
+	mockAccount := &mockaccount.MockAccountManager{
+		Subscriptions: []account.Subscription{
+			{Id: "sub-1", Name: "Alpha", TenantId: "t1", UserAccessTenantId: "t1"},
+		},
+	}
+
+	action := &subFilterRemoveAction{
+		accountManager:    mockAccount,
+		userConfigManager: ucm,
+		console:           mockConsole,
+	}
+
+	// Decline removal
+	mockConsole.WhenConfirm(func(opts input.ConsoleOptions) bool {
+		return true
+	}).Respond(false)
+
+	result, err := action.Run(t.Context())
+	require.NoError(t, err)
+	require.Nil(t, result)
+
+	// Verify filter is still there
+	cfg, err = ucm.Load()
+	require.NoError(t, err)
+	ids, exists := prompt.LoadSubscriptionFilter(cfg, "t1")
+	require.True(t, exists)
+	require.Equal(t, []string{"sub-1"}, ids)
+}

--- a/cli/azd/cmd/config_sub_filter_test.go
+++ b/cli/azd/cmd/config_sub_filter_test.go
@@ -189,3 +189,109 @@ func TestSubFilterRemoveAction_CancelledRemoval(t *testing.T) {
 	require.True(t, exists)
 	require.Equal(t, []string{"sub-1"}, ids)
 }
+
+func TestSubFilterSetAction_MultiTenant_SavesFilterForSelectedTenant(
+	t *testing.T,
+) {
+	mockConsole := mockinput.NewMockConsole()
+	ucm := newTestUserConfigManager(t)
+
+	mockAccount := &mockaccount.MockAccountManager{
+		Subscriptions: []account.Subscription{
+			{Id: "sub-1", Name: "Alpha", TenantId: "t1", UserAccessTenantId: "t1"},
+			{Id: "sub-2", Name: "Bravo", TenantId: "t2", UserAccessTenantId: "t2"},
+			{Id: "sub-3", Name: "Charlie", TenantId: "t2", UserAccessTenantId: "t2"},
+		},
+	}
+
+	action := &subFilterSetAction{
+		accountManager:    mockAccount,
+		userConfigManager: ucm,
+		console:           mockConsole,
+	}
+
+	// Select second tenant (index 1)
+	mockConsole.WhenSelect(func(opts input.ConsoleOptions) bool {
+		return strings.Contains(opts.Message, "tenant")
+	}).Respond(1)
+
+	// Pick the first subscription from tenant t2
+	mockConsole.WhenMultiSelect(func(opts input.ConsoleOptions) bool {
+		return strings.Contains(opts.Message, "subscription")
+	}).RespondFn(func(opts input.ConsoleOptions) (any, error) {
+		if len(opts.Options) > 0 {
+			return []string{opts.Options[0]}, nil
+		}
+		return []string{}, nil
+	})
+
+	result, err := action.Run(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Contains(t, result.Message.Header, "Saved subscription filter")
+
+	// Verify filter was saved under t2
+	cfg, err := ucm.Load()
+	require.NoError(t, err)
+	ids, exists := prompt.LoadSubscriptionFilter(cfg, "t2")
+	require.True(t, exists)
+	require.Len(t, ids, 1)
+
+	// Verify no filter saved under t1
+	_, exists = prompt.LoadSubscriptionFilter(cfg, "t1")
+	require.False(t, exists)
+}
+
+func TestSubFilterRemoveAction_MultiTenant_RemovesCorrectTenant(
+	t *testing.T,
+) {
+	mockConsole := mockinput.NewMockConsole()
+	ucm := newTestUserConfigManager(t)
+
+	// Pre-save filters for both tenants
+	cfg, err := ucm.Load()
+	require.NoError(t, err)
+	err = prompt.SaveSubscriptionFilter(cfg, "t1", []string{"sub-1"})
+	require.NoError(t, err)
+	err = prompt.SaveSubscriptionFilter(cfg, "t2", []string{"sub-2"})
+	require.NoError(t, err)
+	err = ucm.Save(cfg)
+	require.NoError(t, err)
+
+	mockAccount := &mockaccount.MockAccountManager{
+		Subscriptions: []account.Subscription{
+			{Id: "sub-1", Name: "Alpha", TenantId: "t1", UserAccessTenantId: "t1"},
+			{Id: "sub-2", Name: "Bravo", TenantId: "t2", UserAccessTenantId: "t2"},
+		},
+	}
+
+	action := &subFilterRemoveAction{
+		accountManager:    mockAccount,
+		userConfigManager: ucm,
+		console:           mockConsole,
+	}
+
+	// Select second tenant (index 1)
+	mockConsole.WhenSelect(func(opts input.ConsoleOptions) bool {
+		return strings.Contains(opts.Message, "tenant")
+	}).Respond(1)
+
+	// Confirm removal
+	mockConsole.WhenConfirm(func(opts input.ConsoleOptions) bool {
+		return strings.Contains(opts.Message, "Remove subscription filter")
+	}).Respond(true)
+
+	result, err := action.Run(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Contains(t, result.Message.Header, "Removed subscription filter")
+
+	// Verify t2 filter removed, t1 still exists
+	cfg, err = ucm.Load()
+	require.NoError(t, err)
+	_, exists := prompt.LoadSubscriptionFilter(cfg, "t2")
+	require.False(t, exists)
+	ids, exists := prompt.LoadSubscriptionFilter(cfg, "t1")
+	require.True(t, exists)
+	require.Equal(t, []string{"sub-1"}, ids)
+}

--- a/cli/azd/cmd/testdata/TestFigSpec.ts
+++ b/cli/azd/cmd/testdata/TestFigSpec.ts
@@ -223,12 +223,47 @@ const completionSpec: Fig.Spec = {
 					description: 'Ship agents with Microsoft Foundry from your terminal. (Preview)',
 					subcommands: [
 						{
-							name: ['doctor'],
-							description: 'Diagnose problems with an azd ai agent project.',
+							name: ['code'],
+							description: 'Manage agent source code. (Preview)',
+							subcommands: [
+								{
+									name: ['download'],
+									description: 'Download agent source code from Foundry. (Preview)',
+									options: [
+										{
+											name: ['--dest', '-d'],
+											description: 'Destination path (default: ./<agent-name>/ or ./<agent-name>.zip)',
+											args: [
+												{
+													name: 'dest',
+												},
+											],
+										},
+										{
+											name: ['--version', '-v'],
+											description: 'Agent version to download (default: latest)',
+											args: [
+												{
+													name: 'version',
+												},
+											],
+										},
+										{
+											name: ['--zip'],
+											description: 'Save as zip file instead of extracting',
+										},
+									],
+								},
+							],
+						},
+						{
+							name: ['delete'],
+							description: 'Delete a hosted agent.',
 							options: [
 								{
-									name: ['--local-only'],
-									description: 'Skip remote (network-dependent) checks. Useful when offline, behind a proxy, or for a fast local triage.',
+									name: ['--force'],
+									description: 'Force deletion even if the agent has active sessions',
+									isDangerous: true,
 								},
 								{
 									name: ['--output', '-o'],
@@ -236,8 +271,28 @@ const completionSpec: Fig.Spec = {
 									args: [
 										{
 											name: 'output',
+											suggestions: ['json', 'none'],
 										},
 									],
+								},
+								{
+									name: ['--version'],
+									description: 'Delete a specific version only (the agent itself remains)',
+									args: [
+										{
+											name: 'version',
+										},
+									],
+								},
+							],
+						},
+						{
+							name: ['doctor'],
+							description: 'Diagnose problems with an azd ai agent project.',
+							options: [
+								{
+									name: ['--local-only'],
+									description: 'Skip remote (network-dependent) checks. Useful when offline, behind a proxy, or for a fast local triage.',
 								},
 								{
 									name: ['--unredacted'],
@@ -250,8 +305,8 @@ const completionSpec: Fig.Spec = {
 							description: 'Manage agent endpoint and card configuration.',
 							subcommands: [
 								{
-									name: ['update'],
-									description: 'Update an agent\'s endpoint and card configuration without deploying a new version.',
+									name: ['show'],
+									description: 'Show the current endpoint and card configuration of an agent.',
 									options: [
 										{
 											name: ['--output', '-o'],
@@ -259,19 +314,20 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'output',
+													suggestions: ['json', 'table'],
 												},
 											],
 										},
 									],
 								},
-							],
-							options: [
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
+									name: ['update'],
+									description: 'Update an agent\'s endpoint and card configuration without deploying a new version.',
+									options: [
 										{
-											name: 'output',
+											name: ['--force'],
+											description: 'Skip confirmation prompts for breaking changes',
+											isDangerous: true,
 										},
 									],
 								},
@@ -282,7 +338,7 @@ const completionSpec: Fig.Spec = {
 							description: 'Create and run quick evals for an agent.',
 							subcommands: [
 								{
-									name: ['init'],
+									name: ['generate'],
 									description: 'Generate a local eval suite for a deployed agent.',
 									options: [
 										{
@@ -372,15 +428,6 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
-										{
 											name: ['--project-endpoint', '-p'],
 											description: 'Microsoft Foundry project endpoint URL',
 											args: [
@@ -417,15 +464,6 @@ const completionSpec: Fig.Spec = {
 												},
 											],
 										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
 									],
 								},
 								{
@@ -453,15 +491,6 @@ const completionSpec: Fig.Spec = {
 										{
 											name: ['--no-wait'],
 											description: 'Start the run and return immediately without waiting for results',
-										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
 										},
 									],
 								},
@@ -496,15 +525,6 @@ const completionSpec: Fig.Spec = {
 												},
 											],
 										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
 									],
 								},
 								{
@@ -527,26 +547,6 @@ const completionSpec: Fig.Spec = {
 										{
 											name: ['--evaluator-only'],
 											description: 'Only update evaluators',
-										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
-									],
-								},
-							],
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
 										},
 									],
 								},
@@ -584,15 +584,6 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'file',
-												},
-											],
-										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
 												},
 											],
 										},
@@ -648,15 +639,6 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'file',
-												},
-											],
-										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
 												},
 											],
 										},
@@ -773,15 +755,6 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
-										{
 											name: ['--session-id', '-s'],
 											description: 'Session ID override (defaults to last invoke session)',
 											args: [
@@ -885,15 +858,6 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
-										{
 											name: ['--session-id', '-s'],
 											description: 'Session ID override (defaults to last invoke session)',
 											args: [
@@ -919,17 +883,6 @@ const completionSpec: Fig.Spec = {
 													name: 'user-isolation-key',
 												},
 											],
-										},
-									],
-								},
-							],
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
 										},
 									],
 								},
@@ -1004,15 +957,6 @@ const completionSpec: Fig.Spec = {
 									args: [
 										{
 											name: 'model-deployment',
-										},
-									],
-								},
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
 										},
 									],
 								},
@@ -1191,15 +1135,6 @@ const completionSpec: Fig.Spec = {
 									description: 'Stream logs in real-time',
 								},
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--raw'],
 									description: 'Print the raw SSE stream without formatting',
 								},
@@ -1281,15 +1216,6 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
-										{
 											name: ['--project-endpoint', '-p'],
 											description: 'Foundry project endpoint URL',
 											args: [
@@ -1310,15 +1236,6 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'endpoint',
-												},
-											],
-										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
 												},
 											],
 										},
@@ -1365,15 +1282,6 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
-										{
 											name: ['--project-endpoint', '-p'],
 											description: 'Foundry project endpoint URL',
 											args: [
@@ -1407,15 +1315,6 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
-												},
-											],
-										},
-										{
 											name: ['--project-endpoint', '-p'],
 											description: 'Foundry project endpoint URL',
 											args: [
@@ -1445,15 +1344,6 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'endpoint',
-												},
-											],
-										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
 												},
 											],
 										},
@@ -1529,11 +1419,21 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 								{
-									name: ['--max-iterations'],
-									description: 'Maximum number of optimization iterations (must be >= 1; default: 5)',
+									name: ['--evaluator'],
+									description: 'Built-in or custom evaluator name (repeatable; required when not set in config)',
+									isRepeatable: true,
 									args: [
 										{
-											name: 'max-iterations',
+											name: 'evaluator',
+										},
+									],
+								},
+								{
+									name: ['--max-candidates'],
+									description: 'Maximum number of optimization candidates to generate (must be >= 1; default: 5)',
+									args: [
+										{
+											name: 'max-candidates',
 										},
 									],
 								},
@@ -1543,19 +1443,10 @@ const completionSpec: Fig.Spec = {
 								},
 								{
 									name: ['--optimize-model'],
-									description: 'Model for optimization reasoning (gpt-5 family recommended; falls back to eval model when not set)',
+									description: 'Model for optimization reasoning (gpt-5 family recommended; required)',
 									args: [
 										{
 											name: 'optimize-model',
-										},
-									],
-								},
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
 										},
 									],
 								},
@@ -1586,15 +1477,6 @@ const completionSpec: Fig.Spec = {
 								{
 									name: ['--no-inspector'],
 									description: 'Do not open Agent Inspector',
-								},
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
 								},
 								{
 									name: ['--port', '-p'],
@@ -1655,17 +1537,6 @@ const completionSpec: Fig.Spec = {
 													name: 'type',
 												},
 											],
-										},
-									],
-								},
-							],
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
 										},
 									],
 								},
@@ -1773,15 +1644,6 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'isolation-key',
-												},
-											],
-										},
-										{
-											name: ['--output', '-o'],
-											description: 'The output format',
-											args: [
-												{
-													name: 'output',
 												},
 											],
 										},
@@ -1901,17 +1763,6 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 							],
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-							],
 						},
 						{
 							name: ['show'],
@@ -1932,17 +1783,6 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['version'],
 							description: 'Prints the version of the application',
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-							],
 						},
 					],
 				},
@@ -1954,15 +1794,6 @@ const completionSpec: Fig.Spec = {
 							name: ['context'],
 							description: 'Get the context of the azd project & environment.',
 							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
 								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
@@ -2076,15 +1907,6 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
 									args: [
@@ -2140,15 +1962,6 @@ const completionSpec: Fig.Spec = {
 									name: ['--force'],
 									description: 'Skip confirmation prompt',
 									isDangerous: true,
-								},
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
 								},
 								{
 									name: ['--project-endpoint', '-p'],
@@ -2226,7 +2039,7 @@ const completionSpec: Fig.Spec = {
 						},
 						{
 							name: ['update'],
-							description: 'Update a connection\'s target or credentials.',
+							description: 'Update a connection\'s target, credentials, or metadata.',
 							options: [
 								{
 									name: ['--custom-key'],
@@ -2248,11 +2061,12 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
+									name: ['--metadata'],
+									description: 'Set metadata key=value (repeatable, merged with existing metadata)',
+									isRepeatable: true,
 									args: [
 										{
-											name: 'output',
+											name: 'metadata',
 										},
 									],
 								},
@@ -2280,15 +2094,6 @@ const completionSpec: Fig.Spec = {
 							name: ['version'],
 							description: 'Display the extension version',
 							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
 								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
@@ -2786,15 +2591,6 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--port'],
 									description: 'Localhost port of the agent the inspector targets (default: 8088)',
 									args: [
@@ -2817,17 +2613,6 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['version'],
 							description: 'Display the extension version',
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-							],
 						},
 					],
 				},
@@ -3637,17 +3422,6 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['context'],
 							description: 'Get the context of the azd project & environment.',
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-							],
 						},
 						{
 							name: ['set'],
@@ -3700,17 +3474,6 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['version'],
 							description: 'Display the extension version',
-							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-							],
 						},
 					],
 				},
@@ -3722,15 +3485,6 @@ const completionSpec: Fig.Spec = {
 							name: ['context'],
 							description: 'Get the context of the azd project & environment.',
 							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
 								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
@@ -4131,15 +3885,6 @@ const completionSpec: Fig.Spec = {
 							],
 							options: [
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
 									args: [
@@ -4349,15 +4094,6 @@ const completionSpec: Fig.Spec = {
 							description: 'Display the extension version',
 							options: [
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
 									args: [
@@ -4378,15 +4114,6 @@ const completionSpec: Fig.Spec = {
 							name: ['context'],
 							description: 'Get the context of the azd project & environment.',
 							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
 								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env vars and global config)',
@@ -4602,7 +4329,7 @@ const completionSpec: Fig.Spec = {
 								},
 								{
 									name: ['--file'],
-									description: 'Path to a SKILL.md file whose values become the next version\'s inline content',
+									description: 'Path to a SKILL.md file, a .zip archive, or a directory whose contents become the next version. Archives and directories must contain a SKILL.md at the root.',
 									args: [
 										{
 											name: 'file',
@@ -4652,15 +4379,6 @@ const completionSpec: Fig.Spec = {
 							name: ['version'],
 							description: 'Print the extension version.',
 							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
 								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env vars and global config)',
@@ -4791,15 +4509,6 @@ const completionSpec: Fig.Spec = {
 								},
 							],
 							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
 								{
 									name: ['--project-endpoint'],
 									description: 'Foundry project endpoint URL. When unset, falls back to the active azd environment, azd user config, then FOUNDRY_PROJECT_ENDPOINT.',
@@ -5064,15 +4773,6 @@ const completionSpec: Fig.Spec = {
 							],
 							options: [
 								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
-								{
 									name: ['--project-endpoint'],
 									description: 'Foundry project endpoint URL. When unset, falls back to the active azd environment, azd user config, then FOUNDRY_PROJECT_ENDPOINT.',
 									args: [
@@ -5087,15 +4787,6 @@ const completionSpec: Fig.Spec = {
 							name: ['version'],
 							description: 'Display the extension version',
 							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
 								{
 									name: ['--project-endpoint'],
 									description: 'Foundry project endpoint URL. When unset, falls back to the active azd environment, azd user config, then FOUNDRY_PROJECT_ENDPOINT.',
@@ -5138,15 +4829,6 @@ const completionSpec: Fig.Spec = {
 								},
 							],
 							options: [
-								{
-									name: ['--output', '-o'],
-									description: 'The output format',
-									args: [
-										{
-											name: 'output',
-										},
-									],
-								},
 								{
 									name: ['--project-endpoint'],
 									description: 'Foundry project endpoint URL. When unset, falls back to the active azd environment, azd user config, then FOUNDRY_PROJECT_ENDPOINT.',
@@ -5365,6 +5047,12 @@ const completionSpec: Fig.Spec = {
 				{
 					name: ['fig'],
 					description: 'Generate Fig autocomplete spec.',
+					options: [
+						{
+							name: ['--include-help-subcommands'],
+							description: 'Include subcommands under the help command in the Fig spec',
+						},
+					],
 				},
 				{
 					name: ['fish'],
@@ -6812,15 +6500,6 @@ const completionSpec: Fig.Spec = {
 							],
 						},
 						{
-							name: ['--output', '-o'],
-							description: 'The output format',
-							args: [
-								{
-									name: 'output',
-								},
-							],
-						},
-						{
 							name: ['--registry', '-r'],
 							description: 'When set will create a local extension source registry.',
 						},
@@ -6875,15 +6554,6 @@ const completionSpec: Fig.Spec = {
 							args: [
 								{
 									name: 'artifacts',
-								},
-							],
-						},
-						{
-							name: ['--output', '-o'],
-							description: 'The output format',
-							args: [
-								{
-									name: 'output',
 								},
 							],
 						},
@@ -6957,15 +6627,6 @@ const completionSpec: Fig.Spec = {
 							],
 						},
 						{
-							name: ['--output', '-o'],
-							description: 'The output format',
-							args: [
-								{
-									name: 'output',
-								},
-							],
-						},
-						{
 							name: ['--prerelease'],
 							description: 'Create a pre-release version',
 						},
@@ -7001,1072 +6662,16 @@ const completionSpec: Fig.Spec = {
 				{
 					name: ['version'],
 					description: 'Prints the version of the application',
-					options: [
-						{
-							name: ['--output', '-o'],
-							description: 'The output format',
-							args: [
-								{
-									name: 'output',
-								},
-							],
-						},
-					],
 				},
 				{
 					name: ['watch'],
 					description: 'Watches the azd extension project for file changes and rebuilds it.',
-					options: [
-						{
-							name: ['--output', '-o'],
-							description: 'The output format',
-							args: [
-								{
-									name: 'output',
-								},
-							],
-						},
-					],
 				},
 			],
 		},
 		{
 			name: ['help'],
 			description: 'Help about any command',
-			subcommands: [
-				{
-					name: ['add'],
-					description: 'Add a component to your project.',
-				},
-				{
-					name: ['ai'],
-					description: 'Commands for the ai extension namespace.',
-					subcommands: [
-						{
-							name: ['agent'],
-							description: 'Ship agents with Microsoft Foundry from your terminal. (Preview)',
-							subcommands: [
-								{
-									name: ['doctor'],
-									description: 'Diagnose problems with an azd ai agent project.',
-								},
-								{
-									name: ['endpoint'],
-									description: 'Manage agent endpoint and card configuration.',
-									subcommands: [
-										{
-											name: ['update'],
-											description: 'Update an agent\'s endpoint and card configuration without deploying a new version.',
-										},
-									],
-								},
-								{
-									name: ['eval'],
-									description: 'Create and run quick evals for an agent.',
-									subcommands: [
-										{
-											name: ['init'],
-											description: 'Generate a local eval suite for a deployed agent.',
-										},
-										{
-											name: ['list'],
-											description: 'List evaluations for the current project.',
-										},
-										{
-											name: ['run'],
-											description: 'Execute an evaluation run from eval.yaml.',
-										},
-										{
-											name: ['show'],
-											description: 'Show an eval definition, run history, or run details.',
-										},
-										{
-											name: ['update'],
-											description: 'Update evaluators and datasets from local files.',
-										},
-									],
-								},
-								{
-									name: ['files'],
-									description: 'Manage files in a hosted agent session.',
-									subcommands: [
-										{
-											name: ['delete', 'remove', 'rm'],
-											description: 'Delete a file or directory from a hosted agent session.',
-										},
-										{
-											name: ['download'],
-											description: 'Download a file from a hosted agent session.',
-										},
-										{
-											name: ['list', 'ls'],
-											description: 'List files in a hosted agent session.',
-										},
-										{
-											name: ['mkdir'],
-											description: 'Create a directory in a hosted agent session.',
-										},
-										{
-											name: ['stat'],
-											description: 'Get file or directory metadata in a hosted agent session.',
-										},
-										{
-											name: ['upload'],
-											description: 'Upload a file to a hosted agent session.',
-										},
-									],
-								},
-								{
-									name: ['init'],
-									description: 'Initialize a new AI agent project. (Preview)',
-								},
-								{
-									name: ['invoke'],
-									description: 'Send a message to your agent.',
-								},
-								{
-									name: ['monitor'],
-									description: 'Monitor logs from a hosted agent.',
-								},
-								{
-									name: ['optimize'],
-									description: 'Evaluate and optimize AI agents.',
-									subcommands: [
-										{
-											name: ['apply'],
-											description: 'Apply optimized candidate configuration locally to your azd project.',
-										},
-										{
-											name: ['cancel'],
-											description: 'Cancel a running optimization job.',
-										},
-										{
-											name: ['deploy'],
-											description: 'Deploy a winning optimization candidate as a new agent version via the API.',
-										},
-										{
-											name: ['list'],
-											description: 'List recent optimization runs.',
-										},
-										{
-											name: ['status'],
-											description: 'Check the status of an optimization job.',
-										},
-									],
-								},
-								{
-									name: ['run'],
-									description: 'Run your agent locally for development.',
-								},
-								{
-									name: ['sample'],
-									description: 'Browse the curated catalog of agent samples and azd templates.',
-									subcommands: [
-										{
-											name: ['list', 'ls'],
-											description: 'List available agent samples that can be used with `azd ai agent init -m`.',
-										},
-									],
-								},
-								{
-									name: ['sessions'],
-									description: 'Manage sessions for a hosted agent endpoint.',
-									subcommands: [
-										{
-											name: ['create'],
-											description: 'Create a new session for a hosted agent.',
-										},
-										{
-											name: ['delete'],
-											description: 'Delete a session.',
-										},
-										{
-											name: ['list'],
-											description: 'List sessions for a hosted agent.',
-										},
-										{
-											name: ['show'],
-											description: 'Show details of a session.',
-										},
-									],
-								},
-								{
-									name: ['show'],
-									description: 'Show the status of a hosted agent.',
-								},
-								{
-									name: ['version'],
-									description: 'Prints the version of the application',
-								},
-							],
-						},
-						{
-							name: ['connection'],
-							description: 'Manage Microsoft Foundry Connections from your terminal. (Preview)',
-							subcommands: [
-								{
-									name: ['context'],
-									description: 'Get the context of the azd project & environment.',
-								},
-								{
-									name: ['create'],
-									description: 'Create a new Foundry project connection.',
-								},
-								{
-									name: ['delete'],
-									description: 'Delete a connection.',
-								},
-								{
-									name: ['list'],
-									description: 'List connections in the Foundry project.',
-								},
-								{
-									name: ['show'],
-									description: 'Show connection details.',
-								},
-								{
-									name: ['update'],
-									description: 'Update a connection\'s target or credentials.',
-								},
-								{
-									name: ['version'],
-									description: 'Display the extension version',
-								},
-							],
-						},
-						{
-							name: ['finetuning'],
-							description: 'Extension for Foundry Fine Tuning. (Preview)',
-							subcommands: [
-								{
-									name: ['init'],
-									description: 'Initialize a new AI Fine-tuning project. (Preview)',
-								},
-								{
-									name: ['jobs'],
-									description: 'Manage fine-tuning jobs',
-									subcommands: [
-										{
-											name: ['cancel'],
-											description: 'Cancels a running or queued fine-tuning job.',
-										},
-										{
-											name: ['deploy'],
-											description: 'Deploy a fine-tuned model to Azure Cognitive Services',
-										},
-										{
-											name: ['list'],
-											description: 'List fine-tuning jobs.',
-										},
-										{
-											name: ['pause'],
-											description: 'Pauses a running fine-tuning job.',
-										},
-										{
-											name: ['resume'],
-											description: 'Resumes a paused fine-tuning job.',
-										},
-										{
-											name: ['show'],
-											description: 'Shows detailed information about a specific job.',
-										},
-										{
-											name: ['submit'],
-											description: 'Submit fine-tuning job.',
-										},
-									],
-								},
-								{
-									name: ['version'],
-									description: 'Prints the version of the application',
-								},
-							],
-						},
-						{
-							name: ['inspector'],
-							description: 'Browser-based inspector UI for locally running Foundry agents. (Preview)',
-							subcommands: [
-								{
-									name: ['launch'],
-									description: 'Launch the Agent Inspector UI in a browser, pointed at a local agent.',
-								},
-								{
-									name: ['version'],
-									description: 'Display the extension version',
-								},
-							],
-						},
-						{
-							name: ['models'],
-							description: 'Extension for managing custom models in Azure AI Foundry. (Preview)',
-							subcommands: [
-								{
-									name: ['create'],
-									description: 'Upload and register a custom model',
-								},
-								{
-									name: ['custom'],
-									description: 'Manage custom models in Azure AI Foundry',
-									subcommands: [
-										{
-											name: ['create'],
-											description: 'Upload and register a custom model',
-										},
-										{
-											name: ['delete'],
-											description: 'Delete a custom model',
-										},
-										{
-											name: ['list'],
-											description: 'List all custom models',
-										},
-										{
-											name: ['show'],
-											description: 'Show details of a custom model',
-										},
-										{
-											name: ['update'],
-											description: 'Update a custom model',
-										},
-									],
-								},
-								{
-									name: ['delete'],
-									description: 'Delete a custom model',
-								},
-								{
-									name: ['init'],
-									description: 'Initialize a new AI models project. (Preview)',
-								},
-								{
-									name: ['list'],
-									description: 'List all custom models',
-								},
-								{
-									name: ['show'],
-									description: 'Show details of a custom model',
-								},
-								{
-									name: ['update'],
-									description: 'Update a custom model',
-								},
-								{
-									name: ['version'],
-									description: 'Prints the version of the application',
-								},
-							],
-						},
-						{
-							name: ['project'],
-							description: 'Manage Microsoft Foundry Project resources from your terminal. (Preview)',
-							subcommands: [
-								{
-									name: ['context'],
-									description: 'Get the context of the azd project & environment.',
-								},
-								{
-									name: ['set'],
-									description: 'Persist a default Foundry project endpoint.',
-								},
-								{
-									name: ['show'],
-									description: 'Display the currently resolved Foundry project endpoint.',
-								},
-								{
-									name: ['unset'],
-									description: 'Clear the persisted Foundry project endpoint.',
-								},
-								{
-									name: ['version'],
-									description: 'Display the extension version',
-								},
-							],
-						},
-						{
-							name: ['routine'],
-							description: 'Manage Microsoft Foundry Routines from your terminal. (Preview)',
-							subcommands: [
-								{
-									name: ['context'],
-									description: 'Get the context of the azd project & environment.',
-								},
-								{
-									name: ['create'],
-									description: 'Create a new routine.',
-								},
-								{
-									name: ['delete'],
-									description: 'Delete a routine.',
-								},
-								{
-									name: ['disable'],
-									description: 'Disable a routine.',
-								},
-								{
-									name: ['dispatch'],
-									description: 'Manually trigger a routine.',
-								},
-								{
-									name: ['enable'],
-									description: 'Enable a routine.',
-								},
-								{
-									name: ['list'],
-									description: 'List all routines in the Foundry project.',
-								},
-								{
-									name: ['run'],
-									description: 'Manage routine run history.',
-									subcommands: [
-										{
-											name: ['list'],
-											description: 'List runs for a routine.',
-										},
-									],
-								},
-								{
-									name: ['show'],
-									description: 'Show details of a routine.',
-								},
-								{
-									name: ['update'],
-									description: 'Update an existing routine.',
-								},
-								{
-									name: ['version'],
-									description: 'Display the extension version',
-								},
-							],
-						},
-						{
-							name: ['skill'],
-							description: 'Manage Microsoft Foundry skills (reusable agent behavioral guidelines) from your terminal. (Preview)',
-							subcommands: [
-								{
-									name: ['context'],
-									description: 'Get the context of the azd project & environment.',
-								},
-								{
-									name: ['create'],
-									description: 'Create a new Foundry skill.',
-								},
-								{
-									name: ['delete'],
-									description: 'Delete a Foundry skill.',
-								},
-								{
-									name: ['download'],
-									description: 'Download a Foundry skill package.',
-								},
-								{
-									name: ['list'],
-									description: 'List Foundry skills in the project.',
-								},
-								{
-									name: ['show'],
-									description: 'Show metadata for a Foundry skill.',
-								},
-								{
-									name: ['update'],
-									description: 'Create a new default version for a Foundry skill.',
-								},
-								{
-									name: ['version'],
-									description: 'Print the extension version.',
-								},
-							],
-						},
-						{
-							name: ['toolbox'],
-							description: 'Manage Microsoft Foundry Toolboxes from your terminal. (Preview)',
-							subcommands: [
-								{
-									name: ['connection'],
-									description: 'Manage the connection-backed tools attached to a toolbox.',
-									subcommands: [
-										{
-											name: ['add'],
-											description: 'Attach one or more connections to a toolbox.',
-										},
-										{
-											name: ['list'],
-											description: 'List the connection-backed tools attached to a toolbox.',
-										},
-										{
-											name: ['remove'],
-											description: 'Detach one or more connections from a toolbox.',
-										},
-									],
-								},
-								{
-									name: ['create'],
-									description: 'Create a toolbox and its initial version from a file.',
-								},
-								{
-									name: ['delete'],
-									description: 'Delete a toolbox or a single version.',
-								},
-								{
-									name: ['list'],
-									description: 'List toolboxes on the project.',
-								},
-								{
-									name: ['publish'],
-									description: 'Set the default version for a toolbox.',
-								},
-								{
-									name: ['show'],
-									description: 'Show a toolbox version, including its computed MCP endpoint.',
-								},
-								{
-									name: ['skill'],
-									description: 'Manage skill references attached to a toolbox.',
-									subcommands: [
-										{
-											name: ['add'],
-											description: 'Attach one or more skill references to a toolbox.',
-										},
-										{
-											name: ['list'],
-											description: 'List the skill references attached to a toolbox.',
-										},
-										{
-											name: ['remove'],
-											description: 'Detach one or more skill references from a toolbox.',
-										},
-									],
-								},
-								{
-									name: ['version'],
-									description: 'Display the extension version',
-								},
-								{
-									name: ['versions'],
-									description: 'Inspect toolbox versions.',
-									subcommands: [
-										{
-											name: ['list'],
-											description: 'List published versions for a toolbox.',
-										},
-									],
-								},
-							],
-						},
-					],
-				},
-				{
-					name: ['appservice'],
-					description: 'Extension for managing Azure App Service resources.',
-					subcommands: [
-						{
-							name: ['swap'],
-							description: 'Swap deployment slots for an App Service.',
-						},
-						{
-							name: ['version'],
-							description: 'Display the version of the extension.',
-						},
-					],
-				},
-				{
-					name: ['auth'],
-					description: 'Authenticate with Azure.',
-					subcommands: [
-						{
-							name: ['login'],
-							description: 'Log in to Azure.',
-						},
-						{
-							name: ['logout'],
-							description: 'Log out of Azure.',
-						},
-						{
-							name: ['status'],
-							description: 'Show the current authentication status.',
-						},
-					],
-				},
-				{
-					name: ['coding-agent'],
-					description: 'This extension configures GitHub Copilot Coding Agent access to Azure',
-					subcommands: [
-						{
-							name: ['config'],
-							description: 'Configure the GitHub Copilot coding agent to access Azure resources via the Azure MCP',
-						},
-						{
-							name: ['version'],
-							description: 'Prints the version of the application',
-						},
-					],
-				},
-				{
-					name: ['completion'],
-					description: 'Generate shell completion scripts.',
-					subcommands: [
-						{
-							name: ['bash'],
-							description: 'Generate bash completion script.',
-						},
-						{
-							name: ['fig'],
-							description: 'Generate Fig autocomplete spec.',
-						},
-						{
-							name: ['fish'],
-							description: 'Generate fish completion script.',
-						},
-						{
-							name: ['powershell'],
-							description: 'Generate PowerShell completion script.',
-						},
-						{
-							name: ['zsh'],
-							description: 'Generate zsh completion script.',
-						},
-					],
-				},
-				{
-					name: ['concurx'],
-					description: 'Concurrent execution for azd deployment',
-					subcommands: [
-						{
-							name: ['up'],
-							description: 'Runs azd up in concurrent mode',
-						},
-						{
-							name: ['version'],
-							description: 'Prints the version of the application',
-						},
-					],
-				},
-				{
-					name: ['config'],
-					description: 'Manage azd configurations (ex: default Azure subscription, location).',
-					subcommands: [
-						{
-							name: ['get'],
-							description: 'Gets a configuration.',
-						},
-						{
-							name: ['list-alpha'],
-							description: 'Display the list of available features in alpha stage.',
-						},
-						{
-							name: ['options'],
-							description: 'List all available configuration settings.',
-						},
-						{
-							name: ['reset'],
-							description: 'Resets configuration to default.',
-						},
-						{
-							name: ['set'],
-							description: 'Sets a configuration.',
-						},
-						{
-							name: ['show'],
-							description: 'Show all the configuration values.',
-						},
-						{
-							name: ['sub-filter'],
-							description: 'Manage subscription filters for tenant-scoped subscription prompts.',
-							subcommands: [
-								{
-									name: ['remove'],
-									description: 'Remove a saved subscription filter for a tenant.',
-								},
-								{
-									name: ['set'],
-									description: 'Set a subscription filter for a tenant.',
-								},
-							],
-						},
-						{
-							name: ['unset'],
-							description: 'Unsets a configuration.',
-						},
-					],
-				},
-				{
-					name: ['copilot'],
-					description: 'Manage GitHub Copilot agent settings. (Preview)',
-					subcommands: [
-						{
-							name: ['consent'],
-							description: 'Manage tool consent.',
-							subcommands: [
-								{
-									name: ['grant'],
-									description: 'Grant consent trust rules.',
-								},
-								{
-									name: ['list'],
-									description: 'List consent rules.',
-								},
-								{
-									name: ['revoke'],
-									description: 'Revoke consent rules.',
-								},
-							],
-						},
-					],
-				},
-				{
-					name: ['demo'],
-					description: 'This extension provides examples of the azd extension framework.',
-					subcommands: [
-						{
-							name: ['ai'],
-							description: 'Interactive AI model discovery, deployment, and quota demos.',
-							subcommands: [
-								{
-									name: ['deployment'],
-									description: 'Select model/version/SKU/capacity and resolve a valid deployment configuration.',
-								},
-								{
-									name: ['models'],
-									description: 'Browse available AI models interactively.',
-								},
-								{
-									name: ['quota'],
-									description: 'View usage meters and limits for a selected location.',
-								},
-							],
-						},
-						{
-							name: ['colors', 'colours'],
-							description: 'Displays all ASCII colors with their standard and high-intensity variants.',
-						},
-						{
-							name: ['config'],
-							description: 'Set up monitoring configuration for the project and services',
-						},
-						{
-							name: ['context'],
-							description: 'Get the context of the azd project & environment.',
-						},
-						{
-							name: ['gh-url-parse'],
-							description: 'Parse a GitHub URL and extract repository information.',
-						},
-						{
-							name: ['listen'],
-							description: 'Starts the extension and listens for events.',
-						},
-						{
-							name: ['mcp'],
-							description: 'MCP server commands for demo extension',
-							subcommands: [
-								{
-									name: ['start'],
-									description: 'Start MCP server with demo tools',
-								},
-							],
-						},
-						{
-							name: ['prompt'],
-							description: 'Examples of prompting the user for input.',
-						},
-						{
-							name: ['version'],
-							description: 'Prints the version of the application',
-						},
-					],
-				},
-				{
-					name: ['deploy'],
-					description: 'Deploy your project code to Azure.',
-				},
-				{
-					name: ['down'],
-					description: 'Delete your project\'s Azure resources.',
-				},
-				{
-					name: ['env'],
-					description: 'Manage environments (ex: default environment, environment variables).',
-					subcommands: [
-						{
-							name: ['config'],
-							description: 'Manage environment configuration (ex: stored in .azure/<environment>/config.json).',
-							subcommands: [
-								{
-									name: ['get'],
-									description: 'Gets a configuration value from the environment.',
-								},
-								{
-									name: ['set'],
-									description: 'Sets a configuration value in the environment.',
-								},
-								{
-									name: ['unset'],
-									description: 'Unsets a configuration value in the environment.',
-								},
-							],
-						},
-						{
-							name: ['get-value'],
-							description: 'Get specific environment value.',
-						},
-						{
-							name: ['get-values'],
-							description: 'Get all environment values.',
-						},
-						{
-							name: ['list', 'ls'],
-							description: 'List environments.',
-						},
-						{
-							name: ['new'],
-							description: 'Create a new environment and set it as the default.',
-						},
-						{
-							name: ['refresh'],
-							description: 'Refresh environment values by using information from a previous infrastructure provision.',
-						},
-						{
-							name: ['remove', 'rm'],
-							description: 'Remove an environment.',
-						},
-						{
-							name: ['select'],
-							description: 'Set the default environment.',
-						},
-						{
-							name: ['set'],
-							description: 'Set one or more environment values.',
-						},
-						{
-							name: ['set-secret'],
-							description: 'Set a name as a reference to a Key Vault secret in the environment.',
-						},
-					],
-				},
-				{
-					name: ['exec'],
-					description: 'Execute commands and scripts with azd environment context.',
-				},
-				{
-					name: ['extension', 'ext'],
-					description: 'Manage azd extensions.',
-					subcommands: [
-						{
-							name: ['install'],
-							description: 'Installs specified extensions.',
-						},
-						{
-							name: ['list'],
-							description: 'List available extensions.',
-						},
-						{
-							name: ['show'],
-							description: 'Show details for a specific extension.',
-						},
-						{
-							name: ['source'],
-							description: 'View and manage extension sources',
-							subcommands: [
-								{
-									name: ['add'],
-									description: 'Add an extension source with the specified name',
-								},
-								{
-									name: ['list'],
-									description: 'List extension sources',
-								},
-								{
-									name: ['remove'],
-									description: 'Remove an extension source with the specified name',
-								},
-								{
-									name: ['validate'],
-									description: 'Validate an extension source\'s registry.json file.',
-								},
-							],
-						},
-						{
-							name: ['uninstall'],
-							description: 'Uninstall specified extensions.',
-						},
-						{
-							name: ['upgrade'],
-							description: 'Upgrade installed extensions to the latest version.',
-						},
-					],
-				},
-				{
-					name: ['hooks'],
-					description: 'Develop, test and run hooks for a project.',
-					subcommands: [
-						{
-							name: ['run'],
-							description: 'Runs the specified hook for the project, provisioning layers, and services',
-						},
-					],
-				},
-				{
-					name: ['infra'],
-					description: 'Manage your Infrastructure as Code (IaC).',
-					subcommands: [
-						{
-							name: ['generate', 'gen', 'synth'],
-							description: 'Write IaC for your project to disk, allowing you to manually manage it.',
-						},
-					],
-				},
-				{
-					name: ['init'],
-					description: 'Initialize a new application.',
-				},
-				{
-					name: ['mcp'],
-					description: 'Manage Model Context Protocol (MCP) server. (Alpha)',
-					subcommands: [
-						{
-							name: ['start'],
-							description: 'Starts the MCP server.',
-						},
-					],
-				},
-				{
-					name: ['monitor'],
-					description: 'Monitor a deployed project.',
-				},
-				{
-					name: ['package'],
-					description: 'Packages the project\'s code to be deployed to Azure.',
-				},
-				{
-					name: ['pipeline'],
-					description: 'Manage and configure your deployment pipelines.',
-					subcommands: [
-						{
-							name: ['config'],
-							description: 'Configure your deployment pipeline to connect securely to Azure. (Beta)',
-						},
-					],
-				},
-				{
-					name: ['provision'],
-					description: 'Provision Azure resources for your project.',
-				},
-				{
-					name: ['publish'],
-					description: 'Publish a service to a container registry.',
-				},
-				{
-					name: ['restore'],
-					description: 'Restores the project\'s dependencies.',
-				},
-				{
-					name: ['show'],
-					description: 'Display information about your project and its resources.',
-				},
-				{
-					name: ['template'],
-					description: 'Find and view template details.',
-					subcommands: [
-						{
-							name: ['list', 'ls'],
-							description: 'Show list of sample azd templates. (Beta)',
-						},
-						{
-							name: ['show'],
-							description: 'Show details for a given template. (Beta)',
-						},
-						{
-							name: ['source'],
-							description: 'View and manage template sources. (Beta)',
-							subcommands: [
-								{
-									name: ['add'],
-									description: 'Adds an azd template source with the specified key. (Beta)',
-								},
-								{
-									name: ['list', 'ls'],
-									description: 'Lists the configured azd template sources. (Beta)',
-								},
-								{
-									name: ['remove'],
-									description: 'Removes the specified azd template source (Beta)',
-								},
-							],
-						},
-					],
-				},
-				{
-					name: ['tool'],
-					description: 'Manage Azure development tools.',
-					subcommands: [
-						{
-							name: ['check'],
-							description: 'Check for tool updates.',
-						},
-						{
-							name: ['install'],
-							description: 'Install specified tools.',
-						},
-						{
-							name: ['list'],
-							description: 'List all tools with status.',
-						},
-						{
-							name: ['show'],
-							description: 'Show details for a specific tool.',
-						},
-						{
-							name: ['upgrade'],
-							description: 'Upgrade installed tools.',
-						},
-					],
-				},
-				{
-					name: ['up'],
-					description: 'Provision and deploy your project to Azure with a single command.',
-				},
-				{
-					name: ['update'],
-					description: 'Updates azd to the latest version.',
-				},
-				{
-					name: ['version'],
-					description: 'Print the version number of Azure Developer CLI.',
-				},
-				{
-					name: ['x'],
-					description: 'This extension provides a set of tools for azd extension developers to test and debug their extensions.',
-					subcommands: [
-						{
-							name: ['build'],
-							description: 'Build the azd extension project',
-						},
-						{
-							name: ['init'],
-							description: 'Initialize a new azd extension project',
-						},
-						{
-							name: ['pack'],
-							description: 'Build and pack extension artifacts',
-						},
-						{
-							name: ['publish'],
-							description: 'Publish the extension to the extension source',
-						},
-						{
-							name: ['release'],
-							description: 'Create a new extension release from the packaged artifacts',
-						},
-						{
-							name: ['version'],
-							description: 'Prints the version of the application',
-						},
-						{
-							name: ['watch'],
-							description: 'Watches the azd extension project for file changes and rebuilds it.',
-						},
-					],
-				},
-			],
 		},
 	],
 	options: [

--- a/cli/azd/cmd/testdata/TestFigSpec.ts
+++ b/cli/azd/cmd/testdata/TestFigSpec.ts
@@ -223,47 +223,12 @@ const completionSpec: Fig.Spec = {
 					description: 'Ship agents with Microsoft Foundry from your terminal. (Preview)',
 					subcommands: [
 						{
-							name: ['code'],
-							description: 'Manage agent source code. (Preview)',
-							subcommands: [
-								{
-									name: ['download'],
-									description: 'Download agent source code from Foundry. (Preview)',
-									options: [
-										{
-											name: ['--dest', '-d'],
-											description: 'Destination path (default: ./<agent-name>/ or ./<agent-name>.zip)',
-											args: [
-												{
-													name: 'dest',
-												},
-											],
-										},
-										{
-											name: ['--version', '-v'],
-											description: 'Agent version to download (default: latest)',
-											args: [
-												{
-													name: 'version',
-												},
-											],
-										},
-										{
-											name: ['--zip'],
-											description: 'Save as zip file instead of extracting',
-										},
-									],
-								},
-							],
-						},
-						{
-							name: ['delete'],
-							description: 'Delete a hosted agent.',
+							name: ['doctor'],
+							description: 'Diagnose problems with an azd ai agent project.',
 							options: [
 								{
-									name: ['--force'],
-									description: 'Force deletion even if the agent has active sessions',
-									isDangerous: true,
+									name: ['--local-only'],
+									description: 'Skip remote (network-dependent) checks. Useful when offline, behind a proxy, or for a fast local triage.',
 								},
 								{
 									name: ['--output', '-o'],
@@ -271,28 +236,8 @@ const completionSpec: Fig.Spec = {
 									args: [
 										{
 											name: 'output',
-											suggestions: ['json', 'none'],
 										},
 									],
-								},
-								{
-									name: ['--version'],
-									description: 'Delete a specific version only (the agent itself remains)',
-									args: [
-										{
-											name: 'version',
-										},
-									],
-								},
-							],
-						},
-						{
-							name: ['doctor'],
-							description: 'Diagnose problems with an azd ai agent project.',
-							options: [
-								{
-									name: ['--local-only'],
-									description: 'Skip remote (network-dependent) checks. Useful when offline, behind a proxy, or for a fast local triage.',
 								},
 								{
 									name: ['--unredacted'],
@@ -305,8 +250,8 @@ const completionSpec: Fig.Spec = {
 							description: 'Manage agent endpoint and card configuration.',
 							subcommands: [
 								{
-									name: ['show'],
-									description: 'Show the current endpoint and card configuration of an agent.',
+									name: ['update'],
+									description: 'Update an agent\'s endpoint and card configuration without deploying a new version.',
 									options: [
 										{
 											name: ['--output', '-o'],
@@ -314,20 +259,19 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'output',
-													suggestions: ['json', 'table'],
 												},
 											],
 										},
 									],
 								},
+							],
+							options: [
 								{
-									name: ['update'],
-									description: 'Update an agent\'s endpoint and card configuration without deploying a new version.',
-									options: [
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
 										{
-											name: ['--force'],
-											description: 'Skip confirmation prompts for breaking changes',
-											isDangerous: true,
+											name: 'output',
 										},
 									],
 								},
@@ -338,7 +282,7 @@ const completionSpec: Fig.Spec = {
 							description: 'Create and run quick evals for an agent.',
 							subcommands: [
 								{
-									name: ['generate'],
+									name: ['init'],
 									description: 'Generate a local eval suite for a deployed agent.',
 									options: [
 										{
@@ -428,6 +372,15 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
+											name: ['--output', '-o'],
+											description: 'The output format',
+											args: [
+												{
+													name: 'output',
+												},
+											],
+										},
+										{
 											name: ['--project-endpoint', '-p'],
 											description: 'Microsoft Foundry project endpoint URL',
 											args: [
@@ -464,6 +417,15 @@ const completionSpec: Fig.Spec = {
 												},
 											],
 										},
+										{
+											name: ['--output', '-o'],
+											description: 'The output format',
+											args: [
+												{
+													name: 'output',
+												},
+											],
+										},
 									],
 								},
 								{
@@ -491,6 +453,15 @@ const completionSpec: Fig.Spec = {
 										{
 											name: ['--no-wait'],
 											description: 'Start the run and return immediately without waiting for results',
+										},
+										{
+											name: ['--output', '-o'],
+											description: 'The output format',
+											args: [
+												{
+													name: 'output',
+												},
+											],
 										},
 									],
 								},
@@ -525,6 +496,15 @@ const completionSpec: Fig.Spec = {
 												},
 											],
 										},
+										{
+											name: ['--output', '-o'],
+											description: 'The output format',
+											args: [
+												{
+													name: 'output',
+												},
+											],
+										},
 									],
 								},
 								{
@@ -547,6 +527,26 @@ const completionSpec: Fig.Spec = {
 										{
 											name: ['--evaluator-only'],
 											description: 'Only update evaluators',
+										},
+										{
+											name: ['--output', '-o'],
+											description: 'The output format',
+											args: [
+												{
+													name: 'output',
+												},
+											],
+										},
+									],
+								},
+							],
+							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
 										},
 									],
 								},
@@ -584,6 +584,15 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'file',
+												},
+											],
+										},
+										{
+											name: ['--output', '-o'],
+											description: 'The output format',
+											args: [
+												{
+													name: 'output',
 												},
 											],
 										},
@@ -639,6 +648,15 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'file',
+												},
+											],
+										},
+										{
+											name: ['--output', '-o'],
+											description: 'The output format',
+											args: [
+												{
+													name: 'output',
 												},
 											],
 										},
@@ -755,6 +773,15 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
+											name: ['--output', '-o'],
+											description: 'The output format',
+											args: [
+												{
+													name: 'output',
+												},
+											],
+										},
+										{
 											name: ['--session-id', '-s'],
 											description: 'Session ID override (defaults to last invoke session)',
 											args: [
@@ -858,6 +885,15 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
+											name: ['--output', '-o'],
+											description: 'The output format',
+											args: [
+												{
+													name: 'output',
+												},
+											],
+										},
+										{
 											name: ['--session-id', '-s'],
 											description: 'Session ID override (defaults to last invoke session)',
 											args: [
@@ -883,6 +919,17 @@ const completionSpec: Fig.Spec = {
 													name: 'user-isolation-key',
 												},
 											],
+										},
+									],
+								},
+							],
+							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
 										},
 									],
 								},
@@ -957,6 +1004,15 @@ const completionSpec: Fig.Spec = {
 									args: [
 										{
 											name: 'model-deployment',
+										},
+									],
+								},
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
 										},
 									],
 								},
@@ -1135,6 +1191,15 @@ const completionSpec: Fig.Spec = {
 									description: 'Stream logs in real-time',
 								},
 								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
+								{
 									name: ['--raw'],
 									description: 'Print the raw SSE stream without formatting',
 								},
@@ -1216,6 +1281,15 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
+											name: ['--output', '-o'],
+											description: 'The output format',
+											args: [
+												{
+													name: 'output',
+												},
+											],
+										},
+										{
 											name: ['--project-endpoint', '-p'],
 											description: 'Foundry project endpoint URL',
 											args: [
@@ -1236,6 +1310,15 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'endpoint',
+												},
+											],
+										},
+										{
+											name: ['--output', '-o'],
+											description: 'The output format',
+											args: [
+												{
+													name: 'output',
 												},
 											],
 										},
@@ -1282,6 +1365,15 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
+											name: ['--output', '-o'],
+											description: 'The output format',
+											args: [
+												{
+													name: 'output',
+												},
+											],
+										},
+										{
 											name: ['--project-endpoint', '-p'],
 											description: 'Foundry project endpoint URL',
 											args: [
@@ -1315,6 +1407,15 @@ const completionSpec: Fig.Spec = {
 											],
 										},
 										{
+											name: ['--output', '-o'],
+											description: 'The output format',
+											args: [
+												{
+													name: 'output',
+												},
+											],
+										},
+										{
 											name: ['--project-endpoint', '-p'],
 											description: 'Foundry project endpoint URL',
 											args: [
@@ -1344,6 +1445,15 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'endpoint',
+												},
+											],
+										},
+										{
+											name: ['--output', '-o'],
+											description: 'The output format',
+											args: [
+												{
+													name: 'output',
 												},
 											],
 										},
@@ -1419,21 +1529,11 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 								{
-									name: ['--evaluator'],
-									description: 'Built-in or custom evaluator name (repeatable; required when not set in config)',
-									isRepeatable: true,
+									name: ['--max-iterations'],
+									description: 'Maximum number of optimization iterations (must be >= 1; default: 5)',
 									args: [
 										{
-											name: 'evaluator',
-										},
-									],
-								},
-								{
-									name: ['--max-candidates'],
-									description: 'Maximum number of optimization candidates to generate (must be >= 1; default: 5)',
-									args: [
-										{
-											name: 'max-candidates',
+											name: 'max-iterations',
 										},
 									],
 								},
@@ -1443,10 +1543,19 @@ const completionSpec: Fig.Spec = {
 								},
 								{
 									name: ['--optimize-model'],
-									description: 'Model for optimization reasoning (gpt-5 family recommended; required)',
+									description: 'Model for optimization reasoning (gpt-5 family recommended; falls back to eval model when not set)',
 									args: [
 										{
 											name: 'optimize-model',
+										},
+									],
+								},
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
 										},
 									],
 								},
@@ -1477,6 +1586,15 @@ const completionSpec: Fig.Spec = {
 								{
 									name: ['--no-inspector'],
 									description: 'Do not open Agent Inspector',
+								},
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
 								},
 								{
 									name: ['--port', '-p'],
@@ -1537,6 +1655,17 @@ const completionSpec: Fig.Spec = {
 													name: 'type',
 												},
 											],
+										},
+									],
+								},
+							],
+							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
 										},
 									],
 								},
@@ -1644,6 +1773,15 @@ const completionSpec: Fig.Spec = {
 											args: [
 												{
 													name: 'isolation-key',
+												},
+											],
+										},
+										{
+											name: ['--output', '-o'],
+											description: 'The output format',
+											args: [
+												{
+													name: 'output',
 												},
 											],
 										},
@@ -1763,6 +1901,17 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 							],
+							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
+							],
 						},
 						{
 							name: ['show'],
@@ -1783,6 +1932,17 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['version'],
 							description: 'Prints the version of the application',
+							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
+							],
 						},
 					],
 				},
@@ -1794,6 +1954,15 @@ const completionSpec: Fig.Spec = {
 							name: ['context'],
 							description: 'Get the context of the azd project & environment.',
 							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
 								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
@@ -1907,6 +2076,15 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
+								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
 									args: [
@@ -1962,6 +2140,15 @@ const completionSpec: Fig.Spec = {
 									name: ['--force'],
 									description: 'Skip confirmation prompt',
 									isDangerous: true,
+								},
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
 								},
 								{
 									name: ['--project-endpoint', '-p'],
@@ -2039,7 +2226,7 @@ const completionSpec: Fig.Spec = {
 						},
 						{
 							name: ['update'],
-							description: 'Update a connection\'s target, credentials, or metadata.',
+							description: 'Update a connection\'s target or credentials.',
 							options: [
 								{
 									name: ['--custom-key'],
@@ -2061,12 +2248,11 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 								{
-									name: ['--metadata'],
-									description: 'Set metadata key=value (repeatable, merged with existing metadata)',
-									isRepeatable: true,
+									name: ['--output', '-o'],
+									description: 'The output format',
 									args: [
 										{
-											name: 'metadata',
+											name: 'output',
 										},
 									],
 								},
@@ -2094,6 +2280,15 @@ const completionSpec: Fig.Spec = {
 							name: ['version'],
 							description: 'Display the extension version',
 							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
 								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
@@ -2591,6 +2786,15 @@ const completionSpec: Fig.Spec = {
 									],
 								},
 								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
+								{
 									name: ['--port'],
 									description: 'Localhost port of the agent the inspector targets (default: 8088)',
 									args: [
@@ -2613,6 +2817,17 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['version'],
 							description: 'Display the extension version',
+							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
+							],
 						},
 					],
 				},
@@ -3422,6 +3637,17 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['context'],
 							description: 'Get the context of the azd project & environment.',
+							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
+							],
 						},
 						{
 							name: ['set'],
@@ -3474,6 +3700,17 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['version'],
 							description: 'Display the extension version',
+							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
+							],
 						},
 					],
 				},
@@ -3485,6 +3722,15 @@ const completionSpec: Fig.Spec = {
 							name: ['context'],
 							description: 'Get the context of the azd project & environment.',
 							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
 								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
@@ -3885,6 +4131,15 @@ const completionSpec: Fig.Spec = {
 							],
 							options: [
 								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
+								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
 									args: [
@@ -4094,6 +4349,15 @@ const completionSpec: Fig.Spec = {
 							description: 'Display the extension version',
 							options: [
 								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
+								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env var and config)',
 									args: [
@@ -4114,6 +4378,15 @@ const completionSpec: Fig.Spec = {
 							name: ['context'],
 							description: 'Get the context of the azd project & environment.',
 							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
 								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env vars and global config)',
@@ -4329,7 +4602,7 @@ const completionSpec: Fig.Spec = {
 								},
 								{
 									name: ['--file'],
-									description: 'Path to a SKILL.md file, a .zip archive, or a directory whose contents become the next version. Archives and directories must contain a SKILL.md at the root.',
+									description: 'Path to a SKILL.md file whose values become the next version\'s inline content',
 									args: [
 										{
 											name: 'file',
@@ -4379,6 +4652,15 @@ const completionSpec: Fig.Spec = {
 							name: ['version'],
 							description: 'Print the extension version.',
 							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
 								{
 									name: ['--project-endpoint', '-p'],
 									description: 'Foundry project endpoint URL (overrides env vars and global config)',
@@ -4509,6 +4791,15 @@ const completionSpec: Fig.Spec = {
 								},
 							],
 							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
 								{
 									name: ['--project-endpoint'],
 									description: 'Foundry project endpoint URL. When unset, falls back to the active azd environment, azd user config, then FOUNDRY_PROJECT_ENDPOINT.',
@@ -4773,6 +5064,15 @@ const completionSpec: Fig.Spec = {
 							],
 							options: [
 								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
+								{
 									name: ['--project-endpoint'],
 									description: 'Foundry project endpoint URL. When unset, falls back to the active azd environment, azd user config, then FOUNDRY_PROJECT_ENDPOINT.',
 									args: [
@@ -4787,6 +5087,15 @@ const completionSpec: Fig.Spec = {
 							name: ['version'],
 							description: 'Display the extension version',
 							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
 								{
 									name: ['--project-endpoint'],
 									description: 'Foundry project endpoint URL. When unset, falls back to the active azd environment, azd user config, then FOUNDRY_PROJECT_ENDPOINT.',
@@ -4829,6 +5138,15 @@ const completionSpec: Fig.Spec = {
 								},
 							],
 							options: [
+								{
+									name: ['--output', '-o'],
+									description: 'The output format',
+									args: [
+										{
+											name: 'output',
+										},
+									],
+								},
 								{
 									name: ['--project-endpoint'],
 									description: 'Foundry project endpoint URL. When unset, falls back to the active azd environment, azd user config, then FOUNDRY_PROJECT_ENDPOINT.',
@@ -5047,12 +5365,6 @@ const completionSpec: Fig.Spec = {
 				{
 					name: ['fig'],
 					description: 'Generate Fig autocomplete spec.',
-					options: [
-						{
-							name: ['--include-help-subcommands'],
-							description: 'Include subcommands under the help command in the Fig spec',
-						},
-					],
 				},
 				{
 					name: ['fish'],
@@ -5129,6 +5441,20 @@ const completionSpec: Fig.Spec = {
 				{
 					name: ['show'],
 					description: 'Show all the configuration values.',
+				},
+				{
+					name: ['sub-filter'],
+					description: 'Manage subscription filters for tenant-scoped subscription prompts.',
+					subcommands: [
+						{
+							name: ['remove'],
+							description: 'Remove a saved subscription filter for a tenant.',
+						},
+						{
+							name: ['set'],
+							description: 'Set a subscription filter for a tenant.',
+						},
+					],
 				},
 				{
 					name: ['unset'],
@@ -6486,6 +6812,15 @@ const completionSpec: Fig.Spec = {
 							],
 						},
 						{
+							name: ['--output', '-o'],
+							description: 'The output format',
+							args: [
+								{
+									name: 'output',
+								},
+							],
+						},
+						{
 							name: ['--registry', '-r'],
 							description: 'When set will create a local extension source registry.',
 						},
@@ -6540,6 +6875,15 @@ const completionSpec: Fig.Spec = {
 							args: [
 								{
 									name: 'artifacts',
+								},
+							],
+						},
+						{
+							name: ['--output', '-o'],
+							description: 'The output format',
+							args: [
+								{
+									name: 'output',
 								},
 							],
 						},
@@ -6613,6 +6957,15 @@ const completionSpec: Fig.Spec = {
 							],
 						},
 						{
+							name: ['--output', '-o'],
+							description: 'The output format',
+							args: [
+								{
+									name: 'output',
+								},
+							],
+						},
+						{
 							name: ['--prerelease'],
 							description: 'Create a pre-release version',
 						},
@@ -6648,16 +7001,1072 @@ const completionSpec: Fig.Spec = {
 				{
 					name: ['version'],
 					description: 'Prints the version of the application',
+					options: [
+						{
+							name: ['--output', '-o'],
+							description: 'The output format',
+							args: [
+								{
+									name: 'output',
+								},
+							],
+						},
+					],
 				},
 				{
 					name: ['watch'],
 					description: 'Watches the azd extension project for file changes and rebuilds it.',
+					options: [
+						{
+							name: ['--output', '-o'],
+							description: 'The output format',
+							args: [
+								{
+									name: 'output',
+								},
+							],
+						},
+					],
 				},
 			],
 		},
 		{
 			name: ['help'],
 			description: 'Help about any command',
+			subcommands: [
+				{
+					name: ['add'],
+					description: 'Add a component to your project.',
+				},
+				{
+					name: ['ai'],
+					description: 'Commands for the ai extension namespace.',
+					subcommands: [
+						{
+							name: ['agent'],
+							description: 'Ship agents with Microsoft Foundry from your terminal. (Preview)',
+							subcommands: [
+								{
+									name: ['doctor'],
+									description: 'Diagnose problems with an azd ai agent project.',
+								},
+								{
+									name: ['endpoint'],
+									description: 'Manage agent endpoint and card configuration.',
+									subcommands: [
+										{
+											name: ['update'],
+											description: 'Update an agent\'s endpoint and card configuration without deploying a new version.',
+										},
+									],
+								},
+								{
+									name: ['eval'],
+									description: 'Create and run quick evals for an agent.',
+									subcommands: [
+										{
+											name: ['init'],
+											description: 'Generate a local eval suite for a deployed agent.',
+										},
+										{
+											name: ['list'],
+											description: 'List evaluations for the current project.',
+										},
+										{
+											name: ['run'],
+											description: 'Execute an evaluation run from eval.yaml.',
+										},
+										{
+											name: ['show'],
+											description: 'Show an eval definition, run history, or run details.',
+										},
+										{
+											name: ['update'],
+											description: 'Update evaluators and datasets from local files.',
+										},
+									],
+								},
+								{
+									name: ['files'],
+									description: 'Manage files in a hosted agent session.',
+									subcommands: [
+										{
+											name: ['delete', 'remove', 'rm'],
+											description: 'Delete a file or directory from a hosted agent session.',
+										},
+										{
+											name: ['download'],
+											description: 'Download a file from a hosted agent session.',
+										},
+										{
+											name: ['list', 'ls'],
+											description: 'List files in a hosted agent session.',
+										},
+										{
+											name: ['mkdir'],
+											description: 'Create a directory in a hosted agent session.',
+										},
+										{
+											name: ['stat'],
+											description: 'Get file or directory metadata in a hosted agent session.',
+										},
+										{
+											name: ['upload'],
+											description: 'Upload a file to a hosted agent session.',
+										},
+									],
+								},
+								{
+									name: ['init'],
+									description: 'Initialize a new AI agent project. (Preview)',
+								},
+								{
+									name: ['invoke'],
+									description: 'Send a message to your agent.',
+								},
+								{
+									name: ['monitor'],
+									description: 'Monitor logs from a hosted agent.',
+								},
+								{
+									name: ['optimize'],
+									description: 'Evaluate and optimize AI agents.',
+									subcommands: [
+										{
+											name: ['apply'],
+											description: 'Apply optimized candidate configuration locally to your azd project.',
+										},
+										{
+											name: ['cancel'],
+											description: 'Cancel a running optimization job.',
+										},
+										{
+											name: ['deploy'],
+											description: 'Deploy a winning optimization candidate as a new agent version via the API.',
+										},
+										{
+											name: ['list'],
+											description: 'List recent optimization runs.',
+										},
+										{
+											name: ['status'],
+											description: 'Check the status of an optimization job.',
+										},
+									],
+								},
+								{
+									name: ['run'],
+									description: 'Run your agent locally for development.',
+								},
+								{
+									name: ['sample'],
+									description: 'Browse the curated catalog of agent samples and azd templates.',
+									subcommands: [
+										{
+											name: ['list', 'ls'],
+											description: 'List available agent samples that can be used with `azd ai agent init -m`.',
+										},
+									],
+								},
+								{
+									name: ['sessions'],
+									description: 'Manage sessions for a hosted agent endpoint.',
+									subcommands: [
+										{
+											name: ['create'],
+											description: 'Create a new session for a hosted agent.',
+										},
+										{
+											name: ['delete'],
+											description: 'Delete a session.',
+										},
+										{
+											name: ['list'],
+											description: 'List sessions for a hosted agent.',
+										},
+										{
+											name: ['show'],
+											description: 'Show details of a session.',
+										},
+									],
+								},
+								{
+									name: ['show'],
+									description: 'Show the status of a hosted agent.',
+								},
+								{
+									name: ['version'],
+									description: 'Prints the version of the application',
+								},
+							],
+						},
+						{
+							name: ['connection'],
+							description: 'Manage Microsoft Foundry Connections from your terminal. (Preview)',
+							subcommands: [
+								{
+									name: ['context'],
+									description: 'Get the context of the azd project & environment.',
+								},
+								{
+									name: ['create'],
+									description: 'Create a new Foundry project connection.',
+								},
+								{
+									name: ['delete'],
+									description: 'Delete a connection.',
+								},
+								{
+									name: ['list'],
+									description: 'List connections in the Foundry project.',
+								},
+								{
+									name: ['show'],
+									description: 'Show connection details.',
+								},
+								{
+									name: ['update'],
+									description: 'Update a connection\'s target or credentials.',
+								},
+								{
+									name: ['version'],
+									description: 'Display the extension version',
+								},
+							],
+						},
+						{
+							name: ['finetuning'],
+							description: 'Extension for Foundry Fine Tuning. (Preview)',
+							subcommands: [
+								{
+									name: ['init'],
+									description: 'Initialize a new AI Fine-tuning project. (Preview)',
+								},
+								{
+									name: ['jobs'],
+									description: 'Manage fine-tuning jobs',
+									subcommands: [
+										{
+											name: ['cancel'],
+											description: 'Cancels a running or queued fine-tuning job.',
+										},
+										{
+											name: ['deploy'],
+											description: 'Deploy a fine-tuned model to Azure Cognitive Services',
+										},
+										{
+											name: ['list'],
+											description: 'List fine-tuning jobs.',
+										},
+										{
+											name: ['pause'],
+											description: 'Pauses a running fine-tuning job.',
+										},
+										{
+											name: ['resume'],
+											description: 'Resumes a paused fine-tuning job.',
+										},
+										{
+											name: ['show'],
+											description: 'Shows detailed information about a specific job.',
+										},
+										{
+											name: ['submit'],
+											description: 'Submit fine-tuning job.',
+										},
+									],
+								},
+								{
+									name: ['version'],
+									description: 'Prints the version of the application',
+								},
+							],
+						},
+						{
+							name: ['inspector'],
+							description: 'Browser-based inspector UI for locally running Foundry agents. (Preview)',
+							subcommands: [
+								{
+									name: ['launch'],
+									description: 'Launch the Agent Inspector UI in a browser, pointed at a local agent.',
+								},
+								{
+									name: ['version'],
+									description: 'Display the extension version',
+								},
+							],
+						},
+						{
+							name: ['models'],
+							description: 'Extension for managing custom models in Azure AI Foundry. (Preview)',
+							subcommands: [
+								{
+									name: ['create'],
+									description: 'Upload and register a custom model',
+								},
+								{
+									name: ['custom'],
+									description: 'Manage custom models in Azure AI Foundry',
+									subcommands: [
+										{
+											name: ['create'],
+											description: 'Upload and register a custom model',
+										},
+										{
+											name: ['delete'],
+											description: 'Delete a custom model',
+										},
+										{
+											name: ['list'],
+											description: 'List all custom models',
+										},
+										{
+											name: ['show'],
+											description: 'Show details of a custom model',
+										},
+										{
+											name: ['update'],
+											description: 'Update a custom model',
+										},
+									],
+								},
+								{
+									name: ['delete'],
+									description: 'Delete a custom model',
+								},
+								{
+									name: ['init'],
+									description: 'Initialize a new AI models project. (Preview)',
+								},
+								{
+									name: ['list'],
+									description: 'List all custom models',
+								},
+								{
+									name: ['show'],
+									description: 'Show details of a custom model',
+								},
+								{
+									name: ['update'],
+									description: 'Update a custom model',
+								},
+								{
+									name: ['version'],
+									description: 'Prints the version of the application',
+								},
+							],
+						},
+						{
+							name: ['project'],
+							description: 'Manage Microsoft Foundry Project resources from your terminal. (Preview)',
+							subcommands: [
+								{
+									name: ['context'],
+									description: 'Get the context of the azd project & environment.',
+								},
+								{
+									name: ['set'],
+									description: 'Persist a default Foundry project endpoint.',
+								},
+								{
+									name: ['show'],
+									description: 'Display the currently resolved Foundry project endpoint.',
+								},
+								{
+									name: ['unset'],
+									description: 'Clear the persisted Foundry project endpoint.',
+								},
+								{
+									name: ['version'],
+									description: 'Display the extension version',
+								},
+							],
+						},
+						{
+							name: ['routine'],
+							description: 'Manage Microsoft Foundry Routines from your terminal. (Preview)',
+							subcommands: [
+								{
+									name: ['context'],
+									description: 'Get the context of the azd project & environment.',
+								},
+								{
+									name: ['create'],
+									description: 'Create a new routine.',
+								},
+								{
+									name: ['delete'],
+									description: 'Delete a routine.',
+								},
+								{
+									name: ['disable'],
+									description: 'Disable a routine.',
+								},
+								{
+									name: ['dispatch'],
+									description: 'Manually trigger a routine.',
+								},
+								{
+									name: ['enable'],
+									description: 'Enable a routine.',
+								},
+								{
+									name: ['list'],
+									description: 'List all routines in the Foundry project.',
+								},
+								{
+									name: ['run'],
+									description: 'Manage routine run history.',
+									subcommands: [
+										{
+											name: ['list'],
+											description: 'List runs for a routine.',
+										},
+									],
+								},
+								{
+									name: ['show'],
+									description: 'Show details of a routine.',
+								},
+								{
+									name: ['update'],
+									description: 'Update an existing routine.',
+								},
+								{
+									name: ['version'],
+									description: 'Display the extension version',
+								},
+							],
+						},
+						{
+							name: ['skill'],
+							description: 'Manage Microsoft Foundry skills (reusable agent behavioral guidelines) from your terminal. (Preview)',
+							subcommands: [
+								{
+									name: ['context'],
+									description: 'Get the context of the azd project & environment.',
+								},
+								{
+									name: ['create'],
+									description: 'Create a new Foundry skill.',
+								},
+								{
+									name: ['delete'],
+									description: 'Delete a Foundry skill.',
+								},
+								{
+									name: ['download'],
+									description: 'Download a Foundry skill package.',
+								},
+								{
+									name: ['list'],
+									description: 'List Foundry skills in the project.',
+								},
+								{
+									name: ['show'],
+									description: 'Show metadata for a Foundry skill.',
+								},
+								{
+									name: ['update'],
+									description: 'Create a new default version for a Foundry skill.',
+								},
+								{
+									name: ['version'],
+									description: 'Print the extension version.',
+								},
+							],
+						},
+						{
+							name: ['toolbox'],
+							description: 'Manage Microsoft Foundry Toolboxes from your terminal. (Preview)',
+							subcommands: [
+								{
+									name: ['connection'],
+									description: 'Manage the connection-backed tools attached to a toolbox.',
+									subcommands: [
+										{
+											name: ['add'],
+											description: 'Attach one or more connections to a toolbox.',
+										},
+										{
+											name: ['list'],
+											description: 'List the connection-backed tools attached to a toolbox.',
+										},
+										{
+											name: ['remove'],
+											description: 'Detach one or more connections from a toolbox.',
+										},
+									],
+								},
+								{
+									name: ['create'],
+									description: 'Create a toolbox and its initial version from a file.',
+								},
+								{
+									name: ['delete'],
+									description: 'Delete a toolbox or a single version.',
+								},
+								{
+									name: ['list'],
+									description: 'List toolboxes on the project.',
+								},
+								{
+									name: ['publish'],
+									description: 'Set the default version for a toolbox.',
+								},
+								{
+									name: ['show'],
+									description: 'Show a toolbox version, including its computed MCP endpoint.',
+								},
+								{
+									name: ['skill'],
+									description: 'Manage skill references attached to a toolbox.',
+									subcommands: [
+										{
+											name: ['add'],
+											description: 'Attach one or more skill references to a toolbox.',
+										},
+										{
+											name: ['list'],
+											description: 'List the skill references attached to a toolbox.',
+										},
+										{
+											name: ['remove'],
+											description: 'Detach one or more skill references from a toolbox.',
+										},
+									],
+								},
+								{
+									name: ['version'],
+									description: 'Display the extension version',
+								},
+								{
+									name: ['versions'],
+									description: 'Inspect toolbox versions.',
+									subcommands: [
+										{
+											name: ['list'],
+											description: 'List published versions for a toolbox.',
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+				{
+					name: ['appservice'],
+					description: 'Extension for managing Azure App Service resources.',
+					subcommands: [
+						{
+							name: ['swap'],
+							description: 'Swap deployment slots for an App Service.',
+						},
+						{
+							name: ['version'],
+							description: 'Display the version of the extension.',
+						},
+					],
+				},
+				{
+					name: ['auth'],
+					description: 'Authenticate with Azure.',
+					subcommands: [
+						{
+							name: ['login'],
+							description: 'Log in to Azure.',
+						},
+						{
+							name: ['logout'],
+							description: 'Log out of Azure.',
+						},
+						{
+							name: ['status'],
+							description: 'Show the current authentication status.',
+						},
+					],
+				},
+				{
+					name: ['coding-agent'],
+					description: 'This extension configures GitHub Copilot Coding Agent access to Azure',
+					subcommands: [
+						{
+							name: ['config'],
+							description: 'Configure the GitHub Copilot coding agent to access Azure resources via the Azure MCP',
+						},
+						{
+							name: ['version'],
+							description: 'Prints the version of the application',
+						},
+					],
+				},
+				{
+					name: ['completion'],
+					description: 'Generate shell completion scripts.',
+					subcommands: [
+						{
+							name: ['bash'],
+							description: 'Generate bash completion script.',
+						},
+						{
+							name: ['fig'],
+							description: 'Generate Fig autocomplete spec.',
+						},
+						{
+							name: ['fish'],
+							description: 'Generate fish completion script.',
+						},
+						{
+							name: ['powershell'],
+							description: 'Generate PowerShell completion script.',
+						},
+						{
+							name: ['zsh'],
+							description: 'Generate zsh completion script.',
+						},
+					],
+				},
+				{
+					name: ['concurx'],
+					description: 'Concurrent execution for azd deployment',
+					subcommands: [
+						{
+							name: ['up'],
+							description: 'Runs azd up in concurrent mode',
+						},
+						{
+							name: ['version'],
+							description: 'Prints the version of the application',
+						},
+					],
+				},
+				{
+					name: ['config'],
+					description: 'Manage azd configurations (ex: default Azure subscription, location).',
+					subcommands: [
+						{
+							name: ['get'],
+							description: 'Gets a configuration.',
+						},
+						{
+							name: ['list-alpha'],
+							description: 'Display the list of available features in alpha stage.',
+						},
+						{
+							name: ['options'],
+							description: 'List all available configuration settings.',
+						},
+						{
+							name: ['reset'],
+							description: 'Resets configuration to default.',
+						},
+						{
+							name: ['set'],
+							description: 'Sets a configuration.',
+						},
+						{
+							name: ['show'],
+							description: 'Show all the configuration values.',
+						},
+						{
+							name: ['sub-filter'],
+							description: 'Manage subscription filters for tenant-scoped subscription prompts.',
+							subcommands: [
+								{
+									name: ['remove'],
+									description: 'Remove a saved subscription filter for a tenant.',
+								},
+								{
+									name: ['set'],
+									description: 'Set a subscription filter for a tenant.',
+								},
+							],
+						},
+						{
+							name: ['unset'],
+							description: 'Unsets a configuration.',
+						},
+					],
+				},
+				{
+					name: ['copilot'],
+					description: 'Manage GitHub Copilot agent settings. (Preview)',
+					subcommands: [
+						{
+							name: ['consent'],
+							description: 'Manage tool consent.',
+							subcommands: [
+								{
+									name: ['grant'],
+									description: 'Grant consent trust rules.',
+								},
+								{
+									name: ['list'],
+									description: 'List consent rules.',
+								},
+								{
+									name: ['revoke'],
+									description: 'Revoke consent rules.',
+								},
+							],
+						},
+					],
+				},
+				{
+					name: ['demo'],
+					description: 'This extension provides examples of the azd extension framework.',
+					subcommands: [
+						{
+							name: ['ai'],
+							description: 'Interactive AI model discovery, deployment, and quota demos.',
+							subcommands: [
+								{
+									name: ['deployment'],
+									description: 'Select model/version/SKU/capacity and resolve a valid deployment configuration.',
+								},
+								{
+									name: ['models'],
+									description: 'Browse available AI models interactively.',
+								},
+								{
+									name: ['quota'],
+									description: 'View usage meters and limits for a selected location.',
+								},
+							],
+						},
+						{
+							name: ['colors', 'colours'],
+							description: 'Displays all ASCII colors with their standard and high-intensity variants.',
+						},
+						{
+							name: ['config'],
+							description: 'Set up monitoring configuration for the project and services',
+						},
+						{
+							name: ['context'],
+							description: 'Get the context of the azd project & environment.',
+						},
+						{
+							name: ['gh-url-parse'],
+							description: 'Parse a GitHub URL and extract repository information.',
+						},
+						{
+							name: ['listen'],
+							description: 'Starts the extension and listens for events.',
+						},
+						{
+							name: ['mcp'],
+							description: 'MCP server commands for demo extension',
+							subcommands: [
+								{
+									name: ['start'],
+									description: 'Start MCP server with demo tools',
+								},
+							],
+						},
+						{
+							name: ['prompt'],
+							description: 'Examples of prompting the user for input.',
+						},
+						{
+							name: ['version'],
+							description: 'Prints the version of the application',
+						},
+					],
+				},
+				{
+					name: ['deploy'],
+					description: 'Deploy your project code to Azure.',
+				},
+				{
+					name: ['down'],
+					description: 'Delete your project\'s Azure resources.',
+				},
+				{
+					name: ['env'],
+					description: 'Manage environments (ex: default environment, environment variables).',
+					subcommands: [
+						{
+							name: ['config'],
+							description: 'Manage environment configuration (ex: stored in .azure/<environment>/config.json).',
+							subcommands: [
+								{
+									name: ['get'],
+									description: 'Gets a configuration value from the environment.',
+								},
+								{
+									name: ['set'],
+									description: 'Sets a configuration value in the environment.',
+								},
+								{
+									name: ['unset'],
+									description: 'Unsets a configuration value in the environment.',
+								},
+							],
+						},
+						{
+							name: ['get-value'],
+							description: 'Get specific environment value.',
+						},
+						{
+							name: ['get-values'],
+							description: 'Get all environment values.',
+						},
+						{
+							name: ['list', 'ls'],
+							description: 'List environments.',
+						},
+						{
+							name: ['new'],
+							description: 'Create a new environment and set it as the default.',
+						},
+						{
+							name: ['refresh'],
+							description: 'Refresh environment values by using information from a previous infrastructure provision.',
+						},
+						{
+							name: ['remove', 'rm'],
+							description: 'Remove an environment.',
+						},
+						{
+							name: ['select'],
+							description: 'Set the default environment.',
+						},
+						{
+							name: ['set'],
+							description: 'Set one or more environment values.',
+						},
+						{
+							name: ['set-secret'],
+							description: 'Set a name as a reference to a Key Vault secret in the environment.',
+						},
+					],
+				},
+				{
+					name: ['exec'],
+					description: 'Execute commands and scripts with azd environment context.',
+				},
+				{
+					name: ['extension', 'ext'],
+					description: 'Manage azd extensions.',
+					subcommands: [
+						{
+							name: ['install'],
+							description: 'Installs specified extensions.',
+						},
+						{
+							name: ['list'],
+							description: 'List available extensions.',
+						},
+						{
+							name: ['show'],
+							description: 'Show details for a specific extension.',
+						},
+						{
+							name: ['source'],
+							description: 'View and manage extension sources',
+							subcommands: [
+								{
+									name: ['add'],
+									description: 'Add an extension source with the specified name',
+								},
+								{
+									name: ['list'],
+									description: 'List extension sources',
+								},
+								{
+									name: ['remove'],
+									description: 'Remove an extension source with the specified name',
+								},
+								{
+									name: ['validate'],
+									description: 'Validate an extension source\'s registry.json file.',
+								},
+							],
+						},
+						{
+							name: ['uninstall'],
+							description: 'Uninstall specified extensions.',
+						},
+						{
+							name: ['upgrade'],
+							description: 'Upgrade installed extensions to the latest version.',
+						},
+					],
+				},
+				{
+					name: ['hooks'],
+					description: 'Develop, test and run hooks for a project.',
+					subcommands: [
+						{
+							name: ['run'],
+							description: 'Runs the specified hook for the project, provisioning layers, and services',
+						},
+					],
+				},
+				{
+					name: ['infra'],
+					description: 'Manage your Infrastructure as Code (IaC).',
+					subcommands: [
+						{
+							name: ['generate', 'gen', 'synth'],
+							description: 'Write IaC for your project to disk, allowing you to manually manage it.',
+						},
+					],
+				},
+				{
+					name: ['init'],
+					description: 'Initialize a new application.',
+				},
+				{
+					name: ['mcp'],
+					description: 'Manage Model Context Protocol (MCP) server. (Alpha)',
+					subcommands: [
+						{
+							name: ['start'],
+							description: 'Starts the MCP server.',
+						},
+					],
+				},
+				{
+					name: ['monitor'],
+					description: 'Monitor a deployed project.',
+				},
+				{
+					name: ['package'],
+					description: 'Packages the project\'s code to be deployed to Azure.',
+				},
+				{
+					name: ['pipeline'],
+					description: 'Manage and configure your deployment pipelines.',
+					subcommands: [
+						{
+							name: ['config'],
+							description: 'Configure your deployment pipeline to connect securely to Azure. (Beta)',
+						},
+					],
+				},
+				{
+					name: ['provision'],
+					description: 'Provision Azure resources for your project.',
+				},
+				{
+					name: ['publish'],
+					description: 'Publish a service to a container registry.',
+				},
+				{
+					name: ['restore'],
+					description: 'Restores the project\'s dependencies.',
+				},
+				{
+					name: ['show'],
+					description: 'Display information about your project and its resources.',
+				},
+				{
+					name: ['template'],
+					description: 'Find and view template details.',
+					subcommands: [
+						{
+							name: ['list', 'ls'],
+							description: 'Show list of sample azd templates. (Beta)',
+						},
+						{
+							name: ['show'],
+							description: 'Show details for a given template. (Beta)',
+						},
+						{
+							name: ['source'],
+							description: 'View and manage template sources. (Beta)',
+							subcommands: [
+								{
+									name: ['add'],
+									description: 'Adds an azd template source with the specified key. (Beta)',
+								},
+								{
+									name: ['list', 'ls'],
+									description: 'Lists the configured azd template sources. (Beta)',
+								},
+								{
+									name: ['remove'],
+									description: 'Removes the specified azd template source (Beta)',
+								},
+							],
+						},
+					],
+				},
+				{
+					name: ['tool'],
+					description: 'Manage Azure development tools.',
+					subcommands: [
+						{
+							name: ['check'],
+							description: 'Check for tool updates.',
+						},
+						{
+							name: ['install'],
+							description: 'Install specified tools.',
+						},
+						{
+							name: ['list'],
+							description: 'List all tools with status.',
+						},
+						{
+							name: ['show'],
+							description: 'Show details for a specific tool.',
+						},
+						{
+							name: ['upgrade'],
+							description: 'Upgrade installed tools.',
+						},
+					],
+				},
+				{
+					name: ['up'],
+					description: 'Provision and deploy your project to Azure with a single command.',
+				},
+				{
+					name: ['update'],
+					description: 'Updates azd to the latest version.',
+				},
+				{
+					name: ['version'],
+					description: 'Print the version number of Azure Developer CLI.',
+				},
+				{
+					name: ['x'],
+					description: 'This extension provides a set of tools for azd extension developers to test and debug their extensions.',
+					subcommands: [
+						{
+							name: ['build'],
+							description: 'Build the azd extension project',
+						},
+						{
+							name: ['init'],
+							description: 'Initialize a new azd extension project',
+						},
+						{
+							name: ['pack'],
+							description: 'Build and pack extension artifacts',
+						},
+						{
+							name: ['publish'],
+							description: 'Publish the extension to the extension source',
+						},
+						{
+							name: ['release'],
+							description: 'Create a new extension release from the packaged artifacts',
+						},
+						{
+							name: ['version'],
+							description: 'Prints the version of the application',
+						},
+						{
+							name: ['watch'],
+							description: 'Watches the azd extension project for file changes and rebuilds it.',
+						},
+					],
+				},
+			],
 		},
 	],
 	options: [

--- a/cli/azd/cmd/testdata/TestUsage-azd-config-sub-filter-remove.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config-sub-filter-remove.snap
@@ -1,0 +1,17 @@
+
+Remove a saved subscription filter for a tenant.
+
+Usage
+  azd config sub-filter remove [flags]
+
+Global Flags
+    -C, --cwd string         	: Sets the current working directory.
+        --debug              	: Enables debugging and diagnostics logging.
+        --docs               	: Opens the documentation for azd config sub-filter remove in your web browser.
+    -e, --environment string 	: The name of the environment to use.
+    -h, --help               	: Gets help for remove.
+        --no-prompt          	: Runs without prompts. Uses existing values; fails if any required value or decision cannot be resolved automatically.
+
+Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
+
+

--- a/cli/azd/cmd/testdata/TestUsage-azd-config-sub-filter-set.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config-sub-filter-set.snap
@@ -1,0 +1,17 @@
+
+Set a subscription filter for a tenant.
+
+Usage
+  azd config sub-filter set [flags]
+
+Global Flags
+    -C, --cwd string         	: Sets the current working directory.
+        --debug              	: Enables debugging and diagnostics logging.
+        --docs               	: Opens the documentation for azd config sub-filter set in your web browser.
+    -e, --environment string 	: The name of the environment to use.
+    -h, --help               	: Gets help for set.
+        --no-prompt          	: Runs without prompts. Uses existing values; fails if any required value or decision cannot be resolved automatically.
+
+Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
+
+

--- a/cli/azd/cmd/testdata/TestUsage-azd-config-sub-filter.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config-sub-filter.snap
@@ -1,0 +1,23 @@
+
+Manage subscription filters for tenant-scoped subscription prompts.
+
+Usage
+  azd config sub-filter [command]
+
+Available Commands
+  remove	: Remove a saved subscription filter for a tenant.
+  set   	: Set a subscription filter for a tenant.
+
+Global Flags
+    -C, --cwd string         	: Sets the current working directory.
+        --debug              	: Enables debugging and diagnostics logging.
+        --docs               	: Opens the documentation for azd config sub-filter in your web browser.
+    -e, --environment string 	: The name of the environment to use.
+    -h, --help               	: Gets help for sub-filter.
+        --no-prompt          	: Runs without prompts. Uses existing values; fails if any required value or decision cannot be resolved automatically.
+
+Use azd config sub-filter [command] --help to view examples and more information about a specific command.
+
+Find a bug? Want to let us know how we're doing? Fill out this brief survey: https://aka.ms/azure-dev/hats.
+
+

--- a/cli/azd/cmd/testdata/TestUsage-azd-config.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config.snap
@@ -15,6 +15,7 @@ Available Commands
   reset     	: Resets configuration to default.
   set       	: Sets a configuration.
   show      	: Show all the configuration values.
+  sub-filter	: Manage subscription filters for tenant-scoped subscription prompts.
   unset     	: Unsets a configuration.
 
 Global Flags

--- a/cli/azd/internal/cmd/errors_test.go
+++ b/cli/azd/internal/cmd/errors_test.go
@@ -1252,10 +1252,10 @@ func Test_PackageLevelErrorsMapped(t *testing.T) {
 		"ErrNoResourceSelected": "pkg/prompt: interactive prompt error, caught in command callers",
 
 		// Subscription filter errors surfaced as user-facing messages in sub-filter commands
-		"ErrInteractiveRequired":    "internal: sub-filter requires interactive mode, caught in command action",
-		"ErrNoSubscriptionsFound":   "internal: no subscriptions available, caught in command action",
-		"ErrNoTenantsFound":         "internal: no tenants available, caught in command action",
-		"ErrNoFilterExists":         "internal: no filter to remove, caught in command action",
+		"ErrInteractiveRequired":  "internal: sub-filter requires interactive mode, caught in command action",
+		"ErrNoSubscriptionsFound": "internal: no subscriptions available, caught in command action",
+		"ErrNoTenantsFound":       "internal: no tenants available, caught in command action",
+		"ErrNoFilterExists":       "internal: no filter to remove, caught in command action",
 
 		// Template errors caught in init flow
 		"ErrTemplateNotFound": "pkg/templates: caught in init/template callers before reaching telemetry",

--- a/cli/azd/internal/cmd/errors_test.go
+++ b/cli/azd/internal/cmd/errors_test.go
@@ -1251,6 +1251,12 @@ func Test_PackageLevelErrorsMapped(t *testing.T) {
 		"ErrNoResourcesFound":   "pkg/prompt: interactive prompt error, caught in command callers",
 		"ErrNoResourceSelected": "pkg/prompt: interactive prompt error, caught in command callers",
 
+		// Subscription filter errors surfaced as user-facing messages in sub-filter commands
+		"ErrInteractiveRequired":    "internal: sub-filter requires interactive mode, caught in command action",
+		"ErrNoSubscriptionsFound":   "internal: no subscriptions available, caught in command action",
+		"ErrNoTenantsFound":         "internal: no tenants available, caught in command action",
+		"ErrNoFilterExists":         "internal: no filter to remove, caught in command action",
+
 		// Template errors caught in init flow
 		"ErrTemplateNotFound": "pkg/templates: caught in init/template callers before reaching telemetry",
 

--- a/cli/azd/internal/errors.go
+++ b/cli/azd/internal/errors.go
@@ -123,6 +123,14 @@ var (
 	ErrToolUpgradeFailed = errors.New("tool upgrade did not succeed")
 )
 
+// Subscription filter errors
+var (
+	ErrInteractiveRequired    = errors.New("interactive mode required")
+	ErrNoSubscriptionsFound   = errors.New("no subscriptions found")
+	ErrNoTenantsFound         = errors.New("no tenants found")
+	ErrNoFilterExists         = errors.New("no saved filter exists")
+)
+
 // ExitCodeError wraps an error with a specific process exit code.
 // When returned from an action, main.go uses the exit code instead of the
 // default exit code 1. This is used by `azd exec` to propagate the child

--- a/cli/azd/internal/errors.go
+++ b/cli/azd/internal/errors.go
@@ -125,10 +125,10 @@ var (
 
 // Subscription filter errors
 var (
-	ErrInteractiveRequired    = errors.New("interactive mode required")
-	ErrNoSubscriptionsFound   = errors.New("no subscriptions found")
-	ErrNoTenantsFound         = errors.New("no tenants found")
-	ErrNoFilterExists         = errors.New("no saved filter exists")
+	ErrInteractiveRequired  = errors.New("interactive mode required")
+	ErrNoSubscriptionsFound = errors.New("no subscriptions found")
+	ErrNoTenantsFound       = errors.New("no tenants found")
+	ErrNoFilterExists       = errors.New("no saved filter exists")
 )
 
 // ExitCodeError wraps an error with a specific process exit code.

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider_test.go
@@ -582,7 +582,7 @@ func createBicepProvider(t *testing.T, mockContext *mocks.MockContext) *BicepPro
 		envManager,
 		env,
 		mockContext.Console,
-		prompt.NewDefaultPrompter(env, mockContext.Console, accountManager, resourceService, cloud.AzurePublic()),
+		prompt.NewDefaultPrompter(env, mockContext.Console, accountManager, nil, resourceService, cloud.AzurePublic()),
 		&mockCurrentPrincipal{},
 		keyvault.NewKeyVaultService(
 			mockaccount.SubscriptionCredentialProviderFunc(
@@ -1258,7 +1258,7 @@ func TestUserDefinedTypes(t *testing.T) {
 		&mockenv.MockEnvManager{},
 		env,
 		mockContext.Console,
-		prompt.NewDefaultPrompter(env, mockContext.Console, nil, nil, cloud.AzurePublic()),
+		prompt.NewDefaultPrompter(env, mockContext.Console, nil, nil, nil, cloud.AzurePublic()),
 		&mockCurrentPrincipal{},
 		keyvault.NewKeyVaultService(
 			mockaccount.SubscriptionCredentialProviderFunc(
@@ -1924,7 +1924,7 @@ func createBicepProviderWithEnvAndMode(
 		envManager,
 		env,
 		mockContext.Console,
-		prompt.NewDefaultPrompter(env, mockContext.Console, accountManager, resourceService, cloud.AzurePublic()),
+		prompt.NewDefaultPrompter(env, mockContext.Console, accountManager, nil, resourceService, cloud.AzurePublic()),
 		&mockCurrentPrincipal{},
 		keyvault.NewKeyVaultService(
 			mockaccount.SubscriptionCredentialProviderFunc(

--- a/cli/azd/pkg/infra/provisioning/bicep/prompt_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt_test.go
@@ -279,6 +279,7 @@ func TestPromptForParametersLocation(t *testing.T) {
 		env,
 		mockContext.Console,
 		accountManager,
+		nil,
 		p.resourceService,
 		cloud.AzurePublic(),
 	)

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/test"
@@ -353,6 +354,9 @@ func registerContainerDependencies(mockContext *mocks.MockContext, env *environm
 	})
 
 	mockContext.Container.MustRegisterSingleton(azapi.NewResourceService)
+	mockContext.Container.MustRegisterSingleton(func() config.UserConfigManager {
+		return config.NewUserConfigManager(config.NewFileConfigManager(config.NewManager()))
+	})
 	mockContext.Container.MustRegisterSingleton(prompt.NewDefaultPrompter)
 	mockContext.Container.MustRegisterSingleton(azapi.NewResourceService)
 	mockContext.Container.MustRegisterNamedTransient(string(provisioning.Test), test.NewTestProvider)

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -355,7 +355,7 @@ func registerContainerDependencies(mockContext *mocks.MockContext, env *environm
 
 	mockContext.Container.MustRegisterSingleton(azapi.NewResourceService)
 	mockContext.Container.MustRegisterSingleton(func() config.UserConfigManager {
-		return config.NewUserConfigManager(config.NewFileConfigManager(config.NewManager()))
+		return config.NewUserConfigManager(mockContext.ConfigManager)
 	})
 	mockContext.Container.MustRegisterSingleton(prompt.NewDefaultPrompter)
 	mockContext.Container.MustRegisterNamedTransient(string(provisioning.Test), test.NewTestProvider)

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -358,7 +358,6 @@ func registerContainerDependencies(mockContext *mocks.MockContext, env *environm
 		return config.NewUserConfigManager(config.NewFileConfigManager(config.NewManager()))
 	})
 	mockContext.Container.MustRegisterSingleton(prompt.NewDefaultPrompter)
-	mockContext.Container.MustRegisterSingleton(azapi.NewResourceService)
 	mockContext.Container.MustRegisterNamedTransient(string(provisioning.Test), test.NewTestProvider)
 	mockContext.Container.MustRegisterSingleton(func() account.Manager {
 		return &mockaccount.MockAccountManager{

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider_test.go
@@ -140,7 +140,7 @@ func createTerraformProvider(t *testing.T, mockContext *mocks.MockContext) *Terr
 		env,
 		mockContext.Console,
 		&mockCurrentPrincipal{},
-		prompt.NewDefaultPrompter(env, mockContext.Console, accountManager, resourceService, cloud.AzurePublic()),
+		prompt.NewDefaultPrompter(env, mockContext.Console, accountManager, nil, resourceService, cloud.AzurePublic()),
 	)
 
 	err := provider.Initialize(*mockContext.Context, projectDir, options)
@@ -352,6 +352,7 @@ func TestIsRemoteBackendConfig(t *testing.T) {
 					env,
 					mockContext.Console,
 					accountManager,
+					nil,
 					resourceService,
 					cloud.AzurePublic(),
 				),

--- a/cli/azd/pkg/input/asker.go
+++ b/cli/azd/pkg/input/asker.go
@@ -122,6 +122,11 @@ func askOnePrompt(p survey.Prompt, response any, isTerminal bool, stdout io.Writ
 			opts = append(opts, withShowCursor)
 		}
 
+		// Keep the filter text after toggling selections in multi-select prompts.
+		if _, ok := p.(*survey.MultiSelect); ok {
+			opts = append(opts, survey.WithKeepFilter(true))
+		}
+
 		opts = append(opts, survey.WithIcons(func(icons *survey.IconSet) {
 			// use bright, bold, blue question mark for all questions
 			icons.Question.Format = "blue+hb"

--- a/cli/azd/pkg/prompt/format_helpers_test.go
+++ b/cli/azd/pkg/prompt/format_helpers_test.go
@@ -43,7 +43,7 @@ func TestFormatSubscriptionDisplayName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := formatSubscriptionDisplayName(sub, tt.hideId)
+			result := FormatSubscriptionDisplay(sub, tt.hideId)
 			require.NotEmpty(t, result)
 
 			if tt.exactMatch != "" {
@@ -156,7 +156,7 @@ func TestIsDemoModeEnabled(t *testing.T) {
 				t.Setenv("AZD_DEMO_MODE", "")
 			}
 
-			result := isDemoModeEnabled()
+			result := IsDemoModeEnabled()
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -167,7 +167,7 @@ func TestIsDemoModeEnabled_Unset(t *testing.T) {
 	// process env (which should not have it in CI).
 	// This tests the "env var not present" path.
 	t.Setenv("AZD_DEMO_MODE", "")
-	assert.False(t, isDemoModeEnabled())
+	assert.False(t, IsDemoModeEnabled())
 }
 
 func TestNewEmptyAzureContext(t *testing.T) {

--- a/cli/azd/pkg/prompt/prompt_service.go
+++ b/cli/azd/pkg/prompt/prompt_service.go
@@ -355,11 +355,11 @@ func (ps *promptService) PromptSubscription(
 
 	// If user selected "Show all subscriptions", re-prompt with full list
 	if result != nil && result.Id == ShowAllSubscriptionsOption {
-		allSubPtrs := make(
+		allSubSlice := make(
 			[]*account.Subscription, len(unfilteredSubs),
 		)
 		for i := range unfilteredSubs {
-			allSubPtrs[i] = &unfilteredSubs[i]
+			allSubSlice[i] = &unfilteredSubs[i]
 		}
 
 		return PromptCustomResource(
@@ -368,7 +368,7 @@ func (ps *promptService) PromptSubscription(
 				LoadData: func(
 					ctx context.Context,
 				) ([]*account.Subscription, error) {
-					return allSubPtrs, nil
+					return allSubSlice, nil
 				},
 				DisplayResource: func(
 					subscription *account.Subscription,

--- a/cli/azd/pkg/prompt/prompt_service.go
+++ b/cli/azd/pkg/prompt/prompt_service.go
@@ -29,12 +29,14 @@ var (
 	ErrNoResourceSelected = fmt.Errorf("no resource selected")
 )
 
-func isDemoModeEnabled() bool {
+// IsDemoModeEnabled checks if AZD_DEMO_MODE is enabled.
+func IsDemoModeEnabled() bool {
 	v, err := strconv.ParseBool(os.Getenv("AZD_DEMO_MODE"))
 	return err == nil && v
 }
 
-func formatSubscriptionDisplayName(subscription *account.Subscription, hideId bool) string {
+// FormatSubscriptionDisplay formats a subscription for display in selection prompts.
+func FormatSubscriptionDisplay(subscription *account.Subscription, hideId bool) string {
 	if hideId {
 		return subscription.Name
 	}
@@ -258,8 +260,9 @@ func (ps *promptService) PromptSubscription(
 
 	// Apply tenant filtering (after spinner is done so the prompt doesn't overlap)
 	subscriptionList = filterByTenantEnvVar(subscriptionList)
+	var selectedTenantId string
 	if !ps.console.IsNoPromptMode() {
-		subscriptionList, err = promptAndFilterByTenant(
+		subscriptionList, selectedTenantId, err = promptAndFilterByTenant(
 			ctx, ps.console, subscriptionList, ps.subscriptionManager.GetTenantDisplayNames)
 		if err != nil {
 			return nil, err
@@ -276,7 +279,20 @@ func (ps *promptService) PromptSubscription(
 		}
 	}
 
-	hideId := isDemoModeEnabled()
+	// Apply subscription filter if one exists for the selected tenant
+	var filterApplied bool
+	if selectedTenantId != "" && userConfig != nil {
+		filterIds, hasFilter := LoadSubscriptionFilter(
+			userConfig, selectedTenantId,
+		)
+		if hasFilter {
+			subscriptionList, filterApplied = ApplySubscriptionFilter(
+				subscriptionList, filterIds,
+			)
+		}
+	}
+
+	hideId := IsDemoModeEnabled()
 
 	// Use PromptCustomResource with pre-loaded data
 	subscriptions := make([]*account.Subscription, len(subscriptionList))
@@ -284,22 +300,104 @@ func (ps *promptService) PromptSubscription(
 		subscriptions[i] = &subscriptionList[i]
 	}
 
+	// Show note when subscription filter is active
+	if filterApplied {
+		ps.console.Message(ctx, FilteredSubscriptionNote)
+	}
+
 	// Create selector options with spinner disabled since data is already loaded
 	resourceSelectorOptions := *mergedOptions
 	resourceSelectorOptions.SkipLoadingSpinner = true
 
-	return PromptCustomResource(ctx, CustomResourceOptions[account.Subscription]{
-		SelectorOptions: &resourceSelectorOptions,
-		LoadData: func(ctx context.Context) ([]*account.Subscription, error) {
-			return subscriptions, nil
-		},
-		DisplayResource: func(subscription *account.Subscription) (string, error) {
-			return formatSubscriptionDisplayName(subscription, hideId), nil
-		},
-		Selected: func(subscription *account.Subscription) bool {
-			return strings.EqualFold(subscription.Id, defaultSubscriptionId)
-		},
-	})
+	result, err := PromptCustomResource(
+		ctx, CustomResourceOptions[account.Subscription]{
+			SelectorOptions: &resourceSelectorOptions,
+			LoadData: func(
+				ctx context.Context,
+			) ([]*account.Subscription, error) {
+				if filterApplied {
+					// Append sentinel for "Show all subscriptions"
+					withShowAll := make(
+						[]*account.Subscription,
+						len(subscriptions)+1,
+					)
+					copy(withShowAll, subscriptions)
+					withShowAll[len(subscriptions)] = &account.Subscription{
+						Id:   ShowAllSubscriptionsOption,
+						Name: ShowAllSubscriptionsOption,
+					}
+					return withShowAll, nil
+				}
+				return subscriptions, nil
+			},
+			DisplayResource: func(
+				subscription *account.Subscription,
+			) (string, error) {
+				if subscription.Id == ShowAllSubscriptionsOption {
+					return ShowAllSubscriptionsOption, nil
+				}
+				return FormatSubscriptionDisplay(
+					subscription, hideId,
+				), nil
+			},
+			Selected: func(
+				subscription *account.Subscription,
+			) bool {
+				return strings.EqualFold(
+					subscription.Id, defaultSubscriptionId,
+				)
+			},
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	// If user selected "Show all subscriptions", re-prompt with full list
+	if result != nil && result.Id == ShowAllSubscriptionsOption {
+		allSubs, loadErr := ps.subscriptionManager.GetSubscriptions(ctx)
+		if loadErr != nil {
+			return nil, fmt.Errorf(
+				"listing subscriptions: %w", loadErr,
+			)
+		}
+		allSubs = filterByTenantEnvVar(allSubs)
+		if selectedTenantId != "" {
+			allSubs = FilterSubscriptionsByTenantId(
+				allSubs, selectedTenantId,
+			)
+		}
+
+		allSubPtrs := make([]*account.Subscription, len(allSubs))
+		for i := range allSubs {
+			allSubPtrs[i] = &allSubs[i]
+		}
+
+		return PromptCustomResource(
+			ctx, CustomResourceOptions[account.Subscription]{
+				SelectorOptions: &resourceSelectorOptions,
+				LoadData: func(
+					ctx context.Context,
+				) ([]*account.Subscription, error) {
+					return allSubPtrs, nil
+				},
+				DisplayResource: func(
+					subscription *account.Subscription,
+				) (string, error) {
+					return FormatSubscriptionDisplay(
+						subscription, hideId,
+					), nil
+				},
+				Selected: func(
+					subscription *account.Subscription,
+				) bool {
+					return strings.EqualFold(
+						subscription.Id, defaultSubscriptionId,
+					)
+				},
+			})
+	}
+
+	return result, nil
 }
 
 // PromptLocation prompts the user to select an Azure location.

--- a/cli/azd/pkg/prompt/prompt_service.go
+++ b/cli/azd/pkg/prompt/prompt_service.go
@@ -281,6 +281,7 @@ func (ps *promptService) PromptSubscription(
 
 	// Apply subscription filter if one exists for the selected tenant
 	var filterApplied bool
+	unfilteredSubs := subscriptionList
 	if selectedTenantId != "" && userConfig != nil {
 		filterIds, hasFilter := LoadSubscriptionFilter(
 			userConfig, selectedTenantId,
@@ -354,22 +355,11 @@ func (ps *promptService) PromptSubscription(
 
 	// If user selected "Show all subscriptions", re-prompt with full list
 	if result != nil && result.Id == ShowAllSubscriptionsOption {
-		allSubs, loadErr := ps.subscriptionManager.GetSubscriptions(ctx)
-		if loadErr != nil {
-			return nil, fmt.Errorf(
-				"listing subscriptions: %w", loadErr,
-			)
-		}
-		allSubs = filterByTenantEnvVar(allSubs)
-		if selectedTenantId != "" {
-			allSubs = FilterSubscriptionsByTenantId(
-				allSubs, selectedTenantId,
-			)
-		}
-
-		allSubPtrs := make([]*account.Subscription, len(allSubs))
-		for i := range allSubs {
-			allSubPtrs[i] = &allSubs[i]
+		allSubPtrs := make(
+			[]*account.Subscription, len(unfilteredSubs),
+		)
+		for i := range unfilteredSubs {
+			allSubPtrs[i] = &unfilteredSubs[i]
 		}
 
 		return PromptCustomResource(

--- a/cli/azd/pkg/prompt/prompt_service_test.go
+++ b/cli/azd/pkg/prompt/prompt_service_test.go
@@ -69,7 +69,7 @@ func Test_PromptService_PromptSubscription(t *testing.T) {
 }
 
 func TestFormatSubscriptionDisplayName_DemoModeHidesId(t *testing.T) {
-	displayName := formatSubscriptionDisplayName(&account.Subscription{
+	displayName := FormatSubscriptionDisplay(&account.Subscription{
 		Id:   "/subscriptions/sub-1",
 		Name: "Subscription 1",
 	}, true)

--- a/cli/azd/pkg/prompt/prompter.go
+++ b/cli/azd/pkg/prompt/prompter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/azureutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/stringutil"
@@ -46,26 +47,29 @@ type Prompter interface {
 }
 
 type DefaultPrompter struct {
-	console         input.Console
-	env             *environment.Environment
-	accountManager  account.Manager
-	resourceService *azapi.ResourceService
-	portalUrlBase   string
+	console           input.Console
+	env               *environment.Environment
+	accountManager    account.Manager
+	userConfigManager config.UserConfigManager
+	resourceService   *azapi.ResourceService
+	portalUrlBase     string
 }
 
 func NewDefaultPrompter(
 	env *environment.Environment,
 	console input.Console,
 	accountManager account.Manager,
+	userConfigManager config.UserConfigManager,
 	resourceService *azapi.ResourceService,
 	cloud *cloud.Cloud,
 ) Prompter {
 	return &DefaultPrompter{
-		console:         console,
-		env:             env,
-		accountManager:  accountManager,
-		resourceService: resourceService,
-		portalUrlBase:   cloud.PortalUrlBase,
+		console:           console,
+		env:               env,
+		accountManager:    accountManager,
+		userConfigManager: userConfigManager,
+		resourceService:   resourceService,
+		portalUrlBase:     cloud.PortalUrlBase,
 	}
 }
 
@@ -90,11 +94,28 @@ func (p *DefaultPrompter) PromptSubscription(ctx context.Context, msg string) (s
 	subscriptionInfos = filterByTenantEnvVar(subscriptionInfos)
 
 	// Tenant selection: if multiple tenants, prompt user to pick one
+	var selectedTenantId string
 	if !p.console.IsNoPromptMode() {
-		subscriptionInfos, err = promptAndFilterByTenant(
+		subscriptionInfos, selectedTenantId, err = promptAndFilterByTenant(
 			ctx, p.console, subscriptionInfos, p.accountManager.GetTenantDisplayNames)
 		if err != nil {
 			return "", err
+		}
+	}
+
+	// Apply subscription filter if one exists for the selected tenant
+	var filterApplied bool
+	if selectedTenantId != "" && p.userConfigManager != nil {
+		userCfg, cfgErr := p.userConfigManager.Load()
+		if cfgErr == nil {
+			filterIds, hasFilter := LoadSubscriptionFilter(
+				userCfg, selectedTenantId,
+			)
+			if hasFilter {
+				subscriptionInfos, filterApplied = ApplySubscriptionFilter(
+					subscriptionInfos, filterIds,
+				)
+			}
 		}
 	}
 
@@ -109,8 +130,23 @@ func (p *DefaultPrompter) PromptSubscription(ctx context.Context, msg string) (s
 		defaultSubscriptionId = p.accountManager.GetDefaultSubscriptionID(ctx)
 	}
 
+	// Show note when subscription filter is active
+	if filterApplied {
+		p.console.Message(ctx, FilteredSubscriptionNote)
+	}
+
 	subscriptionOptions, subscriptions, defaultSubscription :=
 		formatSubscriptionOptions(subscriptionInfos, defaultSubscriptionId)
+
+	// Add "Show all subscriptions" option when filter is active
+	if filterApplied {
+		subscriptionOptions = append(
+			subscriptionOptions, ShowAllSubscriptionsOption,
+		)
+		subscriptions = append(
+			subscriptions, ShowAllSubscriptionsOption,
+		)
+	}
 
 	for subscriptionId == "" {
 		subscriptionSelectionIndex, err := p.console.Select(ctx, input.ConsoleOptions{
@@ -124,6 +160,44 @@ func (p *DefaultPrompter) PromptSubscription(ctx context.Context, msg string) (s
 		}
 
 		subscriptionId = subscriptions[subscriptionSelectionIndex]
+	}
+
+	// If "Show all subscriptions" was selected, re-prompt with full list
+	if subscriptionId == ShowAllSubscriptionsOption {
+		subscriptionId = ""
+		allSubs, loadErr := p.accountManager.GetSubscriptions(ctx)
+		if loadErr != nil {
+			return "", fmt.Errorf("listing subscriptions: %w", loadErr)
+		}
+		allSubs = filterByTenantEnvVar(allSubs)
+		if selectedTenantId != "" {
+			allSubs = FilterSubscriptionsByTenantId(
+				allSubs, selectedTenantId,
+			)
+		}
+
+		slices.SortFunc(allSubs, func(a, b account.Subscription) int {
+			return stringutil.CompareLower(a.Name, b.Name)
+		})
+
+		allOpts, allIds, allDefault := formatSubscriptionOptions(
+			allSubs, defaultSubscriptionId,
+		)
+
+		for subscriptionId == "" {
+			idx, selErr := p.console.Select(
+				ctx, input.ConsoleOptions{
+					Message:      msg,
+					Options:      allOpts,
+					DefaultValue: allDefault,
+				})
+			if selErr != nil {
+				return "", fmt.Errorf(
+					"reading subscription id: %w", selErr,
+				)
+			}
+			subscriptionId = allIds[idx]
+		}
 	}
 
 	if !p.accountManager.HasDefaultSubscription() {
@@ -143,7 +217,7 @@ func formatSubscriptionOptions(
 	options = make([]string, len(subscriptionInfos))
 	ids = make([]string, len(subscriptionInfos))
 
-	hideId := isDemoModeEnabled()
+	hideId := IsDemoModeEnabled()
 
 	for index, info := range subscriptionInfos {
 		if hideId {

--- a/cli/azd/pkg/prompt/prompter.go
+++ b/cli/azd/pkg/prompt/prompter.go
@@ -105,6 +105,7 @@ func (p *DefaultPrompter) PromptSubscription(ctx context.Context, msg string) (s
 
 	// Apply subscription filter if one exists for the selected tenant
 	var filterApplied bool
+	unfilteredSubs := subscriptionInfos
 	if selectedTenantId != "" && p.userConfigManager != nil {
 		userCfg, cfgErr := p.userConfigManager.Load()
 		if cfgErr == nil {
@@ -165,16 +166,7 @@ func (p *DefaultPrompter) PromptSubscription(ctx context.Context, msg string) (s
 	// If "Show all subscriptions" was selected, re-prompt with full list
 	if subscriptionId == ShowAllSubscriptionsOption {
 		subscriptionId = ""
-		allSubs, loadErr := p.accountManager.GetSubscriptions(ctx)
-		if loadErr != nil {
-			return "", fmt.Errorf("listing subscriptions: %w", loadErr)
-		}
-		allSubs = filterByTenantEnvVar(allSubs)
-		if selectedTenantId != "" {
-			allSubs = FilterSubscriptionsByTenantId(
-				allSubs, selectedTenantId,
-			)
-		}
+		allSubs := unfilteredSubs
 
 		slices.SortFunc(allSubs, func(a, b account.Subscription) int {
 			return stringutil.CompareLower(a.Name, b.Name)

--- a/cli/azd/pkg/prompt/prompter.go
+++ b/cli/azd/pkg/prompt/prompter.go
@@ -141,8 +141,10 @@ func (p *DefaultPrompter) PromptSubscription(ctx context.Context, msg string) (s
 
 	// Add "Show all subscriptions" option when filter is active
 	if filterApplied {
+		nextIdx := len(subscriptionOptions) + 1
 		subscriptionOptions = append(
-			subscriptionOptions, ShowAllSubscriptionsOption,
+			subscriptionOptions,
+			fmt.Sprintf("%2d. %s", nextIdx, ShowAllSubscriptionsOption),
 		)
 		subscriptions = append(
 			subscriptions, ShowAllSubscriptionsOption,

--- a/cli/azd/pkg/prompt/prompter_extra_test.go
+++ b/cli/azd/pkg/prompt/prompter_extra_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/cloud"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
@@ -222,6 +223,91 @@ func TestDefaultPrompter_PromptLocation_WithDefaultSelectedLocation(t *testing.T
 	require.Equal(t, "westus", loc)
 	require.NotNil(t, defaultValue)
 	require.Contains(t, defaultValue.(string), "West US")
+}
+
+func newTestPrompterWithConfig(
+	t *testing.T,
+	mockAccount *mockaccount.MockAccountManager,
+	ucm config.UserConfigManager,
+) (*DefaultPrompter, *mocks.MockContext) {
+	t.Helper()
+	mockContext := mocks.NewMockContext(t.Context())
+	env := environment.New("test")
+	resourceService := azapi.NewResourceService(
+		mockContext.SubscriptionCredentialProvider, mockContext.ArmClientOptions)
+
+	p := NewDefaultPrompter(
+		env, mockContext.Console, mockAccount, ucm, resourceService, cloud.AzurePublic(),
+	).(*DefaultPrompter)
+
+	return p, mockContext
+}
+
+func TestDefaultPrompter_PromptSubscription_FilterApplied(t *testing.T) {
+	t.Parallel()
+
+	// Two subs in the same tenant; filter includes only sub-alpha.
+	mockAccount := &mockaccount.MockAccountManager{
+		Subscriptions: []account.Subscription{
+			{Id: "sub-alpha", Name: "Alpha", TenantId: "t1", UserAccessTenantId: "t1"},
+			{Id: "sub-bravo", Name: "Bravo", TenantId: "t1", UserAccessTenantId: "t1"},
+		},
+	}
+
+	cfg := config.NewEmptyConfig()
+	_ = SaveSubscriptionFilter(cfg, "t1", []string{"sub-alpha"})
+	ucm := newInMemoryUserConfigManager(cfg)
+
+	p, mockCtx := newTestPrompterWithConfig(t, mockAccount, ucm)
+
+	// Capture the options presented and pick the first (Alpha).
+	var shownOptions []string
+	mockCtx.Console.WhenSelect(func(opts input.ConsoleOptions) bool {
+		shownOptions = opts.Options
+		return strings.Contains(opts.Message, "sub")
+	}).Respond(0)
+
+	subId, err := p.PromptSubscription(t.Context(), "Select a sub")
+	require.NoError(t, err)
+	require.Equal(t, "sub-alpha", subId)
+	// Should show only 1 sub + "Show all subscriptions"
+	require.Len(t, shownOptions, 2)
+	require.Equal(t, ShowAllSubscriptionsOption, shownOptions[len(shownOptions)-1])
+}
+
+func TestDefaultPrompter_PromptSubscription_ShowAll(t *testing.T) {
+	t.Parallel()
+
+	mockAccount := &mockaccount.MockAccountManager{
+		Subscriptions: []account.Subscription{
+			{Id: "sub-alpha", Name: "Alpha", TenantId: "t1", UserAccessTenantId: "t1"},
+			{Id: "sub-bravo", Name: "Bravo", TenantId: "t1", UserAccessTenantId: "t1"},
+		},
+	}
+
+	cfg := config.NewEmptyConfig()
+	_ = SaveSubscriptionFilter(cfg, "t1", []string{"sub-alpha"})
+	ucm := newInMemoryUserConfigManager(cfg)
+
+	p, mockCtx := newTestPrompterWithConfig(t, mockAccount, ucm)
+
+	selectCount := 0
+	mockCtx.Console.WhenSelect(func(opts input.ConsoleOptions) bool {
+		return strings.Contains(opts.Message, "sub")
+	}).RespondFn(func(opts input.ConsoleOptions) (any, error) {
+		selectCount++
+		if selectCount == 1 {
+			// Pick "Show all subscriptions" (last option)
+			return len(opts.Options) - 1, nil
+		}
+		// Second prompt shows all subs; pick Bravo (index 1 after sort)
+		return 1, nil
+	})
+
+	subId, err := p.PromptSubscription(t.Context(), "Select a sub")
+	require.NoError(t, err)
+	require.Equal(t, "sub-bravo", subId)
+	require.Equal(t, 2, selectCount)
 }
 
 func TestDefaultPrompter_FormatSubscriptionOptions_DemoMode(t *testing.T) {

--- a/cli/azd/pkg/prompt/prompter_extra_test.go
+++ b/cli/azd/pkg/prompt/prompter_extra_test.go
@@ -272,7 +272,7 @@ func TestDefaultPrompter_PromptSubscription_FilterApplied(t *testing.T) {
 	require.Equal(t, "sub-alpha", subId)
 	// Should show only 1 sub + "Show all subscriptions"
 	require.Len(t, shownOptions, 2)
-	require.Equal(t, ShowAllSubscriptionsOption, shownOptions[len(shownOptions)-1])
+	require.Equal(t, " 2. "+ShowAllSubscriptionsOption, shownOptions[len(shownOptions)-1])
 }
 
 func TestDefaultPrompter_PromptSubscription_ShowAll(t *testing.T) {

--- a/cli/azd/pkg/prompt/prompter_extra_test.go
+++ b/cli/azd/pkg/prompt/prompter_extra_test.go
@@ -26,7 +26,7 @@ func newTestPrompter(t *testing.T, mockAccount *mockaccount.MockAccountManager) 
 		mockContext.SubscriptionCredentialProvider, mockContext.ArmClientOptions)
 
 	p := NewDefaultPrompter(
-		env, mockContext.Console, mockAccount, resourceService, cloud.AzurePublic(),
+		env, mockContext.Console, mockAccount, nil, resourceService, cloud.AzurePublic(),
 	).(*DefaultPrompter)
 
 	return p, mockContext

--- a/cli/azd/pkg/prompt/subscription_filter.go
+++ b/cli/azd/pkg/prompt/subscription_filter.go
@@ -49,12 +49,16 @@ func LoadSubscriptionFilter(
 }
 
 // SaveSubscriptionFilter saves a subscription filter for the given tenant
-// to user config.
+// to user config. Returns an error if tenantId is empty.
 func SaveSubscriptionFilter(
 	cfg config.Config,
 	tenantId string,
 	subscriptionIds []string,
 ) error {
+	if tenantId == "" {
+		return fmt.Errorf("tenantId must not be empty")
+	}
+
 	// Convert to []any for config storage compatibility
 	values := make([]any, len(subscriptionIds))
 	for i, id := range subscriptionIds {
@@ -64,8 +68,11 @@ func SaveSubscriptionFilter(
 }
 
 // RemoveSubscriptionFilter removes the subscription filter for the given tenant
-// from user config.
+// from user config. Returns an error if tenantId is empty.
 func RemoveSubscriptionFilter(cfg config.Config, tenantId string) error {
+	if tenantId == "" {
+		return fmt.Errorf("tenantId must not be empty")
+	}
 	return cfg.Unset(subscriptionFilterConfigPath(tenantId))
 }
 

--- a/cli/azd/pkg/prompt/subscription_filter.go
+++ b/cli/azd/pkg/prompt/subscription_filter.go
@@ -106,9 +106,9 @@ func ApplySubscriptionFilter(
 	return filtered, true
 }
 
-// GetAllSubscriptionFilters returns all saved subscription filters from user config
+// getAllSubscriptionFilters returns all saved subscription filters from user config
 // as a map of tenantId -> []subscriptionId.
-func GetAllSubscriptionFilters(
+func getAllSubscriptionFilters(
 	cfg config.Config,
 ) map[string][]string {
 	raw, exists := cfg.GetMap(subscriptionFiltersConfigKey)
@@ -134,10 +134,10 @@ func GetAllSubscriptionFilters(
 	return result
 }
 
-// SubscriptionsMatchingFilter returns the subscriptions that match saved filter IDs,
+// subscriptionsMatchingFilter returns the subscriptions that match saved filter IDs,
 // preserving the order of the subscription list. Pre-selected items are returned
 // as their display option strings for use with MultiSelect DefaultValue.
-func SubscriptionsMatchingFilter(
+func subscriptionsMatchingFilter(
 	subscriptions []account.Subscription,
 	filterIds []string,
 	displayFn func(*account.Subscription) string,

--- a/cli/azd/pkg/prompt/subscription_filter.go
+++ b/cli/azd/pkg/prompt/subscription_filter.go
@@ -5,7 +5,6 @@ package prompt
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
@@ -162,41 +161,9 @@ func SubscriptionsMatchingFilter(
 	return preSelected
 }
 
-// resolveSelectedTenantId determines the effective tenant ID for a subscription.
-// Prefers UserAccessTenantId, falls back to TenantId.
-func resolveSelectedTenantId(sub *account.Subscription) string {
-	if sub.UserAccessTenantId != "" {
-		return sub.UserAccessTenantId
-	}
-	return sub.TenantId
-}
-
 // FilteredSubscriptionNote is the message shown when a subscription filter is active.
 const FilteredSubscriptionNote = "Using saved subscription filter." +
 	" Run 'azd config sub-filter set' to update."
 
 // ShowAllSubscriptionsOption is the sentinel option text appended to filtered lists.
 const ShowAllSubscriptionsOption = "Show all subscriptions"
-
-// subscriptionIdsByOptions maps option display strings back to subscription IDs.
-// This is used after MultiSelect to determine which subscriptions were selected.
-func subscriptionIdsByOptions(
-	subscriptions []account.Subscription,
-	displayFn func(*account.Subscription) string,
-	selectedOptions []string,
-) []string {
-	optionToId := make(map[string]string, len(subscriptions))
-	for i := range subscriptions {
-		optionToId[displayFn(&subscriptions[i])] = subscriptions[i].Id
-	}
-
-	ids := make([]string, 0, len(selectedOptions))
-	for _, opt := range selectedOptions {
-		if id, ok := optionToId[opt]; ok {
-			ids = append(ids, id)
-		}
-	}
-
-	slices.Sort(ids)
-	return ids
-}

--- a/cli/azd/pkg/prompt/subscription_filter.go
+++ b/cli/azd/pkg/prompt/subscription_filter.go
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package prompt
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/account"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
+)
+
+const subscriptionFiltersConfigKey = "subscriptionFilters"
+
+// subscriptionFilterConfigPath returns the user config path for a tenant's subscription filter.
+func subscriptionFilterConfigPath(tenantId string) string {
+	return fmt.Sprintf("%s.%s", subscriptionFiltersConfigKey, tenantId)
+}
+
+// LoadSubscriptionFilter loads the saved subscription filter for the given tenant
+// from user config. Returns the list of subscription IDs and whether a filter exists.
+func LoadSubscriptionFilter(
+	cfg config.Config,
+	tenantId string,
+) ([]string, bool) {
+	if tenantId == "" {
+		return nil, false
+	}
+
+	raw, exists := cfg.GetSlice(subscriptionFilterConfigPath(tenantId))
+	if !exists || len(raw) == 0 {
+		return nil, false
+	}
+
+	ids := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok && s != "" {
+			ids = append(ids, s)
+		}
+	}
+
+	if len(ids) == 0 {
+		return nil, false
+	}
+
+	return ids, true
+}
+
+// SaveSubscriptionFilter saves a subscription filter for the given tenant
+// to user config.
+func SaveSubscriptionFilter(
+	cfg config.Config,
+	tenantId string,
+	subscriptionIds []string,
+) error {
+	// Convert to []any for config storage compatibility
+	values := make([]any, len(subscriptionIds))
+	for i, id := range subscriptionIds {
+		values[i] = id
+	}
+	return cfg.Set(subscriptionFilterConfigPath(tenantId), values)
+}
+
+// RemoveSubscriptionFilter removes the subscription filter for the given tenant
+// from user config.
+func RemoveSubscriptionFilter(cfg config.Config, tenantId string) error {
+	return cfg.Unset(subscriptionFilterConfigPath(tenantId))
+}
+
+// ApplySubscriptionFilter filters subscriptions to only those whose IDs are in
+// the given filter list. Returns the filtered list and true if a filter was applied.
+// If filterIds is nil or empty, returns the original list unchanged.
+func ApplySubscriptionFilter(
+	subscriptions []account.Subscription,
+	filterIds []string,
+) ([]account.Subscription, bool) {
+	if len(filterIds) == 0 {
+		return subscriptions, false
+	}
+
+	filterSet := make(map[string]bool, len(filterIds))
+	for _, id := range filterIds {
+		filterSet[strings.ToLower(id)] = true
+	}
+
+	filtered := make([]account.Subscription, 0, len(filterIds))
+	for _, sub := range subscriptions {
+		if filterSet[strings.ToLower(sub.Id)] {
+			filtered = append(filtered, sub)
+		}
+	}
+
+	// If filter produced no matches (stale filter), return all subscriptions
+	if len(filtered) == 0 {
+		return subscriptions, false
+	}
+
+	return filtered, true
+}
+
+// GetAllSubscriptionFilters returns all saved subscription filters from user config
+// as a map of tenantId -> []subscriptionId.
+func GetAllSubscriptionFilters(
+	cfg config.Config,
+) map[string][]string {
+	raw, exists := cfg.GetMap(subscriptionFiltersConfigKey)
+	if !exists {
+		return nil
+	}
+
+	result := make(map[string][]string, len(raw))
+	for tenantId, value := range raw {
+		if arr, ok := value.([]any); ok {
+			ids := make([]string, 0, len(arr))
+			for _, v := range arr {
+				if s, ok := v.(string); ok && s != "" {
+					ids = append(ids, s)
+				}
+			}
+			if len(ids) > 0 {
+				result[tenantId] = ids
+			}
+		}
+	}
+
+	return result
+}
+
+// SubscriptionsMatchingFilter returns the subscriptions that match saved filter IDs,
+// preserving the order of the subscription list. Pre-selected items are returned
+// as their display option strings for use with MultiSelect DefaultValue.
+func SubscriptionsMatchingFilter(
+	subscriptions []account.Subscription,
+	filterIds []string,
+	displayFn func(*account.Subscription) string,
+) []string {
+	if len(filterIds) == 0 {
+		return nil
+	}
+
+	filterSet := make(map[string]bool, len(filterIds))
+	for _, id := range filterIds {
+		filterSet[strings.ToLower(id)] = true
+	}
+
+	var preSelected []string
+	for i := range subscriptions {
+		if filterSet[strings.ToLower(subscriptions[i].Id)] {
+			preSelected = append(preSelected, displayFn(&subscriptions[i]))
+		}
+	}
+
+	return preSelected
+}
+
+// resolveSelectedTenantId determines the effective tenant ID for a subscription.
+// Prefers UserAccessTenantId, falls back to TenantId.
+func resolveSelectedTenantId(sub *account.Subscription) string {
+	if sub.UserAccessTenantId != "" {
+		return sub.UserAccessTenantId
+	}
+	return sub.TenantId
+}
+
+// FilteredSubscriptionNote is the message shown when a subscription filter is active.
+const FilteredSubscriptionNote = "Using saved subscription filter." +
+	" Run 'azd config sub-filter set' to update."
+
+// ShowAllSubscriptionsOption is the sentinel option text appended to filtered lists.
+const ShowAllSubscriptionsOption = "Show all subscriptions"
+
+// subscriptionIdsByOptions maps option display strings back to subscription IDs.
+// This is used after MultiSelect to determine which subscriptions were selected.
+func subscriptionIdsByOptions(
+	subscriptions []account.Subscription,
+	displayFn func(*account.Subscription) string,
+	selectedOptions []string,
+) []string {
+	optionToId := make(map[string]string, len(subscriptions))
+	for i := range subscriptions {
+		optionToId[displayFn(&subscriptions[i])] = subscriptions[i].Id
+	}
+
+	ids := make([]string, 0, len(selectedOptions))
+	for _, opt := range selectedOptions {
+		if id, ok := optionToId[opt]; ok {
+			ids = append(ids, id)
+		}
+	}
+
+	slices.Sort(ids)
+	return ids
+}

--- a/cli/azd/pkg/prompt/subscription_filter_test.go
+++ b/cli/azd/pkg/prompt/subscription_filter_test.go
@@ -172,3 +172,19 @@ func TestMultipleTenantsIndependentFilters(t *testing.T) {
 	require.True(t, exists2)
 	require.Equal(t, []string{"sub-b"}, ids2)
 }
+
+func TestSaveSubscriptionFilter_EmptyTenantId(t *testing.T) {
+	cfg := config.NewConfig(nil)
+
+	err := SaveSubscriptionFilter(cfg, "", []string{"sub-a"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tenantId must not be empty")
+}
+
+func TestRemoveSubscriptionFilter_EmptyTenantId(t *testing.T) {
+	cfg := config.NewConfig(nil)
+
+	err := RemoveSubscriptionFilter(cfg, "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tenantId must not be empty")
+}

--- a/cli/azd/pkg/prompt/subscription_filter_test.go
+++ b/cli/azd/pkg/prompt/subscription_filter_test.go
@@ -106,7 +106,7 @@ func TestGetAllSubscriptionFilters(t *testing.T) {
 	_ = SaveSubscriptionFilter(cfg, "tid-1", []string{"sub-a"})
 	_ = SaveSubscriptionFilter(cfg, "tid-2", []string{"sub-b", "sub-c"})
 
-	filters := GetAllSubscriptionFilters(cfg)
+	filters := getAllSubscriptionFilters(cfg)
 	require.Len(t, filters, 2)
 	require.Equal(t, []string{"sub-a"}, filters["tid-1"])
 	require.Equal(t, []string{"sub-b", "sub-c"}, filters["tid-2"])
@@ -115,7 +115,7 @@ func TestGetAllSubscriptionFilters(t *testing.T) {
 func TestGetAllSubscriptionFilters_Empty(t *testing.T) {
 	cfg := config.NewConfig(nil)
 
-	filters := GetAllSubscriptionFilters(cfg)
+	filters := getAllSubscriptionFilters(cfg)
 	require.Nil(t, filters)
 }
 
@@ -130,7 +130,7 @@ func TestSubscriptionsMatchingFilter(t *testing.T) {
 		return s.Name
 	}
 
-	result := SubscriptionsMatchingFilter(
+	result := subscriptionsMatchingFilter(
 		subs, []string{"sub-1", "sub-3"}, displayFn,
 	)
 	require.Equal(t, []string{"Alpha", "Charlie"}, result)
@@ -145,7 +145,7 @@ func TestSubscriptionsMatchingFilter_EmptyFilter(t *testing.T) {
 		return s.Name
 	}
 
-	result := SubscriptionsMatchingFilter(subs, nil, displayFn)
+	result := subscriptionsMatchingFilter(subs, nil, displayFn)
 	require.Nil(t, result)
 }
 

--- a/cli/azd/pkg/prompt/subscription_filter_test.go
+++ b/cli/azd/pkg/prompt/subscription_filter_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package prompt
+
+import (
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/account"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadSubscriptionFilter_NoFilter(t *testing.T) {
+	cfg := config.NewConfig(nil)
+
+	ids, exists := LoadSubscriptionFilter(cfg, "tid-1")
+	require.False(t, exists)
+	require.Nil(t, ids)
+}
+
+func TestLoadSubscriptionFilter_EmptyTenantId(t *testing.T) {
+	cfg := config.NewConfig(nil)
+
+	ids, exists := LoadSubscriptionFilter(cfg, "")
+	require.False(t, exists)
+	require.Nil(t, ids)
+}
+
+func TestSaveAndLoadSubscriptionFilter(t *testing.T) {
+	cfg := config.NewConfig(nil)
+
+	err := SaveSubscriptionFilter(cfg, "tid-1", []string{"sub-a", "sub-b"})
+	require.NoError(t, err)
+
+	ids, exists := LoadSubscriptionFilter(cfg, "tid-1")
+	require.True(t, exists)
+	require.Equal(t, []string{"sub-a", "sub-b"}, ids)
+}
+
+func TestRemoveSubscriptionFilter(t *testing.T) {
+	cfg := config.NewConfig(nil)
+
+	err := SaveSubscriptionFilter(cfg, "tid-1", []string{"sub-a"})
+	require.NoError(t, err)
+
+	err = RemoveSubscriptionFilter(cfg, "tid-1")
+	require.NoError(t, err)
+
+	ids, exists := LoadSubscriptionFilter(cfg, "tid-1")
+	require.False(t, exists)
+	require.Nil(t, ids)
+}
+
+func TestApplySubscriptionFilter_NoFilter(t *testing.T) {
+	subs := []account.Subscription{
+		{Id: "sub-1", Name: "Alpha"},
+		{Id: "sub-2", Name: "Bravo"},
+	}
+
+	result, applied := ApplySubscriptionFilter(subs, nil)
+	require.False(t, applied)
+	require.Len(t, result, 2)
+}
+
+func TestApplySubscriptionFilter_WithFilter(t *testing.T) {
+	subs := []account.Subscription{
+		{Id: "sub-1", Name: "Alpha"},
+		{Id: "sub-2", Name: "Bravo"},
+		{Id: "sub-3", Name: "Charlie"},
+	}
+
+	result, applied := ApplySubscriptionFilter(subs, []string{"sub-1", "sub-3"})
+	require.True(t, applied)
+	require.Len(t, result, 2)
+	require.Equal(t, "sub-1", result[0].Id)
+	require.Equal(t, "sub-3", result[1].Id)
+}
+
+func TestApplySubscriptionFilter_CaseInsensitive(t *testing.T) {
+	subs := []account.Subscription{
+		{Id: "SUB-1", Name: "Alpha"},
+		{Id: "sub-2", Name: "Bravo"},
+	}
+
+	result, applied := ApplySubscriptionFilter(subs, []string{"sub-1"})
+	require.True(t, applied)
+	require.Len(t, result, 1)
+	require.Equal(t, "SUB-1", result[0].Id)
+}
+
+func TestApplySubscriptionFilter_StaleFilter(t *testing.T) {
+	subs := []account.Subscription{
+		{Id: "sub-1", Name: "Alpha"},
+	}
+
+	// Filter references IDs that no longer exist
+	result, applied := ApplySubscriptionFilter(subs, []string{"sub-999"})
+	require.False(t, applied)
+	require.Len(t, result, 1) // returns all
+}
+
+func TestGetAllSubscriptionFilters(t *testing.T) {
+	cfg := config.NewConfig(nil)
+
+	_ = SaveSubscriptionFilter(cfg, "tid-1", []string{"sub-a"})
+	_ = SaveSubscriptionFilter(cfg, "tid-2", []string{"sub-b", "sub-c"})
+
+	filters := GetAllSubscriptionFilters(cfg)
+	require.Len(t, filters, 2)
+	require.Equal(t, []string{"sub-a"}, filters["tid-1"])
+	require.Equal(t, []string{"sub-b", "sub-c"}, filters["tid-2"])
+}
+
+func TestGetAllSubscriptionFilters_Empty(t *testing.T) {
+	cfg := config.NewConfig(nil)
+
+	filters := GetAllSubscriptionFilters(cfg)
+	require.Nil(t, filters)
+}
+
+func TestSubscriptionsMatchingFilter(t *testing.T) {
+	subs := []account.Subscription{
+		{Id: "sub-1", Name: "Alpha"},
+		{Id: "sub-2", Name: "Bravo"},
+		{Id: "sub-3", Name: "Charlie"},
+	}
+
+	displayFn := func(s *account.Subscription) string {
+		return s.Name
+	}
+
+	result := SubscriptionsMatchingFilter(
+		subs, []string{"sub-1", "sub-3"}, displayFn,
+	)
+	require.Equal(t, []string{"Alpha", "Charlie"}, result)
+}
+
+func TestSubscriptionsMatchingFilter_EmptyFilter(t *testing.T) {
+	subs := []account.Subscription{
+		{Id: "sub-1", Name: "Alpha"},
+	}
+
+	displayFn := func(s *account.Subscription) string {
+		return s.Name
+	}
+
+	result := SubscriptionsMatchingFilter(subs, nil, displayFn)
+	require.Nil(t, result)
+}
+
+func TestMultipleTenantsIndependentFilters(t *testing.T) {
+	cfg := config.NewConfig(nil)
+
+	_ = SaveSubscriptionFilter(cfg, "tid-1", []string{"sub-a"})
+	_ = SaveSubscriptionFilter(cfg, "tid-2", []string{"sub-b"})
+
+	ids1, exists1 := LoadSubscriptionFilter(cfg, "tid-1")
+	require.True(t, exists1)
+	require.Equal(t, []string{"sub-a"}, ids1)
+
+	ids2, exists2 := LoadSubscriptionFilter(cfg, "tid-2")
+	require.True(t, exists2)
+	require.Equal(t, []string{"sub-b"}, ids2)
+
+	// Removing one doesn't affect the other
+	_ = RemoveSubscriptionFilter(cfg, "tid-1")
+	_, exists1 = LoadSubscriptionFilter(cfg, "tid-1")
+	require.False(t, exists1)
+
+	ids2, exists2 = LoadSubscriptionFilter(cfg, "tid-2")
+	require.True(t, exists2)
+	require.Equal(t, []string{"sub-b"}, ids2)
+}

--- a/cli/azd/pkg/prompt/tenant_helper.go
+++ b/cli/azd/pkg/prompt/tenant_helper.go
@@ -18,8 +18,8 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
-// tenantInfo holds display metadata for a tenant extracted from the subscription list.
-type tenantInfo struct {
+// TenantInfo holds display metadata for a tenant extracted from the subscription list.
+type TenantInfo struct {
 	// Id is the tenant ID (GUID).
 	Id string
 	// DisplayName is the friendly name of the tenant, or the ID if no name is available.
@@ -28,16 +28,16 @@ type tenantInfo struct {
 	SubscriptionCount int
 }
 
-// extractUniqueTenants extracts unique tenants from a list of subscriptions,
+// ExtractUniqueTenants extracts unique tenants from a list of subscriptions,
 // grouped by UserAccessTenantId (falling back to TenantId when UserAccessTenantId is empty).
 // The returned list is sorted by DisplayName.
 // Tenant display names are resolved from the provided tenantDisplayNames map;
 // if a tenant ID is not in the map, the ID itself is used as the display name.
-func extractUniqueTenants(
+func ExtractUniqueTenants(
 	subscriptions []account.Subscription,
 	tenantDisplayNames map[string]string,
-) []tenantInfo {
-	tenantMap := make(map[string]*tenantInfo)
+) []TenantInfo {
+	tenantMap := make(map[string]*TenantInfo)
 
 	for _, sub := range subscriptions {
 		tid := sub.UserAccessTenantId
@@ -55,7 +55,7 @@ func extractUniqueTenants(
 			if name, ok := tenantDisplayNames[tid]; ok && name != "" {
 				displayName = name
 			}
-			tenantMap[tid] = &tenantInfo{
+			tenantMap[tid] = &TenantInfo{
 				Id:                tid,
 				DisplayName:       displayName,
 				SubscriptionCount: 1,
@@ -63,12 +63,12 @@ func extractUniqueTenants(
 		}
 	}
 
-	tenants := make([]tenantInfo, 0, len(tenantMap))
+	tenants := make([]TenantInfo, 0, len(tenantMap))
 	for _, info := range tenantMap {
 		tenants = append(tenants, *info)
 	}
 
-	slices.SortFunc(tenants, func(a, b tenantInfo) int {
+	slices.SortFunc(tenants, func(a, b TenantInfo) int {
 		if c := cmp.Compare(
 			strings.ToLower(a.DisplayName),
 			strings.ToLower(b.DisplayName),
@@ -81,9 +81,9 @@ func extractUniqueTenants(
 	return tenants
 }
 
-// filterSubscriptionsByTenant filters subscriptions to only those accessible
+// FilterSubscriptionsByTenantId filters subscriptions to only those accessible
 // through the specified tenant ID. If tenantId is empty, all subscriptions are returned.
-func filterSubscriptionsByTenant(
+func FilterSubscriptionsByTenantId(
 	subscriptions []account.Subscription,
 	tenantId string,
 ) []account.Subscription {
@@ -114,7 +114,7 @@ func filterByTenantEnvVar(subscriptions []account.Subscription) []account.Subscr
 		return subscriptions
 	}
 
-	filtered := filterSubscriptionsByTenant(subscriptions, tenantId)
+	filtered := FilterSubscriptionsByTenantId(subscriptions, tenantId)
 	// If filtering produces no results, fall back to showing all subscriptions
 	// rather than erroring out — the tenant ID may be stale
 	if len(filtered) == 0 {
@@ -131,7 +131,7 @@ func filterByTenantEnvVar(subscriptions []account.Subscription) []account.Subscr
 func promptTenantSelection(
 	ctx context.Context,
 	console input.Console,
-	tenants []tenantInfo,
+	tenants []TenantInfo,
 ) (string, error) {
 	if len(tenants) <= 1 {
 		if len(tenants) == 1 {
@@ -147,7 +147,7 @@ func promptTenantSelection(
 
 	options := make([]string, len(tenants)+1)
 	for i, t := range tenants {
-		options[i] = formatTenantOption(i+1, t)
+		options[i] = FormatTenantDisplay(i+1, t)
 	}
 	options[len(tenants)] = allTenantsLabel
 
@@ -171,17 +171,22 @@ func promptTenantSelection(
 type TenantDisplayNameProvider func(ctx context.Context) (map[string]string, error)
 
 // promptAndFilterByTenant prompts the user to select a tenant when subscriptions span multiple tenants.
-// It extracts unique tenants, fetches display names only when needed, and returns filtered subscriptions.
+// It extracts unique tenants, fetches display names only when needed, and returns filtered subscriptions
+// along with the selected tenant ID (empty if "All tenants" was chosen or only one tenant exists).
 func promptAndFilterByTenant(
 	ctx context.Context,
 	console input.Console,
 	subscriptions []account.Subscription,
 	getTenantNames TenantDisplayNameProvider,
-) ([]account.Subscription, error) {
+) ([]account.Subscription, string, error) {
 	// Quick check without display names to avoid unnecessary API call
-	tenants := extractUniqueTenants(subscriptions, nil)
+	tenants := ExtractUniqueTenants(subscriptions, nil)
 	if len(tenants) <= 1 {
-		return subscriptions, nil
+		tenantId := ""
+		if len(tenants) == 1 {
+			tenantId = tenants[0].Id
+		}
+		return subscriptions, tenantId, nil
 	}
 
 	// Only fetch tenant display names when we actually need to prompt
@@ -195,17 +200,20 @@ func promptAndFilterByTenant(
 		}
 	}
 
-	tenants = extractUniqueTenants(subscriptions, tenantNames)
+	tenants = ExtractUniqueTenants(subscriptions, tenantNames)
 
 	selectedTenantId, err := promptTenantSelection(ctx, console, tenants)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
-	return filterSubscriptionsByTenant(subscriptions, selectedTenantId), nil
+	return FilterSubscriptionsByTenantId(
+		subscriptions, selectedTenantId,
+	), selectedTenantId, nil
 }
 
-func formatTenantOption(index int, t tenantInfo) string {
+// FormatTenantDisplay formats a tenant option for display in selection prompts.
+func FormatTenantDisplay(index int, t TenantInfo) string {
 	subCountLabel := fmt.Sprintf(
 		"%d subscription", t.SubscriptionCount,
 	)

--- a/cli/azd/pkg/prompt/tenant_helper.go
+++ b/cli/azd/pkg/prompt/tenant_helper.go
@@ -172,7 +172,8 @@ type TenantDisplayNameProvider func(ctx context.Context) (map[string]string, err
 
 // promptAndFilterByTenant prompts the user to select a tenant when subscriptions span multiple tenants.
 // It extracts unique tenants, fetches display names only when needed, and returns filtered subscriptions
-// along with the selected tenant ID (empty if "All tenants" was chosen or only one tenant exists).
+// along with the selected tenant ID (empty only if "All tenants" was chosen; returns the tenant ID
+// even when a single tenant is auto-selected).
 func promptAndFilterByTenant(
 	ctx context.Context,
 	console input.Console,

--- a/cli/azd/pkg/prompt/tenant_helper_test.go
+++ b/cli/azd/pkg/prompt/tenant_helper_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestExtractUniqueTenants_Empty(t *testing.T) {
-	tenants := extractUniqueTenants(nil, nil)
+	tenants := ExtractUniqueTenants(nil, nil)
 	require.Empty(t, tenants)
 }
 
@@ -28,7 +28,7 @@ func TestExtractUniqueTenants_SingleTenant(t *testing.T) {
 		{Id: "sub-2", UserAccessTenantId: "tid-1"},
 	}
 
-	tenants := extractUniqueTenants(subs, map[string]string{"tid-1": "Contoso"})
+	tenants := ExtractUniqueTenants(subs, map[string]string{"tid-1": "Contoso"})
 	require.Len(t, tenants, 1)
 	require.Equal(t, "tid-1", tenants[0].Id)
 	require.Equal(t, "Contoso", tenants[0].DisplayName)
@@ -47,7 +47,7 @@ func TestExtractUniqueTenants_MultipleTenants(t *testing.T) {
 		"tid-2": "Fabrikam",
 	}
 
-	tenants := extractUniqueTenants(subs, names)
+	tenants := ExtractUniqueTenants(subs, names)
 	require.Len(t, tenants, 2)
 	// Sorted alphabetically by display name
 	require.Equal(t, "Contoso", tenants[0].DisplayName)
@@ -61,7 +61,7 @@ func TestExtractUniqueTenants_FallbackToTenantId(t *testing.T) {
 		{Id: "sub-1", TenantId: "tid-1", UserAccessTenantId: ""},
 	}
 
-	tenants := extractUniqueTenants(subs, nil)
+	tenants := ExtractUniqueTenants(subs, nil)
 	require.Len(t, tenants, 1)
 	require.Equal(t, "tid-1", tenants[0].Id)
 	// Display name falls back to the ID when no names provided
@@ -74,7 +74,7 @@ func TestExtractUniqueTenants_NoDisplayNames(t *testing.T) {
 		{Id: "sub-2", UserAccessTenantId: "tid-2"},
 	}
 
-	tenants := extractUniqueTenants(subs, nil)
+	tenants := ExtractUniqueTenants(subs, nil)
 	require.Len(t, tenants, 2)
 	require.Equal(t, "tid-1", tenants[0].DisplayName)
 	require.Equal(t, "tid-2", tenants[1].DisplayName)
@@ -86,7 +86,7 @@ func TestFilterSubscriptionsByTenant_EmptyTenantId(t *testing.T) {
 		{Id: "sub-2", UserAccessTenantId: "tid-2"},
 	}
 
-	result := filterSubscriptionsByTenant(subs, "")
+	result := FilterSubscriptionsByTenantId(subs, "")
 	require.Len(t, result, 2)
 }
 
@@ -97,7 +97,7 @@ func TestFilterSubscriptionsByTenant_Filtered(t *testing.T) {
 		{Id: "sub-3", UserAccessTenantId: "tid-1"},
 	}
 
-	result := filterSubscriptionsByTenant(subs, "tid-1")
+	result := FilterSubscriptionsByTenantId(subs, "tid-1")
 	require.Len(t, result, 2)
 	require.Equal(t, "sub-1", result[0].Id)
 	require.Equal(t, "sub-3", result[1].Id)
@@ -108,7 +108,7 @@ func TestFilterSubscriptionsByTenant_NoMatch(t *testing.T) {
 		{Id: "sub-1", UserAccessTenantId: "tid-1"},
 	}
 
-	result := filterSubscriptionsByTenant(subs, "tid-unknown")
+	result := FilterSubscriptionsByTenantId(subs, "tid-unknown")
 	require.Empty(t, result)
 }
 
@@ -150,7 +150,7 @@ func TestFilterByTenantEnvVar_NoMatchFallsBack(t *testing.T) {
 func TestPromptTenantSelection_SingleTenant(t *testing.T) {
 	mockContext := mocks.NewMockContext(t.Context())
 
-	tenants := []tenantInfo{
+	tenants := []TenantInfo{
 		{Id: "tid-1", DisplayName: "Contoso", SubscriptionCount: 3},
 	}
 
@@ -166,7 +166,7 @@ func TestPromptTenantSelection_MultipleTenants_SelectFirst(t *testing.T) {
 		return strings.Contains(opts.Message, "Select a tenant")
 	}).Respond(0) // pick first tenant
 
-	tenants := []tenantInfo{
+	tenants := []TenantInfo{
 		{Id: "tid-1", DisplayName: "Contoso", SubscriptionCount: 3},
 		{Id: "tid-2", DisplayName: "Fabrikam", SubscriptionCount: 1},
 	}
@@ -183,7 +183,7 @@ func TestPromptTenantSelection_MultipleTenants_SelectAllTenants(t *testing.T) {
 		return strings.Contains(opts.Message, "Select a tenant")
 	}).Respond(2) // pick "All tenants" (third option with 2 tenants)
 
-	tenants := []tenantInfo{
+	tenants := []TenantInfo{
 		{Id: "tid-1", DisplayName: "Contoso", SubscriptionCount: 3},
 		{Id: "tid-2", DisplayName: "Fabrikam", SubscriptionCount: 1},
 	}
@@ -295,7 +295,7 @@ func newTestPrompterWithCtx(
 		mockCtx.SubscriptionCredentialProvider, mockCtx.ArmClientOptions)
 
 	p := NewDefaultPrompter(
-		env, mockCtx.Console, mockAccount, resourceService, cloud.AzurePublic(),
+		env, mockCtx.Console, mockAccount, nil, resourceService, cloud.AzurePublic(),
 	).(*DefaultPrompter)
 
 	return p, mockCtx

--- a/cli/azd/test/mocks/mockinput/mock_console.go
+++ b/cli/azd/test/mocks/mockinput/mock_console.go
@@ -251,6 +251,18 @@ func (c *MockConsole) WhenSelect(predicate WhenPredicate) *MockConsoleExpression
 	return &expr
 }
 
+// Registers a multi-select expression for mocking in unit tests
+func (c *MockConsole) WhenMultiSelect(predicate WhenPredicate) *MockConsoleExpression {
+	expr := MockConsoleExpression{
+		command:     "MultiSelect",
+		console:     c,
+		predicateFn: predicate,
+	}
+
+	c.expressions = append(c.expressions, &expr)
+	return &expr
+}
+
 // MockConsoleExpression is an expression with options response or error
 type MockConsoleExpression struct {
 	command     string


### PR DESCRIPTION
## Summary

POC implementation for per-tenant subscription filters that narrow subscription prompts. Resolves #351.

## What was added

### New commands
- **`azd config sub-filter set`** — Resolve tenant → multi-select subscriptions (pre-checked if filter exists) → save to user config
- **`azd config sub-filter remove`** — Resolve tenant → confirm → delete filter (no-op if none exists)

### Prompt integration
- Both `PromptSubscription` implementations check for a saved filter after tenant selection
- When a filter is active, displays: `"Using saved subscription filter. Run 'azd config sub-filter set' to update."`
- Appends a "Show all subscriptions" escape option at the end of the filtered list
- If user picks "Show all", re-prompts with the full unfiltered list

### Storage
- Filters stored in user config (`~/.azd/config.json`) under `subscriptionFilters.<tenantId>` as an array of subscription IDs
- One filter per tenant, stored per-device

### User flow

**Setting a filter:**
1. Run `azd config sub-filter set`
2. If multiple tenants, pick one (single tenant auto-selected)
3. Multi-select subscriptions to include (existing filter items pre-checked)
4. Filter saved to user config

**Using the filter:**
1. Any `azd` command that prompts for a subscription
2. After tenant selection, filter is applied automatically
3. Note displayed about active filter
4. "Show all subscriptions" option available as escape hatch

**Removing a filter:**
1. Run `azd config sub-filter remove`
2. Pick tenant → confirm removal

## Files

### New
- `cli/azd/cmd/config_sub_filter.go` — Command actions
- `cli/azd/pkg/prompt/subscription_filter.go` — Filter helpers
- `cli/azd/pkg/prompt/subscription_filter_test.go` — 13 unit tests

### Modified
- `cli/azd/cmd/config.go` — Register sub-filter group
- `cli/azd/pkg/prompt/prompt_service.go` — Filter in `PromptSubscription`
- `cli/azd/pkg/prompt/prompter.go` — Filter in `DefaultPrompter.PromptSubscription`
- `cli/azd/pkg/prompt/tenant_helper.go` — Exported types/functions, return tenant ID
- Test files updated for new `NewDefaultPrompter` signature
- Snapshot files auto-generated

## Testing
- 13 new unit tests for filter helpers (load, save, remove, apply, case sensitivity, stale filters, multi-tenant)
- All existing tests pass (prompt, cmd, infra packages)


https://github.com/user-attachments/assets/12c89592-4a08-4f7d-a9f1-4e5d5ae8a56b

