### PR TITLE
fix(azure.ai.connections): emit empty credentials for managed-connector OAuth2

### DIFF
--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/connection.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/connection.go
@@ -359,7 +359,11 @@ func (a *ConnectionCreateAction) Run(ctx context.Context) error {
 			Scopes:           a.flags.scopes,
 			ConnectorName:    a.flags.connectorName,
 		}
-		if a.flags.clientID != "" || a.flags.clientSecret != "" {
+		// For OAuth2, the ARM connections API requires `credentials` to be present in the
+		// request body even when empty (managed-connector / gateway_connector path uses
+		// Microsoft's OAuth app, so no client id/secret is supplied). An empty object `{}`
+		// is valid; omitting the field entirely returns 400 ValidationError.
+		if a.flags.authType == "oauth2" || a.flags.clientID != "" || a.flags.clientSecret != "" {
 			props.Credentials = &rawCredentials{
 				ClientID:     a.flags.clientID,
 				ClientSecret: a.flags.clientSecret,

--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/connection.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/connection.go
@@ -363,12 +363,7 @@ func (a *ConnectionCreateAction) Run(ctx context.Context) error {
 		// request body even when empty (managed-connector / gateway_connector path uses
 		// Microsoft's OAuth app, so no client id/secret is supplied). An empty object `{}`
 		// is valid; omitting the field entirely returns 400 ValidationError.
-		if a.flags.authType == "oauth2" || a.flags.clientID != "" || a.flags.clientSecret != "" {
-			props.Credentials = &rawCredentials{
-				ClientID:     a.flags.clientID,
-				ClientSecret: a.flags.clientSecret,
-			}
-		}
+		props.Credentials = buildOAuth2Credentials(a.flags.authType, a.flags.clientID, a.flags.clientSecret)
 		err = rawCreateConnection(ctx, connCtx, a.flags.name, props)
 	default:
 		body, buildErr := buildConnectionBody(

--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/connection_test.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/connection_test.go
@@ -475,12 +475,16 @@ func TestParseKVPtrMap(t *testing.T) {
 }
 
 func TestRawConnectionBody_OAuth2_ConnectorNameOnly(t *testing.T) {
-	// When using a managed connector, only connectorName is set ΓÇö no credentials.
+	// When using a managed connector (gateway_connector), connectorName is set and
+	// credentials must be present as an empty object. The ARM connections API rejects
+	// the PUT with `400 ValidationError: Credentials Property can't be empty for auth
+	// type OAuth2` when the field is omitted entirely. See issue #8418.
 	props := rawConnectionProperties{
 		AuthType:      "OAuth2",
 		Category:      "RemoteTool",
 		Target:        "https://example.com",
 		ConnectorName: "github",
+		Credentials:   &rawCredentials{},
 	}
 	body := rawConnectionBody{Properties: props}
 	data, err := json.Marshal(body)
@@ -492,8 +496,16 @@ func TestRawConnectionBody_OAuth2_ConnectorNameOnly(t *testing.T) {
 	p := parsed["properties"].(map[string]any)
 	require.Equal(t, "OAuth2", p["authType"])
 	require.Equal(t, "github", p["connectorName"])
-	_, hasCreds := p["credentials"]
-	require.False(t, hasCreds, "credentials should be omitted for connector-name-only")
+
+	creds, hasCreds := p["credentials"]
+	require.True(t, hasCreds, "credentials must be present (empty object) for managed-connector OAuth2")
+	credsMap, ok := creds.(map[string]any)
+	require.True(t, ok, "credentials should marshal as a JSON object")
+	require.Empty(t, credsMap, "credentials should be an empty object when no clientId/clientSecret supplied")
+
+	// The raw JSON should literally contain `"credentials":{}`.
+	require.Contains(t, string(data), `"credentials":{}`)
+
 	_, hasAuthURL := p["authorizationUrl"]
 	require.False(t, hasAuthURL, "authorizationUrl should be omitted for connector-name-only")
 }

--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/connection_test.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/connection_test.go
@@ -475,17 +475,25 @@ func TestParseKVPtrMap(t *testing.T) {
 }
 
 func TestRawConnectionBody_OAuth2_ConnectorNameOnly(t *testing.T) {
-	// When using a managed connector (gateway_connector), connectorName is set and
-	// credentials must be present as an empty object. The ARM connections API rejects
-	// the PUT with `400 ValidationError: Credentials Property can't be empty for auth
-	// type OAuth2` when the field is omitted entirely. See issue #8418.
+	// Regression test for #8418. When using a managed connector (gateway_connector),
+	// connectorName is set and no --client-id/--client-secret are supplied. The
+	// ConnectionCreateAction.Run path must still populate props.Credentials so the
+	// PUT body marshals to `"credentials": {}` — otherwise the ARM API rejects with
+	// `400 ValidationError: Credentials Property can't be empty for auth type OAuth2`.
+	//
+	// We exercise the same decision Run makes via buildOAuth2Credentials and then
+	// marshal a full body so this guards both the predicate and the resulting JSON.
 	props := rawConnectionProperties{
 		AuthType:      "OAuth2",
 		Category:      "RemoteTool",
 		Target:        "https://example.com",
 		ConnectorName: "github",
-		Credentials:   &rawCredentials{},
+		Credentials:   buildOAuth2Credentials("oauth2", "", ""),
 	}
+	require.NotNil(t, props.Credentials,
+		"buildOAuth2Credentials must return a non-nil object for --auth-type oauth2 "+
+			"with no client id/secret (managed-connector path)")
+
 	body := rawConnectionBody{Properties: props}
 	data, err := json.Marshal(body)
 	require.NoError(t, err)
@@ -508,6 +516,63 @@ func TestRawConnectionBody_OAuth2_ConnectorNameOnly(t *testing.T) {
 
 	_, hasAuthURL := p["authorizationUrl"]
 	require.False(t, hasAuthURL, "authorizationUrl should be omitted for connector-name-only")
+}
+
+func TestBuildOAuth2Credentials(t *testing.T) {
+	tests := []struct {
+		name         string
+		authType     string
+		clientID     string
+		clientSecret string
+		wantNil      bool
+		wantID       string
+		wantSecret   string
+	}{
+		{
+			name:     "oauth2 managed connector emits empty object",
+			authType: "oauth2",
+			wantNil:  false,
+		},
+		{
+			name:         "oauth2 BYO emits client id and secret",
+			authType:     "oauth2",
+			clientID:     "test-cid",
+			clientSecret: "test-csec", //nolint:gosec // test credential, not real
+			wantNil:      false,
+			wantID:       "test-cid",
+			wantSecret:   "test-csec",
+		},
+		{
+			name:     "api-key with no creds returns nil",
+			authType: "api-key",
+			wantNil:  true,
+		},
+		{
+			name:     "user-entra-token with no creds returns nil",
+			authType: "user-entra-token",
+			wantNil:  true,
+		},
+		{
+			name:     "non-oauth2 with client id still emits creds",
+			authType: "api-key",
+			clientID: "cid",
+			wantNil:  false,
+			wantID:   "cid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildOAuth2Credentials(tt.authType, tt.clientID, tt.clientSecret)
+			if tt.wantNil {
+				require.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			require.Equal(t, tt.wantID, got.ClientID)
+			require.Equal(t, tt.wantSecret, got.ClientSecret)
+		})
+	}
 }
 
 func TestBuildCredentialReferences(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/raw_connection.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/raw_connection.go
@@ -40,6 +40,29 @@ type rawCredentials struct {
 	ClientSecret string `json:"clientSecret,omitempty"`
 }
 
+// buildOAuth2Credentials returns the credentials object to embed in a connection
+// PUT body, based on the user-supplied auth type and (optional) BYO OAuth2 client
+// id / secret.
+//
+// The ARM connections API requires `properties.credentials` to be present in the
+// request body for `--auth-type oauth2`, even when no client id/secret is supplied
+// (the managed-connector / gateway_connector path uses Microsoft's OAuth app).
+// Omitting the field entirely returns `400 ValidationError: Credentials Property
+// can't be empty for auth type OAuth2`. An empty object `{}` is valid for that
+// path. See issue #8418.
+//
+// Returns nil for non-OAuth2 auth types that do not supply a client id/secret,
+// so callers can rely on `omitempty` to drop the field.
+func buildOAuth2Credentials(authType, clientID, clientSecret string) *rawCredentials {
+	if authType != "oauth2" && clientID == "" && clientSecret == "" {
+		return nil
+	}
+	return &rawCredentials{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+	}
+}
+
 type rawConnectionBody struct {
 	Properties rawConnectionProperties `json:"properties"`
 }


### PR DESCRIPTION
## Summary

`azd ai connection create --auth-type oauth2 --connector-name <name>` (the Foundry catalog managed-connector / `gateway_connector` flow) failed with `400 ValidationError: Credentials Property can't be empty for auth type OAuth2`.

The ARM connections API requires `properties.credentials` to be present in the request body for OAuth2 — an empty object `{}` is valid for the managed-connector path. The extension only set `Credentials` when `--client-id` or `--client-secret` was provided, so for managed connectors the field was nil and `omitempty` dropped it entirely.

Fixes #8418.

## Changes

- `internal/cmd/connection.go`: always set `Credentials = &rawCredentials{}` when `--auth-type oauth2`, so the body marshals to `"credentials": {}` for managed connectors and `"credentials": {"clientId":..., "clientSecret":...}` for BYO.
- `internal/cmd/connection_test.go`: update `TestRawConnectionBody_OAuth2_ConnectorNameOnly` to assert `"credentials":{}` is present (it previously asserted the buggy behavior).

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean
- `go test ./internal/cmd/... -count=1` — PASS
- E2E against a live Foundry project: `azd ai connection create ... --auth-type oauth2 --connector-name box --metadata type=gateway_connector ...` returned `Connection "..." created` instead of the 400.
