### PR TITLE
fix(azure.ai.routines): align with REST spec PR #43498 and harden CRUD edges

### DIFF
--- a/cli/azd/extensions/azure.ai.routines/AGENTS.md
+++ b/cli/azd/extensions/azure.ai.routines/AGENTS.md
@@ -134,13 +134,15 @@ log.Printf("No routines found on project")                     // use fmt.Print*
 ## API spec alignment
 
 The authoritative TypeSpec is in
-[`azure-rest-api-specs` PR #43186](https://github.com/Azure/azure-rest-api-specs/pull/43186)
-(`specification/ai-foundry/data-plane/Foundry/src/routines/`). The client in
-`internal/pkg/routines/` tracks that spec, with a small number of remaining
-divergences kept for compatibility with the currently deployed Foundry service:
+[`azure-rest-api-specs` PR #43498](https://github.com/Azure/azure-rest-api-specs/pull/43498)
+(`specification/ai-foundry/data-plane/Foundry/src/routines/`), which replaced
+the earlier #43186 draft. The client in `internal/pkg/routines/` tracks that
+spec, with a small number of remaining divergences kept for compatibility
+with the currently deployed Foundry service:
 
-| Concern | Spec | Live service | Client choice |
+| Concern | Spec (#43498) | Live service today | Client choice |
 |---|---|---|---|
-| `github_issue_opened` trigger | renamed in spec | still accepts only `github_issue` | keep `github_issue` wire value (CLI surface is deferred) |
-| `AgentsPagedResult<T>` envelope | `data` + `last_id` + `has_more` | `value` + `nextLink` (routines) / `value` + `nextPageToken` (runs) | match service shape |
+| `github_issue` trigger | retained as `github_issue` | accepts `github_issue` | match; CLI surface deferred |
+| List envelope | `AgentsPagedResult<T>`: `{ data, first_id, last_id, has_more }` with `?limit`/`?after` cursor | rolling out — older regions may still emit `{ value, nextLink }` / `{ value, nextPageToken }` | decode the spec shape via `Items()` / `NextCursor()` and fall back to the legacy fields during the rollout window |
+| Timer trigger `at` | `utcDateTime` (RFC 3339) — validated client-side via `time.Parse(time.RFC3339, …)` | accepts RFC 3339 on PUT; **omits `at` on GET** today (see issue #8421 Bug 5) | validate on input, and refuse a flag-only `routine update` that would PUT a timer trigger with empty `at` |
 

--- a/cli/azd/extensions/azure.ai.routines/cspell.yaml
+++ b/cli/azd/extensions/azure.ai.routines/cspell.yaml
@@ -4,3 +4,4 @@ words:
   - sess
   - routineName
   - azdProjectSources
+  - Deleter

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_create.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_create.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"azure.ai.routines/internal/exterrors"
 	"azure.ai.routines/internal/pkg/routines"
@@ -192,6 +193,25 @@ func runRoutineCreate(ctx context.Context, cmd *cobra.Command, flags *routineCre
 	return nil
 }
 
+// validateAt parses an `--at` value as an RFC 3339 datetime. Foundry's
+// `TimerRoutineTrigger.at` field is a `utcDateTime` per the TypeSpec, so any
+// value the service accepts must round-trip through `time.Parse(time.RFC3339)`.
+// Returning a clear local error here avoids surfacing an opaque 400 from the
+// service for trivially malformed input.
+func validateAt(value string) error {
+	if _, err := time.Parse(time.RFC3339, value); err != nil {
+		return exterrors.Validation(
+			exterrors.CodeInvalidParameter,
+			fmt.Sprintf(
+				"--at must be an ISO 8601 / RFC 3339 datetime, e.g. '2026-04-24T15:00:00Z' (got %q)",
+				value,
+			),
+			"provide an RFC 3339 datetime such as '2026-04-24T15:00:00Z'",
+		)
+	}
+	return nil
+}
+
 // buildTrigger constructs a RoutineTrigger from CLI flags.
 //
 // Supported triggers: timer (one-shot, --at) and recurring (cron, --cron).
@@ -228,6 +248,9 @@ func buildTrigger(flags *routineCreateFlags) (routines.RoutineTrigger, error) {
 				"--at is required for trigger type 'timer'",
 				"provide an ISO 8601 datetime, e.g. '2026-04-24T15:00:00Z'",
 			)
+		}
+		if err := validateAt(flags.at); err != nil {
+			return t, err
 		}
 		t.At = flags.at
 	case "recurring":

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_create_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_create_test.go
@@ -55,6 +55,40 @@ func TestBuildTrigger_TimerMissingAt(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestBuildTrigger_TimerInvalidAt covers issue #8421 Bug 6: `--at` accepts
+// arbitrary strings today, and the CLI should reject obvious garbage with a
+// clear local error instead of round-tripping a 400 through the service.
+func TestBuildTrigger_TimerInvalidAt(t *testing.T) {
+	t.Parallel()
+	flags := &routineCreateFlags{
+		trigger:  "timer",
+		at:       "not-a-date",
+		timeZone: "UTC",
+	}
+	_, err := buildTrigger(flags)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RFC 3339",
+		"error message must reference RFC 3339 so users know what format is expected")
+	assert.Contains(t, err.Error(), "not-a-date",
+		"error message must echo back the invalid value the user provided")
+}
+
+// TestBuildTrigger_TimerAtVariants accepts every flavor that time.RFC3339
+// parses so users can write standard datetimes with or without a numeric zone.
+func TestBuildTrigger_TimerAtVariants(t *testing.T) {
+	t.Parallel()
+	for _, at := range []string{
+		"2026-04-24T15:00:00Z",
+		"2026-04-24T15:00:00+02:00",
+		"2026-04-24T15:00:00-07:00",
+	} {
+		flags := &routineCreateFlags{trigger: "timer", at: at}
+		got, err := buildTrigger(flags)
+		require.NoErrorf(t, err, "RFC 3339 datetime %q should parse", at)
+		assert.Equal(t, at, got.At)
+	}
+}
+
 func TestBuildTrigger_UnknownType(t *testing.T) {
 	t.Parallel()
 	flags := &routineCreateFlags{trigger: "unknown-trigger"}

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_delete.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_delete.go
@@ -8,10 +8,20 @@ import (
 	"fmt"
 
 	"azure.ai.routines/internal/exterrors"
+	"azure.ai.routines/internal/pkg/routines"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/spf13/cobra"
 )
+
+// routineDeleter is the minimal client surface used by runRoutineDelete.
+// Defining it as an interface lets the delete logic — including the defensive
+// existence check that fixes issue #8421 Bug 7 — be unit-tested without a
+// real HTTP client or live Foundry endpoint.
+type routineDeleter interface {
+	GetRoutine(ctx context.Context, name string) (*routines.Routine, error)
+	DeleteRoutine(ctx context.Context, name string) error
+}
 
 func newRoutineDeleteCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 	var force bool
@@ -78,6 +88,32 @@ func runRoutineDelete(ctx context.Context, cmd *cobra.Command, name string, forc
 	client, _, err := newRoutineClient(ctx, cmd)
 	if err != nil {
 		return err
+	}
+
+	return deleteRoutineWithExistenceCheck(ctx, client, name, output)
+}
+
+// deleteRoutineWithExistenceCheck does an explicit GET before DELETE so that
+// deleting a routine that does not exist surfaces the same "not found" error
+// as `routine show` / `routine dispatch`, instead of silently succeeding.
+//
+// The Foundry DELETE endpoint is idempotent and returns 2xx for missing
+// resources; the issue #8421 (Bug 7) bug filer explicitly accepts either a
+// fix or an "did not exist" message — this implementation chooses the
+// fix-and-404 approach for consistency with the rest of the verb surface.
+//
+// There is a small TOCTOU race between the GET and the DELETE: if another
+// caller deletes the routine in that window, the DELETE will still succeed
+// (the endpoint is idempotent), which is the desired user-facing outcome.
+func deleteRoutineWithExistenceCheck(
+	ctx context.Context, client routineDeleter, name, output string,
+) error {
+	if _, err := client.GetRoutine(ctx, name); err != nil {
+		if exterrors.IsNotFound(err) {
+			return exterrors.ServiceFromStatus(404, exterrors.OpDeleteRoutine,
+				fmt.Sprintf("routine %q not found. Verify the name with 'routine list'.", name))
+		}
+		return exterrors.ServiceFromAzure(err, exterrors.OpGetRoutine)
 	}
 
 	if err := client.DeleteRoutine(ctx, name); err != nil {

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_delete_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_delete_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"azure.ai.routines/internal/exterrors"
+	"azure.ai.routines/internal/pkg/routines"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRoutineDeleter is a stub implementation of [routineDeleter] used to
+// drive deleteRoutineWithExistenceCheck in unit tests. It records every call
+// the SUT makes so the tests can assert ordering ("did we GET before DELETE?")
+// and the specific routine name passed through.
+type fakeRoutineDeleter struct {
+	getRoutine    func(ctx context.Context, name string) (*routines.Routine, error)
+	deleteRoutine func(ctx context.Context, name string) error
+
+	getCalls    []string
+	deleteCalls []string
+}
+
+func (f *fakeRoutineDeleter) GetRoutine(
+	ctx context.Context, name string,
+) (*routines.Routine, error) {
+	f.getCalls = append(f.getCalls, name)
+	if f.getRoutine == nil {
+		return &routines.Routine{Name: name}, nil
+	}
+	return f.getRoutine(ctx, name)
+}
+
+func (f *fakeRoutineDeleter) DeleteRoutine(ctx context.Context, name string) error {
+	f.deleteCalls = append(f.deleteCalls, name)
+	if f.deleteRoutine == nil {
+		return nil
+	}
+	return f.deleteRoutine(ctx, name)
+}
+
+// notFoundResponseError builds an azcore.ResponseError shaped like a real 404
+// from the Foundry data plane. exterrors.IsNotFound unwraps it via errors.As.
+func notFoundResponseError() error {
+	return &azcore.ResponseError{
+		ErrorCode:  "NotFound",
+		StatusCode: 404,
+	}
+}
+
+// TestDeleteRoutineWithExistenceCheck_HappyPath verifies the typical flow
+// where the routine exists: GET succeeds, then DELETE is issued.
+func TestDeleteRoutineWithExistenceCheck_HappyPath(t *testing.T) {
+	t.Parallel()
+	f := &fakeRoutineDeleter{}
+	err := deleteRoutineWithExistenceCheck(context.Background(), f, "my-routine", "table")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"my-routine"}, f.getCalls,
+		"GET should be issued before DELETE to check existence")
+	assert.Equal(t, []string{"my-routine"}, f.deleteCalls)
+}
+
+// TestDeleteRoutineWithExistenceCheck_NotFoundSurfacedAs404 is the core
+// regression guard for issue #8421 Bug 7: deleting a routine that doesn't
+// exist must surface the same shape of "not found" error as `routine show`
+// and `routine dispatch`, instead of silently printing "deleted".
+func TestDeleteRoutineWithExistenceCheck_NotFoundSurfacedAs404(t *testing.T) {
+	t.Parallel()
+	f := &fakeRoutineDeleter{
+		getRoutine: func(_ context.Context, _ string) (*routines.Routine, error) {
+			return nil, notFoundResponseError()
+		},
+	}
+	err := deleteRoutineWithExistenceCheck(
+		context.Background(), f, "does-not-exist", "table")
+	require.Error(t, err)
+
+	var svcErr *azdext.ServiceError
+	require.True(t, errors.As(err, &svcErr),
+		"error must be a structured azdext.ServiceError so callers can branch on it")
+	assert.Equal(t, 404, svcErr.StatusCode,
+		"status code must reflect 'not found' so the rest of the verb surface stays consistent")
+	assert.Contains(t, svcErr.Message, "does-not-exist",
+		"error message must echo the routine name the user asked to delete")
+	assert.True(t, exterrors.IsNotFound(err),
+		"IsNotFound must continue to recognize the resulting error")
+
+	assert.Empty(t, f.deleteCalls,
+		"DELETE must NOT be issued once the existence check fails")
+}
+
+// TestDeleteRoutineWithExistenceCheck_GetTransientError ensures transient
+// errors from the existence GET (e.g. 5xx, network) propagate untouched
+// rather than being silently treated as "not found".
+func TestDeleteRoutineWithExistenceCheck_GetTransientError(t *testing.T) {
+	t.Parallel()
+	f := &fakeRoutineDeleter{
+		getRoutine: func(_ context.Context, _ string) (*routines.Routine, error) {
+			return nil, &azcore.ResponseError{
+				ErrorCode:  "InternalError",
+				StatusCode: 500,
+			}
+		},
+	}
+	err := deleteRoutineWithExistenceCheck(context.Background(), f, "r", "table")
+	require.Error(t, err)
+	assert.False(t, exterrors.IsNotFound(err),
+		"a 5xx during the existence GET must not be mistaken for not-found")
+	assert.Empty(t, f.deleteCalls)
+}
+
+// TestDeleteRoutineWithExistenceCheck_DeleteRaceLost handles the TOCTOU race
+// where the routine was deleted between the existence GET and the DELETE: if
+// DELETE returns 404, the verb still surfaces a structured 404 (matching the
+// behavior when the routine did not exist at GET time).
+func TestDeleteRoutineWithExistenceCheck_DeleteRaceLost(t *testing.T) {
+	t.Parallel()
+	f := &fakeRoutineDeleter{
+		deleteRoutine: func(_ context.Context, _ string) error {
+			return notFoundResponseError()
+		},
+	}
+	err := deleteRoutineWithExistenceCheck(context.Background(), f, "r", "table")
+	require.Error(t, err)
+	assert.True(t, exterrors.IsNotFound(err))
+}

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_manifest.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_manifest.go
@@ -109,6 +109,48 @@ func overwriteRoutineFromFile(existing *routines.Routine, file *routines.Routine
 	return changed
 }
 
+// ensureTimerTriggersHaveAt validates that every timer trigger on `r` has a
+// non-empty `at`. The Foundry service currently omits `at` on GET for timer
+// triggers (see issue #8421 Bug 5), so the GET → mutate → PUT round-trip used
+// by `routine update` drops the field and the service rejects the PUT with
+// a 400. Surfacing a clear local error here is far more actionable than
+// forwarding the opaque service error.
+func ensureTimerTriggersHaveAt(r *routines.Routine) error {
+	const timerWireType = "timer"
+
+	var missing []string
+	for _, key := range sortedKeys(r.Triggers) {
+		t := r.Triggers[key]
+		if t.Type == timerWireType && t.At == "" {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	var message string
+	if len(missing) == 1 {
+		message = fmt.Sprintf(
+			"trigger %q is a timer trigger but 'at' is not set; the service does not "+
+				"return 'at' on GET, so it must be re-supplied when updating",
+			missing[0],
+		)
+	} else {
+		message = fmt.Sprintf(
+			"timer triggers %v have no 'at' set; the service does not return 'at' on GET, "+
+				"so it must be re-supplied when updating",
+			missing,
+		)
+	}
+	return exterrors.Validation(
+		exterrors.CodeInvalidParameter,
+		message,
+		"re-supply '--at <RFC 3339 datetime>' for a flag-mode update, or use "+
+			"'--file <manifest>' with a complete trigger block",
+	)
+}
+
 // applyUpdateFlags applies named CLI update flags onto an existing routine body.
 // It returns the count of fields changed.
 func applyUpdateFlags(
@@ -143,6 +185,9 @@ func applyUpdateFlags(
 				"cannot set --at: routine has no default trigger",
 				"add a trigger by recreating the routine, or omit --at",
 			)
+		}
+		if err := validateAt(at); err != nil {
+			return 0, err
 		}
 		trigger.At = at
 		changed++

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_manifest_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_manifest_test.go
@@ -296,6 +296,110 @@ func TestApplyUpdateFlags_SessIDRejectedForAgentResponse(t *testing.T) {
 	assert.Error(t, err, "--session-id must be rejected for agent-response actions")
 }
 
+// TestApplyUpdateFlags_AtSucceedsWithRFC3339 documents the happy path for
+// issue #8421 Bug 6 in the update verb.
+func TestApplyUpdateFlags_AtSucceedsWithRFC3339(t *testing.T) {
+	t.Parallel()
+	r := &routines.Routine{
+		Triggers: map[string]routines.RoutineTrigger{
+			"default": {Type: "timer", At: "2026-01-01T00:00:00Z"},
+		},
+	}
+	n, err := applyUpdateFlags(r,
+		"", "", "2026-06-26T21:37:26Z", "", "", "", "", "",
+		false, false, true, false, false, false, false, false,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, "2026-06-26T21:37:26Z", r.Triggers["default"].At)
+}
+
+// TestApplyUpdateFlags_AtRejectsInvalidString covers issue #8421 Bug 6 in
+// the update verb. The new RFC 3339 check must run before the value reaches
+// the service.
+func TestApplyUpdateFlags_AtRejectsInvalidString(t *testing.T) {
+	t.Parallel()
+	r := &routines.Routine{
+		Triggers: map[string]routines.RoutineTrigger{
+			"default": {Type: "timer", At: "2026-01-01T00:00:00Z"},
+		},
+	}
+	_, err := applyUpdateFlags(r,
+		"", "", "definitely-not-a-date", "", "", "", "", "",
+		false, false, true, false, false, false, false, false,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RFC 3339")
+	assert.Contains(t, err.Error(), "definitely-not-a-date")
+}
+
+// ─── ensureTimerTriggersHaveAt (issue #8421 Bug 4) ────────────────────────────
+
+// TestEnsureTimerTriggersHaveAt_OKWhenAtPresent documents the no-op case.
+func TestEnsureTimerTriggersHaveAt_OKWhenAtPresent(t *testing.T) {
+	t.Parallel()
+	r := &routines.Routine{
+		Triggers: map[string]routines.RoutineTrigger{
+			"default": {Type: "timer", At: "2026-01-01T00:00:00Z"},
+		},
+	}
+	assert.NoError(t, ensureTimerTriggersHaveAt(r))
+}
+
+// TestEnsureTimerTriggersHaveAt_FailsForTimerMissingAt is the core regression
+// guard for Bug 4. The Foundry GET response omits `at` for timer triggers, so
+// without this check the GET → mutate → PUT round-trip would forward an
+// invalid body to the service.
+func TestEnsureTimerTriggersHaveAt_FailsForTimerMissingAt(t *testing.T) {
+	t.Parallel()
+	r := &routines.Routine{
+		Triggers: map[string]routines.RoutineTrigger{
+			"default": {Type: "timer", TimeZone: "UTC" /* no At */},
+		},
+	}
+	err := ensureTimerTriggersHaveAt(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timer")
+	assert.Contains(t, err.Error(), "at")
+	assert.Contains(t, err.Error(), "default",
+		"the offending trigger key should appear in the error message")
+}
+
+// TestEnsureTimerTriggersHaveAt_IgnoresScheduleTriggers confirms the guard
+// only fires for timer triggers — schedule (cron) triggers do not have `at`.
+func TestEnsureTimerTriggersHaveAt_IgnoresScheduleTriggers(t *testing.T) {
+	t.Parallel()
+	r := &routines.Routine{
+		Triggers: map[string]routines.RoutineTrigger{
+			"default": {Type: "schedule", CronExpression: "0 8 * * *"},
+		},
+	}
+	assert.NoError(t, ensureTimerTriggersHaveAt(r))
+}
+
+// TestEnsureTimerTriggersHaveAt_NoTriggers handles a routine with no triggers
+// (e.g. an action-only definition during edits) without false positives.
+func TestEnsureTimerTriggersHaveAt_NoTriggers(t *testing.T) {
+	t.Parallel()
+	assert.NoError(t, ensureTimerTriggersHaveAt(&routines.Routine{}))
+}
+
+// TestEnsureTimerTriggersHaveAt_MultipleTimerTriggersAllListed ensures the
+// error message names every offending trigger when there is more than one.
+func TestEnsureTimerTriggersHaveAt_MultipleTimerTriggersAllListed(t *testing.T) {
+	t.Parallel()
+	r := &routines.Routine{
+		Triggers: map[string]routines.RoutineTrigger{
+			"a": {Type: "timer"},
+			"b": {Type: "timer"},
+		},
+	}
+	err := ensureTimerTriggersHaveAt(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "a")
+	assert.Contains(t, err.Error(), "b")
+}
+
 // ─── getTrigger / getAction ───────────────────────────────────────────────────
 
 func TestGetTrigger_NilWhenEmpty(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_update.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_update.go
@@ -146,6 +146,13 @@ func runRoutineUpdate(ctx context.Context, cmd *cobra.Command, flags *routineUpd
 		return nil
 	}
 
+	// Defensive check before the PUT: the service GET response for a timer
+	// routine omits `at`, so a flag-only update that leaves `at` empty would
+	// be rejected by the server with an opaque 400. See issue #8421 (Bug 4).
+	if err := ensureTimerTriggersHaveAt(existing); err != nil {
+		return err
+	}
+
 	// PUT the updated body.
 	result, err := client.PutRoutine(ctx, flags.name, existing)
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/client.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/client.go
@@ -59,6 +59,17 @@ func newHTTPClient() *http.Client {
 
 // NewClient creates a new Routines data-plane client.
 func NewClient(endpoint string, cred azcore.TokenCredential) *Client {
+	return newClient(endpoint, cred, false)
+}
+
+// newClient is the internal constructor. allowInsecureHTTP is a test-only knob
+// that flips on `BearerTokenOptions.InsecureAllowCredentialWithHTTP` so
+// httptest plain-HTTP servers can exercise the real pipeline; production
+// callers go through [NewClient] and always use HTTPS.
+func newClient(endpoint string, cred azcore.TokenCredential, allowInsecureHTTP bool) *Client {
+	bearerOpts := &policy.BearerTokenOptions{
+		InsecureAllowCredentialWithHTTP: allowInsecureHTTP,
+	}
 	clientOptions := &policy.ClientOptions{
 		Transport: newHTTPClient(),
 		Logging: policy.LogOptions{
@@ -72,11 +83,12 @@ func NewClient(endpoint string, cred azcore.TokenCredential) *Client {
 			runtime.NewBearerTokenPolicy(
 				cred,
 				[]string{"https://ai.azure.com/.default"},
-				nil,
+				bearerOpts,
 			),
 			azsdk.NewMsCorrelationPolicy(),
 			azsdk.NewUserAgentPolicy("azd-ext-azure-ai-routines/0.1.0"),
 		},
+		InsecureAllowCredentialWithHTTP: allowInsecureHTTP,
 	}
 
 	pipeline := runtime.NewPipeline(
@@ -162,8 +174,18 @@ func (c *Client) ListRoutines(ctx context.Context) ([]Routine, error) {
 			return nil, err
 		}
 
-		all = append(all, page.Value...)
-		nextURL = page.NextLink
+		all = append(all, page.Items()...)
+
+		// Prefer the spec-shaped cursor (`?after=<last_id>`); fall back to
+		// the legacy absolute `nextLink` URL during the rollout window.
+		switch {
+		case page.NextCursor() != "":
+			nextURL = c.routinesURL("after=" + url.QueryEscape(page.NextCursor()))
+		case page.NextLinkURL() != "":
+			nextURL = page.NextLinkURL()
+		default:
+			nextURL = ""
+		}
 	}
 
 	return all, nil
@@ -324,7 +346,7 @@ func (c *Client) ListRoutineRuns(
 ) ([]RoutineRun, error) {
 	var all []RoutineRun
 
-	// baseQuery holds the original filter, preserved across pages. maxResults is
+	// baseQuery holds the original filter, preserved across pages. Limit is
 	// only sent on the first page (we cap totals client-side via opts.Top).
 	var baseQuery []string
 	if opts.Filter != "" {
@@ -333,7 +355,9 @@ func (c *Client) ListRoutineRuns(
 
 	firstPageQuery := slices.Clone(baseQuery)
 	if opts.Top > 0 {
-		firstPageQuery = append(firstPageQuery, fmt.Sprintf("maxResults=%d", opts.Top))
+		// Spec uses `?limit=` for cursor pagination; the previous
+		// `?maxResults=` parameter no longer reaches the server.
+		firstPageQuery = append(firstPageQuery, fmt.Sprintf("limit=%d", opts.Top))
 	}
 
 	nextURL := c.routineRunsURL(routineName, firstPageQuery...)
@@ -348,20 +372,22 @@ func (c *Client) ListRoutineRuns(
 			return nil, err
 		}
 
-		all = append(all, page.Value...)
+		all = append(all, page.Items()...)
 
 		if opts.Top > 0 && len(all) >= opts.Top {
 			all = all[:opts.Top]
 			break
 		}
 
-		if page.NextPageToken != "" {
-			pageQuery := append(slices.Clone(baseQuery),
-				"pageToken="+url.QueryEscape(page.NextPageToken))
-			nextURL = c.routineRunsURL(routineName, pageQuery...)
-		} else {
+		cursor := page.NextCursor()
+		if cursor == "" {
 			nextURL = ""
+			continue
 		}
+		// Spec replaces the legacy `?pageToken=` parameter with `?after=`.
+		pageQuery := append(slices.Clone(baseQuery),
+			"after="+url.QueryEscape(cursor))
+		nextURL = c.routineRunsURL(routineName, pageQuery...)
 	}
 
 	return all, nil

--- a/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/client_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/client_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package routines
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCredential satisfies azcore.TokenCredential for tests so we can drive
+// the real pipeline against an httptest server without going through azidentity.
+type fakeCredential struct{}
+
+func (fakeCredential) GetToken(
+	_ context.Context, _ policy.TokenRequestOptions,
+) (azcore.AccessToken, error) {
+	return azcore.AccessToken{
+		Token:     "fake-token",
+		ExpiresOn: time.Now().Add(time.Hour),
+	}, nil
+}
+
+// requestLog records every request URL the test server sees so we can assert
+// the second-page request uses the `?after=<last_id>` cursor introduced by
+// azure-rest-api-specs PR #43498 instead of the previous `?pageToken=` shape.
+type requestLog struct {
+	mu   sync.Mutex
+	urls []string
+}
+
+func (r *requestLog) record(s string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.urls = append(r.urls, s)
+}
+
+func (r *requestLog) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.urls))
+	copy(out, r.urls)
+	return out
+}
+
+// TestClient_ListRoutines_FollowsSpecCursor verifies the full
+// envelope-decode + cursor-pagination flow against an httptest server.
+// Regression cover for issue #8421 Bug 1.
+func TestClient_ListRoutines_FollowsSpecCursor(t *testing.T) {
+	t.Parallel()
+	log := &requestLog{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.record(r.URL.String())
+		w.Header().Set("Content-Type", "application/json")
+
+		// Decide the page based on the `?after=` cursor.
+		after := r.URL.Query().Get("after")
+		var body any
+		switch after {
+		case "":
+			// First page — service returns spec-shaped envelope.
+			body = map[string]any{
+				"data": []map[string]any{
+					{"name": "r-1"},
+					{"name": "r-2"},
+				},
+				"first_id": "r-1",
+				"last_id":  "r-2",
+				"has_more": true,
+			}
+		case "r-2":
+			// Second page — terminal, has_more=false.
+			body = map[string]any{
+				"data": []map[string]any{
+					{"name": "r-3"},
+				},
+				"first_id": "r-3",
+				"last_id":  "r-3",
+				"has_more": false,
+			}
+		default:
+			http.Error(w, "unexpected cursor", http.StatusBadRequest)
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	defer srv.Close()
+
+	client := newClient(srv.URL, fakeCredential{}, true)
+
+	got, err := client.ListRoutines(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, []string{"r-1", "r-2", "r-3"},
+		[]string{got[0].Name, got[1].Name, got[2].Name})
+
+	urls := log.snapshot()
+	require.Len(t, urls, 2, "expected exactly two paginated requests")
+	assert.Equal(t, "/routines?api-version=v1", urls[0])
+	assert.Equal(t, "/routines?api-version=v1&after=r-2", urls[1],
+		"second-page request must use the AgentsPagedResult `?after=<last_id>` cursor, "+
+			"not the deprecated `?pageToken=` query")
+}
+
+// TestClient_ListRoutineRuns_FollowsSpecCursor mirrors the routines pagination
+// regression test for the run-history endpoint (issue #8421 Bug 2).
+func TestClient_ListRoutineRuns_FollowsSpecCursor(t *testing.T) {
+	t.Parallel()
+	log := &requestLog{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.record(r.URL.String())
+		w.Header().Set("Content-Type", "application/json")
+
+		after := r.URL.Query().Get("after")
+		var body any
+		switch after {
+		case "":
+			body = map[string]any{
+				"data": []map[string]any{
+					{"id": "run-1", "status": "Finished", "phase": "completed"},
+					{"id": "run-2", "status": "Finished", "phase": "completed"},
+				},
+				"first_id": "run-1",
+				"last_id":  "run-2",
+				"has_more": true,
+			}
+		case "run-2":
+			body = map[string]any{
+				"data": []map[string]any{
+					{"id": "run-3", "status": "Finished", "phase": "completed"},
+				},
+				"first_id": "run-3",
+				"last_id":  "run-3",
+				"has_more": false,
+			}
+		default:
+			http.Error(w, "unexpected cursor", http.StatusBadRequest)
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	defer srv.Close()
+
+	client := newClient(srv.URL, fakeCredential{}, true)
+
+	got, err := client.ListRoutineRuns(
+		context.Background(), "e2e-timer-matrix", ListRoutineRunsOptions{},
+	)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, []string{"run-1", "run-2", "run-3"},
+		[]string{got[0].ID, got[1].ID, got[2].ID})
+
+	urls := log.snapshot()
+	require.Len(t, urls, 2, "expected exactly two paginated requests")
+	assert.Equal(t, "/routines/e2e-timer-matrix/runs?api-version=v1", urls[0])
+	assert.Equal(t,
+		"/routines/e2e-timer-matrix/runs?api-version=v1&after=run-2", urls[1],
+		"second-page request must use `?after=` cursor instead of `?pageToken=`")
+}
+
+// TestClient_ListRoutineRuns_TopUsesLimit confirms the client emits the new
+// `?limit=` parameter (replacing the deprecated `?maxResults=`) when the
+// caller caps the page size via opts.Top.
+func TestClient_ListRoutineRuns_TopUsesLimit(t *testing.T) {
+	t.Parallel()
+	log := &requestLog{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.record(r.URL.String())
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data":     []map[string]any{{"id": "run-1"}},
+			"has_more": false,
+		})
+	}))
+	defer srv.Close()
+
+	client := newClient(srv.URL, fakeCredential{}, true)
+	_, err := client.ListRoutineRuns(
+		context.Background(), "e2e-timer-matrix",
+		ListRoutineRunsOptions{Top: 5, Filter: "status eq 'Finished'"},
+	)
+	require.NoError(t, err)
+
+	urls := log.snapshot()
+	require.Len(t, urls, 1)
+	assert.Contains(t, urls[0], "limit=5",
+		"client must use spec-mandated `?limit=` query parameter")
+	assert.NotContains(t, urls[0], "maxResults",
+		"client must not use the deprecated `?maxResults=` query parameter")
+	assert.Contains(t, urls[0], "filter=status+eq+%27Finished%27",
+		"filter query must be URL-encoded and preserved")
+}
+
+// TestClient_ListRoutines_LegacyEnvelope_NextLink confirms the rollout
+// fallback: regions that have not yet shipped #43498 still emit the legacy
+// `{ value, nextLink }` envelope and the client must continue to drain it.
+func TestClient_ListRoutines_LegacyEnvelope_NextLink(t *testing.T) {
+	t.Parallel()
+	log := &requestLog{}
+
+	var serverURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.record(r.URL.String())
+		w.Header().Set("Content-Type", "application/json")
+
+		// Distinguish the two pages via the explicit `legacy=2` marker since
+		// the legacy envelope returns an absolute nextLink URL.
+		var body any
+		if r.URL.Query().Get("legacy") == "2" {
+			body = map[string]any{
+				"value": []map[string]any{{"name": "legacy-r-2"}},
+			}
+		} else {
+			body = map[string]any{
+				"value":    []map[string]any{{"name": "legacy-r-1"}},
+				"nextLink": serverURL + "/routines?api-version=v1&legacy=2",
+			}
+		}
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	defer srv.Close()
+	serverURL = srv.URL
+
+	client := newClient(srv.URL, fakeCredential{}, true)
+	got, err := client.ListRoutines(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "legacy-r-1", got[0].Name)
+	assert.Equal(t, "legacy-r-2", got[1].Name)
+
+	urls := log.snapshot()
+	require.Len(t, urls, 2)
+	assert.Equal(t, "/routines?api-version=v1&legacy=2", urls[1],
+		"client must follow the legacy `nextLink` URL when no spec cursor is present")
+}

--- a/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/models.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/models.go
@@ -51,9 +51,48 @@ type RoutineAction struct {
 }
 
 // PagedRoutine represents a page of routine resources.
+//
+// Wire shape is `AgentsPagedResult<Routine>` from the Foundry TypeSpec (see
+// `azure-rest-api-specs` PR #43498): `{ data, first_id, last_id, has_more }`
+// with `?after=<last_id>` as the continuation cursor.
+//
+// `Value` and `NextLink` are kept as fallback decode targets so the CLI still
+// works against any region that has not yet rolled out the new envelope.
+// Use [PagedRoutine.Items] and [PagedRoutine.NextCursor] / [PagedRoutine.NextLinkURL]
+// instead of reading the fields directly.
 type PagedRoutine struct {
-	Value    []Routine `json:"value"`
+	Data    []Routine `json:"data,omitempty"`
+	FirstID string    `json:"first_id,omitempty"`
+	LastID  string    `json:"last_id,omitempty"`
+	HasMore bool      `json:"has_more,omitempty"`
+
+	// Legacy fields kept for backward compatibility with the previous spec.
+	Value    []Routine `json:"value,omitempty"`
 	NextLink string    `json:"nextLink,omitempty"`
+}
+
+// Items returns the routines on the page, preferring the spec-shaped `data`
+// field and falling back to the legacy `value` field.
+func (p *PagedRoutine) Items() []Routine {
+	if len(p.Data) > 0 {
+		return p.Data
+	}
+	return p.Value
+}
+
+// NextCursor returns the opaque cursor to send as `?after=<cursor>` to fetch
+// the next page, or the empty string if there is no next page.
+func (p *PagedRoutine) NextCursor() string {
+	if p.HasMore && p.LastID != "" {
+		return p.LastID
+	}
+	return ""
+}
+
+// NextLinkURL returns the legacy absolute pagination URL, or the empty
+// string if the response does not carry one.
+func (p *PagedRoutine) NextLinkURL() string {
+	return p.NextLink
 }
 
 // RoutineRun represents a single routine execution record.
@@ -76,9 +115,43 @@ type RoutineRun struct {
 }
 
 // PagedRoutineRun represents a page of routine run records.
+//
+// Wire shape is `AgentsPagedResult<RoutineRun>` from the Foundry TypeSpec
+// (see `azure-rest-api-specs` PR #43498): `{ data, first_id, last_id, has_more }`
+// with `?after=<last_id>` as the continuation cursor.
+//
+// `Value` and `NextPageToken` are kept as fallback decode targets so the CLI
+// still works against any region that has not yet rolled out the new envelope.
+// Use [PagedRoutineRun.Items] and [PagedRoutineRun.NextCursor] /
+// [PagedRoutineRun.NextLegacyPageToken] instead of reading the fields directly.
 type PagedRoutineRun struct {
-	Value         []RoutineRun `json:"value"`
+	Data    []RoutineRun `json:"data,omitempty"`
+	FirstID string       `json:"first_id,omitempty"`
+	LastID  string       `json:"last_id,omitempty"`
+	HasMore bool         `json:"has_more,omitempty"`
+
+	// Legacy fields kept for backward compatibility with the previous spec.
+	Value         []RoutineRun `json:"value,omitempty"`
 	NextPageToken string       `json:"nextPageToken,omitempty"`
+}
+
+// Items returns the runs on the page, preferring the spec-shaped `data` field
+// and falling back to the legacy `value` field.
+func (p *PagedRoutineRun) Items() []RoutineRun {
+	if len(p.Data) > 0 {
+		return p.Data
+	}
+	return p.Value
+}
+
+// NextCursor returns the opaque cursor to send as `?after=<cursor>` to fetch
+// the next page. It prefers the spec-shaped `has_more`+`last_id` pair and
+// falls back to the legacy `nextPageToken` field.
+func (p *PagedRoutineRun) NextCursor() string {
+	if p.HasMore && p.LastID != "" {
+		return p.LastID
+	}
+	return p.NextPageToken
 }
 
 // RoutineDispatchPayload is the discriminated dispatch payload. The "type"

--- a/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/models_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/models_test.go
@@ -4,9 +4,11 @@
 package routines
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTriggerCLIToWire_AllEntriesPresent(t *testing.T) {
@@ -58,4 +60,171 @@ func TestActionCLIToWire_NoUnknownEntries(t *testing.T) {
 			t.Errorf("unexpected key %q in ActionCLIToWire", k)
 		}
 	}
+}
+
+// ─── PagedRoutine envelope (issue #8421 Bug 1) ────────────────────────────────
+
+// TestPagedRoutine_SpecEnvelope_AgentsPagedResult verifies that the client
+// correctly decodes the AgentsPagedResult<Routine> envelope introduced by
+// azure-rest-api-specs PR #43498 — `{ data, first_id, last_id, has_more }`.
+// Before the fix the client used the previous `{ value, nextLink }` shape
+// and dropped every item, which is the root cause of issue #8421 Bug 1.
+func TestPagedRoutine_SpecEnvelope_AgentsPagedResult(t *testing.T) {
+	t.Parallel()
+	body := `{
+		"data": [
+			{"name": "e2e-timer-matrix"},
+			{"name": "e2e-timer-matrix-file"}
+		],
+		"first_id": "e2e-timer-matrix",
+		"last_id": "e2e-timer-matrix-file",
+		"has_more": true
+	}`
+
+	var page PagedRoutine
+	require.NoError(t, json.Unmarshal([]byte(body), &page))
+
+	items := page.Items()
+	require.Len(t, items, 2)
+	assert.Equal(t, "e2e-timer-matrix", items[0].Name)
+	assert.Equal(t, "e2e-timer-matrix-file", items[1].Name)
+	assert.Equal(t, "e2e-timer-matrix-file", page.NextCursor(),
+		"NextCursor must surface last_id when has_more is true")
+}
+
+// TestPagedRoutine_SpecEnvelope_HasMoreFalse confirms that a terminal page
+// (has_more=false) reports no further cursor even when last_id is populated.
+func TestPagedRoutine_SpecEnvelope_HasMoreFalse(t *testing.T) {
+	t.Parallel()
+	body := `{
+		"data": [{"name": "only-routine"}],
+		"first_id": "only-routine",
+		"last_id": "only-routine",
+		"has_more": false
+	}`
+
+	var page PagedRoutine
+	require.NoError(t, json.Unmarshal([]byte(body), &page))
+
+	assert.Len(t, page.Items(), 1)
+	assert.Empty(t, page.NextCursor(),
+		"NextCursor must be empty on the last page even with last_id populated")
+}
+
+// TestPagedRoutine_LegacyEnvelope ensures that during the spec rollout window
+// the client still falls back to the previous `{ value, nextLink }` shape, so
+// regions that have not yet shipped #43498 keep working.
+func TestPagedRoutine_LegacyEnvelope(t *testing.T) {
+	t.Parallel()
+	body := `{
+		"value": [
+			{"name": "legacy-routine"}
+		],
+		"nextLink": "https://example.com/routines?api-version=v1&pageToken=abc"
+	}`
+
+	var page PagedRoutine
+	require.NoError(t, json.Unmarshal([]byte(body), &page))
+
+	items := page.Items()
+	require.Len(t, items, 1)
+	assert.Equal(t, "legacy-routine", items[0].Name)
+	assert.Empty(t, page.NextCursor(),
+		"NextCursor only applies to the spec-shaped envelope")
+	assert.Equal(t, "https://example.com/routines?api-version=v1&pageToken=abc",
+		page.NextLinkURL())
+}
+
+// TestPagedRoutine_EmptyResponse confirms that a service that returns neither
+// `data` nor `value` decodes safely to an empty page.
+func TestPagedRoutine_EmptyResponse(t *testing.T) {
+	t.Parallel()
+	var page PagedRoutine
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &page))
+	assert.Empty(t, page.Items())
+	assert.Empty(t, page.NextCursor())
+	assert.Empty(t, page.NextLinkURL())
+}
+
+// TestPagedRoutine_PrefersDataOverValue guards against a transitional service
+// that returns both envelopes simultaneously. Spec wins.
+func TestPagedRoutine_PrefersDataOverValue(t *testing.T) {
+	t.Parallel()
+	body := `{
+		"data": [{"name": "spec"}],
+		"value": [{"name": "legacy"}]
+	}`
+
+	var page PagedRoutine
+	require.NoError(t, json.Unmarshal([]byte(body), &page))
+
+	items := page.Items()
+	require.Len(t, items, 1)
+	assert.Equal(t, "spec", items[0].Name,
+		"Items() must prefer the spec-shaped `data` field over the legacy `value` field")
+}
+
+// ─── PagedRoutineRun envelope (issue #8421 Bug 2) ─────────────────────────────
+
+// TestPagedRoutineRun_SpecEnvelope_AgentsPagedResult mirrors the routines fix
+// for the run-history endpoint, which shares the same AgentsPagedResult shape.
+func TestPagedRoutineRun_SpecEnvelope_AgentsPagedResult(t *testing.T) {
+	t.Parallel()
+	body := `{
+		"data": [
+			{"id": "run-1", "status": "Finished", "phase": "completed"},
+			{"id": "run-2", "status": "Finished", "phase": "completed"}
+		],
+		"first_id": "run-1",
+		"last_id": "run-2",
+		"has_more": true
+	}`
+
+	var page PagedRoutineRun
+	require.NoError(t, json.Unmarshal([]byte(body), &page))
+
+	items := page.Items()
+	require.Len(t, items, 2)
+	assert.Equal(t, "run-1", items[0].ID)
+	assert.Equal(t, "Finished", items[0].Status)
+	assert.Equal(t, "completed", items[0].Phase)
+	assert.Equal(t, "run-2", page.NextCursor())
+}
+
+// TestPagedRoutineRun_LegacyEnvelope keeps the run-list endpoint working on
+// regions that still emit the previous `{ value, nextPageToken }` shape.
+func TestPagedRoutineRun_LegacyEnvelope(t *testing.T) {
+	t.Parallel()
+	body := `{
+		"value": [
+			{"id": "legacy-run", "status": "Finished"}
+		],
+		"nextPageToken": "opaque-token"
+	}`
+
+	var page PagedRoutineRun
+	require.NoError(t, json.Unmarshal([]byte(body), &page))
+
+	items := page.Items()
+	require.Len(t, items, 1)
+	assert.Equal(t, "legacy-run", items[0].ID)
+	assert.Equal(t, "opaque-token", page.NextCursor(),
+		"NextCursor must fall back to nextPageToken on the legacy envelope")
+}
+
+// TestPagedRoutineRun_PrefersDataOverValue guards against a transitional
+// service that returns both envelopes simultaneously.
+func TestPagedRoutineRun_PrefersDataOverValue(t *testing.T) {
+	t.Parallel()
+	body := `{
+		"data": [{"id": "spec"}],
+		"value": [{"id": "legacy"}]
+	}`
+
+	var page PagedRoutineRun
+	require.NoError(t, json.Unmarshal([]byte(body), &page))
+
+	items := page.Items()
+	require.Len(t, items, 1)
+	assert.Equal(t, "spec", items[0].ID)
 }


### PR DESCRIPTION
Fixes the five client-side bugs reported in #8421.

## Root cause

Four of the five client-side bugs trace back to
[azure-rest-api-specs#43498](https://github.com/Azure/azure-rest-api-specs/pull/43498),
which landed after the routines extension was first written:

| Spec change | Bug it triggered in the CLI |
|---|---|
| Replaced the custom `RoutineListResponse` / `RoutineRunsResponse` models with **`AgentsPagedResult<T>`** (`{ data, first_id, last_id, has_more }`, with `?limit` / `?order` / `?after` / `?before` cursor params) | **Bug 1** (`routine list` empty) and **Bug 2** (`routine run list` empty) — the CLI was still decoding the old `{ value, nextLink/nextPageToken }` shape and dropped every item the service returned. |
| Replaced `TimerRoutineTrigger.relative: string` with **`at: utcDateTime`** | **Bug 6** — `utcDateTime` is the TypeSpec scalar that serializes as RFC 3339, so the CLI should reject `--at "not-a-date"` locally instead of round-tripping a 400 from the service. **Bug 5** (service GET omits `at`) is a separate server-side regression created by the same cleanup, and **Bug 4** is the downstream impact on the GET-mutate-PUT flag-update path. |

**Bug 7** (silent delete of nonexistent routine) is unrelated to #43498 — it
is just the verb surface trusting the service's idempotent `DELETE`.

Per the issue's own triage, **Bug 3** (500 on `--filter`) and **Bug 5**
(server omits `at`) are server-side and remain out of scope. Bug 4's
defensive client-side check mitigates the user-facing impact of Bug 5 until
the service ships its fix.

## What this PR changes

- **Pagination (`internal/pkg/routines/models.go`, `client.go`)** — `PagedRoutine`
  and `PagedRoutineRun` now expose `Data` / `FirstID` / `LastID` / `HasMore`
  in line with `AgentsPagedResult<T>`. New `Items()` / `NextCursor()` helpers
  let the client driver code stay simple. `ListRoutines` and
  `ListRoutineRuns` follow `?after=<last_id>` while `has_more` is true and
  use `?limit=` instead of the deprecated `?maxResults=`. The legacy
  `{ value, nextLink/nextPageToken }` envelope is kept as a fallback so the
  CLI keeps working against regions that have not yet shipped #43498.
- **`--at` validation (`routine_create.go`, `routine_manifest.go`)** — new
  `validateAt` helper uses `time.Parse(time.RFC3339, …)` and surfaces the
  exact suggestion text called out in the issue.
- **Timer `at` PUT-time guard (`routine_manifest.go`, `routine_update.go`)** —
  new `ensureTimerTriggersHaveAt` runs after flag merge and before the PUT,
  so a flag-only `update --description …` against a timer routine fails fast
  with an actionable error instead of forwarding an opaque 400 from the
  service.
- **Delete existence check (`routine_delete.go`)** — extracted
  `deleteRoutineWithExistenceCheck` does a defensive GET before the DELETE
  and returns the same shape of 404 as `show` / `dispatch`. A small
  `routineDeleter` interface keeps the change unit-testable.
- **`AGENTS.md`** — refreshed the "API spec alignment" table to reflect the
  new contract and document the rollout-window fallback.

## Tests

New table-driven unit tests in `models_test.go`, `client_test.go`,
`routine_create_test.go`, `routine_manifest_test.go`, and a new
`routine_delete_test.go`:

- Spec-shaped vs legacy envelope decoding (both routines and runs)
- `data` preferred over `value` when both are present (transitional service)
- End-to-end `Client.ListRoutines` / `Client.ListRoutineRuns` against an
  `httptest` server, asserting the second-page request uses
  `?after=<last_id>` and the first-page request uses `?limit=` (regression
  cover for Bugs 1 and 2)
- `--at` accepts every RFC 3339 timezone form and rejects garbage with a
  pointer to the expected format
- `ensureTimerTriggersHaveAt` passes for schedule triggers, fails clearly
  for timer triggers with empty `at`, and lists every offending key
- `deleteRoutineWithExistenceCheck` surfaces a structured 404 when the GET
  returns not-found, propagates 5xx errors untouched, and handles the
  TOCTOU race where the DELETE itself returns 404

Verified locally: `go build ./...`, `go test ./... -count=1`,
`golangci-lint run ./...`, and `cspell` all clean.

Closes #8421 (client-side bugs only — see the issue triage section).