### PR TITLE
[fix] Fix mutations deserialization, dataset path resolution, and tes…

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize.go
@@ -467,11 +467,19 @@ func (a *OptimizeAction) submitJob(
 
 	client := optimize_api.NewOptimizeClient(endpoint, credential)
 
-	// Resolve relative dataset path against the agent project directory so
-	// configs with project-relative dataset_file entries work regardless of
-	// the caller's working directory.
-	if cfg.DatasetFile != "" && !filepath.IsAbs(cfg.DatasetFile) && agentProject != "" {
-		cfg.DatasetFile = filepath.Join(agentProject, cfg.DatasetFile)
+	// Resolve relative local dataset paths against the agent project directory
+	// so configs with project-relative entries work regardless of the caller's
+	// working directory.
+	if agentProject != "" {
+		if cfg.DatasetFile != "" && !filepath.IsAbs(cfg.DatasetFile) {
+			cfg.DatasetFile = filepath.Join(agentProject, cfg.DatasetFile)
+		}
+		if cfg.Dataset.IsLocal() && !filepath.IsAbs(cfg.Dataset.LocalURI) {
+			cfg.Dataset.LocalURI = filepath.Join(agentProject, cfg.Dataset.LocalURI)
+		}
+		if cfg.ValidationDataset.IsLocal() && !filepath.IsAbs(cfg.ValidationDataset.LocalURI) {
+			cfg.ValidationDataset.LocalURI = filepath.Join(agentProject, cfg.ValidationDataset.LocalURI)
+		}
 	}
 
 	optimizeReq, warnings, err := cfg.ToRequest()

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
@@ -148,31 +148,28 @@ func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, []string, e
 
 	var warnings []string
 
-	if ref := c.RemoteDatasetReference(); ref != nil {
-		req.TrainDataset = &optimize_api.Dataset{
-			Type:    optimize_api.DatasetTypeReference,
-			Name:    ref.Name,
-			Version: ref.Version,
-		}
+	// Train dataset: the deprecated dataset_file is normalized into a
+	// DatasetRef so both forms go through the same conversion path.
+	trainRef := c.Dataset
+	if c.DatasetFile != "" {
+		trainRef = &opt_eval.DatasetRef{LocalURI: c.DatasetFile}
 	}
-
-	if c.ValidationDataset != nil {
-		req.ValidationDataset = &optimize_api.Dataset{
-			Type:    optimize_api.DatasetTypeReference,
-			Name:    c.ValidationDataset.Name,
-			Version: c.ValidationDataset.Version,
-		}
-	}
-
-	if localPath := c.LocalDatasetPath(); localPath != "" {
-		lines, err := loadJSONLRawFile(localPath)
+	if trainRef != nil {
+		ds, err := datasetRefToAPI(trainRef)
 		if err != nil {
 			return nil, nil, err
 		}
-		req.TrainDataset = &optimize_api.Dataset{
-			Type:  optimize_api.DatasetTypeInline,
-			Items: lines,
+		req.TrainDataset = ds
+	}
+
+	// Validation dataset (optional): supports both inline (local_uri) and
+	// registered reference (name/version), mirroring the train dataset.
+	if c.ValidationDataset != nil {
+		ds, err := datasetRefToAPI(c.ValidationDataset)
+		if err != nil {
+			return nil, nil, fmt.Errorf("validation dataset: %w", err)
 		}
+		req.ValidationDataset = ds
 	}
 
 	// Populate optimization_config with system_prompt, skills, tools.
@@ -212,6 +209,27 @@ func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, []string, e
 	}
 
 	return req, warnings, nil
+}
+
+// datasetRefToAPI converts a DatasetRef into the API Dataset payload. A local
+// dataset (local_uri, no name) is sent inline with its JSONL items; a
+// registered dataset (name/version) is sent as a reference.
+func datasetRefToAPI(ref *opt_eval.DatasetRef) (*optimize_api.Dataset, error) {
+	if ref.IsLocal() {
+		lines, err := loadJSONLRawFile(ref.LocalURI)
+		if err != nil {
+			return nil, err
+		}
+		return &optimize_api.Dataset{
+			Type:  optimize_api.DatasetTypeInline,
+			Items: lines,
+		}, nil
+	}
+	return &optimize_api.Dataset{
+		Type:    optimize_api.DatasetTypeReference,
+		Name:    ref.Name,
+		Version: ref.Version,
+	}, nil
 }
 
 // evaluatorRefs converts a YAML evaluator list into API evaluator references,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
@@ -157,7 +157,7 @@ func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, []string, e
 	if trainRef != nil {
 		ds, err := datasetRefToAPI(trainRef)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("train dataset: %w", err)
 		}
 		req.TrainDataset = ds
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
@@ -29,8 +29,8 @@ func TestLoadOptimizeConfig_WithDatasetFile(t *testing.T) {
 	dir := t.TempDir()
 
 	datasetPath := writeTestFile(t, dir, "tasks.jsonl",
-		`{"prompt":"What is 2+2?","groundTruth":"4"}
-{"prompt":"Capital of France?","groundTruth":"Paris"}
+		`{"query":"What is 2+2?","ground_truth":"4"}
+{"query":"Capital of France?","ground_truth":"Paris"}
 `)
 
 	yamlContent := `
@@ -63,7 +63,7 @@ options:
 	assert.Equal(t, optimize_api.DatasetTypeInline, req.TrainDataset.Type)
 	assert.Len(t, req.TrainDataset.Items, 2)
 	assert.Contains(t, string(req.TrainDataset.Items[0]), `"What is 2+2?"`)
-	assert.Contains(t, string(req.TrainDataset.Items[0]), `"groundTruth"`)
+	assert.Contains(t, string(req.TrainDataset.Items[0]), `"ground_truth"`)
 	assert.Equal(t, "gpt-4o-mini", req.Options.EvalModel)
 	assert.Equal(t, []optimize_api.EvaluatorRef{{Name: "coherence"}, {Name: "relevance"}}, req.Evaluators)
 }
@@ -143,6 +143,108 @@ options:
 	require.NotNil(t, req.ValidationDataset)
 	assert.Equal(t, "val-dataset", req.ValidationDataset.Name)
 	assert.Equal(t, "3", req.ValidationDataset.Version)
+}
+
+// TestLoadOptimizeConfig_ValidationDataset_Inline verifies a local validation
+// dataset (local_uri) is sent inline with its JSONL items.
+func TestLoadOptimizeConfig_ValidationDataset_Inline(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	valPath := writeTestFile(t, dir, "val.jsonl",
+		`{"query":"Capital of Japan?","ground_truth":"Tokyo"}
+`)
+
+	yamlContent := `
+agent:
+  name: ref-agent
+dataset:
+  name: my-dataset
+  version: "2"
+validation_dataset:
+  local_uri: ` + valPath + `
+evaluators:
+  - builtin.task_adherence
+options:
+  eval_model: gpt-4o-mini
+  optimization_model: gpt-5
+`
+	cfgPath := writeTestFile(t, dir, "optimize.yaml", yamlContent)
+
+	cfg, err := LoadOptimizeConfig(cfgPath)
+	require.NoError(t, err)
+	require.NoError(t, cfg.Validate())
+
+	req, _, err := cfg.ToRequest()
+	require.NoError(t, err)
+
+	require.NotNil(t, req.ValidationDataset)
+	assert.Equal(t, optimize_api.DatasetTypeInline, req.ValidationDataset.Type)
+	require.Len(t, req.ValidationDataset.Items, 1)
+	assert.Contains(t, string(req.ValidationDataset.Items[0]), `"Tokyo"`)
+	assert.Empty(t, req.ValidationDataset.Name)
+}
+
+// TestLoadOptimizeConfig_RelativeLocalURI verifies that relative local_uri
+// paths in dataset and validation_dataset are resolved against the agent
+// project directory (simulating what submitJob does before calling ToRequest).
+func TestLoadOptimizeConfig_RelativeLocalURI(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Create dataset files in a subdirectory of the project directory.
+	sub := filepath.Join(dir, "data")
+	require.NoError(t, os.MkdirAll(sub, 0750))
+	writeTestFile(t, sub, "train.jsonl",
+		`{"query":"hello","ground_truth":"hi"}
+`)
+	writeTestFile(t, sub, "val.jsonl",
+		`{"query":"bye","ground_truth":"goodbye"}
+`)
+
+	yamlContent := `
+agent:
+  name: rel-agent
+dataset:
+  local_uri: data/train.jsonl
+validation_dataset:
+  local_uri: data/val.jsonl
+evaluators:
+  - builtin.task_adherence
+options:
+  eval_model: gpt-4o-mini
+  optimization_model: gpt-5
+`
+	cfgPath := writeTestFile(t, dir, "optimize.yaml", yamlContent)
+
+	cfg, err := LoadOptimizeConfig(cfgPath)
+	require.NoError(t, err)
+	require.NoError(t, cfg.Validate())
+
+	// Simulate submitJob path resolution: resolve relative paths against
+	// the agent project directory (dir).
+	agentProject := dir
+	if cfg.Dataset.IsLocal() && !filepath.IsAbs(cfg.Dataset.LocalURI) {
+		cfg.Dataset.LocalURI = filepath.Join(agentProject, cfg.Dataset.LocalURI)
+	}
+	if cfg.ValidationDataset.IsLocal() && !filepath.IsAbs(cfg.ValidationDataset.LocalURI) {
+		cfg.ValidationDataset.LocalURI = filepath.Join(agentProject, cfg.ValidationDataset.LocalURI)
+	}
+
+	req, _, err := cfg.ToRequest()
+	require.NoError(t, err)
+
+	require.NotNil(t, req.TrainDataset)
+	assert.Equal(t, optimize_api.DatasetTypeInline, req.TrainDataset.Type)
+	require.Len(t, req.TrainDataset.Items, 1)
+	assert.Contains(t, string(req.TrainDataset.Items[0]), `"hello"`)
+
+	require.NotNil(t, req.ValidationDataset)
+	assert.Equal(t, optimize_api.DatasetTypeInline, req.ValidationDataset.Type)
+	require.Len(t, req.ValidationDataset.Items, 1)
+	assert.Contains(t, string(req.ValidationDataset.Items[0]), `"bye"`)
 }
 
 func TestValidate_MissingAgentName(t *testing.T) {
@@ -317,7 +419,7 @@ options:
   budget: 3
 `
 	datasetPath := writeTestFile(t, dir, "eval.jsonl",
-		`{"prompt":"hello","groundTruth":"hi"}
+		`{"query":"hello","ground_truth":"hi"}
 `)
 	// Rewrite dataset_file to the real temp path so Validate+ToRequest work.
 	yamlContent = `
@@ -531,7 +633,7 @@ func TestToRequest_WithToolsFile(t *testing.T) {
 	cfg := &OptimizeConfig{
 		Config: opt_eval.Config{
 			Agent:       opt_eval.AgentRef{Name: "test-agent"},
-			DatasetFile: writeTestFile(t, dir, "dataset.jsonl", `{"prompt":"test"}`),
+			DatasetFile: writeTestFile(t, dir, "dataset.jsonl", `{"query":"test"}`),
 		},
 		Options: &opt_eval.Options{
 			EvalModel: "gpt-4o",
@@ -558,7 +660,7 @@ func TestToRequest_SetsBaselineModelInOptimizationConfig(t *testing.T) {
 	cfg := &OptimizeConfig{
 		Config: opt_eval.Config{
 			Agent:       opt_eval.AgentRef{Name: "agent", Model: "gpt-4o"},
-			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"prompt":"hi"}`),
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
 		},
 		Options: &opt_eval.Options{EvalModel: "gpt-4o-mini"},
 	}
