### PR TITLE
feat(agents): default hosted agent deploy mode to code for Python/.NET

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.41-preview (2026-06-19)
 
+- [[#8706]](https://github.com/Azure/azure-dev/pull/8706) `azd ai agent init` now defaults to **code deploy** (source ZIP upload) for Python and .NET hosted agents instead of container (Docker image) deploy. This applies to the interactive prompt, `--no-prompt`, and `-m` manifest flows. Projects that are not Python/.NET continue to use container deploy. To keep using a Docker image, pass `--deploy-mode container` (or select "Container Image (Docker)" in the prompt). With code deploy in `--no-prompt`, `--runtime` and `--entry-point` are now auto-detected from the project when omitted.
 - [[#8731]](https://github.com/Azure/azure-dev/pull/8731) Improve the post-deploy `Next:` guidance with a stacked layout that puts each command on its own line above its description, adds a blank line between suggestions, and highlights `azd` commands. The new layout applies across deploy, `azd ai agent show`, `init`, and `doctor`. Thanks @therealjohn for the contribution!
 - [[#8645]](https://github.com/Azure/azure-dev/pull/8645) Detect VNET-injected Foundry accounts during `azd ai agent init` and skip remote builds up front so hosted container agents use local builds without a failing remote-build attempt first. Thanks @m5i-work for the contribution!
 - [[#8714]](https://github.com/Azure/azure-dev/pull/8714) Show a tracing disclaimer when `azd ai agent init` connects or adds an Application Insights connection. Thanks @therealjohn for the contribution!

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -886,9 +886,11 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
   # Initialize from local agent code
   azd ai agent init --src ./src/my-agent --agent-name my-unique-agent
 
-  # Non-interactive code deploy (CI/CD)
-  azd ai agent init --no-prompt --project-id "<resource-id>" \
-    --deploy-mode code --runtime python_3_13 --entry-point app.py`,
+  # Non-interactive code deploy (CI/CD) — code is the default for Python/.NET
+  azd ai agent init --no-prompt --project-id "<resource-id>"
+
+  # Non-interactive container deploy
+  azd ai agent init --no-prompt --project-id "<resource-id>" --deploy-mode container`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flags.noPrompt = extCtx.NoPrompt
@@ -1304,13 +1306,16 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 		"Protocols supported by the agent (e.g., 'responses', 'invocations'). Can be specified multiple times.")
 
 	cmd.Flags().StringVar(&flags.deployMode, "deploy-mode", "",
-		"Deployment mode: 'container' (Docker image) or 'code' (ZIP upload). Defaults to 'container' in --no-prompt.")
+		"Deployment mode: 'code' (ZIP upload) or 'container' (Docker image). "+
+			"Defaults to 'code' for Python/.NET projects, 'container' otherwise.")
 
 	cmd.Flags().StringVar(&flags.runtime, "runtime", "",
-		"Runtime for code deploy (e.g., 'python_3_13', 'python_3_14', 'dotnet_10'). Required with --deploy-mode code --no-prompt.")
+		"Runtime for code deploy (e.g., 'python_3_13', 'python_3_14', 'dotnet_10'). "+
+			"Auto-detected from the project when omitted.")
 
 	cmd.Flags().StringVar(&flags.entryPoint, "entry-point", "",
-		"Entry point file for code deploy (e.g., 'app.py', 'MyAgent.dll'). Required with --deploy-mode code --no-prompt.")
+		"Entry point file for code deploy (e.g., 'app.py', 'MyAgent.dll'). "+
+			"Auto-detected from the project when omitted.")
 
 	cmd.Flags().StringVar(&flags.depResolution, "dep-resolution", "",
 		"Dependency resolution for code deploy: 'remote_build' or 'bundled'. Defaults to 'remote_build'.")
@@ -3603,16 +3608,17 @@ func extractConnectionConfigs(
 	return connections, credentialEnvVars, nil
 }
 
-// validateCodeDeployFlags checks that required flags are present when using
-// --deploy-mode code in --no-prompt mode.
+// validateCodeDeployFlags checks that code deploy flag values are valid.
 func (a *InitAction) validateCodeDeployFlags() error {
 	return validateCodeDeployInput(
-		a.flags.noPrompt, a.flags.deployMode, a.flags.runtime, a.flags.entryPoint, a.flags.depResolution)
+		a.flags.deployMode, a.flags.runtime, a.flags.depResolution)
 }
 
 // validateCodeDeployInput is the shared validation logic for code deploy flags.
-// Used by both InitAction and InitFromCodeAction.
-func validateCodeDeployInput(noPrompt bool, deployMode, runtime, entryPoint, depResolution string) error {
+// Used by both InitAction and InitFromCodeAction. It validates flag values only;
+// --runtime and --entry-point are optional and auto-detected from the project when
+// omitted, even with --deploy-mode code --no-prompt.
+func validateCodeDeployInput(deployMode, runtime, depResolution string) error {
 	if deployMode != "" && deployMode != "container" && deployMode != "code" {
 		return exterrors.Validation(
 			exterrors.CodeInvalidParameter,
@@ -3640,22 +3646,6 @@ func validateCodeDeployInput(noPrompt bool, deployMode, runtime, entryPoint, dep
 			"--dep-resolution must be 'remote_build' or 'bundled'",
 			"Specify --dep-resolution remote_build or --dep-resolution bundled",
 		)
-	}
-	if noPrompt && deployMode == "code" {
-		if runtime == "" {
-			return exterrors.Validation(
-				exterrors.CodeInvalidParameter,
-				"--runtime is required when using --deploy-mode code with --no-prompt",
-				"Specify --runtime (e.g., python_3_13, python_3_14, dotnet_10)",
-			)
-		}
-		if entryPoint == "" {
-			return exterrors.Validation(
-				exterrors.CodeInvalidParameter,
-				"--entry-point is required when using --deploy-mode code with --no-prompt",
-				"Specify --entry-point (e.g., app.py, main.py, MyAgent.dll)",
-			)
-		}
 	}
 	return nil
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -3615,9 +3615,9 @@ func (a *InitAction) validateCodeDeployFlags() error {
 }
 
 // validateCodeDeployInput is the shared validation logic for code deploy flags.
-// Used by both InitAction and InitFromCodeAction. It validates flag values only;
-// --runtime and --entry-point are optional and auto-detected from the project when
-// omitted, even with --deploy-mode code --no-prompt.
+// Used by both InitAction and InitFromCodeAction. Validates --deploy-mode, --runtime,
+// and --dep-resolution values when provided. --entry-point is not validated here;
+// it is optional and auto-detected from the project at deploy time when omitted.
 func validateCodeDeployInput(deployMode, runtime, depResolution string) error {
 	if deployMode != "" && deployMode != "container" && deployMode != "code" {
 		return exterrors.Validation(

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -3614,10 +3614,8 @@ func (a *InitAction) validateCodeDeployFlags() error {
 		a.flags.deployMode, a.flags.runtime, a.flags.depResolution)
 }
 
-// validateCodeDeployInput is the shared validation logic for code deploy flags.
-// Used by both InitAction and InitFromCodeAction. Validates --deploy-mode, --runtime,
-// and --dep-resolution values when provided. --entry-point is not validated here;
-// it is optional and auto-detected from the project at deploy time when omitted.
+// validateCodeDeployInput validates --deploy-mode, --runtime, and --dep-resolution flag values.
+// --entry-point is not validated here; it is auto-detected from the project when omitted.
 func validateCodeDeployInput(deployMode, runtime, depResolution string) error {
 	if deployMode != "" && deployMode != "container" && deployMode != "code" {
 		return exterrors.Validation(

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -86,7 +86,7 @@ func (a *InitFromCodeAction) Run(ctx context.Context) error {
 
 	// Validate code deploy flags
 	if err := validateCodeDeployInput(
-		a.flags.noPrompt, a.flags.deployMode, a.flags.runtime, a.flags.entryPoint, a.flags.depResolution,
+		a.flags.deployMode, a.flags.runtime, a.flags.depResolution,
 	); err != nil {
 		return err
 	}
@@ -1338,16 +1338,17 @@ func knownProtocolNames() string {
 
 // promptDeployMode asks the user to choose between code deploy and container deploy.
 // When deployModeFlag is set, it is used directly (for --no-prompt with explicit flag).
-// When noPrompt is true and no flag is provided, defaults to "container" for backward compatibility.
-// When showCodeDeploy is false and no explicit flag overrides, code deploy is not offered.
+// When noPrompt is true and no flag is provided, defaults to "code" for Python/.NET projects.
+// When showCodeDeploy is false, only container deploy is available (code deploy supports
+// Python/.NET only).
 func promptDeployMode(ctx context.Context, azdClient *azdext.AzdClient, noPrompt bool, showCodeDeploy bool, deployModeFlag string, userProvidedManifest bool) (string, error) {
 	// Resolution precedence:
 	//   1. Explicit flag (--deploy-mode) — always wins
 	//   2. !showCodeDeploy — container is the only option (not Python/.NET)
-	//   3. userProvidedManifest — auto-select "container" (opinionated default;
+	//   3. userProvidedManifest — auto-select "code" (opinionated default;
 	//      triggered by -m flag OR interactive template selection)
-	//   4. noPrompt — "container" for backward compatibility (no signal)
-	//   5. Interactive prompt
+	//   4. noPrompt — "code" for Python/.NET projects (no signal)
+	//   5. Interactive prompt (code is the default selection)
 
 	// Explicit flag takes precedence
 	if deployModeFlag != "" {
@@ -1368,23 +1369,23 @@ func promptDeployMode(ctx context.Context, azdClient *azdext.AzdClient, noPrompt
 	}
 
 	// When the user provided a manifest explicitly (-m), auto-select the
-	// opinionated default (container) without prompting. Users who want
-	// code deploy with -m can pass --deploy-mode code explicitly.
+	// opinionated default (code) without prompting. Users who want
+	// container deploy with -m can pass --deploy-mode container explicitly.
 	if userProvidedManifest {
-		log.Printf("Auto-selected deploy mode: container (use --deploy-mode code for code deploy)")
-		return "container", nil
+		log.Printf("Auto-selected deploy mode: code (use --deploy-mode container for container deploy)")
+		return "code", nil
 	}
 
 	if noPrompt {
-		return "container", nil
+		return "code", nil
 	}
 
 	deployModeChoices := []*azdext.SelectChoice{
-		{Label: "Container Image (Docker)", Value: "container"},
 		{Label: "Source Code (ZIP upload)", Value: "code"},
+		{Label: "Container Image (Docker)", Value: "container"},
 	}
 
-	defaultIdx := int32(0) // Container is the default for backward compatibility
+	defaultIdx := int32(0) // Code deploy is the default
 	deployModeResp, err := azdClient.Prompt().Select(ctx, &azdext.SelectRequest{
 		Options: &azdext.SelectOptions{
 			Message:       "How would you like to deploy your agent?",

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -1336,19 +1336,15 @@ func knownProtocolNames() string {
 	return strings.Join(names, ", ")
 }
 
-// promptDeployMode asks the user to choose between code deploy and container deploy.
-// When deployModeFlag is set, it is used directly (for --no-prompt with explicit flag).
-// When noPrompt is true and no flag is provided, defaults to "code" for Python/.NET projects.
-// When showCodeDeploy is false and no explicit --deploy-mode flag is set, only container
-// deploy is available (code deploy supports Python/.NET only).
+// promptDeployMode resolves the deploy mode (code or container).
+// Explicit --deploy-mode always wins; falls back to "code" for Python/.NET or "container" otherwise.
 func promptDeployMode(ctx context.Context, azdClient *azdext.AzdClient, noPrompt bool, showCodeDeploy bool, deployModeFlag string, userProvidedManifest bool) (string, error) {
 	// Resolution precedence:
-	//   1. Explicit flag (--deploy-mode) — always wins
-	//   2. !showCodeDeploy — container is the only option (not Python/.NET)
-	//   3. userProvidedManifest — auto-select "code" (opinionated default;
-	//      triggered by -m flag OR interactive template selection)
-	//   4. noPrompt — "code" for Python/.NET projects (no signal)
-	//   5. Interactive prompt (code is the default selection)
+	//   1. Explicit --deploy-mode flag
+	//   2. !showCodeDeploy (non-Python/.NET) → container
+	//   3. userProvidedManifest (-m or interactive template) → code
+	//   4. noPrompt → code
+	//   5. Interactive prompt (code is default)
 
 	// Explicit flag takes precedence
 	if deployModeFlag != "" {
@@ -1368,9 +1364,8 @@ func promptDeployMode(ctx context.Context, azdClient *azdext.AzdClient, noPrompt
 		return "container", nil
 	}
 
-	// When the user provided a manifest explicitly (-m), auto-select the
-	// opinionated default (code) without prompting. Users who want
-	// container deploy with -m can pass --deploy-mode container explicitly.
+	// Auto-select code when the user provided a manifest (-m or interactive template).
+	// Use --deploy-mode container to override.
 	if userProvidedManifest {
 		log.Printf("Auto-selected deploy mode: code (use --deploy-mode container for container deploy)")
 		return "code", nil

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -1339,8 +1339,8 @@ func knownProtocolNames() string {
 // promptDeployMode asks the user to choose between code deploy and container deploy.
 // When deployModeFlag is set, it is used directly (for --no-prompt with explicit flag).
 // When noPrompt is true and no flag is provided, defaults to "code" for Python/.NET projects.
-// When showCodeDeploy is false, only container deploy is available (code deploy supports
-// Python/.NET only).
+// When showCodeDeploy is false and no explicit --deploy-mode flag is set, only container
+// deploy is available (code deploy supports Python/.NET only).
 func promptDeployMode(ctx context.Context, azdClient *azdext.AzdClient, noPrompt bool, showCodeDeploy bool, deployModeFlag string, userProvidedManifest bool) (string, error) {
 	// Resolution precedence:
 	//   1. Explicit flag (--deploy-mode) — always wins

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go
@@ -931,11 +931,11 @@ func TestPromptDeployMode_FlagOverride(t *testing.T) {
 			wantErrContain: "invalid --deploy-mode value",
 		},
 		{
-			name:           "no flag + noPrompt defaults to container",
+			name:           "no flag + noPrompt defaults to code for Python/.NET",
 			noPrompt:       true,
 			showCodeDeploy: true,
 			flag:           "",
-			want:           "container",
+			want:           "code",
 		},
 		{
 			name:           "no flag + showCodeDeploy=false defaults to container",
@@ -945,12 +945,12 @@ func TestPromptDeployMode_FlagOverride(t *testing.T) {
 			want:           "container",
 		},
 		{
-			name:                 "userProvidedManifest + showCodeDeploy auto-selects container",
+			name:                 "userProvidedManifest + showCodeDeploy auto-selects code",
 			noPrompt:             false,
 			showCodeDeploy:       true,
 			flag:                 "",
 			userProvidedManifest: true,
-			want:                 "container",
+			want:                 "code",
 		},
 		{
 			name:                 "showCodeDeploy=false returns container regardless of userProvidedManifest",

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -2407,16 +2407,19 @@ func TestCodeDeployFlagValidation(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:           "code deploy without runtime fails",
-			flags:          initFlags{noPrompt: true, deployMode: "code", entryPoint: "app.py"},
-			wantErr:        true,
-			wantErrContain: "--runtime is required",
+			name:    "code deploy without runtime passes (auto-detected)",
+			flags:   initFlags{noPrompt: true, deployMode: "code", entryPoint: "app.py"},
+			wantErr: false,
 		},
 		{
-			name:           "code deploy without entry-point fails",
-			flags:          initFlags{noPrompt: true, deployMode: "code", runtime: "python_3_13"},
-			wantErr:        true,
-			wantErrContain: "--entry-point is required",
+			name:    "code deploy without entry-point passes (auto-detected)",
+			flags:   initFlags{noPrompt: true, deployMode: "code", runtime: "python_3_13"},
+			wantErr: false,
+		},
+		{
+			name:    "code deploy with no runtime or entry-point passes (auto-detected)",
+			flags:   initFlags{noPrompt: true, deployMode: "code"},
+			wantErr: false,
 		},
 		{
 			name:    "container deploy without runtime/entry-point passes",

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -2407,12 +2407,12 @@ func TestCodeDeployFlagValidation(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "code deploy without runtime passes (auto-detected)",
+			name:    "code deploy without runtime (entry-point only) passes (auto-detected)",
 			flags:   initFlags{noPrompt: true, deployMode: "code", entryPoint: "app.py"},
 			wantErr: false,
 		},
 		{
-			name:    "code deploy without entry-point passes (auto-detected)",
+			name:    "code deploy without entry-point (runtime only) passes (auto-detected)",
 			flags:   initFlags{noPrompt: true, deployMode: "code", runtime: "python_3_13"},
 			wantErr: false,
 		},


### PR DESCRIPTION
Closes #8707

## Summary

Switches the hosted agent deploy mode default from **container** (Docker image) to **code** (source ZIP upload) for Python and .NET projects.

Code deploy is the recommended and simpler path — no Dockerfile or ACR needed. Container deploy remains fully supported via `--deploy-mode container`.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Python/.NET — interactive prompt default | Container | **Code** |
| Python/.NET — `--no-prompt` (no `--deploy-mode` flag) | Container | **Code** |
| Python/.NET — `-m` manifest auto-select | Container | **Code** |
| Non-Python/.NET project | Container | Container (unchanged) |
| Explicit `--deploy-mode container` | Container | Container (unchanged) |
| Explicit `--deploy-mode code` | Code | Code (unchanged) |

## Related relaxation

`--runtime` and `--entry-point` are now optional even with `--deploy-mode code --no-prompt`. They are auto-detected from the project when omitted, so a minimal CI deploy is just:

```sh
azd ai agent init --no-prompt --project-id "<resource-id>"
```

## Changes

- `init_from_code.go` — `promptDeployMode`: code-first default in `noPrompt`, `userProvidedManifest`, and interactive-prompt branches; reordered Select choices.
- `init.go` — removed the "runtime/entry-point required" no-prompt validation; trimmed `validateCodeDeployInput` signature; updated flag help text and example.
- Tests — `TestPromptDeployMode_FlagOverride` and `TestCodeDeployFlagValidation` updated.
- `CHANGELOG.md` — `## Unreleased` entry with migration note.