### PR TITLE
Self-contained extension bundles (`azd x pack --bundle` and `azd ext install <bundle.zip>`)

### DIFF
--- a/cli/azd/cmd/constructors_coverage3_test.go
+++ b/cli/azd/cmd/constructors_coverage3_test.go
@@ -56,6 +56,7 @@ func Test_NewExtensionInstallAction(t *testing.T) {
 		&extensionInstallFlags{},
 		mockinput.NewMockConsole(),
 		nil, // extensionManager
+		nil, // sourceManager
 	)
 	require.NotNil(t, action)
 }

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -5,10 +5,16 @@ package cmd
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"log"
+	"maps"
 	"net"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"text/tabwriter"
@@ -24,6 +30,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
+	"github.com/azure/azure-dev/cli/azd/pkg/rzip"
 	uxlib "github.com/azure/azure-dev/cli/azd/pkg/ux"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel/codes"
@@ -69,8 +76,13 @@ func extensionActions(root *actions.ActionDescriptor) *actions.ActionDescriptor 
 	// azd extension install <extension-id>
 	group.Add("install", &actions.ActionDescriptorOptions{
 		Command: &cobra.Command{
-			Use:   "install <extension-id>",
+			Use:   "install <extension-id|extension-bundle.zip>",
 			Short: "Installs specified extensions.",
+			Long: `Installs one or more extensions by id from a registered extension source.
+
+You can also pass the path to a self-contained extension bundle (.zip): azd
+extracts it and installs the bundled extension. Bundled extensions aren't
+tracked for updates; reinstall from a newer bundle to update.`,
 		},
 		ActionResolver: newExtensionInstallAction,
 		FlagsResolver:  newExtensionInstallFlags,
@@ -259,6 +271,11 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 	extensionRows := []extensionListItem{}
 	azdVersion := currentAzdSemver()
 
+	// Track installed extensions that are represented by a matching registry row
+	// so the local pass below can surface the rest (e.g. bundle-installed
+	// extensions, or extensions whose source was removed).
+	coveredInstalled := map[string]bool{}
+
 	for _, extension := range registryExtensions {
 		if len(extension.Versions) == 0 {
 			continue
@@ -266,6 +283,9 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 
 		installedExtension, has := installedExtensions[extension.Id]
 		installed := has && installedExtension.Source == extension.Source
+		if installed {
+			coveredInstalled[extension.Id] = true
+		}
 
 		if a.flags.installed && !installed {
 			continue
@@ -316,6 +336,37 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 			DisplayVersion:   displayVersion,
 			Status:           status,
 			StatusSymbol:     extensionStatusSymbol(status),
+		})
+	}
+
+	// Surface installed extensions that are not represented by any configured
+	// registry (e.g. installed from a self-contained bundle, or whose source was
+	// removed). These have no live source to track updates against, so they are
+	// shown as up to date; the SOURCE column distinguishes them (e.g. "bundle").
+	for _, ext := range slices.SortedFunc(maps.Values(installedExtensions),
+		func(a, b *extensions.Extension) int { return strings.Compare(a.Id, b.Id) }) {
+		if coveredInstalled[ext.Id] {
+			continue
+		}
+		// Respect an explicit --source filter.
+		if a.flags.source != "" && !strings.EqualFold(a.flags.source, ext.Source) {
+			continue
+		}
+		// Installed records carry no tag metadata, so they cannot satisfy a tag filter.
+		if len(a.flags.tags) > 0 {
+			continue
+		}
+
+		extensionRows = append(extensionRows, extensionListItem{
+			Id:               ext.Id,
+			Name:             ext.DisplayName,
+			Namespace:        ext.Namespace,
+			Version:          ext.Version,
+			InstalledVersion: ext.Version,
+			Source:           ext.Source,
+			DisplayVersion:   ext.Version,
+			Status:           statusUpToDate,
+			StatusSymbol:     extensionStatusSymbol(statusUpToDate),
 		})
 	}
 
@@ -752,6 +803,14 @@ type extensionInstallAction struct {
 	flags            *extensionInstallFlags
 	console          input.Console
 	extensionManager *extensions.Manager
+	sourceManager    *extensions.SourceManager
+	// bundleSourceName is the transient source registered while installing from a
+	// self-contained bundle (.zip). It is removed during cleanup; extensions
+	// installed under it are re-pointed to extensions.BundleSourceName.
+	bundleSourceName string
+	// bundleTempDir is the temporary directory the bundle was extracted into. It
+	// is deleted during cleanup once installation completes.
+	bundleTempDir string
 }
 
 func newExtensionInstallAction(
@@ -759,12 +818,14 @@ func newExtensionInstallAction(
 	flags *extensionInstallFlags,
 	console input.Console,
 	extensionManager *extensions.Manager,
+	sourceManager *extensions.SourceManager,
 ) actions.Action {
 	return &extensionInstallAction{
 		args:             args,
 		flags:            flags,
 		console:          console,
 		extensionManager: extensionManager,
+		sourceManager:    sourceManager,
 	}
 }
 
@@ -773,6 +834,18 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 		Title:     "Install an azd extension (azd extension install)",
 		TitleNote: "Installs the specified extension onto the local machine",
 	})
+
+	// A single .zip argument is a self-contained bundle: extract it, register an
+	// ephemeral source, and queue its extensions for install (this rewrites
+	// a.args/a.flags.source for the loop below). The deferred cleanup removes the
+	// ephemeral source and temp dir afterwards.
+	if isBundleArg(a.args) {
+		if err := a.prepareBundleInstall(ctx, a.args[0]); err != nil {
+			a.cleanupBundleInstall(ctx)
+			return nil, err
+		}
+		defer a.cleanupBundleInstall(ctx)
+	}
 
 	extensionIds := a.args
 	if len(extensionIds) == 0 {
@@ -878,32 +951,57 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 		var extensionVersion *extensions.ExtensionVersion
 
 		if alreadyInstalled {
-			// Extension is already installed - apply smart upgrade/downgrade logic
+			// Compare sources by raw name: each bundle install registers a unique
+			// transient source, so installing any bundle over an existing install is
+			// always a source change (and prompts), even at the same version.
+			sameSource := strings.EqualFold(installedExtension.Source, compatibleExtension.Source)
 
-			// Check if same version (regardless of source)
-			if installedExtension.Version == targetVersion && !a.flags.force {
-				stepMessage += output.WithGrayFormat(" (version %s already installed)", installedExtension.Version)
-				a.console.StopSpinner(ctx, stepMessage, input.StepSkipped)
-				continue
-			}
+			if !a.flags.force {
+				if sameSource {
+					if installedExtension.Version == targetVersion {
+						stepMessage += output.WithGrayFormat(
+							" (version %s already installed)", installedExtension.Version)
+						a.console.StopSpinner(ctx, stepMessage, input.StepSkipped)
+						continue
+					}
 
-			// Parse versions for semantic comparison. Non-semver tags
-			// (e.g. "nightly", "dev") have no defined ordering, so when
-			// either side fails to parse we skip the downgrade guard and
-			// fall through to the upgrade path. The string equality check
-			// above already short-circuits the no-op case.
-			installedSemver, installedErr := semver.NewVersion(installedExtension.Version)
-			targetSemver, targetErr := semver.NewVersion(targetVersion)
-			if installedErr == nil && targetErr == nil &&
-				targetSemver.LessThan(installedSemver) && !a.flags.force {
-				// Would be a downgrade - require --force
-				stepMessage += output.WithGrayFormat(
-					" (would downgrade from %s to %s, use --force to override)",
-					installedExtension.Version,
-					targetVersion,
-				)
-				a.console.StopSpinner(ctx, stepMessage, input.StepSkipped)
-				continue
+					// Downgrades have no defined order for non-semver tags, so detect
+					// them only when both versions parse as semver.
+					installedSemver, installedErr := semver.NewVersion(installedExtension.Version)
+					targetSemver, targetErr := semver.NewVersion(targetVersion)
+					if installedErr == nil && targetErr == nil && targetSemver.LessThan(installedSemver) {
+						// Confirm before replacing a newer install with an older one.
+						question := fmt.Sprintf(
+							"%s %s is installed. %s?",
+							output.WithHighLightFormat(extensionId), installedExtension.Version,
+							versionTransitionVerb(installedExtension.Version, targetVersion),
+						)
+						skipSuffix := fmt.Sprintf(
+							" (would downgrade from %s to %s, use --force to override)",
+							installedExtension.Version, targetVersion,
+						)
+						proceed, err := a.confirmReplace(ctx, stepMessage, question, skipSuffix)
+						if err != nil {
+							return nil, err
+						}
+						if !proceed {
+							continue
+						}
+					}
+					// Same-source upgrade falls through and proceeds without prompting.
+				} else {
+					// Source is changing (e.g. bundle over registry build); confirm first.
+					proceed, err := a.confirmSourceChange(
+						ctx, stepMessage, extensionId, installedExtension,
+						compatibleExtension.Source, targetVersion,
+					)
+					if err != nil {
+						return nil, err
+					}
+					if !proceed {
+						continue
+					}
+				}
 			}
 
 			// Use upgrade logic for existing installations
@@ -917,7 +1015,7 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 			)
 			if err != nil {
 				a.console.StopSpinner(ctx, stepMessage, input.StepFailed)
-				return nil, fmt.Errorf("failed to upgrade extension: %w", err)
+				return nil, wrapDependencyError(fmt.Errorf("failed to upgrade extension: %w", err))
 			}
 
 			stepMessage += output.WithGrayFormat(" (%s)", extensionVersion.Version)
@@ -936,7 +1034,7 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 			)
 			if err != nil {
 				a.console.StopSpinner(ctx, stepMessage, input.StepFailed)
-				return nil, fmt.Errorf("failed to install extension: %w", err)
+				return nil, wrapDependencyError(fmt.Errorf("failed to install extension: %w", err))
 			}
 
 			stepMessage += output.WithGrayFormat(" (%s)", extensionVersion.Version)
@@ -962,6 +1060,318 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 			Header: "Extension(s) installed successfully",
 		},
 	}, nil
