### PR TITLE
fix: reduce S0 AccountCount MinCapacity from 2 to 1

### DIFF
--- a/cli/azd/pkg/infra/provisioning/bicep/prompt.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/prompt.go
@@ -82,16 +82,18 @@ func autoGenerate(parameter string, azdMetadata azure.AzdMetadata) (string, erro
 // locationsWithQuotaFor finds locations that have sufficient quota for the given usage requirements.
 //
 // The quotaFor parameter uses the Bicep metadata format: "UsageName" or "UsageName, Capacity".
-// An implicit requirement for "OpenAI.S0.AccountCount" with capacity 2 is always included.
+// An implicit requirement for "OpenAI.S0.AccountCount" with capacity 1 is always included.
 func (a *BicepProvider) locationsWithQuotaFor(
 	ctx context.Context, subId string, locations []string, quotaFor []string) ([]string, error) {
 	if a.aiModelService == nil {
 		return nil, fmt.Errorf("AI model service is not configured")
 	}
 
-	// Always require minimum S0 account quota
+	// Always require at least 1 remaining S0 account slot.
+	// Each CognitiveServices/accounts resource consumes exactly 1 unit of
+	// the OpenAI.S0.AccountCount quota regardless of subscription tier.
 	requirements := []ai.QuotaRequirement{
-		{UsageName: "OpenAI.S0.AccountCount", MinCapacity: 2},
+		{UsageName: "OpenAI.S0.AccountCount", MinCapacity: 1},
 	}
 
 	for _, definedUsageName := range quotaFor {


### PR DESCRIPTION
## Problem

After the fix in #8537 for empty `/usages` responses, free-tier Azure subscriptions still fail the AI quota pre-check (issue #8563). The `OpenAI.S0.AccountCount` quota has `Limit=1` on free subscriptions, but the code requires `MinCapacity: 2`, rejecting every location.

## Root Cause

PR #4929 changed the S0 account quota check from `remaining >= 1` to `remaining >= 2` with the comment *"The minimum quota for the S0 SKU in Microsoft.CognitiveServices/accounts is 2 capacity units."* However:

- **No documentation or data backs this claim** — the PR had zero review threads and no linked repro.
- **Azure docs confirm 1 account = 1 unit** — `OpenAI.S0.AccountCount` counts distinct resource instances; creating one S0 account consumes exactly 1 unit.
- **Free subs have `Limit=1`** — so `remaining(1) < MinCapacity(2)` always fails.
- **Paid subs mask the bug** — they have limits of 200+, so `>= 2` is trivially satisfied.
- **The issue reporter** successfully deploys when bypassing the quota check, confirming only 1 unit is needed.

## Fix

Change `MinCapacity` from `2` to `1` in `prompt.go` for the implicit `OpenAI.S0.AccountCount` requirement.

Fixes #8563