### PR TITLE
Rebrand: update ".NET Aspire" references to "Aspire"

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -801,7 +801,7 @@
 
 ### Features Added
 
-- [[5249]](https://github.com/Azure/azure-dev/pull/5249) Add support for deploying a single service in .NET Aspire projects via vs-server.
+- [[5249]](https://github.com/Azure/azure-dev/pull/5249) Add support for deploying a single service in Aspire projects via vs-server.
 - [[5157]](https://github.com/Azure/azure-dev/pull/5157) Update `azd add` integration with AI Foundry to use simplified 1RP setup with all models under a single AI Services account.
 - [[5214]](https://github.com/Azure/azure-dev/pull/5214) Add Linux to Homebrew formulae. Thanks @heaths for the contribution!
 - [[5204]](https://github.com/Azure/azure-dev/pull/5204) Add login guard middleware to auto-prompt for user login in key commands if unauthenticated.
@@ -901,7 +901,7 @@
 - [[4931]](https://github.com/Azure/azure-dev/pull/4931) `azd add` support for Azure AI Search.
 - [[4914]](https://github.com/Azure/azure-dev/pull/4914) `azd show` support for all resources supported by `azd add`.
 - [[4874]](https://github.com/Azure/azure-dev/pull/4874) Provide shortcuts for `azd env set-secrets` to directly use Key Vault created with `azd add`.
-- [[4957]](https://github.com/Azure/azure-dev/pull/4957), [[4959]](https://github.com/Azure/azure-dev/pull/4959), [[4979]](https://github.com/Azure/azure-dev/pull/4979), [[4999]](https://github.com/Azure/azure-dev/pull/4999), [[5008]](https://github.com/Azure/azure-dev/pull/5008) Support .NET Aspire 9.1.
+- [[4957]](https://github.com/Azure/azure-dev/pull/4957), [[4959]](https://github.com/Azure/azure-dev/pull/4959), [[4979]](https://github.com/Azure/azure-dev/pull/4979), [[4999]](https://github.com/Azure/azure-dev/pull/4999), [[5008]](https://github.com/Azure/azure-dev/pull/5008) Support Aspire 9.1.
 - [[4953]](https://github.com/Azure/azure-dev/pull/4953) Support array of model usage names for quota validation.
 - [[5010]](https://github.com/Azure/azure-dev/pull/5010) Support model usage name metadata for main `location` Bicep parameter.
 
@@ -995,7 +995,7 @@
 - [[4719]](https://github.com/Azure/azure-dev/pull/4719) Update Redis AVM to use native secrets export.
 - [[4690]](https://github.com/Azure/azure-dev/pull/4690) Use .NET SDK without Aspire workload in auto-generated pipeline definitions.
 - [[4703]](https://github.com/Azure/azure-dev/pull/4703) Use install scripts in "Install azd" Azure DevOps extension.
-- [[4750]](https://github.com/Azure/azure-dev/pull/4750) Support bicep.v1 resource for .NET Aspire.
+- [[4750]](https://github.com/Azure/azure-dev/pull/4750) Support bicep.v1 resource for Aspire.
 
 ## 1.11.1 (2025-01-07)
 
@@ -1020,7 +1020,7 @@
 
 ### Bugs Fixed
 
-- [[4524]](https://github.com/Azure/azure-dev/pull/4524) Fix using parameters for .NET Aspire deployment.
+- [[4524]](https://github.com/Azure/azure-dev/pull/4524) Fix using parameters for Aspire deployment.
 
 ## 1.10.4 (2024-11-06)
 
@@ -1173,7 +1173,7 @@
 
 - [[3718]](https://github.com/Azure/azure-dev/pull/3718) Deploy AI/ML studio online endpoints with host `ml.endpoint`. Starter templates `azd-ai-starter` and `azd-aistudio-starter` are available to get started with ease.
 - [[3840]](https://github.com/Azure/azure-dev/pull/3840) Filter templates when running `azd init` or `azd template list` with `--filter`
-- .NET Aspire:
+- Aspire:
   - [[3267]](https://github.com/Azure/azure-dev/pull/3267) Support services with multiple exposed ports
   - [[3820]](https://github.com/Azure/azure-dev/pull/3820) Container resources now supports reference expressions, and are now modeled the same as project resources
 
@@ -1212,7 +1212,7 @@
 
 ### Features Added
 
-- [[3731]](https://github.com/Azure/azure-dev/pull/3731) Support Data Protection Runtime feature for .NET Aspire in ACA under feature flag `azd config set alpha.aspire.autoConfigureDataProtection on`
+- [[3731]](https://github.com/Azure/azure-dev/pull/3731) Support Data Protection Runtime feature for Aspire in ACA under feature flag `azd config set alpha.aspire.autoConfigureDataProtection on`
 - [[3715]](https://github.com/Azure/azure-dev/pull/3715) Improved security to prevent committing an environment to the repository
 
 ### Bugs Fixed
@@ -1328,10 +1328,10 @@
 
 - [[2969]](https://github.com/Azure/azure-dev/pull/2969) Relax container names truncation logic for Aspire `redis.v0` and `postgres.database.v0`.
   Truncation now happens above 30 characters instead of 12 characters.
-- [[3035]](https://github.com/Azure/azure-dev/pull/3035) .NET Aspire issues after `azd pipeline config`.
+- [[3035]](https://github.com/Azure/azure-dev/pull/3035) Aspire issues after `azd pipeline config`.
 - [[3038]](https://github.com/Azure/azure-dev/pull/3038) Fix init to not consider parent directories.
 - [[3045]](https://github.com/Azure/azure-dev/pull/3045) Handle interrupt to unhide cursor.
-- [[3069]](https://github.com/Azure/azure-dev/pull/3069) .NET Aspire, enable `admin user` for ACR.
+- [[3069]](https://github.com/Azure/azure-dev/pull/3069) Aspire, enable `admin user` for ACR.
 - [[3049]](https://github.com/Azure/azure-dev/pull/3049) Persist location from provisioning manager.
 - [[3056]](https://github.com/Azure/azure-dev/pull/3056) Fix `azd pipeline config` for resource group deployment.
 - [[3106]](https://github.com/Azure/azure-dev/pull/3106) Fix `azd restore` on .NET projects.

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -1099,9 +1099,9 @@
 ### Bugs Fixed
 
 - [[4111]](https://github.com/Azure/azure-dev/pull/4111) Container Apps: Fail when explicit Dockerfile path not found.
-- [[4149]](https://github.com/Azure/azure-dev/pull/4149) Remove Admin Access as default for all .Net Aspire services.
+- [[4149]](https://github.com/Azure/azure-dev/pull/4149) Remove Admin Access as default for all Aspire services.
 - [[4104]](https://github.com/Azure/azure-dev/pull/4104) Remove Azure Dev Ops git remote constraint for dev.azure.com only.
-- [[4160]](https://github.com/Azure/azure-dev/pull/4160) Fix automatic generation of CI/CD files for .Net Aspire projects.
+- [[4160]](https://github.com/Azure/azure-dev/pull/4160) Fix automatic generation of CI/CD files for Aspire projects.
 - [[4182]](https://github.com/Azure/azure-dev/pull/4182) Allow `.yaml` and `.yml` extension for azure-dev pipeline files.
 - [[4187]](https://github.com/Azure/azure-dev/pull/4187) Fix panic during deployment progress rendering.
 
@@ -1129,7 +1129,7 @@
 - [[4003]](https://github.com/Azure/azure-dev/pull/4003) Add support for deploying flex-consumption function apps.
 - [[4008]](https://github.com/Azure/azure-dev/pull/4008) Add support for container.v1 [Aspire].
 - [[4030]](https://github.com/Azure/azure-dev/pull/4030) Prompt to add pipeline definition file during azd pipeline config.
-- [[3790]](https://github.com/Azure/azure-dev/pull/3790) Adding `alpha` feature `azd.operations` to support .Net Aspire bind mounts.
+- [[3790]](https://github.com/Azure/azure-dev/pull/3790) Adding `alpha` feature `azd.operations` to support Aspire bind mounts.
 - [[4049]](https://github.com/Azure/azure-dev/pull/4049) Adding pipeline config `--applicationServiceManagementReference`.
 
 ### Bugs Fixed
@@ -1224,7 +1224,7 @@
 ### Features Added
 
 - [[3569]](https://github.com/Azure/azure-dev/pull/3569) Adds `--from-code ` flag to initialize from existing code when running `azd init`
-- Dotnet Aspire:
+- Aspire:
   - [[3612]](https://github.com/Azure/azure-dev/pull/3612) Supports Aspire apps with multiple exposed ports
   - [[3484]](https://github.com/Azure/azure-dev/pull/3484) Discovers export port from the result of `dotnet publish`
   - [[3556]](https://github.com/Azure/azure-dev/pull/3556) Adds Aspire volumes support
@@ -1240,7 +1240,7 @@
 
 - [[3651]](https://github.com/Azure/azure-dev/pull/3651) Fixes trailing comma for `todo-nodejs-mongo-aks` template's invalid url in GitHub Action
 - [[3638]](https://github.com/Azure/azure-dev/pull/3638) Fixes `InvalidAuthenticationTokenTenant` error
-- Dotnet Aspire: 
+- Aspire:
   - [[3610]](https://github.com/Azure/azure-dev/pull/3610) Fixes too long auto-generated Azure Key Vault name by using Hash
   - [[3650]](https://github.com/Azure/azure-dev/pull/3650) Writes default port to manifest for docker
   - [[3545]](https://github.com/Azure/azure-dev/pull/3545) Updates Aspire generator to use the build args from the dockerfile resources
@@ -1258,7 +1258,7 @@
 
 - [[3450]](https://github.com/Azure/azure-dev/pull/3450) Adds support for pushing container images to external container registries
 - [[3452]](https://github.com/Azure/azure-dev/pull/3452) Adds support for other clouds
-- Dotnet Aspire:
+- Aspire:
   - [[3349]](https://github.com/Azure/azure-dev/pull/3349) Adds support for bicep and prompts for parameters
   - [[3411]](https://github.com/Azure/azure-dev/pull/3411) Adds support for `value.v0`
   - [[3425]](https://github.com/Azure/azure-dev/pull/3425) Sets `DOTNET_ENVIRONMENT` when running AppHost
@@ -1304,7 +1304,7 @@
 - [[3211]](https://github.com/Azure/azure-dev/pull/3211) Adds support for RBAC enabled AKS clusters using `kubelogin`
 - [[3196]](https://github.com/Azure/azure-dev/pull/3196) Adds support for Helm and Kustomize for AKS service targets
 - [[3173]](https://github.com/Azure/azure-dev/pull/3173) Adds support for defining customizable `azd up` workflows
-- Dotnet Aspire additions:
+- Aspire additions:
   - [[3164]](https://github.com/Azure/azure-dev/pull/3164) Azure Cosmos DB.
   - [[3226]](https://github.com/Azure/azure-dev/pull/3226) Azure SQL Database.
   - [[3276]](https://github.com/Azure/azure-dev/pull/3276) Secrets handling improvement.
@@ -1312,7 +1312,7 @@
 
 ### Bugs Fixed
 
-- [[3097]](https://github.com/Azure/azure-dev/pull/3097) For Dotnet Aspire projects, do not fail if folder `infra` is empty.
+- [[3097]](https://github.com/Azure/azure-dev/pull/3097) For Aspire projects, do not fail if folder `infra` is empty.
 
 ## 1.5.1 (2023-12-20)
 

--- a/cli/azd/docs/environment-variables.md
+++ b/cli/azd/docs/environment-variables.md
@@ -21,7 +21,7 @@ for each environment.
 | `AZURE_RESOURCE_GROUP` | The default resource group name. |
 | `AZURE_CONTAINER_REGISTRY_ENDPOINT` | The endpoint of the Azure Container Registry. |
 | `AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN` | The default domain of the Container Apps environment. |
-| `AZURE_APP_SERVICE_DASHBOARD_URI` | The URI for the .NET Aspire dashboard hosted on Azure App Service. |
+| `AZURE_APP_SERVICE_DASHBOARD_URI` | The URI for the Aspire dashboard hosted on Azure App Service. |
 | `AZURE_AKS_CLUSTER_NAME` | The name of the Azure Kubernetes Service cluster. |
 
 ## Dev Center Variables
@@ -257,8 +257,8 @@ These variables are used by the Terraform provider integration to authenticate w
 | `AZD_DEBUG_SYNTHETIC_SUBSCRIPTION` | If set, provides a synthetic subscription for testing. |
 | `AZD_DEBUG_NO_ALPHA_WARNINGS` | If true, suppresses alpha feature warnings. |
 | `AZD_DEBUG_PROVISION_PROGRESS_DISABLE` | If true, disables provision progress display. Read by both the Bicep provider and the Dev Center provisioner. |
-| `AZD_DEBUG_DOTNET_APPHOST_USE_FIXED_MANIFEST` | If true, uses a fixed manifest for .NET Aspire app host. |
-| `AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES` | If true, ignores unsupported resources in .NET Aspire app host. |
+| `AZD_DEBUG_DOTNET_APPHOST_USE_FIXED_MANIFEST` | If true, uses a fixed manifest for Aspire app host. |
+| `AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES` | If true, ignores unsupported resources in Aspire app host. |
 | `AZD_DEBUG_SERVER_DEBUG_ENDPOINTS` | If true, enables debug endpoints in server mode. |
 | `AZD_DEBUG_EXPERIMENTATION_TAS_ENDPOINT` | Overrides the experimentation TAS endpoint URL. |
 | `AZD_SUBSCRIPTIONS_FETCH_MAX_CONCURRENCY` | Limits the maximum concurrency when fetching subscriptions. |

--- a/cli/azd/extensions/microsoft.azd.concurx/README.md
+++ b/cli/azd/extensions/microsoft.azd.concurx/README.md
@@ -2,12 +2,12 @@
 
 The **ConcurX** extension (`microsoft.azd.concurx`) provides high-performance concurrent deployment capabilities for `azd`. It orchestrates the deployment of multiple services in parallel, reducing total deployment time for complex applications.
 
-> **Note:** This extension is experimental and primarily designed to optimize deployment workflows for multi-service architectures like .NET Aspire.
+> **Note:** This extension is experimental and primarily designed to optimize deployment workflows for multi-service architectures like Aspire.
 
 ## Features
 
 - **Concurrent Deployments**: Deploys multiple services in parallel instead of sequentially.
-- **Aspire Build Gate**: Intelligent coordination for .NET Aspire projects. Automatically detects when the AppHost has generated its manifest, allowing dependent services to build and deploy immediately without waiting for the full AppHost deployment to complete.
+- **Aspire Build Gate**: Intelligent coordination for Aspire projects. Automatically detects when the AppHost has generated its manifest, allowing dependent services to build and deploy immediately without waiting for the full AppHost deployment to complete.
 - **Isolated Logging**: Automatically captures and isolates logs for every service deployment into timestamped directories (`.azure/logs/deploy/<timestamp>/`).
 
 ## Installation
@@ -38,7 +38,7 @@ This command will:
 
 1. Run `azd provision` to set up infrastructure (sequentially, as per standard `azd` behavior).
 2. Once provisioned, launch `azd deploy <service-name>` for all services defined in your `azure.yaml` concurrently.
-3. Monitor .NET Aspire builds to release locks as soon as manifests are available, maximizing parallelism.
+3. Monitor Aspire builds to release locks as soon as manifests are available, maximizing parallelism.
 
 ### Options
 
@@ -55,7 +55,7 @@ azd concurx up --debug
 ## How it Works
 
 1. **Provisioning**: The extension first executes `azd provision` and streams the output to `provision.log`. Once this step completes, it proceeds to start deployments.
-2. **Aspire Gate**: For .NET Aspire applications, the AppHost project must build first to generate the deployment manifest. ConcurX identifies this dependency:
+2. **Aspire Gate**: For Aspire applications, the AppHost project must build first to generate the deployment manifest. ConcurX identifies this dependency:
    - It starts the "First Aspire" service deployment.
    - It monitors the output for the signal `Deploying services (azd deploy)`.
    - As soon as this signal is detected, it "opens the gate," allowing all other Aspire services to begin their deployment processes instantly, rather than waiting for the AppHost deployment to finish.

--- a/cli/azd/internal/appdetect/appdetect.go
+++ b/cli/azd/internal/appdetect/appdetect.go
@@ -34,7 +34,7 @@ func (pt Language) Display() string {
 	case DotNet:
 		return ".NET"
 	case DotNetAppHost:
-		return ".NET (Aspire)"
+		return "Aspire"
 	case Java:
 		return "Java"
 	case JavaScript:

--- a/cli/azd/internal/cmd/add/add.go
+++ b/cli/azd/internal/cmd/add/add.go
@@ -397,7 +397,7 @@ func ensureCompatibleProject(
 	if hasAppHost := importManager.HasAppHost(ctx, prjConfig); hasAppHost {
 		return &internal.ErrorWithSuggestion{
 			Err: fmt.Errorf("incompatible project: found Aspire app host"),
-			Suggestion: fmt.Sprintf("%s does not support .NET Aspire projects.",
+			Suggestion: fmt.Sprintf("%s does not support Aspire projects.",
 				output.WithHighLightFormat("azd add")),
 		}
 	}

--- a/cli/azd/pkg/apphost/manifest.go
+++ b/cli/azd/pkg/apphost/manifest.go
@@ -52,7 +52,7 @@ func (m *Manifest) Warnings() string {
 			"to customize the Azure Container Environment and/or Azure Container Apps",
 			output.WithBackticks("azd infra gen")))
 		sb.WriteString(fmt.Sprintf("  See more: %s",
-			output.WithLinkFormat("https://learn.microsoft.com/dotnet/aspire/azure/configure-aca-environments")))
+			output.WithLinkFormat("https://aspire.dev/integrations/cloud/azure/configure-container-apps/")))
 	}
 
 	if m.publishMode == publishModeHybrid {
@@ -65,7 +65,7 @@ func (m *Manifest) Warnings() string {
 			fmt.Sprintf(
 				"  See more: %s",
 				output.WithLinkFormat(
-					"https://learn.microsoft.com/dotnet/aspire/whats-new/dotnet-aspire-9.4#-azure-container-apps-hybrid-mode-removal",
+					"https://aspire.dev/whats-new/aspire-9-4/#-azure-container-apps-hybrid-mode-removal",
 				),
 			),
 		)

--- a/cli/azd/pkg/apphost/manifest_test.go
+++ b/cli/azd/pkg/apphost/manifest_test.go
@@ -160,7 +160,7 @@ func TestManifest_Warnings(t *testing.T) {
 				//nolint:lll
 				"  This mode is limited. You will not be able to manage the host infrastructure from your AppHost. You'll need to use `azd infra gen` " +
 				"to customize the Azure Container Environment and/or Azure Container Apps" +
-				"  See more: https://learn.microsoft.com/dotnet/aspire/azure/configure-aca-environments",
+				"  See more: https://aspire.dev/integrations/cloud/azure/configure-container-apps/",
 		},
 		{
 			name:        "hybrid mode shows deprecation warning",
@@ -169,7 +169,7 @@ func TestManifest_Warnings(t *testing.T) {
 				" to define the Azure Container App, azd defines the Azure Container Environment.\n  This mode is " +
 				"deprecated since Aspire 9.4.  " +
 				//nolint:lll
-				"See more: https://learn.microsoft.com/dotnet/aspire/whats-new/dotnet-aspire-9.4#-azure-container-apps-hybrid-mode-removal",
+				"See more: https://aspire.dev/whats-new/aspire-9-4/#-azure-container-apps-hybrid-mode-removal",
 		},
 		{
 			name:        "full apphost mode shows no warnings",

--- a/docs/reference/telemetry-data.md
+++ b/docs/reference/telemetry-data.md
@@ -643,7 +643,7 @@ How to find telemetry for a given feature area. Start here if you know the featu
 |-------------|------------|---------------------|---------------------|
 | **Core Workflows (init/up/deploy/provision/down)** | `cmd.init`, `cmd.up`, `cmd.deploy`, `cmd.provision`, `cmd.down` | `cmd.entry`, `cmd.flags` | Adoption, success rate, duration, error patterns |
 | **Deployment Targets** | `cmd.deploy`, `cmd.package` | `project.service.targets` (`appservice`, `containerapp`, `aks`, etc.) | Usage by target, success rate per target |
-| **Container Apps (.NET / Aspire)** | `cmd.deploy`, `cmd.provision` | `project.service.targets` = `containerapp-dotnet`, `platform.type` = `aca` | Aspire-specific adoption and success |
+| **Container Apps (Aspire)** | `cmd.deploy`, `cmd.provision` | `project.service.targets` = `containerapp-dotnet`, `platform.type` = `aca` | Aspire-specific adoption and success |
 | **Language Support** | `cmd.deploy`, `cmd.package`, `cmd.restore` | `project.service.languages`, `project.service.language` | Usage by language |
 | **Templates** | `cmd.init`, `cmd.up` | `project.template.id` (hashed — join with template lookup to resolve) | Template adoption, success by template |
 | **Provisioning (IaC)** | `cmd.provision`, `arm.deploy.*`, `arm.validate.*` | `infra.provider` (`bicep`, `terraform`) | Provision success, ARM errors, duration |

--- a/docs/reference/telemetry-data.md
+++ b/docs/reference/telemetry-data.md
@@ -188,7 +188,7 @@ Valid values for `project.service.hosts` and `project.service.targets`:
 |-------|-------------|
 | `appservice` | Azure App Service |
 | `containerapp` | Azure Container Apps |
-| `containerapp-dotnet` | Azure Container Apps (.NET Aspire) |
+| `containerapp-dotnet` | Azure Container Apps (Aspire) |
 | `function` | Azure Functions |
 | `staticwebapp` | Azure Static Web Apps |
 | `springapp` | Azure Spring Apps |

--- a/eng/pipelines/templates/jobs/build-cli.yml
+++ b/eng/pipelines/templates/jobs/build-cli.yml
@@ -88,7 +88,7 @@ jobs:
 
       - template: /eng/pipelines/templates/steps/install-docker.yml
 
-      # Adding dotnet 8 and 9 for .Net Aspire tests
+      # Adding dotnet 8 and 9 for Aspire tests
       - task: UseDotNet@2
         condition: and(succeeded(), ne(variables['Skip.LiveTest'], 'true'))
         inputs:


### PR DESCRIPTION
## Summary

The product formerly known as **.NET Aspire** was rebranded to simply **Aspire** late last year. This PR updates current, user-facing references from ".NET Aspire" to "Aspire".

Fixes #8578

## Changes

- `cli/azd/internal/cmd/add/add.go` — `azd add` incompatibility suggestion string
- `cli/azd/docs/environment-variables.md` — descriptions for `AZURE_APP_SERVICE_DASHBOARD_URI`, `AZD_DEBUG_DOTNET_APPHOST_USE_FIXED_MANIFEST`, `AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES`
- `cli/azd/extensions/microsoft.azd.concurx/README.md` — four mentions
- `docs/reference/telemetry-data.md` — `containerapp-dotnet` host description
- `eng/pipelines/templates/jobs/build-cli.yml` — pipeline comment

## Intentionally not changed

- **`cli/azd/CHANGELOG.md`** — historical release-note entries reflect the product name at the time of each release; rewriting them would misrepresent that history.
- Identifier values such as the `containerapp-dotnet` telemetry value and `*_DOTNET_APPHOST_*` env-var names are not display names and are left unchanged to preserve compatibility.

## Validation

- `go build` of the `add` package succeeds.
- No active ".NET Aspire" references remain outside `CHANGELOG.md`.