### PR TITLE
feat(agents): add --image flag to agent init command

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -472,22 +472,25 @@ func resolveConversationID(
 	return newConvID, nil
 }
 
-// setACREnvVar sets the AZD_AGENT_SKIP_ACR environment variable based on whether the
-// deployment is code-based (no container registry needed) or container-based.
+// setACREnvVar sets the AZD_AGENT_SKIP_ACR environment variable based on whether ACR
+// should be skipped. ACR is skipped when:
+// - Code deploy mode (no container registry needed)
+// - Pre-built image provided via --image flag (user manages their own registry)
+//
 // This env var is consumed by the Bicep template in Azure-Samples/azd-ai-starter-basic
 // (infra/main.bicep) as `param skipAcr bool` to conditionally skip ACR resource creation.
 //
 // Cross-repo dependency: changes to this variable name must be coordinated with
 // the template parameter mapping in main.parameters.json of the starter template.
-func setACREnvVar(ctx context.Context, azdClient *azdext.AzdClient, envName string, isCodeDeploy bool) error {
+func setACREnvVar(ctx context.Context, azdClient *azdext.AzdClient, envName string, skipACR bool) error {
 	value := "false"
-	if isCodeDeploy {
+	if skipACR {
 		value = "true"
 	}
 
 	if err := setEnvValue(ctx, azdClient, envName, "AZD_AGENT_SKIP_ACR", value); err != nil {
-		if isCodeDeploy {
-			return fmt.Errorf("configuring ACR skip for code deploy: %w", err)
+		if skipACR {
+			return fmt.Errorf("configuring ACR skip: %w", err)
 		}
 		return fmt.Errorf("configuring ACR for container deploy: %w", err)
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
@@ -307,19 +307,19 @@ func TestSetACREnvVar(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		isCodeDeploy bool
-		wantValue    string
+		name      string
+		skipACR   bool
+		wantValue string
 	}{
 		{
-			name:         "code deploy sets true",
-			isCodeDeploy: true,
-			wantValue:    "true",
+			name:      "skip ACR sets true",
+			skipACR:   true,
+			wantValue: "true",
 		},
 		{
-			name:         "container deploy sets false",
-			isCodeDeploy: false,
-			wantValue:    "false",
+			name:      "container deploy sets false",
+			skipACR:   false,
+			wantValue: "false",
 		},
 	}
 
@@ -335,7 +335,7 @@ func TestSetACREnvVar(t *testing.T) {
 			workflowServer := &testWorkflowServiceServer{}
 			azdClient := newTestAzdClient(t, envServer, workflowServer)
 
-			err := setACREnvVar(t.Context(), azdClient, "test-env", tt.isCodeDeploy)
+			err := setACREnvVar(t.Context(), azdClient, "test-env", tt.skipACR)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantValue, envServer.values["test-env"]["AZD_AGENT_SKIP_ACR"])
 		})

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -64,6 +64,10 @@ type initFlags struct {
 	runtime       string // e.g. "python_3_13", "python_3_14", "dotnet_10"
 	entryPoint    string // e.g. "app.py", "MyAgent.dll"
 	depResolution string // "remote_build" or "bundled"; defaults to "remote_build"
+	// image specifies a pre-built container image URL (e.g., "myacr.azurecr.io/agent:v1").
+	// When set, init writes the image field to agent.yaml and skips Dockerfile generation
+	// and ACR connection prompts. Incompatible with --deploy-mode code.
+	image string
 	// force, when true, lets headless callers (--no-prompt) pre-consent to
 	// overwrite prompts that would otherwise return a structured error. It
 	// mirrors the `--force` convention used by `azd down`, `azd env remove`,
@@ -103,6 +107,14 @@ type InitAction struct {
 	// interactively selects a template that resolves to a manifest. When true,
 	// the init flow applies opinionated defaults to minimize interactive prompts.
 	userProvidedManifest bool
+}
+
+// skipACR returns true when ACR provisioning and configuration should be skipped.
+// This happens when:
+// - Code deploy mode is selected (ZIP upload, no container build)
+// - Pre-built image is provided via --image flag (user manages their own registry)
+func (a *InitAction) skipACR() bool {
+	return a.isCodeDeploy || a.flags.image != ""
 }
 
 // modelSelector encapsulates the dependencies needed for model selection and
@@ -585,6 +597,27 @@ func updateAgentDefinition(
 	}
 }
 
+// setImageOnTemplate sets the Image field on a ContainerAgent template.
+// When --image is provided, this function updates the manifest so the image URL
+// is persisted in agent.yaml and used during deployment instead of building from Dockerfile.
+func setImageOnTemplate(agentManifest *agent_yaml.AgentManifest, image string) error {
+	if image == "" {
+		return nil
+	}
+	if agentManifest == nil {
+		return fmt.Errorf("agent manifest is nil")
+	}
+
+	hostedAgent, ok := agentManifest.Template.(agent_yaml.ContainerAgent)
+	if !ok {
+		return fmt.Errorf("--image is only supported for hosted container agents, got %T", agentManifest.Template)
+	}
+
+	hostedAgent.Image = image
+	agentManifest.Template = hostedAgent
+	return nil
+}
+
 func nextAgentNameSuggestion(agentName string) string {
 	const maxAgentNameLength = 63
 	const defaultAgentName = "agent"
@@ -882,7 +915,11 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 
   # Non-interactive code deploy (CI/CD)
   azd ai agent init --no-prompt --project-id "<resource-id>" \
-    --deploy-mode code --runtime python_3_13 --entry-point app.py`,
+    --deploy-mode code --runtime python_3_13 --entry-point app.py
+
+  # Initialize with a pre-built container image (no Dockerfile or ACR setup)
+  azd ai agent init --no-prompt --agent-name my-agent \
+    --image myacr.azurecr.io/agents/my-agent:v1`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flags.noPrompt = extCtx.NoPrompt
@@ -1309,6 +1346,10 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 	cmd.Flags().StringVar(&flags.depResolution, "dep-resolution", "",
 		"Dependency resolution for code deploy: 'remote_build' or 'bundled'. Defaults to 'remote_build'.")
 
+	cmd.Flags().StringVar(&flags.image, "image", "",
+		"Pre-built container image URL (e.g., 'myacr.azurecr.io/agent:v1'). "+
+			"When set, skips Dockerfile generation and ACR setup. Incompatible with --deploy-mode code.")
+
 	cmd.Flags().BoolVar(&flags.force, "force", false,
 		"Overwrite an input manifest that already lives inside the generated src tree without prompting. "+
 			"Required together with --no-prompt when init would otherwise need confirmation.")
@@ -1456,6 +1497,11 @@ func (a *InitAction) Run(ctx context.Context) error {
 			return err
 		}
 		if err := setAgentNameOnTemplate(agentManifest, agentName); err != nil {
+			return err
+		}
+
+		// Set pre-built image if --image was provided
+		if err := setImageOnTemplate(agentManifest, a.flags.image); err != nil {
 			return err
 		}
 
@@ -1678,7 +1724,7 @@ func (a *InitAction) configureModelChoice(
 		); err != nil {
 			return nil, err
 		}
-		if err := setACREnvVar(ctx, a.azdClient, a.environment.Name, a.isCodeDeploy); err != nil {
+		if err := setACREnvVar(ctx, a.azdClient, a.environment.Name, a.skipACR()); err != nil {
 			return nil, err
 		}
 		return agentManifest, nil
@@ -1985,7 +2031,7 @@ func (a *InitAction) configureModelChoice(
 	a.deploymentDetails = deploymentDetails
 
 	// Set AZD_AGENT_SKIP_ACR so Bicep knows whether to create a container registry.
-	if err := setACREnvVar(ctx, a.azdClient, a.environment.Name, a.isCodeDeploy); err != nil {
+	if err := setACREnvVar(ctx, a.azdClient, a.environment.Name, a.skipACR()); err != nil {
 		return nil, err
 	}
 
@@ -3595,8 +3641,43 @@ func extractConnectionConfigs(
 // validateCodeDeployFlags checks that required flags are present when using
 // --deploy-mode code in --no-prompt mode.
 func (a *InitAction) validateCodeDeployFlags() error {
+	// First validate image flag (it has incompatibilities with other flags)
+	if err := validateImageFlag(a.flags.image, a.flags.deployMode); err != nil {
+		return err
+	}
 	return validateCodeDeployInput(
 		a.flags.noPrompt, a.flags.deployMode, a.flags.runtime, a.flags.entryPoint, a.flags.depResolution)
+}
+
+// validateImageFlag checks that --image is valid when provided.
+// Returns an error if:
+// - --image is used with --deploy-mode code (incompatible)
+// - --image URL format is invalid (must contain registry/image pattern)
+func validateImageFlag(image, deployMode string) error {
+	if image == "" {
+		return nil
+	}
+
+	// --image is incompatible with --deploy-mode code
+	if deployMode == "code" {
+		return exterrors.Validation(
+			exterrors.CodeInvalidParameter,
+			"--image cannot be used with --deploy-mode code",
+			"Use --image with --deploy-mode container (default) or omit --deploy-mode",
+		)
+	}
+
+	// Basic image URL validation: must contain registry/image pattern
+	// e.g., "myacr.azurecr.io/agent" or "docker.io/myorg/agent:v1"
+	if !strings.Contains(image, "/") {
+		return exterrors.Validation(
+			exterrors.CodeInvalidParameter,
+			fmt.Sprintf("invalid image URL %q: must be in format registry/image[:tag]", image),
+			"Provide a fully qualified image URL like 'myacr.azurecr.io/agent:v1'",
+		)
+	}
+
+	return nil
 }
 
 // validateCodeDeployInput is the shared validation logic for code deploy flags.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -65,8 +65,11 @@ type initFlags struct {
 	entryPoint    string // e.g. "app.py", "MyAgent.dll"
 	depResolution string // "remote_build" or "bundled"; defaults to "remote_build"
 	// image specifies a pre-built container image URL (e.g., "myacr.azurecr.io/agent:v1").
-	// When set, init writes the image field to agent.yaml and skips Dockerfile generation
-	// and ACR connection prompts. Incompatible with --deploy-mode code.
+	// When set without --manifest, init synthesizes a minimal hosted container manifest and
+	// routes through the manifest flow, skipping template/language selection and code
+	// scaffolding (there is no source to scaffold). It also writes the image field to
+	// agent.yaml, skips Dockerfile generation, and skips ACR connection prompts. Requires
+	// --agent-name when no --manifest is given. Incompatible with --deploy-mode code.
 	image string
 	// force, when true, lets headless callers (--no-prompt) pre-consent to
 	// overwrite prompts that would otherwise return a structured error. It
@@ -618,6 +621,49 @@ func setImageOnTemplate(agentManifest *agent_yaml.AgentManifest, image string) e
 	return nil
 }
 
+// synthesizeImageManifestFile writes a minimal hosted container agent manifest to a
+// temporary file for the bring-your-own-image flow (--image without --manifest).
+// Routing through the manifest path lets init skip template/language selection and code
+// scaffolding, since a pre-built image needs none of those. The returned cleanup removes
+// the temp directory; callers should defer it. The image is also persisted by
+// setImageOnTemplate during Run, but is included here so the manifest is self-describing.
+func synthesizeImageManifestFile(agentName, image string) (string, func(), error) {
+	noop := func() {}
+
+	tmpDir, err := os.MkdirTemp("", "azd-agent-image-")
+	if err != nil {
+		return "", noop, fmt.Errorf("creating temp directory for synthesized manifest: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tmpDir) }
+
+	doc := map[string]any{
+		"name": agentName,
+		"template": map[string]any{
+			"kind":        string(agent_yaml.AgentKindHosted),
+			"name":        agentName,
+			"description": fmt.Sprintf("Hosted container agent using pre-built image %s", image),
+			"image":       image,
+			"protocols": []map[string]any{
+				{"protocol": "responses", "version": "v1"},
+			},
+		},
+	}
+
+	content, err := yaml.Marshal(doc)
+	if err != nil {
+		cleanup()
+		return "", noop, fmt.Errorf("marshaling synthesized manifest: %w", err)
+	}
+
+	manifestPath := filepath.Join(tmpDir, "agent.yaml")
+	if err := os.WriteFile(manifestPath, content, osutil.PermissionFile); err != nil {
+		cleanup()
+		return "", noop, fmt.Errorf("writing synthesized manifest: %w", err)
+	}
+
+	return manifestPath, cleanup, nil
+}
+
 func nextAgentNameSuggestion(agentName string) string {
 	const maxAgentNameLength = 63
 	const defaultAgentName = "agent"
@@ -917,7 +963,7 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
   azd ai agent init --no-prompt --project-id "<resource-id>" \
     --deploy-mode code --runtime python_3_13 --entry-point app.py
 
-  # Initialize with a pre-built container image (no Dockerfile or ACR setup)
+  # Bring your own pre-built image (no template/language selection, Dockerfile, or ACR setup)
   azd ai agent init --no-prompt --agent-name my-agent \
     --image myacr.azurecr.io/agents/my-agent:v1`,
 		Args: cobra.MaximumNArgs(1),
@@ -973,6 +1019,35 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 			// only shown for brand-new top-level project folders, not
 			// when a template adds a subfolder to an existing project.
 			existingProject := fileExists("azure.yaml")
+
+			// Bring-your-own-image fast path: when --image is set without a manifest,
+			// there is no source to scaffold and no template/language to choose.
+			// Synthesize a minimal hosted container manifest and route it through the
+			// manifest flow, which skips the init-mode / template / language prompts
+			// and code scaffolding. The image is wired into agent.yaml and ACR is
+			// skipped by the existing --image handling in InitAction.Run.
+			if flags.image != "" && flags.manifestPointer == "" {
+				// Validate early so we fail before initializing a project/template.
+				if err := validateImageFlag(flags.image, flags.deployMode); err != nil {
+					return err
+				}
+				if flags.agentName == "" {
+					return exterrors.Validation(
+						exterrors.CodeInvalidParameter,
+						"--image requires --agent-name when no --manifest is provided",
+						"pass --agent-name <name> (or provide --manifest with the agent definition)",
+					)
+				}
+				manifestPath, cleanup, err := synthesizeImageManifestFile(flags.agentName, flags.image)
+				if err != nil {
+					return err
+				}
+				defer cleanup()
+				flags.manifestPointer = manifestPath
+				// Treat the synthesized manifest as user-provided so deploy-mode
+				// resolution auto-selects container without prompting.
+				userProvidedManifest = true
+			}
 
 			// Auto-detect an existing agent manifest in the target directory
 			// when no --manifest flag was provided.
@@ -1348,7 +1423,9 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 
 	cmd.Flags().StringVar(&flags.image, "image", "",
 		"Pre-built container image URL (e.g., 'myacr.azurecr.io/agent:v1'). "+
-			"When set, skips Dockerfile generation and ACR setup. Incompatible with --deploy-mode code.")
+			"When set without --manifest, skips template/language selection, code scaffolding, "+
+			"Dockerfile generation, and ACR setup, and requires --agent-name. "+
+			"Incompatible with --deploy-mode code.")
 
 	cmd.Flags().BoolVar(&flags.force, "force", false,
 		"Overwrite an input manifest that already lives inside the generated src tree without prompting. "+

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1965,6 +1965,14 @@ func (a *InitAction) configureModelChoice(
 			}
 		}
 
+		// Persist the ACR-skip signal for the no-model-resources path too.
+		// The deferred-headless and main model-config paths set this, but a
+		// completing no-model flow (e.g. a pre-built --image agent) otherwise
+		// would not, leaving Bicep to provision an ACR the user doesn't need.
+		if err := setACREnvVar(ctx, a.azdClient, a.environment.Name, a.skipACR()); err != nil {
+			return nil, err
+		}
+
 		return agentManifest, nil
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -621,6 +621,19 @@ func setImageOnTemplate(agentManifest *agent_yaml.AgentManifest, image string) e
 	return nil
 }
 
+// agentUsesPreBuiltImage reports whether the manifest's template is a hosted
+// container agent that references a pre-built image. For such agents azd does
+// not build from source, so build-time concerns like the startup command and
+// ACR setup do not apply. Covers both the --image flag (synthesized manifest)
+// and a user-provided -m manifest that already specifies an image.
+func agentUsesPreBuiltImage(agentManifest *agent_yaml.AgentManifest) bool {
+	if agentManifest == nil {
+		return false
+	}
+	ca, ok := agentManifest.Template.(agent_yaml.ContainerAgent)
+	return ok && strings.TrimSpace(ca.Image) != ""
+}
+
 // synthesizeImageManifestFile writes a minimal hosted container agent manifest to a
 // temporary file for the bring-your-own-image flow (--image without --manifest).
 // Routing through the manifest path lets init skip template/language selection and code
@@ -2759,8 +2772,10 @@ func (a *InitAction) addToProject(ctx context.Context, targetDir string, agentMa
 		}
 	}
 
-	// Detect startup command (container deploy only; code deploy does not use startupCommand)
-	if !a.isCodeDeploy {
+	// Detect startup command. Skipped for code deploy (uses ZIP packaging) and
+	// when the agent uses a pre-built container image, since the image's own
+	// entrypoint runs and no startup command applies.
+	if !a.isCodeDeploy && !agentUsesPreBuiltImage(agentManifest) {
 		startupCmd, err := resolveStartupCommandForInit(ctx, a.azdClient, a.projectConfig.Path, targetDir, a.flags.noPrompt)
 		if err != nil {
 			return err

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -3749,10 +3749,18 @@ func (a *InitAction) validateCodeDeployFlags() error {
 		a.flags.noPrompt, a.flags.deployMode, a.flags.runtime, a.flags.entryPoint, a.flags.depResolution)
 }
 
+var initImageRefRe = regexp.MustCompile(
+	`^(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?::[0-9]+)?|` +
+		`localhost(?::[0-9]+)?|[a-z0-9](?:[a-z0-9-]*[a-z0-9])?:[0-9]+)/` +
+		`[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*` +
+		`(?:/[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*)*` +
+		`(?::[\w][\w.-]{0,127}|@sha256:[0-9a-fA-F]{64})?$`,
+)
+
 // validateImageFlag checks that --image is valid when provided.
 // Returns an error if:
 // - --image is used with --deploy-mode code (incompatible)
-// - --image URL format is invalid (must contain registry/image pattern)
+// - --image URL format is invalid (must contain a fully qualified registry/image reference)
 func validateImageFlag(image, deployMode string) error {
 	if image == "" {
 		return nil
@@ -3767,9 +3775,10 @@ func validateImageFlag(image, deployMode string) error {
 		)
 	}
 
-	// Basic image URL validation: must contain registry/image pattern
-	// e.g., "myacr.azurecr.io/agent" or "docker.io/myorg/agent:v1"
-	if !strings.Contains(image, "/") {
+	// Require a fully-qualified image reference with an explicit registry host,
+	// e.g. "myacr.azurecr.io/agent", "docker.io/myorg/agent:v1", or
+	// "localhost:5000/agent@sha256:<digest>".
+	if !initImageRefRe.MatchString(image) {
 		return exterrors.Validation(
 			exterrors.CodeInvalidParameter,
 			fmt.Sprintf("invalid image URL %q: must be in format registry/image[:tag]", image),

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -657,7 +657,7 @@ func synthesizeImageManifestFile(agentName, image string) (string, func(), error
 			"description": fmt.Sprintf("Hosted container agent using pre-built image %s", image),
 			"image":       image,
 			"protocols": []map[string]any{
-				{"protocol": "responses", "version": "v1"},
+				{"protocol": "responses", "version": "1.0.0"},
 			},
 		},
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1825,7 +1825,7 @@ func (a *InitAction) configureModelChoice(
 			selectedProject, err := selectFoundryProject(
 				ctx, a.azdClient, a.credential, a.azureContext, a.environment.Name,
 				a.azureContext.Scope.SubscriptionId, a.flags.projectResourceId,
-				a.isCodeDeploy,
+				a.skipACR(),
 			)
 			if err != nil {
 				return nil, err
@@ -1891,7 +1891,7 @@ func (a *InitAction) configureModelChoice(
 				selectedProject, err := selectFoundryProject(
 					ctx, a.azdClient, a.credential, a.azureContext, a.environment.Name,
 					a.azureContext.Scope.SubscriptionId, "",
-					a.isCodeDeploy,
+					a.skipACR(),
 				)
 				if err != nil {
 					return nil, err
@@ -1970,7 +1970,7 @@ func (a *InitAction) configureModelChoice(
 		selectedProject, err := selectFoundryProject(
 			ctx, a.azdClient, a.credential, a.azureContext, a.environment.Name,
 			a.azureContext.Scope.SubscriptionId, a.flags.projectResourceId,
-			a.isCodeDeploy,
+			a.skipACR(),
 		)
 		if err != nil {
 			return nil, err
@@ -2047,7 +2047,7 @@ func (a *InitAction) configureModelChoice(
 			selectedProject, err := selectFoundryProject(
 				ctx, a.azdClient, a.credential, a.azureContext, a.environment.Name,
 				a.azureContext.Scope.SubscriptionId, "",
-				a.isCodeDeploy,
+				a.skipACR(),
 			)
 			if err != nil {
 				return nil, err

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -1233,8 +1233,8 @@ func selectFoundryProject(
 		return nil, fmt.Errorf("failed to list Foundry projects: %w", err)
 	}
 
-	// When code deploy is selected, restrict to regions that support hosted agents.
-	// Code deploy is available in all hosted-agent regions (no separate allowlist).
+	// When ACR is skipped (code deploy, or a pre-built --image), the agent runs as a
+	// hosted agent, so restrict to regions that support hosted agents.
 	if skipACR {
 		supportedRegions, regErr := supportedRegionsForInit(ctx)
 		if regErr != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -91,8 +91,51 @@ func TestValidateImageFlag(t *testing.T) {
 			image: "myacr.azurecr.io/agent",
 		},
 		{
+			name: "valid image with digest",
+			image: "myacr.azurecr.io/agent@sha256:" +
+				"76a9463463acf11d4068e8468fb232a3de0709177b6b35de95de6a34b33fa686",
+		},
+		{
+			name:  "valid local registry with port",
+			image: "localhost:5000/myorg/agent:v1",
+		},
+		{
+			name:  "valid registry host with port",
+			image: "registry:5000/myorg/agent:v1",
+		},
+		{
 			name:       "image without registry fails",
 			image:      "agent:v1",
+			wantErr:    true,
+			errContain: "must be in format",
+		},
+		{
+			name:       "namespace image without registry fails",
+			image:      "myorg/agent:v1",
+			wantErr:    true,
+			errContain: "must be in format",
+		},
+		{
+			name:       "image with URL scheme fails",
+			image:      "https://myacr.azurecr.io/agent:v1",
+			wantErr:    true,
+			errContain: "must be in format",
+		},
+		{
+			name:       "image missing repository fails",
+			image:      "myacr.azurecr.io/",
+			wantErr:    true,
+			errContain: "must be in format",
+		},
+		{
+			name:       "image with short digest fails",
+			image:      "myacr.azurecr.io/agent@sha256:abc123",
+			wantErr:    true,
+			errContain: "must be in format",
+		},
+		{
+			name:       "uppercase repository fails",
+			image:      "myacr.azurecr.io/MyAgent:v1",
 			wantErr:    true,
 			errContain: "must be in format",
 		},

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -54,6 +54,193 @@ func TestInitCommand_ForceFlag(t *testing.T) {
 	}
 }
 
+func TestInitCommand_ImageFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := newInitCommand(nil)
+
+	flag := cmd.Flags().Lookup("image")
+	require.NotNil(t, flag, "--image flag should be registered")
+	require.Empty(t, flag.DefValue, "expected --image to have empty default")
+}
+
+func TestValidateImageFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		image      string
+		deployMode string
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name:  "empty image is valid",
+			image: "",
+		},
+		{
+			name:  "valid ACR image",
+			image: "myacr.azurecr.io/agent:v1",
+		},
+		{
+			name:  "valid Docker Hub image",
+			image: "docker.io/myorg/agent:latest",
+		},
+		{
+			name:  "valid image without tag",
+			image: "myacr.azurecr.io/agent",
+		},
+		{
+			name:       "image without registry fails",
+			image:      "agent:v1",
+			wantErr:    true,
+			errContain: "must be in format",
+		},
+		{
+			name:       "simple name fails",
+			image:      "agent",
+			wantErr:    true,
+			errContain: "must be in format",
+		},
+		{
+			name:       "image with code deploy fails",
+			image:      "myacr.azurecr.io/agent:v1",
+			deployMode: "code",
+			wantErr:    true,
+			errContain: "cannot be used with --deploy-mode code",
+		},
+		{
+			name:       "container deploy mode with image is valid",
+			image:      "myacr.azurecr.io/agent:v1",
+			deployMode: "container",
+		},
+		{
+			name:       "empty deploy mode with image is valid",
+			image:      "myacr.azurecr.io/agent:v1",
+			deployMode: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateImageFlag(tt.image, tt.deployMode)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errContain)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSetImageOnTemplate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		manifest  *agent_yaml.AgentManifest
+		image     string
+		wantImage string
+		wantErr   bool
+	}{
+		{
+			name:      "empty image is noop",
+			manifest:  &agent_yaml.AgentManifest{Template: agent_yaml.ContainerAgent{}},
+			image:     "",
+			wantImage: "",
+		},
+		{
+			name:      "sets image on container agent",
+			manifest:  &agent_yaml.AgentManifest{Template: agent_yaml.ContainerAgent{}},
+			image:     "myacr.azurecr.io/agent:v1",
+			wantImage: "myacr.azurecr.io/agent:v1",
+		},
+		{
+			name:     "nil manifest returns error",
+			manifest: nil,
+			image:    "myacr.azurecr.io/agent:v1",
+			wantErr:  true,
+		},
+		{
+			name:     "non-container agent returns error",
+			manifest: &agent_yaml.AgentManifest{Template: agent_yaml.Workflow{}},
+			image:    "myacr.azurecr.io/agent:v1",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := setImageOnTemplate(tt.manifest, tt.image)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tt.image != "" {
+				hostedAgent, ok := tt.manifest.Template.(agent_yaml.ContainerAgent)
+				require.True(t, ok)
+				require.Equal(t, tt.wantImage, hostedAgent.Image)
+			}
+		})
+	}
+}
+
+func TestSkipACR(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		isCodeDeploy bool
+		image        string
+		want         bool
+	}{
+		{
+			name:         "code deploy skips ACR",
+			isCodeDeploy: true,
+			image:        "",
+			want:         true,
+		},
+		{
+			name:         "image flag skips ACR",
+			isCodeDeploy: false,
+			image:        "myacr.azurecr.io/agent:v1",
+			want:         true,
+		},
+		{
+			name:         "both set skips ACR",
+			isCodeDeploy: true,
+			image:        "myacr.azurecr.io/agent:v1",
+			want:         true,
+		},
+		{
+			name:         "neither set does not skip ACR",
+			isCodeDeploy: false,
+			image:        "",
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			action := &InitAction{
+				isCodeDeploy: tt.isCodeDeploy,
+				flags:        &initFlags{image: tt.image},
+			}
+
+			require.Equal(t, tt.want, action.skipACR())
+		})
+	}
+}
+
 func TestValidateInitAgentName(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -241,6 +241,39 @@ func TestSkipACR(t *testing.T) {
 	}
 }
 
+func TestSynthesizeImageManifestFile(t *testing.T) {
+	t.Parallel()
+
+	const agentName = "my-agent"
+	const image = "myacr.azurecr.io/agents/my-agent@sha256:" +
+		"76a9463463acf11d4068e8468fb232a3de0709177b6b35de95de6a34b33fa686"
+
+	manifestPath, cleanup, err := synthesizeImageManifestFile(agentName, image)
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	require.FileExists(t, manifestPath)
+	require.Equal(t, "agent.yaml", filepath.Base(manifestPath))
+
+	content, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+
+	// The synthesized file must parse through the same path the manifest flow uses.
+	template, err := agent_yaml.ExtractAgentDefinition(content)
+	require.NoError(t, err)
+
+	containerAgent, ok := template.(agent_yaml.ContainerAgent)
+	require.True(t, ok, "synthesized template should be a ContainerAgent, got %T", template)
+	require.Equal(t, agent_yaml.AgentKindHosted, containerAgent.Kind)
+	require.Equal(t, agentName, containerAgent.Name)
+	require.Equal(t, image, containerAgent.Image)
+	require.Len(t, containerAgent.Protocols, 1)
+	require.Equal(t, "responses", containerAgent.Protocols[0].Protocol)
+
+	// cleanup removes the temp directory.
+	cleanup()
+	require.NoFileExists(t, manifestPath)
+}
+
 func TestValidateInitAgentName(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -274,6 +274,45 @@ func TestSynthesizeImageManifestFile(t *testing.T) {
 	require.NoFileExists(t, manifestPath)
 }
 
+func TestAgentUsesPreBuiltImage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		manifest *agent_yaml.AgentManifest
+		want     bool
+	}{
+		{name: "nil manifest", manifest: nil, want: false},
+		{
+			name:     "container agent with image",
+			manifest: &agent_yaml.AgentManifest{Template: agent_yaml.ContainerAgent{Image: "myacr.azurecr.io/a:v1"}},
+			want:     true,
+		},
+		{
+			name:     "container agent without image",
+			manifest: &agent_yaml.AgentManifest{Template: agent_yaml.ContainerAgent{}},
+			want:     false,
+		},
+		{
+			name:     "container agent with whitespace-only image",
+			manifest: &agent_yaml.AgentManifest{Template: agent_yaml.ContainerAgent{Image: "   "}},
+			want:     false,
+		},
+		{
+			name:     "non-container agent",
+			manifest: &agent_yaml.AgentManifest{Template: agent_yaml.Workflow{}},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, agentUsesPreBuiltImage(tt.manifest))
+		})
+	}
+}
+
 func TestValidateInitAgentName(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -268,6 +268,7 @@ func TestSynthesizeImageManifestFile(t *testing.T) {
 	require.Equal(t, image, containerAgent.Image)
 	require.Len(t, containerAgent.Protocols, 1)
 	require.Equal(t, "responses", containerAgent.Protocols[0].Protocol)
+	require.Equal(t, "1.0.0", containerAgent.Protocols[0].Version)
 
 	// cleanup removes the temp directory.
 	cleanup()

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1076,9 +1076,15 @@ func (p *AgentServiceTargetProvider) shouldUsePreBuiltImage(
 		return false, nil
 	}
 
+	if p.shouldSkipACRForEnvironment(ctx) {
+		log.Printf("AZD_AGENT_SKIP_ACR=true: using pre-built image from agent.yaml")
+		return true, nil
+	}
+
 	// Default to build so the pre-built path requires an explicit choice.
 	// In non-interactive mode (--no-prompt), the framework returns the default
-	// selection (index 0 = build) automatically.
+	// selection (index 0 = build) automatically unless AZD_AGENT_SKIP_ACR=true
+	// was set by init --image.
 	choices := []*azdext.SelectChoice{
 		{Value: "build", Label: "Build a new image for me"},
 		{Value: "prebuilt", Label: fmt.Sprintf("Create hosted agent from %s", imageURL)},
@@ -1096,6 +1102,22 @@ func (p *AgentServiceTargetProvider) shouldUsePreBuiltImage(
 	}
 
 	return resp.Value != nil && choices[*resp.Value].Value == "prebuilt", nil
+}
+
+func (p *AgentServiceTargetProvider) shouldSkipACRForEnvironment(ctx context.Context) bool {
+	if p.env == nil || p.env.Name == "" {
+		return false
+	}
+
+	resp, err := p.azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+		EnvName: p.env.Name,
+		Key:     "AZD_AGENT_SKIP_ACR",
+	})
+	if err != nil || resp == nil {
+		return false
+	}
+
+	return strings.EqualFold(strings.TrimSpace(resp.Value), "true")
 }
 
 // isCodeDeployAgent returns true if the agent.yaml has code_configuration (code deploy mode)


### PR DESCRIPTION
## Summary

Adds `--image` flag to `azd ai agent init` to allow users to specify a pre-built container image directly during initialization. This is a prerequisite for VNet scenarios where users bring their own private ACR with pre-built images.

When `--image` is supplied without `--manifest`, init now **short-circuits template/language selection and code scaffolding** — a pre-built image has no source to scaffold — by synthesizing a minimal hosted container manifest and routing it through the existing manifest flow. The azd starter **infra** project is still initialized (needed for provisioning); only the agent code template/language prompts are skipped.

## Changes

- Add `--image` flag to `initFlags` struct
- Validate image URL format (must contain registry/image pattern)
- Return error when combined with `--deploy-mode code` (incompatible)
- Set `Image` field in agent.yaml when flag is provided
- Skip ACR connection prompts when `--image` is set (via `skipACR()` method)
- Update `setACREnvVar` to take `skipACR` parameter for clarity
- **Short-circuit template/language selection + code scaffolding** when `--image` is used without `--manifest`:
  - Synthesize a minimal hosted container manifest (`synthesizeImageManifestFile`) and route through the manifest flow
  - Require `--agent-name` in this path (used to name the agent/folder/service)
  - Validate the image early, before any project/template init, so failures don't leave a half-scaffolded directory
- Update `--image` flag help, struct doc, and command example to reflect the new behavior

## Testing

Added/updated unit tests:
- Flag registration (`TestInitCommand_ImageFlag`)
- Image URL validation (`TestValidateImageFlag`)
- Template image setting (`TestSetImageOnTemplate`)
- ACR skip logic (`TestSkipACR`)
- Synthesized manifest round-trips through the real parser (`TestSynthesizeImageManifestFile`)

## Manual E2E Test Steps

Validated live against `azd auth login` (output filtered for brevity).

```bash
export NO_COLOR=1

# Test 1: Full headless flow — no language prompt, no agent code scaffold
WORK=$(mktemp -d) && cd "$WORK"
azd ai agent init --no-prompt --agent-name my-agent \
    --image myacr.azurecr.io/agents/my-agent:v1
# Verify:
#  - No "Select a language" / "How do you want to initialize your agent?" prompt
#  - Agent code template is NOT downloaded (only the azd starter infra project)
cat my-agent/src/my-agent/agent.yaml            # contains: image: myacr.azurecr.io/agents/my-agent:v1
grep SKIP_ACR my-agent/.azure/*/.env            # AZD_AGENT_SKIP_ACR="true"

# Test 2: Interactive (no --no-prompt) — language prompt is gone
cd "$(mktemp -d)"
azd ai agent init --agent-name my-agent \
    --image myacr.azurecr.io/agents/my-agent:v1
# Expected: goes straight to project init -> manifest validation -> model
# configuration. No language / init-mode prompt.

# Test 3: --image without --agent-name (no -m) — fails early, no scaffolding
cd "$(mktemp -d)"
azd ai agent init --no-prompt --image myacr.azurecr.io/agents/my-agent:v1
# Expected: ERROR: --image requires --agent-name when no --manifest is provided
#           (working directory remains empty — nothing scaffolded)

# Test 4: --image conflicts with --deploy-mode code — fails early
cd "$(mktemp -d)"
azd ai agent init --no-prompt --agent-name my-agent \
    --image myacr.azurecr.io/agents/my-agent:v1 --deploy-mode code
# Expected: ERROR: --image cannot be used with --deploy-mode code

# Test 5: Invalid image URL (no registry/slash) — fails validation
cd "$(mktemp -d)"
azd ai agent init --no-prompt --agent-name my-agent --image "agent-v1"
# Expected: ERROR: invalid image URL "agent-v1": must be in format registry/image[:tag]

# Test 6: Digest-pinned image is accepted
cd "$(mktemp -d)"
azd ai agent init --no-prompt --agent-name my-agent \
    --image myacr.azurecr.io/echodual@sha256:76a9463463acf11d4068e8468fb232a3de0709177b6b35de95de6a34b33fa686
# Verify: agent.yaml image field is the full digest reference
```

## Related

- Prerequisite for VNet support feature
- Works with existing deploy-side `image` field support (PR #8104)


## Real E2E Validation (`--image`)

Ran a live Azure E2E for the BYO image path:

```bash
azd ai agent init --no-prompt --agent-name echo-dual-e2e2-06171610 \
  --image myacr.azurecr.io/echodual@sha256:76a9463463acf11d4068e8468fb232a3de0709177b6b35de95de6a34b33fa686 \
  --project-id /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<account>/projects/<project>
azd provision --no-prompt
azd deploy --no-prompt
azd ai agent show echo-dual-e2e2-06171610 --output json
azd ai agent invoke --new-session echo-dual-e2e2-06171610 "hello, are you up?"
```

Result: **PASS**

- `init`: wrote `image:` to `agent.yaml`; no scaffold/language/deploy-mode/startup/ACR prompts; wrote `AZD_AGENT_SKIP_ACR="true"`.
- `provision`: succeeded using existing project/resource group
- `deploy`: succeeded; used the pre-built image directly, skipped Dockerfile build/publish, deployed version `2` active.
- `invoke`: succeeded remotely:

```text
[echo-dual-e2e2-06171610] 🔊 Echo: hello, are you up?
```
