### PR TITLE
chore: remove inspector autolaunch readiness timeout

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
@@ -36,7 +36,6 @@ import (
 
 const (
 	agentInspectorExtensionID     = "azure.ai.inspector"
-	agentInspectorReadyTimeout    = 30 * time.Second
 	agentInspectorReadyPollPeriod = 250 * time.Millisecond
 )
 
@@ -318,7 +317,6 @@ func handleInspectorAutoLaunch(
 		ctx,
 		workflow,
 		agentPort,
-		agentInspectorReadyTimeout,
 		agentInspectorReadyPollPeriod,
 		stderr,
 	)
@@ -328,15 +326,11 @@ func startInspectorAfterAgentReadyWithOptions(
 	ctx context.Context,
 	workflow azdext.WorkflowServiceClient,
 	agentPort int,
-	readyTimeout time.Duration,
 	pollPeriod time.Duration,
 	stderr io.Writer,
 ) {
 	go func() {
-		waitCtx, cancel := context.WithTimeout(ctx, readyTimeout)
-		defer cancel()
-
-		if err := waitForLocalPort(waitCtx, agentPort, pollPeriod); err != nil {
+		if err := waitForLocalPort(ctx, agentPort, pollPeriod); err != nil {
 			if ctx.Err() == nil {
 				fmt.Fprintf(
 					stderr,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/run_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/run_test.go
@@ -305,7 +305,6 @@ func TestInspectorLaunchFailureOnlyWarns(t *testing.T) {
 		ctx,
 		workflow,
 		ln.Addr().(*net.TCPAddr).Port,
-		time.Second,
 		time.Millisecond,
 		&stderr,
 	)


### PR DESCRIPTION
## Summary

Removes the fixed 30s readiness timeout before launching Agent Inspector from `azd ai agent run`.

The Inspector autolaunch now waits until either:
- the local agent port starts accepting connections, or
- the agent run context is cancelled, such as when the process exits or the user presses Ctrl+C.

## Why

Some local agents, especially Python agents on cold start, can take more than 30s before binding to the configured port. Previously, Inspector autolaunch was skipped even if the agent became ready shortly afterward.

## Testing

- `go test ./internal/cmd -run "Test(Inspector|WaitForLocalPort|NoInspector)"`
- `go test ./internal/cmd`