### PR TITLE
docs(spec): private networking for host: microsoft.foundry

### DIFF
--- a/docs/specs/foundry-private-network/spec.md
+++ b/docs/specs/foundry-private-network/spec.md
@@ -14,13 +14,13 @@ VNet binds at the Account level, yet `network:` sits on a service entry that rea
 
 ## Solution
 
-Extend the Foundry provisioning synthesizer (`internal/synthesis`, introduced by the bicep-less work) to read a new `network:` block on the service body and emit the network primitives a secured agent account requires: a VNet with an agent subnet and a private-endpoint subnet, account-level `networkInjections`, an account private endpoint, and the AI private DNS zones — each created or referenced per the developer's declaration.
+Extend the Foundry provisioning synthesizer (`internal/synthesis`, introduced by the bicep-less work) to read a new `network:` block on the service body and emit the network primitives a secured agent account requires: optional agent runtime VNet injection, an account private endpoint, and the AI private DNS zones — each created or referenced per the developer's declaration.
 
-The block is purely additive. When `network:` is absent the synthesizer behaves exactly as today (public account). When present, the account flips to private and the network modules are included. No new provider, no new gRPC surface, no core change beyond the schema slice — the block rides the same `AdditionalProperties` channel every other Foundry key already uses.
+The block is purely additive. When `network:` is absent the synthesizer behaves exactly as today (public account). When present, the account data plane is **always private**: the account has `publicNetworkAccess: 'Disabled'`, its network ACL default action is `Deny`, and an account private endpoint is provisioned in `peSubnet`. No new provider, no new gRPC surface, no core change beyond the schema slice — the block rides the same `AdditionalProperties` channel every other Foundry key already uses.
 
 Dependent stores (Cosmos DB, AI Search, Storage) stay **platform-managed**, which is supported under VNet isolation. This removes the bulk of the sample template (BYO stores, their private endpoints, role assignments, and both capability hosts) from azd's responsibility.
 
-The example below illustrates one scenario (BYO VNet with explicit subnets); it is not the full schema. See the `azure.yaml` surface section for the field reference and the create-vs-reference rules.
+The example below illustrates one scenario (BYO egress with explicit subnets); it is not the full schema. See the `azure.yaml` surface section for the field reference and the create-vs-reference rules.
 
 ```yaml
 infra:
@@ -32,17 +32,16 @@ services:
 
     # New: private networking for the Foundry account.
     # Omitted => public account (unchanged behavior).
+    # Present => private data plane (always).
     network:
-      mode: byo                       # byo | managed
-      byo:
-        vnet:
-          id: ${AZURE_VNET_ID}        # required for byo (v1)
-        agentSubnet:
-          name: agent-subnet
-          prefix: 192.168.0.0/24
-        peSubnet:
-          name: pe-subnet
-          prefix: 192.168.1.0/24
+      agentSubnet:
+        vnet: ${AZURE_VNET_ID}
+        name: agent-subnet
+        prefix: 192.168.10.0/24
+      peSubnet:
+        vnet: ${AZURE_VNET_ID}
+        name: pe-subnet
+        prefix: 192.168.11.0/24
       dns:
         resourceGroup: rg-private-dns
         subscription: ${AZURE_DNS_SUBSCRIPTION_ID}
@@ -62,14 +61,18 @@ services:
 
 **In scope**
 
-- **BYO VNet** — bring an existing VNet; create or reference its subnets.
-- **Foundry-managed VNet** — with a selectable isolation mode.
-- **A network-bound (private) Foundry account** — its private endpoint and the AI private DNS zones, created or referenced.
+- **Private data plane** — declaring `network:` always disables account public access and provisions an account private endpoint.
+- **BYO egress** — inject the hosted-agent runtime into an existing customer VNet by declaring `agentSubnet`.
+- **Microsoft-managed egress** — omit `agentSubnet` and optionally choose a managed-network `isolationMode`.
+- **Create or reference subnets** — `prefix` present creates a subnet; `prefix` absent references an existing subnet.
+- **Private DNS** — create/link the AI private DNS zones by default, or reference central/shared zones with `dns:`.
 - **Platform-managed dependent stores** under VNet isolation.
 - **BYO container image** as the registry story for secured agents.
 
 **Out of scope**
 
+- Public opt-out when `network:` is declared — omit `network:` for a public account.
+- Cross-VNet v1 topologies — `agentSubnet` and `peSubnet` must target the same VNet when both are declared.
 - BYO dependent stores and the capability-host wiring they require — managed stores are used instead.
 - Tool subnet, user-assigned managed identity (UAMI), customer-managed keys (CMK) — not core to the secured-agent scenario.
 - Local build into a private ACR — secured agents bring a pre-built image; the developer owns ACR networking. See the ACR private networking section.
@@ -83,13 +86,13 @@ Private networking is the last layer on a stack already in flight on the `huimiu
 unified azure.yaml (huimiu)            #8590 docs → branch huimiu/foundry-azure-yaml
 ├─ bicep-less provisioning (hund030)   #8577 docs / #8643 impl  ← integration point
 ├─ foundry service target + init       #8629 / #8675
-└─ BYO image                           #8689  (+ #8645 remote-build skip, merged)
+└─ BYO image                           #8645 remote-build skip, merged
 ```
 
 Two consequences matter here:
 
 - **No core change.** Unknown service keys ride `ServiceConfig.AdditionalProperties` to the extension (unify §2.1), and the synthesizer reads the raw `azure.yaml` bytes directly, so the only required core edit is the JSON schema slice (see the `azure.yaml` surface section).
-- **ACR is off the critical path.** `--image` (#8689) and the merged #8645 (skip remote build for VNET-injected accounts) keep registry work out of v1 (see the ACR private networking section).
+- **ACR is off the critical path.** The BYO-image flow and the merged remote-build skip for VNet-injected accounts keep registry work out of v1 (see the ACR private networking section).
 
 ## `azure.yaml` surface
 
@@ -100,47 +103,31 @@ services:
   my-project:
     host: microsoft.foundry
 
-    # New: private networking configuration for standard/networked agents.
-    #
-    # If omitted, the project uses public networking.
-    # If present, azd provisions or configures private networking and uses
-    # customer-owned dependent stores for agent data.
-    network:
-      # Required when network is present.
-      # byo     = customer-managed / BYO VNet
-      # managed = Foundry-managed VNet
-      mode: byo
+    network:                          # present => private data plane (always). Omit for public.
 
-      # Used only when mode: byo.
-      byo:
-        # Existing customer VNet. v1 requires this id.
-        vnet:
-          id: ${AZURE_VNET_ID}
+      # ── EGRESS: agent runtime network ──────────────────────────────
+      # agentSubnet PRESENT -> inject agent into YOUR subnet  (useMicrosoftManagedNetwork: false)
+      # agentSubnet ABSENT  -> Microsoft-managed VNet         (useMicrosoftManagedNetwork: true)
+      agentSubnet:
+        vnet: ${AZURE_VNET_ID}        # required — full VNet ARM id
+        name: agent-subnet            # required — subnet leaf name
+        prefix: 192.168.10.0/24       # optional — PRESENT=create, ABSENT=reference existing
 
-        # Agent subnet.
-        # omitted => azd creates default agent subnet
-        # name only => azd references existing subnet and validates it
-        # name + prefix => azd creates subnet with that name/prefix
-        agentSubnet:
-          name: agent-subnet
-          prefix: <CIDR>
+      # Managed-egress outbound posture. VALID ONLY when agentSubnet is ABSENT.
+      # -> properties.managedNetwork.isolationMode
+      isolationMode: AllowOnlyApprovedOutbound      # | AllowInternetOutbound
 
-        # Private endpoint subnet.
-        # Same rules with Agent subnet.
-        peSubnet:
-          name: pe-subnet
-          prefix: <CIDR>
+      # ── INGRESS: account data plane (REQUIRED) ─────────────────────
+      # Always provisions an account private endpoint -> publicNetworkAccess: Disabled.
+      peSubnet:
+        vnet: ${AZURE_VNET_ID}        # required
+        name: pe-subnet               # required
+        prefix: 192.168.11.0/24       # optional — PRESENT=create, ABSENT=reference existing
 
-      # Used only when mode: managed.
-      # Values: AllowInternetOutbound | AllowOnlyApprovedOutbound
-      managed:
-        isolationMode: AllowOnlyApprovedOutbound
-
-      # Optional.
-      # If omitted, or resourceGroup is omitted, azd creates required private DNS zones.
-      # If resourceGroup is set, azd references existing private DNS zones in that resource group.
+      # Private DNS zones for the account PE. Optional; defaults to create + link
+      # to the PE's VNet. Override to reference central/shared zones. Requires peSubnet.
       dns:
-        resourceGroup: rg-private-dns
+        resourceGroup: my-dns-rg
         subscription: ${AZURE_DNS_SUBSCRIPTION_ID}
 ```
 
@@ -148,23 +135,33 @@ services:
 
 | Field | Rule |
 | --- | --- |
-| `mode` | Required when `network:` is present. `byo` and `managed` are mutually exclusive; the matching sub-block is required and the other must be absent. |
-| `byo.vnet.id` | Required in v1. The VNet must already exist. `${VAR}` is resolved from the azd environment before synthesis. |
-| `byo.agentSubnet` / `byo.peSubnet` | **Tri-state.** Omitted → azd creates a default subnet (`agent-subnet` / `pe-subnet`) with a default prefix. Name only → azd **references** an existing subnet and validates it (delegation for the agent subnet, PE network policies for the PE subnet). Name **and** prefix → azd **creates** the subnet with that name and prefix. |
-| `managed.isolationMode` | One of `AllowInternetOutbound`, `AllowOnlyApprovedOutbound`. Maps to the account managed-network isolation setting. |
-| `dns.resourceGroup` | When omitted (or the whole `dns:` block omitted), azd **creates** the required private DNS zones and links them. When set, azd **references** existing zones in that resource group. |
+| `network` | Optional. Omitted means the public-account behavior is unchanged. Present means the data plane is private in every egress mode. |
+| `agentSubnet` | Optional. Present selects BYO egress and sets the account agent `networkInjections` entry to `useMicrosoftManagedNetwork: false`. Absent selects Microsoft-managed egress (`useMicrosoftManagedNetwork: true`). |
+| `agentSubnet.vnet` | Required when `agentSubnet` is present. Full ARM id of the customer VNet. `${VAR}` is resolved from the azd environment before synthesis. |
+| `agentSubnet.name` | Required when `agentSubnet` is present. Subnet leaf name. |
+| `agentSubnet.prefix` | Optional. Present means azd creates the subnet with that prefix. Absent means azd references an existing subnet with `name`. |
+| `isolationMode` | Optional. Valid only when `agentSubnet` is absent (managed egress). One of `AllowInternetOutbound`, `AllowOnlyApprovedOutbound`. Maps to `properties.managedNetwork.isolationMode` on the account managed network. |
+| `peSubnet` | Required when `network:` is present. It is the account private endpoint subnet, and its presence is what makes the account data plane private. |
+| `peSubnet.vnet` | Required. Full ARM id of the customer VNet. `${VAR}` is resolved from the azd environment before synthesis. |
+| `peSubnet.name` | Required. Subnet leaf name. |
+| `peSubnet.prefix` | Optional. Present means azd creates the subnet with that prefix. Absent means azd references an existing subnet with `name`. |
+| `dns.resourceGroup` | Optional. When omitted (or the whole `dns:` block is omitted), azd creates the required private DNS zones and links them to the PE VNet. When set, azd references existing zones in that resource group. |
 | `dns.subscription` | Optional. Defaults to the deployment subscription. Accepts a bare GUID or `${VAR}`. Only meaningful alongside `dns.resourceGroup`. |
 