+}
+
+// extensionBundleTempPrefix is the prefix used for the temporary directory a
+// self-contained bundle (.zip) is extracted into during installation. The
+// directory is removed once installation completes.
+const extensionBundleTempPrefix = "azd-extension-bundle-"
+
+// sourceDisplayLabel returns a user-facing label for an extension source. The
+// transient source registered while installing a bundle is an implementation
+// detail, so it (and the reserved bundle source) are presented as "bundle"
+// rather than by their internal name.
+func (a *extensionInstallAction) sourceDisplayLabel(source string) string {
+	if a.bundleSourceName != "" && strings.EqualFold(source, a.bundleSourceName) {
+		return "bundle"
+	}
+	if strings.EqualFold(source, extensions.BundleSourceName) {
+		return "bundle"
+	}
+	return fmt.Sprintf("source %q", source)
+}
+
+// versionTransitionVerb returns a capitalized verb phrase describing the move
+// from the installed version to the target version: "Reinstall" when they match,
+// "Upgrade to <target>" / "Downgrade to <target>" when both parse as semver, and
+// a neutral "Replace with <target>" when ordering is undefined (non-semver tags).
+func versionTransitionVerb(installedVersion, targetVersion string) string {
+	if installedVersion == targetVersion {
+		return "Reinstall"
+	}
+
+	installedSemver, installedErr := semver.NewVersion(installedVersion)
+	targetSemver, targetErr := semver.NewVersion(targetVersion)
+	switch {
+	case installedErr == nil && targetErr == nil && targetSemver.LessThan(installedSemver):
+		return fmt.Sprintf("Downgrade to %s", targetVersion)
+	case installedErr == nil && targetErr == nil && targetSemver.GreaterThan(installedSemver):
+		return fmt.Sprintf("Upgrade to %s", targetVersion)
+	default:
+		return fmt.Sprintf("Replace with %s", targetVersion)
+	}
+}
+
+// confirmSourceChange prompts before replacing an already-installed extension
+// with one from a different source (e.g. a bundle build over a registry build),
+// since the artifacts may differ. In --no-prompt mode it skips with --force
+// guidance. It reports whether the install should proceed.
+func (a *extensionInstallAction) confirmSourceChange(
+	ctx context.Context,
+	stepMessage string,
+	extensionId string,
+	installed *extensions.Extension,
+	newSource string,
+	targetVersion string,
+) (bool, error) {
+	oldLabel := a.sourceDisplayLabel(installed.Source)
+	newLabel := a.sourceDisplayLabel(newSource)
+
+	question := fmt.Sprintf(
+		"%s %s is installed from %s. %s from %s?",
+		output.WithHighLightFormat(extensionId), installed.Version, oldLabel,
+		versionTransitionVerb(installed.Version, targetVersion), newLabel,
+	)
+	skipSuffix := fmt.Sprintf(
+		" (%s already installed from %s; use --force to install from %s)",
+		installed.Version, oldLabel, newLabel,
+	)
+
+	return a.confirmReplace(ctx, stepMessage, question, skipSuffix)
+}
+
+// confirmReplace prompts with the given question and reports whether to proceed,
+// managing spinner state and prompt spacing. In --no-prompt mode it does not
+// prompt: it skips with noPromptSkipSuffix appended to the step message.
+func (a *extensionInstallAction) confirmReplace(
+	ctx context.Context,
+	stepMessage string,
+	question string,
+	noPromptSkipSuffix string,
+) (bool, error) {
+	if a.flags.global.NoPrompt {
+		a.console.StopSpinner(ctx, stepMessage+output.WithGrayFormat(noPromptSkipSuffix), input.StepSkipped)
+		return false, nil
+	}
+
+	a.console.StopSpinner(ctx, stepMessage, input.Step)
+	a.console.Message(ctx, "")
+	confirm, err := a.console.Confirm(ctx, input.ConsoleOptions{
+		Message:      question,
+		DefaultValue: false,
+	})
+	if err != nil {
+		return false, err
+	}
+	if !confirm {
+		a.console.StopSpinner(ctx, stepMessage+output.WithGrayFormat(" (skipped)"), input.StepSkipped)
+		return false, nil
+	}
+
+	a.console.Message(ctx, "")
+	return true, nil
+}
+
+// wrapDependencyError augments a dependency-not-found failure with actionable
+// guidance. azd does not resolve dependencies across sources during install, so
+// when a required dependency is missing from the parent's source the user is
+// directed to install it explicitly first. Other errors pass through unchanged.
+func wrapDependencyError(err error) error {
+	if depErr, ok := errors.AsType[*extensions.DependencyNotFoundError](err); ok {
+		return &internal.ErrorWithSuggestion{
+			Err: depErr,
+			Suggestion: fmt.Sprintf(
+				"Install the required dependency first with %s, then retry.",
+				output.WithHighLightFormat("azd extension install %s", depErr.DependencyId),
+			),
+		}
+	}
+
+	return err
+}
+
+// isBundleArg reports whether the provided arguments represent a single
+// self-contained extension bundle (.zip) path that exists on disk.
+func isBundleArg(args []string) bool {
+	if len(args) != 1 {
+		return false
+	}
+
+	if !strings.EqualFold(filepath.Ext(args[0]), ".zip") {
+		return false
+	}
+
+	info, err := os.Stat(args[0])
+	return err == nil && !info.IsDir()
+}
+
+// prepareBundleInstall extracts the bundle, registers an ephemeral source over
+// it, and rewrites a.args/a.flags.source so the standard install loop installs
+// the bundled extensions from that source. cleanupBundleInstall tears the
+// ephemeral state down afterwards.
+func (a *extensionInstallAction) prepareBundleInstall(ctx context.Context, zipPath string) error {
+	absZipPath, err := filepath.Abs(zipPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve bundle path: %w", err)
+	}
+
+	// Use a unique transient source name so the ephemeral source never collides
+	// with a user-configured source. The name is an implementation detail and is
+	// not surfaced to the user, since the source is removed after installation.
+	suffix, err := randomHexToken()
+	if err != nil {
+		return fmt.Errorf("failed to generate bundle source name: %w", err)
+	}
+	base := bundleSourceName(absZipPath)
+	if base == "" {
+		base = "bundle"
+	}
+	sourceName := fmt.Sprintf("%s-%s", base, suffix)
+
+	stepMessage := fmt.Sprintf("Extracting bundle %s", output.WithHighLightFormat(filepath.Base(absZipPath)))
+	a.console.ShowSpinner(ctx, stepMessage, input.Step)
+
+	bundleDir, err := os.MkdirTemp("", extensionBundleTempPrefix)
+	if err != nil {
+		a.console.StopSpinner(ctx, stepMessage, input.StepFailed)
+		return fmt.Errorf("failed to create temporary bundle directory: %w", err)
+	}
+	// Record the temp dir immediately so cleanup removes it even if a later step fails.
+	a.bundleTempDir = bundleDir
+
+	if err := rzip.ExtractToDirectory(absZipPath, bundleDir); err != nil {
+		a.console.StopSpinner(ctx, stepMessage, input.StepFailed)
+		return fmt.Errorf("failed to extract bundle: %w", err)
+	}
+
+	registryPath := filepath.Join(bundleDir, extensions.BundleRegistryFileName)
+	if _, err := os.Stat(registryPath); err != nil {
+		a.console.StopSpinner(ctx, stepMessage, input.StepFailed)
+		return &internal.ErrorWithSuggestion{
+			Err: fmt.Errorf("bundle does not contain a %s at its root", extensions.BundleRegistryFileName),
+			Suggestion: "Ensure the .zip is a self-contained azd extension bundle " +
+				"produced by 'azd x pack --bundle'.",
+		}
+	}
+	a.console.StopSpinner(ctx, stepMessage, input.StepDone)
+
+	sourceConfig := &extensions.SourceConfig{
+		Name:     sourceName,
+		Type:     extensions.SourceKindBundle,
+		Location: bundleDir,
+	}
+
+	// Validate the bundle by hydrating the source.
+	source, err := a.sourceManager.CreateSource(ctx, sourceConfig)
+	if err != nil {
+		return fmt.Errorf("bundle validation failed: %w", err)
+	}
+
+	bundledExtensions, err := source.ListExtensions(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to read bundled extensions: %w", err)
+	}
+	if len(bundledExtensions) == 0 {
+		return fmt.Errorf("bundle %q contains no extensions", filepath.Base(absZipPath))
+	}
+
+	// Register the ephemeral bundle source so the install loop can resolve it.
+	if err := a.sourceManager.Add(ctx, sourceName, sourceConfig); err != nil {
+		return fmt.Errorf("failed to register bundle source: %w", err)
+	}
+	// Record the source name immediately so cleanup removes it even if a later step fails.
+	a.bundleSourceName = sourceName
+
+	// The manager cached the source list and a snapshot of user config at startup.
+	// Invalidate the cache so the new bundle source is visible, and reload the
+	// config so the install save below does not clobber it.
+	a.extensionManager.InvalidateSourceCache()
+	if err := a.extensionManager.ReloadUserConfig(); err != nil {
+		return err
+	}
+
+	// Install every extension the bundle declares. Bundles are produced per
+	// extension by 'azd x pack --bundle', so this is typically a single id.
+	ids := make([]string, len(bundledExtensions))
+	for i, ext := range bundledExtensions {
+		ids[i] = ext.Id
+	}
+
+	a.args = ids
+	a.flags.source = sourceName
+
+	return nil
+}
+
+// cleanupBundleInstall tears down the ephemeral state created by
+// prepareBundleInstall: it re-points any extension installed from the transient
+// bundle source to extensions.BundleSourceName, removes the transient source, and
+// deletes the extracted bundle directory. It is safe to call multiple times and
+// when prepareBundleInstall failed partway through.
+func (a *extensionInstallAction) cleanupBundleInstall(ctx context.Context) {
+	if a.bundleSourceName != "" {
+		// Re-point extensions installed from the transient source so they are not
+		// orphaned once the source is removed.
+		if installed, err := a.extensionManager.ListInstalled(); err == nil {
+			for _, ext := range installed {
+				if !strings.EqualFold(ext.Source, a.bundleSourceName) {
+					continue
+				}
+				ext.Source = extensions.BundleSourceName
+				if err := a.extensionManager.UpdateInstalled(ext); err != nil {
+					log.Printf("failed to mark extension %q as bundle-installed: %v", ext.Id, err)
+				}
+			}
+		} else {
+			log.Printf("failed to list installed extensions during bundle cleanup: %v", err)
+		}
+
+		if err := a.sourceManager.Remove(ctx, a.bundleSourceName); err != nil &&
+			!errors.Is(err, extensions.ErrSourceNotFound) {
+			log.Printf("failed to remove bundle source %q: %v", a.bundleSourceName, err)
+		}
+		a.extensionManager.InvalidateSourceCache()
+		a.bundleSourceName = ""
+	}
+
+	if a.bundleTempDir != "" {
+		if err := os.RemoveAll(a.bundleTempDir); err != nil {
+			log.Printf("failed to remove bundle directory %q: %v", a.bundleTempDir, err)
+		}
+		a.bundleTempDir = ""
+	}
+}
+
+// randomHexToken returns a short random hex string used to make the transient
+// bundle source name unique.
+func randomHexToken() (string, error) {
+	buf := make([]byte, 4)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// bundleSourceName derives a normalized source name from a bundle file path by
+// stripping the .zip extension.
+func bundleSourceName(zipPath string) string {
+	base := filepath.Base(zipPath)
+	base = strings.TrimSuffix(base, filepath.Ext(base))
+	return normalizeBundleSourceName(base)
+}
+
+// normalizeBundleSourceName produces a filesystem- and config-safe source name
+// by lowercasing, replacing characters outside [a-z0-9_] with a hyphen, and
+// collapsing consecutive hyphens. Dots are intentionally excluded because
+// extension source names are used as dot-delimited configuration keys, so a
+// dot (e.g. in a version like 1.2.3) would be misinterpreted as a nested key.
+func normalizeBundleSourceName(name string) string {
+	name = strings.ToLower(name)
+	var sb strings.Builder
+	prevHyphen := false
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_':
+			sb.WriteRune(r)
+			prevHyphen = false
+		default:
+			if !prevHyphen {
+				sb.WriteRune('-')
+				prevHyphen = true
+			}
+		}
+	}
+	return strings.Trim(sb.String(), "-")
 }
 
 // azd extension uninstall
@@ -1334,6 +1744,27 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 	}
 	baseResult.FromVersion = installed.Version
 	baseResult.FromSource = installed.Source
