### PR TITLE
fix(ext-agents): resolve AZURE_AI_PROJECT_ENDPOINT in toolbox/connection commands

### DIFF
--- a/cli/azd/extensions/azure.ai.connections/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.connections/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## Unreleased
+
+### Bugs Fixed
+
+- [[#8688]](https://github.com/Azure/azure-dev/issues/8688) Resolve the project endpoint that `azd ai agent init` stores. `azd ai connection` commands now fall back to `AZURE_AI_PROJECT_ENDPOINT` (after `FOUNDRY_PROJECT_ENDPOINT`) in both the active azd environment and the host environment, so the resolution cascade no longer fails with "no Foundry project endpoint resolved" when only the `AZURE_AI_*` key is set.
+
 ## 0.1.1-preview (2026-06-05)
 
 ### Features Added

--- a/cli/azd/extensions/azure.ai.connections/internal/foundry/projectctx/resolver.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/foundry/projectctx/resolver.go
@@ -18,10 +18,12 @@ import (
 var ReadAzdHostedSourcesFunc = readAzdHostedSources
 
 // readAzdHostedSources dials the azd daemon (if reachable) and reads both the
-// active environment's FOUNDRY_PROJECT_ENDPOINT and the global-config project context
-// in a single client lifetime. Errors talking to the daemon are returned only
-// for non-Unavailable cases on the config read — Unavailable is treated as
-// "no daemon" and the caller falls through to subsequent levels.
+// active environment's project endpoint and the global-config project context
+// in a single client lifetime. The active-env read prefers
+// FOUNDRY_PROJECT_ENDPOINT and falls back to AZURE_AI_PROJECT_ENDPOINT (the key
+// `azd ai agent init` / `azd add` persist). Errors talking to the daemon are
+// returned only for non-Unavailable cases on the config read — Unavailable is
+// treated as "no daemon" and the caller falls through to subsequent levels.
 func readAzdHostedSources(ctx context.Context) (AzdHostedSources, error) {
 	var out AzdHostedSources
 
@@ -35,13 +37,16 @@ func readAzdHostedSources(ctx context.Context) (AzdHostedSources, error) {
 	if envResp, err := azdClient.Environment().GetCurrent(
 		ctx, &azdext.EmptyRequest{},
 	); err == nil {
-		envVal, valErr := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
-			EnvName: envResp.Environment.Name,
-			Key:     "FOUNDRY_PROJECT_ENDPOINT",
-		})
-		if valErr == nil && envVal.Value != "" {
-			out.EnvValue = envVal.Value
-			out.EnvName = envResp.Environment.Name
+		for _, key := range []string{foundryEnvKey, azureAiEnvKey} {
+			envVal, valErr := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+				EnvName: envResp.Environment.Name,
+				Key:     key,
+			})
+			if valErr == nil && envVal.Value != "" {
+				out.EnvValue = envVal.Value
+				out.EnvName = envResp.Environment.Name
+				break
+			}
 		}
 	}
 
@@ -78,10 +83,10 @@ func containsGRPCCode(err error, code codes.Code) bool {
 // Resolve resolves a Foundry project endpoint using the 5-level cascade:
 //
 //  1. --project-endpoint flag
-//  2. Active azd env value (FOUNDRY_PROJECT_ENDPOINT)
+//  2. Active azd env value (FOUNDRY_PROJECT_ENDPOINT, then AZURE_AI_PROJECT_ENDPOINT)
 //  3. Global config: extensions.ai-agents.project.context.endpoint (read-only;
 //     owned by azure.ai.agents)
-//  4. Host environment variable FOUNDRY_PROJECT_ENDPOINT
+//  4. Host environment variable (FOUNDRY_PROJECT_ENDPOINT, then AZURE_AI_PROJECT_ENDPOINT)
 //  5. Structured error with actionable suggestion
 //
 // Invalid values at any level produce a hard validation error (no silent fallback).
@@ -101,7 +106,8 @@ func Resolve(ctx context.Context, opts ResolveOpts) (*Resolved, error) {
 		return nil, err
 	}
 
-	// Level 2: active azd environment's FOUNDRY_PROJECT_ENDPOINT.
+	// Level 2: active azd environment's FOUNDRY_PROJECT_ENDPOINT (with the
+	// AZURE_AI_PROJECT_ENDPOINT fallback applied in readAzdHostedSources).
 	if sources.EnvValue != "" {
 		normalized, _, err := Validate(sources.EnvValue)
 		if err != nil {
@@ -127,8 +133,13 @@ func Resolve(ctx context.Context, opts ResolveOpts) (*Resolved, error) {
 		}, nil
 	}
 
-	// Level 4: host environment variable FOUNDRY_PROJECT_ENDPOINT.
-	if envVal := os.Getenv("FOUNDRY_PROJECT_ENDPOINT"); envVal != "" {
+	// Level 4: host environment variable (FOUNDRY_PROJECT_ENDPOINT, then the
+	// AZURE_AI_PROJECT_ENDPOINT fallback).
+	for _, key := range []string{foundryEnvKey, azureAiEnvKey} {
+		envVal := os.Getenv(key)
+		if envVal == "" {
+			continue
+		}
 		normalized, _, err := Validate(envVal)
 		if err != nil {
 			return nil, err

--- a/cli/azd/extensions/azure.ai.connections/internal/foundry/projectctx/types.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/foundry/projectctx/types.go
@@ -12,6 +12,19 @@
 // the one-way import contract that keeps the eventual lift mechanical.
 package projectctx
 
+const (
+	// foundryEnvKey is the canonical project-endpoint key. It is read both from
+	// the active azd environment (level 2) and as a host environment variable
+	// (level 4).
+	foundryEnvKey = "FOUNDRY_PROJECT_ENDPOINT"
+	// azureAiEnvKey is the legacy/sibling project-endpoint key written by
+	// `azd ai agent init` and `azd add` (Bicep output). It is read as a fallback
+	// after foundryEnvKey at both the active-azd-env and host-env levels so the
+	// hosted-agent + toolbox workflow resolves without an extra manual step.
+	// See https://github.com/Azure/azure-dev/issues/8688.
+	azureAiEnvKey = "AZURE_AI_PROJECT_ENDPOINT"
+)
+
 // EndpointSource identifies where a resolved project endpoint came from.
 type EndpointSource string
 
@@ -19,14 +32,14 @@ const (
 	// SourceFlag means the endpoint came from the --project-endpoint flag.
 	SourceFlag EndpointSource = "flag"
 	// SourceAzdEnv means the endpoint came from the active azd environment's
-	// FOUNDRY_PROJECT_ENDPOINT value.
+	// FOUNDRY_PROJECT_ENDPOINT (or, as a fallback, AZURE_AI_PROJECT_ENDPOINT) value.
 	SourceAzdEnv EndpointSource = "azdEnv"
 	// SourceGlobalConfig means the endpoint came from ~/.azd/config.json
 	// (extensions.ai-agents.project.context.endpoint — owned by azure.ai.agents
 	// and shared read-only with sibling extensions).
 	SourceGlobalConfig EndpointSource = "globalConfig"
 	// SourceFoundryEnv means the endpoint came from the FOUNDRY_PROJECT_ENDPOINT
-	// host environment variable.
+	// (or, as a fallback, AZURE_AI_PROJECT_ENDPOINT) host environment variable.
 	SourceFoundryEnv EndpointSource = "foundryEnv"
 )
 
@@ -49,8 +62,9 @@ type Resolved struct {
 // sources (active env + ~/.azd/config.json). Returned as a single struct so
 // tests can stub the whole lookup via ReadAzdHostedSourcesFunc.
 type AzdHostedSources struct {
-	// EnvValue is the FOUNDRY_PROJECT_ENDPOINT value from the active azd env,
-	// or "" if not set / no active env / no azd client available.
+	// EnvValue is the active-azd-env project endpoint: FOUNDRY_PROJECT_ENDPOINT
+	// if set, otherwise AZURE_AI_PROJECT_ENDPOINT, otherwise "" (not set / no
+	// active env / no azd client available).
 	EnvValue string
 	// EnvName is the active azd env name. Only meaningful when EnvValue != "".
 	EnvName string

--- a/cli/azd/extensions/azure.ai.connections/internal/foundry/projectctx/validator.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/foundry/projectctx/validator.go
@@ -108,6 +108,6 @@ func NoEndpointError() error {
 		"persist a workspace default with `azd ai project set <endpoint>`, "+
 			"or set FOUNDRY_PROJECT_ENDPOINT (or AZURE_AI_PROJECT_ENDPOINT) "+
 			"in the active azd environment, "+
-			"or export FOUNDRY_PROJECT_ENDPOINT in your shell",
+			"or export FOUNDRY_PROJECT_ENDPOINT (or AZURE_AI_PROJECT_ENDPOINT) in your shell",
 	)
 }

--- a/cli/azd/extensions/azure.ai.connections/internal/foundry/projectctx/validator.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/foundry/projectctx/validator.go
@@ -106,7 +106,8 @@ func NoEndpointError() error {
 		exterrors.CodeMissingProjectEndpoint,
 		"no Foundry project endpoint resolved",
 		"persist a workspace default with `azd ai project set <endpoint>`, "+
-			"or set FOUNDRY_PROJECT_ENDPOINT in the active azd environment, "+
+			"or set FOUNDRY_PROJECT_ENDPOINT (or AZURE_AI_PROJECT_ENDPOINT) "+
+			"in the active azd environment, "+
 			"or export FOUNDRY_PROJECT_ENDPOINT in your shell",
 	)
 }

--- a/cli/azd/extensions/azure.ai.toolboxes/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.toolboxes/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## Unreleased
+
+### Bugs Fixed
+
+- [[#8688]](https://github.com/Azure/azure-dev/issues/8688) Resolve the project endpoint that `azd ai agent init` stores. `azd ai toolbox` commands now fall back to `AZURE_AI_PROJECT_ENDPOINT` (after `FOUNDRY_PROJECT_ENDPOINT`) in both the active azd environment and the host environment, so the hosted-agent + toolbox workflow no longer fails with "no Foundry project endpoint resolved" after init.
+
 ## 0.1.0-preview (2026-05-28)
 
 Initial release of the `azure.ai.toolboxes` extension for managing Microsoft Foundry Toolboxes from the terminal.

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/foundry/projectctx/resolver.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/foundry/projectctx/resolver.go
@@ -18,10 +18,12 @@ import (
 var ReadAzdHostedSourcesFunc = readAzdHostedSources
 
 // readAzdHostedSources dials the azd daemon (if reachable) and reads both the
-// active environment's FOUNDRY_PROJECT_ENDPOINT and the global-config project context
-// in a single client lifetime. Errors talking to the daemon are returned only
-// for non-Unavailable cases on the config read — Unavailable is treated as
-// "no daemon" and the caller falls through to subsequent levels.
+// active environment's project endpoint and the global-config project context
+// in a single client lifetime. The active-env read prefers
+// FOUNDRY_PROJECT_ENDPOINT and falls back to AZURE_AI_PROJECT_ENDPOINT (the key
+// `azd ai agent init` / `azd add` persist). Errors talking to the daemon are
+// returned only for non-Unavailable cases on the config read — Unavailable is
+// treated as "no daemon" and the caller falls through to subsequent levels.
 func readAzdHostedSources(ctx context.Context) (AzdHostedSources, error) {
 	var out AzdHostedSources
 
@@ -35,13 +37,16 @@ func readAzdHostedSources(ctx context.Context) (AzdHostedSources, error) {
 	if envResp, err := azdClient.Environment().GetCurrent(
 		ctx, &azdext.EmptyRequest{},
 	); err == nil {
-		envVal, valErr := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
-			EnvName: envResp.Environment.Name,
-			Key:     "FOUNDRY_PROJECT_ENDPOINT",
-		})
-		if valErr == nil && envVal.Value != "" {
-			out.EnvValue = envVal.Value
-			out.EnvName = envResp.Environment.Name
+		for _, key := range []string{foundryEnvKey, azureAiEnvKey} {
+			envVal, valErr := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+				EnvName: envResp.Environment.Name,
+				Key:     key,
+			})
+			if valErr == nil && envVal.Value != "" {
+				out.EnvValue = envVal.Value
+				out.EnvName = envResp.Environment.Name
+				break
+			}
 		}
 	}
 
@@ -78,10 +83,10 @@ func containsGRPCCode(err error, code codes.Code) bool {
 // Resolve resolves a Foundry project endpoint using the 5-level cascade:
 //
 //  1. --project-endpoint flag
-//  2. Active azd env value (FOUNDRY_PROJECT_ENDPOINT)
+//  2. Active azd env value (FOUNDRY_PROJECT_ENDPOINT, then AZURE_AI_PROJECT_ENDPOINT)
 //  3. Global config: extensions.ai-agents.project.context.endpoint (read-only;
 //     owned by azure.ai.agents)
-//  4. Host environment variable FOUNDRY_PROJECT_ENDPOINT
+//  4. Host environment variable (FOUNDRY_PROJECT_ENDPOINT, then AZURE_AI_PROJECT_ENDPOINT)
 //  5. Structured error with actionable suggestion
 //
 // Invalid values at any level produce a hard validation error (no silent fallback).
@@ -101,7 +106,8 @@ func Resolve(ctx context.Context, opts ResolveOpts) (*Resolved, error) {
 		return nil, err
 	}
 
-	// Level 2: active azd environment's FOUNDRY_PROJECT_ENDPOINT.
+	// Level 2: active azd environment's FOUNDRY_PROJECT_ENDPOINT (with the
+	// AZURE_AI_PROJECT_ENDPOINT fallback applied in readAzdHostedSources).
 	if sources.EnvValue != "" {
 		normalized, _, err := Validate(sources.EnvValue)
 		if err != nil {
@@ -127,8 +133,13 @@ func Resolve(ctx context.Context, opts ResolveOpts) (*Resolved, error) {
 		}, nil
 	}
 
-	// Level 4: host environment variable FOUNDRY_PROJECT_ENDPOINT.
-	if envVal := os.Getenv("FOUNDRY_PROJECT_ENDPOINT"); envVal != "" {
+	// Level 4: host environment variable (FOUNDRY_PROJECT_ENDPOINT, then the
+	// AZURE_AI_PROJECT_ENDPOINT fallback).
+	for _, key := range []string{foundryEnvKey, azureAiEnvKey} {
+		envVal := os.Getenv(key)
+		if envVal == "" {
+			continue
+		}
 		normalized, _, err := Validate(envVal)
 		if err != nil {
 			return nil, err

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/foundry/projectctx/resolver_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/foundry/projectctx/resolver_test.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"testing"
 
-	"azure.ai.connections/internal/exterrors"
+	"azure.ai.toolboxes/internal/exterrors"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/assert"
@@ -30,7 +30,7 @@ func withHostedSources(t *testing.T, sources AzdHostedSources, err error) {
 // isolateFromAzdDaemon installs an empty hosted-sources stub and clears
 // AZD_SERVER so any code path that bypasses the seam cannot reach a real
 // daemon. After calling this, the resolver only sees the flag and the
-// FOUNDRY_PROJECT_ENDPOINT host env var.
+// FOUNDRY_PROJECT_ENDPOINT / AZURE_AI_PROJECT_ENDPOINT host env vars.
 func isolateFromAzdDaemon(t *testing.T) {
 	t.Helper()
 	t.Setenv("AZD_SERVER", "")
@@ -54,6 +54,9 @@ func TestResolve_FlagWins(t *testing.T) {
 }
 
 func TestResolve_AzdEnvWinsOverConfigAndFoundryEnv(t *testing.T) {
+	// EnvValue here stands in for whichever active-env key readAzdHostedSources
+	// resolved (FOUNDRY_PROJECT_ENDPOINT, or the AZURE_AI_PROJECT_ENDPOINT
+	// fallback); either way level 2 wins over global config and the host env.
 	t.Setenv("FOUNDRY_PROJECT_ENDPOINT", "https://foundry.services.ai.azure.com/api/projects/p")
 	withHostedSources(t, AzdHostedSources{
 		EnvValue: "  HTTPS://Azdenv.Services.AI.Azure.com/api/projects/p/  ",
@@ -170,21 +173,6 @@ func TestResolve_FoundryHostEnvWinsOverAzureAi(t *testing.T) {
 	assert.Equal(t, SourceFoundryEnv, result.Source)
 }
 
-func TestResolve_InvalidAzureAiHostEnvRejected(t *testing.T) {
-	// An invalid AZURE_AI_PROJECT_ENDPOINT fallback is a hard error, not a
-	// silent skip to level 5.
-	isolateFromAzdDaemon(t)
-	t.Setenv("FOUNDRY_PROJECT_ENDPOINT", "")
-	t.Setenv("AZURE_AI_PROJECT_ENDPOINT", "http://not-https.services.ai.azure.com/api/projects/p")
-
-	_, err := Resolve(t.Context(), ResolveOpts{})
-	require.Error(t, err)
-
-	var localErr *azdext.LocalError
-	require.ErrorAs(t, err, &localErr)
-	assert.Contains(t, localErr.Message, "https")
-}
-
 func TestResolve_FoundryEnvNormalized(t *testing.T) {
 	isolateFromAzdDaemon(t)
 	t.Setenv("FOUNDRY_PROJECT_ENDPOINT", "  https://X.SERVICES.AI.AZURE.COM/api/projects/p/  ")
@@ -211,6 +199,21 @@ func TestResolve_InvalidFlagRejected(t *testing.T) {
 func TestResolve_InvalidFoundryEnvRejected(t *testing.T) {
 	isolateFromAzdDaemon(t)
 	t.Setenv("FOUNDRY_PROJECT_ENDPOINT", "http://bad.services.ai.azure.com/api/projects/p")
+
+	_, err := Resolve(t.Context(), ResolveOpts{})
+	require.Error(t, err)
+
+	var localErr *azdext.LocalError
+	require.ErrorAs(t, err, &localErr)
+	assert.Contains(t, localErr.Message, "https")
+}
+
+func TestResolve_InvalidAzureAiHostEnvRejected(t *testing.T) {
+	// An invalid AZURE_AI_PROJECT_ENDPOINT fallback is a hard error, not a
+	// silent skip to level 5.
+	isolateFromAzdDaemon(t)
+	t.Setenv("FOUNDRY_PROJECT_ENDPOINT", "")
+	t.Setenv("AZURE_AI_PROJECT_ENDPOINT", "http://not-https.services.ai.azure.com/api/projects/p")
 
 	_, err := Resolve(t.Context(), ResolveOpts{})
 	require.Error(t, err)

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/foundry/projectctx/types.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/foundry/projectctx/types.go
@@ -10,6 +10,19 @@
 // exported because they cross the package boundary in this layout.
 package projectctx
 
+const (
+	// foundryEnvKey is the canonical project-endpoint key. It is read both from
+	// the active azd environment (level 2) and as a host environment variable
+	// (level 4).
+	foundryEnvKey = "FOUNDRY_PROJECT_ENDPOINT"
+	// azureAiEnvKey is the legacy/sibling project-endpoint key written by
+	// `azd ai agent init` and `azd add` (Bicep output). It is read as a fallback
+	// after foundryEnvKey at both the active-azd-env and host-env levels so the
+	// hosted-agent + toolbox workflow resolves without an extra manual step.
+	// See https://github.com/Azure/azure-dev/issues/8688.
+	azureAiEnvKey = "AZURE_AI_PROJECT_ENDPOINT"
+)
+
 // EndpointSource identifies where a resolved project endpoint came from.
 type EndpointSource string
 
@@ -17,14 +30,14 @@ const (
 	// SourceFlag means the endpoint came from the --project-endpoint flag.
 	SourceFlag EndpointSource = "flag"
 	// SourceAzdEnv means the endpoint came from the active azd environment's
-	// FOUNDRY_PROJECT_ENDPOINT value.
+	// FOUNDRY_PROJECT_ENDPOINT (or, as a fallback, AZURE_AI_PROJECT_ENDPOINT) value.
 	SourceAzdEnv EndpointSource = "azdEnv"
 	// SourceGlobalConfig means the endpoint came from ~/.azd/config.json
 	// (extensions.ai-agents.project.context.endpoint — owned by azure.ai.agents
 	// and shared read-only with sibling extensions).
 	SourceGlobalConfig EndpointSource = "globalConfig"
 	// SourceFoundryEnv means the endpoint came from the FOUNDRY_PROJECT_ENDPOINT
-	// host environment variable.
+	// (or, as a fallback, AZURE_AI_PROJECT_ENDPOINT) host environment variable.
 	SourceFoundryEnv EndpointSource = "foundryEnv"
 )
 
@@ -47,8 +60,9 @@ type Resolved struct {
 // sources (active env + ~/.azd/config.json). Returned as a single struct so
 // tests can stub the whole lookup via ReadAzdHostedSourcesFunc.
 type AzdHostedSources struct {
-	// EnvValue is the FOUNDRY_PROJECT_ENDPOINT value from the active azd env,
-	// or "" if not set / no active env / no azd client available.
+	// EnvValue is the active-azd-env project endpoint: FOUNDRY_PROJECT_ENDPOINT
+	// if set, otherwise AZURE_AI_PROJECT_ENDPOINT, otherwise "" (not set / no
+	// active env / no azd client available).
 	EnvValue string
 	// EnvName is the active azd env name. Only meaningful when EnvValue != "".
 	EnvName string

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/foundry/projectctx/validator.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/foundry/projectctx/validator.go
@@ -108,6 +108,6 @@ func NoEndpointError() error {
 		"persist a workspace default with `azd ai project set <endpoint>`, "+
 			"or set FOUNDRY_PROJECT_ENDPOINT (or AZURE_AI_PROJECT_ENDPOINT) "+
 			"in the active azd environment, "+
-			"or export FOUNDRY_PROJECT_ENDPOINT in your shell",
+			"or export FOUNDRY_PROJECT_ENDPOINT (or AZURE_AI_PROJECT_ENDPOINT) in your shell",
 	)
 }

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/foundry/projectctx/validator.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/foundry/projectctx/validator.go
@@ -106,7 +106,8 @@ func NoEndpointError() error {
 		exterrors.CodeMissingProjectEndpoint,
 		"no Foundry project endpoint resolved",
 		"persist a workspace default with `azd ai project set <endpoint>`, "+
-			"or set FOUNDRY_PROJECT_ENDPOINT in the active azd environment, "+
+			"or set FOUNDRY_PROJECT_ENDPOINT (or AZURE_AI_PROJECT_ENDPOINT) "+
+			"in the active azd environment, "+
 			"or export FOUNDRY_PROJECT_ENDPOINT in your shell",
 	)
 }


### PR DESCRIPTION
## Summary

Closes #8688. `azd ai toolbox` and `azd ai connection` only resolved the Foundry project endpoint from `FOUNDRY_PROJECT_ENDPOINT`, but `azd ai agent init` / `azd add` persist it under `AZURE_AI_PROJECT_ENDPOINT`. Users who just selected a project during init hit `no Foundry project endpoint resolved` on the very next toolbox/connection command and had to re-specify an endpoint they already chose.

## Changes

- **`azure.ai.toolboxes` / `azure.ai.connections` `projectctx`**: resolver now falls back to `AZURE_AI_PROJECT_ENDPOINT` (after `FOUNDRY_PROJECT_ENDPOINT`) at both the active-azd-env level and the host-env level, matching the existing `skills`/`routines` behavior. `FOUNDRY_PROJECT_ENDPOINT` still wins when both are set, so the change is backward-compatible.
- **`validator.go`**: `NoEndpointError` suggestion now mentions `AZURE_AI_PROJECT_ENDPOINT` as an accepted azd-env key.
- **tests**: added `resolver_test.go` for the toolboxes package (it had none) and extended the connections resolver tests — covering AZURE_AI host-env fallback, FOUNDRY-wins precedence, and invalid-AZURE_AI hard-error.
