### PR TITLE
fix: lazy-detect container engine so Podman is used in Aspire dotnet deploys

### DIFF
--- a/cli/azd/pkg/tools/docker/docker.go
+++ b/cli/azd/pkg/tools/docker/docker.go
@@ -36,10 +36,36 @@ type Cli struct {
 }
 
 // ContainerEngine returns the detected container engine name ("docker" or "podman").
-// CheckInstalled() should be called first to detect and set the container engine.
-// If not set, defaults to "docker" for backward compatibility.
+// If CheckInstalled() has already been called, this returns the cached result.
+// Otherwise, it performs a lightweight detection (env var + PATH check) without
+// validating version or daemon readiness. This ensures callers that need the
+// engine name (e.g., dotnet publish with -p:ContainerEngine) get the correct
+// value even when docker.Cli is not in RequiredExternalTools.
 func (d *Cli) ContainerEngine() string {
-	return d.getContainerEngine()
+	if d.containerEngine == "" {
+		d.detectContainerEngine()
+	}
+	return d.containerEngine
+}
+
+// detectContainerEngine performs a lightweight detection of the container engine
+// by checking AZD_CONTAINER_RUNTIME and PATH. Unlike CheckInstalled(), it does
+// not validate versions or daemon readiness.
+func (d *Cli) detectContainerEngine() {
+	if runtime := os.Getenv("AZD_CONTAINER_RUNTIME"); runtime == "docker" || runtime == "podman" {
+		d.containerEngine = runtime
+		return
+	}
+
+	if d.commandRunner.ToolInPath("docker") == nil {
+		d.containerEngine = "docker"
+	} else if d.commandRunner.ToolInPath("podman") == nil {
+		d.containerEngine = "podman"
+	} else {
+		// Fallback — neither found; default to docker for backward compatibility.
+		// CheckInstalled() will produce a proper error if actually invoked.
+		d.containerEngine = "docker"
+	}
 }
 
 // getContainerEngine returns the container engine command to use ("docker" or "podman").

--- a/cli/azd/pkg/tools/docker/docker_test.go
+++ b/cli/azd/pkg/tools/docker/docker_test.go
@@ -865,6 +865,79 @@ func Test_CheckInstalled_NeitherAvailable(t *testing.T) {
 	require.Contains(t, err.Error(), "neither docker nor podman is installed")
 }
 
+func Test_ContainerEngine_LazyDetection(t *testing.T) {
+	t.Run("detects podman when docker not in PATH", func(t *testing.T) {
+		t.Parallel()
+		mockContext := mocks.NewMockContext(t.Context())
+		cli := NewCli(mockContext.CommandRunner)
+
+		// Docker not found, podman found
+		mockContext.CommandRunner.MockToolInPath("docker", errors.New("not found"))
+		mockContext.CommandRunner.MockToolInPath("podman", nil)
+
+		// ContainerEngine() should lazily detect podman without CheckInstalled()
+		engine := cli.ContainerEngine()
+		require.Equal(t, "podman", engine)
+	})
+
+	t.Run("detects docker when both in PATH", func(t *testing.T) {
+		t.Parallel()
+		mockContext := mocks.NewMockContext(t.Context())
+		cli := NewCli(mockContext.CommandRunner)
+
+		mockContext.CommandRunner.MockToolInPath("docker", nil)
+		mockContext.CommandRunner.MockToolInPath("podman", nil)
+
+		engine := cli.ContainerEngine()
+		require.Equal(t, "docker", engine)
+	})
+
+	t.Run("respects AZD_CONTAINER_RUNTIME env var", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(t.Context())
+		cli := NewCli(mockContext.CommandRunner)
+
+		t.Setenv("AZD_CONTAINER_RUNTIME", "podman")
+
+		engine := cli.ContainerEngine()
+		require.Equal(t, "podman", engine)
+	})
+
+	t.Run("defaults to docker when neither in PATH", func(t *testing.T) {
+		t.Parallel()
+		mockContext := mocks.NewMockContext(t.Context())
+		cli := NewCli(mockContext.CommandRunner)
+
+		mockContext.CommandRunner.MockToolInPath("docker", errors.New("not found"))
+		mockContext.CommandRunner.MockToolInPath("podman", errors.New("not found"))
+
+		engine := cli.ContainerEngine()
+		require.Equal(t, "docker", engine)
+	})
+
+	t.Run("does not override CheckInstalled result", func(t *testing.T) {
+		t.Parallel()
+		mockContext := mocks.NewMockContext(t.Context())
+		cli := NewCli(mockContext.CommandRunner)
+
+		// Simulate CheckInstalled having set podman
+		mockContext.CommandRunner.MockToolInPath("docker", errors.New("not found"))
+		mockContext.CommandRunner.MockToolInPath("podman", nil)
+		mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+			return strings.Contains(command, "podman --version")
+		}).Respond(exec.RunResult{Stdout: "podman version 4.3.1", ExitCode: 0})
+		mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+			return strings.Contains(command, "podman ps")
+		}).Respond(exec.RunResult{Stdout: "", ExitCode: 0})
+
+		err := cli.CheckInstalled(t.Context())
+		require.NoError(t, err)
+
+		// ContainerEngine should use the already-set value, not re-detect
+		engine := cli.ContainerEngine()
+		require.Equal(t, "podman", engine)
+	})
+}
+
 func TestSplitDockerImage(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Problem

The fix in #8527 correctly threads the container engine to `dotnet publish`, but **it never actually detects Podman** in the Aspire .NET container app deploy path.

### Root Cause

`dotnetContainerAppTarget.RequiredExternalTools()` returns only `[dotNetCli]` — it does **not** include `docker.Cli`. This means `docker.Cli.CheckInstalled()` is never called via `tools.EnsureInstalled()` during the Aspire deploy flow. As a result, `docker.Cli.containerEngine` stays `""` and `ContainerEngine()` defaults to `"docker"` — so `-p:ContainerEngine=podman` is never appended.

### Fix

`ContainerEngine()` now performs **lazy detection** on first call if `CheckInstalled()` hasn't run yet:
1. Checks `AZD_CONTAINER_RUNTIME` env var
2. Checks if `docker` is in PATH
3. Falls back to `podman` if in PATH
4. Defaults to `docker` if neither found (backward compatible; `CheckInstalled()` will error later if actually needed)

This is a lightweight check — no version validation or daemon readiness — just enough to determine which engine to pass to `dotnet publish`.

### Testing

5 new test cases for the lazy detection path:
- Podman detected when docker not in PATH
- Docker detected when both in PATH  
- `AZD_CONTAINER_RUNTIME` env var respected
- Defaults to docker when neither in PATH
- Does not override `CheckInstalled()` result if already called

All existing docker, dotnet, and project tests pass.

Fixes #8525
Related: #8527, https://github.com/microsoft/aspire/issues/17593