### PR TITLE
feat(agents): add 'endpoint show' command and auth-change warning

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show.go
@@ -163,7 +163,7 @@ func printEndpointTable(agent *agent_api.AgentObject) error {
 	fmt.Fprintf(w, "\nAuthorization:\n")
 	if agent.AgentEndpoint != nil && len(agent.AgentEndpoint.AuthorizationSchemes) > 0 {
 		for _, scheme := range agent.AgentEndpoint.AuthorizationSchemes {
-			isolation := "Entra"
+			isolation := "(not specified)"
 			if scheme.IsolationKeySource != nil {
 				isolation = string(scheme.IsolationKeySource.Kind)
 			}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show.go
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"azureaiagent/internal/pkg/agents/agent_api"
+	"azureaiagent/internal/pkg/agents/agent_yaml"
+	"azureaiagent/internal/pkg/paths"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/spf13/cobra"
+	goyaml "go.yaml.in/yaml/v3"
+)
+
+type endpointShowFlags struct {
+	name   string
+	output string
+}
+
+func newEndpointShowCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
+	flags := &endpointShowFlags{}
+	extCtx = ensureExtensionContext(extCtx)
+
+	cmd := &cobra.Command{
+		Use:   "show [name]",
+		Short: "Show the current endpoint and card configuration of an agent.",
+		Long: `Show the current endpoint and card configuration of an agent.
+
+Displays protocols, version selector (traffic split), authorization schemes,
+and agent card (A2A discovery) as configured on the live agent.`,
+		Example: `  # Show endpoint config (auto-resolves from azure.yaml)
+  azd ai agent endpoint show
+
+  # Show for a specific agent service
+  azd ai agent endpoint show my-agent
+
+  # Output as JSON
+  azd ai agent endpoint show --output json`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				flags.name = args[0]
+			}
+			flags.output = extCtx.OutputFormat
+
+			ctx := azdext.WithAccessToken(cmd.Context())
+
+			azdClient, err := azdext.NewAzdClient()
+			if err != nil {
+				return fmt.Errorf("failed to create azd client: %w", err)
+			}
+			defer azdClient.Close()
+
+			return runEndpointShow(ctx, azdClient, flags, extCtx)
+		},
+	}
+
+	return cmd
+}
+
+func runEndpointShow(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	flags *endpointShowFlags,
+	extCtx *azdext.ExtensionContext,
+) error {
+	svc, proj, err := resolveAgentService(ctx, azdClient, flags.name, extCtx.NoPrompt)
+	if err != nil {
+		return err
+	}
+
+	// Read agent.yaml to get agent name.
+	agentYamlPath, err := paths.JoinAllowRoot(proj.Path, svc.RelativePath, "agent.yaml")
+	if err != nil {
+		return fmt.Errorf("invalid agent.yaml path: %w", err)
+	}
+	data, err := os.ReadFile(agentYamlPath) //nolint:gosec // path validated by JoinAllowRoot
+	if err != nil {
+		return fmt.Errorf("failed to read agent.yaml: %w", err)
+	}
+
+	var agentDef agent_yaml.ContainerAgent
+	if err := goyaml.Unmarshal(data, &agentDef); err != nil {
+		return fmt.Errorf("failed to parse agent.yaml: %w", err)
+	}
+
+	// Resolve endpoint and create client.
+	agentContext, err := newAgentContext(ctx, "", "", agentDef.Name, "")
+	if err != nil {
+		return err
+	}
+
+	agentClient, err := agentContext.NewClient()
+	if err != nil {
+		return err
+	}
+
+	agent, err := agentClient.GetAgent(ctx, agentDef.Name, DefaultAgentAPIVersion)
+	if err != nil {
+		return fmt.Errorf("failed to get agent %q: %w", agentDef.Name, err)
+	}
+
+	if flags.output == "json" {
+		return printEndpointJSON(agent)
+	}
+
+	return printEndpointTable(agent)
+}
+
+func printEndpointJSON(agent *agent_api.AgentObject) error {
+	out := map[string]any{
+		"name":           agent.Name,
+		"agent_endpoint": agent.AgentEndpoint,
+		"agent_card":     agent.AgentCard,
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+func printEndpointTable(agent *agent_api.AgentObject) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+
+	fmt.Fprintf(w, "Agent:\t%s\n", agent.Name)
+	fmt.Fprintln(w)
+
+	// Protocols
+	fmt.Fprintf(w, "Protocols:\t")
+	if agent.AgentEndpoint != nil && len(agent.AgentEndpoint.Protocols) > 0 {
+		protocols := make([]string, len(agent.AgentEndpoint.Protocols))
+		for i, p := range agent.AgentEndpoint.Protocols {
+			protocols[i] = string(p)
+		}
+		fmt.Fprintf(w, "%s\n", strings.Join(protocols, ", "))
+	} else {
+		fmt.Fprintf(w, "(not configured)\n")
+	}
+
+	// Version Selector
+	fmt.Fprintf(w, "\nVersion Selector:\n")
+	if agent.AgentEndpoint != nil && agent.AgentEndpoint.VersionSelector != nil &&
+		len(agent.AgentEndpoint.VersionSelector.VersionSelectionRules) > 0 {
+		for _, rule := range agent.AgentEndpoint.VersionSelector.VersionSelectionRules {
+			pct := ""
+			if rule.TrafficPercentage != nil {
+				pct = fmt.Sprintf("%d%%", *rule.TrafficPercentage)
+			}
+			fmt.Fprintf(w, "  %s\t%s\n", rule.AgentVersion, pct)
+		}
+	} else {
+		fmt.Fprintf(w, "  (default: @latest 100%%)\n")
+	}
+
+	// Authorization
+	fmt.Fprintf(w, "\nAuthorization:\n")
+	if agent.AgentEndpoint != nil && len(agent.AgentEndpoint.AuthorizationSchemes) > 0 {
+		for _, scheme := range agent.AgentEndpoint.AuthorizationSchemes {
+			isolation := "Entra"
+			if scheme.IsolationKeySource != nil {
+				isolation = string(scheme.IsolationKeySource.Kind)
+			}
+			fmt.Fprintf(w, "  Type:\t%s\n", scheme.Type)
+			fmt.Fprintf(w, "  Isolation:\t%s\n", isolation)
+		}
+	} else {
+		fmt.Fprintf(w, "  (not configured)\n")
+	}
+
+	// Agent Card
+	fmt.Fprintf(w, "\nAgent Card:\n")
+	if agent.AgentCard != nil {
+		if agent.AgentCard.Version != nil {
+			fmt.Fprintf(w, "  Version:\t%s\n", *agent.AgentCard.Version)
+		}
+		fmt.Fprintf(w, "  Description:\t%s\n", agent.AgentCard.Description)
+		if len(agent.AgentCard.Skills) > 0 {
+			fmt.Fprintf(w, "  Skills:\n")
+			for _, skill := range agent.AgentCard.Skills {
+				fmt.Fprintf(w, "    - %s:\t%s\n", skill.Name, skill.Description)
+			}
+		}
+	} else {
+		fmt.Fprintf(w, "  (not configured)\n")
+	}
+
+	return w.Flush()
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show.go
@@ -63,6 +63,12 @@ and agent card (A2A discovery) as configured on the live agent.`,
 		},
 	}
 
+	azdext.RegisterFlagOptions(cmd, azdext.FlagOptions{
+		Name:          "output",
+		AllowedValues: []string{"json", "table"},
+		Default:       "table",
+	})
+
 	return cmd
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show_test.go
@@ -153,6 +153,11 @@ func TestGetIsolationKind(t *testing.T) {
 				{Type: "Entra", IsolationKeySource: &agent_api.IsolationKeySource{Kind: "Header"}},
 			},
 		}, "Header"},
+		{"nil isolation source", &agent_api.AgentEndpoint{
+			AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
+				{Type: "BotService"},
+			},
+		}, ""},
 	}
 
 	for _, tt := range tests {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show_test.go
@@ -52,7 +52,7 @@ func TestPrintEndpointTable_FullConfig(t *testing.T) {
 	err := printEndpointTable(agent)
 	require.NoError(t, err)
 
-	w.Close()
+	_ = w.Close() //nolint:gosec
 	os.Stdout = old
 
 	var buf bytes.Buffer
@@ -84,7 +84,7 @@ func TestPrintEndpointTable_NilEndpoint(t *testing.T) {
 	err := printEndpointTable(agent)
 	require.NoError(t, err)
 
-	w.Close()
+	_ = w.Close() //nolint:gosec
 	os.Stdout = old
 
 	var buf bytes.Buffer
@@ -121,7 +121,7 @@ func TestPrintEndpointJSON(t *testing.T) {
 	err := printEndpointJSON(agent)
 	require.NoError(t, err)
 
-	w.Close()
+	_ = w.Close() //nolint:gosec
 	os.Stdout = old
 
 	var buf bytes.Buffer

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show_test.go
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"azureaiagent/internal/pkg/agents/agent_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintEndpointTable_FullConfig(t *testing.T) {
+	pct80 := int32(80)
+	pct20 := int32(20)
+	ver := "2.0"
+	agent := &agent_api.AgentObject{
+		Name: "patch-poc-resp",
+		AgentEndpoint: &agent_api.AgentEndpoint{
+			Protocols: []agent_api.AgentEndpointProtocol{"responses", "a2a", "mcp"},
+			VersionSelector: &agent_api.VersionSelector{
+				VersionSelectionRules: []agent_api.VersionSelectionRule{
+					{Type: "FixedRatio", AgentVersion: "@latest", TrafficPercentage: &pct80},
+					{Type: "FixedRatio", AgentVersion: "1", TrafficPercentage: &pct20},
+				},
+			},
+			AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
+				{
+					Type:               "Entra",
+					IsolationKeySource: &agent_api.IsolationKeySource{Kind: "Header"},
+				},
+			},
+		},
+		AgentCard: &agent_api.AgentCard{
+			Description: "Updated echo agent",
+			Version:     &ver,
+			Skills: []agent_api.AgentCardSkill{
+				{ID: "echo", Name: "Echo", Description: "Echoes user input"},
+				{ID: "stream", Name: "Stream Echo", Description: "Streaming echo"},
+			},
+		},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := printEndpointTable(agent)
+	require.NoError(t, err)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	assert.Contains(t, output, "patch-poc-resp")
+	assert.Contains(t, output, "responses, a2a, mcp")
+	assert.Contains(t, output, "@latest")
+	assert.Contains(t, output, "80%")
+	assert.Contains(t, output, "20%")
+	assert.Contains(t, output, "Header")
+	assert.Contains(t, output, "Updated echo agent")
+	assert.Contains(t, output, "Echo")
+	assert.Contains(t, output, "Stream Echo")
+
+	t.Logf("=== endpoint show output ===\n%s", output)
+}
+
+func TestPrintEndpointTable_NilEndpoint(t *testing.T) {
+	agent := &agent_api.AgentObject{
+		Name: "empty-agent",
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := printEndpointTable(agent)
+	require.NoError(t, err)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	assert.Contains(t, output, "empty-agent")
+	assert.Contains(t, output, "(not configured)")
+
+	t.Logf("=== endpoint show output (nil) ===\n%s", output)
+}
+
+func TestPrintEndpointJSON(t *testing.T) {
+	pct100 := int32(100)
+	agent := &agent_api.AgentObject{
+		Name: "json-test-agent",
+		AgentEndpoint: &agent_api.AgentEndpoint{
+			Protocols: []agent_api.AgentEndpointProtocol{"responses"},
+			VersionSelector: &agent_api.VersionSelector{
+				VersionSelectionRules: []agent_api.VersionSelectionRule{
+					{Type: "FixedRatio", AgentVersion: "@latest", TrafficPercentage: &pct100},
+				},
+			},
+			AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
+				{Type: "Entra", IsolationKeySource: &agent_api.IsolationKeySource{Kind: "Entra"}},
+			},
+		},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := printEndpointJSON(agent)
+	require.NoError(t, err)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	assert.Contains(t, output, `"name": "json-test-agent"`)
+	assert.Contains(t, output, `"protocols"`)
+	assert.Contains(t, output, `"responses"`)
+
+	t.Logf("=== endpoint show --output json ===\n%s", output)
+}
+
+func TestGetIsolationKind(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint *agent_api.AgentEndpoint
+		want     string
+	}{
+		{"nil endpoint", nil, ""},
+		{"empty schemes", &agent_api.AgentEndpoint{}, ""},
+		{"entra", &agent_api.AgentEndpoint{
+			AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
+				{Type: "Entra", IsolationKeySource: &agent_api.IsolationKeySource{Kind: "Entra"}},
+			},
+		}, "Entra"},
+		{"header", &agent_api.AgentEndpoint{
+			AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
+				{Type: "Entra", IsolationKeySource: &agent_api.IsolationKeySource{Kind: "Header"}},
+			},
+		}, "Header"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getIsolationKind(tt.endpoint)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/update.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/update.go
@@ -5,13 +5,16 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 
 	"azureaiagent/internal/pkg/agents/agent_api"
 	"azureaiagent/internal/pkg/agents/agent_yaml"
 	"azureaiagent/internal/pkg/paths"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/spf13/cobra"
@@ -162,8 +165,12 @@ func warnIfAuthChange(
 	// Fetch current agent to compare auth config.
 	current, err := client.GetAgent(ctx, agentName, DefaultAgentAPIVersion)
 	if err != nil {
-		// If agent doesn't exist yet, no warning needed.
-		return nil
+		// Only ignore 404 (agent doesn't exist yet). Other errors should propagate.
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return fmt.Errorf("failed to check current agent state: %w", err)
 	}
 
 	oldIsolation := getIsolationKind(current.AgentEndpoint)
@@ -193,7 +200,9 @@ func warnIfAuthChange(
 
 	fmt.Fprintf(os.Stderr, "\n   Continue? [y/N] ")
 	var answer string
-	fmt.Scanln(&answer)
+	if _, err := fmt.Scanln(&answer); err != nil {
+		return fmt.Errorf("unable to read confirmation (non-interactive terminal?); use --force to skip: %w", err)
+	}
 	if answer != "y" && answer != "Y" {
 		return fmt.Errorf("operation cancelled by user")
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/update.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/update.go
@@ -24,13 +24,15 @@ func newEndpointCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 		Short: "Manage agent endpoint and card configuration.",
 	}
 
+	cmd.AddCommand(newEndpointShowCommand(extCtx))
 	cmd.AddCommand(newEndpointUpdateCommand(extCtx))
 
 	return cmd
 }
 
 type endpointUpdateFlags struct {
-	name string
+	name  string
+	force bool
 }
 
 func newEndpointUpdateCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
@@ -68,6 +70,8 @@ The agent must already exist (i.e., it must have been previously deployed).`,
 			return runEndpointUpdate(ctx, azdClient, flags, extCtx)
 		},
 	}
