### PR TITLE
fix: honor `azd ai project set` in skills and routines extensions

### DIFF
--- a/cli/azd/extensions/azure.ai.routines/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.routines/CHANGELOG.md
@@ -1,3 +1,8 @@
 # Release History
 
 ## 0.0.1-preview - Initial Version
+
+- Shares the Foundry project-endpoint resolution cascade with `azure.ai.projects`,
+  reading `extensions.ai-projects.context.endpoint` (written by
+  `azd ai project set`) first and falling back to the legacy
+  `extensions.ai-agents.project.context.endpoint` key.

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/endpoint.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/endpoint.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"strings"
@@ -34,9 +35,20 @@ var foundryHostSuffixes = []string{
 	".services.ai.azure.com",
 }
 
-// projectContextConfigPath is the global config path for the persisted project context.
-// Matches the azure.ai.agents extension for cross-extension compatibility.
-const projectContextConfigPath = "extensions.ai-agents.project.context"
+// projectContextConfigPath is the global config path for the persisted project
+// context written by the sibling `azure.ai.projects` extension's
+// `azd ai project set` command. The routines extension reads this path; it
+// never writes it.
+const projectContextConfigPath = "extensions.ai-projects.context"
+
+// legacyAgentsContextPath is the global config path written by the removed
+// `azd ai agent project set` command. Read as a fallback so users who
+// configured the endpoint there before the `azure.ai.projects` extension
+// existed still resolve. The `azure.ai.projects` extension auto-migrates
+// this key into projectContextConfigPath the first time any
+// `azd ai project` command runs; the fallback exists for the window in
+// between.
+const legacyAgentsContextPath = "extensions.ai-agents.project.context"
 
 // isFoundryHost reports whether the hostname ends with a recognized Foundry suffix.
 func isFoundryHost(hostname string) bool {
@@ -117,10 +129,19 @@ type azdProjectSources struct {
 	EnvValue string
 	// EnvName is the active azd env name. Only meaningful when EnvValue != "".
 	EnvName string
-	// CfgEndpoint is the endpoint persisted in global config, or "".
+	// CfgEndpoint is the endpoint persisted at projectContextConfigPath
+	// (`extensions.ai-projects.context.endpoint`) in global config, or "".
 	CfgEndpoint string
-	// CfgFound is true when the global config path was found and had a non-empty endpoint.
+	// CfgFound is true when projectContextConfigPath was found and had a
+	// non-empty endpoint.
 	CfgFound bool
+	// LegacyAgentsEndpoint is the endpoint persisted at
+	// legacyAgentsContextPath (`extensions.ai-agents.project.context.endpoint`)
+	// in global config, or "". Read as a fallback only.
+	LegacyAgentsEndpoint string
+	// LegacyAgentsFound is true when legacyAgentsContextPath was found and
+	// had a non-empty endpoint.
+	LegacyAgentsFound bool
 }
 
 // readAzdProjectSourcesFunc is a package-level seam so tests can stub the
@@ -152,7 +173,10 @@ func readAzdProjectSources(ctx context.Context) (azdProjectSources, error) {
 		}
 	}
 