@@ -579,7 +681,7 @@ func TestToRequest_BaselineModelOmittedWhenEmpty(t *testing.T) {
 	cfg := &OptimizeConfig{
 		Config: opt_eval.Config{
 			Agent:       opt_eval.AgentRef{Name: "agent"},
-			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"prompt":"hi"}`),
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
 		},
 		Options: &opt_eval.Options{EvalModel: "gpt-4o-mini"},
 	}
@@ -600,7 +702,7 @@ func TestToRequest_BaselineModelInJSON(t *testing.T) {
 	cfg := &OptimizeConfig{
 		Config: opt_eval.Config{
 			Agent:       opt_eval.AgentRef{Name: "agent", Model: "gpt-4o"},
-			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"prompt":"hi"}`),
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
 		},
 		Options: &opt_eval.Options{EvalModel: "gpt-4o-mini"},
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_test.go
@@ -474,9 +474,15 @@ func TestPrintOptimizeResults_ShowsStrategyColumn(t *testing.T) {
 				{
 					Name:     "candidate_1",
 					AvgScore: 0.95,
-					Mutations: map[string]string{
-						"skill_policy-reviewer": "updated instructions",
-						"system_prompt":         "new prompt",
+					Mutations: map[string]any{
+						"skills": []any{
+							map[string]any{
+								"name":        "policy-reviewer",
+								"description": "Reviews travel requests",
+								"body":        "updated instructions",
+							},
+						},
+						"system_prompt": "new prompt",
 					},
 				},
 			},
@@ -489,7 +495,7 @@ func TestPrintOptimizeResults_ShowsStrategyColumn(t *testing.T) {
 
 	// Strategy header and mutation keys (sorted) are shown.
 	assert.Contains(t, out, "Strategy")
-	assert.Contains(t, out, "skill_policy-reviewer")
+	assert.Contains(t, out, "skills")
 }
 
 func TestPrintOptimizeResults_NoStrategyColumnWhenNoMutations(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
@@ -234,13 +234,13 @@ func (e *JobError) UnmarshalJSON(data []byte) error {
 
 // CandidateResult holds the evaluation result for a single candidate.
 type CandidateResult struct {
-	Name        string            `json:"name"`
-	Mutations   map[string]string `json:"mutations,omitempty"`
-	AvgScore    float64           `json:"avg_score"`
-	AvgTokens   float64           `json:"avg_tokens"`
-	CandidateID string            `json:"candidate_id,omitempty"`
-	EvalID      string            `json:"eval_id,omitempty"`
-	EvalRunID   string            `json:"eval_run_id,omitempty"`
+	Name        string         `json:"name"`
+	Mutations   map[string]any `json:"mutations,omitempty"`
+	AvgScore    float64        `json:"avg_score"`
+	AvgTokens   float64        `json:"avg_tokens"`
+	CandidateID string         `json:"candidate_id,omitempty"`
+	EvalID      string         `json:"eval_id,omitempty"`
+	EvalRunID   string         `json:"eval_run_id,omitempty"`
 }
 
 // MutationKeys returns the candidate's mutation keys (the names of the agent

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models_test.go
@@ -248,3 +248,87 @@ func TestDeploymentReport_JSON_RoundTrip(t *testing.T) {
 	assert.Equal(t, "5", report.AgentVersion)
 	assert.Empty(t, report.CandidateID, "CandidateID should not be populated from JSON")
 }
+
+// ---- CandidateResult.Mutations ----
+
+// TestCandidateResult_MutationsArrayValues verifies that mutations with array
+// values (as returned by newer server versions) unmarshal correctly.
+func TestCandidateResult_MutationsArrayValues(t *testing.T) {
+	t.Parallel()
+
+	body := `{
+		"name": "candidate_1",
+		"avg_score": 0.92,
+		"avg_tokens": 150,
+		"candidate_id": "cand_abc",
+		"mutations": {
+			"skills": [
+				{
+					"name": "handle-return",
+					"description": "Handle product returns and refunds.",
+					"body": "You are a customer support assistant."
+				}
+			],
+			"system_prompt": ["Updated prompt line 1", "Updated prompt line 2"]
+		}
+	}`
+
+	var got CandidateResult
+	require.NoError(t, json.Unmarshal([]byte(body), &got))
+
+	assert.Equal(t, "candidate_1", got.Name)
+	assert.InDelta(t, 0.92, got.AvgScore, 0.001)
+	assert.Equal(t, "cand_abc", got.CandidateID)
+	require.Len(t, got.Mutations, 2)
+
+	// skills is an array of objects
+	skills, ok := got.Mutations["skills"]
+	require.True(t, ok, "skills key should exist")
+	skillSlice, ok := skills.([]any)
+	require.True(t, ok, "skills should be a slice")
+	require.Len(t, skillSlice, 1)
+
+	// system_prompt is an array of strings
+	sp, ok := got.Mutations["system_prompt"]
+	require.True(t, ok, "system_prompt key should exist")
+	spSlice, ok := sp.([]any)
+	require.True(t, ok, "system_prompt should be a slice")
+	assert.Len(t, spSlice, 2)
+
+	// MutationKeys still works
+	assert.Equal(t, []string{"skills", "system_prompt"}, got.MutationKeys())
+}
+
+// TestCandidateResult_MutationsStringValues verifies backward compatibility
+// with the old server format where mutation values are plain strings.
+func TestCandidateResult_MutationsStringValues(t *testing.T) {
+	t.Parallel()
+
+	body := `{
+		"name": "candidate_2",
+		"avg_score": 0.85,
+		"mutations": {
+			"system_prompt": "new prompt text",
+			"skill_policy-reviewer": "updated instructions"
+		}
+	}`
+
+	var got CandidateResult
+	require.NoError(t, json.Unmarshal([]byte(body), &got))
+
+	assert.Equal(t, "new prompt text", got.Mutations["system_prompt"])
+	assert.Equal(t, "updated instructions", got.Mutations["skill_policy-reviewer"])
+	assert.Equal(t, []string{"skill_policy-reviewer", "system_prompt"}, got.MutationKeys())
+}
+
+// TestCandidateResult_MutationsEmpty verifies MutationKeys returns nil for
+// empty or absent mutations.
+func TestCandidateResult_MutationsEmpty(t *testing.T) {
+	t.Parallel()
+
+	var got CandidateResult
+	require.NoError(t, json.Unmarshal([]byte(`{"name":"baseline","avg_score":0.8}`), &got))
+
+	assert.Nil(t, got.Mutations)
+	assert.Nil(t, got.MutationKeys())
+}


### PR DESCRIPTION
Fix mutations deserialization, dataset path resolution, and test schema

## Summary

Fixes a runtime deserialization error when the optimization API returns array-valued mutations, resolves a missing path resolution for the new `dataset.local_uri` format, and unifies train/validation dataset conversion logic.

## Changes

**Fix: `CandidateResult.Mutations` type (`models.go`)**
- Changed `Mutations` from `map[string]string` to `map[string]any` to handle both string values (old server format) and array values (new server format).
- Fixes: `json: cannot unmarshal array into Go struct field CandidateResult.result.candidates.mutations of type string`

**Fix: Resolve `Dataset.LocalURI` against agent project (`optimize.go`)**
- `submitJob` previously resolved `DatasetFile` (deprecated) and `ValidationDataset.LocalURI` against `agentProject`, but missed the new `Dataset.LocalURI` format. Added the missing resolution so relative `local_uri` paths in `eval.yaml` work correctly regardless of the caller's working directory.

**Refactor: Unify dataset conversion in `ToRequest()` (`optimize_config.go`)**
- Train dataset now goes through `datasetRefToAPI` (same as validation dataset), with deprecated `DatasetFile` normalized into a `DatasetRef` first. Removes duplicated inline/reference conversion logic.

**Tests**
- Added `TestCandidateResult_MutationsArrayValues`, `TestCandidateResult_MutationsStringValues`, `TestCandidateResult_MutationsEmpty` in `models_test.go`.
- Added `TestLoadOptimizeConfig_RelativeLocalURI` in `optimize_config_test.go`.
- Updated `TestPrintOptimizeResults_ShowsStrategyColumn` mutations to use array format.
- Updated all JSONL test data from `prompt`/`groundTruth` to `query`/`ground_truth` to match current API schema.

## Files changed

- `cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go`
- `cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models_test.go`
- `cli/azd/extensions/azure.ai.agents/internal/cmd/optimize.go`
- `cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go`
- `cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go`
- `cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_test.go`