### PR TITLE
feat(azure.ai.toolboxes): accept tools[] and policies.rai_config in toolbox create --from-file

### DIFF
--- a/cli/azd/extensions/azure.ai.toolboxes/cspell.yaml
+++ b/cli/azd/extensions/azure.ai.toolboxes/cspell.yaml
@@ -1,5 +1,6 @@
 import: ../../.vscode/cspell.yaml
 words:
+    - connectionless
     - exterrors
     - projectctx
     - retarget

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/context.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/context.go
@@ -101,7 +101,7 @@ func validateToolName(name string) error {
 					"to match ^[A-Za-z0-9_-]+$ (max %d characters)",
 				name, maxToolboxNameLength,
 			),
-			"rename the project connection so its short name matches the regex",
+			"rename the tool entry (or the underlying project connection) so the name matches the regex",
 		)
 	}
 	return nil

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_commands_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_commands_test.go
@@ -208,6 +208,9 @@ func TestRunConnectionAddWith_AppendsAndPromotesDefault(t *testing.T) {
 		Name: "tb", Version: "1", Description: "first", Tools: []map[string]any{
 			{"type": "mcp", "name": "a", "project_connection_id": "/c/a"},
 		},
+		Policies: &azure.ToolboxPolicies{
+			RaiConfig: &azure.RaiConfig{RaiPolicyName: "Microsoft.Default"},
+		},
 	}}
 
 	resolver := newStubConnectionResolver()
@@ -221,8 +224,12 @@ func TestRunConnectionAddWith_AppendsAndPromotesDefault(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, client.createVersionCalls, 1)
-	assert.Equal(t, "first", client.createVersionCalls[0].req.Description, "description carried forward")
-	assert.Len(t, client.createVersionCalls[0].req.Tools, 2)
+	req := client.createVersionCalls[0].req
+	assert.Equal(t, "first", req.Description, "description carried forward")
+	assert.Len(t, req.Tools, 2)
+	require.NotNil(t, req.Policies, "policies must be carried forward")
+	require.NotNil(t, req.Policies.RaiConfig)
+	assert.Equal(t, "Microsoft.Default", req.Policies.RaiConfig.RaiPolicyName)
 	require.Len(t, client.setDefaultCalls, 1, "default version must be retargeted")
 }
 
@@ -326,6 +333,9 @@ func TestRunConnectionRemoveWith_FilteredAndPromoted(t *testing.T) {
 			{"type": "mcp", "name": "a", "project_connection_id": "/c/a"},
 			{"type": "mcp", "name": "b", "project_connection_id": "/c/b"},
 		},
+		Policies: &azure.ToolboxPolicies{
+			RaiConfig: &azure.RaiConfig{RaiPolicyName: "Microsoft.Default"},
+		},
 	}}
 	resolver := newStubConnectionResolver()
 	resolver.byName["a"] = &projectConnection{
@@ -338,7 +348,10 @@ func TestRunConnectionRemoveWith_FilteredAndPromoted(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, client.createVersionCalls, 1)
-	assert.Len(t, client.createVersionCalls[0].req.Tools, 1)
+	req := client.createVersionCalls[0].req
+	assert.Len(t, req.Tools, 1)
+	require.NotNil(t, req.Policies, "policies must be carried forward on remove")
+	assert.Equal(t, "Microsoft.Default", req.Policies.RaiConfig.RaiPolicyName)
 	require.Len(t, client.setDefaultCalls, 1)
 }
 
@@ -579,23 +592,56 @@ tools:
 }
 
 // A raw tools[] entry whose `name` violates the service regex is rejected
