### PR TITLE
fix: add pre-deploy validation for Python bundled mode

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -45,6 +45,7 @@ words:
   - opencode
   - grpcbroker
   - msiexec
+  - manylinux
   - nosec
   - npx
   - oneof

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_validate.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_validate.go
@@ -149,7 +149,7 @@ func validateBundledHint(srcDir string, codeConfig *agent_yaml.CodeConfiguration
 	fmt.Printf("\n%s Bundled mode selected. Before deploying, install dependencies into the source directory.\n",
 		color.YellowString("NOTE:"))
 	fmt.Printf("  The deployment target is Linux x86_64 with Python %s. Example command:\n\n", pythonVersion)
-	fmt.Printf("    cd %s\n", srcDir)
+	fmt.Printf("    cd \"%s\"\n", srcDir)
 	fmt.Printf("    pip install -r requirements.txt -t . \\\n")
 	fmt.Printf("      --platform manylinux_2_17_x86_64 --platform linux_x86_64 --platform any \\\n")
 	fmt.Printf("      --python-version %s --implementation cp --only-binary=:all: --upgrade\n\n", pythonVersion)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_validate.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_validate.go
@@ -25,6 +25,7 @@ func validatePostInit(srcDir string, codeConfig *agent_yaml.CodeConfiguration) {
 	}
 
 	validateDotnetRuntimeVsCsproj(srcDir, codeConfig.Runtime)
+	validateBundledHint(srcDir, codeConfig)
 }
 
 // validateDotnetRuntimeVsCsproj checks whether the selected .NET runtime version is compatible
@@ -121,4 +122,34 @@ func extractTargetFrameworkVersion(csprojContent string) int {
 		return 0
 	}
 	return version