-	// Level 3: global config → extensions.ai-agents.project.context.endpoint.
+	// Level 3: global config. Prefer the new `extensions.ai-projects.context`
+	// path written by `azd ai project set`; fall back to the legacy
+	// `extensions.ai-agents.project.context` path written by the removed
+	// `azd ai agent project set` command.
 	ch, cfgErr := azdext.NewConfigHelper(azdClient)
 	if cfgErr == nil {
 		var state struct {
@@ -161,6 +185,13 @@ func readAzdProjectSources(ctx context.Context) (azdProjectSources, error) {
 		if found, err := ch.GetUserJSON(ctx, projectContextConfigPath, &state); err == nil && found && state.Endpoint != "" {
 			out.CfgEndpoint = state.Endpoint
 			out.CfgFound = true
+		}
+		var legacy struct {
+			Endpoint string `json:"endpoint"`
+		}
+		if found, err := ch.GetUserJSON(ctx, legacyAgentsContextPath, &legacy); err == nil && found && legacy.Endpoint != "" {
+			out.LegacyAgentsEndpoint = legacy.Endpoint
+			out.LegacyAgentsFound = true
 		}
 	}
 
@@ -171,7 +202,8 @@ func readAzdProjectSources(ctx context.Context) (azdProjectSources, error) {
 //
 //  1. -p / --project-endpoint flag
 //  2. Active azd env → AZURE_AI_PROJECT_ENDPOINT
-//  3. Global config → extensions.ai-agents.project.context.endpoint
+//  3. Global config → extensions.ai-projects.context.endpoint (primary),
+//     falling back to extensions.ai-agents.project.context.endpoint
 //  4. FOUNDRY_PROJECT_ENDPOINT environment variable
 //  5. Structured dependency error
 func resolveProjectEndpoint(ctx context.Context, flagValue string) (*resolvedEndpoint, error) {
@@ -206,6 +238,16 @@ func resolveProjectEndpoint(ctx context.Context, flagValue string) (*resolvedEnd
 		return &resolvedEndpoint{Endpoint: normalized, Source: SourceGlobalConfig}, nil
 	}
 
+	if sources.LegacyAgentsFound && sources.LegacyAgentsEndpoint != "" {
+		normalized, err := validateProjectEndpoint(sources.LegacyAgentsEndpoint)
+		if err != nil {
+			return nil, err
+		}
+		log.Printf("resolveProjectEndpoint: using fallback global config key %q; "+
+			"run `azd ai project set <endpoint>` to migrate", legacyAgentsContextPath)
+		return &resolvedEndpoint{Endpoint: normalized, Source: SourceGlobalConfig}, nil
+	}
+
 	// Level 4: FOUNDRY_PROJECT_ENDPOINT env var.
 	if ep := os.Getenv("FOUNDRY_PROJECT_ENDPOINT"); ep != "" {
 		normalized, err := validateProjectEndpoint(ep)
@@ -219,7 +261,7 @@ func resolveProjectEndpoint(ctx context.Context, flagValue string) (*resolvedEnd
 	return nil, exterrors.Dependency(
 		exterrors.CodeMissingProjectEndpoint,
 		"no Foundry project endpoint resolved",
-		"pass -p / --project-endpoint, run 'azd ai agent project set <endpoint>', "+
+		"pass -p / --project-endpoint, run `azd ai project set <endpoint>`, "+
 			"set AZURE_AI_PROJECT_ENDPOINT in the active azd environment, "+
 			"or export FOUNDRY_PROJECT_ENDPOINT in your shell",
 	)

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/endpoint_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/endpoint_test.go
@@ -5,8 +5,10 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -169,6 +171,36 @@ func TestResolveProjectEndpoint_GlobalConfig(t *testing.T) {
 	assert.Equal(t, "https://cfgaccount.services.ai.azure.com/api/projects/cfg", got.Endpoint)
 }
 
+func TestResolveProjectEndpoint_GlobalConfig_PrefersAiProjectsOverLegacyAgents(t *testing.T) {
+	isolateFromAzdDaemon(t)
+	stubAzdProjectSources(t, azdProjectSources{
+		CfgEndpoint:          "https://new.services.ai.azure.com/api/projects/new",
+		CfgFound:             true,
+		LegacyAgentsEndpoint: "https://legacy.services.ai.azure.com/api/projects/legacy",
+		LegacyAgentsFound:    true,
+	}, nil)
+
+	got, err := resolveProjectEndpoint(t.Context(), "")
+	require.NoError(t, err)
+	assert.Equal(t, SourceGlobalConfig, got.Source)
+	assert.Equal(t, "https://new.services.ai.azure.com/api/projects/new", got.Endpoint,
+		"the new ai-projects.context key must win over legacy ai-agents.project.context")
+}
+
+func TestResolveProjectEndpoint_GlobalConfig_FallsBackToLegacyAgents(t *testing.T) {
+	isolateFromAzdDaemon(t)
+	stubAzdProjectSources(t, azdProjectSources{
+		LegacyAgentsEndpoint: "https://legacy.services.ai.azure.com/api/projects/legacy",
+		LegacyAgentsFound:    true,
+	}, nil)
+
+	got, err := resolveProjectEndpoint(t.Context(), "")
+	require.NoError(t, err)
+	assert.Equal(t, SourceGlobalConfig, got.Source,
+		"a legacy-only hit still surfaces as globalConfig source")
+	assert.Equal(t, "https://legacy.services.ai.azure.com/api/projects/legacy", got.Endpoint)
+}
+
 func TestResolveProjectEndpoint_FoundryEnv(t *testing.T) {
 	isolateFromAzdDaemon(t)
 	t.Setenv("FOUNDRY_PROJECT_ENDPOINT", "https://fenv.services.ai.azure.com/api/projects/fe")
@@ -184,7 +216,13 @@ func TestResolveProjectEndpoint_NoSourceReturnsError(t *testing.T) {
 	t.Setenv("FOUNDRY_PROJECT_ENDPOINT", "")
 
 	_, err := resolveProjectEndpoint(t.Context(), "")
-	assert.Error(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no Foundry project endpoint resolved")
+
+	var le *azdext.LocalError
+	require.True(t, errors.As(err, &le), "expected a LocalError")
+	assert.Contains(t, le.Suggestion, "azd ai project set",
+		"the dependency-error suggestion should point at the supported `azd ai project set` command")
 }
 
 func TestResolveProjectEndpoint_FlagNormalizesURL(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.skills/AGENTS.md
+++ b/cli/azd/extensions/azure.ai.skills/AGENTS.md
@@ -12,12 +12,12 @@ Useful places to start:
 - `internal/pkg/skill_api/`: typed Foundry Skills REST client, models, SKILL.md parser, and safe ZIP extractor
 - `internal/exterrors/`: structured error factories and extension-specific codes
 
-## Relationship to `azure.ai.agents`
+## Relationship to `azure.ai.projects` and `azure.ai.agents`
 
-This extension is intentionally separate from `azure.ai.agents`. It shares no code symbols but cooperates with it via the global-config endpoint key:
+This extension is intentionally separate from `azure.ai.agents` and shares no code symbols, but it cooperates with `azure.ai.projects` for the Foundry project endpoint:
 
-- This extension writes to `extensions.ai-skills.project.context.endpoint` (none yet — read-only today).
-- This extension reads `extensions.ai-skills.project.context.endpoint` first, then falls back to `extensions.ai-agents.project.context.endpoint` so users who already configured the endpoint via the agents extension are not forced to re-run `set`.
+- This extension **never writes** any project-context global-config key. The persisted endpoint comes from `azd ai project set` (in `azure.ai.projects`).
+- This extension reads `extensions.ai-projects.context.endpoint` first, then falls back to the legacy `extensions.ai-skills.project.context.endpoint` and `extensions.ai-agents.project.context.endpoint` keys so users who configured the endpoint via earlier extensions are not forced to re-run `set`.
 
 `AgentCardSkill` (in `azure.ai.agents`) is unrelated to the `Skill` resource managed here and lives in a different Go module.
 

--- a/cli/azd/extensions/azure.ai.skills/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.skills/CHANGELOG.md
@@ -24,6 +24,8 @@
   - `azd ai skill delete <name>` — confirmation by default, `--force` to skip.
 - Skill names follow the agentskills.io spec:
   `^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$`, max 64 chars (lowercase only).
-- Shares the Foundry project-endpoint resolution cascade with `azure.ai.agents`,
-  reading `extensions.ai-skills.project.context.endpoint` first and falling
-  back to `extensions.ai-agents.project.context.endpoint`.
+- Shares the Foundry project-endpoint resolution cascade with `azure.ai.projects`,
+  reading `extensions.ai-projects.context.endpoint` (written by
+  `azd ai project set`) first and falling back to the legacy
+  `extensions.ai-skills.project.context.endpoint` and
+  `extensions.ai-agents.project.context.endpoint` keys.

--- a/cli/azd/extensions/azure.ai.skills/README.md
+++ b/cli/azd/extensions/azure.ai.skills/README.md
@@ -34,9 +34,12 @@ The Foundry project endpoint is resolved in this order:
 
 1. `-p` / `--project-endpoint` flag on the command.
 2. Active azd env value `AZURE_AI_PROJECT_ENDPOINT`.
-3. Global config `extensions.ai-skills.project.context.endpoint`
-   (falls back to `extensions.ai-agents.project.context.endpoint` so users who
-   configured the endpoint via the agents extension are not forced to re-run `set`).
+3. Global config `extensions.ai-projects.context.endpoint` (written by
+   `azd ai project set`). Falls back to the legacy
+   `extensions.ai-skills.project.context.endpoint` and
+   `extensions.ai-agents.project.context.endpoint` keys so users who
+   configured the endpoint via earlier extensions are not forced to re-run
+   `set`.
 4. Host environment variable `FOUNDRY_PROJECT_ENDPOINT`.
 5. Structured error with an actionable suggestion.
 

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/endpoint.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/endpoint.go
@@ -26,16 +26,112 @@ const (
 )
 
 const (
+	// projectsContextPath is the global-config path written by the sibling
+	// `azure.ai.projects` extension's `azd ai project set` command. The
+	// value at this path is the projectContextState object {Endpoint, SetAt};
+	// the skills extension reads it but never writes it.
+	projectsContextPath = "extensions.ai-projects.context"
+	// skillsContextEndpointKey is the legacy global-config path read for
+	// backward compatibility. Some hand-edited configurations and earlier
+	// builds of this extension referenced this string-valued path.
 	skillsContextEndpointKey = "extensions.ai-skills.project.context.endpoint"
-	// Read-only fallback to the ai-agents key so users who configured the
-	// endpoint via that extension don't have to re-run `set`.
+	// agentsContextEndpointKey is the legacy global-config path written by
+	// the removed `azd ai agent project set` command. Read as a fallback so
+	// users who configured the endpoint there before the
+	// `azure.ai.projects` extension existed still resolve. The
+	// `azure.ai.projects` extension auto-migrates that key into
+	// projectsContextPath the first time any `azd ai project` command runs;
+	// the fallback exists for the window in between.
 	agentsContextEndpointKey = "extensions.ai-agents.project.context.endpoint"
 	azdEnvKey                = "AZURE_AI_PROJECT_ENDPOINT"
 	foundryEnvKey            = "FOUNDRY_PROJECT_ENDPOINT"
 )
 
+// azdProjectSources holds the values read from azd-managed sources
+// (levels 2 and 3 of resolveProjectEndpoint).
+type azdProjectSources struct {
+	// EnvValue is AZURE_AI_PROJECT_ENDPOINT from the active azd env, or "".
+	EnvValue string
+	// CfgEndpoint is the endpoint persisted at projectsContextPath in global
+	// config, or "". Source of truth for `azd ai project set`.
+	CfgEndpoint string
+	// CfgFound is true when projectsContextPath was found and had a non-empty
+	// endpoint.
+	CfgFound bool
+	// LegacySkillsEndpoint is the endpoint at skillsContextEndpointKey, or "".
+	// Read as a fallback only.
+	LegacySkillsEndpoint string
+	// LegacySkillsFound is true when skillsContextEndpointKey was found and
+	// had a non-empty endpoint.
+	LegacySkillsFound bool
+	// LegacyAgentsEndpoint is the endpoint at agentsContextEndpointKey, or "".
+	// Read as a fallback only.
+	LegacyAgentsEndpoint string
+	// LegacyAgentsFound is true when agentsContextEndpointKey was found and
+	// had a non-empty endpoint.
+	LegacyAgentsFound bool
+}
+
+// readAzdProjectSourcesFunc is a package-level seam so tests can stub the
+// daemon-backed lookup without spinning up a real azd gRPC server.
+var readAzdProjectSourcesFunc = readAzdProjectSources
+
+// readAzdProjectSources dials the azd daemon (if reachable) and reads the
+// active env's AZURE_AI_PROJECT_ENDPOINT and the three candidate global-config
+// keys in a single client lifetime. Errors talking to the daemon are silently
+// ignored (treated as "no daemon"); the caller falls through to the
+// FOUNDRY_PROJECT_ENDPOINT host env var.
+func readAzdProjectSources(ctx context.Context) (azdProjectSources, error) {
+	var out azdProjectSources
+
+	azdClient, err := azdext.NewAzdClient()
+	if err != nil {
+		return out, nil
+	}
+	defer azdClient.Close()
+
+	// Level 2: active azd env → AZURE_AI_PROJECT_ENDPOINT.
+	if envResp, err := azdClient.Environment().GetCurrent(ctx, &azdext.EmptyRequest{}); err == nil {
+		if valResp, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+			EnvName: envResp.Environment.Name,
+			Key:     azdEnvKey,
+		}); err == nil && valResp.Value != "" {
+			out.EnvValue = valResp.Value
+		}
+	}
+
+	// Level 3: global config. Read the new path written by
+	// `azd ai project set` plus both legacy paths in one daemon round-trip
+	// so resolveProjectEndpoint can pick the highest-priority hit.
+	ch, cfgErr := azdext.NewConfigHelper(azdClient)
+	if cfgErr == nil {
+		var state struct {
+			Endpoint string `json:"endpoint"`
+		}
+		if found, err := ch.GetUserJSON(ctx, projectsContextPath, &state); err == nil && found && state.Endpoint != "" {
+			out.CfgEndpoint = state.Endpoint
+			out.CfgFound = true
+		}
+
+		var legacySkills string
+		if found, err := ch.GetUserJSON(ctx, skillsContextEndpointKey, &legacySkills); err == nil && found && legacySkills != "" {
+			out.LegacySkillsEndpoint = legacySkills
+			out.LegacySkillsFound = true
+		}
+
+		var legacyAgents string
+		if found, err := ch.GetUserJSON(ctx, agentsContextEndpointKey, &legacyAgents); err == nil && found && legacyAgents != "" {
+			out.LegacyAgentsEndpoint = legacyAgents
+			out.LegacyAgentsFound = true
+		}
+	}
+
+	return out, nil
+}
+
 // resolveProjectEndpoint implements the 5-level cascade from the design spec:
-// flag, azd env, global config (skills then agents), host env, error.
+// flag, azd env, global config (ai-projects then legacy ai-skills then legacy
+// ai-agents), host env, error.
 func resolveProjectEndpoint(ctx context.Context, flagEndpoint string) (string, endpointSource, error) {
 	if flagEndpoint != "" {
 		if err := validateEndpoint(flagEndpoint); err != nil {
@@ -44,35 +140,41 @@ func resolveProjectEndpoint(ctx context.Context, flagEndpoint string) (string, e
 		return flagEndpoint, sourceFlag, nil
 	}
 
-	if azdClient, err := azdext.NewAzdClient(); err == nil {
-		defer azdClient.Close()
+	sources, err := readAzdProjectSourcesFunc(ctx)
+	if err != nil {
+		return "", "", err
+	}
 
-		if envResp, envErr := azdClient.Environment().GetCurrent(ctx, &azdext.EmptyRequest{}); envErr == nil {
-			if valResp, valErr := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
-				EnvName: envResp.Environment.Name,
-				Key:     azdEnvKey,
-			}); valErr == nil && valResp.Value != "" {
-				if err := validateEndpoint(valResp.Value); err != nil {
-					return "", "", err
-				}
-				return valResp.Value, sourceAzdEnv, nil
-			}
+	if sources.EnvValue != "" {
+		if err := validateEndpoint(sources.EnvValue); err != nil {
+			return "", "", err
 		}
+		return sources.EnvValue, sourceAzdEnv, nil
+	}
 
-		if ch, chErr := azdext.NewConfigHelper(azdClient); chErr == nil {
-			for _, key := range []string{skillsContextEndpointKey, agentsContextEndpointKey} {
-				var endpoint string
-				if found, getErr := ch.GetUserJSON(ctx, key, &endpoint); getErr == nil && found && endpoint != "" {
-					if key == agentsContextEndpointKey {
-						log.Printf("resolveProjectEndpoint: using fallback global config key %q", agentsContextEndpointKey)
-					}
-					if err := validateEndpoint(endpoint); err != nil {
-						return "", "", err
-					}
-					return endpoint, sourceGlobalConfig, nil
-				}
-			}
+	if sources.CfgFound && sources.CfgEndpoint != "" {
+		if err := validateEndpoint(sources.CfgEndpoint); err != nil {
+			return "", "", err
 		}
+		return sources.CfgEndpoint, sourceGlobalConfig, nil
+	}
+
+	if sources.LegacySkillsFound && sources.LegacySkillsEndpoint != "" {
+		if err := validateEndpoint(sources.LegacySkillsEndpoint); err != nil {
+			return "", "", err
+		}
+		log.Printf("resolveProjectEndpoint: using fallback global config key %q; "+
+			"run `azd ai project set <endpoint>` to migrate", skillsContextEndpointKey)
+		return sources.LegacySkillsEndpoint, sourceGlobalConfig, nil
+	}
+
+	if sources.LegacyAgentsFound && sources.LegacyAgentsEndpoint != "" {
+		if err := validateEndpoint(sources.LegacyAgentsEndpoint); err != nil {
+			return "", "", err
+		}
+		log.Printf("resolveProjectEndpoint: using fallback global config key %q; "+
+			"run `azd ai project set <endpoint>` to migrate", agentsContextEndpointKey)
+		return sources.LegacyAgentsEndpoint, sourceGlobalConfig, nil
 	}
 
 	if ep := os.Getenv(foundryEnvKey); ep != "" {
@@ -86,7 +188,7 @@ func resolveProjectEndpoint(ctx context.Context, flagEndpoint string) (string, e
 		exterrors.CodeMissingProjectEndpoint,
 		"no Foundry project endpoint resolved",
 		"pass --project-endpoint, set "+azdEnvKey+" in the active azd environment, "+
-			"persist a workspace default with `azd ai agent project set <endpoint>`, "+
+			"persist a workspace default with `azd ai project set <endpoint>`, "+
 			"or export "+foundryEnvKey+" in your shell",
 	)
 }

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/endpoint_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/endpoint_test.go
@@ -5,25 +5,121 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// stubAzdProjectSources replaces readAzdProjectSourcesFunc for the duration of
+// the test with a function that returns the given sources/err.
+func stubAzdProjectSources(t *testing.T, sources azdProjectSources, err error) {
+	t.Helper()
+	orig := readAzdProjectSourcesFunc
+	readAzdProjectSourcesFunc = func(context.Context) (azdProjectSources, error) {
+		return sources, err
+	}
+	t.Cleanup(func() { readAzdProjectSourcesFunc = orig })
+}
+
+// isolateFromAzdDaemon makes the test independent of any azd daemon that
+// might be reachable on the developer machine via AZD_SERVER. It clears
+// AZD_SERVER and stubs readAzdProjectSourcesFunc to return no project sources,
+// so the resolver under test only sees the flag and FOUNDRY_PROJECT_ENDPOINT.
+func isolateFromAzdDaemon(t *testing.T) {
+	t.Helper()
+	t.Setenv("AZD_SERVER", "")
+	stubAzdProjectSources(t, azdProjectSources{}, nil)
+}
+
 func TestResolveProjectEndpoint_FlagWins(t *testing.T) {
-	ep, src, err := resolveProjectEndpoint(context.Background(), "https://flag.example.com")
+	// Even with FOUNDRY_PROJECT_ENDPOINT and azd-hosted sources set, the flag wins.
+	t.Setenv("FOUNDRY_PROJECT_ENDPOINT", "https://other.example.com")
+	stubAzdProjectSources(t, azdProjectSources{
+		EnvValue: "https://envaccount.example.com",
+	}, nil)
+
+	ep, src, err := resolveProjectEndpoint(t.Context(), "https://flag.example.com")
 	require.NoError(t, err)
-	require.Equal(t, "https://flag.example.com", ep)
-	require.Equal(t, sourceFlag, src)
+	assert.Equal(t, "https://flag.example.com", ep)
+	assert.Equal(t, sourceFlag, src)
+}
+
+func TestResolveProjectEndpoint_AzdEnvBeatsGlobalConfig(t *testing.T) {
+	isolateFromAzdDaemon(t)
+	stubAzdProjectSources(t, azdProjectSources{
+		EnvValue:             "https://envaccount.example.com",
+		CfgEndpoint:          "https://cfg.example.com",
+		CfgFound:             true,
+		LegacySkillsEndpoint: "https://legacy-skills.example.com",
+		LegacySkillsFound:    true,
+		LegacyAgentsEndpoint: "https://legacy-agents.example.com",
+		LegacyAgentsFound:    true,
+	}, nil)
+
+	ep, src, err := resolveProjectEndpoint(t.Context(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://envaccount.example.com", ep)
+	assert.Equal(t, sourceAzdEnv, src)
+}
+
+func TestResolveProjectEndpoint_GlobalConfig_PrefersAiProjects(t *testing.T) {
+	isolateFromAzdDaemon(t)
+	stubAzdProjectSources(t, azdProjectSources{
+		CfgEndpoint:          "https://new.example.com",
+		CfgFound:             true,
+		LegacySkillsEndpoint: "https://legacy-skills.example.com",
+		LegacySkillsFound:    true,
+		LegacyAgentsEndpoint: "https://legacy-agents.example.com",
+		LegacyAgentsFound:    true,
+	}, nil)
+
+	ep, src, err := resolveProjectEndpoint(t.Context(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://new.example.com", ep,
+		"the new ai-projects.context key must win over both legacy paths")
+	assert.Equal(t, sourceGlobalConfig, src)
+}
+
+func TestResolveProjectEndpoint_GlobalConfig_FallsBackToLegacySkills(t *testing.T) {
+	isolateFromAzdDaemon(t)
+	stubAzdProjectSources(t, azdProjectSources{
+		LegacySkillsEndpoint: "https://legacy-skills.example.com",
+		LegacySkillsFound:    true,
+		LegacyAgentsEndpoint: "https://legacy-agents.example.com",
+		LegacyAgentsFound:    true,
+	}, nil)
+
+	ep, src, err := resolveProjectEndpoint(t.Context(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://legacy-skills.example.com", ep,
+		"with no ai-projects hit, the ai-skills legacy key wins over ai-agents")
+	assert.Equal(t, sourceGlobalConfig, src)
+}
+
+func TestResolveProjectEndpoint_GlobalConfig_FallsBackToLegacyAgents(t *testing.T) {
+	isolateFromAzdDaemon(t)
+	stubAzdProjectSources(t, azdProjectSources{
+		LegacyAgentsEndpoint: "https://legacy-agents.example.com",
+		LegacyAgentsFound:    true,
+	}, nil)
+
+	ep, src, err := resolveProjectEndpoint(t.Context(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://legacy-agents.example.com", ep)
+	assert.Equal(t, sourceGlobalConfig, src)
 }
 
 func TestResolveProjectEndpoint_HostEnvVar(t *testing.T) {
+	isolateFromAzdDaemon(t)
 	t.Setenv("FOUNDRY_PROJECT_ENDPOINT", "https://host.example.com")
 
-	ep, src, err := resolveProjectEndpoint(context.Background(), "")
+	ep, src, err := resolveProjectEndpoint(t.Context(), "")
 	require.NoError(t, err)
-	require.Equal(t, "https://host.example.com", ep)
-	require.Equal(t, sourceFoundryEnv, src)
+	assert.Equal(t, "https://host.example.com", ep)
+	assert.Equal(t, sourceFoundryEnv, src)
 }
 
 func TestResolveProjectEndpoint_InvalidScheme(t *testing.T) {
@@ -41,15 +137,21 @@ func TestResolveProjectEndpoint_InvalidScheme(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, _, err := resolveProjectEndpoint(context.Background(), tc.endpoint)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.wantMsg)
+			assert.Contains(t, err.Error(), tc.wantMsg)
 		})
 	}
 }
 
 func TestResolveProjectEndpoint_MissingAll(t *testing.T) {
+	isolateFromAzdDaemon(t)
 	t.Setenv("FOUNDRY_PROJECT_ENDPOINT", "")
 
-	_, _, err := resolveProjectEndpoint(context.Background(), "")
+	_, _, err := resolveProjectEndpoint(t.Context(), "")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no Foundry project endpoint resolved")
+	assert.Contains(t, err.Error(), "no Foundry project endpoint resolved")
+
+	var le *azdext.LocalError
+	require.True(t, errors.As(err, &le), "expected a LocalError")
+	assert.Contains(t, le.Suggestion, "azd ai project set",
+		"the dependency-error suggestion should point at the supported `azd ai project set` command")
 }


### PR DESCRIPTION
Fixes #8432.

## Problem

`azd ai project set` writes the endpoint to `extensions.ai-projects.context.endpoint` (the central store described in `azure.ai.projects/AGENTS.md`), but the `azure.ai.skills` and `azure.ai.routines` extensions read from different config keys. So after `azd ai project set …`, `azd ai skill list` and `azd ai routine list` (no `-p` flag) fall through the cascade and error with "no Foundry project endpoint resolved".

The routines extension is most affected because `azure.ai.projects` actively migrates the legacy `extensions.ai-agents.project.context` key — which is the only level-3 source routines currently reads — into the new key.

## Fix

Symmetric change in both extensions: at level 3 of the resolution cascade, read `extensions.ai-projects.context.endpoint` first. Keep the existing legacy keys (`ai-skills`, `ai-agents`) as fallbacks so users with stale configs still resolve.

### `azure.ai.skills`

- Refactor `resolveProjectEndpoint` to use the same `readAzdProjectSourcesFunc` package-level seam routines already has. Makes the level-3 precedence testable without a real azd daemon.
- New level-3 order: `ai-projects` > legacy `ai-skills` > legacy `ai-agents`.
- `--debug` log line when a legacy key is used, nudging users to `azd ai project set`.
- `noProjectEndpointError` suggestion updated to mention `azd ai project set`.

### `azure.ai.routines`

- `projectContextConfigPath` switched to `extensions.ai-projects.context`.
- `legacyAgentsContextPath` added for the existing `ai-agents.project.context` key, read as fallback.
- Level-5 dependency-error suggestion updated to mention `azd ai project set` (the suggestion still referenced the removed `azd ai agent project set`).

### Docs / changelog

- `azure.ai.skills/README.md` "Project endpoint resolution" section and the "Relationship to …" section in `AGENTS.md` now describe the new precedence.
- Unreleased changelog bullets in both extensions describe the new behavior.

## Test plan

- New unit tests in both `endpoint_test.go` files cover precedence: new key preferred over legacy, each legacy key still found when only it is present, azd env beats global config, no source returns the structured error with a suggestion that names `azd ai project set`.
- `go test ./...` and `golangci-lint run ./...` green in both extensions.
- `cspell` clean on all changed files.
