### PR TITLE
feat(agents): add microsoft.foundry azure.yaml schema

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/Agent.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Agent.json",
   "title": "Foundry agent definition",
   "description": "Hosted or prompt agent. Items in an agents array may be inline (hosted or prompt) or a $ref to an external file.",
   "oneOf": [

--- a/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
@@ -135,7 +135,11 @@
         { "$ref": "#/definitions/CommonProps" },
         {
           "type": "object",
-          "required": ["name", "kind", "instructions"],
+          "required": ["name", "kind"],
+          "anyOf": [
+            { "required": ["instructions"] },
+            { "required": ["skill"] }
+          ],
           "additionalProperties": false,
           "properties": {
             "name":        true,

--- a/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
@@ -55,10 +55,12 @@
         {
           "type": "object",
           "required": ["name", "kind"],
-          "dependencies": {
-            "docker": ["project"],
-            "runtime": ["project"]
-          },
+          "allOf": [
+            {
+              "if": { "anyOf": [{ "required": ["docker"] }, { "required": ["runtime"] }] },
+              "then": { "required": ["project"] }
+            }
+          ],
           "additionalProperties": false,
           "properties": {
             "name":        true,

--- a/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/Agent.json",
+  "title": "Foundry agent definition",
+  "description": "Hosted or prompt agent. Items in an agents array may be inline (hosted or prompt) or a $ref to an external file.",
+  "oneOf": [
+    { "$ref": "#/definitions/HostedAgent" },
+    { "$ref": "#/definitions/PromptAgent" },
+    { "$ref": "FileRef.json" }
+  ],
+  "definitions": {
+    "CommonProps": {
+      "type": "object",
+      "properties": {
+        "name":        { "type": "string", "description": "Name of the agent." },
+        "kind":        { "type": "string", "enum": ["hosted", "prompt"] },
+        "description": { "type": "string" },
+        "env": {
+          "type": "object",
+          "description": "Environment variables for the agent runtime. Values may use ${VAR} (azd env) or ${{...}} (Foundry server-side resolution).",
+          "additionalProperties": { "type": "string" }
+        },
+        "toolboxes": {
+          "type": "array",
+          "description": "Names of toolboxes the agent uses (declared in toolboxes[]).",
+          "items": { "type": "string" }
+        },
+        "tools": {
+          "type": "array",
+          "description": "Tools attached directly to this agent (alternative or in addition to toolboxes[]).",
+          "items": {
+            "type": "object",
+            "required": ["type"],
+            "additionalProperties": true,
+            "properties": {
+              "type":       { "type": "string" },
+              "connection": { "type": "string" }
+            }
+          }
+        },
+        "skill": {
+          "type": "string",
+          "description": "Name of a skill (declared in skills[]) this agent is backed by."
+        },
+        "metadata": {
+          "type": "object",
+          "description": "Free-form metadata key-value pairs.",
+          "additionalProperties": true
+        }
+      }
+    },
+    "HostedAgent": {
+      "allOf": [
+        { "$ref": "#/definitions/CommonProps" },
+        {
+          "type": "object",
+          "required": ["name", "kind"],
+          "additionalProperties": false,
+          "properties": {
+            "name":        true,
+            "kind":        { "const": "hosted" },
+            "description": true,
+            "env":         true,
+            "toolboxes":   true,
+            "tools":       true,
+            "skill":       true,
+            "metadata":    true,
+            "protocols": {
+              "type": "array",
+              "description": "Protocols the agent implements.",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": ["protocol", "version"],
+                "additionalProperties": false,
+                "properties": {
+                  "protocol": { "type": "string" },
+                  "version":  { "type": "string" }
+                }
+              }
+            },
+            "project": {
+              "type": "string",
+              "description": "Relative path to the agent source directory. Required when docker: or runtime: is set."
+            },
+            "image": {
+              "type": "string",
+              "description": "Pre-built container image. Mutually exclusive with project + docker / runtime."
+            },
+            "docker": {
+              "type": "object",
+              "description": "Container build options. Mutually exclusive with runtime:.",
+              "additionalProperties": false,
+              "properties": {
+                "path":        { "type": "string", "description": "Path to Dockerfile relative to project." },
+                "remoteBuild": { "type": "boolean", "description": "If true, build in Azure Container Registry instead of locally." }
+              }
+            },
+            "runtime": {
+              "type": "object",
+              "description": "Code-deploy runtime stack. Mutually exclusive with docker:.",
+              "required": ["stack"],
+              "additionalProperties": false,
+              "properties": {
+                "stack":       { "type": "string", "enum": ["python", "dotnet", "node", "java"] },
+                "version":     { "type": "string" },
+                "remoteBuild": { "type": "boolean" }
+              }
+            },
+            "startupCommand": {
+              "type": "string",
+              "description": "Command to start the agent process (e.g., 'python main.py')."
+            },
+            "container": {
+              "type": "object",
+              "description": "Container runtime settings.",
+              "additionalProperties": false,
+              "properties": {
+                "resources": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "cpu":    { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?m?$" },
+                    "memory": { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?(Ki|Mi|Gi|Ti|Pi|Ei|k|M|G|T|P|E)?$" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "PromptAgent": {
+      "allOf": [
+        { "$ref": "#/definitions/CommonProps" },
+        {
+          "type": "object",
+          "required": ["name", "kind", "instructions"],
+          "additionalProperties": false,
+          "properties": {
+            "name":        true,
+            "kind":        { "const": "prompt" },
+            "description": true,
+            "env":         true,
+            "toolboxes":   true,
+            "tools":       true,
+            "skill":       true,
+            "metadata":    true,
+            "instructions": {
+              "type": "string",
+              "description": "Inline prompt text or a relative path to a markdown file the extension reads at deploy time."
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
@@ -55,6 +55,10 @@
         {
           "type": "object",
           "required": ["name", "kind"],
+          "dependencies": {
+            "docker": ["project"],
+            "runtime": ["project"]
+          },
           "additionalProperties": false,
           "properties": {
             "name":        true,

--- a/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Agent.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Agent.json",
   "title": "Foundry agent definition",
   "description": "Hosted or prompt agent. Items in an agents array may be inline (hosted or prompt) or a $ref to an external file.",
   "oneOf": [

--- a/cli/azd/extensions/azure.ai.agents/schemas/Connection.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Connection.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Connection.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Connection.json",
   "title": "Foundry project connection",
   "description": "A project connection (matches the existing azure.ai.agent.json Connection shape). Items in a connections array may be inline or a $ref to an external file.",
   "oneOf": [

--- a/cli/azd/extensions/azure.ai.agents/schemas/Connection.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Connection.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/Connection.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Connection.json",
   "title": "Foundry project connection",
   "description": "A project connection (matches the existing azure.ai.agent.json Connection shape). Items in a connections array may be inline or a $ref to an external file.",
   "oneOf": [

--- a/cli/azd/extensions/azure.ai.agents/schemas/Connection.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Connection.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/Connection.json",
+  "title": "Foundry project connection",
+  "description": "A project connection (matches the existing azure.ai.agent.json Connection shape). Items in a connections array may be inline or a $ref to an external file.",
+  "oneOf": [
+    { "$ref": "#/definitions/Inline" },
+    { "$ref": "FileRef.json" }
+  ],
+  "definitions": {
+    "Inline": {
+      "type": "object",
+      "required": ["name", "category", "target", "authType"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Connection name.",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+        },
+        "category": {
+          "type": "string",
+          "description": "Connection category (e.g., 'CustomKeys', 'ApiKey', 'AzureOpenAI', 'CognitiveSearch', 'RemoteTool')."
+        },
+        "target": {
+          "type": "string",
+          "description": "Target endpoint URL or ARM resource ID."
+        },
+        "authType": {
+          "type": "string",
+          "description": "Authentication type.",
+          "enum": [
+            "AAD",
+            "AccessKey",
+            "AccountKey",
+            "AgenticIdentity",
+            "AgenticIdentityToken",
+            "ApiKey",
+            "CustomKeys",
+            "ManagedIdentity",
+            "None",
+            "OAuth2",
+            "PAT",
+            "ProjectManagedIdentity",
+            "SAS",
+            "ServicePrincipal",
+            "UserEntraToken",
+            "UsernamePassword"
+          ]
+        },
+        "credentials": {
+          "type": "object",
+          "description": "Credentials. Values may contain ${VAR} (azd env, resolved client-side) or ${{...}} (Foundry server-side resolution, passed through untouched).",
+          "additionalProperties": true
+        },
+        "metadata": {
+          "type": "object",
+          "description": "Additional metadata as key-value pairs.",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/cli/azd/extensions/azure.ai.agents/schemas/Deployment.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Deployment.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Deployment.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Deployment.json",
   "title": "Foundry model deployment",
   "description": "A model deployment on the Foundry project. Matches the existing azure.ai.agent.json shape (name, model, sku). Items in a deployments array may be inline or a $ref to an external file.",
   "oneOf": [

--- a/cli/azd/extensions/azure.ai.agents/schemas/Deployment.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Deployment.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/Deployment.json",
+  "title": "Foundry model deployment",
+  "description": "A model deployment on the Foundry project. Matches the existing azure.ai.agent.json shape (name, model, sku). Items in a deployments array may be inline or a $ref to an external file.",
+  "oneOf": [
+    { "$ref": "#/definitions/Inline" },
+    { "$ref": "FileRef.json" }
+  ],
+  "definitions": {
+    "Inline": {
+      "type": "object",
+      "required": ["name", "model", "sku"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the model deployment."
+        },
+        "model": {
+          "type": "object",
+          "required": ["format", "name", "version"],
+          "additionalProperties": false,
+          "properties": {
+            "format": { "type": "string", "description": "Model format (e.g., 'OpenAI')." },
+            "name":   { "type": "string", "description": "Model name (e.g., 'gpt-4.1-mini')." },
+            "version":{ "type": "string", "description": "Model version (e.g., '2025-04-14')." }
+          }
+        },
+        "sku": {
+          "type": "object",
+          "required": ["capacity", "name"],
+          "additionalProperties": false,
+          "properties": {
+            "capacity": { "type": "integer", "description": "SKU capacity (TPM units)." },
+            "name":     { "type": "string",  "description": "SKU name (e.g., 'Standard', 'GlobalStandard', 'GlobalBatch')." }
+          }
+        }
+      }
+    }
+  }
+}

--- a/cli/azd/extensions/azure.ai.agents/schemas/Deployment.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Deployment.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/Deployment.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Deployment.json",
   "title": "Foundry model deployment",
   "description": "A model deployment on the Foundry project. Matches the existing azure.ai.agent.json shape (name, model, sku). Items in a deployments array may be inline or a $ref to an external file.",
   "oneOf": [

--- a/cli/azd/extensions/azure.ai.agents/schemas/FileRef.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/FileRef.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/FileRef.json",
+  "title": "External file reference",
+  "description": "Replace an inline definition with a reference to an external YAML or JSON file. Sibling properties on the same object act as overlay overrides on top of the loaded file.",
+  "type": "object",
+  "required": ["$ref"],
+  "properties": {
+    "$ref": {
+      "type": "string",
+      "description": "Path to a YAML or JSON file containing the definition. Relative paths resolve from the file containing this $ref. Absolute paths and URLs are also accepted."
+    }
+  },
+  "additionalProperties": true
+}

--- a/cli/azd/extensions/azure.ai.agents/schemas/FileRef.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/FileRef.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/FileRef.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/FileRef.json",
   "title": "External file reference",
   "description": "Replace an inline definition with a reference to an external YAML or JSON file. Sibling properties on the same object act as overlay overrides on top of the loaded file.",
   "type": "object",

--- a/cli/azd/extensions/azure.ai.agents/schemas/FileRef.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/FileRef.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/FileRef.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/FileRef.json",
   "title": "External file reference",
   "description": "Replace an inline definition with a reference to an external YAML or JSON file. Sibling properties on the same object act as overlay overrides on top of the loaded file.",
   "type": "object",

--- a/cli/azd/extensions/azure.ai.agents/schemas/README.md
+++ b/cli/azd/extensions/azure.ai.agents/schemas/README.md
@@ -1,0 +1,98 @@
+# Foundry `azure.yaml` schemas (preview — integration branch)
+
+These schemas model `host: microsoft.foundry` in `azure.yaml`. They are **not on `main`**.
+They live on the long-lived integration branch **`huimiu/foundry-azure-yaml`** so the feature can
+be prototyped and tested without being published to every `azd` user before it is ready.
+
+## Why the URLs point at the branch
+
+The core `azure.yaml` schema is consumed *live* from `main`:
+
+- `schemas/schemastore-catalog-entry.json` registers it with **SchemaStore** at the `main` raw URL.
+- `azd` stamps `# yaml-language-server: $schema=…/main/schemas/<ver>/azure.yaml.json` into generated
+  `azure.yaml` files.
+
+So merging `microsoft.foundry` into `main` would immediately surface an unfinished feature in every
+editor. To test on the branch instead, the **new Foundry** schema URLs are rewritten from
+`refs/heads/main` to `refs/heads/huimiu/foundry-azure-yaml`:
+
+- the `$id` of every file in this directory (`Agent.json`, `Skill.json`, `Routine.json`,
+  `Connection.json`, `Toolbox.json`, `Deployment.json`, `FileRef.json`, `microsoft.foundry.json`);
+- the `microsoft.foundry.json` `$ref` added to `schemas/v1.0/azure.yaml.json` and
+  `schemas/alpha/azure.yaml.json`;
+- the `$schema` annotation in `examples/*.azure.yaml`.
+
+Relative `$ref`s (for example `"FileRef.json"`) resolve against the parent's `$id`, so they follow
+the branch automatically.
+
+**Deliberately left pointing at `main`** (published / shared surfaces, unchanged by this work):
+
+- the core schema's own root `$id`;
+- the pre-existing `azure.ai.agent.json` `$ref` in the core schema;
+- `schemas/schemastore-catalog-entry.json`;
+- `cli/azd/pkg/project/project.go` and `resources/apphost/templates/azure.yamlt`.
+
+## How to test on the branch
+
+1. Push the integration branch to `origin` (the raw URLs only resolve once the branch is published).
+2. **In an editor (primary):** open `examples/simple.azure.yaml` or `examples/complex.azure.yaml`.
+   The `$schema` comment makes the YAML language server validate the file against the branch schema,
+   resolving the composed Foundry sub-schemas over the branch raw URLs.
+3. **CLI (optional, offline):** validate the samples with `ajv`, loading the local schema files by
+   their `$id` so no network fetch is needed:
+
+   ```bash
+   # from the repo root, in a scratch dir
+   npm init -y && npm install ajv@8 ajv-formats js-yaml glob
+   node - <<'EOF'
+   const fs = require('fs');
+   const path = require('path');
+   const yaml = require('js-yaml');
+   const Ajv = require('ajv/dist/2019').default;
+   const addFormats = require('ajv-formats').default;
+   const { globSync } = require('glob');
+
+   const repo = process.env.REPO || '.';
+   const ajv = new Ajv({ allErrors: true, strict: false });
+   addFormats(ajv);
+   ajv.addMetaSchema(require('ajv/dist/refs/json-schema-draft-07.json'));
+
+   // Register every schema under its own $id (core + Foundry sub-schemas + existing agent schema).
+   // The pre-existing azure.ai.agent.json has no $id, so register it under the `main` raw URL the
+   // core schema references.
+   const core = path.join(repo, 'schemas/v1.0/azure.yaml.json');
+   const subs = globSync(path.join(repo, 'cli/azd/extensions/azure.ai.agents/schemas/*.json'));
+   for (const f of [core, ...subs]) {
+     const s = JSON.parse(fs.readFileSync(f, 'utf8'));
+     const rel = path.relative(repo, f).replace(/\\/g, '/');
+     const id = s.$id || `https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/${rel}`;
+     ajv.addSchema(s, id);
+   }
+
+   const validate = ajv.getSchema(JSON.parse(fs.readFileSync(core, 'utf8')).$id);
+   for (const s of globSync(path.join(repo,
+       'cli/azd/extensions/azure.ai.agents/schemas/examples/*.azure.yaml'))) {
+     const ok = validate(yaml.load(fs.readFileSync(s, 'utf8')));
+     console.log(`${ok ? 'PASS' : 'FAIL'}  ${path.basename(s)}`);
+     if (!ok) { console.error(validate.errors); process.exitCode = 1; }
+   }
+   EOF
+   ```
+
+   The example file-ref targets (`./agents/triage.yaml`, etc.) are illustrative; they are validated as
+   `FileRef` shapes, so the referenced files do not need to exist for schema validation.
+
+## Before merging to `main` — flip-back checklist (required)
+
+When the prototype is ready and the integration branch is merged into `main`, rewrite the branch URLs
+back so the published schema is self-consistent on `main`:
+
+- [ ] In all files in this directory, change `$id` `refs/heads/huimiu/foundry-azure-yaml` →
+      `refs/heads/main`.
+- [ ] In `schemas/v1.0/azure.yaml.json` and `schemas/alpha/azure.yaml.json`, change the
+      `microsoft.foundry.json` `$ref` `refs/heads/huimiu/foundry-azure-yaml` → `refs/heads/main`.
+- [ ] In `examples/*.azure.yaml`, change the `$schema` annotation
+      `refs/heads/huimiu/foundry-azure-yaml` → `main`.
+- [ ] Confirm no `huimiu/foundry-azure-yaml` references remain:
+      `git grep -n "huimiu/foundry-azure-yaml"` returns nothing.
+- [ ] Re-validate the samples (steps above) against the `main` URLs.

--- a/cli/azd/extensions/azure.ai.agents/schemas/README.md
+++ b/cli/azd/extensions/azure.ai.agents/schemas/README.md
@@ -13,8 +13,10 @@ The core `azure.yaml` schema is consumed *live* from `main`:
   `azure.yaml` files.
 
 So merging `microsoft.foundry` into `main` would immediately surface an unfinished feature in every
-editor. To test on the branch instead, the **new Foundry** schema URLs are rewritten from
-`refs/heads/main` to `refs/heads/huimiu/foundry-azure-yaml`:
+editor. To test on the branch instead, the **new Foundry** schema URLs are rewritten from the `main`
+raw URL to the `huimiu/foundry-azure-yaml` branch. All schema URLs use the short
+`raw.githubusercontent.com/Azure/azure-dev/<ref>/…` form (no `refs/heads/` segment), matching the
+core schema's own root `$id` and the SchemaStore retrieval URL:
 
 - the `$id` of every file in this directory (`Agent.json`, `Skill.json`, `Routine.json`,
   `Connection.json`, `Toolbox.json`, `Deployment.json`, `FileRef.json`, `microsoft.foundry.json`);
@@ -28,7 +30,8 @@ the branch automatically.
 **Deliberately left pointing at `main`** (published / shared surfaces, unchanged by this work):
 
 - the core schema's own root `$id`;
-- the pre-existing `azure.ai.agent.json` `$ref` in the core schema;
+- the pre-existing `azure.ai.agent.json` `$ref` in the core schema (still `main`; only its URL form
+  was normalized to the short form for consistency);
 - `schemas/schemastore-catalog-entry.json`;
 - `cli/azd/pkg/project/project.go` and `resources/apphost/templates/azure.yamlt`.
 
@@ -65,7 +68,7 @@ the branch automatically.
    for (const f of [core, ...subs]) {
      const s = JSON.parse(fs.readFileSync(f, 'utf8'));
      const rel = path.relative(repo, f).replace(/\\/g, '/');
-     const id = s.$id || `https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/${rel}`;
+     const id = s.$id || `https://raw.githubusercontent.com/Azure/azure-dev/main/${rel}`;
      ajv.addSchema(s, id);
    }
 
@@ -87,12 +90,11 @@ the branch automatically.
 When the prototype is ready and the integration branch is merged into `main`, rewrite the branch URLs
 back so the published schema is self-consistent on `main`:
 
-- [ ] In all files in this directory, change `$id` `refs/heads/huimiu/foundry-azure-yaml` →
-      `refs/heads/main`.
+- [ ] In all files in this directory, change `$id` `huimiu/foundry-azure-yaml` → `main`.
 - [ ] In `schemas/v1.0/azure.yaml.json` and `schemas/alpha/azure.yaml.json`, change the
-      `microsoft.foundry.json` `$ref` `refs/heads/huimiu/foundry-azure-yaml` → `refs/heads/main`.
+      `microsoft.foundry.json` `$ref` `huimiu/foundry-azure-yaml` → `main`.
 - [ ] In `examples/*.azure.yaml`, change the `$schema` annotation
-      `refs/heads/huimiu/foundry-azure-yaml` → `main`.
+      `huimiu/foundry-azure-yaml` → `main`.
 - [ ] Confirm no `huimiu/foundry-azure-yaml` references remain:
       `git grep -n "huimiu/foundry-azure-yaml"` returns nothing.
 - [ ] Re-validate the samples (steps above) against the `main` URLs.

--- a/cli/azd/extensions/azure.ai.agents/schemas/Routine.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Routine.json
@@ -21,11 +21,11 @@
           "additionalProperties": true,
           "allOf": [
             {
-              "if": { "properties": { "type": { "const": "schedule" } } },
+              "if": { "properties": { "type": { "const": "schedule" } }, "required": ["type"] },
               "then": { "required": ["cron"] }
             },
             {
-              "if": { "properties": { "type": { "enum": ["webhook", "event"] } } },
+              "if": { "properties": { "type": { "enum": ["webhook", "event"] } }, "required": ["type"] },
               "then": { "required": ["filter"] }
             }
           ],

--- a/cli/azd/extensions/azure.ai.agents/schemas/Routine.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Routine.json
@@ -19,6 +19,16 @@
           "type": "object",
           "required": ["type"],
           "additionalProperties": true,
+          "allOf": [
+            {
+              "if": { "properties": { "type": { "const": "schedule" } } },
+              "then": { "required": ["cron"] }
+            },
+            {
+              "if": { "properties": { "type": { "enum": ["webhook", "event"] } } },
+              "then": { "required": ["filter"] }
+            }
+          ],
           "properties": {
             "type":   { "type": "string", "enum": ["schedule", "webhook", "event"] },
             "cron":   { "type": "string", "description": "Cron expression. Required for type: schedule." },

--- a/cli/azd/extensions/azure.ai.agents/schemas/Routine.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Routine.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/Routine.json",
+  "title": "Foundry routine (scheduled or event-driven agent invocation)",
+  "description": "Items in a routines array may be inline or a $ref to an external file.",
+  "oneOf": [
+    { "$ref": "#/definitions/Inline" },
+    { "$ref": "FileRef.json" }
+  ],
+  "definitions": {
+    "Inline": {
+      "type": "object",
+      "required": ["name", "trigger", "agent"],
+      "additionalProperties": false,
+      "properties": {
+        "name":        { "type": "string", "description": "Name of the routine." },
+        "description": { "type": "string" },
+        "trigger": {
+          "type": "object",
+          "required": ["type"],
+          "additionalProperties": true,
+          "properties": {
+            "type":   { "type": "string", "enum": ["schedule", "webhook", "event"] },
+            "cron":   { "type": "string", "description": "Cron expression. Required for type: schedule." },
+            "filter": { "type": "object", "description": "Event/webhook filter. Required for type: webhook | event." }
+          }
+        },
+        "agent": {
+          "type": "string",
+          "description": "Name of the agent (declared in agents[]) the routine invokes."
+        },
+        "input": {
+          "type": "object",
+          "description": "Input payload passed to the agent. Values may use ${VAR} or ${{event.<field>}}.",
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}

--- a/cli/azd/extensions/azure.ai.agents/schemas/Routine.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Routine.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/Routine.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Routine.json",
   "title": "Foundry routine (scheduled or event-driven agent invocation)",
   "description": "Items in a routines array may be inline or a $ref to an external file.",
   "oneOf": [

--- a/cli/azd/extensions/azure.ai.agents/schemas/Routine.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Routine.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Routine.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Routine.json",
   "title": "Foundry routine (scheduled or event-driven agent invocation)",
   "description": "Items in a routines array may be inline or a $ref to an external file.",
   "oneOf": [

--- a/cli/azd/extensions/azure.ai.agents/schemas/Skill.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Skill.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/Skill.json",
+  "title": "Foundry skill",
+  "description": "A reusable capability bundle (instructions + tools). Items in a skills array may be inline or a $ref to an external file.",
+  "oneOf": [
+    { "$ref": "#/definitions/Inline" },
+    { "$ref": "FileRef.json" }
+  ],
+  "definitions": {
+    "Inline": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name":        { "type": "string", "description": "Name of the skill." },
+        "description": { "type": "string", "description": "Description of the skill." },
+        "instructions": {
+          "type": "string",
+          "description": "Inline instruction text, or a file path (.md, .txt) the extension reads at deploy time."
+        },
+        "tools": {
+          "type": "array",
+          "description": "Tool type names the skill uses (must be declared on a toolbox the agent references, or attached directly to the agent's tools list).",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/cli/azd/extensions/azure.ai.agents/schemas/Skill.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Skill.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/Skill.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Skill.json",
   "title": "Foundry skill",
   "description": "A reusable capability bundle (instructions + tools). Items in a skills array may be inline or a $ref to an external file.",
   "oneOf": [

--- a/cli/azd/extensions/azure.ai.agents/schemas/Skill.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Skill.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Skill.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Skill.json",
   "title": "Foundry skill",
   "description": "A reusable capability bundle (instructions + tools). Items in a skills array may be inline or a $ref to an external file.",
   "oneOf": [

--- a/cli/azd/extensions/azure.ai.agents/schemas/Toolbox.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Toolbox.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/Toolbox.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Toolbox.json",
   "title": "Foundry toolbox",
   "description": "A named bundle of tools that agents reference by name (matches the existing azure.ai.agent.json Toolbox shape). Items in a toolboxes array may be inline or a $ref to an external file.",
   "oneOf": [

--- a/cli/azd/extensions/azure.ai.agents/schemas/Toolbox.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Toolbox.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Toolbox.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/Toolbox.json",
   "title": "Foundry toolbox",
   "description": "A named bundle of tools that agents reference by name (matches the existing azure.ai.agent.json Toolbox shape). Items in a toolboxes array may be inline or a $ref to an external file.",
   "oneOf": [

--- a/cli/azd/extensions/azure.ai.agents/schemas/Toolbox.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Toolbox.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/Toolbox.json",
+  "title": "Foundry toolbox",
+  "description": "A named bundle of tools that agents reference by name (matches the existing azure.ai.agent.json Toolbox shape). Items in a toolboxes array may be inline or a $ref to an external file.",
+  "oneOf": [
+    { "$ref": "#/definitions/Inline" },
+    { "$ref": "FileRef.json" }
+  ],
+  "definitions": {
+    "Inline": {
+      "type": "object",
+      "required": ["name", "tools"],
+      "additionalProperties": false,
+      "properties": {
+        "name":        { "type": "string", "description": "Name of the toolbox." },
+        "description": { "type": "string", "description": "Description of the toolbox." },
+        "tools": {
+          "type": "array",
+          "description": "List of tools in the toolbox.",
+          "items": {
+            "type": "object",
+            "required": ["type"],
+            "additionalProperties": true,
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Tool type (e.g., 'web_search', 'code_interpreter', 'file_search', 'mcp', 'azure_ai_search', 'bing_grounding', 'openapi')."
+              },
+              "connection": {
+                "type": "string",
+                "description": "Name of a connection (required for connection-backed tool types like 'mcp', 'azure_ai_search')."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/cli/azd/extensions/azure.ai.agents/schemas/examples/complex.azure.yaml
+++ b/cli/azd/extensions/azure.ai.agents/schemas/examples/complex.azure.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/schemas/v1.0/azure.yaml.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/schemas/v1.0/azure.yaml.json
 
 # Exercises the full microsoft.foundry surface: deployments, connections,
 # toolboxes, skills, routines, hosted + prompt agents, inline tools, and

--- a/cli/azd/extensions/azure.ai.agents/schemas/examples/complex.azure.yaml
+++ b/cli/azd/extensions/azure.ai.agents/schemas/examples/complex.azure.yaml
@@ -1,0 +1,96 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/schemas/v1.0/azure.yaml.json
+
+# Exercises the full microsoft.foundry surface: deployments, connections,
+# toolboxes, skills, routines, hosted + prompt agents, inline tools, and
+# external file references ($ref). Schema-validation fixture for the
+# integration branch (see ../README.md). File-ref paths are illustrative.
+name: foundry-complex
+
+metadata:
+  template: foundry-complex@0.0.1
+
+services:
+  ai:
+    host: microsoft.foundry
+    deployments:
+      - name: gpt-4o
+        model:
+          format: OpenAI
+          name: gpt-4o
+          version: "2024-08-06"
+        sku:
+          name: GlobalStandard
+          capacity: 50
+      - $ref: ./deployments/embeddings.yaml
+    connections:
+      - name: search-conn
+        category: CognitiveSearch
+        target: https://my-search.search.windows.net
+        authType: ApiKey
+        credentials:
+          key: ${SEARCH_API_KEY}
+      - name: bing-conn
+        category: ApiKey
+        target: https://api.bing.microsoft.com
+        authType: ApiKey
+    toolboxes:
+      - name: research-tools
+        description: Tools used by research agents.
+        tools:
+          - type: bing_grounding
+            connection: bing-conn
+          - type: azure_ai_search
+            connection: search-conn
+          - type: code_interpreter
+    skills:
+      - name: summarize
+        description: Summarize long documents.
+        instructions: ./skills/summarize.md
+        tools:
+          - code_interpreter
+      - $ref: ./skills/translate.yaml
+    agents:
+      - name: researcher
+        kind: hosted
+        description: Hosted research agent built from source.
+        project: ./agents/researcher
+        runtime:
+          stack: python
+          version: "3.12"
+        startupCommand: python main.py
+        toolboxes:
+          - research-tools
+        env:
+          LOG_LEVEL: info
+          MODEL_ENDPOINT: ${{project.endpoint}}
+        protocols:
+          - protocol: a2a
+            version: "0.2"
+        container:
+          resources:
+            cpu: "1.0"
+            memory: 2Gi
+      - name: writer
+        kind: prompt
+        description: Prompt agent backed by the summarize skill.
+        skill: summarize
+        toolboxes:
+          - research-tools
+      - $ref: ./agents/triage.yaml
+    routines:
+      - name: nightly-digest
+        description: Summarize the day's documents every night.
+        trigger:
+          type: schedule
+          cron: "0 2 * * *"
+        agent: researcher
+        input:
+          topic: ${DIGEST_TOPIC}
+      - name: on-upload
+        description: React to newly uploaded blobs.
+        trigger:
+          type: event
+          filter:
+            source: blob
+            eventType: Microsoft.Storage.BlobCreated
+        agent: writer

--- a/cli/azd/extensions/azure.ai.agents/schemas/examples/simple.azure.yaml
+++ b/cli/azd/extensions/azure.ai.agents/schemas/examples/simple.azure.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/schemas/v1.0/azure.yaml.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/schemas/v1.0/azure.yaml.json
 
 # Minimal microsoft.foundry service: one model deployment and one prompt agent.
 # Schema-validation fixture for the integration branch (see ../README.md).

--- a/cli/azd/extensions/azure.ai.agents/schemas/examples/simple.azure.yaml
+++ b/cli/azd/extensions/azure.ai.agents/schemas/examples/simple.azure.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/schemas/v1.0/azure.yaml.json
+
+# Minimal microsoft.foundry service: one model deployment and one prompt agent.
+# Schema-validation fixture for the integration branch (see ../README.md).
+name: foundry-simple
+
+services:
+  ai:
+    host: microsoft.foundry
+    deployments:
+      - name: gpt-4o-mini
+        model:
+          format: OpenAI
+          name: gpt-4o-mini
+          version: "2024-07-18"
+        sku:
+          name: GlobalStandard
+          capacity: 10
+    agents:
+      - name: assistant
+        kind: prompt
+        description: A simple prompt-based assistant.
+        instructions: You are a helpful assistant. Answer concisely.

--- a/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json",
   "title": "Microsoft Foundry project (services entry with host: microsoft.foundry)",
   "description": "Schema for a Foundry project as a service in azure.yaml. Composes per-resource sub-schemas via $ref, modeled on microsoft/AgentSchema's split-file pattern.",
   "type": "object",

--- a/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json",
+  "title": "Microsoft Foundry project (services entry with host: microsoft.foundry)",
+  "description": "Schema for a Foundry project as a service in azure.yaml. Composes per-resource sub-schemas via $ref, modeled on microsoft/AgentSchema's split-file pattern.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "endpoint": {
+      "type": "string",
+      "description": "URL of an existing Foundry project. When present, azd connects to the existing project instead of provisioning a new one. Absence of this field is the signal to provision a new project."
+    },
+    "deployments": {
+      "type": "array",
+      "description": "Model deployments to create on the Foundry project.",
+      "items": { "$ref": "Deployment.json" }
+    },
+    "connections": {
+      "type": "array",
+      "description": "Project connections.",
+      "items": { "$ref": "Connection.json" }
+    },
+    "toolboxes": {
+      "type": "array",
+      "description": "Named toolboxes that agents can reference by name.",
+      "items": { "$ref": "Toolbox.json" }
+    },
+    "skills": {
+      "type": "array",
+      "description": "Named skills that agents can reference by name.",
+      "items": { "$ref": "Skill.json" }
+    },
+    "routines": {
+      "type": "array",
+      "description": "Scheduled or event-driven agent invocations.",
+      "items": { "$ref": "Routine.json" }
+    },
+    "agents": {
+      "type": "array",
+      "description": "All agent definitions (hosted and prompt).",
+      "items": { "$ref": "Agent.json" }
+    }
+  }
+}

--- a/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json",
   "title": "Microsoft Foundry project (services entry with host: microsoft.foundry)",
   "description": "Schema for a Foundry project as a service in azure.yaml. Composes per-resource sub-schemas via $ref, modeled on microsoft/AgentSchema's split-file pattern.",
   "type": "object",

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -228,7 +228,8 @@
                             "staticwebapp",
                             "aks",
                             "ai.endpoint",
-                            "azure.ai.agent"
+                            "azure.ai.agent",
+                            "microsoft.foundry"
                         ]
                     },
                     "language": {
@@ -426,6 +427,26 @@
                                 "k8s": false,
                                 "apiVersion": false,
                                 "env": false
+                            }
+                        }
+                    },
+                    {
+                        "comment": "Microsoft Foundry host - project config composed at the service level",
+                        "if": {
+                            "properties": {
+                                "host": { "const": "microsoft.foundry" }
+                            }
+                        },
+                        "then": {
+                            "allOf": [
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json" }
+                            ],
+                            "properties": {
+                                "project": false,
+                                "runtime": false,
+                                "docker": false,
+                                "image": false,
+                                "config": false
                             }
                         }
                     },

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -419,7 +419,7 @@
                             "required": ["project"],
                             "properties": {
                                 "config": {
-                                    "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json",
+                                    "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/main/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json",
                                     "title": "The Azure AI Agent configuration.",
                                     "description": "Optional. Provides additional configuration for Azure AI Agent deployment."
                                 },
@@ -439,7 +439,7 @@
                         },
                         "then": {
                             "allOf": [
-                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json" }
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json" }
                             ],
                             "properties": {
                                 "project": false,

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -439,7 +439,7 @@
                         },
                         "then": {
                             "allOf": [
-                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json" }
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json" }
                             ],
                             "properties": {
                                 "project": false,

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -399,7 +399,7 @@
                         },
                         "then": {
                             "allOf": [
-                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json" }
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json" }
                             ],
                             "properties": {
                                 "project": false,

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -379,7 +379,7 @@
                             "required": ["project"],
                             "properties": {
                                 "config": {
-                                    "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json",
+                                    "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/main/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json",
                                     "title": "The Azure AI Agent configuration.",
                                     "description": "Optional. Provides additional configuration for Azure AI Agent deployment."
                                 },
@@ -399,7 +399,7 @@
                         },
                         "then": {
                             "allOf": [
-                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json" }
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json" }
                             ],
                             "properties": {
                                 "project": false,

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -189,7 +189,8 @@
                             "staticwebapp",
                             "aks",
                             "ai.endpoint",
-                            "azure.ai.agent"
+                            "azure.ai.agent",
+                            "microsoft.foundry"
                         ]
                     },
                     "language": {
@@ -386,6 +387,26 @@
                                 "k8s": false,
                                 "apiVersion": false,
                                 "env": false
+                            }
+                        }
+                    },
+                    {
+                        "comment": "Microsoft Foundry host - project config composed at the service level",
+                        "if": {
+                            "properties": {
+                                "host": { "const": "microsoft.foundry" }
+                            }
+                        },
+                        "then": {
+                            "allOf": [
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/azure.ai.agents/schemas/microsoft.foundry.json" }
+                            ],
+                            "properties": {
+                                "project": false,
+                                "runtime": false,
+                                "docker": false,
+                                "image": false,
+                                "config": false
                             }
                         }
                     },


### PR DESCRIPTION
Schema-only scaffolding for unifying Foundry agent config in `azure.yaml`. Implements design spec [#8590](https://github.com/Azure/azure-dev/pull/8590) §2.3.

### Changes

**Core schema** (`schemas/v1.0/azure.yaml.json` + `schemas/alpha/azure.yaml.json`):
- Added `microsoft.foundry` to the `host` examples list.
- Added a service-level conditional after `azure.ai.agent`, composing `microsoft.foundry.json` via `allOf` -> `$ref` and disabling `project`/`runtime`/`docker`/`image`/`config`.

**Extension schemas** (`cli/azd/extensions/azure.ai.agents/schemas/`) ported from `therealjohn/foundry-azd-config-preview`:
`microsoft.foundry.json`, `Agent.json`, `Skill.json`, `Routine.json`, `Connection.json`, `Toolbox.json`, `Deployment.json`, `FileRef.json`.

Transformations: `$id` rewritten to the azure-dev path; relative `$ref`s preserved.

### Deliberate deviations from preview

- `microsoft.foundry.json`: top-level `additionalProperties: true`, per the PM brief and design spec §2.3, so future Foundry resource types do not break the schema.
- `Agent.json`: `PromptAgent` accepts either `instructions` or `skill`, so a skill-backed prompt agent does not need duplicate instructions.
- `Agent.json`: `HostedAgent` requires `project` when `docker` or `runtime` is set, matching its property description.
- `Routine.json`: `trigger` now enforces `cron` for `schedule` and `filter` for `webhook`/`event`, matching its property descriptions.

### Validation

- All JSON files parse.
- `simple` and `complex` samples validate end-to-end with ajv against the core schema plus composed sub-schemas.
- Targeted negative checks confirm missing routine `cron`/`filter` and missing hosted-agent `project` are rejected.
- cspell (misc + cli configs): 0 issues.

Fixes #8611