+}
+
+// validateBundledHint prints guidance when Python bundled mode is selected,
+// reminding the user to install dependencies before deploying.
+func validateBundledHint(srcDir string, codeConfig *agent_yaml.CodeConfiguration) {
+	if codeConfig.DependencyResolution == nil || *codeConfig.DependencyResolution != "bundled" {
+		return
+	}
+
+	// Only show hint for Python projects
+	if !strings.HasPrefix(codeConfig.Runtime, "python_") {
+		return
+	}
+
+	// Check if requirements.txt exists
+	reqPath := filepath.Join(srcDir, "requirements.txt")
+	if _, err := os.Stat(reqPath); err != nil {
+		return
+	}
+
+	// Extract Python version from runtime (e.g. "python_3_14" -> "3.14")
+	pythonVersion := strings.TrimPrefix(codeConfig.Runtime, "python_")
+	pythonVersion = strings.Replace(pythonVersion, "_", ".", 1)
+
+	fmt.Printf("\n%s Bundled mode selected. Before deploying, install dependencies targeting the deployment platform:\n",
+		color.YellowString("NOTE:"))
+	fmt.Printf("  cd %s\n", srcDir)
+	fmt.Printf("  pip install -r requirements.txt -t . \\\n")
+	fmt.Printf("    --platform manylinux_2_17_x86_64 --platform linux_x86_64 --platform any \\\n")
+	fmt.Printf("    --python-version %s --implementation cp --only-binary=:all: --upgrade\n\n", pythonVersion)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_validate.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_validate.go
@@ -146,10 +146,13 @@ func validateBundledHint(srcDir string, codeConfig *agent_yaml.CodeConfiguration
 	pythonVersion := strings.TrimPrefix(codeConfig.Runtime, "python_")
 	pythonVersion = strings.Replace(pythonVersion, "_", ".", 1)
 
-	fmt.Printf("\n%s Bundled mode selected. Before deploying, install dependencies targeting the deployment platform:\n",
+	fmt.Printf("\n%s Bundled mode selected. Before deploying, install dependencies into the source directory.\n",
 		color.YellowString("NOTE:"))
-	fmt.Printf("  cd %s\n", srcDir)
-	fmt.Printf("  pip install -r requirements.txt -t . \\\n")
-	fmt.Printf("    --platform manylinux_2_17_x86_64 --platform linux_x86_64 --platform any \\\n")
-	fmt.Printf("    --python-version %s --implementation cp --only-binary=:all: --upgrade\n\n", pythonVersion)
+	fmt.Printf("  The deployment target is Linux x86_64 with Python %s. Example command:\n\n", pythonVersion)
+	fmt.Printf("    cd %s\n", srcDir)
+	fmt.Printf("    pip install -r requirements.txt -t . \\\n")
+	fmt.Printf("      --platform manylinux_2_17_x86_64 --platform linux_x86_64 --platform any \\\n")
+	fmt.Printf("      --python-version %s --implementation cp --only-binary=:all: --upgrade\n\n", pythonVersion)
+	fmt.Printf("  If some packages lack pre-built wheels, you may need to remove --only-binary=:all:\n")
+	fmt.Printf("  and build on a matching Linux environment instead.\n\n")
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_validate_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_validate_test.go
@@ -129,3 +129,101 @@ func TestValidatePostInit_PythonSkipsValidation(t *testing.T) {
 	}
 	validatePostInit("/any/path", codeConfig)
 }
+
+func TestValidateBundledHint_PythonBundled(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("azure-ai-agents>=1.0\n"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bundled := "bundled"
+	codeConfig := &agent_yaml.CodeConfiguration{
+		Runtime:              "python_3_14",
+		EntryPoint:           "main.py",
+		DependencyResolution: &bundled,
+	}
+
+	output, _ := captureStdout(t, func() error {
+		validateBundledHint(dir, codeConfig)
+		return nil
+	})
+
+	if !strings.Contains(output, "NOTE:") {
+		t.Errorf("expected NOTE in output, got: %s", output)
+	}
+	if !strings.Contains(output, "Example command") {
+		t.Errorf("expected 'Example command' in output, got: %s", output)
+	}
+	if !strings.Contains(output, "--python-version 3.14") {
+		t.Errorf("expected python version 3.14 in output, got: %s", output)
+	}
+	if !strings.Contains(output, "--only-binary=:all:") {
+		t.Errorf("expected --only-binary flag in output, got: %s", output)
+	}
+}
+
+func TestValidateBundledHint_RemoteBuildSkipped(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("azure-ai-agents>=1.0\n"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	remoteBuild := "remote_build"
+	codeConfig := &agent_yaml.CodeConfiguration{
+		Runtime:              "python_3_13",
+		EntryPoint:           "main.py",
+		DependencyResolution: &remoteBuild,
+	}
+
+	output, _ := captureStdout(t, func() error {
+		validateBundledHint(dir, codeConfig)
+		return nil
+	})
+
+	if output != "" {
+		t.Errorf("expected no output for remote_build, got: %s", output)
+	}
+}
+
+func TestValidateBundledHint_DotnetBundledSkipped(t *testing.T) {
+	dir := t.TempDir()
+
+	bundled := "bundled"
+	codeConfig := &agent_yaml.CodeConfiguration{
+		Runtime:              "dotnet_9",
+		EntryPoint:           "Agent.dll",
+		DependencyResolution: &bundled,
+	}
+
+	output, _ := captureStdout(t, func() error {
+		validateBundledHint(dir, codeConfig)
+		return nil
+	})
+
+	if output != "" {
+		t.Errorf("expected no output for dotnet bundled, got: %s", output)
+	}
+}
+
+func TestValidateBundledHint_NoRequirements(t *testing.T) {
+	dir := t.TempDir()
+	// No requirements.txt
+
+	bundled := "bundled"
+	codeConfig := &agent_yaml.CodeConfiguration{
+		Runtime:              "python_3_13",
+		EntryPoint:           "main.py",
+		DependencyResolution: &bundled,
+	}
+
+	output, _ := captureStdout(t, func() error {
+		validateBundledHint(dir, codeConfig)
+		return nil
+	})
+
+	if output != "" {
+		t.Errorf("expected no output without requirements.txt, got: %s", output)
+	}
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
@@ -114,6 +114,11 @@ const (
 	CodeInvalidFilePath  = "invalid_file_path"
 )
 
+// Error codes for packaging/deploy errors.
+const (
+	CodeBundledDepsNotFound = "bundled_deps_not_found"
+)
+
 // Error codes for toolbox operations.
 const (
 	CodeInvalidToolbox             = "invalid_toolbox"

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1744,6 +1744,8 @@ func validatePythonBundledDeps(srcDir string) error {
 			" --implementation cp --only-binary=:all:",
 	)
 }
+
+// deployHostedCodeAgent deploys a code-based hosted agent via multipart ZIP upload.
 func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 	ctx context.Context,
 	serviceConfig *azdext.ServiceConfig,

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1687,8 +1687,15 @@ func validatePythonBundledDeps(srcDir string) error {
 	reqPath := filepath.Join(srcDir, "requirements.txt")
 	data, err := os.ReadFile(reqPath) //nolint:gosec // path from internal state
 	if err != nil {
-		// No requirements.txt — nothing to validate
-		return nil
+		if errors.Is(err, os.ErrNotExist) {
+			// No requirements.txt — nothing to validate
+			return nil
+		}
+		return exterrors.Dependency(
+			exterrors.CodeInvalidFilePath,
+			fmt.Sprintf("failed to read requirements.txt: %s", err),
+			"check file permissions for "+reqPath,
+		)
 	}
 
 	// Check if requirements.txt has any non-comment, non-empty lines
@@ -1709,7 +1716,11 @@ func validatePythonBundledDeps(srcDir string) error {
 	// for common patterns like vendor/ or lib/.
 	entries, err := os.ReadDir(srcDir)
 	if err != nil {
-		return nil
+		return exterrors.Dependency(
+			exterrors.CodeInvalidFilePath,
+			fmt.Sprintf("failed to read source directory: %s", err),
+			"check that the source directory exists and is readable: "+srcDir,
+		)
 	}
 
 	for _, e := range entries {
@@ -1739,7 +1750,7 @@ func validatePythonBundledDeps(srcDir string) error {
 		exterrors.CodeBundledDepsNotFound,
 		"bundled mode is configured but no installed packages were found in the source directory. "+
 			"Dependencies must be installed locally before deploying",
-		"run: pip install -r requirements.txt -t "+srcDir+
+		"run: pip install -r requirements.txt -t \""+srcDir+"\""+
 			" --platform manylinux_2_17_x86_64 --platform linux_x86_64 --platform any"+
 			" --implementation cp --only-binary=:all:",
 	)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1704,7 +1704,9 @@ func validatePythonBundledDeps(srcDir string) error {
 		return nil
 	}
 
-	// Look for any *.dist-info directory in srcDir (top-level only)
+	// Look for any *.dist-info directory in srcDir (top-level only, which is
+	// where pip install --target . places them). Also check one level deep
+	// for common patterns like vendor/ or lib/.
 	entries, err := os.ReadDir(srcDir)
 	if err != nil {
 		return nil
@@ -1714,6 +1716,22 @@ func validatePythonBundledDeps(srcDir string) error {
 		if e.IsDir() && strings.HasSuffix(e.Name(), ".dist-info") {
 			// Found at least one installed package — pass
 			return nil
+		}
+	}
+
+	// Check one level of subdirectories for .dist-info (e.g., vendor/, lib/)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		subEntries, err := os.ReadDir(filepath.Join(srcDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		for _, se := range subEntries {
+			if se.IsDir() && strings.HasSuffix(se.Name(), ".dist-info") {
+				return nil
+			}
 		}
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1700,9 +1700,9 @@ func validatePythonBundledDeps(srcDir string) error {
 
 	// Check if requirements.txt has any non-comment, non-empty lines
 	hasRequirements := false
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if line != "" && !strings.HasPrefix(line, "#") {
+	for line := range strings.SplitSeq(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
 			hasRequirements = true
 			break
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1420,6 +1420,14 @@ func (p *AgentServiceTargetProvider) packageCodeDeploy(ctx context.Context, serv
 			if isDotnet && isBundled {
 				return p.packageDotnetBundled(srcDir)
 			}
+
+			// Python bundled: validate that dependencies are installed in srcDir
+			isPython := strings.HasPrefix(agentDef.CodeConfiguration.Runtime, "python_")
+			if isPython && isBundled {
+				if err := validatePythonBundledDeps(srcDir); err != nil {
+					return "", "", err
+				}
+			}
 		}
 	}
 
@@ -1669,7 +1677,55 @@ func (p *AgentServiceTargetProvider) packageDotnetBundled(srcDir string) (string
 	return tmpPath, sha256Hex, nil
 }
 
-// deployHostedCodeAgent deploys a code-based hosted agent via multipart ZIP upload.
+// validatePythonBundledDeps checks that a Python project in bundled mode has
+// installed dependencies in the source directory. It looks for .dist-info
+// directories which are always created by pip install --target.
+// Only returns an error if requirements.txt exists AND has content AND no
+// .dist-info directories are found — this avoids false positives.
+func validatePythonBundledDeps(srcDir string) error {
+	// Check if requirements.txt exists and has non-empty content
+	reqPath := filepath.Join(srcDir, "requirements.txt")
+	data, err := os.ReadFile(reqPath) //nolint:gosec // path from internal state
+	if err != nil {
+		// No requirements.txt — nothing to validate
+		return nil
+	}
+
+	// Check if requirements.txt has any non-comment, non-empty lines
+	hasRequirements := false
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && !strings.HasPrefix(line, "#") {
+			hasRequirements = true
+			break
+		}
+	}
+	if !hasRequirements {
+		return nil
+	}
+
+	// Look for any *.dist-info directory in srcDir (top-level only)
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return nil
+	}
+
+	for _, e := range entries {
+		if e.IsDir() && strings.HasSuffix(e.Name(), ".dist-info") {
+			// Found at least one installed package — pass
+			return nil
+		}
+	}
+
+	return exterrors.Dependency(
+		exterrors.CodeBundledDepsNotFound,
+		"bundled mode is configured but no installed packages were found in the source directory. "+
+			"Dependencies must be installed locally before deploying",
+		"run: pip install -r requirements.txt -t "+srcDir+
+			" --platform manylinux_2_17_x86_64 --platform linux_x86_64 --platform any"+
+			" --implementation cp --only-binary=:all:",
+	)
+}
 func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 	ctx context.Context,
 	serviceConfig *azdext.ServiceConfig,

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -1912,7 +1912,7 @@ func TestValidatePythonBundledDeps_NoDepsInstalled(t *testing.T) {
 func TestValidatePythonBundledDeps_TopLevelDistInfo(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("azure-ai-agents>=1.0\n"), 0600))
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "azure_ai_agents-1.0.dist-info"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "azure_ai_agents-1.0.dist-info"), 0o750))
 
 	err := validatePythonBundledDeps(dir)
 	require.NoError(t, err)
@@ -1922,7 +1922,7 @@ func TestValidatePythonBundledDeps_SubdirDistInfo(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("azure-ai-agents>=1.0\n"), 0600))
 	// Installed into vendor/ subdir
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "vendor", "azure_ai_agents-1.0.dist-info"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "vendor", "azure_ai_agents-1.0.dist-info"), 0o750))
 
 	err := validatePythonBundledDeps(dir)
 	require.NoError(t, err)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -1884,3 +1884,58 @@ func TestFilterServicesByName(t *testing.T) {
 	require.Equal(t, services, filterServicesByName(services, ""),
 		"empty name returns input unchanged (defensive)")
 }
+
+func TestValidatePythonBundledDeps_NoRequirements(t *testing.T) {
+	dir := t.TempDir()
+	// No requirements.txt — should pass
+	err := validatePythonBundledDeps(dir)
+	require.NoError(t, err)
+}
+
+func TestValidatePythonBundledDeps_EmptyRequirements(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("# just a comment\n\n"), 0600)
+
+	err := validatePythonBundledDeps(dir)
+	require.NoError(t, err)
+}
+
+func TestValidatePythonBundledDeps_NoDepsInstalled(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("azure-ai-agents>=1.0\n"), 0600)
+
+	err := validatePythonBundledDeps(dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no installed packages were found")
+}
+
+func TestValidatePythonBundledDeps_TopLevelDistInfo(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("azure-ai-agents>=1.0\n"), 0600)
+	os.MkdirAll(filepath.Join(dir, "azure_ai_agents-1.0.dist-info"), 0755)
+
+	err := validatePythonBundledDeps(dir)
+	require.NoError(t, err)
+}
+
+func TestValidatePythonBundledDeps_SubdirDistInfo(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("azure-ai-agents>=1.0\n"), 0600)
+	// Installed into vendor/ subdir
+	os.MkdirAll(filepath.Join(dir, "vendor", "azure_ai_agents-1.0.dist-info"), 0755)
+
+	err := validatePythonBundledDeps(dir)
+	require.NoError(t, err)
+}
+
+func TestValidatePythonBundledDeps_ErrorCodeCorrect(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("some-package\n"), 0600)
+
+	err := validatePythonBundledDeps(dir)
+	require.Error(t, err)
+
+	var localErr *azdext.LocalError
+	require.True(t, errors.As(err, &localErr))
+	require.Equal(t, exterrors.CodeBundledDepsNotFound, localErr.Code)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -1894,7 +1894,7 @@ func TestValidatePythonBundledDeps_NoRequirements(t *testing.T) {
 
 func TestValidatePythonBundledDeps_EmptyRequirements(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("# just a comment\n\n"), 0600)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("# just a comment\n\n"), 0600))
 
 	err := validatePythonBundledDeps(dir)
 	require.NoError(t, err)
