### PR TITLE
fix(skills): accept directory uploads on azd ai skill create

### DIFF
--- a/cli/azd/extensions/azure.ai.skills/AGENTS.md
+++ b/cli/azd/extensions/azure.ai.skills/AGENTS.md
@@ -64,8 +64,8 @@ Each `--debug` run writes to `azd-ai-skills-<date>.log` in the current working d
 ## File handling
 
 - `--file` is **not** a manifest. It is read at invocation time only; the CLI does not track or re-read it after the command returns.
-- `create`: accepts `.md` or `.zip`. Mode is inferred from extension; conflicting modes (inline + `--file`) are rejected. `.md` and inline modes send `inline_content` JSON; `.zip` is uploaded as `multipart/form-data` with a single `files[]` part.
-- `update`: accepts `.md` only. `.zip` is rejected with a structured suggestion to use `create --force` (which deletes the skill and all its versions before re-creating). Pass `--set-default-version <ver>` to repoint `default_version` at an existing immutable version without uploading new content.
+- `create`: accepts `.md`, `.zip`, or a **directory** whose root contains `SKILL.md`. Mode is inferred from the path: directories take precedence over extension matching so callers can hand the output of `azd ai skill download` straight back. Conflicting modes (inline + `--file`) are rejected. `.md` and inline modes send `inline_content` JSON; `.zip` and directory modes upload `multipart/form-data` with a single `files[]` part. Directory mode packages the directory into an in-memory zip using `skill_api.ArchiveDirectory`, which enforces the same safety caps as `SafeExtract` on the way down (no symlinks / non-regular entries, 10,000-entry / 512 MB total cap).
+- `update`: accepts `.md` only. `.zip` and directories are rejected with a structured suggestion to use `create --force` (which deletes the skill and all its versions before re-creating). Pass `--set-default-version <ver>` to repoint `default_version` at an existing immutable version without uploading new content.
 - `download`: writes either an extracted directory (default) or the unmodified zip archive (`--raw`). Pass `--version <ver>` to download a non-default version. The server always returns `application/zip` (from `GET /skills/{name}/content` or `GET /skills/{name}/versions/{version}/content`).
 
 ## Versioning

--- a/cli/azd/extensions/azure.ai.skills/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.skills/CHANGELOG.md
@@ -8,12 +8,16 @@
   - `azd ai skill create <name>` — creates a skill and uploads its first
     default version via `POST /skills/{name}/versions`. Modes: inline
     (`--description` + `--instructions`), SKILL.md file (`--file ./SKILL.md`),
-    or ZIP package via `multipart/form-data` (`--file ./skill.zip`).
+    ZIP package via `multipart/form-data` (`--file ./skill.zip`), or a
+    directory whose root contains `SKILL.md` (`--file ./skill-src/`) — the
+    CLI packages the directory in memory and uploads it as multipart, so the
+    output of `azd ai skill download` round-trips back through `create`
+    without a manual zip step.
   - `azd ai skill update <name>` — uploads a new default version using the
-    same inline / SKILL.md modes; ZIP is rejected with a pointer to
-    `create --force`. Pass `--set-default-version <ver>` to repoint
-    `default_version` at an existing version without uploading new content
-    (`POST /skills/{name}`).
+    same inline / SKILL.md modes; ZIP and directory `--file` inputs are
+    rejected with a pointer to `create --force`. Pass `--set-default-version
+    <ver>` to repoint `default_version` at an existing version without
+    uploading new content (`POST /skills/{name}`).
   - `azd ai skill show <name>` — returns `Skill { id, name, description,
     default_version, latest_version, created_at }`.
   - `azd ai skill list` — paginated, supports `--top` and `--orderby`.

--- a/cli/azd/extensions/azure.ai.skills/README.md
+++ b/cli/azd/extensions/azure.ai.skills/README.md
@@ -10,6 +10,7 @@ terminal.
 azd ai skill create <name> [--description "..." --instructions "..."]
 azd ai skill create <name> --file ./SKILL.md
 azd ai skill create <name> --file ./skill.zip
+azd ai skill create <name> --file ./skill-src/
 
 azd ai skill update <name> [--description "..."] [--instructions "..."] [--file ./SKILL.md]
 azd ai skill update <name> --set-default-version <version>
@@ -24,6 +25,16 @@ version; `update` uploads a new default version (or, with
 `--set-default-version`, just repoints `default_version` at an existing
 version). Names follow the agentskills.io spec
 (`^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$`, max 64 chars).