-// locally rather than producing a generic 400.
+// locally rather than producing a generic 400. Covers invalid characters,
+// explicit empty string, and non-string YAML scalars.
 func TestRunToolboxCreateWith_RawToolInvalidName(t *testing.T) {
-	client := newMockToolboxClient("https://e/")
-
-	inputPath := t.TempDir() + "/create.yaml"
-	require.NoError(t, os.WriteFile(inputPath, []byte(`
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "invalid chars",
+			yaml: `
 tools:
   - type: web_search
     name: bad.name
-`), 0o600))
+`,
+			wantErr: exterrors.CodeInvalidToolboxName,
+		},
+		{
+			name: "empty string",
+			yaml: `
+tools:
+  - type: web_search
+    name: ""
+`,
+			wantErr: exterrors.CodeInvalidToolboxName,
+		},
+		{
+			name: "non-string scalar",
+			yaml: `
+tools:
+  - type: web_search
+    name: 42
+`,
+			wantErr: exterrors.CodeInvalidParameter,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newMockToolboxClient("https://e/")
+			inputPath := t.TempDir() + "/create.yaml"
+			require.NoError(t, os.WriteFile(inputPath, []byte(tc.yaml), 0o600))
 
-	err := runToolboxCreateWith(
-		t.Context(), client, newStubConnectionResolver(), "https://e/", "tb",
-		toolboxCreateFlags{fromFile: inputPath}, toolboxFlags{output: "table"},
-	)
-	requireLocalError(t, err, exterrors.CodeInvalidToolboxName)
-	assert.Empty(t, client.createVersionCalls)
+			err := runToolboxCreateWith(
+				t.Context(), client, newStubConnectionResolver(), "https://e/", "tb",
+				toolboxCreateFlags{fromFile: inputPath}, toolboxFlags{output: "table"},
+			)
+			requireLocalError(t, err, tc.wantErr)
+			assert.Empty(t, client.createVersionCalls)
+		})
+	}
 }
 
 // Two entries sharing the same `name` collide regardless of source. A common

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_commands_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_commands_test.go
@@ -444,6 +444,65 @@ func TestRunToolboxCreateWith_NoConnectionsRejected(t *testing.T) {
 	assert.Empty(t, client.createVersionCalls)
 }
 