@@ -1902,7 +1902,7 @@ func TestValidatePythonBundledDeps_EmptyRequirements(t *testing.T) {
 
 func TestValidatePythonBundledDeps_NoDepsInstalled(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("azure-ai-agents>=1.0\n"), 0600)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("azure-ai-agents>=1.0\n"), 0600))
 
 	err := validatePythonBundledDeps(dir)
 	require.Error(t, err)
@@ -1911,8 +1911,8 @@ func TestValidatePythonBundledDeps_NoDepsInstalled(t *testing.T) {
 
 func TestValidatePythonBundledDeps_TopLevelDistInfo(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("azure-ai-agents>=1.0\n"), 0600)
-	os.MkdirAll(filepath.Join(dir, "azure_ai_agents-1.0.dist-info"), 0755)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("azure-ai-agents>=1.0\n"), 0600))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "azure_ai_agents-1.0.dist-info"), 0755))
 
 	err := validatePythonBundledDeps(dir)
 	require.NoError(t, err)
@@ -1920,9 +1920,9 @@ func TestValidatePythonBundledDeps_TopLevelDistInfo(t *testing.T) {
 
 func TestValidatePythonBundledDeps_SubdirDistInfo(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("azure-ai-agents>=1.0\n"), 0600)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("azure-ai-agents>=1.0\n"), 0600))
 	// Installed into vendor/ subdir
