### PR TITLE
feat(agents): resolve Foundry project from endpoint so deploy runs without provision

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_project_resolve.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_project_resolve.go
@@ -1,0 +1,198 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"azureaiagent/internal/exterrors"
+	"azureaiagent/internal/pkg/azure"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+)
+
+// foundryProjectResourceType is the ARM resource type for a Foundry project.
+const foundryProjectResourceType = "Microsoft.CognitiveServices/accounts/projects"
+
+// foundryEndpointHostSuffix is the host suffix of a Foundry project endpoint.
+const foundryEndpointHostSuffix = ".services.ai.azure.com"
+
+// parseFoundryEndpoint extracts the account and project names from a Foundry
+// project endpoint of the form
+// https://<account>.services.ai.azure.com/api/projects/<project>.
+func parseFoundryEndpoint(endpoint string) (account string, project string, err error) {
+	trimmed := strings.TrimSpace(endpoint)
+	if trimmed == "" {
+		return "", "", fmt.Errorf("endpoint is empty")
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid endpoint %q: %w", endpoint, err)
+	}
+
+	host := parsed.Hostname()
+	if !strings.HasSuffix(strings.ToLower(host), foundryEndpointHostSuffix) {
+		return "", "", fmt.Errorf("endpoint host %q is not a Foundry project endpoint", host)
+	}
+	account = host[:len(host)-len(foundryEndpointHostSuffix)]
+	if account == "" {
+		return "", "", fmt.Errorf("endpoint %q is missing the account name", endpoint)
+	}
+
+	// Path is /api/projects/<project>; take the segment after "projects".
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	for i := 0; i+1 < len(segments); i++ {
+		if segments[i] == "projects" && segments[i+1] != "" {
+			project = segments[i+1]
+			break
+		}
+	}
+	if project == "" {
+		return "", "", fmt.Errorf("endpoint %q is missing the project name", endpoint)
+	}
+
+	return account, project, nil
+}
+
+// resolveFoundryProjectIDFromEndpoint resolves the ARM resource ID of a Foundry
+// project from its data-plane endpoint by listing the Foundry projects in the
+// subscription and matching the account and project names. It enables the
+// `endpoint:` path (design spec #8590 §1.4): connect to an existing project
+// without provisioning, so `azd deploy` can run without AZURE_AI_PROJECT_ID.
+func resolveFoundryProjectIDFromEndpoint(
+	ctx context.Context,
+	credential azcore.TokenCredential,
+	subscriptionID string,
+	endpoint string,
+) (string, error) {
+	account, project, err := parseFoundryEndpoint(endpoint)
+	if err != nil {
+		return "", err
+	}
+
+	client, err := armresources.NewClient(subscriptionID, credential, azure.NewArmClientOptions())
+	if err != nil {
+		return "", fmt.Errorf("failed to create resources client: %w", err)
+	}
+
+	pager := client.NewListPager(&armresources.ClientListOptions{
+		Filter: new(fmt.Sprintf("resourceType eq '%s'", foundryProjectResourceType)),
+	})
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to list Foundry projects: %w", err)
+		}
+		for _, resource := range page.Value {
+			if resource == nil || resource.ID == nil {
+				continue
+			}
+			parsed, err := arm.ParseResourceID(*resource.ID)
+			if err != nil || parsed.Parent == nil {
+				continue
+			}
+			if strings.EqualFold(parsed.Parent.Name, account) && strings.EqualFold(parsed.Name, project) {
+				return *resource.ID, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf(
+		"no Foundry project matching endpoint %q was found in subscription %s", endpoint, subscriptionID)
+}
+
+// resolveProjectFromEndpoint connects to an existing Foundry project when the
+// service sets `endpoint:` but no project was provisioned. It resolves the
+// project's ARM resource ID from the endpoint and persists it as
+// AZURE_AI_PROJECT_ID, so the shared deploy machinery (GetTargetResource,
+// finalizeDeploy) works without `azd provision` (design spec #8590 §1.4).
+func (p *FoundryServiceTargetProvider) resolveProjectFromEndpoint(ctx context.Context) error {
+	// Already provisioned or previously resolved: nothing to do.
+	existing, err := p.azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+		EnvName: p.agent.env.Name,
+		Key:     "AZURE_AI_PROJECT_ID",
+	})
+	if err == nil && existing.Value != "" {
+		return nil
+	}
+
+	endpoint := p.resolveEndpoint(ctx)
+	if endpoint == "" {
+		// No endpoint and no project ID: leave resolution to provision. The
+		// deploy path surfaces an actionable error if neither is present.
+		return nil
+	}
+
+	subscriptionID, err := p.subscriptionID(ctx)
+	if err != nil {
+		return err
+	}
+
+	projectID, err := resolveFoundryProjectIDFromEndpoint(ctx, p.agent.credential, subscriptionID, endpoint)
+	if err != nil {
+		return exterrors.Dependency(
+			exterrors.CodeMissingAiProjectId,
+			fmt.Sprintf("failed to resolve the Foundry project from endpoint %q: %s", endpoint, err),
+			"verify the 'endpoint:' on the microsoft.foundry service points at an existing project "+
+				"you can access, or run 'azd provision'",
+		)
+	}
+
+	if _, err := p.azdClient.Environment().SetValue(ctx, &azdext.SetEnvRequest{
+		EnvName: p.agent.env.Name,
+		Key:     "AZURE_AI_PROJECT_ID",
+		Value:   projectID,
+	}); err != nil {
+		return fmt.Errorf("failed to persist AZURE_AI_PROJECT_ID: %w", err)
+	}
+
+	return nil
+}
+
+// resolveEndpoint returns the Foundry project endpoint to connect to, preferring
+// the service `endpoint:` field (with ${VAR} expansion, since core does not
+// expand AdditionalProperties) and falling back to the FOUNDRY_PROJECT_ENDPOINT
+// azd environment value.
+func (p *FoundryServiceTargetProvider) resolveEndpoint(ctx context.Context) string {
+	if p.config != nil && p.config.Endpoint != "" {
+		azdEnv, _ := p.environmentValues(ctx)
+		expanded, err := ExpandEnv(p.config.Endpoint, func(name string) string { return azdEnv[name] })
+		if err == nil && strings.TrimSpace(expanded) != "" {
+			return expanded
+		}
+		return p.config.Endpoint
+	}
+
+	resp, err := p.azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+		EnvName: p.agent.env.Name,
+		Key:     "FOUNDRY_PROJECT_ENDPOINT",
+	})
+	if err != nil {
+		return ""
+	}
+	return resp.Value
+}
+
+// subscriptionID reads AZURE_SUBSCRIPTION_ID from the active azd environment.
+func (p *FoundryServiceTargetProvider) subscriptionID(ctx context.Context) (string, error) {
+	resp, err := p.azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+		EnvName: p.agent.env.Name,
+		Key:     "AZURE_SUBSCRIPTION_ID",
+	})
+	if err != nil || resp.Value == "" {
+		return "", exterrors.Dependency(
+			exterrors.CodeMissingAzureSubscription,
+			"AZURE_SUBSCRIPTION_ID is required to resolve the Foundry project from 'endpoint:'",
+			"run 'azd env set AZURE_SUBSCRIPTION_ID <id>' or 'azd provision'",
+		)
+	}
+	return resp.Value, nil
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_project_resolve_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_project_resolve_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import "testing"
+
+func TestParseFoundryEndpoint(t *testing.T) {
+	tests := []struct {
+		name        string
+		endpoint    string
+		wantAccount string
+		wantProject string
+		wantErr     bool
+	}{
+		{
+			name:        "standard endpoint",
+			endpoint:    "https://my-account.services.ai.azure.com/api/projects/my-project",
+			wantAccount: "my-account",
+			wantProject: "my-project",
+		},
+		{
+			name:        "trailing slash",
+			endpoint:    "https://acct.services.ai.azure.com/api/projects/proj/",
+			wantAccount: "acct",
+			wantProject: "proj",
+		},
+		{
+			name:        "uppercase host",
+			endpoint:    "https://Acct.Services.AI.Azure.Com/api/projects/Proj",
+			wantAccount: "Acct",
+			wantProject: "Proj",
+		},
+		{
+			name:     "empty",
+			endpoint: "",
+			wantErr:  true,
+		},
+		{
+			name:     "non-foundry host",
+			endpoint: "https://example.com/api/projects/proj",
+			wantErr:  true,
+		},
+		{
+			name:     "missing project",
+			endpoint: "https://acct.services.ai.azure.com/api/projects",
+			wantErr:  true,
+		},
+		{
+			name:     "missing project segment",
+			endpoint: "https://acct.services.ai.azure.com/",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			account, project, err := parseFoundryEndpoint(tt.endpoint)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseFoundryEndpoint(%q) expected error, got none", tt.endpoint)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseFoundryEndpoint(%q) unexpected error: %v", tt.endpoint, err)
+			}
+			if account != tt.wantAccount {
+				t.Errorf("account = %q, want %q", account, tt.wantAccount)
+			}
+			if project != tt.wantProject {
+				t.Errorf("project = %q, want %q", project, tt.wantProject)
+			}
+		})
+	}
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_foundry.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_foundry.go
@@ -102,6 +102,12 @@ func (p *FoundryServiceTargetProvider) Initialize(ctx context.Context, serviceCo
 		return err
 	}
 