+
+`create` accepts inline content (`--description` / `--instructions`), a
+single `SKILL.md` file, a `.zip` package, or a directory whose root contains
+a `SKILL.md`. Directory mode is the round-trip inverse of
+`azd ai skill download`: the CLI packages the directory as a zip in memory
+and uploads it as multipart/form-data, identical to the `.zip` path.
+
+`update` is inline-only: a `.zip` or a directory is rejected with a pointer
+to `azd ai skill create --force` (a destructive delete-then-create), since
+swapping the entire package shape is a `create` concern, not an `update`.
 
 All commands accept the standard cross-cutting flags: `-p` / `--project-endpoint`,
 `--output table|json`, `--no-prompt`, and `--debug`.

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create.go
@@ -412,22 +412,35 @@ func selectCreateMode(f *createFlags) (createMode, error) {
 		// Detect directories before extension matching so callers can point
 		// --file at the directory `azd ai skill download` extracted (which
 		// has no file extension at all).
-		if info, err := os.Stat(f.file); err == nil && info.IsDir() {
+		info, statErr := os.Stat(f.file)
+		if statErr == nil && info.IsDir() {
 			return modeFileDirectory, nil
 		}
-		switch strings.ToLower(filepath.Ext(f.file)) {
+		ext := strings.ToLower(filepath.Ext(f.file))
+		switch ext {
 		case ".md":
 			return modeFileMd, nil
 		case ".zip":
 			return modeFilePackage, nil
-		default:
+		}
+		// A --file value with no extension can only be a directory; if
+		// stat failed (typically fs.ErrNotExist), surface the stat error
+		// so users aren't told the extension is unsupported when the path
+		// is simply missing or unreadable.
+		if statErr != nil && ext == "" {
 			return modeNone, exterrors.Validation(
 				exterrors.CodeInvalidSkillFile,
-				fmt.Sprintf("unsupported --file extension %q", filepath.Ext(f.file)),
-				"use .md for inline metadata, .zip for a package upload, "+
+				fmt.Sprintf("inspect --file %q: %s", f.file, statErr),
+				"verify the path exists and points to a SKILL.md, a .zip, "+
 					"or a directory containing SKILL.md",
 			)
 		}
+		return modeNone, exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf("unsupported --file extension %q", ext),
+			"use .md for inline metadata, .zip for a package upload, "+
+				"or a directory containing SKILL.md",
+		)
 	}
 
 	if inlineProvided {

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create.go
@@ -231,6 +231,10 @@ func (a *createAction) runFileDirectory(ctx context.Context, client *skill_api.C
 
 // classifyArchiveDirectoryError wraps ArchiveDirectory's sentinel errors in
 // structured extension errors so the host prints a useful message.
+// Non-sentinel I/O errors (permission denied mid-walk, EvalSymlinks failure,
+// TOCTOU file-disappeared, etc.) fall through to the default case so they
+// still surface as a structured CodeInvalidSkillFile rather than a raw Go
+// error with no Suggestion or telemetry code.
 func classifyArchiveDirectoryError(err error, srcDir string) error {
 	switch {
 	case errors.Is(err, skill_api.ErrUnsafeEntry):
@@ -251,8 +255,13 @@ func classifyArchiveDirectoryError(err error, srcDir string) error {
 			err.Error(),
 			"verify the directory exists, is readable, and contains at least one file",
 		)
+	default:
+		return exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf("failed to package %s: %s", srcDir, err),
+			"verify the directory and its contents are readable",
+		)
 	}
-	return err
 }
 
 // printCreateResult prints either the created version envelope or, when the

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -87,6 +88,8 @@ func (a *createAction) Run(ctx context.Context) error {
 		return a.runFileMd(ctx, skillCtx.client)
 	case modeFilePackage:
 		return a.runFilePackage(ctx, skillCtx.client)
+	case modeFileDirectory:
+		return a.runFileDirectory(ctx, skillCtx.client)
 	}
 	return exterrors.Validation(
 		exterrors.CodeInvalidParameter,
@@ -193,6 +196,65 @@ func (a *createAction) runFilePackage(ctx context.Context, client *skill_api.Cli
 	return a.printCreateResult(ctx, client, version)
 }
 
+// runFileDirectory packages the directory as an in-memory zip and uploads
+// it via the same multipart path as runFilePackage. The directory must
+// contain a SKILL.md at its root (matching what `azd ai skill download`
+// writes by default), so the natural download → edit → create flow works
+// without any manual zip step.
+func (a *createAction) runFileDirectory(ctx context.Context, client *skill_api.Client) error {
+	if _, found, err := skill_api.LocateSkillMdInDir(a.flags.file); err != nil {
+		return exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf("cannot inspect SKILL.md in %s: %s", a.flags.file, err),
+			"verify the directory is readable and SKILL.md is a regular file",
+		)
+	} else if !found {
+		return exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf("--file %s is a directory without a SKILL.md at its root", a.flags.file),
+			"add a SKILL.md to the directory root (matches `azd ai skill download` output) or pass a .zip archive",
+		)
+	}
+
+	data, archiveErr := skill_api.ArchiveDirectory(a.flags.file, skill_api.ArchiveOptions{})
+	if archiveErr != nil {
+		return classifyArchiveDirectoryError(archiveErr, a.flags.file)
+	}
+
+	archiveName := filepath.Base(filepath.Clean(a.flags.file)) + ".zip"
+	version, err := client.CreateVersionFromZip(ctx, a.flags.name, archiveName, bytes.NewReader(data), true)
+	if err != nil {
+		return exterrors.ServiceFromAzure(err, exterrors.OpCreateSkill)
+	}
+	return a.printCreateResult(ctx, client, version)
+}
+
+// classifyArchiveDirectoryError wraps ArchiveDirectory's sentinel errors in
+// structured extension errors so the host prints a useful message.
+func classifyArchiveDirectoryError(err error, srcDir string) error {
+	switch {
+	case errors.Is(err, skill_api.ErrUnsafeEntry):
+		return exterrors.Validation(
+			exterrors.CodeSkillArchiveUnsafe,
+			err.Error(),
+			"remove symlinks and non-regular files from the directory and re-run",
+		)
+	case errors.Is(err, skill_api.ErrLimitExceeded):
+		return exterrors.Validation(
+			exterrors.CodeSkillArchiveUnsafe,
+			err.Error(),
+			fmt.Sprintf("the contents of %s exceed the per-skill archive safety limit", srcDir),
+		)
+	case errors.Is(err, skill_api.ErrInvalidArchive):
+		return exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			err.Error(),
+			"verify the directory exists, is readable, and contains at least one file",
+		)
+	}
+	return err
+}
+
 // printCreateResult prints either the created version envelope or, when the
 // caller wants a human-readable summary, the freshly-loaded Skill that the
 // version belongs to so users see default_version / latest_version.
