### PR TITLE
fix: render interactive prompts once on Windows by using ux components

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- [[#8648]](https://github.com/Azure/azure-dev/pull/8648) Fix interactive prompts (for example the `azd init` environment-name prompt) rendering twice on Windows terminals by rendering prompts with azd's own UX components instead of the archived survey library.
+
 ### Other Changes
 
 ## 1.25.6 (2026-06-12)

--- a/cli/azd/pkg/input/console.go
+++ b/cli/azd/pkg/input/console.go
@@ -719,6 +719,10 @@ func (c *AskerConsole) Prompt(ctx context.Context, options ConsoleOptions) (stri
 		return response, nil
 	}
 
+	if c.isTerminal {
+		return c.promptUx(ctx, options)
+	}
+
 	err := c.doInteraction(func(c *AskerConsole) error {
 		return c.asker(promptFromOptions(options), &response)
 	})
@@ -779,6 +783,10 @@ func (c *AskerConsole) Select(ctx context.Context, options ConsoleOptions) (int,
 		}
 
 		return res, nil
+	}
+
+	if c.isTerminal {
+		return c.selectUx(ctx, options)
 	}
 
 	surveyOptions := make([]string, len(options.Options))
@@ -852,6 +860,10 @@ func (c *AskerConsole) MultiSelect(ctx context.Context, options ConsoleOptions) 
 		}
 
 		return response, nil
+	}
+
+	if c.isTerminal {
+		return c.multiSelectUx(ctx, options)
 	}
 
 	surveyOptions := make([]string, len(options.Options))
@@ -929,6 +941,10 @@ func (c *AskerConsole) Confirm(ctx context.Context, options ConsoleOptions) (boo
 			return false, fmt.Errorf("invalid response: %s", response)
 
 		}
+	}
+
+	if c.isTerminal {
+		return c.confirmUx(ctx, options)
 	}
 
 	var defaultValue bool

--- a/cli/azd/pkg/input/console_ux.go
+++ b/cli/azd/pkg/input/console_ux.go
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package input
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	surveyterm "github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	uxlib "github.com/azure/azure-dev/cli/azd/pkg/ux"
+)
+
+// The interactive prompts below are rendered with the in-repo ux package instead
+// of AlecAivazis/survey. survey has a Windows-specific double-render bug (the
+// prompt and its answer are redrawn above the next prompt) that was never fixed
+// upstream and the library is archived. See Azure/azure-dev#435.
+//
+// Only the terminal path is routed through ux. The non-terminal / no-prompt paths
+// continue to use the lightweight asker implementation so machine-friendly input
+// behavior (used by tests, CI, and piped stdin) is unchanged.
+
+// mapUxCancel converts a ux cancellation error into the survey interrupt error
+// that the rest of azd already recognizes, preserving existing error handling.
+func mapUxCancel(err error) error {
+	if err != nil && errors.Is(err, uxlib.ErrCancelled) {
+		return surveyterm.InterruptErr
+	}
+
+	return err
+}
+
+// optionLabel returns the display label for an option, appending the gray detail
+// text (when present) the same way the previous survey-based rendering did.
+func optionLabel(options ConsoleOptions, index int) string {
+	option := options.Options[index]
+	if index < len(options.OptionDetails) && options.OptionDetails[index] != "" {
+		return fmt.Sprintf("%s %s", option, output.WithGrayFormat("(%s)", options.OptionDetails[index]))
+	}
+
+	return option
+}
+
+func (c *AskerConsole) promptUx(ctx context.Context, options ConsoleOptions) (string, error) {
+	var defaultValue string
+	if value, ok := options.DefaultValue.(string); ok {
+		defaultValue = value
+	}
+
+	prompt := uxlib.NewPrompt(&uxlib.PromptOptions{
+		Writer:       c.writer,
+		Message:      options.Message,
+		HelpMessage:  options.Help,
+		DefaultValue: defaultValue,
+		Secret:       options.IsPassword,
+	})
+
+	var response string
+	err := c.doInteraction(func(c *AskerConsole) error {
+		var askErr error
+		response, askErr = prompt.Ask(ctx)
+		return askErr
+	})
+	if err != nil {
+		return "", mapUxCancel(err)
+	}
+
+	c.updateLastBytes(afterIoSentinel)
+	return response, nil
+}
+
+func (c *AskerConsole) selectUx(ctx context.Context, options ConsoleOptions) (int, error) {
+	choices := make([]*uxlib.SelectChoice, len(options.Options))
+	for i, option := range options.Options {
+		choices[i] = &uxlib.SelectChoice{
+			Value: option,
+			Label: optionLabel(options, i),
+		}
+	}
+
+	selectedIndex := 0
+	if value, ok := options.DefaultValue.(string); ok {
+		if idx := slices.Index(options.Options, value); idx >= 0 {
+			selectedIndex = idx
+		}
+	}
+
+	component := uxlib.NewSelect(&uxlib.SelectOptions{
+		Writer:        c.writer,
+		Message:       options.Message,
+		HelpMessage:   options.Help,
+		Choices:       choices,
+		SelectedIndex: &selectedIndex,
+	})
+
+	var result *int
+	err := c.doInteraction(func(c *AskerConsole) error {
+		var askErr error
+		result, askErr = component.Ask(ctx)
+		return askErr
+	})
+	if err != nil {
+		return -1, mapUxCancel(err)
+	}
+	if result == nil {
+		return -1, surveyterm.InterruptErr
+	}
+
+	c.updateLastBytes(afterIoSentinel)
+	return *result, nil
+}
+
+func (c *AskerConsole) confirmUx(ctx context.Context, options ConsoleOptions) (bool, error) {
+	defaultValue := false
+	if value, ok := options.DefaultValue.(bool); ok {
+		defaultValue = value
+	}
+
+	component := uxlib.NewConfirm(&uxlib.ConfirmOptions{
+		Writer:       c.writer,
+		Message:      options.Message,
+		HelpMessage:  options.Help,
+		DefaultValue: &defaultValue,
+	})
+
+	var result *bool
+	err := c.doInteraction(func(c *AskerConsole) error {
+		var askErr error
+		result, askErr = component.Ask(ctx)
+		return askErr
+	})
+	if err != nil {
+		return false, mapUxCancel(err)
+	}
+	if result == nil {
+		return false, surveyterm.InterruptErr
+	}
+
+	c.updateLastBytes(afterIoSentinel)
+	return *result, nil
+}
+
+func (c *AskerConsole) multiSelectUx(ctx context.Context, options ConsoleOptions) ([]string, error) {
+	defaultValues, _ := options.DefaultValue.([]string)
+
+	choices := make([]*uxlib.MultiSelectChoice, len(options.Options))
+	for i, option := range options.Options {
+		choices[i] = &uxlib.MultiSelectChoice{
+			Value:    option,
+			Label:    optionLabel(options, i),
+			Selected: slices.Contains(defaultValues, option),
+		}
+	}
+
+	component := uxlib.NewMultiSelect(&uxlib.MultiSelectOptions{
+		Writer:      c.writer,
+		Message:     options.Message,
+		HelpMessage: options.Help,
+		Choices:     choices,
+	})
+
+	var selected []*uxlib.MultiSelectChoice
+	err := c.doInteraction(func(c *AskerConsole) error {
+		var askErr error
+		selected, askErr = component.Ask(ctx)
+		return askErr
+	})
+	if err != nil {
+		return nil, mapUxCancel(err)
+	}
+
+	response := make([]string, len(selected))
+	for i, choice := range selected {
+		response[i] = choice.Value
+	}
+
+	c.updateLastBytes(afterIoSentinel)
+	return response, nil
+}


