### PR TITLE
Show tracing disclaimer when connecting App Insights during init

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -553,6 +553,20 @@ func configureAcrConnection(
 	return nil
 }
 
+// disableTracingURL points to guidance on disabling agent tracing/telemetry.
+const disableTracingURL = "https://aka.ms/disable-tracing"
+
+// tracingDisclaimer returns the telemetry/tracing disclaimer shown during init
+// wherever Application Insights is connected or added. The body is rendered in a
+// muted (gray) style with a clickable "Learn more" hyperlink to disableTracingURL.
+func tracingDisclaimer() string {
+	return output.WithGrayFormat(
+		"Use Hosted Agents with appropriate safeguards. "+
+			"If you connect to third-party systems, you are responsible for their use and data handling. "+
+			"Telemetry may be visible to others and include sensitive data. ") +
+		output.WithHyperlink(disableTracingURL, "Learn more")
+}
+
 // configureAppInsightsConnection handles AppInsights connection selection and env var setting.
 func configureAppInsightsConnection(
 	ctx context.Context,
@@ -560,14 +574,19 @@ func configureAppInsightsConnection(
 	envName string,
 	appInsightsConnections []azure.Connection,
 ) error {
+	// Show the tracing/telemetry disclaimer once, before any branch, since each
+	// path below connects or adds an Application Insights resource.
+	fmt.Println(tracingDisclaimer())
+	fmt.Println()
+
 	if len(appInsightsConnections) == 0 {
-		fmt.Println("\n" +
+		fmt.Println(
 			"Application Insights (optional)\n\n" +
-			"Enable telemetry to collect logs, traces, and diagnostics for this agent.\n\n" +
-			"You can:\n" +
-			"  • Use an existing Application Insights resource\n" +
-			"  • Or create a new one during 'azd up'\n\n" +
-			"Docs: " + output.WithLinkFormat("https://aka.ms/azdaiagent/docs"))
+				"Enable telemetry to collect logs, traces, and diagnostics for this agent.\n\n" +
+				"You can:\n" +
+				"  • Use an existing Application Insights resource\n" +
+				"  • Or create a new one during 'azd up'\n\n" +
+				"Docs: " + output.WithLinkFormat("https://aka.ms/azdaiagent/docs"))
 
 		resourceIdResp, err := azdClient.Prompt().Prompt(ctx, &azdext.PromptRequest{
 			Options: &azdext.PromptOptions{

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -558,13 +558,15 @@ const disableTracingURL = "https://aka.ms/disable-tracing"
 
 // tracingDisclaimer returns the telemetry/tracing disclaimer shown during init
 // wherever Application Insights is connected or added. The body is rendered in a
-// muted (gray) style with a clickable "Learn more" hyperlink to disableTracingURL.
+// muted (gray) style. The "Learn more:" label lives in the gray text (so it is
+// always shown) and is followed by disableTracingURL, which renders as a
+// clickable hyperlink in a terminal and as the plain URL in non-terminal output.
 func tracingDisclaimer() string {
 	return output.WithGrayFormat(
 		"Use Hosted Agents with appropriate safeguards. "+
 			"If you connect to third-party systems, you are responsible for their use and data handling. "+
-			"Telemetry may be visible to others and include sensitive data. ") +
-		output.WithHyperlink(disableTracingURL, "Learn more")
+			"Telemetry may be visible to others and include sensitive data. Learn more: ") +
+		output.WithHyperlink(disableTracingURL, disableTracingURL)
 }
 
 // configureAppInsightsConnection handles AppInsights connection selection and env var setting.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
@@ -657,3 +657,17 @@ func TestConfigureDeferredInitAzureContext_PersistsProjectSignalOnly(t *testing.
 	require.Contains(t, output, "deployments:")
 	require.Contains(t, output, "format: OpenAI")
 }
+
+func TestTracingDisclaimer(t *testing.T) {
+	t.Parallel()
+
+	got := tracingDisclaimer()
+
+	// String-contains assertions are safe against any surrounding ANSI color or
+	// OSC-8 hyperlink escape sequences, since the phrases/URL appear contiguously.
+	require.Contains(t, got, "Use Hosted Agents with appropriate safeguards")
+	require.Contains(t, got, "you are responsible for their use and data handling")
+	require.Contains(t, got, "Telemetry may be visible to others and include sensitive data")
+	require.Contains(t, got, disableTracingURL)
+	require.Equal(t, "https://aka.ms/disable-tracing", disableTracingURL)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
@@ -668,6 +668,7 @@ func TestTracingDisclaimer(t *testing.T) {
 	require.Contains(t, got, "Use Hosted Agents with appropriate safeguards")
 	require.Contains(t, got, "you are responsible for their use and data handling")
 	require.Contains(t, got, "Telemetry may be visible to others and include sensitive data")
+	require.Contains(t, got, "Learn more:")
 	require.Contains(t, got, disableTracingURL)
 	require.Equal(t, "https://aka.ms/disable-tracing", disableTracingURL)
 }


### PR DESCRIPTION
Fixes #8647

## Summary

Surfaces a telemetry/tracing disclaimer wherever Application Insights is
connected or added during `azd ai agent init`. The disclaimer is printed once
at the top of `configureAppInsightsConnection`, so it appears in all three
flows:

- no existing connection (prompt for a resource ID, or create a new one during `azd up`)
- a single connection auto-used
- multiple connections to select from

It renders in muted gray with a clickable "Learn more" hyperlink to
https://aka.ms/disable-tracing (falls back to the plain URL in non-terminal/CI
output).

Disclaimer text (verbatim from the issue):

> Use Hosted Agents with appropriate safeguards. If you connect to third-party
> systems, you are responsible for their use and data handling. Telemetry may be
> visible to others and include sensitive data. [Learn more](https://aka.ms/disable-tracing).

<img width="2646" height="385" alt="image" src="https://github.com/user-attachments/assets/6a0f88a6-0ecd-4ec0-9ec6-15acb3386b96" />


## Changes

- `cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go`
  -- new `disableTracingURL` const + `tracingDisclaimer()` helper; printed at the
  top of `configureAppInsightsConnection`.
- `cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go`
  -- new `TestTracingDisclaimer`.

## Testing

- `go build ./...`
- `go test ./internal/cmd/` (full package, including the new test)
- `go vet`, `gofmt -l` (clean), `cspell` (clean)

## Notes

- Scope is the existing-project init flows. The brand-new-project path (which
  provisions a fresh Application Insights during `azd up` without calling
  `configureAppInsightsConnection`) is intentionally out of scope here and could
  be a follow-up.
- No `CHANGELOG.md` change -- handled during release prep.
