### PR TITLE
fix: replace hardcoded fixture fallback with fail-fast :? syntax

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/tests/cli-interactive-tester-scenarios/10-init-deploy-mode-code.yaml
+++ b/cli/azd/extensions/azure.ai.agents/tests/cli-interactive-tester-scenarios/10-init-deploy-mode-code.yaml
@@ -19,7 +19,7 @@ pre:
   - run: "rm -rf ~/working/azd-agents-t1-code-deploy-{instance}"
     cwd: "~/working"
     name: "reset working dir"
-  - run: "mkdir -p ~/working/azd-agents-t1-code-deploy-{instance} && cp -r \"${AZD_AGENTS_FIXTURES:-/mnt/c/Repos/azure-dev/cli/azd/extensions/azure.ai.agents/tests/cli-interactive-tester-scenarios/fixtures}/from-code/.\" ~/working/azd-agents-t1-code-deploy-{instance}/"
+  - run: "mkdir -p ~/working/azd-agents-t1-code-deploy-{instance} && cp -r \"${AZD_AGENTS_FIXTURES:?Set AZD_AGENTS_FIXTURES to the WSL path of your fixtures directory (e.g. /mnt/d/w1/azure-dev/.../tests/cli-interactive-tester-scenarios/fixtures)}/from-code/.\" ~/working/azd-agents-t1-code-deploy-{instance}/"
     cwd: "~/working"
     name: "seed from-code agent fixture (app.py + requirements.txt)"
 

--- a/cli/azd/extensions/azure.ai.agents/tests/cli-interactive-tester-scenarios/10-init-deploy-mode-container.yaml
+++ b/cli/azd/extensions/azure.ai.agents/tests/cli-interactive-tester-scenarios/10-init-deploy-mode-container.yaml
@@ -19,7 +19,7 @@ pre:
   - run: "rm -rf ~/working/azd-agents-t1-container-deploy-{instance}"
     cwd: "~/working"
     name: "reset working dir"
-  - run: "mkdir -p ~/working/azd-agents-t1-container-deploy-{instance} && cp -r \"${AZD_AGENTS_FIXTURES:-/mnt/c/Repos/azure-dev/cli/azd/extensions/azure.ai.agents/tests/cli-interactive-tester-scenarios/fixtures}/from-code/.\" ~/working/azd-agents-t1-container-deploy-{instance}/"
+  - run: "mkdir -p ~/working/azd-agents-t1-container-deploy-{instance} && cp -r \"${AZD_AGENTS_FIXTURES:?Set AZD_AGENTS_FIXTURES to the WSL path of your fixtures directory (e.g. /mnt/d/w1/azure-dev/.../tests/cli-interactive-tester-scenarios/fixtures)}/from-code/.\" ~/working/azd-agents-t1-container-deploy-{instance}/"
     cwd: "~/working"
     name: "seed from-code agent fixture (app.py + requirements.txt)"
 

--- a/cli/azd/extensions/azure.ai.agents/tests/cli-interactive-tester-scenarios/10-init-from-code.yaml
+++ b/cli/azd/extensions/azure.ai.agents/tests/cli-interactive-tester-scenarios/10-init-from-code.yaml
@@ -18,7 +18,7 @@ pre:
   - run: "rm -rf ~/working/azd-agents-t1-from-code-{instance}"
     cwd: "~/working"
     name: "reset working dir"
-  - run: "mkdir -p ~/working/azd-agents-t1-from-code-{instance} && cp -r \"${AZD_AGENTS_FIXTURES:-/mnt/c/Repos/azure-dev/cli/azd/extensions/azure.ai.agents/tests/cli-interactive-tester-scenarios/fixtures}/from-code/.\" ~/working/azd-agents-t1-from-code-{instance}/"
+  - run: "mkdir -p ~/working/azd-agents-t1-from-code-{instance} && cp -r \"${AZD_AGENTS_FIXTURES:?Set AZD_AGENTS_FIXTURES to the WSL path of your fixtures directory (e.g. /mnt/d/w1/azure-dev/.../tests/cli-interactive-tester-scenarios/fixtures)}/from-code/.\" ~/working/azd-agents-t1-from-code-{instance}/"
     cwd: "~/working"
     name: "seed from-code agent fixture (app.py + requirements.txt)"
 

--- a/cli/azd/extensions/azure.ai.agents/tests/cli-interactive-tester-scenarios/10-init-validate-deploy-mode.yaml
+++ b/cli/azd/extensions/azure.ai.agents/tests/cli-interactive-tester-scenarios/10-init-validate-deploy-mode.yaml
@@ -26,7 +26,7 @@ pre:
   - run: "rm -rf ~/working/azd-agents-validate-deploy-mode-{instance}"
     cwd: "~/working"
     name: "reset working dir"
-  - run: "mkdir -p ~/working/azd-agents-validate-deploy-mode-{instance} && cp -r \"${AZD_AGENTS_FIXTURES:-/mnt/c/Repos/azure-dev/cli/azd/extensions/azure.ai.agents/tests/cli-interactive-tester-scenarios/fixtures}/from-code/.\" ~/working/azd-agents-validate-deploy-mode-{instance}/"
+  - run: "mkdir -p ~/working/azd-agents-validate-deploy-mode-{instance} && cp -r \"${AZD_AGENTS_FIXTURES:?Set AZD_AGENTS_FIXTURES to the WSL path of your fixtures directory (e.g. /mnt/d/w1/azure-dev/.../tests/cli-interactive-tester-scenarios/fixtures)}/from-code/.\" ~/working/azd-agents-validate-deploy-mode-{instance}/"
     cwd: "~/working"
     name: "seed from-code agent fixture (app.py + requirements.txt)"
 


### PR DESCRIPTION
Replaces the hardcoded `/mnt/c/Repos/azure-dev/...` fallback in 4 Tier 1 scenario pre-hooks with bash `:?` expansion.

**Before:** If `AZD_AGENTS_FIXTURES` is unset, `cp` silently tries Travis's local path → cryptic 'No such file or directory'.

**After:** Shell immediately errors with: *'Set AZD_AGENTS_FIXTURES to the WSL path of your fixtures directory'* — fail-fast, clear message.

**Files changed:**
- `10-init-deploy-mode-code.yaml`
- `10-init-deploy-mode-container.yaml`
- `10-init-from-code.yaml`
- `10-init-validate-deploy-mode.yaml`