### PR TITLE
feat(agents): skip remote build for VNET-injected Foundry accounts

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -98,6 +98,12 @@ type InitAction struct {
 	serviceNameOverride  string // when set, addToProject uses this instead of the manifest name
 	createdFolderDisplay string // pre-computed relative display path for the created folder
 
+	// selectedFoundryProject holds the existing Foundry project resolved during
+	// init (nil when creating a new project). It carries NetworkInjected so
+	// addToProject can disable remote build for VNET-injected accounts
+	// without issuing a second account read.
+	selectedFoundryProject *FoundryProjectInfo
+
 	// userProvidedManifest is true when the init flow is driven by a manifest —
 	// either explicitly via the -m flag/positional argument, or when the user
 	// interactively selects a template that resolves to a manifest. When true,
@@ -1707,6 +1713,7 @@ func (a *InitAction) configureModelChoice(
 			if err != nil {
 				return nil, err
 			}
+			a.selectedFoundryProject = selectedProject
 
 			if selectedProject == nil {
 				return nil, fmt.Errorf("specified foundry project was not found or is not eligible for the current configuration: %s", a.flags.projectResourceId)
@@ -1773,6 +1780,7 @@ func (a *InitAction) configureModelChoice(
 				if err != nil {
 					return nil, err
 				}
+				a.selectedFoundryProject = selectedProject
 
 				if selectedProject == nil {
 					// No existing project selected → fall back to "create new" path
@@ -1852,6 +1860,7 @@ func (a *InitAction) configureModelChoice(
 		if err != nil {
 			return nil, err
 		}
+		a.selectedFoundryProject = selectedProject
 
 		if selectedProject != nil {
 			if err := setEnvValue(
@@ -1929,6 +1938,7 @@ func (a *InitAction) configureModelChoice(
 			if err != nil {
 				return nil, err
 			}
+			a.selectedFoundryProject = selectedProject
 
 			if selectedProject == nil {
 				// No existing project selected → fall back to "create new" path
@@ -2669,9 +2679,10 @@ func (a *InitAction) addToProject(ctx context.Context, targetDir string, agentMa
 				serviceConfig.Language = "csharp"
 			}
 		} else {
-			serviceConfig.Docker = &azdext.DockerProjectOptions{
-				RemoteBuild: true,
-			}
+			// Disable remote build when the Foundry account is VNET-injected; remote
+			// build runs on worker IPs that can't reach a registry in the VNET.
+			networkInjected := a.selectedFoundryProject != nil && a.selectedFoundryProject.NetworkInjected
+			serviceConfig.Docker = &azdext.DockerProjectOptions{RemoteBuild: !networkInjected}
 		}
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -34,6 +34,9 @@ type FoundryProjectInfo struct {
 	ProjectName       string
 	Location          string // may be empty when parsed from resource ID alone
 	ResourceId        string // full ARM resource ID
+	// NetworkInjected is true when the owning Foundry account has VNET network
+	// injection (agent scenario); used to disable remote build.
+	NetworkInjected bool
 }
 
 // FoundryDeploymentInfo holds information about an existing model deployment in a Foundry project.
@@ -213,12 +216,14 @@ func getFoundryProject(
 		return nil, fmt.Errorf("provided project resource ID does not match the selected subscription")
 	}
 
-	projectsClient, err := armcognitiveservices.NewProjectsClient(project.SubscriptionId, credential, azure.NewArmClientOptions())
+	projectsClient, err := armcognitiveservices.NewProjectsClient(
+		project.SubscriptionId, credential, azure.NewArmClientOptions())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create projects client: %w", err)
 	}
 
-	response, err := projectsClient.Get(ctx, project.ResourceGroupName, project.AccountName, project.ProjectName, nil)
+	response, err := projectsClient.Get(
+		ctx, project.ResourceGroupName, project.AccountName, project.ProjectName, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Foundry project: %w", err)
 	}
@@ -226,6 +231,45 @@ func getFoundryProject(
 	updateFoundryProjectInfo(project, &response.Project)
 
 	return project, nil
+}
+
+// foundryAccountNetworkInjected reports whether the Foundry account that owns the
+// project has VNET network injection (agent scenario), used to disable remote
+// build. Best-effort: any failure returns false with a logged warning so init is
+// never blocked.
+func foundryAccountNetworkInjected(
+	ctx context.Context,
+	credential azcore.TokenCredential,
+	project *FoundryProjectInfo,
+) bool {
+	accountsClient, err := armcognitiveservices.NewAccountsClient(
+		project.SubscriptionId, credential, azure.NewArmClientOptions())
+	if err != nil {
+		log.Printf("warning: could not create Cognitive Services accounts client for "+
+			"network-injection check, assuming no injection: %v", err)
+		return false
+	}
+
+	response, err := accountsClient.Get(ctx, project.ResourceGroupName, project.AccountName, nil)
+	if err != nil {
+		log.Printf("warning: could not read Foundry account '%s' for network-injection "+
+			"check, assuming no injection: %v", project.AccountName, err)
+		return false
+	}
+
+	props := response.Account.Properties
+	if props == nil {
+		return false
+	}
+
+	for _, injection := range props.NetworkInjections {
+		if injection != nil && injection.Scenario != nil &&
+			*injection.Scenario == armcognitiveservices.ScenarioTypeAgent {
+			return true
+		}
+	}
+
+	return false
 }
 
 // listProjectDeployments lists all model deployments in a Foundry account.
@@ -1306,6 +1350,11 @@ func selectFoundryProject(
 	}
 
 	selectedProject := projects[selectedIdx]
+
+	// Resolve the account's VNET network-injection status for the chosen project
+	// (best-effort) so remote build is disabled when injection is present. Done here
+	// so both the provided-id and interactive-picker paths are covered from one place.
+	selectedProject.NetworkInjected = foundryAccountNetworkInjected(ctx, credential, &selectedProject)
 
 	// Set location from the selected project
 	azureContext.Scope.Location = selectedProject.Location

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -43,6 +43,12 @@ type InitFromCodeAction struct {
 	deploymentDetails []project.Deployment
 	needsProvision    bool
 	httpClient        *http.Client
+
+	// selectedFoundryProject holds the existing Foundry project resolved during
+	// init (nil when creating a new project). It carries NetworkInjected so
+	// addToProject can disable remote build for VNET-injected accounts
+	// without issuing a second account read.
+	selectedFoundryProject *FoundryProjectInfo
 }
 
 // templateFileInfo represents a file from the GitHub template repository.
@@ -758,6 +764,7 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 	}
 
 	// Step 2: Model configuration
+	a.selectedFoundryProject = selectedProject
 	var modelConfigChoices []*azdext.SelectChoice
 	if selectedProject != nil {
 		modelConfigChoices = []*azdext.SelectChoice{
@@ -1173,11 +1180,12 @@ func (a *InitFromCodeAction) addToProject(ctx context.Context, targetDir string,
 		Config:       agentConfigStruct,
 	}
 
-	// For hosted container-based agents, set remoteBuild to true by default
+	// For hosted container-based agents, enable remote build by default. It is
+	// silently disabled when the target Foundry account has VNET network injection
+	// configured, since it cannot reach a registry in the VNET.
 	if !isCodeDeploy {
-		serviceConfig.Docker = &azdext.DockerProjectOptions{
-			RemoteBuild: true,
-		}
+		networkInjected := a.selectedFoundryProject != nil && a.selectedFoundryProject.NetworkInjected
+		serviceConfig.Docker = &azdext.DockerProjectOptions{RemoteBuild: !networkInjected}
 	}
 
 	// Set AZD_AGENT_SKIP_ACR so Bicep knows whether to create a container registry.


### PR DESCRIPTION
## What
For a hosted container agent on a VNET-injected Foundry account, init enabled remote
build, which can't reach the registry inside the customer's VNET. azd already fell back
to a local build reactively — but only after the user saw the remote build fail, resulting in
a poor user experience.

## Change
Detect the account's network-injection state during project resolution and set
`remoteBuild: false` for VNET-injected accounts, so they build locally from the start.
Detection runs once at the point the selected project is resolved, so it applies whether the
project is supplied via `--project-id` or chosen from the interactive picker. The check is
best-effort — any lookup failure leaves remote build enabled, so init is never blocked. This
makes the existing reactive fallback proactive — same outcome, without the avoidable failure.

Detection is a single synchronous lookup at the shared resolution point (no extra
goroutines), which also addresses the earlier review note about the concurrent reads.

Fixes #8644

---
_Suggested labels (need maintainer to apply): `ext-agents`, `area/ux`._