-`${VAR}` resolves client-side from the azd environment for `byo.vnet.id` and `dns.subscription`. `${{...}}` Foundry expressions are not expected in network fields and are passed through verbatim if present, consistent with the shared expander.
+`${VAR}` resolves client-side from the azd environment for VNet ids and `dns.subscription`. `${{...}}` Foundry expressions are not expected in network fields and are passed through verbatim if present, consistent with the shared expander.
 
 ## Synthesizer and template changes (high level)
 
 The bicep-less work landed `internal/synthesis/synthesizer.go` plus an embedded `templates/` tree (`main.bicep`, `modules/acr.bicep`, `abbreviations.json`, and a precompiled `main.arm.json` fallback). The account today is hardcoded to public. The changes are additive and local to this package.
 
-- **Read `network:`** — extend the `foundryService` view the synthesizer decodes so it captures the `network` sub-tree (mode, byo, managed, dns), and resolve `${VAR}` in `byo.vnet.id` / `dns.subscription` before emitting parameters. Absent block → all network parameters default off and output is byte-identical to today.
-- **Emit parameters** — add the network parameter set to the synthesizer `Result.Parameters` (mode, vnet id, subnet tri-state descriptors, isolation mode, DNS zone map + subscription).
-- **`main.bicep`** — guard the network path on a single `enableNetworkIsolation` condition. When on: include `modules/network.bicep`, set the account's `publicNetworkAccess: 'Disabled'`, `networkAcls.defaultAction: 'Deny'`, and `networkInjections` (scenario `agent`) from the agent subnet, and include `modules/private-endpoint-dns.bicep`. When off: the account block is exactly today's.
-- **New modules** — `modules/network.bicep` (VNet + two subnets, create or reference, agent-subnet delegation) and `modules/private-endpoint-dns.bicep` (account private endpoint + the three AI DNS zones `privatelink.services.ai.azure.com`, `privatelink.openai.azure.com`, `privatelink.cognitiveservices.azure.com` + VNet links, create or reference).
+- **Read `network:`** — extend the `foundryService` view the synthesizer decodes so it captures the flat `network` sub-tree (`agentSubnet`, `isolationMode`, `peSubnet`, `dns`) and resolves `${VAR}` in VNet ids / `dns.subscription` before emitting parameters. Absent block → all network parameters default off and output is byte-identical to today.
+- **Derive egress** — do not expose a `mode` enum. `agentSubnet == nil` selects Microsoft-managed egress; `agentSubnet != nil` selects BYO egress.
+- **Emit parameters** — add the network parameter set to the synthesizer `Result.Parameters`: `enableNetworkIsolation`, `useManagedEgress`, the subnet descriptors, managed isolation mode, and DNS zone RG/subscription.
+- **`main.bicep`** — guard the network path on a single `enableNetworkIsolation` condition. When on: include `modules/network.bicep`, set the account's `publicNetworkAccess: 'Disabled'`, `networkAcls.defaultAction: 'Deny'`, and the account agent `networkInjections`, and include `modules/private-endpoint-dns.bicep`. When off: the account block is exactly today's.
+- **BYO egress** — when `agentSubnet` is present, provision/reference the agent subnet and write an account `networkInjections` entry pointing at that subnet with `useMicrosoftManagedNetwork: false`.
+- **Managed egress** — when `agentSubnet` is absent, write an account agent `networkInjections` entry with `useMicrosoftManagedNetwork: true`; when `isolationMode` is set, provision the `managedNetworks/default` child resource with that value.
+- **Ingress** — when `network:` is present, `peSubnet` is required and the private endpoint is always provisioned in it. There is no managed-mode public data-plane exception.
+- **New modules** — `modules/network.bicep` (reference the VNet + create/reference subnets, agent-subnet delegation when creating) and `modules/private-endpoint-dns.bicep` (account private endpoint + the three AI DNS zones `privatelink.services.ai.azure.com`, `privatelink.openai.azure.com`, `privatelink.cognitiveservices.azure.com` + VNet links, create or reference).
 - **Regenerate `main.arm.json`** — the precompiled ARM fallback must be rebuilt from the extended `main.bicep` and committed alongside it. The byte-stability contract from the bicep-less spec applies: same `azure.yaml` → byte-identical output within a patch version.
 
 The provisioning provider, on-disk/eject behavior, and parameter wiring need no structural change — they consume whatever `Result.Parameters` carries.
@@ -173,13 +170,29 @@ The provisioning provider, on-disk/eject behavior, and parameter wiring need no 
 
 Network validation slots into the synthesizer's existing pre-synthesis checks and runs on every `provision`, `preview`, and eject:
 
-- **Mode coherence** — `mode` is `byo` or `managed`; the matching sub-block is present and the other is absent.
-- **BYO VNet** — `byo.vnet.id` is present (v1) and is a well-formed `Microsoft.Network/virtualNetworks` ARM id after `${VAR}` resolution.
-- **Subnet tri-state** — for each of `agentSubnet` / `peSubnet`: reject `prefix` without `name`; validate CIDR shape when `prefix` is present; surface a clear field path on failure.
+- **Private means private** — if `network:` is present, `peSubnet` is required; missing `peSubnet` is an error, never a silent public fallback.
+- **Subnet shape** — each declared subnet (`agentSubnet`, `peSubnet`) requires `vnet` and `name`; `prefix` is optional and must be a valid CIDR when present.
+- **VNet ids** — every subnet `vnet` is a well-formed `Microsoft.Network/virtualNetworks` ARM id after `${VAR}` resolution.
+- **Single VNet v1** — when both subnets are declared, `agentSubnet.vnet` and `peSubnet.vnet` must resolve to the same VNet.
+- **Egress coherence** — `isolationMode` is valid only when `agentSubnet` is absent (managed egress). If `agentSubnet` is present, managed-network isolation is rejected with a clear error.
 - **DNS** — when `dns.resourceGroup` is set, validate the resource-group name; normalize `dns.subscription` to a bare GUID (accept `/subscriptions/<guid>` or a bare GUID), matching the sample's behavior.
 - **Env resolvability** — every `${VAR}` in a network field resolves from the azd environment; an unresolved reference fails with the variable name.
 
-Failures surface with the service-scoped field path, e.g. `services.my-project.network.byo.agentSubnet: prefix set without name`.
+Failures surface with the service-scoped field path, e.g. `services.my-project.network.agentSubnet: isolationMode is only valid when agentSubnet is absent`.
+
+## Update behavior
+
+Re-running `azd provision` against the same environment re-synthesizes from the current `azure.yaml` and performs an ARM incremental update against the same account name. Whether a particular edit succeeds is constrained by the Foundry resource provider:
+
+| Edit | Expected behavior |
+| --- | --- |
+| Add `network:` to a public greenfield account | Supported when the service accepts the resulting account update and private endpoint creation. |
+| Change DNS from create to reference (or the reverse) | Supported as an infrastructure update if the referenced zones and VNet links already exist. |
+| Tighten managed `isolationMode` | Supported in the service direction of more restriction (for example `AllowInternetOutbound` → `AllowOnlyApprovedOutbound`). |
+| Relax managed `isolationMode` or disable managed network after enabling it | Not supported by the service. Create a new environment/account instead. |
+| Switch BYO egress ↔ managed egress after agents/capability host exist | Not a v1 contract. Create a new environment/account instead. |
+
+The docs should present network topology changes as provision-time configuration, with update support limited to safe/idempotent re-provisioning and service-supported tightening.
 
 ## Brownfield interaction
 
