### PR TITLE
Fix azd auth status reporting unauthenticated in Cloud Shell

### DIFF
--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -1462,6 +1462,11 @@ func (m *Manager) LogInDetails(ctx context.Context) (*LogInDetails, error) {
 
 	currentUser, err := readUserProperties(cfg)
 	if err != nil {
+		// In Cloud Shell azd uses the ambient credential, so report that user
+		// rather than treating the session as unauthenticated.
+		if runcontext.IsRunningInCloudShell() {
+			return m.cloudShellLogInDetails(ctx)
+		}
 		return nil, ErrNoCurrentUser
 	}
 
@@ -1486,6 +1491,21 @@ func (m *Manager) LogInDetails(ctx context.Context) (*LogInDetails, error) {
 	}
 
 	return nil, ErrNoCurrentUser
+}
+
+// cloudShellLogInDetails reports the Cloud Shell user, derived from the ambient
+// credential. The session is always a valid user, so an empty account (no
+// username claim) is not an error.
+func (m *Manager) cloudShellLogInDetails(ctx context.Context) (*LogInDetails, error) {
+	claims, err := m.ClaimsForCurrentUser(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("fetching claims for Cloud Shell user: %w", err)
+	}
+
+	return &LogInDetails{
+		LoginType: EmailLoginType,
+		Account:   strings.TrimSpace(claims.DisplayUsername()),
+	}, nil
 }
 
 type AuthSource string

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -1463,11 +1463,16 @@ func (m *Manager) LogInDetails(ctx context.Context) (*LogInDetails, error) {
 	currentUser, err := readUserProperties(cfg)
 	if err != nil {
 		// In Cloud Shell azd uses the ambient credential, so report that user
-		// rather than treating the session as unauthenticated.
-		if runcontext.IsRunningInCloudShell() {
-			return m.cloudShellLogInDetails(ctx)
+		// rather than treating the session as unauthenticated. Only fall back
+		// when there is genuinely no logged-in user; other errors (e.g. corrupted
+		// stored user properties) should surface so they aren't silently hidden.
+		if errors.Is(err, ErrNoCurrentUser) {
+			if runcontext.IsRunningInCloudShell() {
+				return m.cloudShellLogInDetails(ctx)
+			}
+			return nil, ErrNoCurrentUser
 		}
-		return nil, ErrNoCurrentUser
+		return nil, fmt.Errorf("reading current user properties: %w", err)
 	}
 
 	if currentUser.HomeAccountID != nil {

--- a/cli/azd/pkg/auth/manager.go
+++ b/cli/azd/pkg/auth/manager.go
@@ -1402,6 +1402,9 @@ type LogInDetails struct {
 // return the account name from the az CLI. When external authentication is
 // configured, it will acquire a token from the external auth endpoint (an
 // outbound HTTP call) and derive the account identifier from the token claims.
+// When running in Azure Cloud Shell and no azd-managed user is logged in,
+// it derives the account from the ambient Cloud Shell credential and reports
+// an authenticated user.
 func (m *Manager) LogInDetails(ctx context.Context) (*LogInDetails, error) {
 	if m.UseExternalAuth() {
 		claims, err := m.ClaimsForCurrentUser(ctx, nil)

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -499,6 +499,7 @@ func TestLogInDetails(t *testing.T) {
 		_, err := m.LogInDetails(t.Context())
 		require.Error(t, err)
 		require.NotErrorIs(t, err, ErrNoCurrentUser)
+		require.ErrorContains(t, err, "reading current user properties")
 	})
 
 	t.Run("external auth - error when token has no usable account identifier", func(t *testing.T) {

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -413,6 +413,71 @@ func TestLogInDetails(t *testing.T) {
 		require.Equal(t, "user@contoso.com", details.Account)
 	})
 
+	t.Run("cloud shell - returns user login type from token claims", func(t *testing.T) {
+		t.Setenv(runcontext.AzdInCloudShellEnvVar, "1")
+
+		// Build an access token with a username claim and mock the Cloud Shell
+		// token endpoint to return it.
+		token := buildTestJWT(t, map[string]any{
+			"unique_name": "user@contoso.com",
+			"oid":         "oid-abc",
+			"tid":         "tenant-xyz",
+		})
+
+		mockContext := mocks.NewMockContext(t.Context())
+		mockContext.HttpClient.When(func(request *http.Request) bool {
+			return request.URL.String() == "http://localhost:50342/oauth2/token"
+		}).Respond(&http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(bytes.NewBufferString(
+				fmt.Sprintf(`{"access_token":"%s","expires_on":"4070908800"}`, token))),
+		})
+
+		m := Manager{
+			configManager:     newMemoryConfigManager(),
+			userConfigManager: newMemoryUserConfigManager(),
+			httpClient:        mockContext.HttpClient,
+			cloud:             cloud.AzurePublic(),
+		}
+
+		details, err := m.LogInDetails(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, EmailLoginType, details.LoginType)
+		require.Equal(t, "user@contoso.com", details.Account)
+	})
+
+	t.Run("cloud shell - authenticated even when token has no username claim", func(t *testing.T) {
+		t.Setenv(runcontext.AzdInCloudShellEnvVar, "1")
+
+		// A Cloud Shell session is always a valid authenticated user, even if
+		// the token does not expose a username claim.
+		token := buildTestJWT(t, map[string]any{
+			"oid": "oid-abc",
+			"tid": "tenant-xyz",
+		})
+
+		mockContext := mocks.NewMockContext(t.Context())
+		mockContext.HttpClient.When(func(request *http.Request) bool {
+			return request.URL.String() == "http://localhost:50342/oauth2/token"
+		}).Respond(&http.Response{
+			StatusCode: http.StatusOK,
+			Body: io.NopCloser(bytes.NewBufferString(
+				fmt.Sprintf(`{"access_token":"%s","expires_on":"4070908800"}`, token))),
+		})
+
+		m := Manager{
+			configManager:     newMemoryConfigManager(),
+			userConfigManager: newMemoryUserConfigManager(),
+			httpClient:        mockContext.HttpClient,
+			cloud:             cloud.AzurePublic(),
+		}
+
+		details, err := m.LogInDetails(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, EmailLoginType, details.LoginType)
+		require.Empty(t, details.Account)
+	})
+
 	t.Run("external auth - error when token has no usable account identifier", func(t *testing.T) {
 		// Build a JWT token with no username claims
 		token := buildTestJWT(t, map[string]any{

--- a/cli/azd/pkg/auth/manager_test.go
+++ b/cli/azd/pkg/auth/manager_test.go
@@ -478,6 +478,29 @@ func TestLogInDetails(t *testing.T) {
 		require.Empty(t, details.Account)
 	})
 
+	t.Run("cloud shell - corrupted user properties surface error instead of fallback", func(t *testing.T) {
+		t.Setenv(runcontext.AzdInCloudShellEnvVar, "1")
+
+		// A stored currentUser value that cannot be unmarshalled into userProperties
+		// represents real config corruption. It must surface as an error rather than
+		// being silently masked by the Cloud Shell fallback.
+		userCfg := config.NewEmptyConfig()
+		require.NoError(t, userCfg.Set(currentUserKey, "not-an-object"))
+
+		userCfgMgr := newMemoryUserConfigManager()
+		require.NoError(t, userCfgMgr.Save(userCfg))
+
+		m := Manager{
+			configManager:     newMemoryConfigManager(),
+			userConfigManager: userCfgMgr,
+			cloud:             cloud.AzurePublic(),
+		}
+
+		_, err := m.LogInDetails(t.Context())
+		require.Error(t, err)
+		require.NotErrorIs(t, err, ErrNoCurrentUser)
+	})
+
 	t.Run("external auth - error when token has no usable account identifier", func(t *testing.T) {
 		// Build a JWT token with no username claims
 		token := buildTestJWT(t, map[string]any{


### PR DESCRIPTION
Contributes to #8458

This PR fixes azd incorrectly reporting an unauthenticated state in Azure Cloud Shell, even though Cloud Shell provides an ambient managed credential that azd already uses for token acquisition.

**Without changes:**
<img width="676" height="76" alt="image" src="https://github.com/user-attachments/assets/ce8fadbe-c532-4ccd-8d52-bb728717c0cd" />

**With changes:**

<img width="824" height="382" alt="image" src="https://github.com/user-attachments/assets/8b20e682-256e-4bfd-bb45-0dc3c3fbff71" />

## Root cause

`auth.Manager.LogInDetails()` was the only user-state auth method missing a Cloud Shell fallback. Its siblings `CredentialForCurrentUser` and `GetLoggedInServicePrincipalTenantID` already fall back to the ambient Cloud Shell credential when no azd-managed user is logged in. `CredentialForCurrentUser` gates that fallback on `errors.Is(err, ErrNoCurrentUser)`, whereas `GetLoggedInServicePrincipalTenantID` currently falls back on any error from `readUserProperties`. `LogInDetails` had no fallback at all and returned the error, because in Cloud Shell the user never runs `azd auth login` and therefore has no stored user properties.

## Impact

That single gap surfaced as two distinct, confusing failures in Cloud Shell:

- `azd provision` failed during parameter loading, because the Bicep provider calls `CurrentPrincipalType`, which calls `LogInDetails` and propagated the error as "fetching current principal type".
- `azd ai agent init` blocked with a "not logged in" message, because it gates on parsing `azd auth status --output json`, which reported `unauthenticated` for the same reason.

Both flows actually work in Cloud Shell once the underlying login-state check is corrected, so no extension-side change is required.

## Fix

The fix adds a Cloud Shell fallback to `LogInDetails` that mirrors the existing pattern in the other auth methods. When no user is logged in via azd's own flow but the process is running in Cloud Shell, it derives the identity from the ambient credential and reports a User (email) login, populating the account from the token claims on a best-effort basis. An empty account is intentionally not treated as an error, since a Cloud Shell session is always a valid authenticated user and the principal type is what downstream callers such as `CurrentPrincipalType` actually depend on.

Consistent with `CredentialForCurrentUser`, the fallback is gated on `errors.Is(err, ErrNoCurrentUser)` so that other failures (e.g. corrupted stored user properties) surface instead of being silently masked. Tightening `GetLoggedInServicePrincipalTenantID` to do the same is left as a follow-up.

As a result, `azd auth status` now reports authenticated in Cloud Shell, `azd provision` resolves the principal type correctly, and `azd ai agent init` proceeds.

## Testing

Test coverage was added to `TestLogInDetails` for both the case where the Cloud Shell token exposes a username claim and the case where it does not, asserting that the session is reported as an authenticated User login in both, plus a case verifying that a non-`ErrNoCurrentUser` failure is surfaced rather than masked. Existing auth, provisioning, and command tests continue to pass, including under `-race`.