### PR DESCRIPTION
## Summary

Fixes #435.

On Windows terminals (PowerShell 7, Windows Terminal, VS Code terminal), azd's interactive prompts render **twice** — after the user submits a value, the prompt and its answer are redrawn above the next prompt. Originally reported for the `azd init` environment-name prompt, later confirmed for Select/Confirm prompts as well.

### Root cause

azd uses the archived [`AlecAivazis/survey`](https://github.com/AlecAivazis/survey) library for interactive input. survey has a long-standing Windows-specific double-render bug ([survey#368](https://github.com/AlecAivazis/survey/issues/368), [#406](https://github.com/AlecAivazis/survey/issues/406), [#479](https://github.com/AlecAivazis/survey/issues/479)) that was never fixed upstream; the project was archived in April 2024.

### Fix

Per maintainer guidance on the issue, route the **terminal** rendering path of `Prompt`, `Select`, `Confirm`, and `MultiSelect` through the in-repo `pkg/ux` components (`ux.NewPrompt`, `ux.NewSelect`, `ux.NewConfirm`, `ux.NewMultiSelect`). These components render prompts themselves and do not exhibit the double-render.

The non-terminal, `--no-prompt`, and external prompt-client (`promptClient`) paths are left untouched, so machine-friendly behavior used by tests, CI, and piped stdin is unchanged.

### Changes

- **New** `cli/azd/pkg/input/console_ux.go`: `promptUx`, `selectUx`, `confirmUx`, `multiSelectUx` helpers, plus:
  - `mapUxCancel` — maps `ux.ErrCancelled` to `surveyterm.InterruptErr` so existing Ctrl+C / interrupt handling continues to work.
  - `optionLabel` — preserves the gray "(detail)" suffix previously rendered for select option details.
- `cli/azd/pkg/input/console.go`: each of the four methods now dispatches to its `ux` helper when `c.isTerminal`.

## Testing

- `go build ./...` — clean
- `go test ./pkg/input/...` — pass
- `golangci-lint run ./...` — 0 issues
- `mage preflight` — gofmt, go fix, copyright, cspell, cspell-misc, build, and test all pass.

> Note: The playback functional tests fail in the sandbox with `downloading bicep: http error 400` (no Bicep binary available and the recordings don't include its download). These failures are environmental and unrelated to this change; the prompt portions of those flows succeed.

Manual Windows verification recommended on each prompt type to confirm single-render output.