### PR TITLE
workaround: api-version query param for non-conformant openai agent endpoints (azure.ai.agents)

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/agent_endpoint.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/agent_endpoint.go
@@ -27,9 +27,12 @@ const agentEndpointHint = "run `azd ai agent show` to see the agent endpoint URL
 //
 //	[1] project name (URL-escaped),
 //	[2] agent name (URL-escaped),
-//	[3] protocol tail ("invocations" or "openai/v1/responses").
+//	[3] protocol tail ("invocations" or "openai/responses").
+//
+// The "openai/v1/responses" tail is also accepted and rebuilt to the canonical
+// query-parameter form when invoked.
 var agentEndpointPathRegex = regexp.MustCompile(
-	`^/api/projects/([^/]+)/agents/([^/]+)/endpoint/protocols/(invocations|openai/v1/responses)/?$`,
+	`^/api/projects/([^/]+)/agents/([^/]+)/endpoint/protocols/(invocations|openai/v1/responses|openai/responses)/?$`,
 )
 
 // parsedAgentEndpoint describes a deployed agent invocation endpoint.
@@ -47,7 +50,7 @@ type parsedAgentEndpoint struct {
 // Accepted shapes:
 //
 //	https://<acct>.services.ai.azure.com/api/projects/<proj>/agents/<name>/endpoint/protocols/invocations[?api-version=…]
-//	https://<acct>.services.ai.azure.com/api/projects/<proj>/agents/<name>/endpoint/protocols/openai/v1/responses
+//	https://<acct>.services.ai.azure.com/api/projects/<proj>/agents/<name>/endpoint/protocols/openai/responses?api-version=v1
 //
 // The host must be a `*.services.ai.azure.com` Foundry host. The path must include the
 // protocol-specific suffix; the protocol is derived from the URL.
@@ -131,7 +134,7 @@ func parseAgentEndpoint(rawURL string) (*parsedAgentEndpoint, error) {
 	switch protocolTail {
 	case "invocations":
 		protocol = agent_api.AgentProtocolInvocations
-	case "openai/v1/responses":
+	case "openai/responses", "openai/v1/responses":
 		protocol = agent_api.AgentProtocolResponses
 	}
 
@@ -160,11 +163,15 @@ func parseAgentEndpoint(rawURL string) (*parsedAgentEndpoint, error) {
 	}, nil
 }
 
-// buildResponsesURL builds the Foundry "openai/v1/responses" protocol URL for an agent.
-func buildResponsesURL(projectEndpoint, agentName string) string {
+// buildResponsesURL builds the Foundry "openai/responses" protocol URL for an agent.
+// apiVersion is URL-encoded so unusual characters cannot break out of the query value.
+func buildResponsesURL(projectEndpoint, agentName, apiVersion string) string {
+	if apiVersion == "" {
+		apiVersion = DefaultAgentAPIVersion
+	}
 	return fmt.Sprintf(
-		"%s/agents/%s/endpoint/protocols/openai/v1/responses",
-		projectEndpoint, agentName,
+		"%s/agents/%s/endpoint/protocols/openai/responses?api-version=%s",
+		projectEndpoint, agentName, url.QueryEscape(apiVersion),
 	)
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/agent_endpoint_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/agent_endpoint_test.go
@@ -45,6 +45,14 @@ func TestParseAgentEndpoint(t *testing.T) {
 			wantProto: agent_api.AgentProtocolResponses,
 		},
 		{
+			name:       "responses canonical (openai/responses?api-version=v1)",
+			raw:        "https://acct.services.ai.azure.com/api/projects/proj/agents/echo/endpoint/protocols/openai/responses?api-version=v1",
+			wantProj:   "https://acct.services.ai.azure.com/api/projects/proj",
+			wantAgent:  "echo",
+			wantProto:  agent_api.AgentProtocolResponses,
+			wantAPIVer: "v1",
+		},
+		{
 			name:      "trailing slash tolerated",
 			raw:       "https://acct.services.ai.azure.com/api/projects/proj/agents/hello/endpoint/protocols/invocations/",
 			wantProj:  "https://acct.services.ai.azure.com/api/projects/proj",
@@ -186,7 +194,9 @@ func TestParseAgentEndpoint_RejectsInvalidAgentNames(t *testing.T) {
 }
 
 // TestBuildResponsesURL verifies that the responses URL builder uses the
-// openai/v1 path with no api-version query parameter.
+// openai/responses path with the api-version query parameter, and that the
+// openai/v1/responses input is still accepted and rebuilt to the canonical
+// query-parameter form.
 func TestBuildResponsesURL(t *testing.T) {
 	t.Parallel()
 	parsed, err := parseAgentEndpoint(
@@ -195,8 +205,8 @@ func TestBuildResponsesURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseAgentEndpoint: %v", err)
 	}
-	got := buildResponsesURL(parsed.ProjectEndpoint, parsed.AgentName)
-	want := "https://acct.services.ai.azure.com/api/projects/proj/agents/echo/endpoint/protocols/openai/v1/responses"
+	got := buildResponsesURL(parsed.ProjectEndpoint, parsed.AgentName, parsed.APIVersion)
+	want := "https://acct.services.ai.azure.com/api/projects/proj/agents/echo/endpoint/protocols/openai/responses?api-version=v1"
 	if got != want {
 		t.Errorf("buildResponsesURL = %q, want %q", got, want)
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -444,6 +444,7 @@ func resolveConversationID(
 	projectEndpoint string,
 	bearerToken string,
 	agentName string,
+	apiVersion string,
 	options *agent_api.SessionRequestOptions,
 	legacyKeys ...string,
 ) (string, error) {
@@ -461,7 +462,7 @@ func resolveConversationID(
 	}
 
 	// Create and persist a new conversation for multi-turn memory.
-	newConvID, err := createConversation(ctx, projectEndpoint, agentName, bearerToken, options)
+	newConvID, err := createConversation(ctx, projectEndpoint, agentName, bearerToken, apiVersion, options)
 	if err != nil {
 		return "", fmt.Errorf("failed to create conversation: %w", err)
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -130,7 +130,7 @@ suppressed in raw mode.`,
 
   # Invoke a deployed agent from any directory using the endpoint URL shown by 'azd ai agent show'
   azd ai agent invoke \
-	  --agent-endpoint https://<acct>.services.ai.azure.com/api/projects/<proj>/agents/<name>/endpoint/protocols/openai/v1/responses \
+	  --agent-endpoint https://<acct>.services.ai.azure.com/api/projects/<proj>/agents/<name>/endpoint/protocols/openai/responses?api-version=v1 \
        "Hello!"`,
 		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -906,6 +906,7 @@ func (a *InvokeAction) responsesRemote(ctx context.Context) error {
 			rc.projectEndpoint,
 			rc.bearerToken,
 			rc.name,
+			rc.apiVersion,
 			a.flags.sessionRequestOptions(),
 			rc.legacyKeys()...,
 		)
@@ -920,6 +921,7 @@ func (a *InvokeAction) responsesRemote(ctx context.Context) error {
 			rc.projectEndpoint,
 			rc.name,
 			rc.bearerToken,
+			rc.apiVersion,
 			a.flags.sessionRequestOptions(),
 		)
 		if err != nil {
@@ -945,7 +947,7 @@ func (a *InvokeAction) responsesRemote(ctx context.Context) error {
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	respURL := buildResponsesURL(rc.projectEndpoint, rc.name)
+	respURL := buildResponsesURL(rc.projectEndpoint, rc.name, rc.apiVersion)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, respURL, bytes.NewReader(payload))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
@@ -1627,12 +1629,15 @@ func handleInvocationLRO(
 // createConversation creates a new Foundry conversation for multi-turn memory.
 func createConversation(
 	ctx context.Context,
-	projectEndpoint, agentName, bearerToken string,
+	projectEndpoint, agentName, bearerToken, apiVersion string,
 	options *agent_api.SessionRequestOptions,
 ) (string, error) {
+	if apiVersion == "" {
+		apiVersion = DefaultAgentAPIVersion
+	}
 	convURL := fmt.Sprintf(
-		"%s/agents/%s/endpoint/protocols/openai/v1/conversations",
-		projectEndpoint, agentName,
+		"%s/agents/%s/endpoint/protocols/openai/conversations?api-version=%s",
+		projectEndpoint, agentName, url.QueryEscape(apiVersion),
 	)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, convURL, bytes.NewReader([]byte("{}")))
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
@@ -1004,6 +1004,7 @@ func TestVersionedExplicitConversationPersistsUnderVersionKey(t *testing.T) {
 		projectEndpoint,
 		"token",
 		"hello",
+		"v1",
 		nil,
 	)
 	if err != nil {
@@ -1752,14 +1753,14 @@ func TestCreateConversation(t *testing.T) {
 
 				// Verify path includes the agent name and conversations endpoint
 				wantPath := "/agents/" + tt.agentName +
-					"/endpoint/protocols/openai/v1/conversations"
+					"/endpoint/protocols/openai/conversations"
 				if r.URL.Path != wantPath {
 					t.Errorf("path = %s, want %s", r.URL.Path, wantPath)
 				}
 
-				// OpenAI v1 routes should not include an api-version query parameter.
-				if got := r.URL.Query().Get("api-version"); got != "" {
-					t.Errorf("api-version = %q, want empty", got)
+				// The api-version must travel as a query parameter, not in the route.
+				if got := r.URL.Query().Get("api-version"); got != "v1" {
+					t.Errorf("api-version = %q, want %q", got, "v1")
 				}
 
 				// Verify auth header
@@ -1777,7 +1778,7 @@ func TestCreateConversation(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			id, err := createConversation(t.Context(), srv.URL, tt.agentName, "test-token", nil)
+			id, err := createConversation(t.Context(), srv.URL, tt.agentName, "test-token", "v1", nil)
 
 			if tt.wantErr {
 				if err == nil {
@@ -1817,6 +1818,7 @@ func TestCreateConversation_PropagatesIsolationHeaders(t *testing.T) {
 		srv.URL,
 		"my-agent",
 		"test-token",
+		"v1",
 		&agent_api.SessionRequestOptions{
 			UserIsolationKey: "user-1",
 			ChatIsolationKey: "chat-1",

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/show_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/show_test.go
@@ -158,7 +158,7 @@ func TestPrintAgentVersionJSON_Format(t *testing.T) {
 		AgentVersionObject: version,
 		PlaygroundURL:      "https://ai.azure.com/nextgen/r/test/build/agents/test-agent/build?version=2",
 		Endpoints: map[string]string{
-			"Responses": "https://acct.services.ai.azure.com/api/projects/proj/agents/test-agent/endpoint/protocols/openai/v1/responses",
+			"Responses": "https://acct.services.ai.azure.com/api/projects/proj/agents/test-agent/endpoint/protocols/openai/responses?api-version=v1",
 		},
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -83,7 +83,8 @@ var displayableProtocols = []displayableProtocolEntry{
 // buildResponsesProtocolURL builds the per-agent HTTPS URL for the "responses" protocol.
 func buildResponsesProtocolURL(projectEndpoint, agentName string) string {
 	return fmt.Sprintf(
-		"%s/agents/%s/endpoint/protocols/openai/v1/responses", projectEndpoint, agentName,
+		"%s/agents/%s/endpoint/protocols/openai/responses?api-version=%s",
+		projectEndpoint, agentName, agent_api.AgentEndpointAPIVersion,
 	)
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -459,7 +459,7 @@ func TestRegisterAgentEnvironmentVariables(t *testing.T) {
 	require.Contains(t, envStub.values, "AGENT_MY_SVC_RESPONSES_ENDPOINT")
 	require.Equal(
 		t,
-		"https://proj.azure.com/agents/my-agent/endpoint/protocols/openai/v1/responses",
+		"https://proj.azure.com/agents/my-agent/endpoint/protocols/openai/responses?api-version=v1",
 		envStub.values["AGENT_MY_SVC_RESPONSES_ENDPOINT"],
 	)
 	require.Contains(t, envStub.values, "AGENT_MY_SVC_INVOCATIONS_ENDPOINT")
@@ -570,7 +570,7 @@ func TestDisplayableProtocolFor(t *testing.T) {
 			protocol:        "responses",
 			wantProtocol:    agent_api.AgentProtocolResponses,
 			wantEnvSuffix:   "RESPONSES",
-			wantURLContains: "/agents/my-agent/endpoint/protocols/openai/v1/responses",
+			wantURLContains: "/agents/my-agent/endpoint/protocols/openai/responses?api-version=v1",
 			wantURLScheme:   "https",
 		},
 		{
@@ -651,7 +651,7 @@ func TestAgentInvocationEndpoints(t *testing.T) {
 			expected: []protocolEndpointInfo{
 				{
 					Protocol: "responses",
-					URL:      baseURL + "openai/v1/responses",
+					URL:      baseURL + "openai/responses?api-version=v1",
 				},
 			},
 		},
@@ -690,7 +690,7 @@ func TestAgentInvocationEndpoints(t *testing.T) {
 			expected: []protocolEndpointInfo{
 				{
 					Protocol: "responses",
-					URL:      baseURL + "openai/v1/responses",
+					URL:      baseURL + "openai/responses?api-version=v1",
 				},
 				{
 					Protocol: "invocations",
@@ -796,7 +796,7 @@ func TestDeployArtifacts_HostedAgent_ProtocolEndpoints(t *testing.T) {
 	require.Len(t, artifacts, 2)
 
 	wantResponses := ep +
-		"/agents/test-agent/endpoint/protocols/openai/v1/responses"
+		"/agents/test-agent/endpoint/protocols/openai/responses?api-version=v1"
 	require.Equal(t, wantResponses, artifacts[0].Location)
 	require.Equal(t, "Agent endpoint (responses)", artifacts[0].Metadata["label"])
 	require.Empty(t, artifacts[0].Metadata["note"],
@@ -829,7 +829,7 @@ func TestDeployArtifacts_ResponsesProtocol(t *testing.T) {
 
 	require.Len(t, artifacts, 1)
 	wantURL := ep +
-		"/agents/prompt-agent/endpoint/protocols/openai/v1/responses"
+		"/agents/prompt-agent/endpoint/protocols/openai/responses?api-version=v1"
 	require.Equal(t, wantURL, artifacts[0].Location)
 	require.Equal(t, "Agent endpoint (responses)", artifacts[0].Metadata["label"])
 	require.Contains(t, artifacts[0].Metadata["note"], "invoking the agent")


### PR DESCRIPTION
## Summary

Fixes #8499.

`azd ai agent invoke` was failing against deployed Foundry agents with HTTP 400
`Missing required query parameter: api-version` on both the conversation-creation and
responses calls.

## Root cause

PR #8347 ("[azure.ai.agents] Use v1 for endpoint requests") correctly set
`AgentEndpointAPIVersion = "v1"`, but also moved `v1` into the URL **route path** and
dropped the `?api-version=` query parameter for the `openai/*` protocol surface. The
service expects `v1` as the `api-version` query parameter value, not as a path segment.

## Fix

Restore the query-parameter form while keeping the version value `v1`:

```
.../agents/<name>/endpoint/protocols/openai/conversations?api-version=v1
.../agents/<name>/endpoint/protocols/openai/responses?api-version=v1
```

- `internal/project/service_target_agent.go` - `buildResponsesProtocolURL` (drives
  `azd ai agent show` output and the `*_RESPONSES` env var)
- `internal/cmd/agent_endpoint.go` - regex/switch accept the canonical `openai/responses`
  and, for backward compatibility, the legacy `openai/v1/responses` shape;
  `buildResponsesURL` regained its `apiVersion` argument and always rebuilds the canonical URL
- `internal/cmd/invoke.go` - `createConversation` gained an `apiVersion` parameter;
  `responsesRemote` threads `rc.apiVersion`
- `internal/cmd/helpers.go` - `resolveConversationID` threads `apiVersion` through

The invocations protocol and the `eval_api` `/openai/v1/evals` surface (which still appends
`api-version` separately) are unaffected.

## Validation

- `go build ./...`, `internal/cmd` + `internal/project` tests pass, `golangci-lint` 0 issues,
  `gofmt` clean
- Live: `azd ai agent invoke "hello"` against a deployed agent now returns a streamed
  response with no 400