### PR TITLE
fix(connections): remove leaked projectctx debug log

### DIFF
--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/connection_context.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/connection_context.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"azure.ai.connections/internal/exterrors"
 	"azure.ai.connections/internal/foundry/projectctx"
@@ -45,8 +44,6 @@ func resolveConnectionContext(
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("projectctx: resolved endpoint=%s source=%s",
-		resolved.Endpoint, resolved.Source)
 	endpoint := resolved.Endpoint
 
 	account, project, err := parseEndpointComponents(endpoint)


### PR DESCRIPTION
## Summary

`azd ai connection <command>` printed an internal diagnostic (`projectctx: resolved endpoint=... source=...`) on every invocation. The extension never silenced Go's default logger, so this `log.Printf` surfaced as user-facing noise.

## Changes

- **`connection_context.go`**: Remove the `log.Printf` from `resolveConnectionContext` (and the now-unused `log` import). Endpoint resolution is owned by `projectctx.Resolve`; any such diagnostic belongs in that package, not in the consuming caller.
