### PR TITLE
Switch PAT to GitHubApps

### DIFF
--- a/eng/pipelines/templates/steps/publish-cli.yml
+++ b/eng/pipelines/templates/steps/publish-cli.yml
@@ -8,6 +8,11 @@ steps:
   - ${{ if eq('true', parameters.CreateGitHubRelease) }}:
     # This step must run first because a duplicated tag means we don't need to
     # continue with any of the subsequent steps.
+    - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+      parameters:
+        TokenOwners:
+          - ${{ split(variables['Build.Repository.Name'], '/')[0] }}
+
     - pwsh: |
         $tag = "azure-dev-cli_$(CLI_VERSION)"
         Write-Host "Release tag: $tag"
@@ -32,7 +37,7 @@ steps:
         exit 0
       displayName: Check for existing GitHub release
       env:
-        GH_TOKEN: $(azuresdk-github-pat)
+        GH_TOKEN: $(GH_TOKEN)
 
     - pwsh: |
         Remove-Item -Path release/_manifest -Recurse -Force
@@ -50,7 +55,7 @@ steps:
         gh release upload $(GH_RELEASE_TAG) release/* --repo $(Build.Repository.Name)
       displayName: Create GitHub Release and upload artifacts
       env:
-        GH_TOKEN: $(azuresdk-github-pat)
+        GH_TOKEN: $(GH_TOKEN)
 
     - pwsh: |
         $goModuleTag = "cli/azd/v$(CLI_VERSION)"
@@ -115,7 +120,7 @@ steps:
         Write-Host "Successfully created tag: $goModuleTag"
       displayName: Create Go module version tag
       env:
-        GH_TOKEN: $(azuresdk-github-pat)
+        GH_TOKEN: $(GH_TOKEN)
 
   - ${{ if eq('true', parameters.UploadInstaller) }}:
     - pwsh: |


### PR DESCRIPTION
This pull request updates the `eng/pipelines/templates/steps/publish-cli.yml` pipeline to improve how GitHub authentication is handled during the CLI publishing process. The changes focus on standardizing the use of the `GH_TOKEN` environment variable and introducing a login step for GitHub, which helps ensure secure and consistent authentication across steps.

Authentication improvements:

* Added a step to log in to GitHub using a shared template (`login-to-github.yml`), with `TokenOwners` dynamically set based on the repository name.
* Replaced usage of the `azuresdk-github-pat` secret with the `GH_TOKEN` environment variable in all steps that interact with GitHub, including checking for releases, uploading artifacts, and creating tags. [[1]](diffhunk://#diff-97440691b051b7593395361d95cba18f367e3e8155c120eff3a00a0c51ecfb18L35-R40) [[2]](diffhunk://#diff-97440691b051b7593395361d95cba18f367e3e8155c120eff3a00a0c51ecfb18L53-R58) [[3]](diffhunk://#diff-97440691b051b7593395361d95cba18f367e3e8155c120eff3a00a0c51ecfb18L118-R123)

@JeffreyCA 
[Test Pipeline](https://dev.azure.com/azure-sdk/internal/_build?definitionId=4643&_a=summary)