### PR TITLE
[azure.ai.agents] Fix 403 preview_feature_required on hosted agent deploy

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
@@ -363,6 +363,11 @@ func (c *AgentClient) CreateAgentVersion(ctx context.Context, agentName string, 
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
+	// Opt-in to the hosted-agents preview feature. The Foundry v1 endpoint
+	// gates POST /agents/{name}/versions with definition.kind=="hosted" behind
+	// this header and returns HTTP 403 (preview_feature_required) without it.
+	req.Raw().Header.Set("Foundry-Features", "HostedAgents=V1Preview")
+
 	if err := req.SetBody(streaming.NopCloser(bytes.NewReader(payload)), "application/json"); err != nil {
 		return nil, fmt.Errorf("failed to set request body: %w", err)
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
@@ -772,3 +772,39 @@ func TestZipDeployRequest_NoAgentNameHeader_OnUpdate(t *testing.T) {
 	require.Equal(t, "CodeAgents=V1Preview,HostedAgents=V1Preview", transport.lastReq.Header.Get("Foundry-Features"))
 	require.Equal(t, "sha", transport.lastReq.Header.Get("x-ms-code-zip-sha256"))
 }
+
+func TestCreateAgentVersion_SetsHostedAgentsPreviewHeader(t *testing.T) {
+	// The Foundry v1 endpoint gates POST /agents/{name}/versions on the
+	// HostedAgents=V1Preview opt-in header and returns 403 preview_feature_required
+	// without it. Make sure the client always sends the header so callers don't
+	// silently regress to the pre-v1 (preview-API-version) behavior.
+	versionResp := `{
+		"object": "agent.version",
+		"id": "test-agent:1",
+		"name": "test-agent",
+		"version": "1"
+	}`
+	transport := &capturingTransport{statusCode: http.StatusCreated, respBody: versionResp}
+	client := newTestClient("https://test.example.com/api/projects/proj", transport)
+
+	desc := "test desc"
+	req := &CreateAgentVersionRequest{Description: &desc}
+
+	_, err := client.CreateAgentVersion(context.Background(), "test-agent", req, "v1")
+	require.NoError(t, err)
+
+	require.NotNil(t, transport.lastReq, "expected request to be captured")
+	require.Equal(t, http.MethodPost, transport.lastReq.Method)
+	require.Equal(
+		t,
+		"https://test.example.com/api/projects/proj/agents/test-agent/versions",
+		transport.lastReq.URL.Scheme+"://"+transport.lastReq.URL.Host+transport.lastReq.URL.Path,
+	)
+	require.Equal(t, "v1", transport.lastReq.URL.Query().Get("api-version"))
+	require.Equal(
+		t,
+		"HostedAgents=V1Preview",
+		transport.lastReq.Header.Get("Foundry-Features"),
+		"CreateAgentVersion must opt in to HostedAgents=V1Preview on the v1 endpoint",
+	)
+}


### PR DESCRIPTION
Fixes #8442

## Bug

`azd deploy` fails for container (hosted) agents with:

```
RESPONSE 403: 403 Forbidden
ERROR CODE: preview_feature_required
{
  "error": {
    "code": "preview_feature_required",
    "message": "Hosted agents is in preview. This operation requires the following opt-in preview feature(s): HostedAgents=V1Preview. Include the 'Foundry-Features: HostedAgents=V1Preview' header in your request."
  }
}
```

## Root cause

PR #8347 (`[azure.ai.agents] Use v1 for endpoint requests`) switched the API version used by hosted-agent management calls in `service_target_agent.go` from `agentAPIVersion` (= `"2025-11-15-preview"`) to `agent_api.AgentEndpointAPIVersion` (= `"v1"`).

The preview API version had implicitly satisfied the Foundry preview-feature gate, so the omission of `Foundry-Features: HostedAgents=V1Preview` from `CreateAgentVersion` had no visible effect. The `v1` endpoint enforces the gate explicitly: `POST /agents/{name}/versions` with `definition.kind: "hosted"` now returns HTTP 403 `preview_feature_required` unless the caller sends the header.

## Verification

Direct API probes against a live Foundry project. Same URL/body/auth, only `api-version` and header differ:

| `api-version` | `Foundry-Features` header | Status |
|---|---|---|
| `2025-11-15-preview` | none | **200** |
| `v1` | none | **403** `preview_feature_required` |
| `v1` | `HostedAgents=V1Preview` | **200** |

## Scope

Only `CreateAgentVersion` needs the fix. Sibling v1 management calls (`GetAgent`, `GetAgentVersion`, `ListAgents`, `ListAgentVersions`, `PatchAgent`) were probed against the same live project without the header and all returned 200 (or unrelated errors). The preview gate is currently only enforced on the write path that creates a new hosted resource.

## Changes

- `internal/pkg/agents/agent_api/operations.go`: Set `Foundry-Features: HostedAgents=V1Preview` on `CreateAgentVersion` requests. One line + comment.
- `internal/pkg/agents/agent_api/operations_test.go`: Add `TestCreateAgentVersion_SetsHostedAgentsPreviewHeader` asserting the header is always present.

## Validation

- `go build ./...` -- pass
- `go test ./... -short` -- all packages pass, including the new test
- `gofmt -l` -- clean
- `go vet` -- clean
- `golangci-lint run` -- 0 issues
- `cspell` (Go + misc configs) -- clean
- `copyright-check.sh` -- clean