+
+	// Extensions installed from a self-contained bundle have no live registry to
+	// upgrade against. Skip them gracefully and direct the user to reinstall with
+	// a newer bundle (or re-point to a registry via `azd extension install`).
+	if installed.Source == extensions.BundleSourceName {
+		baseResult.Status = extensions.UpgradeStatusSkipped
+		baseResult.SkipReason = "installed from a self-contained bundle; " +
+			"reinstall with a newer bundle to update"
+		if !isJsonOutput {
+			skipMsg := fmt.Sprintf(
+				"Upgrading %s extension",
+				output.WithHighLightFormat(extensionId),
+			) + output.WithGrayFormat(
+				" (Installed from a bundle)",
+			)
+			a.console.StopSpinner(
+				ctx, skipMsg, input.StepSkipped,
+			)
+		}
+		return baseResult
+	}
 
 	// Resolve which registry source to use.
 	allMatchOptions := &extensions.FilterOptions{
@@ -2013,6 +2444,7 @@ func (a *extensionSourceRemoveAction) Run(ctx context.Context) (*actions.ActionR
 	var key = strings.ToLower(a.args[0])
 	spinnerMessage := fmt.Sprintf("Removing extension source (%s)", key)
 	a.console.ShowSpinner(ctx, spinnerMessage, input.Step)
+
 	err := a.sourceManager.Remove(ctx, key)
 	a.console.StopSpinner(ctx, spinnerMessage, input.GetStepResultFormat(err))
 	if err != nil {

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -1081,6 +1081,17 @@ func (a *extensionInstallAction) sourceDisplayLabel(source string) string {
 	return fmt.Sprintf("source %q", source)
 }
 
+// sourceDisplayLabelForInstalled is like sourceDisplayLabel but phrases the
+// bundle case with an article ("a bundle") so it reads naturally after
+// "installed from".
+func (a *extensionInstallAction) sourceDisplayLabelForInstalled(source string) string {
+	label := a.sourceDisplayLabel(source)
+	if label == "bundle" {
+		return "a bundle"
+	}
+	return label
+}
+
 // versionTransitionVerb returns a capitalized verb phrase describing the move
 // from the installed version to the target version: "Reinstall" when they match,
 // "Upgrade to <target>" / "Downgrade to <target>" when both parse as semver, and
@@ -1114,11 +1125,11 @@ func (a *extensionInstallAction) confirmSourceChange(
 	newSource string,
 	targetVersion string,
 ) (bool, error) {
-	oldLabel := a.sourceDisplayLabel(installed.Source)
+	oldLabel := a.sourceDisplayLabelForInstalled(installed.Source)
 	newLabel := a.sourceDisplayLabel(newSource)
 
 	question := fmt.Sprintf(
-		"%s %s is installed from %s. %s from %s?",
+		"%s %s is already installed from %s. %s from %s?",
 		output.WithHighLightFormat(extensionId), installed.Version, oldLabel,
 		versionTransitionVerb(installed.Version, targetVersion), newLabel,
 	)

--- a/cli/azd/cmd/extension_bundle_test.go
+++ b/cli/azd/cmd/extension_bundle_test.go
@@ -1,0 +1,276 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsBundleArg(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "bundle.zip")
+	require.NoError(t, os.WriteFile(zipPath, []byte("zip"), 0600))
+
+	require.True(t, isBundleArg([]string{zipPath}))
+	require.True(t, isBundleArg([]string{filepath.Join(dir, "BUNDLE.ZIP")}) == false) // does not exist
+	require.False(t, isBundleArg([]string{"some.extension.id"}))
+	require.False(t, isBundleArg([]string{zipPath, "other"}))
+	require.False(t, isBundleArg([]string{dir})) // directory, not a file
+	require.False(t, isBundleArg(nil))
+}
+
+func TestNormalizeBundleSourceName(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"My Bundle":            "my-bundle",
+		"ext_1.0.0":            "ext_1-0-0",
+		"weird@@name!!":        "weird-name",
+		"--leading-trailing--": "leading-trailing",
+		"UPPER":                "upper",
+	}
+
+	for input, expected := range cases {
+		require.Equal(t, expected, normalizeBundleSourceName(input), "input %q", input)
+	}
+}
+
+func TestBundleSourceName(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "my-ext_1-0-0", bundleSourceName("/tmp/My Ext_1.0.0.zip"))
+	require.Equal(t, "bundle", bundleSourceName("bundle.zip"))
+}
+
+func TestCleanupBundleInstall_RemovesTempDir(t *testing.T) {
+	t.Parallel()
+
+	bundleDir := t.TempDir()
+	marker := filepath.Join(bundleDir, "registry.json")
+	require.NoError(t, os.WriteFile(marker, []byte("{}"), 0600))
+
+	// With no transient source recorded, cleanup only removes the temp dir and
+	// does not touch the (nil) managers.
+	action := &extensionInstallAction{bundleTempDir: bundleDir}
+	action.cleanupBundleInstall(context.Background())
+
+	require.NoDirExists(t, bundleDir)
+	require.Empty(t, action.bundleTempDir)
+
+	// Idempotent: a second call is a no-op and does not panic.
+	require.NotPanics(t, func() {
+		action.cleanupBundleInstall(context.Background())
+	})
+}
+
+func TestRandomHexToken(t *testing.T) {
+	t.Parallel()
+
+	a, err := randomHexToken()
+	require.NoError(t, err)
+	require.Len(t, a, 8)
+
+	b, err := randomHexToken()
+	require.NoError(t, err)
+	require.NotEqual(t, a, b)
+}
+
+func TestSourceDisplayLabel(t *testing.T) {
+	t.Parallel()
+
+	// During a bundle install the transient source name is presented as "bundle".
+	withBundle := &extensionInstallAction{bundleSourceName: "demo-abc123"}
+	require.Equal(t, "bundle", withBundle.sourceDisplayLabel("demo-abc123"))
+	require.Equal(t, "bundle", withBundle.sourceDisplayLabel("DEMO-ABC123"))
+
+	// The reserved bundle source is also presented as "bundle".
+	require.Equal(t, "bundle", withBundle.sourceDisplayLabel(extensions.BundleSourceName))
+
+	// Regular sources are quoted by name.
+	require.Equal(t, `source "azd"`, withBundle.sourceDisplayLabel("azd"))
+
+	noBundle := &extensionInstallAction{}
+	require.Equal(t, "bundle", noBundle.sourceDisplayLabel(extensions.BundleSourceName))
+	require.Equal(t, `source "local"`, noBundle.sourceDisplayLabel("local"))
+}
+
+func TestWrapDependencyError(t *testing.T) {
+	t.Parallel()
+
+	// Non-dependency errors pass through unchanged.
+	plain := fmt.Errorf("some other failure")
+	require.Equal(t, plain, wrapDependencyError(plain))
+
+	// Dependency-not-found errors are wrapped with an actionable suggestion.
+	depErr := fmt.Errorf("install failed: %w", &extensions.DependencyNotFoundError{
+		DependencyId: "azure.ai.inspector",
+		ParentId:     "azure.ai.agents",
+	})
+	wrapped := wrapDependencyError(depErr)
+
+	suggestErr, ok := errors.AsType[*internal.ErrorWithSuggestion](wrapped)
+	require.True(t, ok, "expected ErrorWithSuggestion, got %T", wrapped)
+	require.Contains(t, suggestErr.Suggestion, "azd extension install azure.ai.inspector")
+	require.ErrorAs(t, suggestErr.Err, new(*extensions.DependencyNotFoundError))
+}
+
+func newConfirmTestAction(console input.Console, noPrompt bool) *extensionInstallAction {
+	return &extensionInstallAction{
+		console: console,
+		flags: &extensionInstallFlags{
+			global: &internal.GlobalCommandOptions{NoPrompt: noPrompt},
+		},
+	}
+}
+
+func TestConfirmSourceChange(t *testing.T) {
+	t.Parallel()
+
+	installed := &extensions.Extension{
+		Id:      "azure.ai.agents",
+		Version: "1.0.0",
+		Source:  "azd",
+	}
+
+	t.Run("ReinstallSameVersion", func(t *testing.T) {
+		console := mockinput.NewMockConsole()
+		console.WhenConfirm(func(input.ConsoleOptions) bool { return true }).Respond(true)
+		action := newConfirmTestAction(console, false)
+
+		proceed, err := action.confirmSourceChange(
+			context.Background(), "Installing", installed.Id, installed, extensions.BundleSourceName, "1.0.0",
+		)
+		require.NoError(t, err)
+		require.True(t, proceed)
+		require.Contains(t, lastConfirmMessage(console),
+			`azure.ai.agents 1.0.0 is installed from source "azd". Reinstall from bundle?`)
+	})
+
+	t.Run("UpgradeShowsTargetVersion", func(t *testing.T) {
+		console := mockinput.NewMockConsole()
+		console.WhenConfirm(func(input.ConsoleOptions) bool { return true }).Respond(true)
+		action := newConfirmTestAction(console, false)
+
+		proceed, err := action.confirmSourceChange(
+			context.Background(), "Installing", installed.Id, installed, extensions.BundleSourceName, "2.0.0",
+		)
+		require.NoError(t, err)
+		require.True(t, proceed)
+		require.Contains(t, lastConfirmMessage(console),
+			`azure.ai.agents 1.0.0 is installed from source "azd". Upgrade to 2.0.0 from bundle?`)
+	})
+
+	t.Run("DowngradeDeclined", func(t *testing.T) {
+		console := mockinput.NewMockConsole()
+		console.WhenConfirm(func(input.ConsoleOptions) bool { return true }).Respond(false)
+		action := newConfirmTestAction(console, false)
+
+		proceed, err := action.confirmSourceChange(
+			context.Background(), "Installing", installed.Id, installed, extensions.BundleSourceName, "0.9.0",
+		)
+		require.NoError(t, err)
+		require.False(t, proceed)
+		require.Contains(t, lastConfirmMessage(console),
+			`azure.ai.agents 1.0.0 is installed from source "azd". Downgrade to 0.9.0 from bundle?`)
+	})
+
+	t.Run("NoPromptSkipsWithoutAsking", func(t *testing.T) {
+		console := mockinput.NewMockConsole()
+		// No WhenConfirm registered: if Confirm were called it would panic/fail.
+		action := newConfirmTestAction(console, true)
+
+		proceed, err := action.confirmSourceChange(
+			context.Background(), "Installing", installed.Id, installed, extensions.BundleSourceName, "1.0.0",
+		)
+		require.NoError(t, err)
+		require.False(t, proceed)
+	})
+}
+
+// lastConfirmMessage returns the most recent non-empty message the mock console
+// captured, which for a confirm prompt is the prompt text (ignoring blank-line
+// spacing messages).
+func lastConfirmMessage(console *mockinput.MockConsole) string {
+	out := console.Output()
+	for i := len(out) - 1; i >= 0; i-- {
+		if out[i] != "" {
+			return out[i]
+		}
+	}
+	return ""
+}
+
+func TestConfirmReplace(t *testing.T) {
+	t.Parallel()
+
+	const question = "azure.ai.agents version 1.0.0 is installed. Downgrade to 0.9.0?"
+	const skipSuffix = " (would downgrade from 1.0.0 to 0.9.0, use --force to override)"
+
+	t.Run("Confirmed", func(t *testing.T) {
+		console := mockinput.NewMockConsole()
+		console.WhenConfirm(func(input.ConsoleOptions) bool { return true }).Respond(true)
+		action := newConfirmTestAction(console, false)
+
+		proceed, err := action.confirmReplace(context.Background(), "Installing", question, skipSuffix)
+		require.NoError(t, err)
+		require.True(t, proceed)
+		require.Contains(t, lastConfirmMessage(console), question)
+	})
+
+	t.Run("Declined", func(t *testing.T) {
+		console := mockinput.NewMockConsole()
+		console.WhenConfirm(func(input.ConsoleOptions) bool { return true }).Respond(false)
+		action := newConfirmTestAction(console, false)
+
+		proceed, err := action.confirmReplace(context.Background(), "Installing", question, skipSuffix)
+		require.NoError(t, err)
+		require.False(t, proceed)
+	})
+
+	t.Run("NoPromptSkipsWithoutAsking", func(t *testing.T) {
+		console := mockinput.NewMockConsole()
+		// No WhenConfirm registered: if Confirm were called it would fail.
+		action := newConfirmTestAction(console, true)
+
+		proceed, err := action.confirmReplace(context.Background(), "Installing", question, skipSuffix)
+		require.NoError(t, err)
+		require.False(t, proceed)
+	})
+}
+
+func TestVersionTransitionVerb(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		installed string
+		target    string
+		expected  string
+	}{
+		{"1.0.0", "1.0.0", "Reinstall"},
+		{"1.0.0", "2.0.0", "Upgrade to 2.0.0"},
+		{"1.0.0", "0.9.0", "Downgrade to 0.9.0"},
+		{"1.0.0-preview", "1.0.0", "Upgrade to 1.0.0"},
+		// Non-semver tags have no defined ordering -> neutral verb.
+		{"nightly", "1.0.0", "Replace with 1.0.0"},
+		{"1.0.0", "nightly", "Replace with nightly"},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.expected, versionTransitionVerb(tc.installed, tc.target),
+			"installed=%s target=%s", tc.installed, tc.target)
+	}
+}