@@ -219,8 +281,32 @@ func verifyFileNameMatches(filePath, positionalName string, mode createMode) err
 		return verifyPackageNameMatches(filePath, positionalName)
 	case modeFileMd:
 		return verifyMdNameMatches(filePath, positionalName)
+	case modeFileDirectory:
+		return verifyDirectoryNameMatches(filePath, positionalName)
 	}
 	return nil
+}
+
+// verifyDirectoryNameMatches reads the directory's SKILL.md and refuses
+// --force on a `name` mismatch. Returns nil when SKILL.md omits `name` or
+// the names agree.
+func verifyDirectoryNameMatches(dirPath, positionalName string) error {
+	mdPath, found, err := skill_api.LocateSkillMdInDir(dirPath)
+	if err != nil {
+		return exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf("cannot inspect SKILL.md in %s: %s", dirPath, err),
+			"verify the directory is readable and SKILL.md is a regular file",
+		)
+	}
+	if !found {
+		return exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf("--file %s is a directory without a SKILL.md at its root", dirPath),
+			"add a SKILL.md to the directory root before re-running with --force",
+		)
+	}
+	return verifyMdNameMatches(mdPath, positionalName)
 }
 
 // verifyMdNameMatches reads the SKILL.md front matter and refuses --force on
@@ -298,6 +384,7 @@ const (
 	modeInline
 	modeFileMd
 	modeFilePackage
+	modeFileDirectory
 )
 
 func selectCreateMode(f *createFlags) (createMode, error) {
@@ -313,6 +400,12 @@ func selectCreateMode(f *createFlags) (createMode, error) {
 	}
 
 	if fileProvided {
+		// Detect directories before extension matching so callers can point
+		// --file at the directory `azd ai skill download` extracted (which
+		// has no file extension at all).
+		if info, err := os.Stat(f.file); err == nil && info.IsDir() {
+			return modeFileDirectory, nil
+		}
 		switch strings.ToLower(filepath.Ext(f.file)) {
 		case ".md":
 			return modeFileMd, nil
@@ -322,7 +415,8 @@ func selectCreateMode(f *createFlags) (createMode, error) {
 			return modeNone, exterrors.Validation(
 				exterrors.CodeInvalidSkillFile,
 				fmt.Sprintf("unsupported --file extension %q", filepath.Ext(f.file)),
-				"use .md for inline metadata or .zip for a package upload",
+				"use .md for inline metadata, .zip for a package upload, "+
+					"or a directory containing SKILL.md",
 			)
 		}
 	}
@@ -383,18 +477,24 @@ func newCreateCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <name>",
 		Short: "Create a new Foundry skill.",
-		Long: `Create a new Foundry skill in one of three mutually exclusive modes:
+		Long: `Create a new Foundry skill in one of four mutually exclusive modes:
 
-  1. Inline:   --description "..." --instructions "..."
-  2. SKILL.md: --file ./SKILL.md   (CLI parses YAML front matter + body)
-  3. Package:  --file ./skill.zip   (CLI uploads the archive as multipart/form-data)
+  1. Inline:    --description "..." --instructions "..."
+  2. SKILL.md:  --file ./SKILL.md   (CLI parses YAML front matter + body)
+  3. Package:   --file ./skill.zip  (CLI uploads the archive as multipart/form-data)
+  4. Directory: --file ./skill-src  (CLI packages the directory as a zip and uploads it)
+
+Directory mode requires SKILL.md at the root of the directory — the same
+layout that ` + "`azd ai skill download`" + ` writes by default, so the natural
+round-trip works without a manual zip step.
 
 Skills are versioned. ` + "`create`" + ` creates a new skill (if it does not exist)
 and uploads its first version as the default. Pass --force to delete an existing
 skill of the same name before creating.`,
 		Example: `  azd ai skill create greet-user --description "Welcomes a new user" --instructions "Greet ..."
   azd ai skill create greet-user --file ./SKILL.md
-  azd ai skill create greet-user --file ./skill.zip --force`,
+  azd ai skill create greet-user --file ./skill.zip --force
+  azd ai skill create greet-user --file ./skill-src/ --force`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flags.name = args[0]
@@ -409,7 +509,8 @@ skill of the same name before creating.`,
 
 	cmd.Flags().StringVar(&flags.description, "description", "", "Inline mode: human-readable summary of the skill")
 	cmd.Flags().StringVar(&flags.instructions, "instructions", "", "Inline mode: Markdown body defining skill behavior")
-	cmd.Flags().StringVar(&flags.file, "file", "", "Path to SKILL.md (.md) or a ZIP package (.zip)")
+	cmd.Flags().StringVar(&flags.file, "file", "",
+		"Path to SKILL.md (.md), a ZIP package (.zip), or a directory containing SKILL.md at its root")
 	cmd.Flags().BoolVar(&flags.force, "force", false, "Delete an existing skill of the same name before creating")
 	azdext.RegisterFlagOptions(cmd, azdext.FlagOptions{
 		Name: "output", AllowedValues: []string{outputJSON, outputTable}, Default: outputJSON,

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create_test.go
@@ -156,3 +156,95 @@ func writeTempFile(t *testing.T, data []byte, pattern string) string {
 	require.NoError(t, f.Close())
 	return filepath.Clean(f.Name())
 }
+
+// writeSkillDir creates a temp directory containing a SKILL.md whose front
+// matter declares skillName. Returns the directory path.
+func writeSkillDir(t *testing.T, skillName string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "SKILL.md"),
+		[]byte("---\nname: "+skillName+"\ndescription: hi\n---\nbody\n"),
+		0600,
+	))
+	return dir
+}
+
+// --- selectCreateMode directory routing ---
+
+func TestSelectCreateMode_DirectoryRoute(t *testing.T) {
+	dir := writeSkillDir(t, "my-skill")
+	mode, err := selectCreateMode(&createFlags{file: dir})
+	require.NoError(t, err)
+	require.Equal(t, modeFileDirectory, mode)
+}
+
+func TestSelectCreateMode_FileWithoutExtensionFailsClean(t *testing.T) {
+	// A file (not a directory) without a .md/.zip extension keeps the
+	// "unsupported --file extension" error path. The directory route must
+	// not accidentally accept a regular file.
+	f := writeTempFile(t, []byte("hi"), "no-ext-*")
+	mode, err := selectCreateMode(&createFlags{file: f})
+	require.Error(t, err)
+	require.Equal(t, modeNone, mode)
+	var le *azdext.LocalError
+	require.True(t, errors.As(err, &le))
+	require.Equal(t, exterrors.CodeInvalidSkillFile, le.Code)
+}
+
+// --- verifyFileNameMatches (directory mode) ---
+
+func TestVerifyFileNameMatches_DirectoryMatch(t *testing.T) {
+	dir := writeSkillDir(t, "my-skill")
+	require.NoError(t, verifyFileNameMatches(dir, "my-skill", modeFileDirectory))
+}
+
+func TestVerifyFileNameMatches_DirectoryMismatch(t *testing.T) {
+	dir := writeSkillDir(t, "other-skill")
+	err := verifyFileNameMatches(dir, "my-skill", modeFileDirectory)
+	require.Error(t, err)
+	var le *azdext.LocalError
+	require.True(t, errors.As(err, &le))
+	require.Equal(t, exterrors.CodeInvalidSkillFile, le.Code)
+}
+
+func TestVerifyFileNameMatches_DirectoryMissingSkillMd(t *testing.T) {
+	// A directory with no SKILL.md cannot prove the name matches; --force
+	// must be blocked rather than silently deleting an existing skill.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("hi"), 0600))
+	err := verifyFileNameMatches(dir, "my-skill", modeFileDirectory)
+	require.Error(t, err)
+	var le *azdext.LocalError
+	require.True(t, errors.As(err, &le))
+	require.Equal(t, exterrors.CodeInvalidSkillFile, le.Code)
+}
+
+func TestVerifyFileNameMatches_DirectoryNoNameClaim(t *testing.T) {
+	// SKILL.md without a name field: no claim, --force allowed (matches
+	// MD-mode behavior).
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "SKILL.md"),
+		[]byte("---\ndescription: hi\n---\nbody"),
+		0600,
+	))
+	require.NoError(t, verifyFileNameMatches(dir, "my-skill", modeFileDirectory))
+}
+
+// --- runFileDirectory missing SKILL.md ---
+
+func TestCreateAction_DirectoryWithoutSkillMdFails(t *testing.T) {
+	// A directory without a SKILL.md at its root is rejected by
+	// runFileDirectory before any network call. We don't have a real client,
+	// so we call runFileDirectory directly with a nil client and rely on the
+	// SKILL.md check happening first.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("hi"), 0600))
+	a := &createAction{flags: &createFlags{name: "my-skill", file: dir}}
+	err := a.runFileDirectory(context.Background(), nil)
+	require.Error(t, err)
+	var le *azdext.LocalError
+	require.True(t, errors.As(err, &le))
+	require.Equal(t, exterrors.CodeInvalidSkillFile, le.Code)
+}

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create_test.go
@@ -192,6 +192,23 @@ func TestSelectCreateMode_FileWithoutExtensionFailsClean(t *testing.T) {
 	require.Equal(t, exterrors.CodeInvalidSkillFile, le.Code)
 }
 
+// TestSelectCreateMode_MissingNoExtPathSurfacesStatError guards the
+// regression where a --file value with no extension that did not exist on
+// disk produced a misleading "unsupported --file extension \"\"" error. With
+// directory uploads supported, the more actionable message is the underlying
+// stat failure (typically fs.ErrNotExist).
+func TestSelectCreateMode_MissingNoExtPathSurfacesStatError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	mode, err := selectCreateMode(&createFlags{file: missing})
+	require.Error(t, err)
+	require.Equal(t, modeNone, mode)
+	var le *azdext.LocalError
+	require.True(t, errors.As(err, &le))
+	require.Equal(t, exterrors.CodeInvalidSkillFile, le.Code)
+	require.NotContains(t, le.Message, `unsupported --file extension ""`)
+	require.Contains(t, le.Message, "inspect --file")
+}
+
 // --- verifyFileNameMatches (directory mode) ---
 
 func TestVerifyFileNameMatches_DirectoryMatch(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_update.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_update.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -160,6 +161,17 @@ func (a *updateAction) validateFlags() error {
 	}
 
 	if fileProvided {
+		// Detect directory uploads before extension matching: update is
+		// inline-only by design, so a multi-file directory is rejected the
+		// same way .zip is — with a pointer to `create --force`.
+		if info, statErr := os.Stat(a.flags.file); statErr == nil && info.IsDir() {
+			return exterrors.Validation(
+				exterrors.CodeInvalidSkillFile,
+				"directory uploads cannot be applied via `skill update`",
+				"use `azd ai skill create <name> --file <directory> --force` to replace the skill "+
+					"(this deletes the existing skill and all of its versions first)",
+			)
+		}
 		ext := strings.ToLower(filepath.Ext(a.flags.file))
 		switch ext {
 		case ".md":

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_update_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_update_test.go
@@ -6,6 +6,8 @@ package cmd
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"azureaiskills/internal/exterrors"
@@ -59,6 +61,28 @@ func TestUpdateAction_ZipSuggestionMentionsDestructive(t *testing.T) {
 	require.Equal(t, exterrors.CodeInvalidSkillFile, le.Code)
 	require.Contains(t, le.Suggestion, "deletes",
 		"suggestion must warn that the operation is destructive")
+}
+
+// TestUpdateAction_DirectoryRejectedWithDestructivePointer verifies that
+// directory --file (multi-file uploads) is rejected on update with the same
+// `create --force` pointer as .zip — keeping update inline-only by design.
+func TestUpdateAction_DirectoryRejectedWithDestructivePointer(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "SKILL.md"),
+		[]byte("---\nname: my-skill\n---\nbody"),
+		0600,
+	))
+	a := &updateAction{flags: &updateFlags{file: dir}}
+	err := a.validateFlags()
+	require.Error(t, err)
+	var le *azdext.LocalError
+	require.True(t, errors.As(err, &le))
+	require.Equal(t, exterrors.CodeInvalidSkillFile, le.Code)
+	require.Contains(t, le.Suggestion, "deletes",
+		"directory rejection must warn that the create --force fallback is destructive")
+	require.Contains(t, le.Suggestion, "directory",
+		"suggestion should point at the --file <directory> --force flow")
 }
 
 func TestUpdateAction_SetDefaultVersion_AcceptsAlone(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/archive_create.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/archive_create.go
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package skill_api
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// ArchiveOptions tunes the safety caps for ArchiveDirectory. Zero values
+// fall back to the same defaults as ExtractOptions on the way down so a
+// directory that round-trips through download → edit → create cannot trip
+// the upload-side caps when extraction would have accepted it.
+type ArchiveOptions struct {
+	MaxEntries           int
+	MaxTotalUncompressed int64
+}
+
+// ArchiveDirectory builds an in-memory zip of srcDir's contents and returns
+// the raw bytes. Symmetric with SafeExtract:
+//
+//   - rejects symlinks and non-regular entries (devices, sockets, named pipes)
+//   - caps the number of file entries (MaxEntries, default 10,000)
+//   - caps the total uncompressed bytes (MaxTotalUncompressed, default 512 MB)
+//
+// Entry names are written with forward-slash separators so the archive
+// extracts identically on any OS.
+//
+// If srcDir itself is a symlink it is resolved once (so users can pass a
+// symlinked source directory); symlinks *inside* the tree are rejected.
+// Empty directories are not preserved (no zip entry is written for them);
+// SKILL.md presence is the caller's job to validate.
+func ArchiveDirectory(srcDir string, opts ArchiveOptions) ([]byte, error) {
+	info, err := os.Stat(srcDir)
+	if err != nil {
+		return nil, fmt.Errorf("stat %q: %w", srcDir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%w: %q is not a directory", ErrInvalidArchive, srcDir)
+	}
+
+	maxEntries := opts.MaxEntries
+	if maxEntries <= 0 {
+		maxEntries = DefaultMaxEntries
+	}
+	maxBytes := opts.MaxTotalUncompressed
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxTotalUncompressed
+	}
+
+	// Resolve a top-level symlink so WalkDir descends into the real tree.
+	// Symlinks discovered inside the tree are rejected by the walker below.
+	realSrc, err := filepath.EvalSymlinks(srcDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve source dir: %w", err)
+	}
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	var (
+		entries    int
+		totalBytes int64
+	)
+	walkErr := filepath.WalkDir(realSrc, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == realSrc {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(realSrc, path)
+		if relErr != nil {
+			return fmt.Errorf("compute relative path: %w", relErr)
+		}
+		relSlash := filepath.ToSlash(rel)
+
+		entryInfo, lstatErr := os.Lstat(path)
+		if lstatErr != nil {
+			return fmt.Errorf("stat %q: %w", relSlash, lstatErr)
+		}
+		mode := entryInfo.Mode()
+
+		if mode&os.ModeSymlink != 0 {
+			return fmt.Errorf("%w: %q is a symlink", ErrUnsafeEntry, relSlash)
+		}
+		if d.IsDir() {
+			// Empty directories aren't part of the skill contract; skip the
+			// entry. Non-empty directories will materialize implicitly when
+			// their files are added.
+			return nil
+		}
+		if !mode.IsRegular() {
+			return fmt.Errorf("%w: %q has irregular file mode %v", ErrUnsafeEntry, relSlash, mode)
+		}
+
+		entries++
+		if entries > maxEntries {
+			return fmt.Errorf("%w: entry count exceeds %d", ErrLimitExceeded, maxEntries)
+		}
+
+		// Fail fast on advertised size before we open the file.
+		if entryInfo.Size() > maxBytes-totalBytes {
+			return fmt.Errorf("%w: uncompressed size would exceed budget", ErrLimitExceeded)
+		}
+
+		header := &zip.FileHeader{
+			Name:     relSlash,
+			Method:   zip.Deflate,
+			Modified: entryInfo.ModTime(),
+		}
+		// SetMode keeps the entry's "regular file" classification in the
+		// archive's external-attrs so SafeExtract sees IsRegular() on the
+		// way back down. 0644 is a neutral mode that round-trips cleanly.
+		header.SetMode(0644)
+
+		w, headerErr := zw.CreateHeader(header)
+		if headerErr != nil {
+			return fmt.Errorf("create zip header for %q: %w", relSlash, headerErr)
+		}
+
+		f, openErr := os.Open(path) //nolint:gosec // path is under user-supplied srcDir, walked on user behalf
+		if openErr != nil {
+			return fmt.Errorf("open %q: %w", relSlash, openErr)
+		}
+		// LimitReader caps actual bytes copied at one past the remaining
+		// budget so we can detect a file that grew between Lstat and Open
+		// (TOCTOU) and refuse it before exceeding the total cap.
+		remaining := maxBytes - totalBytes
+		n, copyErr := io.Copy(w, io.LimitReader(f, remaining+1))
+		_ = f.Close()
+		if copyErr != nil {
+			return fmt.Errorf("write %q to zip: %w", relSlash, copyErr)
+		}
+		if n > remaining {
+			return fmt.Errorf("%w: uncompressed size would exceed budget", ErrLimitExceeded)
+		}
+		totalBytes += n
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("close zip writer: %w", err)
+	}
+	if entries == 0 {
+		return nil, fmt.Errorf("%w: directory %q contains no files to archive", ErrInvalidArchive, srcDir)
+	}
+	return buf.Bytes(), nil
+}
+
+// LocateSkillMdInDir returns the path to a SKILL.md at the root of dir, or
+// ("", false, nil) when the directory has no SKILL.md. An error is returned
+// only when the entry exists but is not a regular file (symlink, device,
+// etc.) or when stat itself fails for a reason other than "not exist".
+//
+// Lookup is intentionally shallow (root only): the directory contract for
+// `azd ai skill create --file <dir>` mirrors what `azd ai skill download`
+// writes, which is SKILL.md at the top of the destination.
+func LocateSkillMdInDir(dir string) (string, bool, error) {
+	candidate := filepath.Join(dir, SkillMdFileName)
+	info, err := os.Lstat(candidate)
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("stat %q: %w", candidate, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", false, fmt.Errorf("%w: %q is a symlink", ErrUnsafeEntry, candidate)
+	}
+	if !info.Mode().IsRegular() {
+		return "", false, fmt.Errorf("%w: %q is not a regular file", ErrUnsafeEntry, candidate)
+	}
+	return candidate, true, nil
+}

--- a/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/archive_create.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/archive_create.go
@@ -85,7 +85,7 @@ func ArchiveDirectory(srcDir string, opts ArchiveOptions) ([]byte, error) {
 
 		entryInfo, lstatErr := os.Lstat(path)
 		if lstatErr != nil {
-			return fmt.Errorf("stat %q: %w", relSlash, lstatErr)
+			return fmt.Errorf("lstat %q: %w", relSlash, lstatErr)
 		}
 		mode := entryInfo.Mode()
 
@@ -173,7 +173,7 @@ func LocateSkillMdInDir(dir string) (string, bool, error) {
 		return "", false, nil
 	}
 	if err != nil {
-		return "", false, fmt.Errorf("stat %q: %w", candidate, err)
+		return "", false, fmt.Errorf("lstat %q: %w", candidate, err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
 		return "", false, fmt.Errorf("%w: %q is a symlink", ErrUnsafeEntry, candidate)

--- a/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/archive_create_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/archive_create_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package skill_api
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// symlinkAvailable reports whether the OS supports creating symlinks. On
+// Windows without Developer Mode, os.Symlink fails with a privilege error;
+// the symlink-rejection tests are skipped in that environment.
+func symlinkAvailable(t *testing.T) bool {
+	t.Helper()
+	tmp := t.TempDir()
+	return os.Symlink(".", filepath.Join(tmp, "testlink")) == nil
+}
+
+func TestArchiveDirectory_HappyPathRoundTrips(t *testing.T) {
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(src, "SKILL.md"),
+		[]byte("---\nname: my-skill\ndescription: hi\n---\nbody\n"),
+		0600,
+	))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "assets"), 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "assets", "icon.svg"), []byte("<svg/>"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "assets", "notes.txt"), []byte("hello"), 0600))
+
+	data, err := ArchiveDirectory(src, ArchiveOptions{})
+	require.NoError(t, err)
+	require.Equal(t, ArchiveZip, DetectArchiveFormat(data))
+
+	// Round-trip through SafeExtract: every file should land in dst with the
+	// same content, using forward-slash paths regardless of the OS.
+	dst := t.TempDir()
+	result, err := SafeExtract(data, ExtractOptions{OutputDir: dst})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		"SKILL.md",
+		"assets/icon.svg",
+		"assets/notes.txt",
+	}, result.Files)
+	require.FileExists(t, filepath.Join(dst, "SKILL.md"))
+	require.FileExists(t, filepath.Join(dst, "assets", "icon.svg"))
+	require.FileExists(t, filepath.Join(dst, "assets", "notes.txt"))
+}
+
+func TestArchiveDirectory_RejectsNonDirectory(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "not-a-dir.txt")
+	require.NoError(t, os.WriteFile(f, []byte("not a dir"), 0600))
+	_, err := ArchiveDirectory(f, ArchiveOptions{})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidArchive)
+}
+
+func TestArchiveDirectory_RejectsEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	_, err := ArchiveDirectory(dir, ArchiveOptions{})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidArchive)
+}
+
+func TestArchiveDirectory_FollowsTopLevelSymlink(t *testing.T) {
+	if !symlinkAvailable(t) {
+		t.Skip("OS does not allow creating symlinks")
+	}
+	real := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(real, "SKILL.md"), []byte("---\nname: s\n---\n"), 0600))
+
+	linkParent := t.TempDir()
+	link := filepath.Join(linkParent, "link-to-real")
+	require.NoError(t, os.Symlink(real, link))
+
+	data, err := ArchiveDirectory(link, ArchiveOptions{})
+	require.NoError(t, err)
+	require.Equal(t, ArchiveZip, DetectArchiveFormat(data))
+}
+
+func TestArchiveDirectory_RejectsInnerSymlink(t *testing.T) {
+	if !symlinkAvailable(t) {
+		t.Skip("OS does not allow creating symlinks")
+	}
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("---\nname: s\n---\n"), 0600))
+
+	target := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(target, "secret"), []byte("oops"), 0600))
+	require.NoError(t, os.Symlink(filepath.Join(target, "secret"), filepath.Join(src, "leak")))
+
+	_, err := ArchiveDirectory(src, ArchiveOptions{})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrUnsafeEntry)
+}
+
+func TestArchiveDirectory_EnforcesEntryCap(t *testing.T) {
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("---\nname: s\n---\n"), 0600))
+	for i := range 5 {
+		name := filepath.Join(src, "file"+string(rune('a'+i))+".txt")
+		require.NoError(t, os.WriteFile(name, []byte("x"), 0600))
+	}
+	_, err := ArchiveDirectory(src, ArchiveOptions{MaxEntries: 3})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrLimitExceeded)
+}
+
+func TestArchiveDirectory_EnforcesByteCap(t *testing.T) {
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("---\nname: s\n---\n"), 0600))
+	// One ~200 byte file with a 100 byte total cap must trip ErrLimitExceeded.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(src, "big.txt"),
+		[]byte(strings.Repeat("A", 200)),
+		0600,
+	))
+	_, err := ArchiveDirectory(src, ArchiveOptions{MaxTotalUncompressed: 100})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrLimitExceeded)
+}
+
+func TestArchiveDirectory_PreservesNestedPathsForwardSlash(t *testing.T) {
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("---\nname: s\n---\n"), 0600))
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "a", "b", "c"), 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "a", "b", "c", "deep.txt"), []byte("d"), 0600))
+
+	data, err := ArchiveDirectory(src, ArchiveOptions{})
+	require.NoError(t, err)
+
+	dst := t.TempDir()
+	result, err := SafeExtract(data, ExtractOptions{OutputDir: dst})
+	require.NoError(t, err)
+	// Path inside the archive uses forward slashes.
+	require.Contains(t, result.Files, "a/b/c/deep.txt")
+}
+
+func TestLocateSkillMdInDir_FoundAtRoot(t *testing.T) {
+	dir := t.TempDir()
+	want := filepath.Join(dir, SkillMdFileName)
+	require.NoError(t, os.WriteFile(want, []byte("---\nname: s\n---\n"), 0600))
+
+	got, found, err := LocateSkillMdInDir(dir)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, want, got)
+}
+
+func TestLocateSkillMdInDir_Missing(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("hi"), 0600))
+
+	got, found, err := LocateSkillMdInDir(dir)
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Empty(t, got)
+}
+
+func TestLocateSkillMdInDir_NotShallow(t *testing.T) {
+	// SKILL.md one directory deep must not be picked up: lookup is shallow
+	// by design (see archive_create.go docstring).
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "nested"), 0700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "nested", SkillMdFileName),
+		[]byte("---\nname: s\n---\n"),
+		0600,
+	))
+	_, found, err := LocateSkillMdInDir(dir)
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+func TestLocateSkillMdInDir_RejectsSymlink(t *testing.T) {
+	if !symlinkAvailable(t) {
+		t.Skip("OS does not allow creating symlinks")
+	}
+	target := t.TempDir()
+	realFile := filepath.Join(target, "real-skill.md")
+	require.NoError(t, os.WriteFile(realFile, []byte("---\nname: s\n---\n"), 0600))
+
+	dir := t.TempDir()
+	require.NoError(t, os.Symlink(realFile, filepath.Join(dir, SkillMdFileName)))
+
+	_, _, err := LocateSkillMdInDir(dir)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrUnsafeEntry)
+}
+
+// Ensure errors.Is wiring matches what callers can branch on.
+func TestArchiveDirectory_ErrorsAreSentinels(t *testing.T) {
+	_, err := ArchiveDirectory(filepath.Join(t.TempDir(), "does-not-exist"), ArchiveOptions{})
+	require.Error(t, err)
+	// The underlying error is fs.PathError — not a sentinel — so this just
+	// guards against future refactors that might swallow the cause.
+	var pathErr *os.PathError
+	require.True(t, errors.As(err, &pathErr) || strings.Contains(err.Error(), "stat"))
+}

--- a/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/archive_create_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/archive_create_test.go
@@ -194,12 +194,14 @@ func TestLocateSkillMdInDir_RejectsSymlink(t *testing.T) {
 	require.ErrorIs(t, err, ErrUnsafeEntry)
 }
 
-// Ensure errors.Is wiring matches what callers can branch on.
-func TestArchiveDirectory_ErrorsAreSentinels(t *testing.T) {
+// TestArchiveDirectory_MissingDirPropagatesCause guards against a future
+// refactor that might swallow the underlying fs.PathError cause when the
+// source directory does not exist. The error is intentionally *not* a
+// sentinel (it bubbles up from os.Stat), so callers can use errors.As to
+// recover the path-level detail.
+func TestArchiveDirectory_MissingDirPropagatesCause(t *testing.T) {
 	_, err := ArchiveDirectory(filepath.Join(t.TempDir(), "does-not-exist"), ArchiveOptions{})
 	require.Error(t, err)
-	// The underlying error is fs.PathError — not a sentinel — so this just
-	// guards against future refactors that might swallow the cause.
 	var pathErr *os.PathError
 	require.True(t, errors.As(err, &pathErr) || strings.Contains(err.Error(), "stat"))
 }


### PR DESCRIPTION
Fixes #8412.

## Problem

`azd ai skill create <name> --file ./skill-src` (a directory) currently fails with:

```text
ERROR: unsupported --file extension ""
Suggestion: use .md for inline metadata or .zip for a package upload
```

`selectCreateMode` only inspects the file extension and never `os.Stat`s the path, so a directory falls straight into the "unsupported extension" error. This breaks the natural round-trip from `azd ai skill download` (which extracts an existing skill into a directory by default) back to `azd ai skill create`.

## Fix

Add a fourth `--file` mode — directory upload — that's symmetric with `download`.

### `create`
- Detect directories in `selectCreateMode` via `os.Stat` (directories take precedence over extension matching, since callers can hand the output of `download` straight back).
- A new `runFileDirectory` action:
  - Requires a `SKILL.md` at the root of the directory (matches what `download` writes).
  - Packages the directory into an in-memory zip via a new `skill_api.ArchiveDirectory` helper that enforces the **same safety caps as `SafeExtract`** on the way down: no symlinks / non-regular entries, 10K-entry / 512 MB total cap.
  - Uploads through the existing `CreateVersionFromZip` multipart path (same as `.zip`).
- The destructive `--force` name-match guard now reads the directory's `SKILL.md` and refuses the delete-then-create if the embedded `name` disagrees with the positional argument.

### `update`
- Update is inline-only by design. Directories (like `.zip`) are rejected with a structured pointer at `azd ai skill create --force`, since silently dropping non-`SKILL.md` assets would be worse than the current error.

### Docs
- `README.md` — directory mode added to the command summary + a paragraph on the create/update split.
- `AGENTS.md` "File handling" bullet — describes directory mode, safety caps, and update's rejection.
- `CHANGELOG.md` — preview-release bullets updated in place (extension is unreleased).

## Test plan

- **New helper tests** (`internal/pkg/skill_api/archive_create_test.go`):
  - Happy-path: `ArchiveDirectory` → `SafeExtract` round-trip preserves files and forward-slash paths.
  - Rejects non-directories, empty directories, inner symlinks.
  - Top-level symlink-to-directory is followed (so callers can pass symlinked source dirs).
  - Enforces `MaxEntries` and `MaxTotalUncompressed` caps.
  - `LocateSkillMdInDir`: found at root, missing, **not** picked up one directory deep, rejects symlinks.
  - Symlink tests skip cleanly on Windows without Developer Mode (same pattern as `rzip_test.go`).
- **New command tests** (`internal/cmd/`):
  - `selectCreateMode` routes directories to `modeFileDirectory`; regular files without `.md`/`.zip` still error.
  - `--force` name-match guard for directory: match, mismatch, missing `SKILL.md`, no `name` claim.
  - `runFileDirectory` rejects directories without `SKILL.md` before any network call.
  - `update` directory rejection: `CodeInvalidSkillFile` + suggestion contains `deletes` and `directory`.
- All extension tests: `go test ./...` green (`golangci-lint run ./...` and `cspell` also clean).