### PR TITLE
feat(agents): support Foundry ${{...}} server-side expressions in env expansion

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
@@ -24,7 +24,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/braydonk/yaml"
-	"github.com/drone/envsubst"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -930,9 +929,10 @@ func resolveTemplateRef(s string) string {
 	return s
 }
 
-// resolveEnvValue resolves ${VAR} references in a string using envsubst.
+// resolveEnvValue resolves ${VAR} references in a string against the azd environment while
+// leaving Foundry server-side ${{...}} expressions untouched. See [project.ExpandEnv].
 func resolveEnvValue(value string, azdEnv map[string]string) string {
-	resolved, err := envsubst.Eval(value, func(varName string) string {
+	resolved, err := project.ExpandEnv(value, func(varName string) string {
 		return azdEnv[varName]
 	})
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
@@ -514,10 +514,8 @@ func resolveAgentDefinitionEnvVars(
 		if _, isConn := connRefEnvNames[ev.Name]; isConn {
 			continue
 		}
-		resolved, evalErr := project.ExpandEnv(ev.Value, lookup)
-		if evalErr != nil {
-			resolved = ev.Value
-		}
+		// ExpandEnv returns the original value on error, so a failed expansion is a no-op.
+		resolved, _ := project.ExpandEnv(ev.Value, lookup)
 		result = append(result, fmt.Sprintf("%s=%s", ev.Name, resolved))
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
@@ -25,9 +25,9 @@ import (
 
 	"azureaiagent/internal/cmd/nextstep"
 	"azureaiagent/internal/pkg/agents/agent_yaml"
+	"azureaiagent/internal/project"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
-	"github.com/drone/envsubst"
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v3"
 	"google.golang.org/grpc/codes"
@@ -514,7 +514,7 @@ func resolveAgentDefinitionEnvVars(
 		if _, isConn := connRefEnvNames[ev.Name]; isConn {
 			continue
 		}
-		resolved, evalErr := envsubst.Eval(ev.Value, lookup)
+		resolved, evalErr := project.ExpandEnv(ev.Value, lookup)
 		if evalErr != nil {
 			resolved = ev.Value
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -40,7 +40,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/braydonk/yaml"
-	"github.com/drone/envsubst"
 	"github.com/fatih/color"
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -2272,7 +2271,7 @@ func (p *AgentServiceTargetProvider) registerAgentEnvironmentVariables(
 // resolveEnvironmentVariables resolves ${ENV_VAR} style references in value using azd environment variables.
 // Supports default values (e.g., "${VAR:-default}") and multiple expressions (e.g., "${VAR1}-${VAR2}").
 func (p *AgentServiceTargetProvider) resolveEnvironmentVariables(value string, azdEnv map[string]string) string {
-	resolved, err := envsubst.Eval(value, func(varName string) string {
+	resolved, err := ExpandEnv(value, func(varName string) string {
 		return azdEnv[varName]
 	})
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/templating.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/templating.go
@@ -25,7 +25,8 @@ var foundryTemplatePattern = regexp.MustCompile(`(?s)\$\{\{.*?\}\}`)
 // and ${{...}} are handled consistently. drone/envsubst cannot parse ${{...}} and fails the
 // whole string, so without this split any ${VAR} that appears alongside a ${{...}} span is
 // silently left unexpanded. The string is split on ${{...}} spans, only the gaps between them
-// are expanded, and the spans are reattached untouched.
+// are expanded, and the spans are reattached untouched. A ${VAR} that appears inside a ${{...}}
+// span is therefore left as-is, since the whole span is reserved for Foundry's resolver.
 func ExpandEnv(value string, mapping func(string) string) (string, error) {
 	spans := foundryTemplatePattern.FindAllStringIndex(value, -1)
 	if len(spans) == 0 {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/templating.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/templating.go
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/drone/envsubst"
+)
+
+// foundryTemplatePattern matches Foundry server-side ${{...}} expressions. These are resolved
+// by Foundry at runtime (for example ${{connections.x.credentials.key}} or ${{event.body}})
+// and must survive azd's client-side ${VAR} expansion untouched. The (?s) flag lets the span
+// cross newlines; the lazy quantifier stops at the first closing }}.
+var foundryTemplatePattern = regexp.MustCompile(`(?s)\$\{\{.*?\}\}`)
+
+// ExpandEnv expands ${VAR} references in value against the azd environment (via mapping) while
+// preserving Foundry server-side ${{...}} expressions verbatim. It supports default values
+// (${VAR:-default}) and multiple expressions, matching drone/envsubst semantics for the ${VAR}
+// portion. On expansion error the original value is returned unchanged alongside the error.
+//
+// This is the single shared expander every Foundry field should route through so that ${VAR}
+// and ${{...}} are handled consistently. drone/envsubst cannot parse ${{...}} and fails the
+// whole string, so without this split any ${VAR} that appears alongside a ${{...}} span is
+// silently left unexpanded. The string is split on ${{...}} spans, only the gaps between them
+// are expanded, and the spans are reattached untouched.
+func ExpandEnv(value string, mapping func(string) string) (string, error) {
+	spans := foundryTemplatePattern.FindAllStringIndex(value, -1)
+	if len(spans) == 0 {
+		expanded, err := envsubst.Eval(value, mapping)
+		if err != nil {
+			return value, err
+		}
+		return expanded, nil
+	}
+
+	var sb strings.Builder
+	cursor := 0
+	for _, span := range spans {
+		expanded, err := envsubst.Eval(value[cursor:span[0]], mapping)
+		if err != nil {
+			return value, err
+		}
+		sb.WriteString(expanded)
+		sb.WriteString(value[span[0]:span[1]])
+		cursor = span[1]
+	}
+
+	expanded, err := envsubst.Eval(value[cursor:], mapping)
+	if err != nil {
+		return value, err
+	}
+	sb.WriteString(expanded)
+
+	return sb.String(), nil
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/templating.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/templating.go
@@ -4,6 +4,7 @@
 package project
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -16,19 +17,25 @@ import (
 // cross newlines; the lazy quantifier stops at the first closing }}.
 var foundryTemplatePattern = regexp.MustCompile(`(?s)\$\{\{.*?\}\}`)
 
+// foundrySentinelBase is the prefix for placeholders that temporarily replace ${{...}} spans
+// while ${VAR} expansion runs. It contains no '$', '{', or '}', so drone/envsubst (which only
+// expands the braced ${...} form) copies it through untouched, even when a literal '$' precedes
+// it.
+const foundrySentinelBase = "azdFoundryTemplateSpan_"
+
 // ExpandEnv expands ${VAR} references in value against the azd environment (via mapping) while
 // preserving Foundry server-side ${{...}} expressions verbatim. It supports default values
 // (${VAR:-default}) and multiple expressions, matching drone/envsubst semantics for the ${VAR}
 // portion. On expansion error the original value is returned unchanged alongside the error.
 //
-// This is the single shared expander every Foundry field should route through so that ${VAR}
-// and ${{...}} are handled consistently. drone/envsubst cannot parse ${{...}} and fails the
-// whole string, so without this split any ${VAR} that appears alongside a ${{...}} span is
-// silently left unexpanded. The string is split on ${{...}} spans, only the gaps between them
-// are expanded, and the spans are reattached untouched. A ${VAR} that appears inside a ${{...}}
-// span is therefore left as-is, since the whole span is reserved for Foundry's resolver.
+// This is the single shared expander every Foundry field should route through so ${VAR} and
+// ${{...}} are handled consistently. drone/envsubst cannot parse ${{...}}, so each span is
+// masked with a sentinel placeholder, a single Eval expands the ${VAR} references, then the
+// spans are restored. Masking rather than splitting preserves full ${VAR:-default} semantics
+// even when a ${{...}} expression is the default value (e.g. ${MISSING:-${{event.body}}}).
+// A ${VAR} inside a ${{...}} span is left as-is, since the span is reserved for Foundry.
 func ExpandEnv(value string, mapping func(string) string) (string, error) {
-	spans := foundryTemplatePattern.FindAllStringIndex(value, -1)
+	spans := foundryTemplatePattern.FindAllString(value, -1)
 	if len(spans) == 0 {
 		expanded, err := envsubst.Eval(value, mapping)
 		if err != nil {
@@ -37,23 +44,26 @@ func ExpandEnv(value string, mapping func(string) string) (string, error) {
 		return expanded, nil
 	}
 
-	var sb strings.Builder
-	cursor := 0
-	for _, span := range spans {
-		expanded, err := envsubst.Eval(value[cursor:span[0]], mapping)
-		if err != nil {
-			return value, err
-		}
-		sb.WriteString(expanded)
-		sb.WriteString(value[span[0]:span[1]])
-		cursor = span[1]
+	// Choose a sentinel that does not already occur in the input so restoration is exact.
+	sentinel := foundrySentinelBase
+	for strings.Contains(value, sentinel) {
+		sentinel += "_"
 	}
 
-	expanded, err := envsubst.Eval(value[cursor:], mapping)
+	index := 0
+	masked := foundryTemplatePattern.ReplaceAllStringFunc(value, func(string) string {
+		placeholder := fmt.Sprintf("%s%d_", sentinel, index)
+		index++
+		return placeholder
+	})
+
+	expanded, err := envsubst.Eval(masked, mapping)
 	if err != nil {
 		return value, err
 	}
-	sb.WriteString(expanded)
 
-	return sb.String(), nil
+	for i, span := range spans {
+		expanded = strings.Replace(expanded, fmt.Sprintf("%s%d_", sentinel, i), span, 1)
+	}
+	return expanded, nil
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/templating_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/templating_test.go
@@ -56,6 +56,21 @@ func TestExpandEnv(t *testing.T) {
 			want:  "${{ outer ${FOO} }}",
 		},
 		{
+			name:  "foundry expression as default value, var unset",
+			input: "${MISSING:-${{event.body}}}",
+			want:  "${{event.body}}",
+		},
+		{
+			name:  "foundry expression as default value, var set",
+			input: "${FOO:-${{event.body}}}",
+			want:  "bar",
+		},
+		{
+			name:  "literal dollar before foundry span",
+			input: "$${{event.body}}",
+			want:  "$${{event.body}}",
+		},
+		{
 			name:  "foundry span across newline with var",
 			input: "${{first\nsecond}}\n${FOO}",
 			want:  "${{first\nsecond}}\nbar",

--- a/cli/azd/extensions/azure.ai.agents/internal/project/templating_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/templating_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandEnv(t *testing.T) {
+	env := map[string]string{
+		"FOO":      "bar",
+		"ENDPOINT": "https://example.com",
+	}
+	mapping := func(name string) string { return env[name] }
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "plain var", input: "${FOO}", want: "bar"},
+		{name: "var with default present", input: "${FOO:-fallback}", want: "bar"},
+		{name: "var with default absent", input: "${MISSING:-fallback}", want: "fallback"},
+		{name: "missing var no default", input: "${MISSING}", want: ""},
+		{name: "no templating", input: "plain text", want: "plain text"},
+		{name: "empty string", input: "", want: ""},
+		{name: "embedded var", input: "url=${ENDPOINT}/api", want: "url=https://example.com/api"},
+		{
+			name:  "foundry expression preserved",
+			input: "${{connections.x.credentials.key}}",
+			want:  "${{connections.x.credentials.key}}",
+		},
+		{
+			name:  "mixed var and foundry expression",
+			input: "prefix ${FOO} ${{event.body}} suffix",
+			want:  "prefix bar ${{event.body}} suffix",
+		},
+		{
+			name:  "adjacent foundry and var spans",
+			input: "${{a}}${FOO}${{b}}",
+			want:  "${{a}}bar${{b}}",
+		},
+		{
+			name:  "multiple foundry expressions only",
+			input: "${{a}} and ${{b}}",
+			want:  "${{a}} and ${{b}}",
+		},
+		{
+			name:  "foundry span across newline with var",
+			input: "${{first\nsecond}}\n${FOO}",
+			want:  "${{first\nsecond}}\nbar",
+		},
+		{
+			name:    "malformed unterminated expression returns original",
+			input:   "${{ unterminated",
+			want:    "${{ unterminated",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExpandEnv(tt.input, mapping)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestExpandEnvNeverCorruptsFoundryExpressions guards the core invariant: a ${{...}} span is
+// always returned byte-for-byte, regardless of what surrounds it.
+func TestExpandEnvNeverCorruptsFoundryExpressions(t *testing.T) {
+	mapping := func(name string) string { return map[string]string{"TOKEN": "secret"}[name] }
+
+	const foundry = "${{connections.github-mcp-conn.credentials.x-api-key}}"
+	got, err := ExpandEnv("Authorization: ${TOKEN}; key: "+foundry, mapping)
+	require.NoError(t, err)
+	assert.Equal(t, "Authorization: secret; key: "+foundry, got)
+	assert.Contains(t, got, foundry)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/templating_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/templating_test.go
@@ -51,6 +51,11 @@ func TestExpandEnv(t *testing.T) {
 			want:  "${{a}} and ${{b}}",
 		},
 		{
+			name:  "var inside foundry span not expanded",
+			input: "${{ outer ${FOO} }}",
+			want:  "${{ outer ${FOO} }}",
+		},
+		{
 			name:  "foundry span across newline with var",
 			input: "${{first\nsecond}}\n${FOO}",
 			want:  "${{first\nsecond}}\nbar",


### PR DESCRIPTION
## Summary

First incremental PR toward unifying Foundry config in `azure.yaml` (design spec #8590). It introduces the shared env expander the unified Foundry experience needs: a single helper that resolves azd `${VAR}` references while preserving Foundry's server-side `${{...}}` expressions verbatim. This is the building block called out in design spec §2.5 ("Templating: `${VAR}` and `${{...}}`").

Framed as a feature because it adds support for a new templating syntax (`${{...}}`) the extension did not handle before. It also corrects a latent bug where a value mixing both syntaxes was returned unexpanded.

## What it adds

- New shared helper `project.ExpandEnv(value, mapping)` in the `azure.ai.agents` extension.
  - Resolves `${VAR}` (including `${VAR:-default}` and multiple expressions) via `drone/envsubst`.
  - Preserves every `${{...}}` span verbatim for Foundry's server-side resolver.
  - Implementation: masks each `${{...}}` span with a sentinel placeholder (no `$`/`{`/`}`, which `envsubst` never rewrites since it only expands the braced `${...}` form), runs a single `envsubst.Eval`, then restores the spans. Masking instead of splitting preserves full `${VAR:-default}` semantics even when the default value is itself a `${{...}}` expression (for example `${MISSING:-${{event.body}}}`).

## Behavior change

| Input | Before | After |
|---|---|---|
| `${VAR}` | resolved | resolved (unchanged) |
| `${{x}}` | preserved as a side effect of a swallowed parse error (+ stderr warning) | preserved cleanly |
| `prefix ${VAR} ${{x}}` | returned unexpanded (`${VAR}` silently dropped) | `${VAR}` resolved, `${{x}}` preserved |
| `${MISSING:-${{x}}}` | returned unexpanded | resolves to default `${{x}}` |

## Affected areas

Extension-only (`cli/azd/extensions/azure.ai.agents`). The three existing `${VAR}` expansion call sites now route through `ExpandEnv`:

- `internal/project/service_target_agent.go` -> `resolveEnvironmentVariables`: agent env-var resolution during `azd ai agent` deploy (service target).
- `internal/cmd/listen.go` -> `resolveEnvValue` (+ the recursive map/slice walk): env reference resolution in the provision/deploy lifecycle hooks (connection credentials, toolbox env, and similar).
- `internal/cmd/run.go` -> `resolveAgentDefinitionEnvVars`: env-var resolution for `azd ai agent run` (local dev).

Not affected:
- azd core: no changes. Core `pkg/osutil/expandable_string.go` is intentionally untouched (design spec §2.5 places this in the extension, not core).
- Schema: none here. The `host: microsoft.foundry` schema is the separate PR #8603.
- Public API / gRPC contract: none. This is an internal helper plus call-site routing.

Blast radius is low: pure `${VAR}` values behave exactly as before; the only change is that previously-broken mixed and `${VAR:-default}` cases now expand correctly.

## Tests

`go build`, `go vet`, `gofmt`, `golangci-lint` (0 issues), `cspell`, and the full extension test suite pass. `templating_test.go` covers plain/defaulted/missing vars, preserved `${{...}}`, mixed, adjacent spans, a var nested inside a span, the `${MISSING:-${{event.body}}}` default case, a leading-`$` case, multiline spans, and malformed input.

Fixes #8609
