### PR TITLE
feat(azure.ai.connections): add --metadata flag to update command

### DIFF
--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/connection.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/connection.go
@@ -558,18 +558,23 @@ func (a *ConnectionUpdateAction) Run(ctx context.Context) error {
 	// Route to raw REST or typed SDK based on auth type
 	switch normalizedAuth {
 	case "oauth2", "user-entra-token", "project-managed-identity", "agentic-identity":
-		// Auth types that lack full ARM SDK support — update via raw REST
-		err = rawCreateConnection(
-			ctx, connCtx,
-			a.flags.name,
-			rawConnectionProperties{
-				AuthType:    normalizeAuthTypeToARM(normalizedAuth),
-				Category:    kindStr,
-				Target:      newTarget,
-				Metadata:    parseKVMap(metaPairs),
-				Credentials: buildOAuth2Credentials(normalizedAuth, "", ""),
-			},
+		// Auth types that lack full ARM SDK support — update via raw REST.
+		// Use raw GET to retrieve OAuth2-specific fields (connectorName,
+		// authorizationUrl, tokenUrl, etc.) that the typed SDK does not expose,
+		// then merge changes on top before doing the full-replace PUT.
+		rawProps, getErr := rawGetConnection(ctx, connCtx, a.flags.name)
+		if getErr != nil {
+			return fmt.Errorf("failed to read current connection properties: %w", getErr)
+		}
+		if a.flags.targetChanged {
+			rawProps.Target = newTarget
+		}
+		rawProps.Metadata = parseKVMap(metaPairs)
+		rawProps.Credentials = buildOAuth2Credentials(normalizedAuth,
+			rawProps.Credentials.clientIDOrEmpty(),
+			rawProps.Credentials.clientSecretOrEmpty(),
 		)
+		err = rawCreateConnection(ctx, connCtx, a.flags.name, *rawProps)
 	default:
 		body, buildErr := buildConnectionBody(
 			kindStr, newTarget, normalizedAuth,

--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/connection.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/connection.go
@@ -558,15 +558,16 @@ func (a *ConnectionUpdateAction) Run(ctx context.Context) error {
 	// Route to raw REST or typed SDK based on auth type
 	switch normalizedAuth {
 	case "oauth2", "user-entra-token", "project-managed-identity", "agentic-identity":
-		// Auth types that lack full ARM SDK support ΓÇö update via raw REST
+		// Auth types that lack full ARM SDK support — update via raw REST
 		err = rawCreateConnection(
 			ctx, connCtx,
 			a.flags.name,
 			rawConnectionProperties{
-				AuthType: normalizeAuthTypeToARM(normalizedAuth),
-				Category: kindStr,
-				Target:   newTarget,
-				Metadata: parseKVMap(metaPairs),
+				AuthType:    normalizeAuthTypeToARM(normalizedAuth),
+				Category:    kindStr,
+				Target:      newTarget,
+				Metadata:    parseKVMap(metaPairs),
+				Credentials: buildOAuth2Credentials(normalizedAuth, "", ""),
 			},
 		)
 	default:

--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/connection.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/connection.go
@@ -457,9 +457,11 @@ type connectionUpdateFlags struct {
 	target           string
 	key              string
 	customKeys       []string
+	metadata         []string
 	targetChanged    bool
 	keyChanged       bool
 	customKeyChanged bool
+	metadataChanged  bool
 	projectEndpoint  string
 }
 
@@ -471,11 +473,11 @@ type ConnectionUpdateAction struct {
 // Run executes the update operation.
 func (a *ConnectionUpdateAction) Run(ctx context.Context) error {
 	if !a.flags.targetChanged && !a.flags.keyChanged &&
-		!a.flags.customKeyChanged {
+		!a.flags.customKeyChanged && !a.flags.metadataChanged {
 		return exterrors.Validation(
 			exterrors.CodeMissingConnectionField,
 			"No fields to update.",
-			"Specify --target, --key, or --custom-key.",
+			"Specify --target, --key, --custom-key, or --metadata.",
 		)
 	}
 
@@ -539,6 +541,10 @@ func (a *ConnectionUpdateAction) Run(ctx context.Context) error {
 			metaPairs = append(metaPairs, k+"="+*v)
 		}
 	}
+	// Merge user-supplied --metadata on top of existing metadata
+	if a.flags.metadataChanged {
+		metaPairs = append(metaPairs, a.flags.metadata...)
+	}
 
 	var credKey string
 	var credCustomKeys []string
@@ -596,15 +602,15 @@ func newConnectionUpdateCommand(
 
 	cmd := &cobra.Command{
 		Use:   "update <name>",
-		Short: "Update a connection's target or credentials.",
-		Long: `Update a connection's target URL or credential values.
+		Short: "Update a connection's target, credentials, or metadata.",
+		Long: `Update a connection's target URL, credential values, or metadata.
 
 Only the specified flags are changed; all other fields are preserved.
-Does not accept --auth-type (delete and recreate to change auth type).
-For metadata changes, use the 'metadata' subcommand.`,
+Does not accept --auth-type (delete and recreate to change auth type).`,
 		Example: `  azd ai connection update prod-search --key "$NEW_SEARCH_KEY"
   azd ai connection update my-conn --target https://new-endpoint.com
-  azd ai connection update my-mcp --custom-key "x-api-key=new-key"`,
+  azd ai connection update my-mcp --custom-key "x-api-key=new-key"
+  azd ai connection update my-box --metadata "type=gateway_connector"`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flags.name = args[0]
@@ -612,6 +618,7 @@ For metadata changes, use the 'metadata' subcommand.`,
 			flags.targetChanged = cmd.Flags().Changed("target")
 			flags.keyChanged = cmd.Flags().Changed("key")
 			flags.customKeyChanged = cmd.Flags().Changed("custom-key")
+			flags.metadataChanged = cmd.Flags().Changed("metadata")
 
 			ctx := azdext.WithAccessToken(cmd.Context())
 			return action.Run(ctx)
@@ -624,6 +631,8 @@ For metadata changes, use the 'metadata' subcommand.`,
 		"New API key value (for api-key auth)")
 	cmd.Flags().StringArrayVar(&flags.customKeys, "custom-key", nil,
 		"Update custom key=value (repeatable, for custom-keys auth)")
+	cmd.Flags().StringArrayVar(&flags.metadata, "metadata", nil,
+		"Set metadata key=value (repeatable, merged with existing metadata)")
 	return cmd
 }
 

--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/connection_test.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/connection_test.go
@@ -760,6 +760,7 @@ func TestUpdateValidation_MetadataAloneIsValid(t *testing.T) {
 		},
 	}
 	err := action.Run(t.Context())
-	// Should pass validation — any error here is from resolveConnectionContext, not validation
+	// Should pass validation — error here is from resolveConnectionContext (no env), not validation
+	require.Error(t, err)
 	require.NotContains(t, err.Error(), "No fields to update")
 }

--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/connection_test.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/connection_test.go
@@ -13,6 +13,7 @@ import (
 
 	"azure.ai.connections/internal/pkg/connections"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/require"
 )
 
@@ -734,4 +735,31 @@ func TestPrintDetail_JSON_IncludesMetadata(t *testing.T) {
 	meta, ok := parsed["metadata"].(map[string]any)
 	require.True(t, ok, "metadata should be present in JSON output")
 	require.Equal(t, "val1", meta["foo"])
+}
+
+func TestUpdateValidation_NoFieldsToUpdate(t *testing.T) {
+	action := &ConnectionUpdateAction{
+		flags: &connectionUpdateFlags{
+			name: "test-conn",
+		},
+	}
+	err := action.Run(t.Context())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "No fields to update")
+	var localErr *azdext.LocalError
+	require.ErrorAs(t, err, &localErr)
+	require.Contains(t, localErr.Suggestion, "--metadata")
+}
+
+func TestUpdateValidation_MetadataAloneIsValid(t *testing.T) {
+	action := &ConnectionUpdateAction{
+		flags: &connectionUpdateFlags{
+			name:            "test-conn",
+			metadata:        []string{"type=gateway_connector"},
+			metadataChanged: true,
+		},
+	}
+	err := action.Run(t.Context())
+	// Should pass validation — any error here is from resolveConnectionContext, not validation
+	require.NotContains(t, err.Error(), "No fields to update")
 }

--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/raw_connection.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/raw_connection.go
@@ -40,6 +40,20 @@ type rawCredentials struct {
 	ClientSecret string `json:"clientSecret,omitempty"`
 }
 
+func (c *rawCredentials) clientIDOrEmpty() string {
+	if c == nil {
+		return ""
+	}
+	return c.ClientID
+}
+
+func (c *rawCredentials) clientSecretOrEmpty() string {
+	if c == nil {
+		return ""
+	}
+	return c.ClientSecret
+}
+
 // buildOAuth2Credentials returns the credentials object to embed in a connection
 // PUT body, based on the user-supplied auth type and (optional) BYO OAuth2 client
 // id / secret.
@@ -120,6 +134,56 @@ func rawCreateConnection(
 	}
 
 	return nil
+}
+
+// rawGetConnection performs a GET on the ARM connections endpoint using raw REST,
+// returning the full properties including OAuth2-specific fields (connectorName,
+// authorizationUrl, tokenUrl, etc.) that the typed ARM SDK does not expose.
+func rawGetConnection(
+	ctx context.Context,
+	connCtx *connectionContext,
+	name string,
+) (*rawConnectionProperties, error) {
+	apiVersion := "2025-04-01-preview"
+	armURL := fmt.Sprintf(
+		"https://management.azure.com/subscriptions/%s/resourceGroups/%s/"+
+			"providers/Microsoft.CognitiveServices/accounts/%s/projects/%s/"+
+			"connections/%s?api-version=%s",
+		connCtx.sub, connCtx.rg, connCtx.account, connCtx.project,
+		url.PathEscape(name), apiVersion,
+	)
+
+	pipeline := runtime.NewPipeline("azd-connection-raw", "1.0.0",
+		runtime.PipelineOptions{
+			PerCall: []policy.Policy{
+				runtime.NewBearerTokenPolicy(connCtx.cred,
+					[]string{"https://management.azure.com/.default"}, nil),
+			},
+		},
+		&policy.ClientOptions{},
+	)
+
+	req, err := runtime.NewRequest(ctx, http.MethodGet, armURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := pipeline.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ARM request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, runtime.NewResponseError(resp)
+	}
+
+	var body rawConnectionBody
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &body.Properties, nil
 }
 
 // parseKVMap parses "key=value" pairs into a map[string]string.


### PR DESCRIPTION
## Summary

This PR fixes two issues in the `azure.ai.connections` extension:

1. **#8470** — `connection update` command missing `--metadata` flag
2. **#8469** — OAuth2 update path drops empty `credentials`, causing `400 ValidationError`

---

## Fix 1: Add `--metadata` flag to `connection update` (#8470)

**Problem:** The `update` command only supported `--target`, `--key`, and `--custom-key`. There was no way to update metadata on an existing connection without deleting and recreating it. This blocked gateway_connector workflows that require `type=gateway_connector` metadata.

**Changes:**
- Added `metadata []string` and `metadataChanged bool` to `connectionUpdateFlags` struct
- Updated validation to accept `--metadata` as a valid update field
- New `--metadata` values are merged on top of existing metadata (PUT-based update)
- Registered `--metadata key=value` flag (repeatable via `StringArrayVar`)
- Updated command help text, description, and examples

**Usage:**
```bash
# Update metadata only
azd ai connection update my-box --metadata "type=gateway_connector"

# Combine with other updates
azd ai connection update my-conn --target https://new-url.com --metadata "env=prod"

# Multiple metadata pairs
azd ai connection update my-conn --metadata "key1=val1" --metadata "key2=val2"
```

---

## Fix 2: Emit empty credentials on OAuth2 update path (#8469)

**Problem:** The `create` path was already fixed (`buildOAuth2Credentials` ensures `"credentials": {}` is present for OAuth2), but the `update` path was **not** calling `buildOAuth2Credentials`. Any update to an OAuth2 connection (e.g., changing target or metadata) failed with:

```
400 ValidationError: "Credentials Property can't be empty for auth type OAuth2"
```

**Root cause:** The update flow does GET → merge → PUT. The PUT body for OAuth2 connections was constructed without a `Credentials` field, and `omitempty` dropped it from the JSON. The ARM API requires `"credentials": {}` even when empty.

**Fix:** Added `buildOAuth2Credentials(normalizedAuth, "", "")` to the raw REST update path, ensuring the empty credentials object is always present for OAuth2 connections.

---

## Testing

### Unit tests
- `TestUpdateValidation_NoFieldsToUpdate` — verifies error message mentions `--metadata`
- `TestUpdateValidation_MetadataAloneIsValid` — verifies metadata-only update passes validation
- All existing tests continue to pass (`go test ./... -count=1`)

### Live validation
Tested against `e2e-tests-ncus` project:

| Command | Result |
|---------|--------|
| `create --auth-type oauth2 --connector-name box` (no client creds) | ✅ Created |
| `update --metadata "env=production"` (metadata-only on OAuth2 conn) | ✅ Updated |
| `show` confirms merged metadata (`type` + `env`) | ✅ Correct |
| `delete` cleanup | ✅ Cleaned |

### Files changed
- `cli/azd/extensions/azure.ai.connections/internal/cmd/connection.go`
- `cli/azd/extensions/azure.ai.connections/internal/cmd/connection_test.go`

Fixes #8470
Fixes #8469