+
+	cmd.Flags().BoolVar(&flags.force, "force", false, "Skip confirmation prompts for breaking changes")
 
 	return cmd
 }
@@ -124,6 +128,13 @@ func runEndpointUpdate(
 		return err
 	}
 
+	// Check for breaking auth changes and warn unless --force is set.
+	if !flags.force && apiEndpoint != nil && len(apiEndpoint.AuthorizationSchemes) > 0 {
+		if err := warnIfAuthChange(ctx, agentClient, agentDef.Name, apiEndpoint, extCtx.NoPrompt); err != nil {
+			return err
+		}
+	}
+
 	// Patch endpoint/card fields.
 	patchRequest := &agent_api.PatchAgentRequest{
 		AgentEndpoint: apiEndpoint,
@@ -137,4 +148,79 @@ func runEndpointUpdate(
 
 	fmt.Fprint(os.Stdout, output.WithSuccessFormat("Agent %q endpoint/card configuration updated successfully.\n", agentDef.Name))
 	return nil
+}
+
+// warnIfAuthChange detects authorization scheme changes that may break existing callers
+// and prompts for confirmation.
+func warnIfAuthChange(
+	ctx context.Context,
+	client *agent_api.AgentClient,
+	agentName string,
+	newEndpoint *agent_api.AgentEndpoint,
+	noPrompt bool,
+) error {
+	// Fetch current agent to compare auth config.
+	current, err := client.GetAgent(ctx, agentName, DefaultAgentAPIVersion)
+	if err != nil {
+		// If agent doesn't exist yet, no warning needed.
+		return nil
+	}
+
+	oldIsolation := getIsolationKind(current.AgentEndpoint)
+	newIsolation := getIsolationKindFromSchemes(newEndpoint.AuthorizationSchemes)
+
+	if oldIsolation == newIsolation || oldIsolation == "" || newIsolation == "" {
+		return nil
+	}
+
+	// Auth is changing — warn the user.
+	fmt.Fprintf(os.Stderr,
+		"\n⚠️  WARNING: Changing isolation key source from %q to %q.\n"+
+			"   This is a BREAKING CHANGE — all existing API callers must immediately\n"+
+			"   update their requests to match the new authorization scheme.\n",
+		oldIsolation, newIsolation,
+	)
+
+	if newIsolation == string(agent_api.IsolationKeySourceKindHeader) {
+		fmt.Fprintf(os.Stderr,
+			"   Callers must include the \"x-ms-user-isolation-key\" header, or they will receive 400 errors.\n",
+		)
+	}
+
+	if noPrompt {
+		return fmt.Errorf("auth scheme change requires confirmation; use --force to skip")
+	}
+
+	fmt.Fprintf(os.Stderr, "\n   Continue? [y/N] ")
+	var answer string
+	fmt.Scanln(&answer)
+	if answer != "y" && answer != "Y" {
+		return fmt.Errorf("operation cancelled by user")
+	}
+
+	return nil
+}
+
+func getIsolationKind(endpoint *agent_api.AgentEndpoint) string {
+	if endpoint == nil || len(endpoint.AuthorizationSchemes) == 0 {
+		return ""
+	}
+	for _, scheme := range endpoint.AuthorizationSchemes {
+		if scheme.IsolationKeySource != nil {
+			return string(scheme.IsolationKeySource.Kind)
+		}
+	}
+	return ""
+}
+
+func getIsolationKindFromSchemes(schemes []agent_api.AgentEndpointAuthorizationScheme) string {
+	if len(schemes) == 0 {
+		return ""
+	}
+	for _, scheme := range schemes {
+		if scheme.IsolationKeySource != nil {
+			return string(scheme.IsolationKeySource.Kind)
+		}
+	}
+	return ""
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
@@ -315,10 +315,12 @@ type AgentVersionError struct {
 
 // AgentObject represents an agent
 type AgentObject struct {
-	Object   string `json:"object"`
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Versions struct {
+	Object        string         `json:"object"`
+	ID            string         `json:"id"`
+	Name          string         `json:"name"`
+	AgentEndpoint *AgentEndpoint `json:"agent_endpoint,omitempty"`
+	AgentCard     *AgentCard     `json:"agent_card,omitempty"`
+	Versions      struct {
 		Latest AgentVersionObject `json:"latest"`
 	} `json:"versions"`
 }


### PR DESCRIPTION
## Summary

Adds two UX improvements to the existing `azd ai agent endpoint update` command, which already supports PATCH on agents.

### `azd deploy` vs `azd ai agent endpoint update`

| | `azd deploy` | `azd ai agent endpoint update` |
|--|----------------|----------------------------------|
| What it does | Creates a **new agent version** (new code/model/instructions) | **Patches endpoint metadata** without creating a new version |
| Triggers deployment | Yes (container rebuild, provisioning) | No (instant, Cosmos DB update only) |
| Changes definition | Yes (model, instructions, tools, code) | No |
| Changes routing/auth/card | Only at initial create | Yes -- this is its purpose |
| Typical use | Ship new agent logic | Enable a2a/mcp, set canary traffic, configure auth |
| Time | Minutes (build + provision) | Seconds |

### Existing PATCH capabilities (already implemented)

`azd ai agent endpoint update` reads agent.yaml and patches the live agent. The user manually edits agent.yaml, then runs the command. It supports all 4 PATCH scenarios:

| Scenario | agent.yaml field | Example value |
|----------|-----------------|---------------|
| Protocol enablement | `agent_endpoint.protocols` | `[responses, a2a, mcp]` |
| Traffic routing / Canary | `agent_endpoint.version_selector` | `@latest: 80%, v1: 20%` |
| Authorization config | `agent_endpoint.authorization_schemes` | Entra / Header isolation |
| Agent Card (A2A discovery) | `agent_card` | description + skills |

---

### What this PR adds (gap fixes)

**1. `azd ai agent endpoint show [name]`**

Displays the current live endpoint configuration. Example output:

`
Agent:  patch-poc-resp

Protocols:  responses, a2a, mcp

Version Selector:
  @latest  80%
  1        20%

Authorization:
  Type:       Entra
  Isolation:  Header

Agent Card:
  Version:      2.0
  Description:  Updated echo agent
  Skills:
    - Echo:         Echoes user input
    - Stream Echo:  Streaming echo
`

JSON output (`--output json`):
`json
{
  "name": "json-test-agent",
  "agent_endpoint": {
    "version_selector": {
      "version_selection_rules": [
        { "type": "FixedRatio", "agent_version": "@latest", "traffic_percentage": 100 }
      ]
    },
    "protocols": ["responses"],
    "authorization_schemes": [
      { "type": "Entra", "isolation_key_source": { "kind": "Entra" } }
    ]
  },
  "agent_card": null
}
`

**2. Auth-change breaking-change warning**

When `endpoint update` detects isolation_key_source is changing (e.g., Entra to Header):

`
WARNING: Changing isolation key source from "Entra" to "Header".
   This is a BREAKING CHANGE -- all existing API callers must immediately
   update their requests to match the new authorization scheme.
   Callers must include the "x-ms-user-isolation-key" header, or they will receive 400 errors.

   Continue? [y/N]
`

`--force` skips the prompt.

### Implementation

- `endpoint_show.go` (new): registered as `azd ai agent endpoint show`
- `endpoint_show_test.go` (new): unit tests for table/JSON output and isolation helpers
- `update.go`: added `--force` flag + `warnIfAuthChange()` that GETs current agent and compares auth config before PATCHing
- `models.go`: added `AgentEndpoint` and `AgentCard` fields to `AgentObject`

### Testing

`
=== RUN   TestPrintEndpointTable_FullConfig
--- PASS: TestPrintEndpointTable_FullConfig (0.00s)
=== RUN   TestPrintEndpointTable_NilEndpoint
--- PASS: TestPrintEndpointTable_NilEndpoint (0.00s)
=== RUN   TestPrintEndpointJSON
--- PASS: TestPrintEndpointJSON (0.00s)
=== RUN   TestGetIsolationKind
--- PASS: TestGetIsolationKind (0.00s)
    --- PASS: TestGetIsolationKind/nil_endpoint (0.00s)
    --- PASS: TestGetIsolationKind/empty_schemes (0.00s)
    --- PASS: TestGetIsolationKind/entra (0.00s)
    --- PASS: TestGetIsolationKind/header (0.00s)
=== RUN   TestPatchAgent_Success
--- PASS: TestPatchAgent_Success (0.00s)
=== RUN   TestPatchAgent_OmitsNilFields
--- PASS: TestPatchAgent_OmitsNilFields (0.00s)
PASS
`

- All extension tests pass (`go test ./...`)
- `go vet` clean
- Binary builds successfully

Fixes #8573