### PR TITLE
fix(ext-agents): default local run venv to Python >=3.13

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
@@ -584,7 +584,7 @@ func installPythonDeps(projectDir string) error {
 	venvDir := filepath.Join(projectDir, ".venv")
 	if _, err := os.Stat(venvDir); os.IsNotExist(err) {
 		fmt.Println("Setting up Python environment...")
-		cmd := exec.Command("uv", "venv", venvDir, "--python", ">=3.12") //nolint:gosec // G204: venvDir is derived from the project directory path
+		cmd := exec.Command("uv", "venv", venvDir, "--python", ">=3.13") //nolint:gosec // G204: venvDir is derived from the project directory path
 		cmd.Dir = projectDir
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
## Description

`azd ai agent run` provisioned the local Python virtual environment with
`uv venv --python ">=3.12"`. On machines whose default interpreter is 3.12.x,
`uv` resolves `>=3.12` to Python 3.12 -- but the supported Foundry agent service
runtimes are Python 3.13 and 3.14 only (3.11/3.12 were removed in #8293, and the
no-prompt default deploy runtime is `python_3_13`).

This breaks local/deploy parity: an agent can run locally on an interpreter that
is no longer a valid deploy target.

This change bumps the local venv default from `>=3.12` to `>=3.13` so the local
environment aligns with the minimum supported service runtime.

## Changes

- `cli/azd/extensions/azure.ai.agents/internal/cmd/run.go`: `installPythonDeps`
  now creates the venv with `--python ">=3.13"`. This is the only occurrence of
  the version string, and no existing test asserts on it.

## Testing

- `go build ./...`
- `go test ./internal/cmd/...` (all pass)

Fixes #8684