-	os.MkdirAll(filepath.Join(dir, "vendor", "azure_ai_agents-1.0.dist-info"), 0755)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "vendor", "azure_ai_agents-1.0.dist-info"), 0755))
 
 	err := validatePythonBundledDeps(dir)
 	require.NoError(t, err)
@@ -1930,7 +1930,7 @@ func TestValidatePythonBundledDeps_SubdirDistInfo(t *testing.T) {
 
 func TestValidatePythonBundledDeps_ErrorCodeCorrect(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("some-package\n"), 0600)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("some-package\n"), 0600))
 
 	err := validatePythonBundledDeps(dir)
 	require.Error(t, err)


### PR DESCRIPTION
## Problem

When users select "Bundled" during `azd ai agent init` but forget to run `pip install --target .` before `azd deploy`, the deployment succeeds but the container crashes at runtime with `ModuleNotFoundError` (see #8610).

## Fix

1. **Post-init hint** (`azd ai agent init`): When bundled mode is selected for a Python project with `requirements.txt`, print the correct platform-specific `pip install` example command targeting the deployment platform (Linux x86_64). Includes a note that `--only-binary=:all:` may need to be removed for packages lacking pre-built wheels.

2. **Pre-deploy check** (`azd deploy`): When Python + bundled mode is configured and `requirements.txt` exists with content but no `.dist-info` directories are found in the source directory (top-level or one subdirectory deep), fail with a clear error message and remediation steps.

## Changes

- `internal/cmd/init_validate.go` — Added `validateBundledHint()` to print pip install guidance after init
- `internal/project/service_target_agent.go` — Added `validatePythonBundledDeps()` pre-deploy check
- `internal/exterrors/codes.go` — Added `CodeBundledDepsNotFound` error code
- `internal/cmd/init_validate_test.go` — 4 new tests for the hint function
- `internal/project/service_target_agent_test.go` — 6 new tests for the deploy check

## Design Decisions

- **Advisory, not blocking at init**: The hint is printed but does not prevent init from completing
- **Blocking at deploy**: The pre-deploy check returns an error to prevent deploying a broken package
- **No false positives**: Check passes if ANY `.dist-info` dir exists (top-level or one level deep). IO errors on ReadDir are surfaced (not silently skipped). Only `os.ErrNotExist` for requirements.txt is ignored.
- **Does not validate completeness**: Only catches "didn't install at all", not partial installs
- **Shell-safe paths**: `srcDir` is quoted in all user-facing commands to handle paths with spaces

## Test Results

Unit tests pass (`go test ./... -count=1`).

### Integration Tests (Windows, manual validation)

All 5 scenarios tested on Windows using extension built from this branch (`bdc12a90e`, 2026-06-12):

| # | Scenario | Result | Evidence |
|---|----------|--------|----------|
| 1 | Python bundled `init` | **PASS** | NOTE hint printed with correct `pip install` command including `--platform manylinux_2_17_x86_64` flags and quoted path |
| 2 | Python bundled `deploy` without deps | **PASS** | Deploy blocked at Packaging step: `bundled mode is configured but no installed packages were found in the source directory` |
| 3 | Python bundled `deploy` with deps | **PASS** | After installing packages (`.dist-info` present), deploy passes Packaging and proceeds to Publishing |
| 4 | Python `remote_build` deploy (non-regression) | **PASS** | No hint at init, no validation block at deploy — proceeds directly past Packaging without deps |
| 5 | .NET bundled `init` (non-regression) | **PASS** | `dotnet_10 --dep-resolution bundled` completes without printing the Python bundled hint |

**Note**: Full end-to-end deploy to Azure was not tested (only validation gate behavior), as the validation fires locally before any Azure API calls.

Fixes #8610