--- a/cli/azd/cmd/extension_bundle_test.go
+++ b/cli/azd/cmd/extension_bundle_test.go
@@ -114,6 +114,11 @@ func TestSourceDisplayLabel(t *testing.T) {
 	noBundle := &extensionInstallAction{}
 	require.Equal(t, "bundle", noBundle.sourceDisplayLabel(extensions.BundleSourceName))
 	require.Equal(t, `source "local"`, noBundle.sourceDisplayLabel("local"))
+
+	// The installed-from variant phrases the bundle case with an article.
+	require.Equal(t, "a bundle", noBundle.sourceDisplayLabelForInstalled(extensions.BundleSourceName))
+	require.Equal(t, "a bundle", withBundle.sourceDisplayLabelForInstalled("demo-abc123"))
+	require.Equal(t, `source "azd"`, noBundle.sourceDisplayLabelForInstalled("azd"))
 }
 
 func TestWrapDependencyError(t *testing.T) {
@@ -165,7 +170,7 @@ func TestConfirmSourceChange(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, proceed)
 		require.Contains(t, lastConfirmMessage(console),
-			`azure.ai.agents 1.0.0 is installed from source "azd". Reinstall from bundle?`)
+			`azure.ai.agents 1.0.0 is already installed from source "azd". Reinstall from bundle?`)
 	})
 
 	t.Run("UpgradeShowsTargetVersion", func(t *testing.T) {
@@ -179,7 +184,7 @@ func TestConfirmSourceChange(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, proceed)
 		require.Contains(t, lastConfirmMessage(console),
-			`azure.ai.agents 1.0.0 is installed from source "azd". Upgrade to 2.0.0 from bundle?`)
+			`azure.ai.agents 1.0.0 is already installed from source "azd". Upgrade to 2.0.0 from bundle?`)
 	})
 
 	t.Run("DowngradeDeclined", func(t *testing.T) {
@@ -193,7 +198,28 @@ func TestConfirmSourceChange(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, proceed)
 		require.Contains(t, lastConfirmMessage(console),
-			`azure.ai.agents 1.0.0 is installed from source "azd". Downgrade to 0.9.0 from bundle?`)
+			`azure.ai.agents 1.0.0 is already installed from source "azd". Downgrade to 0.9.0 from bundle?`)
+	})
+
+	t.Run("InstalledFromBundleReadsWithArticle", func(t *testing.T) {
+		// Reverse direction: a bundle-installed extension being replaced from a
+		// registry source. The installed-from clause reads "a bundle".
+		bundleInstalled := &extensions.Extension{
+			Id:      "azure.ai.agents",
+			Version: "1.0.0",
+			Source:  extensions.BundleSourceName,
+		}
+		console := mockinput.NewMockConsole()
+		console.WhenConfirm(func(input.ConsoleOptions) bool { return true }).Respond(true)
+		action := newConfirmTestAction(console, false)
+
+		proceed, err := action.confirmSourceChange(
+			context.Background(), "Installing", bundleInstalled.Id, bundleInstalled, "azd", "1.0.0",
+		)
+		require.NoError(t, err)
+		require.True(t, proceed)
+		require.Contains(t, lastConfirmMessage(console),
+			`azure.ai.agents 1.0.0 is already installed from a bundle. Reinstall from source "azd"?`)
 	})
 
 	t.Run("NoPromptSkipsWithoutAsking", func(t *testing.T) {

--- a/cli/azd/cmd/extension_bundle_test.go
+++ b/cli/azd/cmd/extension_bundle_test.go
@@ -26,7 +26,7 @@ func TestIsBundleArg(t *testing.T) {
 	require.NoError(t, os.WriteFile(zipPath, []byte("zip"), 0600))
 
 	require.True(t, isBundleArg([]string{zipPath}))
-	require.True(t, isBundleArg([]string{filepath.Join(dir, "BUNDLE.ZIP")}) == false) // does not exist
+	require.False(t, isBundleArg([]string{filepath.Join(dir, "missing.zip")})) // does not exist
 	require.False(t, isBundleArg([]string{"some.extension.id"}))
 	require.False(t, isBundleArg([]string{zipPath, "other"}))
 	require.False(t, isBundleArg([]string{dir})) // directory, not a file

--- a/cli/azd/cmd/extension_bundle_test.go
+++ b/cli/azd/cmd/extension_bundle_test.go
@@ -4,16 +4,24 @@
 package cmd
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
 	"github.com/stretchr/testify/require"
 )
@@ -273,4 +281,243 @@ func TestVersionTransitionVerb(t *testing.T) {
 		require.Equal(t, tc.expected, versionTransitionVerb(tc.installed, tc.target),
 			"installed=%s target=%s", tc.installed, tc.target)
 	}
+}
+
+// makeBundleZip builds a minimal self-contained bundle .zip on disk containing a
+// registry.json (with the given extensions) plus a dummy artifact, and returns
+// its path. Artifact URLs in the registry should be relative (e.g.
+// "artifacts/ext.tar.gz") so the bundle source can anchor them.
+func makeBundleZip(t *testing.T, exts []*extensions.ExtensionMetadata) string {
+	t.Helper()
+
+	stagingDir := t.TempDir()
+	registry := &extensions.Registry{
+		SchemaVersion: extensions.CurrentRegistrySchemaVersion,
+		Extensions:    exts,
+	}
+	data, err := json.Marshal(registry)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(stagingDir, "registry.json"), data, 0600))
+	require.NoError(t, os.MkdirAll(filepath.Join(stagingDir, "artifacts"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(stagingDir, "artifacts", "ext.tar.gz"), []byte("x"), 0600))
+
+	zipPath := filepath.Join(t.TempDir(), "bundle.zip")
+	zipFile, err := os.Create(zipPath)
+	require.NoError(t, err)
+	defer zipFile.Close()
+
+	zw := zip.NewWriter(zipFile)
+	require.NoError(t, filepath.Walk(stagingDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(stagingDir, path)
+		if err != nil {
+			return err
+		}
+		w, err := zw.Create(filepath.ToSlash(rel))
+		if err != nil {
+			return err
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(b)
+		return err
+	}))
+	require.NoError(t, zw.Close())
+
+	return zipPath
+}
+
+// newBundleInstallTestAction wires up an install action backed by real extension
+// and source managers over a mock config, for exercising the bundle install
+// lifecycle. It returns the action and the user config manager so tests can seed
+// installed-extension state.
+func newBundleInstallTestAction(t *testing.T) (*extensionInstallAction, config.UserConfigManager) {
+	t.Helper()
+
+	mockContext := mocks.NewMockContext(t.Context())
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := extensions.NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*extensions.Runner, error) {
+		return extensions.NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := extensions.NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	action := &extensionInstallAction{
+		console:          mockinput.NewMockConsole(),
+		extensionManager: manager,
+		sourceManager:    sourceManager,
+		flags:            &extensionInstallFlags{global: &internal.GlobalCommandOptions{}},
+	}
+	return action, userConfigManager
+}
+
+func TestPrepareBundleInstall_Success(t *testing.T) {
+	t.Parallel()
+
+	action, _ := newBundleInstallTestAction(t)
+	zipPath := makeBundleZip(t, []*extensions.ExtensionMetadata{
+		{
+			Id:          "test.ext",
+			DisplayName: "Test Extension",
+			Versions: []extensions.ExtensionVersion{
+				{Version: "1.0.0", Artifacts: map[string]extensions.ExtensionArtifact{
+					"linux/amd64": {URL: "artifacts/ext.tar.gz"},
+				}},
+			},
+		},
+	})
+
+	err := action.prepareBundleInstall(context.Background(), zipPath)
+	require.NoError(t, err)
+
+	// The bundled extension is queued for install against the transient source.
+	require.Equal(t, []string{"test.ext"}, action.args)
+	require.NotEmpty(t, action.bundleSourceName)
+	require.Equal(t, action.bundleSourceName, action.flags.source)
+	require.NotEmpty(t, action.bundleTempDir)
+	require.DirExists(t, action.bundleTempDir)
+
+	// The transient source is registered and resolvable.
+	src, err := action.sourceManager.Get(context.Background(), action.bundleSourceName)
+	require.NoError(t, err)
+	require.Equal(t, extensions.SourceKindBundle, src.Type)
+
+	// Cleanup removes the transient source and temp dir.
+	action.cleanupBundleInstall(context.Background())
+	require.NoDirExists(t, action.bundleTempDir)
+	require.Empty(t, action.bundleSourceName)
+	_, err = action.sourceManager.Get(context.Background(), src.Name)
+	require.ErrorIs(t, err, extensions.ErrSourceNotFound)
+}
+
+func TestPrepareBundleInstall_MissingRegistry(t *testing.T) {
+	t.Parallel()
+
+	// A .zip without a registry.json at its root is rejected with guidance.
+	stagingDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(stagingDir, "not-registry.txt"), []byte("x"), 0600))
+	zipPath := filepath.Join(t.TempDir(), "bad.zip")
+	zipFile, err := os.Create(zipPath)
+	require.NoError(t, err)
+	zw := zip.NewWriter(zipFile)
+	w, err := zw.Create("not-registry.txt")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("x"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	require.NoError(t, zipFile.Close())
+
+	action, _ := newBundleInstallTestAction(t)
+	err = action.prepareBundleInstall(context.Background(), zipPath)
+	require.Error(t, err)
+	require.ErrorAs(t, err, new(*internal.ErrorWithSuggestion))
+
+	// Temp dir is recorded so the deferred cleanup can still reclaim it.
+	action.cleanupBundleInstall(context.Background())
+	require.Empty(t, action.bundleTempDir)
+}
+
+func TestCleanupBundleInstall_RepointsInstalledToBundle(t *testing.T) {
+	t.Parallel()
+
+	action, userConfigManager := newBundleInstallTestAction(t)
+	zipPath := makeBundleZip(t, []*extensions.ExtensionMetadata{
+		{
+			Id:          "test.ext",
+			DisplayName: "Test Extension",
+			Versions: []extensions.ExtensionVersion{
+				{Version: "1.0.0", Artifacts: map[string]extensions.ExtensionArtifact{
+					"linux/amd64": {URL: "artifacts/ext.tar.gz"},
+				}},
+			},
+		},
+	})
+
+	require.NoError(t, action.prepareBundleInstall(context.Background(), zipPath))
+
+	// Simulate an extension installed from the transient bundle source.
+	cfg, err := userConfigManager.Load()
+	require.NoError(t, err)
+	require.NoError(t, cfg.Set("extension.installed", map[string]*extensions.Extension{
+		"test.ext": {Id: "test.ext", Version: "1.0.0", Source: action.bundleSourceName},
+	}))
+	require.NoError(t, userConfigManager.Save(cfg))
+	require.NoError(t, action.extensionManager.ReloadUserConfig())
+
+	action.cleanupBundleInstall(context.Background())
+
+	// The installed record is re-pointed to the reserved bundle source.
+	installed, err := action.extensionManager.GetInstalled(extensions.FilterOptions{Id: "test.ext"})
+	require.NoError(t, err)
+	require.Equal(t, extensions.BundleSourceName, installed.Source)
+}
+
+func TestExtensionList_SurfacesBundleInstalledExtension(t *testing.T) {
+	t.Parallel()
+
+	mockContext := mocks.NewMockContext(t.Context())
+
+	// The default registry source is fetched over HTTP; return an empty registry
+	// so the installed (untracked) extension is surfaced solely by the local pass.
+	mockContext.HttpClient.When(func(*http.Request) bool { return true }).
+		RespondFn(func(request *http.Request) (*http.Response, error) {
+			return mocks.CreateHttpResponseWithBody(
+				request, http.StatusOK,
+				extensions.Registry{SchemaVersion: extensions.CurrentRegistrySchemaVersion})
+		})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := extensions.NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*extensions.Runner, error) {
+		return extensions.NewRunner(mockContext.CommandRunner), nil
+	})
+
+	// Seed an installed extension whose source is not backed by any configured
+	// registry (as a bundle-installed extension would be).
+	cfg, err := userConfigManager.Load()
+	require.NoError(t, err)
+	require.NoError(t, cfg.Set("extension.installed", map[string]*extensions.Extension{
+		"test.bundle.ext": {
+			Id:          "test.bundle.ext",
+			DisplayName: "Bundled Extension",
+			Version:     "1.0.0",
+			Source:      extensions.BundleSourceName,
+		},
+	}))
+	require.NoError(t, userConfigManager.Save(cfg))
+
+	manager, err := extensions.NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	action := &extensionListAction{
+		flags:            &extensionListFlags{},
+		formatter:        &output.JsonFormatter{},
+		console:          mockinput.NewMockConsole(),
+		writer:           &buf,
+		sourceManager:    sourceManager,
+		extensionManager: manager,
+	}
+
+	_, err = action.Run(context.Background())
+	require.NoError(t, err)
+
+	var rows []extensionListItem
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &rows))
+
+	var found *extensionListItem
+	for i := range rows {
+		if rows[i].Id == "test.bundle.ext" {
+			found = &rows[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "bundle-installed extension should be surfaced in list output")
+	require.Equal(t, extensions.BundleSourceName, found.Source)
+	require.Equal(t, "1.0.0", found.InstalledVersion)
 }

--- a/cli/azd/cmd/testdata/TestFigSpec.ts
+++ b/cli/azd/cmd/testdata/TestFigSpec.ts
@@ -5686,8 +5686,7 @@ const completionSpec: Fig.Spec = {
 						},
 					],
 					args: {
-						name: 'extension-id',
-						generators: azdGenerators.listExtensions,
+						name: 'extension-id|extension-bundle.zip',
 					},
 				},
 				{

--- a/cli/azd/cmd/testdata/TestFigSpec.ts
+++ b/cli/azd/cmd/testdata/TestFigSpec.ts
@@ -5687,6 +5687,8 @@ const completionSpec: Fig.Spec = {
 					],
 					args: {
 						name: 'extension-id|extension-bundle.zip',
+						generators: azdGenerators.listExtensions,
+						template: 'filepaths',
 					},
 				},
 				{

--- a/cli/azd/cmd/testdata/TestUsage-azd-extension-install.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-extension-install.snap
@@ -2,7 +2,7 @@
 Installs specified extensions.
 
 Usage
-  azd extension install <extension-id> [flags]
+  azd extension install <extension-id|extension-bundle.zip> [flags]
 
 Flags
     -f, --force          	: Force installation, including downgrades and reinstalls

--- a/cli/azd/docs/extensions/extension-resolution-and-versioning.md
+++ b/cli/azd/docs/extensions/extension-resolution-and-versioning.md
@@ -6,12 +6,14 @@ This document describes how the Azure Developer CLI (`azd`) resolves extensions 
 
 ### Source Types
 
-Extension sources are manifests that describe the extensions available for installation. Each source has a name, a type, and a location. `azd` supports two source types:
+Extension sources are manifests that describe the extensions available for installation. Each source has a name, a type, and a location. `azd` supports two configurable source types:
 
 | Type | Location | Description |
 |------|----------|-------------|
 | `url` | HTTP/HTTPS endpoint | Remote JSON manifest fetched over the network. |
 | `file` | Local filesystem path | Local JSON file, useful for development and offline scenarios. |
+
+In addition, extensions installed from a [self-contained bundle](#self-contained-bundles) are tagged with a reserved `bundle` source. `bundle` is not a configurable source type and never appears in `azd extension source list` — it simply marks an extension that has no live registry to track updates against. Such extensions are listed with their `bundle` source in `azd extension list` and are skipped by `azd extension upgrade`. The name `bundle` is reserved, so it cannot be used as a user-configured source name.
 
 Sources are configured in `~/.azd/config.json`. You can manage them with the following commands:
 
@@ -156,6 +158,75 @@ Once a version is resolved, installation proceeds through these steps:
    - Other — treated as a raw binary and copied directly
 7. **Set permissions** — On Unix-like systems, set the executable permission on the extension binary.
 8. **Update configuration** — Record the installed extension and version in `~/.azd/config.json` under the `extension.installed` section.
+
+### Re-installing over an existing extension
+
+`azd extension install <id>` keys off the extension **id**, so installing an id that is already present is handled based on whether the **source** is changing and on the version relationship. `--force` bypasses all of these guards.
+
+When the source is **not** changing (same source as the installed extension):
+
+- **Same version** — a no-op; the install is skipped.
+- **Newer version** — upgraded in place.
+- **Older version** — a downgrade; `azd` **prompts for confirmation** before replacing the newer install with an older one. Declining skips the install. In `--no-prompt` mode `azd` skips with guidance to pass `--force`, and `--force` proceeds without prompting.
+
+When the source **is** changing (for example installing a bundle build over a registry build, or vice versa), the artifacts may differ, so `azd` does not silently proceed, no-op, or block a downgrade. Instead it **prompts for confirmation** before replacing the installed extension. The prompt states the version transition explicitly — *Reinstall*, *Upgrade to `<version>`*, or *Downgrade to `<version>`* — and the target source. Declining skips the install; confirming reinstalls and re-points the extension to the new source. In `--no-prompt` mode `azd` skips with guidance to pass `--force`, and `--force` proceeds without prompting.
+
+Because each bundle install registers a unique transient source, installing from **any** bundle over an already-installed extension is always treated as a source change — so it prompts even when the bundled version matches the installed one (the two builds may not be byte-identical).
+
+If a required dependency cannot be resolved from the parent's source and is not already installed, the install fails with an actionable error directing you to install the dependency first (consistent with the no cross-source dependency resolution behavior described above).
+
+## Self-Contained Bundles
+
+A **self-contained bundle** is a single portable `.zip` that contains a well-known `registry.json` plus the extension artifacts it references. It lets you share a one-off build (for example, a PR build or an internal extension) without hosting a registry or making the artifacts reachable over the network — the recipient runs a single command to install everything from the file.
+
+### Producing a bundle
+
+Extension authors create a bundle with the `azd x` developer extension:
+
+```bash
+azd x pack --bundle
+```
+
+This builds the platform artifacts and emits a single `<id>_<version>.zip` whose root contains a `registry.json` and an `artifacts/` directory. The registry's artifact URLs are **relative** (for example, `artifacts/my-ext-linux-amd64.tar.gz`), and each artifact carries an embedded `sha256` checksum. Extension packs (which have no binaries of their own) are supported as registry-only bundles.
+
+### Installing a bundle
+
+Consumers install a bundle by passing its path to `azd extension install`:
+
+```bash
+azd extension install ./my-ext_1.0.0.zip
+```
+
+The install flow treats the bundle as an **installer, not a registry** — nothing about the bundle persists as a configured source once installation finishes:
+
+1. **Extract** the bundle into a temporary directory.
+2. **Register an ephemeral source** that reads the extracted `registry.json` and rewrites each relative artifact URL to an absolute path anchored inside the extracted directory. This is what allows the standard install flow — including checksum validation — to resolve the bundled artifacts unchanged. Relative paths that escape the bundle directory are rejected. The source name is transient and is never surfaced to the user.
+3. **Install** the bundled extension through the normal install path. Bundles are produced per extension by `azd x pack --bundle`, so a bundle declares a single extension.
+4. **Clean up** — once the extension is installed, `azd` re-points it to the reserved `bundle` source, removes the ephemeral source, and deletes the temporary extraction directory. The only durable state left behind is the installed extension itself (its binary under `~/.azd/extensions/<id>/` and its `extension.installed` record).
+
+### Lifecycle of a bundle-installed extension
+
+Because a bundle does not register a lasting source, a bundle-installed extension is tracked under the reserved `bundle` source:
+
+- `azd extension list` shows it with its `bundle` source and a normal `✓ Up to date` status. It has no "latest" version to compare against, so no update is ever reported.
+- `azd extension upgrade` skips bundle-installed extensions with a note that they were installed from a self-contained bundle.
+- `azd extension source list` does **not** show an entry for the bundle — there is no leftover source to clean up.
+
+To update a bundle-installed extension, install a newer bundle:
+
+```bash
+azd extension install ./my-ext_2.0.0.zip
+```
+
+To switch a bundle-installed extension back to a registry-tracked one, install it explicitly from a configured source:
+
+```bash
+azd extension install <extension-id> --source <source-name>
+```
+
+### Trust model
+
+Bundles run arbitrary extension binaries on your machine. The embedded `sha256` checksums protect the **integrity** of each artifact within the bundle (they guarantee the bytes were not altered after packing), but bundles are **not signed** — there is no verification of the publisher's identity. Only install bundles you obtained from a source you trust.
 
 ## Declaring Extensions in `azure.yaml`
 

--- a/cli/azd/extensions/microsoft.azd.extensions/CHANGELOG.md
+++ b/cli/azd/extensions/microsoft.azd.extensions/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.12.0 (Unreleased)
 
+- [[#8619]](https://github.com/Azure/azure-dev/issues/8619) Add `azd x pack --bundle` (alias `--zip`) to emit a portable bundle `.zip` containing a `registry.json` with relative artifact URLs plus the platform artifacts, installable via `azd extension install <bundle.zip>` without hosting a registry.
 - [[#8552]](https://github.com/Azure/azure-dev/pull/8552) Embed language template dotfiles so generated extensions include a `.gitignore` (the Go template excludes `bin/`).
 - [[#8552]](https://github.com/Azure/azure-dev/pull/8552) Warn during `azd x build` when the local extension source registry is missing or does not contain the extension, since the binaries are installed but the extension would not appear in `azd extension list`.
 - [[#8570]](https://github.com/Azure/azure-dev/pull/8570) Add `--internal` to `azd x init` to scaffold first-party Go extensions in the `Azure/azure-dev` repository, including CI workflows, release pipeline, and a suitable `.github/CODEOWNERS` entry.

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/bundle.go
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/bundle.go
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/extensions/microsoft.azd.extensions/internal"
+	"github.com/azure/azure-dev/cli/azd/extensions/microsoft.azd.extensions/internal/models"
+	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+)
+
+// bundleArtifactsDir is the directory within a self-contained bundle that holds
+// the per-platform artifact archives. Registry artifact URLs reference files
+// relative to this directory.
+const bundleArtifactsDir = "artifacts"
+
+// resolveBundleOutputPath determines the destination .zip path for a
+// self-contained bundle. When outputPath is empty the bundle is written to the
+// current working directory using a derived file name. When outputPath is a
+// directory the derived file name is placed within it; when it ends in .zip it
+// is used verbatim.
+func resolveBundleOutputPath(outputPath string, extensionMetadata *models.ExtensionSchema) (string, error) {
+	defaultName := fmt.Sprintf("%s_%s.zip", extensionMetadata.SafeDashId(), extensionMetadata.Version)
+
+	if outputPath == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("failed to get working directory: %w", err)
+		}
+		return filepath.Join(cwd, defaultName), nil
+	}
+
+	absOutputPath, err := filepath.Abs(outputPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve output path: %w", err)
+	}
+
+	if strings.EqualFold(filepath.Ext(absOutputPath), ".zip") {
+		return absOutputPath, nil
+	}
+
+	return filepath.Join(absOutputPath, defaultName), nil
+}
+
+// packSelfContainedBundle builds a portable bundle zip at bundleOutputPath. The
+// bundle contains a registry.json at its root (with artifact URLs relative to
+// the bundle) alongside the per-platform artifact archives under artifacts/.
+// Extension packs (which have no artifacts) produce a registry-only bundle.
+func packSelfContainedBundle(extensionMetadata *models.ExtensionSchema, bundleOutputPath string) error {
+	stagingDir, err := os.MkdirTemp("", "azd-ext-bundle-")
+	if err != nil {
+		return fmt.Errorf("failed to create staging directory: %w", err)
+	}
+	defer os.RemoveAll(stagingDir)
+
+	artifactMap := map[string]extensions.ExtensionArtifact{}
+
+	if !isExtensionPack(extensionMetadata) {
+		artifactsDir := filepath.Join(stagingDir, bundleArtifactsDir)
+		if err := packExtensionBinaries(extensionMetadata, artifactsDir); err != nil {
+			return fmt.Errorf("failed to package extension binaries: %w", err)
+		}
+
+		entries, err := os.ReadDir(artifactsDir)
+		if err != nil {
+			return fmt.Errorf("failed to read packaged artifacts: %w", err)
+		}
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+
+			artifactName := entry.Name()
+			osArch, err := internal.InferOSArch(artifactName)
+			if err != nil {
+				return fmt.Errorf("failed to infer os/arch from %q: %w", artifactName, err)
+			}
+
+			checksum, err := internal.ComputeChecksum(filepath.Join(artifactsDir, artifactName))
+			if err != nil {
+				return fmt.Errorf("failed to compute checksum for %q: %w", artifactName, err)
+			}
+
+			artifactMetadata, err := createPlatformMetadata(extensionMetadata, osArch, artifactName)
+			if err != nil {
+				return fmt.Errorf("failed to create platform metadata for %q: %w", artifactName, err)
+			}
+
+			artifactMap[osArch] = extensions.ExtensionArtifact{
+				// Forward slashes keep the URL portable across platforms.
+				URL: bundleArtifactsDir + "/" + artifactName,
+				Checksum: extensions.ExtensionChecksum{
+					Algorithm: "sha256",
+					Value:     checksum,
+				},
+				AdditionalMetadata: artifactMetadata,
+			}
+		}
+
+		if len(artifactMap) == 0 {
+			return fmt.Errorf("no artifacts were produced for the extension")
+		}
+	}
+
+	registry := &extensions.Registry{
+		SchemaVersion: extensions.CurrentRegistrySchemaVersion,
+	}
+	addOrUpdateExtension(registry, extensionMetadata, artifactMap)
+
+	registryPath := filepath.Join(stagingDir, extensions.BundleRegistryFileName)
+	if err := saveRegistry(registryPath, registry); err != nil {
+		return fmt.Errorf("failed to write bundle registry: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(bundleOutputPath), osutil.PermissionDirectory); err != nil {
+		return fmt.Errorf("failed to create bundle output directory: %w", err)
+	}
+
+	if err := zipDirectory(stagingDir, bundleOutputPath); err != nil {
+		return fmt.Errorf("failed to create bundle archive: %w", err)
+	}
+
+	return nil
+}
+
+// zipDirectory writes all files under sourceDir into a zip archive at target,
+// preserving the relative directory structure using forward-slash paths. It
+// writes to a temporary file and renames it onto target only after a fully
+// successful close, so a failed (re)pack never leaves a corrupt archive or
+// clobbers a previously good bundle.
+func zipDirectory(sourceDir string, target string) (err error) {
+	tempFile, err := os.CreateTemp(filepath.Dir(target), ".bundle-*.zip.tmp")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+
+	// Remove the temp file unless it is successfully committed (renamed) below.
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tempFile.Close()
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	zipWriter := zip.NewWriter(tempFile)
+
+	walkErr := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return err
+		}
+
+		header := &zip.FileHeader{
+			Name:     filepath.ToSlash(relPath),
+			Modified: info.ModTime(),
+			Method:   zip.Deflate,
+		}
+
+		headerWriter, err := zipWriter.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		_, err = io.Copy(headerWriter, file)
+		return err
+	})
+	if walkErr != nil {
+		return walkErr
+	}
+
+	// Close (flushing the central directory) and check both errors before the
+	// rename, so a failed flush is never reported as success.
+	if err := zipWriter.Close(); err != nil {
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tempPath, osutil.PermissionFile); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, target); err != nil {
+		return err
+	}
+
+	committed = true
+	return nil
+}

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/bundle.go
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/bundle.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"archive/zip"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -54,7 +55,11 @@ func resolveBundleOutputPath(outputPath string, extensionMetadata *models.Extens
 // bundle contains a registry.json at its root (with artifact URLs relative to
 // the bundle) alongside the per-platform artifact archives under artifacts/.
 // Extension packs (which have no artifacts) produce a registry-only bundle.
-func packSelfContainedBundle(extensionMetadata *models.ExtensionSchema, bundleOutputPath string) error {
+func packSelfContainedBundle(
+	ctx context.Context,
+	extensionMetadata *models.ExtensionSchema,
+	bundleOutputPath string,
+) error {
 	stagingDir, err := os.MkdirTemp("", "azd-ext-bundle-")
 	if err != nil {
 		return fmt.Errorf("failed to create staging directory: %w", err)
@@ -125,7 +130,7 @@ func packSelfContainedBundle(extensionMetadata *models.ExtensionSchema, bundleOu
 		return fmt.Errorf("failed to create bundle output directory: %w", err)
 	}
 
-	if err := zipDirectory(stagingDir, bundleOutputPath); err != nil {
+	if err := zipDirectory(ctx, stagingDir, bundleOutputPath); err != nil {
 		return fmt.Errorf("failed to create bundle archive: %w", err)
 	}
 
@@ -137,7 +142,7 @@ func packSelfContainedBundle(extensionMetadata *models.ExtensionSchema, bundleOu
 // writes to a temporary file and renames it onto target only after a fully
 // successful close, so a failed (re)pack never leaves a corrupt archive or
 // clobbers a previously good bundle.
-func zipDirectory(sourceDir string, target string) (err error) {
+func zipDirectory(ctx context.Context, sourceDir string, target string) (err error) {
 	tempFile, err := os.CreateTemp(filepath.Dir(target), ".bundle-*.zip.tmp")
 	if err != nil {
 		return err
@@ -203,7 +208,7 @@ func zipDirectory(sourceDir string, target string) (err error) {
 	if err := os.Chmod(tempPath, osutil.PermissionFile); err != nil {
 		return err
 	}
-	if err := os.Rename(tempPath, target); err != nil {
+	if err := osutil.Rename(ctx, tempPath, target); err != nil {
 		return err
 	}
 

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/bundle_test.go
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/bundle_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/extensions/microsoft.azd.extensions/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveBundleOutputPath(t *testing.T) {
+	t.Parallel()
+
+	ext := &models.ExtensionSchema{Id: "microsoft.test", Version: "1.2.3"}
+	expectedName := "microsoft-test_1.2.3.zip"
+
+	t.Run("empty uses cwd", func(t *testing.T) {
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		got, err := resolveBundleOutputPath("", ext)
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(cwd, expectedName), got)
+	})
+
+	t.Run("directory appends derived name", func(t *testing.T) {
+		dir := t.TempDir()
+		got, err := resolveBundleOutputPath(dir, ext)
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(dir, expectedName), got)
+	})
+
+	t.Run("explicit zip used verbatim", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "custom.zip")
+		got, err := resolveBundleOutputPath(target, ext)
+		require.NoError(t, err)
+		require.Equal(t, target, got)
+	})
+}
+
+func TestZipDirectory_PreservesStructure(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "registry.json"), []byte("{}"), 0600))
+	require.NoError(t, os.MkdirAll(filepath.Join(sourceDir, "artifacts"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "artifacts", "ext.zip"), []byte("bin"), 0600))
+
+	target := filepath.Join(t.TempDir(), "bundle.zip")
+	require.NoError(t, zipDirectory(sourceDir, target))
+
+	reader, err := zip.OpenReader(target)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	names := map[string]bool{}
+	for _, f := range reader.File {
+		names[f.Name] = true
+	}
+
+	// Nested directory structure is preserved with forward-slash paths.
+	require.True(t, names["registry.json"])
+	require.True(t, names["artifacts/ext.zip"])
+}
+
+func TestZipDirectory_OverwriteIsAtomic(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "registry.json"), []byte("{}"), 0600))
+
+	outDir := t.TempDir()
+	target := filepath.Join(outDir, "bundle.zip")
+
+	// A pre-existing file at the target is replaced cleanly.
+	require.NoError(t, os.WriteFile(target, []byte("stale"), 0600))
+	require.NoError(t, zipDirectory(sourceDir, target))
+
+	// Re-packing over the existing bundle succeeds.
+	require.NoError(t, zipDirectory(sourceDir, target))
+
+	// The result is a valid, readable zip.
+	reader, err := zip.OpenReader(target)
+	require.NoError(t, err)
+	defer reader.Close()
+	require.NotEmpty(t, reader.File)
+
+	// No temporary files are left behind in the output directory.
+	entries, err := os.ReadDir(outDir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		require.Equal(t, "bundle.zip", e.Name(), "unexpected leftover file %q", e.Name())
+	}
+}

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/bundle_test.go
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/bundle_test.go
@@ -52,7 +52,7 @@ func TestZipDirectory_PreservesStructure(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "artifacts", "ext.zip"), []byte("bin"), 0600))
 
 	target := filepath.Join(t.TempDir(), "bundle.zip")
-	require.NoError(t, zipDirectory(sourceDir, target))
+	require.NoError(t, zipDirectory(t.Context(), sourceDir, target))
 
 	reader, err := zip.OpenReader(target)
 	require.NoError(t, err)
@@ -79,10 +79,10 @@ func TestZipDirectory_OverwriteIsAtomic(t *testing.T) {
 
 	// A pre-existing file at the target is replaced cleanly.
 	require.NoError(t, os.WriteFile(target, []byte("stale"), 0600))
-	require.NoError(t, zipDirectory(sourceDir, target))
+	require.NoError(t, zipDirectory(t.Context(), sourceDir, target))
 
 	// Re-packing over the existing bundle succeeds.
-	require.NoError(t, zipDirectory(sourceDir, target))
+	require.NoError(t, zipDirectory(t.Context(), sourceDir, target))
 
 	// The result is a valid, readable zip.
 	reader, err := zip.OpenReader(target)

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/pack.go
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/pack.go
@@ -225,7 +225,7 @@ func runPackageAction(ctx context.Context, flags *packageFlags) (bool, error) {
 			Title: "Packaging extension",
 			Action: func(spf ux.SetProgressFunc) (ux.TaskState, error) {
 				if flags.bundle {
-					if err := packSelfContainedBundle(extensionMetadata, bundleOutputPath); err != nil {
+					if err := packSelfContainedBundle(ctx, extensionMetadata, bundleOutputPath); err != nil {
 						return ux.Error, common.NewDetailedError(
 							"Packaging failed",
 							fmt.Errorf("failed to create self-contained bundle: %w", err),

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/pack.go
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/pack.go
@@ -26,6 +26,8 @@ type packageFlags struct {
 	inputPath  string
 	outputPath string
 	rebuild    bool
+	bundle     bool
+	zip        bool
 }
 
 func newPackCommand(outputPath *string) *cobra.Command {
@@ -79,6 +81,21 @@ func newPackCommand(outputPath *string) *cobra.Command {
 		"Rebuild the extension before packaging.",
 	)
 
+	packageCmd.Flags().BoolVar(
+		&flags.bundle,
+		"bundle", false,
+		"Produce a single self-contained bundle (.zip) containing a registry.json and the "+
+			"extension artifacts, installable via 'azd extension install <bundle.zip>'.",
+	)
+
+	// --zip is a hidden alias for --bundle.
+	packageCmd.Flags().BoolVar(
+		&flags.zip,
+		"zip", false,
+		"Alias for --bundle.",
+	)
+	_ = packageCmd.Flags().MarkHidden("zip")
+
 	return packageCmd
 }
 
@@ -113,7 +130,15 @@ func runPackageAction(ctx context.Context, flags *packageFlags) (bool, error) {
 
 	extensionPack := isExtensionPack(extensionMetadata)
 
-	if flags.outputPath == "" && !extensionPack {
+	// For self-contained bundles the output is a single .zip file rather than a
+	// directory of artifacts. Resolve the destination bundle path up front.
+	var bundleOutputPath string
+	if flags.bundle {
+		bundleOutputPath, err = resolveBundleOutputPath(flags.outputPath, extensionMetadata)
+		if err != nil {
+			return false, err
+		}
+	} else if flags.outputPath == "" && !extensionPack {
 		localRegistryArtifactsPath, err := internal.LocalRegistryArtifactsPath()
 		if err != nil {
 			return false, err
@@ -127,12 +152,17 @@ func runPackageAction(ctx context.Context, flags *packageFlags) (bool, error) {
 		fmt.Printf("%s: Extension pack\n", output.WithBold("Extension Type"))
 	} else {
 		absInputPath := filepath.Join(extensionMetadata.Path, flags.inputPath)
+		fmt.Printf("%s: %s\n", output.WithBold("Input Path"), output.WithHyperlink(absInputPath, absInputPath))
+	}
+
+	if flags.bundle {
+		fmt.Printf("%s: %s\n", output.WithBold("Bundle"), output.WithHyperlink(bundleOutputPath, bundleOutputPath))
+	} else if !extensionPack {
 		absOutputPath, err := filepath.Abs(flags.outputPath)
 		if err != nil {
 			return false, fmt.Errorf("failed to get absolute path for output directory: %w", err)
 		}
 
-		fmt.Printf("%s: %s\n", output.WithBold("Input Path"), output.WithHyperlink(absInputPath, absInputPath))
 		fmt.Printf("%s: %s\n", output.WithBold("Output Path"), output.WithHyperlink(absOutputPath, absOutputPath))
 	}
 
@@ -194,6 +224,17 @@ func runPackageAction(ctx context.Context, flags *packageFlags) (bool, error) {
 		AddTask(ux.TaskOptions{
 			Title: "Packaging extension",
 			Action: func(spf ux.SetProgressFunc) (ux.TaskState, error) {
+				if flags.bundle {
+					if err := packSelfContainedBundle(extensionMetadata, bundleOutputPath); err != nil {
+						return ux.Error, common.NewDetailedError(
+							"Packaging failed",
+							fmt.Errorf("failed to create self-contained bundle: %w", err),
+						)
+					}
+
+					return ux.Success, nil
+				}
+
 				if extensionPack {
 					spf("Extension packs contain no artifacts; nothing to package")
 					return ux.Skipped, nil
@@ -210,7 +251,13 @@ func runPackageAction(ctx context.Context, flags *packageFlags) (bool, error) {
 			},
 		})
 
-	return extensionPack, taskList.Run()
+	// A self-contained bundle is always produced (even for extension packs), so
+	// report it as a successful package rather than an empty extension pack.
+	if err := taskList.Run(); err != nil {
+		return false, err
+	}
+
+	return extensionPack && !flags.bundle, nil
 }
 
 func packExtensionBinaries(
@@ -264,6 +311,10 @@ func packExtensionBinaries(
 func defaultPackageFlags(flags *packageFlags) {
 	if flags.inputPath == "" {
 		flags.inputPath = "bin"
+	}
+	// --zip is an alias for --bundle.
+	if flags.zip {
+		flags.bundle = true
 	}
 }
 

--- a/cli/azd/internal/figspec/customizations.go
+++ b/cli/azd/internal/figspec/customizations.go
@@ -88,7 +88,7 @@ func (c *Customizations) GetCommandArgGenerator(ctx *CommandContext, argName str
 		if argName == "template" {
 			return FigGenListTemplates
 		}
-	case "azd extension install", "azd extension show":
+	case "azd extension show":
 		if argName == "extension-id" {
 			return FigGenListExtensions
 		}
@@ -139,6 +139,12 @@ func (c *Customizations) GetCommandArgs(ctx *CommandContext) []Arg {
 	case "azd hooks run":
 		return []Arg{
 			{Name: "name", Suggestions: hookNameValues},
+		}
+	case "azd extension install":
+		// The argument is either an extension id or a path to a self-contained
+		// bundle (.zip), so offer both id completion and file-path suggestions.
+		return []Arg{
+			{Name: "extension-id|extension-bundle.zip", Generator: FigGenListExtensions, Template: "filepaths"},
 		}
 	}
 

--- a/cli/azd/internal/figspec/figspec_coverage_test.go
+++ b/cli/azd/internal/figspec/figspec_coverage_test.go
@@ -750,7 +750,8 @@ func TestCustomizations_GetCommandArgGenerator(t *testing.T) {
 		{"env_get_value_other", "azd env get-value", "other", ""},
 		{"env_select", "azd env select", "environment", FigGenListEnvironments},
 		{"template_show", "azd template show", "template", FigGenListTemplates},
-		{"ext_install", "azd extension install", "extension-id", FigGenListExtensions},
+		// install is handled via GetCommandArgs (combined id|zip arg), not here.
+		{"ext_install", "azd extension install", "extension-id", ""},
 		{"ext_show", "azd extension show", "extension-id", FigGenListExtensions},
 		{"ext_upgrade", "azd extension upgrade", "extension-id", FigGenListInstalledExtensions},
 		{"ext_uninstall", "azd extension uninstall", "extension-id", FigGenListInstalledExtensions},
@@ -826,6 +827,16 @@ func TestCustomizations_GetCommandArgs(t *testing.T) {
 				require.True(t, args[0].IsOptional)
 			})
 		}
+	})
+
+	t.Run("ext_install", func(t *testing.T) {
+		ctx := &CommandContext{CommandPath: "azd extension install"}
+		args := c.GetCommandArgs(ctx)
+		require.Len(t, args, 1)
+		require.Equal(t, "extension-id|extension-bundle.zip", args[0].Name)
+		// Offers both extension-id completion and file-path suggestions.
+		require.Equal(t, FigGenListExtensions, args[0].Generator)
+		require.Equal(t, "filepaths", args[0].Template)
 	})
 
 	t.Run("unknown", func(t *testing.T) {

--- a/cli/azd/pkg/extensions/bundle_source.go
+++ b/cli/azd/pkg/extensions/bundle_source.go
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package extensions
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+)
+
+// BundleRegistryFileName is the well-known registry file name expected at the
+// root of a self-contained extension bundle.
+const BundleRegistryFileName = "registry.json"
+
+// newBundleSource creates a new extension source backed by an extracted
+// self-contained extension bundle. A bundle is a directory (typically the
+// extraction target of a portable .zip) that contains a registry.json at its
+// root alongside artifact archives referenced by paths relative to that
+// directory.
+//
+// Unlike a plain file source, a bundle source rewrites relative artifact URLs
+// to absolute paths anchored at the bundle directory. This allows the bundle to
+// be fully portable: the registry.json author does not need to know the final
+// extraction location, and the installer's local-path artifact handling works
+// unchanged because it receives absolute paths.
+func newBundleSource(name string, location string) (Source, error) {
+	bundleDir, registryPath, err := resolveBundlePaths(location)
+	if err != nil {
+		return nil, err
+	}
+
+	registryBytes, err := os.ReadFile(registryPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading bundle registry '%s': %w", registryPath, err)
+	}
+
+	var registry *Registry
+	if err := json.Unmarshal(registryBytes, &registry); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal bundle registry '%s': %w", registryPath, err)
+	}
+
+	if registry == nil {
+		return nil, fmt.Errorf("bundle registry '%s' is empty or null", registryPath)
+	}
+
+	if err := CheckRegistrySchemaVersion(registry.SchemaVersion); err != nil {
+		return nil, err
+	}
+
+	if err := anchorRelativeArtifacts(registry, bundleDir); err != nil {
+		return nil, err
+	}
+
+	return newRegistrySource(name, registry)
+}
+
+// resolveBundlePaths normalizes a bundle source location to the bundle directory
+// and the absolute path of its registry.json. The location may be either the
+// bundle directory itself or the path to the registry.json within it.
+func resolveBundlePaths(location string) (bundleDir string, registryPath string, err error) {
+	absLocation, err := filepath.Abs(location)
+	if err != nil {
+		return "", "", fmt.Errorf("failed resolving bundle location '%s': %w", location, err)
+	}
+
+	info, err := os.Stat(absLocation)
+	if err != nil {
+		return "", "", fmt.Errorf("failed accessing bundle location '%s': %w", location, err)
+	}
+
+	if info.IsDir() {
+		bundleDir = absLocation
+		registryPath = filepath.Join(absLocation, BundleRegistryFileName)
+	} else {
+		bundleDir = filepath.Dir(absLocation)
+		registryPath = absLocation
+	}
+
+	return bundleDir, registryPath, nil
+}
+
+// anchorRelativeArtifacts rewrites relative artifact URLs in the registry to
+// absolute paths rooted at bundleDir. Absolute paths and remote (http/https)
+// URLs are left untouched. Relative paths that escape the bundle directory are
+// rejected to prevent path traversal.
+func anchorRelativeArtifacts(registry *Registry, bundleDir string) error {
+	for _, extension := range registry.Extensions {
+		for vi := range extension.Versions {
+			version := &extension.Versions[vi]
+			for key, artifact := range version.Artifacts {
+				resolved, err := anchorArtifactURL(artifact.URL, bundleDir)
+				if err != nil {
+					return fmt.Errorf(
+						"extension '%s' version '%s' artifact '%s': %w",
+						extension.Id, version.Version, key, err,
+					)
+				}
+
+				artifact.URL = resolved
+				version.Artifacts[key] = artifact
+			}
+		}
+	}
+
+	return nil
+}
+
+// anchorArtifactURL converts a relative artifact URL to an absolute path within
+// bundleDir. Remote URLs and already-absolute paths are returned unchanged.
+func anchorArtifactURL(url string, bundleDir string) (string, error) {
+	if url == "" {
+		return url, nil
+	}
+
+	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
+		return url, nil
+	}
+
+	if filepath.IsAbs(url) {
+		return url, nil
+	}
+
+	resolved := filepath.Join(bundleDir, filepath.FromSlash(url))
+	if !osutil.IsPathContained(bundleDir, resolved) {
+		return "", fmt.Errorf(
+			"artifact path %q resolves outside the bundle directory; relative paths must not contain '..' sequences",
+			url,
+		)
+	}
+
+	return resolved, nil
+}

--- a/cli/azd/pkg/extensions/bundle_source_test.go
+++ b/cli/azd/pkg/extensions/bundle_source_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package extensions
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeBundleRegistry(t *testing.T, dir string, registry *Registry) string {
+	t.Helper()
+
+	data, err := json.Marshal(registry)
+	require.NoError(t, err)
+
+	registryPath := filepath.Join(dir, BundleRegistryFileName)
+	require.NoError(t, os.WriteFile(registryPath, data, 0600))
+
+	return registryPath
+}
+
+func TestNewBundleSource_AnchorsRelativeArtifacts(t *testing.T) {
+	t.Parallel()
+
+	bundleDir := t.TempDir()
+	remoteURL := "https://example.com/ext.zip"
+	registry := &Registry{
+		SchemaVersion: CurrentRegistrySchemaVersion,
+		Extensions: []*ExtensionMetadata{
+			{
+				Id:          "test.ext",
+				DisplayName: "Test",
+				Versions: []ExtensionVersion{
+					{
+						Version: "1.0.0",
+						Artifacts: map[string]ExtensionArtifact{
+							"linux/amd64":  {URL: "artifacts/ext-linux-amd64.tar.gz"},
+							"darwin/arm64": {URL: remoteURL},
+						},
+					},
+				},
+			},
+		},
+	}
+	writeBundleRegistry(t, bundleDir, registry)
+
+	source, err := newBundleSource("bundle", bundleDir)
+	require.NoError(t, err)
+
+	exts, err := source.ListExtensions(t.Context())
+	require.NoError(t, err)
+	require.Len(t, exts, 1)
+
+	artifacts := exts[0].Versions[0].Artifacts
+
+	// Relative artifact URL is anchored to an absolute path within the bundle dir.
+	expected := filepath.Join(bundleDir, "artifacts", "ext-linux-amd64.tar.gz")
+	require.Equal(t, expected, artifacts["linux/amd64"].URL)
+	require.True(t, filepath.IsAbs(artifacts["linux/amd64"].URL))
+
+	// Remote URLs are left untouched.
+	require.Equal(t, remoteURL, artifacts["darwin/arm64"].URL)
+}
+
+func TestNewBundleSource_LocationAsRegistryFile(t *testing.T) {
+	t.Parallel()
+
+	bundleDir := t.TempDir()
+	registry := &Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id:          "test.ext",
+				DisplayName: "Test",
+				Versions: []ExtensionVersion{
+					{
+						Version:   "1.0.0",
+						Artifacts: map[string]ExtensionArtifact{"linux/amd64": {URL: "bin/ext"}},
+					},
+				},
+			},
+		},
+	}
+	registryPath := writeBundleRegistry(t, bundleDir, registry)
+
+	source, err := newBundleSource("bundle", registryPath)
+	require.NoError(t, err)
+
+	exts, err := source.ListExtensions(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(bundleDir, "bin", "ext"), exts[0].Versions[0].Artifacts["linux/amd64"].URL)
+}
+
+func TestNewBundleSource_RejectsPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	bundleDir := t.TempDir()
+	registry := &Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id:          "test.ext",
+				DisplayName: "Test",
+				Versions: []ExtensionVersion{
+					{
+						Version:   "1.0.0",
+						Artifacts: map[string]ExtensionArtifact{"linux/amd64": {URL: "../../etc/passwd"}},
+					},
+				},
+			},
+		},
+	}
+	writeBundleRegistry(t, bundleDir, registry)
+
+	_, err := newBundleSource("bundle", bundleDir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "outside the bundle directory")
+}
+
+func TestNewBundleSource_MissingRegistry(t *testing.T) {
+	t.Parallel()
+
+	_, err := newBundleSource("bundle", t.TempDir())
+	require.Error(t, err)
+}
+
+func TestAnchorArtifactURL_AbsolutePathUnchanged(t *testing.T) {
+	t.Parallel()
+
+	bundleDir := t.TempDir()
+	abs := filepath.Join(bundleDir, "artifacts", "ext")
+	if runtime.GOOS == "windows" {
+		abs = `C:\some\path\ext`
+	}
+
+	result, err := anchorArtifactURL(abs, bundleDir)
+	require.NoError(t, err)
+	require.Equal(t, abs, result)
+}

--- a/cli/azd/pkg/extensions/manager.go
+++ b/cli/azd/pkg/extensions/manager.go
@@ -14,6 +14,7 @@ import (
 	"hash"
 	"io"
 	"log"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -46,6 +47,59 @@ var (
 	ErrRegistryExtensionNotFound  = errors.New("extension not found in registry")
 	ErrExtensionInstalled         = errors.New("extension already installed")
 )
+
+// DependencyNotFoundError indicates that a required dependency of an extension
+// could not be located in the same source as its parent. azd does not perform
+// cross-source dependency resolution during install, so the dependency must be
+// available in the parent's source or already installed.
+type DependencyNotFoundError struct {
+	// DependencyId is the id of the dependency that could not be resolved.
+	DependencyId string
+	// ParentId is the id of the extension that declares the dependency.
+	ParentId string
+}
+
+func (e *DependencyNotFoundError) Error() string {
+	return fmt.Sprintf("dependency %s required by %s was not found", e.DependencyId, e.ParentId)
+}
+
+// DependencyAmbiguousSourceError indicates that a required dependency of an
+// extension was found in more than one configured source, so azd cannot decide
+// which one to use. The caller must disambiguate by specifying an exact source.
+type DependencyAmbiguousSourceError struct {
+	// DependencyId is the id of the dependency that matched multiple sources.
+	DependencyId string
+	// ParentId is the id of the extension that declares the dependency.
+	ParentId string
+	// Sources lists the source names the dependency was found in.
+	Sources []string
+}
+
+func (e *DependencyAmbiguousSourceError) Error() string {
+	if len(e.Sources) > 0 {
+		return fmt.Sprintf(
+			"dependency %s required by %s was found in multiple sources (%s); specify an exact source",
+			e.DependencyId, e.ParentId, strings.Join(e.Sources, ", "),
+		)
+	}
+	return fmt.Sprintf(
+		"dependency %s required by %s was found in multiple sources; specify an exact source",
+		e.DependencyId, e.ParentId,
+	)
+}
+
+// dependencySources returns the de-duplicated, sorted source names present in a
+// set of extension matches. It is used to report which sources a dependency was
+// found in when the match is ambiguous.
+func dependencySources(matches []*ExtensionMetadata) []string {
+	seen := map[string]struct{}{}
+	for _, m := range matches {
+		if m.Source != "" {
+			seen[m.Source] = struct{}{}
+		}
+	}
+	return slices.Sorted(maps.Keys(seen))
+}
 
 // FilterOptions is used to filter, lookup, and list extensions with various criteria
 type FilterOptions struct {
@@ -537,11 +591,15 @@ func (m *Manager) installInternal(
 			}
 
 			if len(dependencyMatches) == 0 {
-				return nil, fmt.Errorf("dependency %s not found", dependency.Id)
+				return nil, &DependencyNotFoundError{DependencyId: dependency.Id, ParentId: extension.Id}
 			}
 
 			if len(dependencyMatches) > 1 {
-				return nil, fmt.Errorf("dependency %s found in multiple sources, specify exact source", dependency.Id)
+				return nil, &DependencyAmbiguousSourceError{
+					DependencyId: dependency.Id,
+					ParentId:     extension.Id,
+					Sources:      dependencySources(dependencyMatches),
+				}
 			}
 
 			dependencyMetadata := dependencyMatches[0]
@@ -1026,7 +1084,11 @@ func (m *Manager) findDependencyChild(
 		return nil, fmt.Errorf("dependency %s not found in any registry", childId)
 	}
 	if len(matches) > 1 {
-		return nil, fmt.Errorf("dependency %s found in multiple sources, specify exact source", childId)
+		return nil, &DependencyAmbiguousSourceError{
+			DependencyId: childId,
+			ParentId:     parent.Id,
+			Sources:      dependencySources(matches),
+		}
 	}
 	return matches[0], nil
 }
@@ -1133,11 +1195,34 @@ func (m *Manager) copyFromLocalPath(artifactPath string) (string, error) {
 	return tempFilePath, nil
 }
 
+// InvalidateSourceCache clears the in-memory extension source cache so that
+// subsequent source lookups re-read the configured sources. This is required
+// when a source is added within the same process (e.g. registering a bundle
+// source during install) after the source list may already have been cached.
+func (tm *Manager) InvalidateSourceCache() {
+	tm.sources = nil
+}
+
+// ReloadUserConfig re-reads the user configuration from disk into the manager's
+// cached copy. This is required when the configuration is mutated out-of-band
+// within the same process (e.g. registering a bundle source during install);
+// without it, a subsequent install save would persist the manager's stale
+// snapshot and clobber the externally added changes.
+func (tm *Manager) ReloadUserConfig() error {
+	userConfig, err := tm.configManager.Load()
+	if err != nil {
+		return fmt.Errorf("reloading user configuration: %w", err)
+	}
+
+	tm.userConfig = userConfig
+	tm.installed = nil
+	return nil
+}
+
 func (tm *Manager) getSources(ctx context.Context, filter sourceFilterPredicate) ([]Source, error) {
 	if tm.sources != nil {
 		return tm.sources, nil
 	}
-
 	configs, err := tm.sourceManager.List(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed parsing extension sources: %w", err)

--- a/cli/azd/pkg/extensions/manager_test.go
+++ b/cli/azd/pkg/extensions/manager_test.go
@@ -9,6 +9,8 @@ import (
 	"crypto/sha512"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -193,6 +195,33 @@ func Test_List_Install_Uninstall_Flow(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, installed)
 	require.Equal(t, 0, len(installed))
+}
+
+func Test_ReloadUserConfig_PicksUpOutOfBandChanges(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	// Mutate the user configuration out-of-band, after the manager has cached its snapshot.
+	err = sourceManager.Add(*mockContext.Context, "my-bundle", &SourceConfig{
+		Type:     SourceKindBundle,
+		Location: "/tmp/bundle",
+	})
+	require.NoError(t, err)
+
+	sourcePath := fmt.Sprintf("%s.%s", baseConfigKey, "my-bundle")
+
+	// After reloading, the cached snapshot reflects the out-of-band change, so a
+	// subsequent install save will not clobber the newly added source.
+	require.NoError(t, manager.ReloadUserConfig())
+	_, ok := manager.userConfig.Get(sourcePath)
+	require.True(t, ok)
 }
 
 func Test_Install_With_SemverConstraints(t *testing.T) {
@@ -2738,4 +2767,58 @@ func Test_Upgrade_DependencyUpgrade_NoOpStillPinsForSiblings(t *testing.T) {
 	cFinal, err := manager.GetInstalled(FilterOptions{Id: "leaf.c"})
 	require.NoError(t, err)
 	require.Equal(t, "1.0.0", cFinal.Version)
+}
+
+func Test_DependencyNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	err := &DependencyNotFoundError{DependencyId: "azure.ai.inspector", ParentId: "azure.ai.agents"}
+	require.Contains(t, err.Error(), "azure.ai.inspector")
+	require.Contains(t, err.Error(), "azure.ai.agents")
+
+	// Unwraps correctly through fmt.Errorf chains.
+	wrapped := fmt.Errorf("install failed: %w", err)
+	typed, ok := errorsAsDependencyNotFound(wrapped)
+	require.True(t, ok)
+	require.Equal(t, "azure.ai.inspector", typed.DependencyId)
+}
+
+func errorsAsDependencyNotFound(err error) (*DependencyNotFoundError, bool) {
+	return errors.AsType[*DependencyNotFoundError](err)
+}
+
+func Test_DependencyAmbiguousSourceError(t *testing.T) {
+	t.Parallel()
+
+	err := &DependencyAmbiguousSourceError{
+		DependencyId: "azure.ai.inspector",
+		ParentId:     "azure.ai.agents",
+		Sources:      []string{"azd", "dev"},
+	}
+	msg := err.Error()
+	require.Contains(t, msg, "azure.ai.inspector")
+	require.Contains(t, msg, "azure.ai.agents")
+	require.Contains(t, msg, "azd, dev")
+
+	// Degrades gracefully when no sources are captured.
+	noSources := &DependencyAmbiguousSourceError{DependencyId: "x", ParentId: "y"}
+	require.Contains(t, noSources.Error(), "multiple sources")
+
+	// Unwraps correctly through fmt.Errorf chains.
+	wrapped := fmt.Errorf("install failed: %w", err)
+	typed, ok := errors.AsType[*DependencyAmbiguousSourceError](wrapped)
+	require.True(t, ok)
+	require.Equal(t, []string{"azd", "dev"}, typed.Sources)
+}
+
+func Test_dependencySources(t *testing.T) {
+	t.Parallel()
+
+	matches := []*ExtensionMetadata{
+		{Id: "x", Source: "dev"},
+		{Id: "x", Source: "azd"},
+		{Id: "x", Source: "dev"}, // duplicate
+		{Id: "x", Source: ""},    // empty ignored
+	}
+	require.Equal(t, []string{"azd", "dev"}, dependencySources(matches))
 }

--- a/cli/azd/pkg/extensions/source_manager.go
+++ b/cli/azd/pkg/extensions/source_manager.go
@@ -22,15 +22,26 @@ type SourceKind string
 const (
 	SourceKindFile SourceKind = "file"
 	SourceKindUrl  SourceKind = "url"
+	// SourceKindBundle is a self-contained extension bundle extracted from a
+	// portable .zip. It behaves like a file source but anchors relative
+	// artifact paths to the extracted bundle directory.
+	SourceKindBundle SourceKind = "bundle"
 
 	baseConfigKey      string = "extension.sources"
 	installedConfigKey string = "extension.installed"
+
+	// BundleSourceName is the reserved source recorded for extensions installed
+	// from a self-contained bundle (.zip). The bundle's own source is ephemeral
+	// and removed after install, so the extension is marked with this name; it has
+	// no live registry to track updates against and cannot be user-configured.
+	BundleSourceName string = "bundle"
 )
 
 var (
 	ErrSourceNotFound    = errors.New("extension source not found")
 	ErrSourceExists      = errors.New("extension source already exists")
 	ErrSourceTypeInvalid = errors.New("invalid extension source type")
+	ErrSourceReserved    = errors.New("extension source name is reserved")
 )
 
 // SourceConfig represents the configuration for an extension source.
@@ -78,6 +89,13 @@ func (sm *SourceManager) Get(ctx context.Context, name string) (*SourceConfig, e
 // Add adds a new extension source.
 func (sm *SourceManager) Add(ctx context.Context, name string, source *SourceConfig) error {
 	newKey := normalizeKey(name)
+
+	if strings.EqualFold(newKey, BundleSourceName) {
+		return fmt.Errorf(
+			"'%s' is reserved for extensions installed from a self-contained bundle, %w",
+			BundleSourceName, ErrSourceReserved,
+		)
+	}
 
 	existing, err := sm.Get(ctx, newKey)
 	if existing != nil && err == nil {
@@ -190,6 +208,8 @@ func (sm *SourceManager) CreateSource(ctx context.Context, config *SourceConfig)
 	switch config.Type {
 	case SourceKindFile:
 		source, err = newFileSource(config.Name, config.Location)
+	case SourceKindBundle:
+		source, err = newBundleSource(config.Name, config.Location)
 	case SourceKindUrl:
 		source, err = newUrlSource(ctx, config.Name, config.Location, sm.transport)
 	default:

--- a/cli/azd/pkg/extensions/source_manager_test.go
+++ b/cli/azd/pkg/extensions/source_manager_test.go
@@ -38,6 +38,22 @@ func TestSourceManager_Add(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrSourceExists)
 	})
+
+	t.Run("ReservedBundleName", func(t *testing.T) {
+		reserved := &SourceConfig{
+			Name:     BundleSourceName,
+			Type:     SourceKindFile,
+			Location: "/tmp/registry.json",
+		}
+		err := sourceManager.Add(ctx, BundleSourceName, reserved)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrSourceReserved)
+
+		// Case-insensitive: the normalized name is also reserved.
+		err = sourceManager.Add(ctx, "Bundle", reserved)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrSourceReserved)
+	})
 }
 
 func TestSourceManager_Get(t *testing.T) {
@@ -128,4 +144,38 @@ func TestSourceManager_List(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, sources, 1)
 	require.Equal(t, expected, *sources[0])
+}
+
+func TestSourceManager_CreateSource_Bundle(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+	ctx := t.Context()
+
+	configManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, configManager, mockContext.HttpClient)
+
+	bundleDir := t.TempDir()
+	registry := &Registry{
+		SchemaVersion: CurrentRegistrySchemaVersion,
+		Extensions: []*ExtensionMetadata{
+			{
+				Id:          "test.ext",
+				DisplayName: "Test",
+				Versions: []ExtensionVersion{
+					{
+						Version:   "1.0.0",
+						Artifacts: map[string]ExtensionArtifact{"linux/amd64": {URL: "artifacts/ext.tar.gz"}},
+					},
+				},
+			},
+		},
+	}
+	writeBundleRegistry(t, bundleDir, registry)
+
+	source, err := sourceManager.CreateSource(ctx, &SourceConfig{
+		Name:     "bundle",
+		Type:     SourceKindBundle,
+		Location: bundleDir,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "bundle", source.Name())
 }


### PR DESCRIPTION
Resolves #8619
Relates to #7317

This PR adds self-contained extension bundles so an extension build can be shared and installed from a single `.zip` without hosting or configuring a registry. This makes it easy to hand off a PR or internal build to a partner team for testing: the author packs a bundle, and the consumer installs it with one command, with no source build from scratch and no waiting for a release.

### Producing a bundle (`azd x pack --bundle`)

`azd x pack` gains a `--bundle` flag (with a hidden `--zip` alias) that emits a portable `.zip` containing a well-known `registry.json` plus the per-platform extension artifacts under `artifacts/`. The registry's artifact URLs are relative paths anchored to the bundle, and each artifact keeps its embedded `sha256` checksum, so the standard install flow — including checksum validation — resolves the bundled artifacts unchanged. Bundle creation is atomic: it writes to a temporary file and renames onto the destination only after a fully successful close, so a failed or interrupted re-pack never corrupts or clobbers an existing bundle. Extension packs (which have no binaries of their own) are supported as registry-only bundles.

<img width="665" height="322" alt="image" src="https://github.com/user-attachments/assets/eb3acbc8-c387-490f-8246-c9c108138590" />

### Installing a bundle (`azd extension install <bundle.zip>`)

Passing a `.zip` path to `azd extension install` extracts it, registers an ephemeral source over the extracted directory, installs the bundled extension through the normal install path, and then cleans up — re-pointing the installed extension to a reserved `bundle` source, removing the transient source, and deleting the temporary directory.

The bundle is treated as an installer rather than a registry: nothing about it persists as a configured source, and the only durable state left behind is the installed extension itself. The ephemeral source anchors relative artifact URLs to absolute paths inside the extracted directory and rejects any path that escapes it. The `bundle` source name is reserved and cannot be used for a user-configured source.

Because a bundle does not register a lasting source, a bundle-installed extension has no live registry to track updates against. It is surfaced in `azd extension list` under its `bundle` source and is skipped by `azd extension upgrade`; to update one, install a newer bundle.

**Installation**

<img width="868" height="173" alt="image" src="https://github.com/user-attachments/assets/3c230968-32c3-43c1-b034-f7a959828973" />

**`azd ext list`**

<img width="695" height="255" alt="image" src="https://github.com/user-attachments/assets/3deba6a6-f13c-40dd-afee-671eef98e6ce" />

### Installing over an existing extension

Installing an extension that is already installed but from a different source — for example installing a bundle build over a registry build, or vice versa — now prompts for confirmation before replacing it, since the artifacts may differ. The prompt states the version transition explicitly (Reinstall, Upgrade to `<version>`, or Downgrade to `<version>`) and the target source. Same-source downgrades likewise prompt rather than silently skipping. `--force` bypasses the prompt and `--no-prompt` skips with guidance to pass `--force`. As part of this, the install flow no longer silently no-ops when the same version is already installed from a different source, and a required dependency that cannot be resolved from the same source now produces an actionable error pointing the user to install the dependency first.

**Bundle → source**

<img width="706" height="101" alt="image" src="https://github.com/user-attachments/assets/2866e214-6620-48a7-b824-7d5305215084" />

**Source → bundle**

<img width="869" height="115" alt="image" src="https://github.com/user-attachments/assets/696911da-4fee-4a3f-aa7b-3098a442a0e5" />

**Downgrading**

<img width="872" height="115" alt="image" src="https://github.com/user-attachments/assets/b92f6ee3-fc85-47f9-9f5d-f1dba60db25e" />

**Upgrading**

<img width="869" height="112" alt="image" src="https://github.com/user-attachments/assets/d3cef2c2-e4ce-4d69-ae7f-606760b41174" />

### Implementation notes

A `Manager.ReloadUserConfig` was added so the install save does not clobber the just-registered transient bundle source (the manager caches a snapshot of user config at startup), and a typed `DependencyNotFoundError` carries the parent/dependency ids for the actionable suggestion. The trust model is unchanged and worth calling out: embedded `sha256` checksums protect the integrity of each artifact within a bundle, but bundles are not signed — only install bundles you obtained from a source you trust.