+// policies.rai_config in --from-file is forwarded to the data-plane request
+// as ToolboxPolicies.RaiConfig.RaiPolicyName.
+func TestRunToolboxCreateWith_ForwardsRaiPolicy(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	resolver := newStubConnectionResolver()
+	resolver.byName["mcp"] = &projectConnection{
+		ID: "/c/mcp", Category: connections.ConnectionTypeRemoteTool, Name: "mcp",
+		Target: "https://mcp.example.com",
+	}
+
+	inputPath := t.TempDir() + "/create.yaml"
+	require.NoError(t, os.WriteFile(inputPath, []byte(`
+description: tb with rai
+connections:
+  - name: mcp
+policies:
+  rai_config:
+    rai_policy_name: Microsoft.Default
+`), 0o600))
+
+	err := runToolboxCreateWith(
+		t.Context(), client, resolver, "https://e/", "tb",
+		toolboxCreateFlags{fromFile: inputPath}, toolboxFlags{output: "json"},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+	req := client.createVersionCalls[0].req
+	require.NotNil(t, req.Policies)
+	require.NotNil(t, req.Policies.RaiConfig)
+	assert.Equal(t, "Microsoft.Default", req.Policies.RaiConfig.RaiPolicyName)
+}
+
+// policies.rai_config with an empty/whitespace name is rejected locally with a
+// fix-it suggestion rather than forwarded to the data plane.
+func TestRunToolboxCreateWith_EmptyRaiPolicyNameRejected(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	resolver := newStubConnectionResolver()
+	resolver.byName["mcp"] = &projectConnection{
+		ID: "/c/mcp", Category: connections.ConnectionTypeRemoteTool, Name: "mcp",
+		Target: "https://mcp.example.com",
+	}
+
+	inputPath := t.TempDir() + "/create.yaml"
+	require.NoError(t, os.WriteFile(inputPath, []byte(`
+connections:
+  - name: mcp
+policies:
+  rai_config:
+    rai_policy_name: "   "
+`), 0o600))
+
+	err := runToolboxCreateWith(
+		t.Context(), client, resolver, "https://e/", "tb",
+		toolboxCreateFlags{fromFile: inputPath}, toolboxFlags{output: "table"},
+	)
+	requireLocalError(t, err, exterrors.CodeInvalidParameter)
+	assert.Empty(t, client.createVersionCalls)
+}
+
 // Client-side ^[A-Za-z0-9_-]+$ enforcement on tool entry names.
 func TestBuildToolEntry_RejectsInvalidName(t *testing.T) {
 	_, err := buildToolEntry(&projectConnection{

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_commands_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_commands_test.go
@@ -433,7 +433,7 @@ func TestRunToolboxCreateWith_AlreadyExists(t *testing.T) {
 	requireLocalError(t, err, exterrors.CodeInvalidToolboxName)
 }
 
-func TestRunToolboxCreateWith_NoConnectionsRejected(t *testing.T) {
+func TestRunToolboxCreateWith_NoEntriesRejected(t *testing.T) {
 	client := newMockToolboxClient("https://e/")
 
 	err := runToolboxCreateWith(
@@ -500,6 +500,128 @@ policies:
 		toolboxCreateFlags{fromFile: inputPath}, toolboxFlags{output: "table"},
 	)
 	requireLocalError(t, err, exterrors.CodeInvalidParameter)
+	assert.Empty(t, client.createVersionCalls)
+}
+
+// A tools-only --from-file payload (no connections) is valid and the raw
+// entries reach the data plane verbatim.
+func TestRunToolboxCreateWith_ToolsOnlyFromFile(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+
+	inputPath := t.TempDir() + "/create.yaml"
+	require.NoError(t, os.WriteFile(inputPath, []byte(`
+description: connectionless toolbox
+tools:
+  - type: web_search
+    name: web
+  - type: file_search
+    name: files
+`), 0o600))
+
+	err := runToolboxCreateWith(
+		t.Context(), client, newStubConnectionResolver(), "https://e/", "tb",
+		toolboxCreateFlags{fromFile: inputPath}, toolboxFlags{output: "json"},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+	tools := client.createVersionCalls[0].req.Tools
+	require.Len(t, tools, 2)
+	assert.Equal(t, "web_search", tools[0]["type"])
+	assert.Equal(t, "file_search", tools[1]["type"])
+}
+
+// Connection-backed entries come first, raw tools[] entries after.
+func TestRunToolboxCreateWith_MixedConnectionsAndTools(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	resolver := newStubConnectionResolver()
+	resolver.byName["mcp"] = &projectConnection{
+		ID: "/c/mcp", Category: connections.ConnectionTypeRemoteTool, Name: "mcp",
+		Target: "https://mcp.example.com",
+	}
+
+	inputPath := t.TempDir() + "/create.yaml"
+	require.NoError(t, os.WriteFile(inputPath, []byte(`
+connections:
+  - name: mcp
+tools:
+  - type: web_search
+    name: web
+`), 0o600))
+
+	err := runToolboxCreateWith(
+		t.Context(), client, resolver, "https://e/", "tb",
+		toolboxCreateFlags{fromFile: inputPath}, toolboxFlags{output: "json"},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+	tools := client.createVersionCalls[0].req.Tools
+	require.Len(t, tools, 2)
+	assert.Equal(t, "mcp", tools[0]["type"])
+	assert.Equal(t, "web_search", tools[1]["type"])
+}
+
+// A tools[] entry missing the discriminator `type` is rejected locally.
+func TestRunToolboxCreateWith_RawToolMissingType(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+
+	inputPath := t.TempDir() + "/create.yaml"
+	require.NoError(t, os.WriteFile(inputPath, []byte(`
+tools:
+  - name: oops
+`), 0o600))
+
+	err := runToolboxCreateWith(
+		t.Context(), client, newStubConnectionResolver(), "https://e/", "tb",
+		toolboxCreateFlags{fromFile: inputPath}, toolboxFlags{output: "table"},
+	)
+	requireLocalError(t, err, exterrors.CodeMissingToolType)
+	assert.Empty(t, client.createVersionCalls)
+}
+
+// A raw tools[] entry whose `name` violates the service regex is rejected
+// locally rather than producing a generic 400.
+func TestRunToolboxCreateWith_RawToolInvalidName(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+
+	inputPath := t.TempDir() + "/create.yaml"
+	require.NoError(t, os.WriteFile(inputPath, []byte(`
+tools:
+  - type: web_search
+    name: bad.name
+`), 0o600))
+
+	err := runToolboxCreateWith(
+		t.Context(), client, newStubConnectionResolver(), "https://e/", "tb",
+		toolboxCreateFlags{fromFile: inputPath}, toolboxFlags{output: "table"},
+	)
+	requireLocalError(t, err, exterrors.CodeInvalidToolboxName)
+	assert.Empty(t, client.createVersionCalls)
+}
+
+// Two entries sharing the same `name` collide regardless of source. A common
+// mistake is a raw tool whose name matches an attached connection's short name.
+func TestRunToolboxCreateWith_DuplicateToolNameRejected(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	resolver := newStubConnectionResolver()
+	resolver.byName["mcp"] = &projectConnection{
+		ID: "/c/mcp", Category: connections.ConnectionTypeRemoteTool, Name: "mcp",
+		Target: "https://mcp.example.com",
+	}
+
+	inputPath := t.TempDir() + "/create.yaml"
+	require.NoError(t, os.WriteFile(inputPath, []byte(`
+connections:
+  - name: mcp
+tools:
+  - type: web_search
+    name: mcp
+`), 0o600))
+
+	err := runToolboxCreateWith(
+		t.Context(), client, resolver, "https://e/", "tb",
+		toolboxCreateFlags{fromFile: inputPath}, toolboxFlags{output: "table"},
+	)
+	requireLocalError(t, err, exterrors.CodeDuplicateToolName)
 	assert.Empty(t, client.createVersionCalls)
 }
 

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_add.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_add.go
@@ -237,6 +237,7 @@ func runConnectionAddWith(
 		Description: current.Description,
 		Metadata:    current.Metadata,
 		Tools:       newTools,
+		Policies:    current.Policies,
 	}
 	created, err := client.CreateToolboxVersion(ctx, toolboxName, req)
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_remove.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_remove.go
@@ -166,6 +166,7 @@ func runConnectionRemoveWith(
 		Description: current.Description,
 		Metadata:    current.Metadata,
 		Tools:       filtered,
+		Policies:    current.Policies,
 	}
 	created, err := client.CreateToolboxVersion(ctx, toolboxName, req)
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_create.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_create.go
@@ -276,7 +276,15 @@ func validateRawToolEntries(tools []map[string]any) ([]map[string]any, error) {
 				"set 'type' to a Foundry tool type (e.g. web_search, file_search, code_interpreter)",
 			)
 		}
-		if nameVal, ok := t["name"].(string); ok && nameVal != "" {
+		if raw, present := t["name"]; present {
+			nameVal, ok := raw.(string)
+			if !ok {
+				return nil, exterrors.Validation(
+					exterrors.CodeInvalidParameter,
+					fmt.Sprintf("tools[%d].name must be a string, got %T", i, raw),
+					"set 'name' to a string matching ^[A-Za-z0-9_-]+$ or omit it",
+				)
+			}
 			if err := validateToolName(nameVal); err != nil {
 				return nil, err
 			}

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_create.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_create.go
@@ -113,6 +113,7 @@ func runToolboxCreateWith(
 
 	description := ""
 	entries := []map[string]any{}
+	var policies *azure.ToolboxPolicies
 
 	if strings.TrimSpace(verb.fromFile) != "" {
 		var input toolboxCreateFile
@@ -125,6 +126,11 @@ func runToolboxCreateWith(
 			return err
 		}
 		entries = append(entries, resolvedEntries...)
+
+		policies, err = buildToolboxPolicies(input.Policies)
+		if err != nil {
+			return err
+		}
 	}
 
 	if len(entries) == 0 {
@@ -142,6 +148,7 @@ func runToolboxCreateWith(
 	req := &azure.CreateToolboxVersionRequest{
 		Description: description,
 		Tools:       entries,
+		Policies:    policies,
 	}
 	created, err := client.CreateToolboxVersion(ctx, name, req)
 	if err != nil {
@@ -216,4 +223,24 @@ func validateNoDuplicateConnectionIDs(entries []map[string]any) error {
 		}
 	}
 	return nil
+}
+
+// buildToolboxPolicies converts the file-shaped policy spec into the
+// data-plane request shape. Returns nil when no policies are configured.
+// Currently the only supported policy is the RAI policy name.
+func buildToolboxPolicies(spec *toolboxPoliciesSpec) (*azure.ToolboxPolicies, error) {
+	if spec == nil || spec.RaiConfig == nil {
+		return nil, nil
+	}
+	name := spec.RaiConfig.resolvedPolicyName()
+	if name == "" {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidParameter,
+			"policies.rai_config requires a policy name",
+			"set policies.rai_config.rai_policy_name (or 'name') to the RAI policy to apply",
+		)
+	}
+	return &azure.ToolboxPolicies{
+		RaiConfig: &azure.RaiConfig{RaiPolicyName: name},
+	}, nil
 }

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_create.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_create.go
@@ -32,13 +32,13 @@ func newToolboxCreateCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 		Short: "Create a toolbox and publish its initial version from a file.",
 		Long: `Create a toolbox and publish its initial version.
 
-The Foundry service requires the initial version to ship with a non-empty
-connection list, so 'create' takes its inputs from a JSON or YAML file via
+The Foundry service requires the initial version to ship with at least one
+tool entry, so 'create' takes its inputs from a JSON or YAML file via
 --from-file.
 
 ` + fileShapeBlurb(true) + `
 
-At least one connection must be provided.
+At least one of 'connections' or 'tools' must be non-empty.
 
 Examples:
 
@@ -127,6 +127,12 @@ func runToolboxCreateWith(
 		}
 		entries = append(entries, resolvedEntries...)
 
+		rawEntries, err := validateRawToolEntries(input.Tools)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, rawEntries...)
+
 		policies, err = buildToolboxPolicies(input.Policies)
 		if err != nil {
 			return err
@@ -136,12 +142,15 @@ func runToolboxCreateWith(
 	if len(entries) == 0 {
 		return exterrors.Validation(
 			exterrors.CodeInvalidToolboxName,
-			"toolbox create requires at least one connection",
-			"pass --from-file with a non-empty 'connections' list",
+			"toolbox create requires at least one tool entry",
+			"pass --from-file with a non-empty 'connections' or 'tools' list",
 		)
 	}
 
 	if err := validateNoDuplicateConnectionIDs(entries); err != nil {
+		return err
+	}
+	if err := validateNoDuplicateToolNames(entries); err != nil {
 		return err
 	}
 
@@ -243,4 +252,61 @@ func buildToolboxPolicies(spec *toolboxPoliciesSpec) (*azure.ToolboxPolicies, er
 	return &azure.ToolboxPolicies{
 		RaiConfig: &azure.RaiConfig{RaiPolicyName: name},
 	}, nil
+}
+
+// validateRawToolEntries checks the local invariants on a verbatim tools[]
+// entry: non-empty object, required `type` discriminator, and (when set) a
+// `name` that matches the service regex. Type-specific shape is left to the
+// data plane.
+func validateRawToolEntries(tools []map[string]any) ([]map[string]any, error) {
+	out := make([]map[string]any, 0, len(tools))
+	for i, t := range tools {
+		if len(t) == 0 {
+			return nil, exterrors.Validation(
+				exterrors.CodeInvalidParameter,
+				fmt.Sprintf("tools[%d] is empty", i),
+				"each entry must be an object with at least a 'type' field",
+			)
+		}
+		typeVal, _ := t["type"].(string)
+		if strings.TrimSpace(typeVal) == "" {
+			return nil, exterrors.Validation(
+				exterrors.CodeMissingToolType,
+				fmt.Sprintf("tools[%d] is missing the required 'type' field", i),
+				"set 'type' to a Foundry tool type (e.g. web_search, file_search, code_interpreter)",
+			)
+		}
+		if nameVal, ok := t["name"].(string); ok && nameVal != "" {
+			if err := validateToolName(nameVal); err != nil {
+				return nil, err
+			}
+		}
+		out = append(out, t)
+	}
+	return out, nil
+}
+
+// validateNoDuplicateToolNames rejects entries that share the same top-level
+// `name`. Names are optional on raw entries but collide in `tools/list` and
+// tool_search when set.
+func validateNoDuplicateToolNames(entries []map[string]any) error {
+	names := []string{}
+	for _, t := range entries {
+		name, _ := t["name"].(string)
+		if strings.TrimSpace(name) == "" {
+			continue
+		}
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	for i := 1; i < len(names); i++ {
+		if names[i] == names[i-1] {
+			return exterrors.Validation(
+				exterrors.CodeDuplicateToolName,
+				fmt.Sprintf("tool name %q appears more than once in the input", names[i]),
+				"give each tool entry a unique 'name'",
+			)
+		}
+	}
+	return nil
 }

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_files.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_files.go
@@ -39,9 +39,39 @@ type toolboxToolsFile struct {
 //
 // description is optional and stored on the initial version.
 // connections[] is required and lists existing project connections to attach.
+// policies carries the toolbox version's RAI policy.
 type toolboxCreateFile struct {
 	Description string                  `json:"description,omitempty" yaml:"description,omitempty"`
 	Connections []toolboxConnectionSpec `json:"connections,omitempty" yaml:"connections,omitempty"`
+	Policies    *toolboxPoliciesSpec    `json:"policies,omitempty"    yaml:"policies,omitempty"`
+}
+
+// toolboxPoliciesSpec mirrors the data-plane ToolboxPolicies model.
+type toolboxPoliciesSpec struct {
+	RaiConfig *toolboxRaiConfigSpec `json:"rai_config,omitempty" yaml:"rai_config,omitempty"`
+}
+
+// toolboxRaiConfigSpec mirrors the data-plane RaiConfig model.
+//
+// The wire field per the Foundry TypeSpec is `rai_policy_name`. We also accept
+// the friendlier `name` alias and map it onto `rai_policy_name` at validation
+// time so existing user docs that use either form keep working.
+type toolboxRaiConfigSpec struct {
+	RaiPolicyName string `json:"rai_policy_name,omitempty" yaml:"rai_policy_name,omitempty"`
+	Name          string `json:"name,omitempty"            yaml:"name,omitempty"`
+}
+
+// resolvedPolicyName returns the effective RAI policy name from the spec,
+// preferring the wire-shaped `rai_policy_name` over the `name` alias.
+// Returns "" if neither is set.
+func (r *toolboxRaiConfigSpec) resolvedPolicyName() string {
+	if r == nil {
+		return ""
+	}
+	if strings.TrimSpace(r.RaiPolicyName) != "" {
+		return strings.TrimSpace(r.RaiPolicyName)
+	}
+	return strings.TrimSpace(r.Name)
 }
 
 // parseToolboxFile reads a JSON or YAML file into out. Unknown fields are

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_files.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_files.go
@@ -37,12 +37,16 @@ type toolboxToolsFile struct {
 
 // toolboxCreateFile is the file shape for `toolbox create --from-file`.
 //
-// description is optional and stored on the initial version.
-// connections[] is required and lists existing project connections to attach.
-// policies carries the toolbox version's RAI policy.
+// connections[] is azd sugar over the project connections data-plane and
+// builds the matching tool entry (mcp, azure_ai_search, a2a_preview, or
+// connection-backed web_search). tools[] is a verbatim pass-through to the
+// data plane's OpenAI.Tool[] shape; use it for connectionless tools (built-in
+// web_search, file_search, code_interpreter, ...) or any tool type not yet
+// exposed by connections[]. At least one of the two must be non-empty.
 type toolboxCreateFile struct {
 	Description string                  `json:"description,omitempty" yaml:"description,omitempty"`
 	Connections []toolboxConnectionSpec `json:"connections,omitempty" yaml:"connections,omitempty"`
+	Tools       []map[string]any        `json:"tools,omitempty"       yaml:"tools,omitempty"`
 	Policies    *toolboxPoliciesSpec    `json:"policies,omitempty"    yaml:"policies,omitempty"`
 }
 

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_files_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_files_test.go
@@ -137,6 +137,44 @@ func TestParseToolboxFile_RejectsUnsupportedExtension(t *testing.T) {
 	assert.Contains(t, le.Suggestion, ".json")
 }
 
+// `tools` on the create shape is accepted as a raw OpenAI.Tool[] pass-through.
+// YAML must decode nested objects as map[string]any (not map[any]any) so the
+// JSON marshaller in the data-plane client emits valid JSON.
+func TestParseToolboxFile_AcceptsRawToolsOnCreate(t *testing.T) {
+	t.Run("json", func(t *testing.T) {
+		path := writeTempFile(t, ".json", `
+{
+  "tools": [
+    { "type": "web_search",  "name": "web" },
+    { "type": "file_search", "name": "files" }
+  ]
+}`)
+		var out toolboxCreateFile
+		require.NoError(t, parseToolboxFile(path, &out))
+		require.Len(t, out.Tools, 2)
+		assert.Equal(t, "web_search", out.Tools[0]["type"])
+		assert.Equal(t, "files", out.Tools[1]["name"])
+	})
+
+	t.Run("yaml decodes nested maps as map[string]any", func(t *testing.T) {
+		path := writeTempFile(t, ".yaml", `
+tools:
+  - type: web_search
+    name: web
+  - type: code_interpreter
+    name: ci
+    container:
+      type: auto
+`)
+		var out toolboxCreateFile
+		require.NoError(t, parseToolboxFile(path, &out))
+		require.Len(t, out.Tools, 2)
+		nested, ok := out.Tools[1]["container"].(map[string]any)
+		require.True(t, ok, "expected nested map[string]any, got %T", out.Tools[1]["container"])
+		assert.Equal(t, "auto", nested["type"])
+	})
+}
+
 func TestParseToolboxFile_RejectsMissingFile(t *testing.T) {
 	var out toolboxCreateFile
 	err := parseToolboxFile(filepath.Join(t.TempDir(), "nope.json"), &out)

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_files_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_files_test.go
@@ -142,3 +142,55 @@ func TestParseToolboxFile_RejectsMissingFile(t *testing.T) {
 	err := parseToolboxFile(filepath.Join(t.TempDir(), "nope.json"), &out)
 	requireLocalError(t, err, exterrors.CodeInvalidParameter)
 }
+
+// `policies.rai_config` is accepted by `toolbox create` and the wire-shaped
+// `rai_policy_name` field round-trips through the file struct.
+func TestParseToolboxFile_AcceptsPolicies(t *testing.T) {
+	t.Run("yaml with rai_policy_name", func(t *testing.T) {
+		path := writeTempFile(t, ".yaml", `
+description: with policy
+connections:
+  - name: my-mcp
+policies:
+  rai_config:
+    rai_policy_name: Microsoft.Default
+`)
+		var out toolboxCreateFile
+		require.NoError(t, parseToolboxFile(path, &out))
+		require.NotNil(t, out.Policies)
+		require.NotNil(t, out.Policies.RaiConfig)
+		assert.Equal(t, "Microsoft.Default", out.Policies.RaiConfig.RaiPolicyName)
+		assert.Equal(t, "Microsoft.Default", out.Policies.RaiConfig.resolvedPolicyName())
+	})
+
+	// The friendlier `name` alias also resolves, but is not the wire field.
+	t.Run("yaml with name alias", func(t *testing.T) {
+		path := writeTempFile(t, ".yaml", `
+description: with policy
+connections:
+  - name: my-mcp
+policies:
+  rai_config:
+    name: Microsoft.Default
+`)
+		var out toolboxCreateFile
+		require.NoError(t, parseToolboxFile(path, &out))
+		require.NotNil(t, out.Policies)
+		require.NotNil(t, out.Policies.RaiConfig)
+		assert.Equal(t, "", out.Policies.RaiConfig.RaiPolicyName)
+		assert.Equal(t, "Microsoft.Default", out.Policies.RaiConfig.Name)
+		assert.Equal(t, "Microsoft.Default", out.Policies.RaiConfig.resolvedPolicyName())
+	})
+
+	// rai_policy_name wins over name when both are set.
+	t.Run("rai_policy_name wins over name alias", func(t *testing.T) {
+		spec := &toolboxRaiConfigSpec{RaiPolicyName: "wire", Name: "alias"}
+		assert.Equal(t, "wire", spec.resolvedPolicyName())
+	})
+
+	// Empty/whitespace-only fields return "" so the create flow can reject.
+	t.Run("empty resolves to empty string", func(t *testing.T) {
+		spec := &toolboxRaiConfigSpec{RaiPolicyName: "  "}
+		assert.Equal(t, "", spec.resolvedPolicyName())
+	})
+}

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_help.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_help.go
@@ -21,6 +21,10 @@ func fileShapeBlurb(includeDescription bool) string {
       { "name": "my-bing",   "instance_name": "docs-config" },
       { "name": "my-a2a" }
     ],
+    "tools": [
+      { "type": "web_search",   "name": "web" },
+      { "type": "file_search",  "name": "files" }
+    ],
     "policies": {
       "rai_config": { "rai_policy_name": "Microsoft.Default" }
     }
@@ -36,24 +40,37 @@ Equivalent YAML:
     - name: my-bing
       instance_name: docs-config
     - name: my-a2a
+  tools:
+    - type: web_search
+      name: web
+    - type: file_search
+      name: files
   policies:
     rai_config:
       rai_policy_name: Microsoft.Default
 
 Fields:
   description     Optional. Stored on the initial toolbox version.
-  connections     Required. List of existing project connections to attach.
-                  Each entry needs 'name' (the project connection short name).
+  connections     List of existing project connections to attach. Each entry
+                  needs 'name' (the project connection short name).
                   'index' is required only for CognitiveSearch connections.
                   'instance_name' is required only for
                   GroundingWithCustomSearch connections.
                   Supported connection categories: RemoteTool (MCP),
                   CognitiveSearch (Azure AI Search), RemoteA2A,
                   GroundingWithCustomSearch.
+  tools           List of raw Foundry tool entries (OpenAI.Tool shape),
+                  forwarded verbatim. Use for connectionless tools (e.g.,
+                  built-in web_search, file_search, code_interpreter,
+                  capture_structured_outputs) or any tool type not yet
+                  exposed by 'connections'. Each entry must include 'type';
+                  an optional 'name' must match ^[A-Za-z0-9_-]+$.
   policies        Optional. Per-version governance settings.
                   policies.rai_config.rai_policy_name selects the Responsible
                   AI content-filter policy applied to this toolbox version
                   (the alias 'name' is also accepted).
+
+At least one of 'connections' or 'tools' must be non-empty.
 
 Project connections must already exist on the Foundry project; this command
 does not create them. Run 'azd ai agent connection list' to see available

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_help.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_help.go
@@ -20,7 +20,10 @@ func fileShapeBlurb(includeDescription bool) string {
       { "name": "my-search", "index": "products" },
       { "name": "my-bing",   "instance_name": "docs-config" },
       { "name": "my-a2a" }
-    ]
+    ],
+    "policies": {
+      "rai_config": { "rai_policy_name": "Microsoft.Default" }
+    }
   }
 
 Equivalent YAML:
@@ -33,6 +36,9 @@ Equivalent YAML:
     - name: my-bing
       instance_name: docs-config
     - name: my-a2a
+  policies:
+    rai_config:
+      rai_policy_name: Microsoft.Default
 
 Fields:
   description     Optional. Stored on the initial toolbox version.
@@ -44,6 +50,10 @@ Fields:
                   Supported connection categories: RemoteTool (MCP),
                   CognitiveSearch (Azure AI Search), RemoteA2A,
                   GroundingWithCustomSearch.
+  policies        Optional. Per-version governance settings.
+                  policies.rai_config.rai_policy_name selects the Responsible
+                  AI content-filter policy applied to this toolbox version
+                  (the alias 'name' is also accepted).
 
 Project connections must already exist on the Foundry project; this command
 does not create them. Run 'azd ai agent connection list' to see available

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/exterrors/codes.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/exterrors/codes.go
@@ -41,6 +41,8 @@ const (
 	CodeMissingInstanceName           = "missing_instance_name"
 	CodeUnsupportedInstanceNameFlag   = "unsupported_instance_name_flag"
 	CodeDuplicateConnection           = "duplicate_connection"
+	CodeDuplicateToolName             = "duplicate_tool_name"
+	CodeMissingToolType               = "missing_tool_type"
 	CodeConnectionNotFound            = "connection_not_found"
 	CodeConnectionNotInToolbox        = "connection_not_in_toolbox"
 	CodeConnectionMissingTarget       = "connection_missing_target"

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/pkg/azure/foundry_toolsets_client.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/pkg/azure/foundry_toolsets_client.go
@@ -188,6 +188,19 @@ type CreateToolboxVersionRequest struct {
 	Description string            `json:"description,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
 	Tools       []map[string]any  `json:"tools"`
+	Policies    *ToolboxPolicies  `json:"policies,omitempty"`
+}
+
+// ToolboxPolicies mirrors the data-plane ToolboxPolicies model: per-version
+// governance settings (currently RAI content filtering).
+type ToolboxPolicies struct {
+	RaiConfig *RaiConfig `json:"rai_config,omitempty"`
+}
+
+// RaiConfig mirrors the data-plane RaiConfig model: the name of the
+// Responsible AI policy to apply to this toolbox version.
+type RaiConfig struct {
+	RaiPolicyName string `json:"rai_policy_name"`
 }
 
 // ToolboxObject is the lightweight response for a toolbox (no tools list).
@@ -206,6 +219,7 @@ type ToolboxVersionObject struct {
 	CreatedAt   int64             `json:"created_at"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
 	Tools       []map[string]any  `json:"tools"`
+	Policies    *ToolboxPolicies  `json:"policies,omitempty"`
 }
 
 // toolboxURL builds the canonical toolboxes URL with the api-version query.


### PR DESCRIPTION
## Summary

Fixes #8354. `azd ai toolbox create --from-file` now accepts connectionless tools (built-in `web_search`, `file_search`, `code_interpreter`, ...) and a per-version `policies.rai_config` block, matching the Foundry toolboxes data-plane shape ([TypeSpec](https://github.com/Azure/azure-rest-api-specs/blob/feature/foundry-release/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp)).

```yaml
description: research toolbox
connections:
  - name: my-mcp
tools:
  - type: web_search
    name: web
policies:
  rai_config:
    rai_policy_name: Microsoft.Default
```

## Changes

- `toolboxCreateFile` gains `tools[]` (verbatim `OpenAI.Tool[]` pass-through) and `policies.rai_config`.
- `CreateToolboxVersionRequest` / `ToolboxVersionObject` carry `policies` so reads round-trip.
- "≥1 connection" check relaxes to "≥1 tool entry"; local validation rejects empty entries, missing `type`, invalid `name`, and duplicate names across `connections[] + tools[]`.
- Suggestion text on the tool-name regex error is now source-agnostic (was connection-specific).
- New unit tests + verified end-to-end against a live Foundry project.
