### PR TITLE
Update Hosted Agents tracing disclaimer text and links

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [[#8645]](https://github.com/Azure/azure-dev/pull/8645) Detect VNET-injected Foundry accounts during `azd ai agent init` and skip remote builds up front so hosted container agents use local builds without a failing remote-build attempt first. Thanks @m5i-work for the contribution!
 - [[#8714]](https://github.com/Azure/azure-dev/pull/8714) Show a tracing disclaimer when `azd ai agent init` connects or adds an Application Insights connection. Thanks @therealjohn for the contribution!
 - [[#8685]](https://github.com/Azure/azure-dev/pull/8685) Default `azd ai agent run` local Python virtual environments to Python >= 3.13 so local runs match the minimum supported Foundry runtime. Thanks @therealjohn for the contribution!
+- [[#8732]](https://github.com/Azure/azure-dev/pull/8732) Update the Application Insights tracing disclaimer shown during `azd ai agent init` with revised wording and a `Learn more` link. Thanks @therealjohn for the contribution!
 
 ## 0.1.40-preview (2026-06-15)
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -553,20 +553,31 @@ func configureAcrConnection(
 	return nil
 }
 
+// tracingOverviewURL points to an overview of agent tracing/telemetry behavior.
+const tracingOverviewURL = "https://aka.ms/tracing-overview"
+
 // disableTracingURL points to guidance on disabling agent tracing/telemetry.
 const disableTracingURL = "https://aka.ms/disable-tracing"
 
 // tracingDisclaimer returns the telemetry/tracing disclaimer shown during init
 // wherever Application Insights is connected or added. The body is rendered in a
-// muted (gray) style. The "Learn more:" label lives in the gray text (so it is
-// always shown) and is followed by disableTracingURL, which renders as a
-// clickable hyperlink in a terminal and as the plain URL in non-terminal output.
+// muted (gray) style. The "Learn more" label renders as a clickable hyperlink to
+// tracingOverviewURL (and as the plain URL in non-terminal output), and
+// disableTracingURL renders as a clickable hyperlink in a terminal and as the
+// plain URL in non-terminal output.
 func tracingDisclaimer() string {
 	return output.WithGrayFormat(
-		"Use Hosted Agents with appropriate safeguards. "+
-			"If you connect to third-party systems, you are responsible for their use and data handling. "+
-			"Telemetry may be visible to others and include sensitive data. Learn more: ") +
-		output.WithHyperlink(disableTracingURL, disableTracingURL)
+		"When using Hosted Agents apply appropriate safeguards. "+
+			"You are responsible for managing all data that may flow outside "+
+			"your organization's compliance and geographic boundaries. "+
+			"Use third-party systems at your own risk. ") +
+		output.WithHyperlink(tracingOverviewURL, "Learn more") +
+		output.WithGrayFormat(
+			". When AppInsights is enabled, this project logs traces to help "+
+				"you monitor your agents. Certain project members may be able to "+
+				"view user data. See ") +
+		output.WithHyperlink(disableTracingURL, disableTracingURL) +
+		output.WithGrayFormat(".")
 }
 
 // configureAppInsightsConnection handles AppInsights connection selection and env var setting.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
@@ -665,10 +665,14 @@ func TestTracingDisclaimer(t *testing.T) {
 
 	// String-contains assertions are safe against any surrounding ANSI color or
 	// OSC-8 hyperlink escape sequences, since the phrases/URL appear contiguously.
-	require.Contains(t, got, "Use Hosted Agents with appropriate safeguards")
-	require.Contains(t, got, "you are responsible for their use and data handling")
-	require.Contains(t, got, "Telemetry may be visible to others and include sensitive data")
-	require.Contains(t, got, "Learn more:")
+	require.Contains(t, got, "When using Hosted Agents apply appropriate safeguards")
+	require.Contains(t, got, "You are responsible for managing all data that may flow outside")
+	require.Contains(t, got, "your organization's compliance and geographic boundaries")
+	require.Contains(t, got, "Use third-party systems at your own risk")
+	require.Contains(t, got, "When AppInsights is enabled, this project logs traces")
+	require.Contains(t, got, "Certain project members may be able to view user data")
+	require.Contains(t, got, tracingOverviewURL)
 	require.Contains(t, got, disableTracingURL)
+	require.Equal(t, "https://aka.ms/tracing-overview", tracingOverviewURL)
 	require.Equal(t, "https://aka.ms/disable-tracing", disableTracingURL)
 }


### PR DESCRIPTION
## Summary

Updates the App Insights tracing/telemetry disclaimer shown during `azd ai` init (wherever Application Insights is connected or added) to the new approved wording.

Fixes #8647

## Changes

- Reworded `tracingDisclaimer()` in `cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go`.
- Added a new `tracingOverviewURL` constant (`https://aka.ms/tracing-overview`), rendered as a clickable "Learn more" hyperlink in terminals and as the plain URL in non-terminal output.
- Kept the existing `https://aka.ms/disable-tracing` reference for the closing "See ..." sentence.
- Updated `TestTracingDisclaimer` assertions to match the new phrases and both URLs.

### New disclaimer text

> When using Hosted Agents apply appropriate safeguards. You are responsible for managing all data that may flow outside your organization's compliance and geographic boundaries. Use third-party systems at your own risk. [Learn more](https://aka.ms/tracing-overview). When AppInsights is enabled, this project logs traces to help you monitor your agents. Certain project members may be able to view user data. See https://aka.ms/disable-tracing.

## Validation

- `go build ./...` passes.
- `go test ./internal/cmd/ -run TestTracingDisclaimer` passes.
- `gofmt` clean; no new lines exceed the 125-char `lll` limit.
