### PR TITLE
fix(agents): add Foundry-Features header to all data-plane endpoint requests

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -954,6 +954,7 @@ func (a *InvokeAction) responsesRemote(ctx context.Context) error {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+rc.bearerToken)
+	req.Header.Set("Foundry-Features", "HostedAgents=V1Preview")
 	applyIsolationHeaders(req, &a.flags.isolationHeaderFlags)
 	if raw {
 		// Disable Go's transparent gzip handling so the dumped headers and
@@ -1181,6 +1182,7 @@ func (a *InvokeAction) invocationsRemote(ctx context.Context) error {
 	}
 	req.Header.Set("Content-Type", contentTypeForBody(body))
 	req.Header.Set("Authorization", "Bearer "+rc.bearerToken)
+	req.Header.Set("Foundry-Features", "HostedAgents=V1Preview")
 	applyIsolationHeaders(req, &a.flags.isolationHeaderFlags)
 	if raw {
 		// Disable Go's transparent gzip handling so the dumped headers and
@@ -1525,6 +1527,7 @@ func handleInvocationLRO(
 		if bearerToken != "" {
 			req.Header.Set("Authorization", "Bearer "+bearerToken)
 		}
+		req.Header.Set("Foundry-Features", "HostedAgents=V1Preview")
 		options.ApplyHeaders(req.Header)
 		if raw {
 			// Disable Go's transparent gzip handling so the dumped headers
@@ -1645,6 +1648,7 @@ func createConversation(
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+bearerToken)
+	req.Header.Set("Foundry-Features", "HostedAgents=V1Preview")
 	options.ApplyHeaders(req.Header)
 
 	client := &http.Client{Timeout: 30 * time.Second}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
@@ -1664,6 +1664,9 @@ func assertPollRequestsHaveHeaders(
 		if got := r.Header.Get("Authorization"); got != "Bearer token" {
 			t.Errorf("poll %d: Authorization = %q, want Bearer token", pollNumber, got)
 		}
+		if got := r.Header.Get("Foundry-Features"); got != "HostedAgents=V1Preview" {
+			t.Errorf("poll %d: Foundry-Features = %q, want HostedAgents=V1Preview", pollNumber, got)
+		}
 		if got := r.Header.Get(agent_api.AgentUserIsolationKeyHeader); got != wantUser {
 			t.Errorf("poll %d: %s = %q, want %q", pollNumber, agent_api.AgentUserIsolationKeyHeader, got, wantUser)
 		}
@@ -1832,6 +1835,9 @@ func TestCreateConversation_PropagatesIsolationHeaders(t *testing.T) {
 	}
 
 	request := <-reqCh
+	if got := request.Header.Get("Foundry-Features"); got != "HostedAgents=V1Preview" {
+		t.Errorf("Foundry-Features = %q, want HostedAgents=V1Preview", got)
+	}
 	if got := request.Header.Get(agent_api.AgentUserIsolationKeyHeader); got != "user-1" {
 		t.Errorf("%s = %q, want user-1", agent_api.AgentUserIsolationKeyHeader, got)
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
@@ -816,6 +816,7 @@ func (c *AgentClient) GetAgentSessionLogStream(
 
 	req.Header.Set("Authorization", "Bearer "+token.Token)
 	req.Header.Set("User-Agent", fmt.Sprintf("azd-ext-azure-ai-agents/%s", version.Version))
+	req.Header.Set("Foundry-Features", "HostedAgents=V1Preview")
 	options.ApplyHeaders(req.Header)
 
 	httpClient := &http.Client{}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
@@ -1190,7 +1190,7 @@ func (c *AgentClient) CreateSession(
 		return nil, fmt.Errorf("failed to set request body: %w", err)
 	}
 
-	req.Raw().Header.Set("Foundry-Features", "AgentEndpoints=V1Preview")
+	req.Raw().Header.Set("Foundry-Features", "HostedAgents=V1Preview")
 	options.ApplyHeaders(req.Raw().Header)
 
 	resp, err := c.pipeline.Do(req)
@@ -1241,7 +1241,7 @@ func (c *AgentClient) GetSession(
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Raw().Header.Set("Foundry-Features", "AgentEndpoints=V1Preview")
+	req.Raw().Header.Set("Foundry-Features", "HostedAgents=V1Preview")
 	options.ApplyHeaders(req.Raw().Header)
 
 	resp, err := c.pipeline.Do(req)
@@ -1292,7 +1292,7 @@ func (c *AgentClient) DeleteSession(
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Raw().Header.Set("Foundry-Features", "AgentEndpoints=V1Preview")
+	req.Raw().Header.Set("Foundry-Features", "HostedAgents=V1Preview")
 	options.ApplyHeaders(req.Raw().Header)
 
 	resp, err := c.pipeline.Do(req)
@@ -1341,7 +1341,7 @@ func (c *AgentClient) ListSessions(
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Raw().Header.Set("Foundry-Features", "AgentEndpoints=V1Preview")
+	req.Raw().Header.Set("Foundry-Features", "HostedAgents=V1Preview")
 	options.ApplyHeaders(req.Raw().Header)
 
 	resp, err := c.pipeline.Do(req)

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
@@ -391,6 +391,7 @@ func TestSessionLifecycleOperations_ApplyIsolationHeaders(t *testing.T) {
 
 			require.NoError(t, tt.call(client, options))
 			require.Len(t, transport.requests, 1)
+			require.Equal(t, "HostedAgents=V1Preview", transport.requests[0].Header.Get("Foundry-Features"))
 			requireIsolationHeaders(t, transport.requests[0], "user-1", "chat-1", tt.wantSession)
 		})
 	}
@@ -555,6 +556,7 @@ func TestGetAgentSessionLogStream_ApplyIsolationHeaders(t *testing.T) {
 	}
 	require.NotNil(t, request)
 	require.Equal(t, "Bearer test-token", request.Header.Get("Authorization"))
+	require.Equal(t, "HostedAgents=V1Preview", request.Header.Get("Foundry-Features"))
 	requireIsolationHeaders(t, request, "user-1", "chat-1", "")
 }
 


### PR DESCRIPTION
## Summary

After PR #8347 switched agent endpoints from api-version=2025-11-15-preview to v1, the invoke and session commands lost implicit preview-gate satisfaction and now need the explicit Foundry-Features: HostedAgents=V1Preview header. PR #8441 only fixed the deploy path, so this PR adds/corrects the header across all remaining data-plane call sites.

Fixes #8473

## Root Cause

1. **PR #8347** switched all agent endpoint calls to api-version=v1. The old preview version implicitly satisfied the Foundry feature gate; v1 enforces it explicitly.
2. **PR #8441** added the header for CreateAgentVersion (deploy) but missed invoke and session endpoints.
3. Session CRUD used AgentEndpoints=V1Preview which is not the gate the service checks -- Vienna's SessionController requires HostedAgents=V1Preview.

## Changes (verified against Vienna service repo)

### Fixed in this PR

| azd Command | Function | Vienna Gate | Change |
|-------------|----------|-------------|--------|
| azd ai agent invoke (responses) | responsesRemote | ResponseController (ungated) | Added header (defensive) |
| azd ai agent invoke (invocations) | invocationsRemote | [FoundryFeatures(HostedAgents=V1Preview)] | Added header |
| azd ai agent invoke (poll async) | pollInvocationResult | [FoundryFeatures(HostedAgents=V1Preview)] | Added header |
| azd ai agent invoke (conversation) | createConversation | (ungated) | Added header (defensive) |
| azd ai agent monitor --follow | GetAgentSessionLogStream | [FoundryFeatures(HostedAgents=V1Preview)] | Added header |
| azd ai agent sessions create | CreateSession | [FoundryFeatures(HostedAgents=V1Preview)] | Fixed AgentEndpoints to HostedAgents |
| azd ai agent sessions show | GetSession | [FoundryFeatures(HostedAgents=V1Preview)] | Fixed AgentEndpoints to HostedAgents |
| azd ai agent sessions delete | DeleteSession | [FoundryFeatures(HostedAgents=V1Preview)] | Fixed AgentEndpoints to HostedAgents |
| azd ai agent sessions list | ListSessions | [FoundryFeatures(HostedAgents=V1Preview)] | Fixed AgentEndpoints to HostedAgents |

### Already correct (no changes needed)

| azd Command | Function | Header | Added by |
|-------------|----------|--------|----------|
| azd deploy (container) | CreateAgentVersion | HostedAgents=V1Preview | PR #8441 |
| azd deploy (code/zip) | zipDeployRequest | CodeAgents=V1Preview,HostedAgents=V1Preview | PR #8146 |
| azd ai agent file upload | UploadSessionFile | HostedAgents=V1Preview | PR #7141 |
| azd ai agent file download | DownloadSessionFile | HostedAgents=V1Preview | PR #7141 |
| azd ai agent file list | ListSessionFiles | HostedAgents=V1Preview | PR #7141 |
| azd ai agent file rm | RemoveSessionFile | HostedAgents=V1Preview | PR #7141 |
| azd ai agent file mkdir | MkdirSessionFile | HostedAgents=V1Preview | PR #7141 |
| azd ai agent file stat | StatSessionFile | HostedAgents=V1Preview | PR #7141 |

### Files changed

| File | Description |
|------|-------------|
| internal/cmd/invoke.go | Add Foundry-Features: HostedAgents=V1Preview to 4 remote request sites |
| internal/pkg/agents/agent_api/operations.go | Add header to GetAgentSessionLogStream; fix 4 session CRUD ops (AgentEndpoints to HostedAgents) |

## Testing

- [x] go build ./... passes
- [x] go test ./internal/cmd/ passes
- [x] go test ./internal/pkg/agents/agent_api/ passes

### E2E Results (local build from this branch, North Central US)

| Command | Protocol/Details | Result |
|---------|-----------------|--------|
| `azd ai agent invoke` | invocations protocol | PASS |
| `azd ai agent invoke` | responses protocol (SSE streaming) | PASS |
| `azd ai agent sessions list` | ListSessions | PASS (13 sessions returned) |
| `azd ai agent sessions show <id>` | GetSession | PASS |
| `azd ai agent sessions create` | CreateSession | PASS |
| `azd ai agent sessions delete <id>` | DeleteSession | PASS |
| `azd ai agent monitor --session-id <id> --tail 5` | GetAgentSessionLogStream | PASS |

**Not tested:** `handleInvocationLRO` (async 202 polling) - only triggers for agents returning 202 Accepted; same mechanical header pattern as all other fixes.

**Test agents:**
- `hello-world-python-invocations` (invocations protocol, code deploy, v1)
- `test-responses-agent` (responses protocol, code deploy, v2)
- Project: `wujia-aifproject-260601` (North Central US)