+	// Connect to an existing project via `endpoint:` when no project was
+	// provisioned, so deploy can run without `azd provision` (spec §1.4).
+	if err := p.resolveProjectFromEndpoint(ctx); err != nil {
+		return err
+	}
+
 	p.initialized = true
 	return nil
 }


### PR DESCRIPTION
## What

Stacks on #8629. Adds endpoint-based Foundry project resolution so `azd deploy` can target an existing Foundry project via `endpoint:` **without `azd provision`** (design spec #8590 §1.4).

Today the `microsoft.foundry` deploy path resolves the target resource through the shared `GetTargetResource` -> `ensureFoundryProject`, which hard-requires `AZURE_AI_PROJECT_ID` (an ARM id normally written by provision). With only `endpoint:` set, deploy fails before any data-plane call. This unblocks the minimal end-to-end demo against an existing project.

## Changes

- `internal/project/foundry_project_resolve.go` (new):
  - `parseFoundryEndpoint` - parse account/project from `https://<account>.services.ai.azure.com/api/projects/<project>`.
  - `resolveFoundryProjectIDFromEndpoint` - list Foundry projects in the subscription, match account+project, return the ARM resource id.
  - `FoundryServiceTargetProvider.resolveProjectFromEndpoint` - when `AZURE_AI_PROJECT_ID` is absent and an endpoint is available (service `endpoint:` with `${VAR}` expansion, or `FOUNDRY_PROJECT_ENDPOINT`), resolve and persist `AZURE_AI_PROJECT_ID`.
- `internal/project/service_target_foundry.go` - `Initialize` calls `resolveProjectFromEndpoint` after auth setup.
- `internal/project/foundry_project_resolve_test.go` (new) - table-driven `parseFoundryEndpoint` coverage.

Provisioned projects are unaffected: resolution is skipped when `AZURE_AI_PROJECT_ID` already exists.

## Out of scope (follow-ups toward the minimal demo)

`init` rework (one-file azure.yaml), data-plane reconcile (deployments/connections/...), built-in Bicep provision, `$ref` wiring, multi-agent fan-out.

## Testing

Extension module: `go build ./...`, `go vet`, `go test ./internal/project/...`, `golangci-lint run` (0 issues), `gofmt`, `cspell` - all clean.