@@ -189,20 +202,20 @@ Therefore, when `endpoint:` is present, `network:` is **ignored** (the account's
 
 ## ACR private networking — decision and RoI
 
-A secured agent still needs its image to come from somewhere reachable inside the VNet. Two paths:
+A secured agent still needs its image to come from somewhere reachable from the agent runtime. Two paths:
 
 | Path | What azd must do | Effort | v1 |
 | --- | --- | --- | --- |
-| **BYO image (`--image`)** | Nothing. The developer brings `registry/image:tag` and owns the registry's SKU, private endpoint, DNS, and firewall. | ~0 (lands with #8689) | **Chosen** |
+| **BYO image (`--image`)** | Nothing. The developer brings `registry/image:tag` and owns the registry's SKU, private endpoint, DNS, and firewall. | ~0 | **Chosen** |
 | **Local build → private ACR** | Provision a Premium ACR with a private endpoint and `privatelink.azurecr.io`, then solve build connectivity: a remote ACR-task build must egress to a private registry, or a local push must reach it from outside the VNet (developer IP allowlist). | High; many connectivity edge cases | **Deferred** |
 
-The hard part of the local-build path is not creating the registry — it is making the build actually reach a network-isolated registry, which drags in build-agent network placement azd does not control. v1 therefore standardizes on BYO image for secured agents; #8645 (merged) already skips remote build for network-injected accounts, so the flow is coherent end to end. Revisit local-build-into-private-ACR after telemetry shows `--image` adoption and real demand.
+The hard part of the local-build path is not creating the registry — it is making the build actually reach a network-isolated registry, which drags in build-agent network placement azd does not control. v1 therefore standardizes on BYO image for secured agents. Revisit local-build-into-private-ACR after telemetry shows `--image` adoption and real demand.
 
 ## Telemetry and docs
 
 **Telemetry**
 
-- `provision.network_mode` — `none` | `byo` | `managed`, emitted at provision start. Lets us measure secured-agent adoption and BYO-vs-managed split. Implementation PRs add it to `docs/reference/telemetry-data.md`.
+- `provision.network_mode` — `none` | `byo` | `managed`, emitted at provision start. The value is derived from `network:` presence and `agentSubnet` presence. Lets us measure secured-agent adoption and BYO-vs-managed split. Implementation PRs add it to `docs/reference/telemetry-data.md`.
 
 **Docs**
 
@@ -212,5 +225,6 @@ The hard part of the local-build path is not creating the registry — it is mak
 ## References
 
 - Service team's standard network-secured agent template (source of truth for the ARM shape, primitives, and the keep/drop decisions in this spec): [`15-private-network-standard-agent-setup`](https://github.com/microsoft-foundry/foundry-samples/tree/main/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup).
+- Service team's managed-network sample for private data plane + Microsoft-managed egress: [`18-managed-virtual-network`](https://github.com/microsoft-foundry/foundry-samples/tree/main/infrastructure/infrastructure-setup-bicep/18-managed-virtual-network).
 - [Unified `azure.yaml` design](https://github.com/Azure/azure-dev/pull/8590) — establishes the `host: microsoft.foundry` shape and defers VNet to this work (§1.4).
 - [Bicep-less provisioning](https://github.com/Azure/azure-dev/pull/8577) — the synthesizer and provider this spec extends.

--- a/docs/specs/foundry-private-network/spec.md
+++ b/docs/specs/foundry-private-network/spec.md
@@ -1,0 +1,316 @@
+<!-- cspell:ignore networkinjections caphost privatelink documentdb azurecr Vnet vnet subnet subnets myprivacr cognitiveservices UAMI hund -->
+
+# Private networking for `host: microsoft.foundry`
+
+## Problem
+
+Foundry network isolation is unreachable from `azure.yaml` today. The
+[unified `azure.yaml` design](../unify-azure-yaml/spec.md) (§1.4) is explicit:
+VNet binding lives on the Foundry **Account** resource, the unified shape only
+models the **Project**, and so "customizing them today means ejecting to Bicep.
+That built-in Bicep work must provide a path to create and customize those
+network settings."
+
+A developer who needs a network-secured agent must therefore abandon the
+declarative flow, hand-author the service team's
+[standard network-secured template](https://github.com/microsoft-foundry/foundry-samples/tree/main/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup)
+(7+ modules, dependent stores, capability-host wiring, DNS), and maintain it by
+hand. There is no `network:` surface, and the in-memory synthesizer that
+[bicep-less provisioning](../bicepless-foundry/spec.md) introduced always emits
+a public account (`publicNetworkAccess: 'Enabled'`).
+
+This spec adds a declarative `network:` block to the `host: microsoft.foundry`
+service and teaches the existing synthesizer to provision a network-bound
+account from it.
+
+## Solution
+
+Extend the Foundry provisioning synthesizer
+(`internal/synthesis`, introduced by the bicep-less work) to read a new
+`network:` block on the service body and emit the network primitives a secured
+agent account requires: a VNet with an agent subnet and a private-endpoint
+subnet, account-level `networkInjections`, an account private endpoint, and the
+AI private DNS zones — each created or referenced per the developer's
+declaration.
+
+The block is purely additive. When `network:` is absent the synthesizer behaves
+exactly as today (public account). When present, the account flips to private
+and the network modules are included. No new provider, no new gRPC surface, no
+core change beyond the schema slice — the block rides the same
+`AdditionalProperties` channel every other Foundry key already uses.
+
+Dependent stores (Cosmos DB, AI Search, Storage) stay **platform-managed**,
+which is supported under VNet isolation. This removes the bulk of the sample
+template (BYO stores, their private endpoints, role assignments, and both
+capability hosts) from azd's responsibility.
+
+```yaml
+infra:
+  provider: microsoft.foundry
+
+services:
+  my-project:
+    host: microsoft.foundry
+
+    # New: private networking for the Foundry account.
+    # Omitted => public account (unchanged behavior).
+    network:
+      mode: byo                       # byo | managed
+      byo:
+        vnet:
+          id: ${AZURE_VNET_ID}        # required for byo (v1)
+        agentSubnet:
+          name: agent-subnet
+          prefix: 192.168.0.0/24
+        peSubnet:
+          name: pe-subnet
+          prefix: 192.168.1.0/24
+      dns:
+        resourceGroup: rg-private-dns
+        subscription: ${AZURE_DNS_SUBSCRIPTION_ID}
+
+    deployments:
+      - name: gpt-4.1-mini
+        model: { format: OpenAI, name: gpt-4.1-mini, version: "2025-04-14" }
+        sku:   { name: GlobalStandard, capacity: 10 }
+    agents:
+      - name: my-agent
+        kind: hosted
+        project: src/my-agent
+        image: myprivacr.azurecr.io/agents/my-agent:v1   # BYO image (no ACR)
+```
+
+## Scope
+
+**In scope**
+
+- `network.mode: byo` — bring-your-own VNet, with create-or-reference subnets.
+- `network.mode: managed` — Foundry-managed VNet with an isolation mode.
+- Account `networkInjections` (scenario `agent`) bound to the agent subnet.
+- Account private endpoint + the three AI private DNS zones
+  (`privatelink.services.ai.azure.com`, `privatelink.openai.azure.com`,
+  `privatelink.cognitiveservices.azure.com`), created or referenced.
+- Platform-managed dependent stores (confirmed supported under VNet).
+- BYO container image via `--image` as the registry story for secured agents.
+
+**Out of scope**
+
+- BYO dependent stores (Cosmos DB / AI Search / Storage) and the
+  capability-host wiring they require — managed stores are used instead.
+- Tool subnet, user-assigned managed identity (UAMI), customer-managed keys
+  (CMK) — not core to the secured-agent scenario.
+- **Local build into a private ACR** — secured agents bring a pre-built image
+  via `--image`; the developer owns ACR networking. See §9.
+- The bicep-less synthesizer/provider itself and the unified `azure.yaml`
+  shape — prerequisites tracked by their own specs (see §3).
+
+## §3 Relationship to in-flight work
+
+Private networking is the last layer on top of a stack already in flight on the
+`huimiu/foundry-azure-yaml` feature branch. It does not start from `main`; it
+lands as a follow-on PR into that branch after the synthesizer merges.
+
+| PR | Author | Target | State | Why it matters here |
+| --- | --- | --- | --- | --- |
+| #8590 unify `azure.yaml` (docs) | huimiu | main | open | Establishes the single `host: microsoft.foundry` shape and defers VNet to this work (§1.4). |
+| #8577 bicep-less provisioning (docs) | hund030 | main | open | Establishes the extension-owned synthesizer/provider this spec extends. |
+| #8603 schema scaffold | huimiu | feature branch | merged | Home of `microsoft.foundry.json` and its slice files. |
+| #8627 `$ref` includes | huimiu | feature branch | merged | Config-binding plumbing. |
+| #8629 foundry service target | huimiu | feature branch | open | Deploy-side per-agent fan-out. |
+| #8675 unified `init` | huimiu | service-target | open | Writes the single service entry that carries `network:`. |
+| **#8643 bicep-less init** | **hund030** | **feature branch** | **open** | **The integration point — owns `internal/synthesis` and `main.bicep`.** |
+| #8689 `--image` flag | (this author) | feature branch | open | Removes ACR from the secured-agent path. |
+| #8645 skip remote build for VNET-injected accounts | (this author) | main | merged | Build step already detects network-bound accounts. |
+
+Two consequences:
+
+- **`network:` needs no core change.** Per the unify design §2.1, unknown
+  service keys land in `ServiceConfig.AdditionalProperties` and travel to the
+  extension over gRPC unchanged. The only required core edit is the JSON
+  schema slice (§4). The synthesizer reads the raw `azure.yaml` bytes directly
+  (it already does, via `synthesis.Input.RawAzureYAML`), so the block is in
+  reach without any struct plumbing in azd core.
+- **ACR is off the critical path.** `--image` (#8689) lets a secured agent
+  reference a pre-built image, and the merged #8645 already skips remote build
+  for network-injected accounts. Together they mean v1 never has to provision
+  or reach a registry from inside the VNet (§9).
+
+## §4 `azure.yaml` surface
+
+`network:` is a sibling of `deployments:` / `agents:` on the service body.
+
+```yaml
+network:
+  mode: byo | managed              # required when network is present
+
+  byo:                             # used only when mode: byo
+    vnet:
+      id: <existing VNet ARM id>   # required for byo in v1
+    agentSubnet:                   # optional; see tri-state below
+      name: <subnet name>
+      prefix: <CIDR>
+    peSubnet:                      # optional; same tri-state
+      name: <subnet name>
+      prefix: <CIDR>
+
+  managed:                         # used only when mode: managed
+    isolationMode: AllowInternetOutbound | AllowOnlyApprovedOutbound
+
+  dns:                             # optional
+    resourceGroup: <rg name>       # when set, zones are referenced, not created
+    subscription: <sub id>
+```
+
+### Field semantics
+
+| Field | Rule |
+| --- | --- |
+| `mode` | Required when `network:` is present. `byo` and `managed` are mutually exclusive; the matching sub-block is required and the other must be absent. |
+| `byo.vnet.id` | Required in v1. The VNet must already exist. `${VAR}` is resolved from the azd environment before synthesis. |
+| `byo.agentSubnet` / `byo.peSubnet` | **Tri-state.** Omitted → azd creates a default subnet (`agent-subnet` / `pe-subnet`) with a default prefix. Name only → azd **references** an existing subnet and validates it (delegation for the agent subnet, PE network policies for the PE subnet). Name **and** prefix → azd **creates** the subnet with that name and prefix. |
+| `managed.isolationMode` | One of `AllowInternetOutbound`, `AllowOnlyApprovedOutbound`. Maps to the account managed-network isolation setting. |
+| `dns.resourceGroup` | When omitted (or the whole `dns:` block omitted), azd **creates** the required private DNS zones and links them. When set, azd **references** existing zones in that resource group. |
+| `dns.subscription` | Optional. Defaults to the deployment subscription. Accepts a bare GUID or `${VAR}`. Only meaningful alongside `dns.resourceGroup`. |
+
+`${VAR}` resolves client-side from the azd environment for `byo.vnet.id` and
+`dns.subscription`. `${{...}}` Foundry expressions are not expected in network
+fields and are passed through verbatim if present, consistent with the shared
+expander.
+
+## §5 Primitives captured from sample template 15
+
+The service team's
+[`15-private-network-standard-agent-setup`](https://github.com/microsoft-foundry/foundry-samples/tree/main/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup)
+is the source of truth for the ARM shape. azd captures the irreducible network
+primitives and drops everything that managed stores make unnecessary.
+
+| Sample module / param | azd treatment | Notes |
+| --- | --- | --- |
+| `network-agent-vnet.bicep` → `vnet.bicep` / `existing-vnet.bicep` | **Kept** as `modules/network.bicep` | Create-vs-reference VNet; agent subnet (with delegation) + PE subnet; `reuseExistingSubnets` for the reference path. |
+| `ai-account-identity.bicep` `agentSubnetId` + `networkInjections` | **Kept**, folded into `main.bicep` account resource | Flips `publicNetworkAccess` to `Disabled`, sets `networkAcls.defaultAction: 'Deny'`, adds `networkInjections` scenario `agent`. |
+| `private-endpoint-and-dns.bicep` (account portion) | **Kept** as `modules/private-endpoint-dns.bicep` | Only the account PE + the 3 AI DNS zones (`services.ai.azure.com`, `openai.azure.com`, `cognitiveservices.azure.com`) and their VNet links. |
+| `existingDnsZones` object map + `dnsZonesSubscriptionId` | **Kept** (subset) | Create-vs-reference per zone; cross-subscription/RG reference. |
+| `standard-dependent-resources.bicep` (Cosmos / Search / Storage) | **Dropped** | Managed stores. |
+| Dependent-store PEs, DNS zones (`documents`, `search`, `blob`), role assignments | **Dropped** | Consequence of managed stores. |
+| `add-account-capability-host.bicep` / `add-project-capability-host.bicep` | **Dropped** | Platform auto-provisions the capability host for a network-injected account; no BYO-store wiring to configure. |
+| `container-registry.bicep` (ACR + PE) | **Deferred** | BYO image in v1; see §9. |
+| Tool subnet, UAMI, CMK | **Dropped** | Out of scope. |
+
+Net result: from ~10 modules in the sample, azd v1 needs three artifacts — the
+existing `main.bicep` (extended), a new `modules/network.bicep`, and a new
+`modules/private-endpoint-dns.bicep`.
+
+## §6 Synthesizer and template changes (high level)
+
+The bicep-less work landed `internal/synthesis/synthesizer.go` plus an embedded
+`templates/` tree (`main.bicep`, `modules/acr.bicep`, `abbreviations.json`,
+and a precompiled `main.arm.json` fallback). The account today is hardcoded to
+public. The changes are additive and local to this package.
+
+- **Read `network:`** — extend the `foundryService` view the synthesizer
+  decodes so it captures the `network` sub-tree (mode, byo, managed, dns), and
+  resolve `${VAR}` in `byo.vnet.id` / `dns.subscription` before emitting
+  parameters. Absent block → all network parameters default off and output is
+  byte-identical to today.
+- **Emit parameters** — add the network parameter set to the synthesizer
+  `Result.Parameters` (mode, vnet id, subnet tri-state descriptors, isolation
+  mode, DNS zone map + subscription).
+- **`main.bicep`** — guard the network path on a single `enableNetworkIsolation`
+  condition. When on: include `modules/network.bicep`, set the account's
+  `publicNetworkAccess`/`networkAcls`/`networkInjections` from the agent subnet,
+  and include `modules/private-endpoint-dns.bicep`. When off: the account block
+  is exactly today's.
+- **New modules** — `modules/network.bicep` (VNet + two subnets, create or
+  reference, agent-subnet delegation) and `modules/private-endpoint-dns.bicep`
+  (account PE + 3 AI DNS zones + links, create or reference).
+- **Regenerate `main.arm.json`** — the precompiled ARM fallback must be rebuilt
+  from the extended `main.bicep` and committed alongside it. The byte-stability
+  contract from the bicep-less spec applies: same `azure.yaml` → byte-identical
+  output within a patch version.
+
+The provisioning provider, on-disk/eject behavior, and parameter wiring need no
+structural change — they consume whatever `Result.Parameters` carries.
+
+## §7 Validation pipeline additions
+
+Network validation slots into the synthesizer's existing pre-synthesis checks
+and runs on every `provision`, `preview`, and eject:
+
+- **Mode coherence** — `mode` is `byo` or `managed`; the matching sub-block is
+  present and the other is absent.
+- **BYO VNet** — `byo.vnet.id` is present (v1) and is a well-formed
+  `Microsoft.Network/virtualNetworks` ARM id after `${VAR}` resolution.
+- **Subnet tri-state** — for each of `agentSubnet` / `peSubnet`: reject `prefix`
+  without `name`; validate CIDR shape when `prefix` is present; surface a clear
+  field path on failure.
+- **DNS** — when `dns.resourceGroup` is set, validate the resource-group name;
+  normalize `dns.subscription` to a bare GUID (accept `/subscriptions/<guid>`
+  or a bare GUID), matching the sample's behavior.
+- **Env resolvability** — every `${VAR}` in a network field resolves from the
+  azd environment; an unresolved reference fails with the variable name.
+
+Failures surface with the service-scoped field path, e.g.
+`services.my-project.network.byo.agentSubnet: prefix set without name`.
+
+## §8 Brownfield interaction
+
+`endpoint:` on the service already short-circuits synthesis — the synthesizer
+returns `ErrEndpointBrownfield` and the provider connects to the existing
+project without provisioning. A network-secured account reached this way is
+**already** network-bound by whoever created it.
+
+Therefore, when `endpoint:` is present, `network:` is **ignored** (the account's
+network posture is fixed and not azd's to change). This is documented as
+explicit precedence: `endpoint:` wins, and a project that wants azd to manage
+its network posture must be greenfield (no `endpoint:`). If both are present,
+azd warns that `network:` has no effect in brownfield mode.
+
+## §9 ACR private networking — decision and RoI
+
+A secured agent still needs its image to come from somewhere reachable inside
+the VNet. Two paths:
+
+| Path | What azd must do | Effort | v1 |
+| --- | --- | --- | --- |
+| **BYO image (`--image`)** | Nothing. The developer brings `registry/image:tag` and owns the registry's SKU, private endpoint, DNS, and firewall. | ~0 (lands with #8689) | **Chosen** |
+| **Local build → private ACR** | Provision a Premium ACR with a private endpoint and `privatelink.azurecr.io`, then solve build connectivity: a remote ACR-task build must egress to a private registry, or a local push must reach it from outside the VNet (developer IP allowlist). | High; many connectivity edge cases | **Deferred** |
+
+The hard part of the local-build path is not creating the registry — it is
+making the build actually reach a network-isolated registry, which drags in
+build-agent network placement azd does not control. v1 therefore standardizes on
+BYO image for secured agents; #8645 (merged) already skips remote build for
+network-injected accounts, so the flow is coherent end to end. Revisit
+local-build-into-private-ACR after telemetry shows `--image` adoption and real
+demand.
+
+## §10 Telemetry, docs, and open questions
+
+**Telemetry**
+
+- `provision.network_mode` — `none` | `byo` | `managed`, emitted at provision
+  start. Lets us measure secured-agent adoption and BYO-vs-managed split.
+  Implementation PRs add it to `docs/reference/telemetry-data.md`.
+
+**Docs**
+
+- New env vars consumed for network fields (`AZURE_VNET_ID`,
+  `AZURE_DNS_SUBSCRIPTION_ID`, or whatever the synthesizer reads) are documented
+  in `cli/azd/docs/environment-variables.md` with format and default.
+- Extension README documents the `network:` block and the BYO-image requirement
+  for secured agents.
+
+**Open questions**
+
+1. **Agent-subnet delegation target.** Confirm the exact delegation the agent
+   subnet requires for `networkInjections` scenario `agent`, and whether the
+   reference path must validate it or may assume the platform team set it.
+2. **`managed` reference template.** Template 15 is BYO-only. The
+   Foundry-managed VNet (`mode: managed`, `isolationMode`) needs a service-team
+   reference for the account-level managed-network ARM shape before that branch
+   can be authored.
+3. **DNS collision on create.** When azd creates the AI DNS zones but a zone of
+   the same name already exists in the target RG (created out of band), define
+   whether azd references it, fails, or warns.
+4. **Subnet reference validation depth.** For name-only subnets, decide how much
+   azd validates at synthesis time (existence, delegation, PE policies) versus
+   deferring to ARM, given synthesis runs before any ARM call.

--- a/docs/specs/foundry-private-network/spec.md
+++ b/docs/specs/foundry-private-network/spec.md
@@ -4,58 +4,23 @@
 
 ## Problem
 
-Foundry network isolation is unreachable from `azure.yaml` today. Per the
-[unified `azure.yaml` design](../unify-azure-yaml/spec.md) (§1.4), VNet binding
-is an **Account** setting while the unified shape models the **Project**, so
-customizing it requires ejecting to Bicep. A developer who needs a
-network-secured agent must hand-author the service team's standard
-network-secured template and maintain it by hand. There is no `network:`
-surface, and the in-memory synthesizer that
-[bicep-less provisioning](../bicepless-foundry/spec.md) introduced always emits
-a public account (`publicNetworkAccess: 'Enabled'`).
+Foundry network isolation is unreachable from `azure.yaml` today. Per the [unified `azure.yaml` design](../unify-azure-yaml/spec.md) (§1.4), VNet binding is an **Account** setting while the unified shape models the **Project**, so customizing it requires ejecting to Bicep. A developer who needs a network-secured agent must hand-author the service team's standard network-secured template and maintain it by hand. There is no `network:` surface, and the in-memory synthesizer that [bicep-less provisioning](../bicepless-foundry/spec.md) introduced always emits a public account (`publicNetworkAccess: 'Enabled'`).
 
-This spec adds a declarative `network:` block to the `host: microsoft.foundry`
-service and teaches the existing synthesizer to provision a network-bound
-account from it.
+This spec adds a declarative `network:` block to the `host: microsoft.foundry` service and teaches the existing synthesizer to provision a network-bound account from it.
 
 ### Why the block sits on the service
 
-VNet binds at the Account level, yet `network:` sits on a service entry that
-reads as a project. This is intentional and unambiguous in the greenfield flow:
-the synthesizer provisions **one Account plus one Project per Foundry service**
-(1:1), so "network on the service" is exactly "network on that service's
-account." azd does not model multiple projects sharing a single network-bound
-account — multiple Foundry services produce multiple accounts, each with its own
-`network:`. Brownfield (`endpoint:`) ignores `network:` because the account is
-already bound by whoever created it (see §7), so the service-level declaration
-never reconciles against an account azd did not create. If Foundry later needs
-N projects under one network-bound account, the block would promote to an
-account-scoped surface (see §9, open questions).
+VNet binds at the Account level, yet `network:` sits on a service entry that reads as a project. This is intentional and unambiguous in the greenfield flow: the synthesizer provisions **one Account plus one Project per Foundry service** (1:1), so "network on the service" is exactly "network on that service's account." azd does not model multiple projects sharing a single network-bound account — multiple Foundry services produce multiple accounts, each with its own `network:`. Brownfield (`endpoint:`) ignores `network:` because the account is already bound by whoever created it (see §7), so the service-level declaration never reconciles against an account azd did not create. If Foundry later needs N projects under one network-bound account, the block would promote to an account-scoped surface (see §9, open questions).
 
 ## Solution
 
-Extend the Foundry provisioning synthesizer
-(`internal/synthesis`, introduced by the bicep-less work) to read a new
-`network:` block on the service body and emit the network primitives a secured
-agent account requires: a VNet with an agent subnet and a private-endpoint
-subnet, account-level `networkInjections`, an account private endpoint, and the
-AI private DNS zones — each created or referenced per the developer's
-declaration.
+Extend the Foundry provisioning synthesizer (`internal/synthesis`, introduced by the bicep-less work) to read a new `network:` block on the service body and emit the network primitives a secured agent account requires: a VNet with an agent subnet and a private-endpoint subnet, account-level `networkInjections`, an account private endpoint, and the AI private DNS zones — each created or referenced per the developer's declaration.
 
-The block is purely additive. When `network:` is absent the synthesizer behaves
-exactly as today (public account). When present, the account flips to private
-and the network modules are included. No new provider, no new gRPC surface, no
-core change beyond the schema slice — the block rides the same
-`AdditionalProperties` channel every other Foundry key already uses.
+The block is purely additive. When `network:` is absent the synthesizer behaves exactly as today (public account). When present, the account flips to private and the network modules are included. No new provider, no new gRPC surface, no core change beyond the schema slice — the block rides the same `AdditionalProperties` channel every other Foundry key already uses.
 
-Dependent stores (Cosmos DB, AI Search, Storage) stay **platform-managed**,
-which is supported under VNet isolation. This removes the bulk of the sample
-template (BYO stores, their private endpoints, role assignments, and both
-capability hosts) from azd's responsibility.
+Dependent stores (Cosmos DB, AI Search, Storage) stay **platform-managed**, which is supported under VNet isolation. This removes the bulk of the sample template (BYO stores, their private endpoints, role assignments, and both capability hosts) from azd's responsibility.
 
-The example below illustrates one scenario (BYO VNet with explicit subnets); it
-is not the full schema. See §4 for the field reference and the create-vs-
-reference rules.
+The example below illustrates one scenario (BYO VNet with explicit subnets); it is not the full schema. See §4 for the field reference and the create-vs-reference rules.
 
 ```yaml
 infra:
@@ -99,27 +64,20 @@ services:
 
 - **BYO VNet** — bring an existing VNet; create or reference its subnets.
 - **Foundry-managed VNet** — with a selectable isolation mode.
-- **A network-bound (private) Foundry account** — its private endpoint and the
-  AI private DNS zones, created or referenced.
+- **A network-bound (private) Foundry account** — its private endpoint and the AI private DNS zones, created or referenced.
 - **Platform-managed dependent stores** under VNet isolation.
 - **BYO container image** as the registry story for secured agents.
 
 **Out of scope**
 
-- BYO dependent stores and the capability-host wiring they require — managed
-  stores are used instead.
-- Tool subnet, user-assigned managed identity (UAMI), customer-managed keys
-  (CMK) — not core to the secured-agent scenario.
-- Local build into a private ACR — secured agents bring a pre-built image; the
-  developer owns ACR networking. See §8.
-- The bicep-less synthesizer/provider itself and the unified `azure.yaml`
-  shape — prerequisites tracked by their own specs (see §3).
+- BYO dependent stores and the capability-host wiring they require — managed stores are used instead.
+- Tool subnet, user-assigned managed identity (UAMI), customer-managed keys (CMK) — not core to the secured-agent scenario.
+- Local build into a private ACR — secured agents bring a pre-built image; the developer owns ACR networking. See §8.
+- The bicep-less synthesizer/provider itself and the unified `azure.yaml` shape — prerequisites tracked by their own specs (see §3).
 
 ## §3 Relationship to in-flight work
 
-Private networking is the last layer on a stack already in flight on the
-`huimiu/foundry-azure-yaml` feature branch. It does not start from `main`; it
-lands as a follow-on into that branch after the synthesizer merges.
+Private networking is the last layer on a stack already in flight on the `huimiu/foundry-azure-yaml` feature branch. It does not start from `main`; it lands as a follow-on into that branch after the synthesizer merges.
 
 ```
 unified azure.yaml (huimiu)            #8590 docs → branch huimiu/foundry-azure-yaml
@@ -130,13 +88,8 @@ unified azure.yaml (huimiu)            #8590 docs → branch huimiu/foundry-azur
 
 Two consequences matter here:
 
-- **No core change.** Unknown service keys ride
-  `ServiceConfig.AdditionalProperties` to the extension (unify §2.1), and the
-  synthesizer reads the raw `azure.yaml` bytes directly, so the only required
-  core edit is the JSON schema slice (§4).
-- **ACR is off the critical path.** `--image` (#8689) and the merged #8645
-  (skip remote build for VNET-injected accounts) keep registry work out of v1
-  (see §8).
+- **No core change.** Unknown service keys ride `ServiceConfig.AdditionalProperties` to the extension (unify §2.1), and the synthesizer reads the raw `azure.yaml` bytes directly, so the only required core edit is the JSON schema slice (§4).
+- **ACR is off the critical path.** `--image` (#8689) and the merged #8645 (skip remote build for VNET-injected accounts) keep registry work out of v1 (see §8).
 
 ## §4 `azure.yaml` surface
 
@@ -175,138 +128,70 @@ network:
 | `dns.resourceGroup` | When omitted (or the whole `dns:` block omitted), azd **creates** the required private DNS zones and links them. When set, azd **references** existing zones in that resource group. |
 | `dns.subscription` | Optional. Defaults to the deployment subscription. Accepts a bare GUID or `${VAR}`. Only meaningful alongside `dns.resourceGroup`. |
 
-`${VAR}` resolves client-side from the azd environment for `byo.vnet.id` and
-`dns.subscription`. `${{...}}` Foundry expressions are not expected in network
-fields and are passed through verbatim if present, consistent with the shared
-expander.
+`${VAR}` resolves client-side from the azd environment for `byo.vnet.id` and `dns.subscription`. `${{...}}` Foundry expressions are not expected in network fields and are passed through verbatim if present, consistent with the shared expander.
 
 ## §5 Synthesizer and template changes (high level)
 
-The bicep-less work landed `internal/synthesis/synthesizer.go` plus an embedded
-`templates/` tree (`main.bicep`, `modules/acr.bicep`, `abbreviations.json`,
-and a precompiled `main.arm.json` fallback). The account today is hardcoded to
-public. The changes are additive and local to this package.
+The bicep-less work landed `internal/synthesis/synthesizer.go` plus an embedded `templates/` tree (`main.bicep`, `modules/acr.bicep`, `abbreviations.json`, and a precompiled `main.arm.json` fallback). The account today is hardcoded to public. The changes are additive and local to this package.
 
-- **Read `network:`** — extend the `foundryService` view the synthesizer
-  decodes so it captures the `network` sub-tree (mode, byo, managed, dns), and
-  resolve `${VAR}` in `byo.vnet.id` / `dns.subscription` before emitting
-  parameters. Absent block → all network parameters default off and output is
-  byte-identical to today.
-- **Emit parameters** — add the network parameter set to the synthesizer
-  `Result.Parameters` (mode, vnet id, subnet tri-state descriptors, isolation
-  mode, DNS zone map + subscription).
-- **`main.bicep`** — guard the network path on a single `enableNetworkIsolation`
-  condition. When on: include `modules/network.bicep`, set the account's
-  `publicNetworkAccess: 'Disabled'`, `networkAcls.defaultAction: 'Deny'`, and
-  `networkInjections` (scenario `agent`) from the agent subnet, and include
-  `modules/private-endpoint-dns.bicep`. When off: the account block is exactly
-  today's.
-- **New modules** — `modules/network.bicep` (VNet + two subnets, create or
-  reference, agent-subnet delegation) and `modules/private-endpoint-dns.bicep`
-  (account private endpoint + the three AI DNS zones
-  `privatelink.services.ai.azure.com`, `privatelink.openai.azure.com`,
-  `privatelink.cognitiveservices.azure.com` + VNet links, create or reference).
-- **Regenerate `main.arm.json`** — the precompiled ARM fallback must be rebuilt
-  from the extended `main.bicep` and committed alongside it. The byte-stability
-  contract from the bicep-less spec applies: same `azure.yaml` → byte-identical
-  output within a patch version.
+- **Read `network:`** — extend the `foundryService` view the synthesizer decodes so it captures the `network` sub-tree (mode, byo, managed, dns), and resolve `${VAR}` in `byo.vnet.id` / `dns.subscription` before emitting parameters. Absent block → all network parameters default off and output is byte-identical to today.
+- **Emit parameters** — add the network parameter set to the synthesizer `Result.Parameters` (mode, vnet id, subnet tri-state descriptors, isolation mode, DNS zone map + subscription).
+- **`main.bicep`** — guard the network path on a single `enableNetworkIsolation` condition. When on: include `modules/network.bicep`, set the account's `publicNetworkAccess: 'Disabled'`, `networkAcls.defaultAction: 'Deny'`, and `networkInjections` (scenario `agent`) from the agent subnet, and include `modules/private-endpoint-dns.bicep`. When off: the account block is exactly today's.
+- **New modules** — `modules/network.bicep` (VNet + two subnets, create or reference, agent-subnet delegation) and `modules/private-endpoint-dns.bicep` (account private endpoint + the three AI DNS zones `privatelink.services.ai.azure.com`, `privatelink.openai.azure.com`, `privatelink.cognitiveservices.azure.com` + VNet links, create or reference).
+- **Regenerate `main.arm.json`** — the precompiled ARM fallback must be rebuilt from the extended `main.bicep` and committed alongside it. The byte-stability contract from the bicep-less spec applies: same `azure.yaml` → byte-identical output within a patch version.
 
-The provisioning provider, on-disk/eject behavior, and parameter wiring need no
-structural change — they consume whatever `Result.Parameters` carries.
+The provisioning provider, on-disk/eject behavior, and parameter wiring need no structural change — they consume whatever `Result.Parameters` carries.
 
 ## §6 Validation pipeline additions
 
-Network validation slots into the synthesizer's existing pre-synthesis checks
-and runs on every `provision`, `preview`, and eject:
+Network validation slots into the synthesizer's existing pre-synthesis checks and runs on every `provision`, `preview`, and eject:
 
-- **Mode coherence** — `mode` is `byo` or `managed`; the matching sub-block is
-  present and the other is absent.
-- **BYO VNet** — `byo.vnet.id` is present (v1) and is a well-formed
-  `Microsoft.Network/virtualNetworks` ARM id after `${VAR}` resolution.
-- **Subnet tri-state** — for each of `agentSubnet` / `peSubnet`: reject `prefix`
-  without `name`; validate CIDR shape when `prefix` is present; surface a clear
-  field path on failure.
-- **DNS** — when `dns.resourceGroup` is set, validate the resource-group name;
-  normalize `dns.subscription` to a bare GUID (accept `/subscriptions/<guid>`
-  or a bare GUID), matching the sample's behavior.
-- **Env resolvability** — every `${VAR}` in a network field resolves from the
-  azd environment; an unresolved reference fails with the variable name.
+- **Mode coherence** — `mode` is `byo` or `managed`; the matching sub-block is present and the other is absent.
+- **BYO VNet** — `byo.vnet.id` is present (v1) and is a well-formed `Microsoft.Network/virtualNetworks` ARM id after `${VAR}` resolution.
+- **Subnet tri-state** — for each of `agentSubnet` / `peSubnet`: reject `prefix` without `name`; validate CIDR shape when `prefix` is present; surface a clear field path on failure.
+- **DNS** — when `dns.resourceGroup` is set, validate the resource-group name; normalize `dns.subscription` to a bare GUID (accept `/subscriptions/<guid>` or a bare GUID), matching the sample's behavior.
+- **Env resolvability** — every `${VAR}` in a network field resolves from the azd environment; an unresolved reference fails with the variable name.
 
-Failures surface with the service-scoped field path, e.g.
-`services.my-project.network.byo.agentSubnet: prefix set without name`.
+Failures surface with the service-scoped field path, e.g. `services.my-project.network.byo.agentSubnet: prefix set without name`.
 
 ## §7 Brownfield interaction
 
-`endpoint:` on the service already short-circuits synthesis — the synthesizer
-returns `ErrEndpointBrownfield` and the provider connects to the existing
-project without provisioning. A network-secured account reached this way is
-**already** network-bound by whoever created it.
+`endpoint:` on the service already short-circuits synthesis — the synthesizer returns `ErrEndpointBrownfield` and the provider connects to the existing project without provisioning. A network-secured account reached this way is **already** network-bound by whoever created it.
 
-Therefore, when `endpoint:` is present, `network:` is **ignored** (the account's
-network posture is fixed and not azd's to change). This is documented as
-explicit precedence: `endpoint:` wins, and a project that wants azd to manage
-its network posture must be greenfield (no `endpoint:`). If both are present,
-azd warns that `network:` has no effect in brownfield mode.
+Therefore, when `endpoint:` is present, `network:` is **ignored** (the account's network posture is fixed and not azd's to change). This is documented as explicit precedence: `endpoint:` wins, and a project that wants azd to manage its network posture must be greenfield (no `endpoint:`). If both are present, azd warns that `network:` has no effect in brownfield mode.
 
 ## §8 ACR private networking — decision and RoI
 
-A secured agent still needs its image to come from somewhere reachable inside
-the VNet. Two paths:
+A secured agent still needs its image to come from somewhere reachable inside the VNet. Two paths:
 
 | Path | What azd must do | Effort | v1 |
 | --- | --- | --- | --- |
 | **BYO image (`--image`)** | Nothing. The developer brings `registry/image:tag` and owns the registry's SKU, private endpoint, DNS, and firewall. | ~0 (lands with #8689) | **Chosen** |
 | **Local build → private ACR** | Provision a Premium ACR with a private endpoint and `privatelink.azurecr.io`, then solve build connectivity: a remote ACR-task build must egress to a private registry, or a local push must reach it from outside the VNet (developer IP allowlist). | High; many connectivity edge cases | **Deferred** |
 
-The hard part of the local-build path is not creating the registry — it is
-making the build actually reach a network-isolated registry, which drags in
-build-agent network placement azd does not control. v1 therefore standardizes on
-BYO image for secured agents; #8645 (merged) already skips remote build for
-network-injected accounts, so the flow is coherent end to end. Revisit
-local-build-into-private-ACR after telemetry shows `--image` adoption and real
-demand.
+The hard part of the local-build path is not creating the registry — it is making the build actually reach a network-isolated registry, which drags in build-agent network placement azd does not control. v1 therefore standardizes on BYO image for secured agents; #8645 (merged) already skips remote build for network-injected accounts, so the flow is coherent end to end. Revisit local-build-into-private-ACR after telemetry shows `--image` adoption and real demand.
 
 ## §9 Telemetry, docs, and open questions
 
 **Telemetry**
 
-- `provision.network_mode` — `none` | `byo` | `managed`, emitted at provision
-  start. Lets us measure secured-agent adoption and BYO-vs-managed split.
-  Implementation PRs add it to `docs/reference/telemetry-data.md`.
+- `provision.network_mode` — `none` | `byo` | `managed`, emitted at provision start. Lets us measure secured-agent adoption and BYO-vs-managed split. Implementation PRs add it to `docs/reference/telemetry-data.md`.
 
 **Docs**
 
-- New env vars consumed for network fields (`AZURE_VNET_ID`,
-  `AZURE_DNS_SUBSCRIPTION_ID`, or whatever the synthesizer reads) are documented
-  in `cli/azd/docs/environment-variables.md` with format and default.
-- Extension README documents the `network:` block and the BYO-image requirement
-  for secured agents.
+- New env vars consumed for network fields (`AZURE_VNET_ID`, `AZURE_DNS_SUBSCRIPTION_ID`, or whatever the synthesizer reads) are documented in `cli/azd/docs/environment-variables.md` with format and default.
+- Extension README documents the `network:` block and the BYO-image requirement for secured agents.
 
 **Open questions**
 
-1. **Agent-subnet delegation target.** Confirm the exact delegation the agent
-   subnet requires for `networkInjections` scenario `agent`, and whether the
-   reference path must validate it or may assume the platform team set it.
-2. **`managed` reference template.** Template 15 is BYO-only. The
-   Foundry-managed VNet (`mode: managed`, `isolationMode`) needs a service-team
-   reference for the account-level managed-network ARM shape before that branch
-   can be authored.
-3. **DNS collision on create.** When azd creates the AI DNS zones but a zone of
-   the same name already exists in the target RG (created out of band), define
-   whether azd references it, fails, or warns.
-4. **Subnet reference validation depth.** For name-only subnets, decide how much
-   azd validates at synthesis time (existence, delegation, PE policies) versus
-   deferring to ARM, given synthesis runs before any ARM call.
-5. **Account-scoped surface.** If Foundry adds multiple projects under one
-   network-bound account, decide whether `network:` promotes from the service
-   entry to an account-scoped surface (see "Why the block sits on the service").
+1. **Agent-subnet delegation target.** Confirm the exact delegation the agent subnet requires for `networkInjections` scenario `agent`, and whether the reference path must validate it or may assume the platform team set it.
+2. **`managed` reference template.** Template 15 is BYO-only. The Foundry-managed VNet (`mode: managed`, `isolationMode`) needs a service-team reference for the account-level managed-network ARM shape before that branch can be authored.
+3. **DNS collision on create.** When azd creates the AI DNS zones but a zone of the same name already exists in the target RG (created out of band), define whether azd references it, fails, or warns.
+4. **Subnet reference validation depth.** For name-only subnets, decide how much azd validates at synthesis time (existence, delegation, PE policies) versus deferring to ARM, given synthesis runs before any ARM call.
+5. **Account-scoped surface.** If Foundry adds multiple projects under one network-bound account, decide whether `network:` promotes from the service entry to an account-scoped surface (see "Why the block sits on the service").
 
 ## References
 
-- Service team's standard network-secured agent template (source of truth for
-  the ARM shape, primitives, and the keep/drop decisions in this spec):
-  [`15-private-network-standard-agent-setup`](https://github.com/microsoft-foundry/foundry-samples/tree/main/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup).
-- [Unified `azure.yaml` design](../unify-azure-yaml/spec.md) — establishes the
-  `host: microsoft.foundry` shape and defers VNet to this work (§1.4).
-- [Bicep-less provisioning](../bicepless-foundry/spec.md) — the synthesizer and
-  provider this spec extends.
+- Service team's standard network-secured agent template (source of truth for the ARM shape, primitives, and the keep/drop decisions in this spec): [`15-private-network-standard-agent-setup`](https://github.com/microsoft-foundry/foundry-samples/tree/main/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup).
+- [Unified `azure.yaml` design](../unify-azure-yaml/spec.md) — establishes the `host: microsoft.foundry` shape and defers VNet to this work (§1.4).
+- [Bicep-less provisioning](../bicepless-foundry/spec.md) — the synthesizer and provider this spec extends.

--- a/docs/specs/foundry-private-network/spec.md
+++ b/docs/specs/foundry-private-network/spec.md
@@ -96,25 +96,52 @@ Two consequences matter here:
 `network:` is a sibling of `deployments:` / `agents:` on the service body.
 
 ```yaml
-network:
-  mode: byo | managed              # required when network is present
+services:
+  my-project:
+    host: microsoft.foundry
 
-  byo:                             # used only when mode: byo
-    vnet:
-      id: <existing VNet ARM id>   # required for byo in v1
-    agentSubnet:                   # optional; see tri-state below
-      name: <subnet name>
-      prefix: <CIDR>
-    peSubnet:                      # optional; same tri-state
-      name: <subnet name>
-      prefix: <CIDR>
+    # New: private networking configuration for standard/networked agents.
+    #
+    # If omitted, the project uses public networking.
+    # If present, azd provisions or configures private networking and uses
+    # customer-owned dependent stores for agent data.
+    network:
+      # Required when network is present.
+      # byo     = customer-managed / BYO VNet
+      # managed = Foundry-managed VNet
+      mode: byo
 
-  managed:                         # used only when mode: managed
-    isolationMode: AllowInternetOutbound | AllowOnlyApprovedOutbound
+      # Used only when mode: byo.
+      byo:
+        # Existing customer VNet. v1 requires this id.
+        vnet:
+          id: ${AZURE_VNET_ID}
 
-  dns:                             # optional
-    resourceGroup: <rg name>       # when set, zones are referenced, not created
-    subscription: <sub id>
+        # Agent subnet.
+        # omitted => azd creates default agent subnet
+        # name only => azd references existing subnet and validates it
+        # name + prefix => azd creates subnet with that name/prefix
+        agentSubnet:
+          name: agent-subnet
+          prefix: 192.168.0.0/24
+
+        # Private endpoint subnet.
+        # Same rules with Agent subnet.
+        peSubnet:
+          name: pe-subnet
+          prefix: 192.168.1.0/24
+
+      # Used only when mode: managed.
+      # Values: AllowInternetOutbound | AllowOnlyApprovedOutbound
+      managed:
+        isolationMode: AllowOnlyApprovedOutbound
+
+      # Optional.
+      # If omitted, or resourceGroup is omitted, azd creates required private DNS zones.
+      # If resourceGroup is set, azd references existing private DNS zones in that resource group.
+      dns:
+        resourceGroup: rg-private-dns
+        subscription: ${AZURE_DNS_SUBSCRIPTION_ID}
 ```
 
 ### Field semantics

--- a/docs/specs/foundry-private-network/spec.md
+++ b/docs/specs/foundry-private-network/spec.md
@@ -10,7 +10,7 @@ This spec adds a declarative `network:` block to the `host: microsoft.foundry` s
 
 ### Why the block sits on the service
 
-VNet binds at the Account level, yet `network:` sits on a service entry that reads as a project. This is intentional and unambiguous in the greenfield flow: the synthesizer provisions **one Account plus one Project per Foundry service** (1:1), so "network on the service" is exactly "network on that service's account." azd does not model multiple projects sharing a single network-bound account — multiple Foundry services produce multiple accounts, each with its own `network:`. Brownfield (`endpoint:`) ignores `network:` because the account is already bound by whoever created it (see §7), so the service-level declaration never reconciles against an account azd did not create. If Foundry later needs N projects under one network-bound account, the block would promote to an account-scoped surface (see §9, open questions).
+VNet binds at the Account level, yet `network:` sits on a service entry that reads as a project. This is intentional and unambiguous in the greenfield flow: the synthesizer provisions **one Account plus one Project per Foundry service** (1:1), so "network on the service" is exactly "network on that service's account." azd does not model multiple projects sharing a single network-bound account — multiple Foundry services produce multiple accounts, each with its own `network:`. Brownfield (`endpoint:`) ignores `network:` because the account is already bound by whoever created it (see the Brownfield interaction section), so the service-level declaration never reconciles against an account azd did not create. If Foundry later needs N projects under one network-bound account, the block would promote to an account-scoped surface.
 
 ## Solution
 
@@ -20,7 +20,7 @@ The block is purely additive. When `network:` is absent the synthesizer behaves 
 
 Dependent stores (Cosmos DB, AI Search, Storage) stay **platform-managed**, which is supported under VNet isolation. This removes the bulk of the sample template (BYO stores, their private endpoints, role assignments, and both capability hosts) from azd's responsibility.
 
-The example below illustrates one scenario (BYO VNet with explicit subnets); it is not the full schema. See §4 for the field reference and the create-vs-reference rules.
+The example below illustrates one scenario (BYO VNet with explicit subnets); it is not the full schema. See the `azure.yaml` surface section for the field reference and the create-vs-reference rules.
 
 ```yaml
 infra:
@@ -72,10 +72,10 @@ services:
 
 - BYO dependent stores and the capability-host wiring they require — managed stores are used instead.
 - Tool subnet, user-assigned managed identity (UAMI), customer-managed keys (CMK) — not core to the secured-agent scenario.
-- Local build into a private ACR — secured agents bring a pre-built image; the developer owns ACR networking. See §8.
-- The bicep-less synthesizer/provider itself and the unified `azure.yaml` shape — prerequisites tracked by their own specs (see §3).
+- Local build into a private ACR — secured agents bring a pre-built image; the developer owns ACR networking. See the ACR private networking section.
+- The bicep-less synthesizer/provider itself and the unified `azure.yaml` shape — prerequisites tracked by their own specs (see the Relationship to in-flight work section).
 
-## §3 Relationship to in-flight work
+## Relationship to in-flight work
 
 Private networking is the last layer on a stack already in flight on the `huimiu/foundry-azure-yaml` feature branch. It does not start from `main`; it lands as a follow-on into that branch after the synthesizer merges.
 
@@ -88,10 +88,10 @@ unified azure.yaml (huimiu)            #8590 docs → branch huimiu/foundry-azur
 
 Two consequences matter here:
 
-- **No core change.** Unknown service keys ride `ServiceConfig.AdditionalProperties` to the extension (unify §2.1), and the synthesizer reads the raw `azure.yaml` bytes directly, so the only required core edit is the JSON schema slice (§4).
-- **ACR is off the critical path.** `--image` (#8689) and the merged #8645 (skip remote build for VNET-injected accounts) keep registry work out of v1 (see §8).
+- **No core change.** Unknown service keys ride `ServiceConfig.AdditionalProperties` to the extension (unify §2.1), and the synthesizer reads the raw `azure.yaml` bytes directly, so the only required core edit is the JSON schema slice (see the `azure.yaml` surface section).
+- **ACR is off the critical path.** `--image` (#8689) and the merged #8645 (skip remote build for VNET-injected accounts) keep registry work out of v1 (see the ACR private networking section).
 
-## §4 `azure.yaml` surface
+## `azure.yaml` surface
 
 `network:` is a sibling of `deployments:` / `agents:` on the service body.
 
@@ -130,7 +130,7 @@ network:
 
 `${VAR}` resolves client-side from the azd environment for `byo.vnet.id` and `dns.subscription`. `${{...}}` Foundry expressions are not expected in network fields and are passed through verbatim if present, consistent with the shared expander.
 
-## §5 Synthesizer and template changes (high level)
+## Synthesizer and template changes (high level)
 
 The bicep-less work landed `internal/synthesis/synthesizer.go` plus an embedded `templates/` tree (`main.bicep`, `modules/acr.bicep`, `abbreviations.json`, and a precompiled `main.arm.json` fallback). The account today is hardcoded to public. The changes are additive and local to this package.
 
@@ -142,7 +142,7 @@ The bicep-less work landed `internal/synthesis/synthesizer.go` plus an embedded 
 
 The provisioning provider, on-disk/eject behavior, and parameter wiring need no structural change — they consume whatever `Result.Parameters` carries.
 
-## §6 Validation pipeline additions
+## Validation pipeline additions
 
 Network validation slots into the synthesizer's existing pre-synthesis checks and runs on every `provision`, `preview`, and eject:
 
@@ -154,13 +154,13 @@ Network validation slots into the synthesizer's existing pre-synthesis checks an
 
 Failures surface with the service-scoped field path, e.g. `services.my-project.network.byo.agentSubnet: prefix set without name`.
 
-## §7 Brownfield interaction
+## Brownfield interaction
 
 `endpoint:` on the service already short-circuits synthesis — the synthesizer returns `ErrEndpointBrownfield` and the provider connects to the existing project without provisioning. A network-secured account reached this way is **already** network-bound by whoever created it.
 
 Therefore, when `endpoint:` is present, `network:` is **ignored** (the account's network posture is fixed and not azd's to change). This is documented as explicit precedence: `endpoint:` wins, and a project that wants azd to manage its network posture must be greenfield (no `endpoint:`). If both are present, azd warns that `network:` has no effect in brownfield mode.
 
-## §8 ACR private networking — decision and RoI
+## ACR private networking — decision and RoI
 
 A secured agent still needs its image to come from somewhere reachable inside the VNet. Two paths:
 
@@ -171,7 +171,7 @@ A secured agent still needs its image to come from somewhere reachable inside th
 
 The hard part of the local-build path is not creating the registry — it is making the build actually reach a network-isolated registry, which drags in build-agent network placement azd does not control. v1 therefore standardizes on BYO image for secured agents; #8645 (merged) already skips remote build for network-injected accounts, so the flow is coherent end to end. Revisit local-build-into-private-ACR after telemetry shows `--image` adoption and real demand.
 
-## §9 Telemetry, docs, and open questions
+## Telemetry and docs
 
 **Telemetry**
 
@@ -181,14 +181,6 @@ The hard part of the local-build path is not creating the registry — it is mak
 
 - New env vars consumed for network fields (`AZURE_VNET_ID`, `AZURE_DNS_SUBSCRIPTION_ID`, or whatever the synthesizer reads) are documented in `cli/azd/docs/environment-variables.md` with format and default.
 - Extension README documents the `network:` block and the BYO-image requirement for secured agents.
-
-**Open questions**
-
-1. **Agent-subnet delegation target.** Confirm the exact delegation the agent subnet requires for `networkInjections` scenario `agent`, and whether the reference path must validate it or may assume the platform team set it.
-2. **`managed` reference template.** Template 15 is BYO-only. The Foundry-managed VNet (`mode: managed`, `isolationMode`) needs a service-team reference for the account-level managed-network ARM shape before that branch can be authored.
-3. **DNS collision on create.** When azd creates the AI DNS zones but a zone of the same name already exists in the target RG (created out of band), define whether azd references it, fails, or warns.
-4. **Subnet reference validation depth.** For name-only subnets, decide how much azd validates at synthesis time (existence, delegation, PE policies) versus deferring to ARM, given synthesis runs before any ARM call.
-5. **Account-scoped surface.** If Foundry adds multiple projects under one network-bound account, decide whether `network:` promotes from the service entry to an account-scoped surface (see "Why the block sits on the service").
 
 ## References
 

--- a/docs/specs/foundry-private-network/spec.md
+++ b/docs/specs/foundry-private-network/spec.md
@@ -1,27 +1,36 @@
-<!-- cspell:ignore networkinjections caphost privatelink documentdb azurecr Vnet vnet subnet subnets myprivacr cognitiveservices UAMI hund -->
+<!-- cspell:ignore privatelink azurecr vnet subnet subnets myprivacr cognitiveservices UAMI hund -->
 
 # Private networking for `host: microsoft.foundry`
 
 ## Problem
 
-Foundry network isolation is unreachable from `azure.yaml` today. The
-[unified `azure.yaml` design](../unify-azure-yaml/spec.md) (§1.4) is explicit:
-VNet binding lives on the Foundry **Account** resource, the unified shape only
-models the **Project**, and so "customizing them today means ejecting to Bicep.
-That built-in Bicep work must provide a path to create and customize those
-network settings."
-
-A developer who needs a network-secured agent must therefore abandon the
-declarative flow, hand-author the service team's
-[standard network-secured template](https://github.com/microsoft-foundry/foundry-samples/tree/main/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup)
-(7+ modules, dependent stores, capability-host wiring, DNS), and maintain it by
-hand. There is no `network:` surface, and the in-memory synthesizer that
+Foundry network isolation is unreachable from `azure.yaml` today. Per the
+[unified `azure.yaml` design](../unify-azure-yaml/spec.md) (§1.4), VNet binding
+is an **Account** setting while the unified shape models the **Project**, so
+customizing it requires ejecting to Bicep. A developer who needs a
+network-secured agent must hand-author the service team's standard
+network-secured template and maintain it by hand. There is no `network:`
+surface, and the in-memory synthesizer that
 [bicep-less provisioning](../bicepless-foundry/spec.md) introduced always emits
 a public account (`publicNetworkAccess: 'Enabled'`).
 
 This spec adds a declarative `network:` block to the `host: microsoft.foundry`
 service and teaches the existing synthesizer to provision a network-bound
 account from it.
+
+### Why the block sits on the service
+
+VNet binds at the Account level, yet `network:` sits on a service entry that
+reads as a project. This is intentional and unambiguous in the greenfield flow:
+the synthesizer provisions **one Account plus one Project per Foundry service**
+(1:1), so "network on the service" is exactly "network on that service's
+account." azd does not model multiple projects sharing a single network-bound
+account — multiple Foundry services produce multiple accounts, each with its own
+`network:`. Brownfield (`endpoint:`) ignores `network:` because the account is
+already bound by whoever created it (see §7), so the service-level declaration
+never reconciles against an account azd did not create. If Foundry later needs
+N projects under one network-bound account, the block would promote to an
+account-scoped surface (see §9, open questions).
 
 ## Solution
 
@@ -100,40 +109,32 @@ services:
 - Tool subnet, user-assigned managed identity (UAMI), customer-managed keys
   (CMK) — not core to the secured-agent scenario.
 - **Local build into a private ACR** — secured agents bring a pre-built image
-  via `--image`; the developer owns ACR networking. See §9.
+  via `--image`; the developer owns ACR networking. See §8.
 - The bicep-less synthesizer/provider itself and the unified `azure.yaml`
   shape — prerequisites tracked by their own specs (see §3).
 
 ## §3 Relationship to in-flight work
 
-Private networking is the last layer on top of a stack already in flight on the
+Private networking is the last layer on a stack already in flight on the
 `huimiu/foundry-azure-yaml` feature branch. It does not start from `main`; it
-lands as a follow-on PR into that branch after the synthesizer merges.
+lands as a follow-on into that branch after the synthesizer merges.
 
-| PR | Author | Target | State | Why it matters here |
-| --- | --- | --- | --- | --- |
-| #8590 unify `azure.yaml` (docs) | huimiu | main | open | Establishes the single `host: microsoft.foundry` shape and defers VNet to this work (§1.4). |
-| #8577 bicep-less provisioning (docs) | hund030 | main | open | Establishes the extension-owned synthesizer/provider this spec extends. |
-| #8603 schema scaffold | huimiu | feature branch | merged | Home of `microsoft.foundry.json` and its slice files. |
-| #8627 `$ref` includes | huimiu | feature branch | merged | Config-binding plumbing. |
-| #8629 foundry service target | huimiu | feature branch | open | Deploy-side per-agent fan-out. |
-| #8675 unified `init` | huimiu | service-target | open | Writes the single service entry that carries `network:`. |
-| **#8643 bicep-less init** | **hund030** | **feature branch** | **open** | **The integration point — owns `internal/synthesis` and `main.bicep`.** |
-| #8689 `--image` flag | (this author) | feature branch | open | Removes ACR from the secured-agent path. |
-| #8645 skip remote build for VNET-injected accounts | (this author) | main | merged | Build step already detects network-bound accounts. |
+```
+unified azure.yaml (huimiu)            #8590 docs → branch huimiu/foundry-azure-yaml
+├─ bicep-less provisioning (hund030)   #8577 docs / #8643 impl  ← integration point
+├─ foundry service target + init       #8629 / #8675
+└─ BYO image                           #8689  (+ #8645 remote-build skip, merged)
+```
 
-Two consequences:
+Two consequences matter here:
 
-- **`network:` needs no core change.** Per the unify design §2.1, unknown
-  service keys land in `ServiceConfig.AdditionalProperties` and travel to the
-  extension over gRPC unchanged. The only required core edit is the JSON
-  schema slice (§4). The synthesizer reads the raw `azure.yaml` bytes directly
-  (it already does, via `synthesis.Input.RawAzureYAML`), so the block is in
-  reach without any struct plumbing in azd core.
-- **ACR is off the critical path.** `--image` (#8689) lets a secured agent
-  reference a pre-built image, and the merged #8645 already skips remote build
-  for network-injected accounts. Together they mean v1 never has to provision
-  or reach a registry from inside the VNet (§9).
+- **No core change.** Unknown service keys ride
+  `ServiceConfig.AdditionalProperties` to the extension (unify §2.1), and the
+  synthesizer reads the raw `azure.yaml` bytes directly, so the only required
+  core edit is the JSON schema slice (§4).
+- **ACR is off the critical path.** `--image` (#8689) and the merged #8645
+  (skip remote build for VNET-injected accounts) keep registry work out of v1
+  (see §8).
 
 ## §4 `azure.yaml` surface
 
@@ -177,30 +178,7 @@ network:
 fields and are passed through verbatim if present, consistent with the shared
 expander.
 
-## §5 Primitives captured from sample template 15
-
-The service team's
-[`15-private-network-standard-agent-setup`](https://github.com/microsoft-foundry/foundry-samples/tree/main/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup)
-is the source of truth for the ARM shape. azd captures the irreducible network
-primitives and drops everything that managed stores make unnecessary.
-
-| Sample module / param | azd treatment | Notes |
-| --- | --- | --- |
-| `network-agent-vnet.bicep` → `vnet.bicep` / `existing-vnet.bicep` | **Kept** as `modules/network.bicep` | Create-vs-reference VNet; agent subnet (with delegation) + PE subnet; `reuseExistingSubnets` for the reference path. |
-| `ai-account-identity.bicep` `agentSubnetId` + `networkInjections` | **Kept**, folded into `main.bicep` account resource | Flips `publicNetworkAccess` to `Disabled`, sets `networkAcls.defaultAction: 'Deny'`, adds `networkInjections` scenario `agent`. |
-| `private-endpoint-and-dns.bicep` (account portion) | **Kept** as `modules/private-endpoint-dns.bicep` | Only the account PE + the 3 AI DNS zones (`services.ai.azure.com`, `openai.azure.com`, `cognitiveservices.azure.com`) and their VNet links. |
-| `existingDnsZones` object map + `dnsZonesSubscriptionId` | **Kept** (subset) | Create-vs-reference per zone; cross-subscription/RG reference. |
-| `standard-dependent-resources.bicep` (Cosmos / Search / Storage) | **Dropped** | Managed stores. |
-| Dependent-store PEs, DNS zones (`documents`, `search`, `blob`), role assignments | **Dropped** | Consequence of managed stores. |
-| `add-account-capability-host.bicep` / `add-project-capability-host.bicep` | **Dropped** | Platform auto-provisions the capability host for a network-injected account; no BYO-store wiring to configure. |
-| `container-registry.bicep` (ACR + PE) | **Deferred** | BYO image in v1; see §9. |
-| Tool subnet, UAMI, CMK | **Dropped** | Out of scope. |
-
-Net result: from ~10 modules in the sample, azd v1 needs three artifacts — the
-existing `main.bicep` (extended), a new `modules/network.bicep`, and a new
-`modules/private-endpoint-dns.bicep`.
-
-## §6 Synthesizer and template changes (high level)
+## §5 Synthesizer and template changes (high level)
 
 The bicep-less work landed `internal/synthesis/synthesizer.go` plus an embedded
 `templates/` tree (`main.bicep`, `modules/acr.bicep`, `abbreviations.json`,
@@ -217,12 +195,15 @@ public. The changes are additive and local to this package.
   mode, DNS zone map + subscription).
 - **`main.bicep`** — guard the network path on a single `enableNetworkIsolation`
   condition. When on: include `modules/network.bicep`, set the account's
-  `publicNetworkAccess`/`networkAcls`/`networkInjections` from the agent subnet,
-  and include `modules/private-endpoint-dns.bicep`. When off: the account block
-  is exactly today's.
+  `publicNetworkAccess: 'Disabled'`, `networkAcls.defaultAction: 'Deny'`, and
+  `networkInjections` (scenario `agent`) from the agent subnet, and include
+  `modules/private-endpoint-dns.bicep`. When off: the account block is exactly
+  today's.
 - **New modules** — `modules/network.bicep` (VNet + two subnets, create or
   reference, agent-subnet delegation) and `modules/private-endpoint-dns.bicep`
-  (account PE + 3 AI DNS zones + links, create or reference).
+  (account private endpoint + the three AI DNS zones
+  `privatelink.services.ai.azure.com`, `privatelink.openai.azure.com`,
+  `privatelink.cognitiveservices.azure.com` + VNet links, create or reference).
 - **Regenerate `main.arm.json`** — the precompiled ARM fallback must be rebuilt
   from the extended `main.bicep` and committed alongside it. The byte-stability
   contract from the bicep-less spec applies: same `azure.yaml` → byte-identical
@@ -231,7 +212,7 @@ public. The changes are additive and local to this package.
 The provisioning provider, on-disk/eject behavior, and parameter wiring need no
 structural change — they consume whatever `Result.Parameters` carries.
 
-## §7 Validation pipeline additions
+## §6 Validation pipeline additions
 
 Network validation slots into the synthesizer's existing pre-synthesis checks
 and runs on every `provision`, `preview`, and eject:
@@ -252,7 +233,7 @@ and runs on every `provision`, `preview`, and eject:
 Failures surface with the service-scoped field path, e.g.
 `services.my-project.network.byo.agentSubnet: prefix set without name`.
 
-## §8 Brownfield interaction
+## §7 Brownfield interaction
 
 `endpoint:` on the service already short-circuits synthesis — the synthesizer
 returns `ErrEndpointBrownfield` and the provider connects to the existing
@@ -265,7 +246,7 @@ explicit precedence: `endpoint:` wins, and a project that wants azd to manage
 its network posture must be greenfield (no `endpoint:`). If both are present,
 azd warns that `network:` has no effect in brownfield mode.
 
-## §9 ACR private networking — decision and RoI
+## §8 ACR private networking — decision and RoI
 
 A secured agent still needs its image to come from somewhere reachable inside
 the VNet. Two paths:
@@ -283,7 +264,7 @@ network-injected accounts, so the flow is coherent end to end. Revisit
 local-build-into-private-ACR after telemetry shows `--image` adoption and real
 demand.
 
-## §10 Telemetry, docs, and open questions
+## §9 Telemetry, docs, and open questions
 
 **Telemetry**
 
@@ -314,3 +295,16 @@ demand.
 4. **Subnet reference validation depth.** For name-only subnets, decide how much
    azd validates at synthesis time (existence, delegation, PE policies) versus
    deferring to ARM, given synthesis runs before any ARM call.
+5. **Account-scoped surface.** If Foundry adds multiple projects under one
+   network-bound account, decide whether `network:` promotes from the service
+   entry to an account-scoped surface (see "Why the block sits on the service").
+
+## References
+
+- Service team's standard network-secured agent template (source of truth for
+  the ARM shape, primitives, and the keep/drop decisions in this spec):
+  [`15-private-network-standard-agent-setup`](https://github.com/microsoft-foundry/foundry-samples/tree/main/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup).
+- [Unified `azure.yaml` design](../unify-azure-yaml/spec.md) — establishes the
+  `host: microsoft.foundry` shape and defers VNet to this work (§1.4).
+- [Bicep-less provisioning](../bicepless-foundry/spec.md) — the synthesizer and
+  provider this spec extends.

--- a/docs/specs/foundry-private-network/spec.md
+++ b/docs/specs/foundry-private-network/spec.md
@@ -123,13 +123,13 @@ services:
         # name + prefix => azd creates subnet with that name/prefix
         agentSubnet:
           name: agent-subnet
-          prefix: 192.168.0.0/24
+          prefix: <CIDR>
 
         # Private endpoint subnet.
         # Same rules with Agent subnet.
         peSubnet:
           name: pe-subnet
-          prefix: 192.168.1.0/24
+          prefix: <CIDR>
 
       # Used only when mode: managed.
       # Values: AllowInternetOutbound | AllowOnlyApprovedOutbound

--- a/docs/specs/foundry-private-network/spec.md
+++ b/docs/specs/foundry-private-network/spec.md
@@ -1,10 +1,10 @@
-<!-- cspell:ignore privatelink azurecr vnet subnet subnets myprivacr cognitiveservices UAMI hund -->
+<!-- cspell:ignore privatelink azurecr vnet subnet subnets myprivacr cognitiveservices UAMI hund hund030 huimiu -->
 
 # Private networking for `host: microsoft.foundry`
 
 ## Problem
 
-Foundry network isolation is unreachable from `azure.yaml` today. Per the [unified `azure.yaml` design](../unify-azure-yaml/spec.md) (§1.4), VNet binding is an **Account** setting while the unified shape models the **Project**, so customizing it requires ejecting to Bicep. A developer who needs a network-secured agent must hand-author the service team's standard network-secured template and maintain it by hand. There is no `network:` surface, and the in-memory synthesizer that [bicep-less provisioning](../bicepless-foundry/spec.md) introduced always emits a public account (`publicNetworkAccess: 'Enabled'`).
+Foundry network isolation is unreachable from `azure.yaml` today. Per the [unified `azure.yaml` design](https://github.com/Azure/azure-dev/pull/8590) (§1.4), VNet binding is an **Account** setting while the unified shape models the **Project**, so customizing it requires ejecting to Bicep. A developer who needs a network-secured agent must hand-author the service team's standard network-secured template and maintain it by hand. There is no `network:` surface, and the in-memory synthesizer that [bicep-less provisioning](https://github.com/Azure/azure-dev/pull/8577) introduced always emits a public account (`publicNetworkAccess: 'Enabled'`).
 
 This spec adds a declarative `network:` block to the `host: microsoft.foundry` service and teaches the existing synthesizer to provision a network-bound account from it.
 
@@ -193,5 +193,5 @@ The hard part of the local-build path is not creating the registry — it is mak
 ## References
 
 - Service team's standard network-secured agent template (source of truth for the ARM shape, primitives, and the keep/drop decisions in this spec): [`15-private-network-standard-agent-setup`](https://github.com/microsoft-foundry/foundry-samples/tree/main/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup).
-- [Unified `azure.yaml` design](../unify-azure-yaml/spec.md) — establishes the `host: microsoft.foundry` shape and defers VNet to this work (§1.4).
-- [Bicep-less provisioning](../bicepless-foundry/spec.md) — the synthesizer and provider this spec extends.
+- [Unified `azure.yaml` design](https://github.com/Azure/azure-dev/pull/8590) — establishes the `host: microsoft.foundry` shape and defers VNet to this work (§1.4).
+- [Bicep-less provisioning](https://github.com/Azure/azure-dev/pull/8577) — the synthesizer and provider this spec extends.

--- a/docs/specs/foundry-private-network/spec.md
+++ b/docs/specs/foundry-private-network/spec.md
@@ -53,6 +53,10 @@ which is supported under VNet isolation. This removes the bulk of the sample
 template (BYO stores, their private endpoints, role assignments, and both
 capability hosts) from azd's responsibility.
 
+The example below illustrates one scenario (BYO VNet with explicit subnets); it
+is not the full schema. See §4 for the field reference and the create-vs-
+reference rules.
+
 ```yaml
 infra:
   provider: microsoft.foundry
@@ -93,23 +97,21 @@ services:
 
 **In scope**
 
-- `network.mode: byo` — bring-your-own VNet, with create-or-reference subnets.
-- `network.mode: managed` — Foundry-managed VNet with an isolation mode.
-- Account `networkInjections` (scenario `agent`) bound to the agent subnet.
-- Account private endpoint + the three AI private DNS zones
-  (`privatelink.services.ai.azure.com`, `privatelink.openai.azure.com`,
-  `privatelink.cognitiveservices.azure.com`), created or referenced.
-- Platform-managed dependent stores (confirmed supported under VNet).
-- BYO container image via `--image` as the registry story for secured agents.
+- **BYO VNet** — bring an existing VNet; create or reference its subnets.
+- **Foundry-managed VNet** — with a selectable isolation mode.
+- **A network-bound (private) Foundry account** — its private endpoint and the
+  AI private DNS zones, created or referenced.
+- **Platform-managed dependent stores** under VNet isolation.
+- **BYO container image** as the registry story for secured agents.
 
 **Out of scope**
 
-- BYO dependent stores (Cosmos DB / AI Search / Storage) and the
-  capability-host wiring they require — managed stores are used instead.
+- BYO dependent stores and the capability-host wiring they require — managed
+  stores are used instead.
 - Tool subnet, user-assigned managed identity (UAMI), customer-managed keys
   (CMK) — not core to the secured-agent scenario.
-- **Local build into a private ACR** — secured agents bring a pre-built image
-  via `--image`; the developer owns ACR networking. See §8.
+- Local build into a private ACR — secured agents bring a pre-built image; the
+  developer owns ACR networking. See §8.
 - The bicep-less synthesizer/provider itself and the unified `azure.yaml`
   shape — prerequisites tracked by their own specs (see §3).
 


### PR DESCRIPTION
Resolves #8165

## Summary

Doc-only PR. Adds `docs/specs/foundry-private-network/spec.md`, a technical design spec for declarative private networking on the `host: microsoft.foundry` service in `azure.yaml`. No product code changes — the spec is the implementation contract; code PRs follow.

The [unified `azure.yaml` design](https://github.com/Azure/azure-dev/pull/8590) (§1.4) explicitly defers VNet binding (a Foundry **Account** setting) to the built-in Bicep work. This spec is that path: a flat `network:` block the existing [bicep-less synthesizer](https://github.com/Azure/azure-dev/pull/8643) reads to provision a network-bound account.

## What changed in this update

Stakeholders approved the final `azure.yaml` surface. This PR now reflects that shape:

- `network:` present means **private data plane always** (`publicNetworkAccess: Disabled` + account private endpoint). Omit `network:` for public.
- `peSubnet` is required whenever `network:` is declared.
- `agentSubnet` presence derives egress:
  - present ⇒ BYO/customer subnet (`useMicrosoftManagedNetwork: false`)
  - absent ⇒ Microsoft-managed egress (`useMicrosoftManagedNetwork: true`)
- `isolationMode` is valid only when `agentSubnet` is absent.
- `prefix` presence controls subnet create vs reference:
  - present ⇒ create subnet
  - absent ⇒ reference existing subnet
- `dns` is optional; omitted means create/link zones, while `dns.resourceGroup` references central/shared zones.

## What the spec covers

- **Flat `network:` surface** — `agentSubnet`, `peSubnet`, `dns`, and managed-egress `isolationMode`; no `mode: byo | managed` enum.
- **Primitives from the service team's templates** — what azd keeps, drops (managed stores, caphost wiring, tool subnet, UAMI, CMK), and defers (ACR).
- **Additive synthesizer / `main.bicep` changes** (high level), including regenerating the precompiled `main.arm.json` fallback.
- **Validation** — `peSubnet` required, subnet VNet/name required, CIDR validation, same-VNet v1 constraint, `isolationMode` only for managed egress, brownfield precedence (`endpoint:` wins).
- **Update behavior** — re-provision is incremental, but topology changes are limited by service mutability; tightening managed isolation is supported, relaxing/switching egress is not a v1 contract.
- **ACR private-networking RoI decision** — BYO image (`--image`) in v1; defer local-build-into-private-ACR.

## Relationship to in-flight work

Lands as a follow-on into the `huimiu/foundry-azure-yaml` feature branch after the synthesizer (#8643) merges. Rides `ServiceConfig.AdditionalProperties`, so no core change beyond the schema slice. The BYO-image flow and the merged remote-build skip for VNet-injected accounts keep ACR off the critical path. See §3 for the in-flight work overview.

## Out of scope

Public opt-out under `network:`, cross-VNet v1 topologies, BYO stores + capability-host wiring, tool subnet, UAMI, CMK, and local-build-into-private-ACR are explicitly excluded from v1.
