### PR TITLE
Add 'azd ai agent code download' command

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/code.go
@@ -1,0 +1,346 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/spf13/cobra"
+)
+
+func newCodeCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "code",
+		Short: "Manage agent source code. (Preview)",
+		Long:  `Commands for managing the source code of code-based hosted agents.`,
+	}
+
+	cmd.AddCommand(newCodeDownloadCommand(extCtx))
+
+	return cmd
+}
+
+type codeDownloadFlags struct {
+	name    string
+	version string
+	dest    string
+	zip     bool
+}
+
+// CodeDownloadAction handles downloading agent source code.
+type CodeDownloadAction struct {
+	*AgentContext
+	flags *codeDownloadFlags
+}
+
+func newCodeDownloadCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
+	flags := &codeDownloadFlags{}
+	extCtx = ensureExtensionContext(extCtx)
+
+	cmd := &cobra.Command{
+		Use:   "download [service]",
+		Short: "Download agent source code from Foundry. (Preview)",
+		Long: `Download the source code of a code-based hosted agent.
+
+Downloads the deployed source code as a zip archive and extracts it to
+the output directory. Use --zip to save the raw zip file instead.
+
+The [service] argument identifies the azd service whose agent name is resolved
+from the azd environment. When omitted, the default agent service is used.`,
+		Example: `  # Download latest version (extracts to ./my-agent/)
+  azd ai agent code download my-agent
+
+  # Download a specific version
+  azd ai agent code download my-agent --version 3
+
+  # Save as zip file without extracting
+  azd ai agent code download my-agent --zip
+
+  # Download to a custom directory
+  azd ai agent code download my-agent --dest ./backup`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				flags.name = args[0]
+			}
+
+			ctx := azdext.WithAccessToken(cmd.Context())
+
+			azdClient, err := azdext.NewAzdClient()
+			if err != nil {
+				return fmt.Errorf("failed to create azd client: %w", err)
+			}
+			defer azdClient.Close()
+
+			info, err := resolveAgentServiceFromProject(ctx, azdClient, flags.name, extCtx.NoPrompt)
+			if err != nil {
+				return err
+			}
+
+			agentName := info.AgentName
+			if agentName == "" {
+				return fmt.Errorf(
+					"agent name could not be resolved from azd environment for service '%s'\n\n"+
+						"Run 'azd deploy' first to deploy the agent, or provide the agent name as a positional argument",
+					info.ServiceName,
+				)
+			}
+
+			agentContext, err := newAgentContext(ctx, "", "", agentName, info.Version)
+			if err != nil {
+				return err
+			}
+
+			action := &CodeDownloadAction{
+				AgentContext: agentContext,
+				flags:        flags,
+			}
+
+			return action.Run(ctx)
+		},
+	}
+
+	cmd.Flags().StringVarP(&flags.version, "version", "v", "", "Agent version to download (default: latest)")
+	cmd.Flags().StringVarP(&flags.dest, "dest", "d", "", "Destination path (default: ./<agent-name>/ or ./<agent-name>.zip)")
+	cmd.Flags().BoolVar(&flags.zip, "zip", false, "Save as zip file instead of extracting")
+
+	return cmd
+}
+
+func (a *CodeDownloadAction) Run(ctx context.Context) error {
+	agentClient, err := a.NewClient()
+	if err != nil {
+		return err
+	}
+
+	// Determine output path
+	outputPath := a.flags.dest
+	if outputPath == "" {
+		if a.flags.zip {
+			outputPath = a.Name + ".zip"
+		} else {
+			outputPath = a.Name
+		}
+	}
+
+	// Check if output path already exists
+	if _, statErr := os.Stat(outputPath); statErr == nil {
+		return fmt.Errorf(
+			"output path %q already exists\n\nUse --dest (-d) to specify a different path",
+			outputPath,
+		)
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return fmt.Errorf("failed to check output path %q: %w", outputPath, statErr)
+	}
+
+	// Download
+	result, err := agentClient.DownloadAgentCode(
+		ctx,
+		a.Name,
+		DefaultAgentAPIVersion,
+		a.flags.version,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to download agent code: %w", err)
+	}
+	defer result.Body.Close()
+
+	if a.flags.zip {
+		// Save zip directly
+		if err := saveZipFile(outputPath, result.Body, result.ContentHash); err != nil {
+			return err
+		}
+	} else {
+		// Save to temp file, verify hash, then extract
+		if err := downloadAndExtract(outputPath, result.Body, result.ContentHash); err != nil {
+			return err
+		}
+	}
+
+	// Print summary
+	versionStr := result.AgentVersion
+	if versionStr == "" {
+		versionStr = "latest"
+	}
+	fmt.Printf("Downloaded agent %q (version %s) -> %s\n", a.Name, versionStr, outputPath)
+	if result.ContentHash != "" {
+		fmt.Printf("SHA-256: %s\n", result.ContentHash)
+	}
+
+	return nil
+}
+
+// saveZipFile writes the response body to a zip file and optionally verifies the hash.
+func saveZipFile(outputPath string, body io.Reader, expectedHash string) error {
+	//nolint:gosec // G304: outputPath is provided by the user via CLI flag
+	outFile, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create output file %q: %w", outputPath, err)
+	}
+
+	hasher := sha256.New()
+	writer := io.MultiWriter(outFile, hasher)
+
+	if _, err := io.Copy(writer, body); err != nil {
+		// Clean up partial file
+		_ = outFile.Close()
+		_ = os.Remove(outputPath)
+		return fmt.Errorf("failed to write zip file: %w", err)
+	}
+
+	if expectedHash != "" {
+		actualHash := hex.EncodeToString(hasher.Sum(nil))
+		if !equalFoldHash(actualHash, expectedHash) {
+			_ = outFile.Close()
+			_ = os.Remove(outputPath)
+			return fmt.Errorf(
+				"SHA-256 verification failed: expected %s, got %s",
+				expectedHash, actualHash,
+			)
+		}
+	}
+
+	if err := outFile.Close(); err != nil {
+		_ = os.Remove(outputPath)
+		return fmt.Errorf("failed to close output file %q: %w", outputPath, err)
+	}
+
+	return nil
+}
+
+// downloadAndExtract saves the body to a temp file, verifies hash, and extracts to outputDir.
+func downloadAndExtract(outputDir string, body io.Reader, expectedHash string) error {
+	// Write to temp file
+	tmpFile, err := os.CreateTemp("", "azd-agent-code-*.zip")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	hasher := sha256.New()
+	writer := io.MultiWriter(tmpFile, hasher)
+
+	if _, err := io.Copy(writer, body); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("failed to download zip: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	// Verify hash
+	if expectedHash != "" {
+		actualHash := hex.EncodeToString(hasher.Sum(nil))
+		if !equalFoldHash(actualHash, expectedHash) {
+			return fmt.Errorf(
+				"SHA-256 verification failed: expected %s, got %s",
+				expectedHash, actualHash,
+			)
+		}
+	}
+
+	// Extract zip
+	return extractZip(tmpPath, outputDir)
+}
+
+// extractZip extracts a zip archive to the specified directory.
+func extractZip(zipPath, outputDir string) error {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return fmt.Errorf("failed to open zip: %w", err)
+	}
+	defer r.Close()
+
+	absOutput, err := filepath.Abs(outputDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve output directory: %w", err)
+	}
+
+	for _, f := range r.File {
+		if err := extractZipEntry(f, absOutput); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// extractZipEntry extracts a single zip entry to the output directory with zip-slip protection.
+func extractZipEntry(f *zip.File, absOutput string) error {
+	// Resolve absolute path of target and verify it stays under absOutput.
+	//nolint:gosec // G305: zip-slip is checked via filepath.Rel below
+	target := filepath.Join(absOutput, f.Name)
+	rel, err := filepath.Rel(absOutput, target)
+	if err != nil || rel == ".." || len(rel) > 2 && rel[:3] == ".."+string(os.PathSeparator) {
+		return fmt.Errorf("invalid file path in zip (zip-slip detected): %s", f.Name)
+	}
+
+	if f.FileInfo().IsDir() {
+		if err := os.MkdirAll(target, 0750); err != nil {
+			return fmt.Errorf("failed to create directory %q: %w", target, err)
+		}
+		return nil
+	}
+
+	// Ensure parent directory exists
+	if err := os.MkdirAll(filepath.Dir(target), 0750); err != nil {
+		return fmt.Errorf("failed to create parent directory for %q: %w", target, err)
+	}
+
+	//nolint:gosec // G304: target path is validated above via filepath.Rel
+	outFile, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+	if err != nil {
+		return fmt.Errorf("failed to create file %q: %w", target, err)
+	}
+
+	rc, err := f.Open()
+	if err != nil {
+		_ = outFile.Close()
+		return fmt.Errorf("failed to open zip entry %q: %w", f.Name, err)
+	}
+
+	//nolint:gosec // G110: controlled extraction with zip-slip protection above
+	if _, err := io.Copy(outFile, rc); err != nil {
+		_ = rc.Close()
+		_ = outFile.Close()
+		return fmt.Errorf("failed to extract %q: %w", f.Name, err)
+	}
+
+	_ = rc.Close()
+	if err := outFile.Close(); err != nil {
+		return fmt.Errorf("failed to close extracted file %q: %w", target, err)
+	}
+
+	return nil
+}
+
+// equalFoldHash compares two hex-encoded hash strings case-insensitively.
+func equalFoldHash(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		ca, cb := a[i], b[i]
+		if ca >= 'A' && ca <= 'Z' {
+			ca += 'a' - 'A'
+		}
+		if cb >= 'A' && cb <= 'Z' {
+			cb += 'a' - 'A'
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/code_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/code_test.go
@@ -1,0 +1,258 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodeDownloadCommand_AcceptsPositionalArg(t *testing.T) {
+	cmd := newCodeDownloadCommand(nil)
+	err := cmd.Args(cmd, []string{"my-service"})
+	assert.NoError(t, err)
+}
+
+func TestCodeDownloadCommand_AcceptsNoArgs(t *testing.T) {
+	cmd := newCodeDownloadCommand(nil)
+	err := cmd.Args(cmd, []string{})
+	assert.NoError(t, err)
+}
+
+func TestCodeDownloadCommand_RejectsMultipleArgs(t *testing.T) {
+	cmd := newCodeDownloadCommand(nil)
+	err := cmd.Args(cmd, []string{"svc1", "svc2"})
+	assert.Error(t, err)
+}
+
+func TestCodeDownloadCommand_Flags(t *testing.T) {
+	cmd := newCodeDownloadCommand(nil)
+
+	tests := []struct {
+		name     string
+		defValue string
+	}{
+		{"version", ""},
+		{"dest", ""},
+		{"zip", "false"},
+	}
+
+	for _, tt := range tests {
+		flag := cmd.Flags().Lookup(tt.name)
+		if flag == nil {
+			t.Fatalf("expected --%s flag to be registered", tt.name)
+		}
+		if flag.DefValue != tt.defValue {
+			t.Fatalf("expected --%s default %q, got %q", tt.name, tt.defValue, flag.DefValue)
+		}
+	}
+}
+
+func TestCodeDownloadCommand_VersionShorthand(t *testing.T) {
+	cmd := newCodeDownloadCommand(nil)
+	flag := cmd.Flags().ShorthandLookup("v")
+	require.NotNil(t, flag, "expected -v shorthand for --version")
+	assert.Equal(t, "version", flag.Name)
+}
+
+func TestCodeDownloadCommand_DestShorthand(t *testing.T) {
+	cmd := newCodeDownloadCommand(nil)
+	flag := cmd.Flags().ShorthandLookup("d")
+	require.NotNil(t, flag, "expected -d shorthand for --dest")
+	assert.Equal(t, "dest", flag.Name)
+}
+
+func TestSaveZipFile_WritesAndVerifiesHash(t *testing.T) {
+	content := []byte("fake zip content for testing")
+	hash := sha256.Sum256(content)
+	expectedHash := hex.EncodeToString(hash[:])
+
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "test.zip")
+
+	err := saveZipFile(outputPath, bytes.NewReader(content), expectedHash)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(outputPath) //nolint:gosec // G304: test file path from t.TempDir()
+	require.NoError(t, err)
+	assert.Equal(t, content, data)
+}
+
+func TestSaveZipFile_FailsOnHashMismatch(t *testing.T) {
+	content := []byte("fake zip content")
+	wrongHash := "0000000000000000000000000000000000000000000000000000000000000000"
+
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "test.zip")
+
+	err := saveZipFile(outputPath, bytes.NewReader(content), wrongHash)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SHA-256 verification failed")
+
+	// File should be cleaned up
+	_, statErr := os.Stat(outputPath)
+	assert.True(t, os.IsNotExist(statErr), "file should be removed on hash mismatch")
+}
+
+func TestSaveZipFile_SkipsHashVerificationWhenEmpty(t *testing.T) {
+	content := []byte("fake zip content")
+
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "test.zip")
+
+	err := saveZipFile(outputPath, bytes.NewReader(content), "")
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(outputPath) //nolint:gosec // G304: test file path from t.TempDir()
+	require.NoError(t, err)
+	assert.Equal(t, content, data)
+}
+
+func TestExtractZip_ExtractsFilesCorrectly(t *testing.T) {
+	// Create a zip in memory
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	files := map[string]string{
+		"hello.txt":       "Hello, World!",
+		"subdir/file.txt": "nested content",
+	}
+	for name, content := range files {
+		w, err := zw.Create(name)
+		require.NoError(t, err)
+		_, err = w.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+
+	// Write zip to temp file
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "test.zip")
+	require.NoError(t, os.WriteFile(zipPath, buf.Bytes(), 0600))
+
+	// Extract
+	outputDir := filepath.Join(tmpDir, "output")
+	err := extractZip(zipPath, outputDir)
+	require.NoError(t, err)
+
+	// Verify
+	for name, expectedContent := range files {
+		data, err := os.ReadFile(filepath.Join(outputDir, name)) //nolint:gosec // G304: test path from t.TempDir()
+		require.NoError(t, err, "expected file %s to exist", name)
+		assert.Equal(t, expectedContent, string(data))
+	}
+}
+
+func TestExtractZip_BlocksZipSlip(t *testing.T) {
+	// Create a zip with a path traversal entry
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("../../../etc/passwd")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("malicious"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "evil.zip")
+	require.NoError(t, os.WriteFile(zipPath, buf.Bytes(), 0600))
+
+	outputDir := filepath.Join(tmpDir, "output")
+	err = extractZip(zipPath, outputDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "zip-slip detected")
+}
+
+func TestExtractZip_WorksWithDotOutputDir(t *testing.T) {
+	// Regression test: extractZip should work when outputDir is "."
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("test.txt")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("content"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "test.zip")
+	require.NoError(t, os.WriteFile(zipPath, buf.Bytes(), 0600))
+
+	// Use a subdirectory as "." equivalent
+	outputDir := filepath.Join(tmpDir, "out")
+	err = extractZip(zipPath, outputDir)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(outputDir, "test.txt")) //nolint:gosec // G304: test path
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(data))
+}
+
+func TestEqualFoldHash(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want bool
+	}{
+		{"abc123", "ABC123", true},
+		{"abc123", "abc123", true},
+		{"ABC123", "ABC123", true},
+		{"abc123", "abc124", false},
+		{"abc", "abcd", false},
+		{"", "", true},
+	}
+	for _, tt := range tests {
+		got := equalFoldHash(tt.a, tt.b)
+		assert.Equal(t, tt.want, got, "equalFoldHash(%q, %q)", tt.a, tt.b)
+	}
+}
+
+func TestDownloadAndExtract_VerifiesHashAndExtracts(t *testing.T) {
+	// Create a valid zip
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("readme.md")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("# Hello"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	zipBytes := buf.Bytes()
+	hash := sha256.Sum256(zipBytes)
+	expectedHash := hex.EncodeToString(hash[:])
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "extracted")
+
+	err = downloadAndExtract(outputDir, bytes.NewReader(zipBytes), expectedHash)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(outputDir, "readme.md")) //nolint:gosec // G304: test path
+	require.NoError(t, err)
+	assert.Equal(t, "# Hello", string(data))
+}
+
+func TestDownloadAndExtract_FailsOnHashMismatch(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("file.txt")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("data"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "extracted")
+
+	wrongHash := "0000000000000000000000000000000000000000000000000000000000000000"
+	err = downloadAndExtract(outputDir, bytes.NewReader(buf.Bytes()), wrongHash)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SHA-256 verification failed")
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/root.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/root.go
@@ -65,6 +65,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.AddCommand(newSampleCommand(extCtx))
 	rootCmd.AddCommand(newDoctorCommand())
 
+	rootCmd.AddCommand(newCodeCommand(extCtx))
 	rootCmd.AddCommand(newEvalCommand(extCtx))
 	rootCmd.AddCommand(newOptimizeCommand(extCtx))
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
@@ -949,6 +949,63 @@ func (c *AgentClient) DownloadSessionFile(
 	return resp.Body, nil
 }
 
+// CodeDownloadResult holds the response metadata from a code download operation.
+type CodeDownloadResult struct {
+	// Body is the zip content stream. The caller must close it.
+	Body io.ReadCloser
+	// ContentHash is the SHA-256 hash of the zip content (from x-ms-code-zip-sha256 header).
+	ContentHash string
+	// AgentVersion is the version that was downloaded (from x-ms-agent-version header).
+	AgentVersion string
+}
+
+// DownloadAgentCode downloads the source code of a code-based agent as a zip archive.
+// If agentVersion is empty, the latest version is downloaded.
+func (c *AgentClient) DownloadAgentCode(
+	ctx context.Context,
+	agentName, apiVersion string,
+	agentVersion string,
+) (*CodeDownloadResult, error) {
+	u, err := url.Parse(c.endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid endpoint URL: %w", err)
+	}
+
+	u.Path += fmt.Sprintf("/agents/%s/code:download", agentName)
+
+	query := u.Query()
+	query.Set("api-version", apiVersion)
+	if agentVersion != "" {
+		query.Set("agent_version", agentVersion)
+	}
+	u.RawQuery = query.Encode()
+
+	req, err := runtime.NewRequest(ctx, http.MethodGet, u.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	runtime.SkipBodyDownload(req)
+
+	req.Raw().Header.Set("Foundry-Features", "CodeAgents=V1Preview,HostedAgents=V1Preview")
+
+	resp, err := c.pipeline.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+		defer resp.Body.Close()
+		return nil, runtime.NewResponseError(resp)
+	}
+
+	return &CodeDownloadResult{
+		Body:         resp.Body,
+		ContentHash:  resp.Header.Get("x-ms-code-zip-sha256"),
+		AgentVersion: resp.Header.Get("x-ms-agent-version"),
+	}, nil
+}
+
 // ListSessionFiles lists files in a session's filesystem.
 // remotePath is the directory path to list (empty string for root).
 func (c *AgentClient) ListSessionFiles(

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"maps"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -848,4 +849,126 @@ func TestCreateAgentVersion_SetsHostedAgentsPreviewHeader(t *testing.T) {
 		transport.lastReq.Header.Get("Foundry-Features"),
 		"CreateAgentVersion must opt in to HostedAgents=V1Preview on the v1 endpoint",
 	)
+}
+
+// ---------------------------------------------------------------------------
+// DownloadAgentCode tests
+// ---------------------------------------------------------------------------
+
+// downloadTransport captures the request and returns a response with custom headers.
+type downloadTransport struct {
+	lastReq    *http.Request
+	statusCode int
+	respBody   string
+	respHeader http.Header
+}
+
+func (d *downloadTransport) Do(req *http.Request) (*http.Response, error) {
+	d.lastReq = req
+	header := http.Header{}
+	maps.Copy(header, d.respHeader)
+	if header.Get("Content-Type") == "" {
+		header.Set("Content-Type", "application/zip")
+	}
+	return &http.Response{
+		StatusCode: d.statusCode,
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(d.respBody)),
+		Request:    req,
+	}, nil
+}
+
+func TestDownloadAgentCode_BuildsCorrectURL(t *testing.T) {
+	transport := &downloadTransport{
+		statusCode: http.StatusOK,
+		respBody:   "fake-zip-bytes",
+		respHeader: http.Header{
+			"X-Ms-Code-Zip-Sha256": {"abc123"},
+			"X-Ms-Agent-Version":   {"5"},
+		},
+	}
+	client := newTestClient("https://test.example.com/api/projects/proj", transport)
+
+	result, err := client.DownloadAgentCode(context.Background(), "my-agent", "v1", "")
+	require.NoError(t, err)
+	defer result.Body.Close()
+
+	require.NotNil(t, transport.lastReq)
+	require.Equal(t, http.MethodGet, transport.lastReq.Method)
+	require.Equal(
+		t,
+		"https://test.example.com/api/projects/proj/agents/my-agent/code:download",
+		transport.lastReq.URL.Scheme+"://"+transport.lastReq.URL.Host+transport.lastReq.URL.Path,
+	)
+	require.Equal(t, "v1", transport.lastReq.URL.Query().Get("api-version"))
+	require.Empty(t, transport.lastReq.URL.Query().Get("agent_version"), "agent_version should not be set when empty")
+}
+
+func TestDownloadAgentCode_IncludesVersionParam(t *testing.T) {
+	transport := &downloadTransport{
+		statusCode: http.StatusOK,
+		respBody:   "fake-zip-bytes",
+		respHeader: http.Header{},
+	}
+	client := newTestClient("https://test.example.com/api/projects/proj", transport)
+
+	result, err := client.DownloadAgentCode(context.Background(), "my-agent", "v1", "3")
+	require.NoError(t, err)
+	defer result.Body.Close()
+
+	require.Equal(t, "3", transport.lastReq.URL.Query().Get("agent_version"))
+}
+
+func TestDownloadAgentCode_SetsFeatureHeader(t *testing.T) {
+	transport := &downloadTransport{
+		statusCode: http.StatusOK,
+		respBody:   "fake-zip",
+		respHeader: http.Header{},
+	}
+	client := newTestClient("https://test.example.com/api/projects/proj", transport)
+
+	result, err := client.DownloadAgentCode(context.Background(), "my-agent", "v1", "")
+	require.NoError(t, err)
+	defer result.Body.Close()
+
+	require.Equal(
+		t,
+		"CodeAgents=V1Preview,HostedAgents=V1Preview",
+		transport.lastReq.Header.Get("Foundry-Features"),
+	)
+}
+
+func TestDownloadAgentCode_ReturnsResponseHeaders(t *testing.T) {
+	transport := &downloadTransport{
+		statusCode: http.StatusOK,
+		respBody:   "zip-content",
+		respHeader: http.Header{
+			"X-Ms-Code-Zip-Sha256": {"deadbeef"},
+			"X-Ms-Agent-Version":   {"7"},
+		},
+	}
+	client := newTestClient("https://test.example.com/api/projects/proj", transport)
+
+	result, err := client.DownloadAgentCode(context.Background(), "my-agent", "v1", "")
+	require.NoError(t, err)
+	defer result.Body.Close()
+
+	require.Equal(t, "deadbeef", result.ContentHash)
+	require.Equal(t, "7", result.AgentVersion)
+
+	body, err := io.ReadAll(result.Body)
+	require.NoError(t, err)
+	require.Equal(t, "zip-content", string(body))
+}
+
+func TestDownloadAgentCode_ReturnsErrorOnNon200(t *testing.T) {
+	transport := &downloadTransport{
+		statusCode: http.StatusNotFound,
+		respBody:   `{"error":{"code":"not_found","message":"agent not found"}}`,
+		respHeader: http.Header{"Content-Type": {"application/json"}},
+	}
+	client := newTestClient("https://test.example.com/api/projects/proj", transport)
+
+	_, err := client.DownloadAgentCode(context.Background(), "no-such-agent", "v1", "")
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Summary

- Add new `azd ai agent code download [name]` command to download deployed source code of a code-based hosted agent from Azure AI Foundry
- Completes the round-trip: `azd deploy` pushes code, `code download` pulls it back

## Details

**New API method** (`operations.go`):
- `DownloadAgentCode()` — streaming GET to `/agents/{name}/code:download?agent_version=N`
- Feature header: `CodeAgents=V1Preview,HostedAgents=V1Preview` (same gate as zip upload)
- Returns body stream + SHA-256 hash + version from response headers

**New command** (`code.go`):
- `azd ai agent code download [name]` — downloads and extracts source code
- `--version, -v` — specific version (default: latest)
- `--dest, -d` — destination path (default: `./<agent-name>/` or `./<agent-name>.zip`)
- `--zip` — save raw zip instead of extracting
- SHA-256 verification against `x-ms-code-zip-sha256` response header
- Zip-slip protection on extraction
- Error if output path already exists (suggests `--dest`)

**Command registration** (`root.go`):
- New `code` subcommand group registered alongside `files`, `sessions`, `eval`, etc.

**Note:** Renamed `--output/-o` to `--dest/-d` because `--output/-o` is a reserved azd global flag.

## Testing

### Build & Unit Tests
- `go build ./...` passes
- All existing tests pass (`go test ./internal/...`)
- No breaking changes to existing commands

### Live Testing (against real deployed agents)

All tests run against agent `hello-world-python-invocations` (v1) and `hello-world-voice` (v7) in project `wujia-aifproject-260601` (North Central US).

#### Test 1: Download latest version (auto-extract) ✅
```
$ azd ai agent code download
Downloaded agent "hello-world-python-invocations" (version 1) -> hello-world-python-invocations
SHA-256: d057042b12ec4daf54079da2779fe6a66d8078e2b914a095bad576415c8456f5
```
Extracted files: `main.py` (7415B), `README.md` (11594B), `requirements.txt` (106B)

#### Test 2: Download as zip (`--zip`) ✅
```
$ azd ai agent code download --zip
Downloaded agent "hello-world-python-invocations" (version 1) -> hello-world-python-invocations.zip
SHA-256: d057042b12ec4daf54079da2779fe6a66d8078e2b914a095bad576415c8456f5
```
Zip file size: 7718 bytes. SHA-256 verified independently via `Get-FileHash` — matches.

#### Test 3: Download with `--dest` ✅
```
$ azd ai agent code download --dest custom-output-dir
Downloaded agent "hello-world-python-invocations" (version 1) -> custom-output-dir
SHA-256: d057042b12ec4daf54079da2779fe6a66d8078e2b914a095bad576415c8456f5
```

#### Test 4: Download specific version (`--version 1`) ✅
```
$ azd ai agent code download --version 1 --dest v1-test
Downloaded agent "hello-world-python-invocations" (version 1) -> v1-test
SHA-256: d057042b12ec4daf54079da2779fe6a66d8078e2b914a095bad576415c8456f5
```

#### Test 5: Error — output path already exists ✅
```
$ azd ai agent code download
ERROR: output path "hello-world-python-invocations" already exists

Use --dest (-d) to specify a different path
```

#### Test 6: Error — non-existent version (404) ✅
```
$ azd ai agent code download --version 999 --dest v999-test
ERROR: failed to download agent code: GET .../agents/hello-world-python-invocations/code:download
RESPONSE 404: 404 Not Found
ERROR CODE: not_found
{
  "error": {
    "message": "Agent hello-world-python-invocations with version 999 not found [Request ID: ...]"
  }
}
```

#### Test 7: Download different code agent (`hello-world-voice`) ✅
```
$ azd ai agent code download voice
Downloaded agent "hello-world-voice" (version 7) -> hello-world-voice
SHA-256: cff9776c21bade65067503f18bc62381df635aec223c5e52d90271ceb8192835
```
Extracted 9 files including `main.py`, `proxy.py`, `index.html`, `requirements.txt`.

Closes #8575