### PR TITLE
feat(agents): native Activity protocol support (use-case profiles, digital-worker init/deploy)

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 0.1.41-preview (2026-06-21)
+
+- [[#8753]](https://github.com/Azure/azure-dev/pull/8753) Add native Activity-protocol support: auto-inject the agent endpoint with `activity` + `BotServiceRbac`, send the `AgentEndpoints=V1Preview` Foundry feature header, and normalize the user-facing `activity` protocol name. Introduce `activity.use_case` (`simple` | `digital_worker`) profiles that gate endpoint injection, blueprint reference, and M365 onboarding; round-trip `use_case` through `azd ai agent init`; set `ENABLE_DIGITAL_WORKER`/`AGENT_NAME` so the starter template provisions the MAIB and Bot Service; and print digital-worker M365 onboarding next steps after `azd deploy`.
+
 ## 0.1.40-preview (2026-06-15)
 
 - [[#8641]](https://github.com/Azure/azure-dev/pull/8641) Fix optimize/eval handling for array-valued mutations, resolve `dataset.local_uri` relative to the agent project, and align optimize test schema data with the current API format. Thanks @Zyysurely for the contribution!

--- a/cli/azd/extensions/azure.ai.agents/extension.yaml
+++ b/cli/azd/extensions/azure.ai.agents/extension.yaml
@@ -5,7 +5,7 @@ displayName: Foundry agents (Preview)
 description: Ship agents with Microsoft Foundry from your terminal. (Preview)
 usage: azd ai agent <command> [options]
 # NOTE: Make sure version.txt is in sync with this version.
-version: 0.1.40-preview
+version: 0.1.41-preview
 requiredAzdVersion: ">1.25.2"
 dependencies:
   - id: azure.ai.inspector

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -888,7 +888,8 @@ func protocolFromAgentYaml(
 				"agent.yaml declares only non-invocable protocols: %s",
 				strings.Join(names, ", "),
 			),
-			"azd can only invoke agents using the responses or invocations protocols",
+			"azd can only invoke agents using the responses or invocations protocols. "+
+				"Use 'azd ai agent endpoint show' to verify other protocol configurations.",
 		)
 	case 1:
 		// Exactly one invocable protocol — but if the agent declares

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -59,6 +59,10 @@ type initFlags struct {
 	src               string
 	env               string
 	protocols         []string
+	// activityUseCase selects the activity deployment profile written to
+	// agent.yaml for activity agents: "digital_worker" or "simple". Empty defaults
+	// to "digital_worker" (the only profile with full init support today).
+	activityUseCase string
 	// deploy mode flags for non-interactive code deploy support
 	deployMode    string // "container" or "code"; empty = prompt interactively
 	runtime       string // e.g. "python_3_13", "python_3_14", "dotnet_10"
@@ -1297,6 +1301,9 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 	cmd.Flags().StringSliceVar(&flags.protocols, "protocol", nil,
 		"Protocols supported by the agent (e.g., 'responses', 'invocations'). Can be specified multiple times.")
 
+	cmd.Flags().StringVar(&flags.activityUseCase, "activity-use-case", "",
+		"Activity deployment profile for activity agents: 'digital_worker' (default) or 'simple'.")
+
 	cmd.Flags().StringVar(&flags.deployMode, "deploy-mode", "",
 		"Deployment mode: 'container' (Docker image) or 'code' (ZIP upload). Defaults to 'container' in --no-prompt.")
 
@@ -1508,8 +1515,16 @@ func ensureProject(
 			envName = base + "-dev"
 		}
 
+		// Template defaults to the published starter. AZD_AI_STARTER_TEMPLATE allows
+		// pointing at a local clone or fork for testing infra changes before they
+		// land upstream (azd init -t accepts a local directory path).
+		starterTemplate := "Azure-Samples/azd-ai-starter-basic"
+		if override := os.Getenv("AZD_AI_STARTER_TEMPLATE"); override != "" {
+			starterTemplate = override
+		}
+
 		initArgs := []string{
-			"init", "-t", "Azure-Samples/azd-ai-starter-basic", targetDir,
+			"init", "-t", starterTemplate, targetDir,
 			"--environment", envName,
 		}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -760,8 +760,13 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 	// Step 2: Model configuration — skipped for activity-only agents which use M365 SDK, not AI models.
 	if isActivityOnlyProtocols(protocols) {
 		fmt.Println(output.WithGrayFormat(
-			"Skipping model configuration: activity_protocol agents use the M365 Agents SDK and do not require a model deployment.",
+			"Skipping model configuration: activity agents use the M365 Agents SDK and do not require a model deployment.",
 		))
+
+		// Resolve the activity deployment profile. Only "digital_worker" has full
+		// init support today; an unset flag defaults to it.
+		useCase := resolveActivityUseCase(a.flags.activityUseCase)
+
 		// Build the definition directly without model prompts.
 		agentKind := agent_yaml.AgentKindHosted
 		definition := &agent_yaml.ContainerAgent{
@@ -771,11 +776,26 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 			},
 			Protocols:         protocols,
 			CodeConfiguration: codeConfig,
-			// activity_protocol requires agent_endpoint.protocols=["activity"] for the Foundry PATCH call.
+			// activity agents require agent_endpoint.protocols=["activity"] for the Foundry PATCH call.
 			AgentEndpoint: &agent_yaml.AgentEndpoint{
 				Protocols: []string{"activity"},
 			},
+			Activity: &agent_yaml.ActivityConfig{UseCase: string(useCase)},
 		}
+
+		if useCase == agent_yaml.ActivityUseCaseDigitalWorker {
+			// From-code init does not scaffold the MAIB + Bot Service infrastructure
+			// a digital worker requires. Point users to the sample manifest, which
+			// carries that infra alongside the agent code.
+			fmt.Println(output.WithWarningFormat(
+				"Digital-worker agents require Managed Agent Identity Blueprint (MAIB) and Bot Service\n"+
+					"infrastructure that this from-code init does not generate. To get a complete,\n"+
+					"deployable digital worker (infra + agent.yaml), initialize from the echo-agent manifest:\n"+
+					"  azd ai agent init -m https://github.com/microsoft-foundry/foundry-samples/blob/main/"+
+					"samples/python/hosted-agents/bring-your-own/activity/echo-agent/agent.manifest.yaml",
+			))
+		}
+
 		return definition, nil
 	}
 
@@ -878,12 +898,17 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 		CodeConfiguration: codeConfig,
 	}
 
-	// When activity_protocol is among the selected protocols, set agent_endpoint.protocols
-	// so the Foundry PATCH call registers the activity endpoint correctly.
+	// When the activity protocol is among the selected protocols, set
+	// agent_endpoint.protocols so the Foundry PATCH call registers the activity
+	// endpoint correctly, and record the activity deployment profile. Accepts
+	// both "activity" and "activity_protocol".
 	for _, p := range protocols {
-		if p.Protocol == "activity_protocol" {
+		if isActivityProtocolName(p.Protocol) {
 			definition.AgentEndpoint = &agent_yaml.AgentEndpoint{
 				Protocols: []string{"activity"},
+			}
+			definition.Activity = &agent_yaml.ActivityConfig{
+				UseCase: string(resolveActivityUseCase(a.flags.activityUseCase)),
 			}
 			break
 		}
@@ -1247,21 +1272,46 @@ type protocolInfo struct {
 var knownProtocols = []protocolInfo{
 	{Name: "responses", Version: "1.0.0"},
 	{Name: "invocations", Version: "1.0.0"},
-	{Name: "activity_protocol", Version: "1.0.0"},
+	{Name: "activity", Version: "1.0.0"},
 }
 
-// isActivityOnlyProtocols reports whether protocols contains only activity_protocol.
-// Activity-protocol agents use the M365 Agents SDK and don't require a model deployment.
+// isActivityOnlyProtocols reports whether protocols contains only the activity
+// protocol. agent.yaml may use the friendly name "activity" or the canonical
+// wire name "activity_protocol"; both are recognized. Activity agents use the
+// M365 Agents SDK and don't require a model deployment.
 func isActivityOnlyProtocols(protocols []agent_yaml.ProtocolVersionRecord) bool {
 	if len(protocols) == 0 {
 		return false
 	}
 	for _, p := range protocols {
-		if p.Protocol != "activity_protocol" {
+		if !isActivityProtocolName(p.Protocol) {
 			return false
 		}
 	}
 	return true
+}
+
+// isActivityProtocolName reports whether the given protocol name refers to the
+// activity protocol, accepting both "activity" and "activity_protocol".
+func isActivityProtocolName(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "activity", "activity_protocol":
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveActivityUseCase normalizes the --activity-use-case flag value to a known
+// ActivityUseCase. An empty or unrecognized value defaults to digital_worker,
+// the only activity profile with full init support today.
+func resolveActivityUseCase(flag string) agent_yaml.ActivityUseCase {
+	switch strings.ToLower(strings.TrimSpace(flag)) {
+	case string(agent_yaml.ActivityUseCaseSimple):
+		return agent_yaml.ActivityUseCaseSimple
+	default:
+		return agent_yaml.ActivityUseCaseDigitalWorker
+	}
 }
 
 // promptProtocols asks the user which protocols their agent supports.
@@ -1277,6 +1327,10 @@ func promptProtocols(
 	versionOf := make(map[string]string, len(knownProtocols))
 	for _, p := range knownProtocols {
 		versionOf[p.Name] = p.Version
+	}
+	// Accept "activity_protocol" as a backward-compatible alias for "activity".
+	if v, ok := versionOf["activity"]; ok {
+		versionOf["activity_protocol"] = v
 	}
 
 	// If explicit flag values were provided, use them directly (with dedup).
@@ -1298,8 +1352,13 @@ func promptProtocols(
 					fmt.Sprintf("Use one of the supported protocol values: %s", knownProtocolNames()),
 				)
 			}
+			// Normalize the activity alias to the friendly "activity" name.
+			recordName := name
+			if isActivityProtocolName(name) {
+				recordName = "activity"
+			}
 			records = append(records, agent_yaml.ProtocolVersionRecord{
-				Protocol: name,
+				Protocol: recordName,
 				Version:  version,
 			})
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -757,7 +757,28 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 		}
 	}
 
-	// Step 2: Model configuration
+	// Step 2: Model configuration — skipped for activity-only agents which use M365 SDK, not AI models.
+	if isActivityOnlyProtocols(protocols) {
+		fmt.Println(output.WithGrayFormat(
+			"Skipping model configuration: activity_protocol agents use the M365 Agents SDK and do not require a model deployment.",
+		))
+		// Build the definition directly without model prompts.
+		agentKind := agent_yaml.AgentKindHosted
+		definition := &agent_yaml.ContainerAgent{
+			AgentDefinition: agent_yaml.AgentDefinition{
+				Name: agentName,
+				Kind: agentKind,
+			},
+			Protocols:         protocols,
+			CodeConfiguration: codeConfig,
+			// activity_protocol requires agent_endpoint.protocols=["activity"] for the Foundry PATCH call.
+			AgentEndpoint: &agent_yaml.AgentEndpoint{
+				Protocols: []string{"activity"},
+			},
+		}
+		return definition, nil
+	}
+
 	var modelConfigChoices []*azdext.SelectChoice
 	if selectedProject != nil {
 		modelConfigChoices = []*azdext.SelectChoice{
@@ -855,6 +876,17 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 		},
 		Protocols:         protocols,
 		CodeConfiguration: codeConfig,
+	}
+
+	// When activity_protocol is among the selected protocols, set agent_endpoint.protocols
+	// so the Foundry PATCH call registers the activity endpoint correctly.
+	for _, p := range protocols {
+		if p.Protocol == "activity_protocol" {
+			definition.AgentEndpoint = &agent_yaml.AgentEndpoint{
+				Protocols: []string{"activity"},
+			}
+			break
+		}
 	}
 
 	// Add model resource if a model was selected
@@ -1215,6 +1247,21 @@ type protocolInfo struct {
 var knownProtocols = []protocolInfo{
 	{Name: "responses", Version: "1.0.0"},
 	{Name: "invocations", Version: "1.0.0"},
+	{Name: "activity_protocol", Version: "1.0.0"},
+}
+
+// isActivityOnlyProtocols reports whether protocols contains only activity_protocol.
+// Activity-protocol agents use the M365 Agents SDK and don't require a model deployment.
+func isActivityOnlyProtocols(protocols []agent_yaml.ProtocolVersionRecord) bool {
+	if len(protocols) == 0 {
+		return false
+	}
+	for _, p := range protocols {
+		if p.Protocol != "activity_protocol" {
+			return false
+		}
+	}
+	return true
 }
 
 // promptProtocols asks the user which protocols their agent supports.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go
@@ -768,13 +768,14 @@ func TestKnownProtocolNames(t *testing.T) {
 	if !strings.Contains(result, "invocations") {
 		t.Errorf("knownProtocolNames() = %q, want to contain 'invocations'", result)
 	}
-	if !strings.Contains(result, "activity_protocol") {
-		t.Errorf("knownProtocolNames() = %q, want to contain 'activity_protocol'", result)
+	if !strings.Contains(result, "activity") {
+		t.Errorf("knownProtocolNames() = %q, want to contain 'activity'", result)
 	}
 }
 
-// TestPromptProtocols_ActivityProtocol verifies that activity_protocol can be
-// selected via flag and is returned with its canonical version.
+// TestPromptProtocols_ActivityProtocol verifies that the "activity_protocol"
+// alias can be selected via flag and is normalized to the friendly "activity"
+// name with its canonical version.
 func TestPromptProtocols_ActivityProtocol(t *testing.T) {
 	t.Parallel()
 
@@ -785,11 +786,33 @@ func TestPromptProtocols_ActivityProtocol(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("got %d protocols, want 1", len(got))
 	}
-	if got[0].Protocol != "activity_protocol" {
-		t.Errorf("protocol = %q, want %q", got[0].Protocol, "activity_protocol")
+	if got[0].Protocol != "activity" {
+		t.Errorf("protocol = %q, want %q", got[0].Protocol, "activity")
 	}
 	if got[0].Version != "1.0.0" {
 		t.Errorf("version = %q, want %q", got[0].Version, "1.0.0")
+	}
+}
+
+// TestResolveActivityUseCase verifies the --activity-use-case flag normalization.
+func TestResolveActivityUseCase(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want agent_yaml.ActivityUseCase
+	}{
+		{"", agent_yaml.ActivityUseCaseDigitalWorker},
+		{"digital_worker", agent_yaml.ActivityUseCaseDigitalWorker},
+		{"  Digital_Worker ", agent_yaml.ActivityUseCaseDigitalWorker},
+		{"simple", agent_yaml.ActivityUseCaseSimple},
+		{"SIMPLE", agent_yaml.ActivityUseCaseSimple},
+		{"unknown", agent_yaml.ActivityUseCaseDigitalWorker},
+	}
+	for _, tc := range cases {
+		if got := resolveActivityUseCase(tc.in); got != tc.want {
+			t.Errorf("resolveActivityUseCase(%q) = %q, want %q", tc.in, got, tc.want)
+		}
 	}
 }
 
@@ -805,6 +828,11 @@ func TestIsActivityOnlyProtocols(t *testing.T) {
 		{
 			name:      "activity only",
 			protocols: []agent_yaml.ProtocolVersionRecord{{Protocol: "activity_protocol", Version: "1.0.0"}},
+			want:      true,
+		},
+		{
+			name:      "activity only (friendly name)",
+			protocols: []agent_yaml.ProtocolVersionRecord{{Protocol: "activity", Version: "1.0.0"}},
 			want:      true,
 		},
 		{
@@ -903,18 +931,18 @@ func TestPromptProtocols_Interactive(t *testing.T) {
 			wantErrContain: "cancelled",
 		},
 		{
-			name: "activity_protocol selected interactively",
+			name: "activity selected interactively",
 			multiSelectFn: func(_ context.Context, _ *azdext.MultiSelectRequest, _ ...grpc.CallOption) (*azdext.MultiSelectResponse, error) {
 				return &azdext.MultiSelectResponse{
 					Values: []*azdext.MultiSelectChoice{
 						{Value: "responses", Label: "responses", Selected: false},
 						{Value: "invocations", Label: "invocations", Selected: false},
-						{Value: "activity_protocol", Label: "activity_protocol", Selected: true},
+						{Value: "activity", Label: "activity", Selected: true},
 					},
 				}, nil
 			},
 			wantProtocols: []agent_yaml.ProtocolVersionRecord{
-				{Protocol: "activity_protocol", Version: "1.0.0"},
+				{Protocol: "activity", Version: "1.0.0"},
 			},
 		},
 		{

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go
@@ -768,6 +768,73 @@ func TestKnownProtocolNames(t *testing.T) {
 	if !strings.Contains(result, "invocations") {
 		t.Errorf("knownProtocolNames() = %q, want to contain 'invocations'", result)
 	}
+	if !strings.Contains(result, "activity_protocol") {
+		t.Errorf("knownProtocolNames() = %q, want to contain 'activity_protocol'", result)
+	}
+}
+
+// TestPromptProtocols_ActivityProtocol verifies that activity_protocol can be
+// selected via flag and is returned with its canonical version.
+func TestPromptProtocols_ActivityProtocol(t *testing.T) {
+	t.Parallel()
+
+	got, err := promptProtocols(t.Context(), nil, false, []string{"activity_protocol"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d protocols, want 1", len(got))
+	}
+	if got[0].Protocol != "activity_protocol" {
+		t.Errorf("protocol = %q, want %q", got[0].Protocol, "activity_protocol")
+	}
+	if got[0].Version != "1.0.0" {
+		t.Errorf("version = %q, want %q", got[0].Version, "1.0.0")
+	}
+}
+
+// TestIsActivityOnlyProtocols verifies the helper that gates model-prompt skipping.
+func TestIsActivityOnlyProtocols(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		protocols []agent_yaml.ProtocolVersionRecord
+		want      bool
+	}{
+		{
+			name:      "activity only",
+			protocols: []agent_yaml.ProtocolVersionRecord{{Protocol: "activity_protocol", Version: "1.0.0"}},
+			want:      true,
+		},
+		{
+			name: "activity + invocations",
+			protocols: []agent_yaml.ProtocolVersionRecord{
+				{Protocol: "activity_protocol", Version: "1.0.0"},
+				{Protocol: "invocations", Version: "1.0.0"},
+			},
+			want: false,
+		},
+		{
+			name:      "responses only",
+			protocols: []agent_yaml.ProtocolVersionRecord{{Protocol: "responses", Version: "1.0.0"}},
+			want:      false,
+		},
+		{
+			name:      "nil",
+			protocols: nil,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isActivityOnlyProtocols(tt.protocols); got != tt.want {
+				t.Errorf("isActivityOnlyProtocols() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 // fakePromptClient is a lightweight test double for azdext.PromptServiceClient.
@@ -834,6 +901,21 @@ func TestPromptProtocols_Interactive(t *testing.T) {
 			},
 			wantErr:        true,
 			wantErrContain: "cancelled",
+		},
+		{
+			name: "activity_protocol selected interactively",
+			multiSelectFn: func(_ context.Context, _ *azdext.MultiSelectRequest, _ ...grpc.CallOption) (*azdext.MultiSelectResponse, error) {
+				return &azdext.MultiSelectResponse{
+					Values: []*azdext.MultiSelectChoice{
+						{Value: "responses", Label: "responses", Selected: false},
+						{Value: "invocations", Label: "invocations", Selected: false},
+						{Value: "activity_protocol", Label: "activity_protocol", Selected: true},
+					},
+				}, nil
+			},
+			wantProtocols: []agent_yaml.ProtocolVersionRecord{
+				{Protocol: "activity_protocol", Version: "1.0.0"},
+			},
 		},
 		{
 			name: "empty selection returns validation error",

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -97,6 +97,9 @@ azd creates or reuses a hosted agent session backed by that version.
 For agents configured with header-based isolation, pass --user-isolation-key
 and --chat-isolation-key on each remote invoke.
 
+Activity protocol is not supported for invocation (it is push-based, not pull-based).
+Use 'azd ai agent endpoint show' to view activity protocol configuration.
+
 Use --output raw (or -o raw) to dump the unmodified server response (status
 line, headers, and body verbatim) to stdout. Useful for debugging server
 behavior and inspecting response headers (for example, the agent version
@@ -219,7 +222,7 @@ suppressed in raw mode.`,
 
 	cmd.Flags().BoolVarP(&flags.local, "local", "l", false, "Invoke on localhost instead of Foundry")
 	cmd.Flags().StringVarP(&flags.inputFile, "input-file", "f", "", "Path to a file whose contents are sent as the request body")
-	cmd.Flags().StringVarP(&flags.protocol, "protocol", "p", "", "Protocol to use: responses (default) or invocations")
+	cmd.Flags().StringVarP(&flags.protocol, "protocol", "p", "", "Protocol to use for invocation: responses (default) or invocations")
 	cmd.Flags().IntVar(&flags.port, "port", DefaultPort, "Local server port")
 	cmd.Flags().IntVarP(
 		&flags.timeout,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
@@ -21,6 +21,7 @@ import (
 	"azureaiagent/internal/pkg/paths"
 	"azureaiagent/internal/project"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/braydonk/yaml"
@@ -128,11 +129,65 @@ func postprovisionHandler(
 					pendingProvisionEnvVar, clearErr,
 				)
 			}
+
+			// For activity-protocol agents, register the blueprint into M365
+			// (delegated OAuth2 grants + blueprint owner). Gated on the presence
+			// of AGENT_IDENTITY_BLUEPRINT_ID, which only activity agents emit.
+			// Best-effort: a failure is logged and does not fail provision.
+			if err := runBlueprintM365Provisioning(ctx, azdClient, envName); err != nil {
+				log.Printf("warning: blueprint M365 provisioning failed: %v", err)
+			}
 		}
 	}
 
 	return nil
 }
+
+// runBlueprintM365Provisioning performs the post-provision M365 registration for
+// an activity-protocol agent's blueprint (delegated OAuth2 grants + blueprint
+// owner). It is a no-op when AGENT_IDENTITY_BLUEPRINT_ID is not present in the
+// environment (non-activity agents). All underlying steps are best-effort.
+func runBlueprintM365Provisioning(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	envName string,
+) error {
+	blueprintAppID := getEnvValueOrEmpty(ctx, azdClient, envName, "AGENT_IDENTITY_BLUEPRINT_ID")
+	if blueprintAppID == "" {
+		return nil
+	}
+
+	tenantID := getEnvValueOrEmpty(ctx, azdClient, envName, "AZURE_TENANT_ID")
+	cred, err := azidentity.NewAzureDeveloperCLICredential(
+		&azidentity.AzureDeveloperCLICredentialOptions{
+			TenantID:                   tenantID,
+			AdditionallyAllowedTenants: []string{"*"},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create credential for blueprint M365 provisioning: %w", err)
+	}
+
+	return project.EnsureBlueprintM365Provisioning(ctx, cred, blueprintAppID)
+}
+
+// getEnvValueOrEmpty reads a single azd environment value, returning "" on any
+// error or when the key is unset.
+func getEnvValueOrEmpty(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	envName, key string,
+) string {
+	resp, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+		EnvName: envName,
+		Key:     key,
+	})
+	if err != nil || resp == nil {
+		return ""
+	}
+	return resp.Value
+}
+
 
 // currentEnvName returns the name of the currently selected azd
 // environment, or empty string + error when no environment is
@@ -261,6 +316,8 @@ func postdeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *a
 
 	// Build name→principalID map by fetching the agent version for each hosted service.
 	agentIdentities := make(map[string]string)
+	// Track agent GUIDs per service for activity-protocol M365 publish (post-deploy).
+	agentGUIDs := make(map[string]string)
 	for _, svc := range hostedAgents {
 		serviceKey := toServiceKey(svc.Name)
 
@@ -278,14 +335,24 @@ func postdeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *a
 			continue
 		}
 
+		// Resolve the agent's actual name. The agent name comes from agent.yaml's
+		// `name` field (registered as AGENT_{serviceKey}_NAME during deploy) and may
+		// differ from the azure.yaml service name (svc.Name). Using svc.Name here
+		// would 404 whenever they differ, so prefer the registered agent name and
+		// fall back to the service name only when it is unavailable.
+		agentName := getEnvValueOrEmpty(ctx, azdClient, envName, fmt.Sprintf("AGENT_%s_NAME", serviceKey))
+		if agentName == "" {
+			agentName = svc.Name
+		}
+
 		// Fetch the agent version to get the instance identity principal ID.
 		versionObj, err := agentClient.GetAgentVersion(
-			ctx, svc.Name, versionResp.Value, DefaultAgentAPIVersion,
+			ctx, agentName, versionResp.Value, DefaultAgentAPIVersion,
 		)
 		if err != nil {
 			return fmt.Errorf(
 				"failed to fetch agent version for %s/%s: %w",
-				svc.Name, versionResp.Value, err,
+				agentName, versionResp.Value, err,
 			)
 		}
 
@@ -294,7 +361,10 @@ func postdeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *a
 			principalID = versionObj.InstanceIdentity.PrincipalID
 		}
 
-		agentIdentities[svc.Name] = principalID
+		agentIdentities[agentName] = principalID
+		if versionObj.AgentGUID != "" {
+			agentGUIDs[agentName] = versionObj.AgentGUID
+		}
 	}
 
 	if len(agentIdentities) == 0 {
@@ -303,6 +373,14 @@ func postdeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *a
 
 	if err := project.EnsureAgentIdentityRBAC(ctx, azdClient, agentIdentities); err != nil {
 		return fmt.Errorf("agent identity RBAC setup failed: %w", err)
+	}
+
+	// For activity-protocol agents, publish the deployed agent as an M365 digital
+	// worker and configure its Teams backend. Gated on AGENT_IDENTITY_BLUEPRINT_ID
+	// (emitted only by activity agents). Best-effort: failures are logged and do
+	// not fail the deploy.
+	if err := runDigitalWorkerPublish(ctx, azdClient, cred, envName, agentGUIDs); err != nil {
+		log.Printf("warning: digital worker publish failed: %v", err)
 	}
 
 	// Report optimization candidate deployments to the optimization service.
@@ -314,6 +392,54 @@ func postdeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *a
 			return optimize_api.NewOptimizeClient(endpoint, cred)
 		},
 	)
+
+	return nil
+}
+
+// runDigitalWorkerPublish publishes each deployed activity-protocol agent as an
+// M365 digital worker and configures its Teams backend. It is a no-op when
+// AGENT_IDENTITY_BLUEPRINT_ID is not present (non-activity agents) or when no agent
+// GUID was captured. All underlying steps are best-effort.
+func runDigitalWorkerPublish(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	cred azcore.TokenCredential,
+	envName string,
+	agentGUIDs map[string]string,
+) error {
+	blueprintAppID := getEnvValueOrEmpty(ctx, azdClient, envName, "AGENT_IDENTITY_BLUEPRINT_ID")
+	if blueprintAppID == "" || len(agentGUIDs) == 0 {
+		return nil
+	}
+
+	first := func(keys ...string) string {
+		for _, k := range keys {
+			if v := getEnvValueOrEmpty(ctx, azdClient, envName, k); v != "" {
+				return v
+			}
+		}
+		return ""
+	}
+
+	base := project.PublishDigitalWorkerParams{
+		BlueprintAppID: blueprintAppID,
+		SubscriptionID: first("SUBSCRIPTION_ID", "AZURE_SUBSCRIPTION_ID"),
+		ResourceGroup:  first("RESOURCE_GROUP", "AZURE_RESOURCE_GROUP"),
+		Location:       first("LOCATION", "AZURE_LOCATION"),
+		AccountName:    first("ACCOUNT_NAME", "AZURE_AI_ACCOUNT_NAME"),
+		ProjectName:    first("PROJECT_NAME", "AZURE_AI_PROJECT_NAME"),
+	}
+
+	// agentGUIDs is keyed by the resolved agent name (from AGENT_{serviceKey}_NAME),
+	// so the map key is the agent name to publish.
+	for agentName, guid := range agentGUIDs {
+		p := base
+		p.AgentGUID = guid
+		p.AgentName = agentName
+		if err := project.PublishDigitalWorker(ctx, cred, p); err != nil {
+			log.Printf("warning: digital worker publish for %q failed: %v", agentName, err)
+		}
+	}
 
 	return nil
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
@@ -130,17 +130,69 @@ func postprovisionHandler(
 				)
 			}
 
-			// For activity-protocol agents, register the blueprint into M365
-			// (delegated OAuth2 grants + blueprint owner). Gated on the presence
-			// of AGENT_IDENTITY_BLUEPRINT_ID, which only activity agents emit.
+			// For digital-worker activity agents, register the blueprint into
+			// M365 (delegated OAuth2 grants + blueprint owner). Gated on the
+			// resolved activity profile (agent.yaml activity.use_case, with an
+			// env-var fallback). Simple activity agents skip this.
 			// Best-effort: a failure is logged and does not fail provision.
-			if err := runBlueprintM365Provisioning(ctx, azdClient, envName); err != nil {
-				log.Printf("warning: blueprint M365 provisioning failed: %v", err)
+			hasBlueprintEnv := getEnvValueOrEmpty(ctx, azdClient, envName, "AGENT_IDENTITY_BLUEPRINT_ID") != "" ||
+				getEnvValueOrEmpty(ctx, azdClient, envName, "MAIB_NAME") != ""
+			if anyDigitalWorkerService(args.Project, hasBlueprintEnv, func(p agent_yaml.ActivityProfile) bool {
+				return p.M365Provision
+			}) {
+				if err := runBlueprintM365Provisioning(ctx, azdClient, envName); err != nil {
+					log.Printf("warning: blueprint M365 provisioning failed: %v", err)
+				}
 			}
 		}
 	}
 
 	return nil
+}
+
+// loadContainerAgentForService reads and parses agent.yaml for the given hosted
+// agent service. Returns false when the file is absent or cannot be parsed.
+func loadContainerAgentForService(
+	proj *azdext.ProjectConfig,
+	svc *azdext.ServiceConfig,
+) (agent_yaml.ContainerAgent, bool) {
+	agentYamlPath, err := paths.JoinAllowRoot(proj.Path, svc.RelativePath, "agent.yaml")
+	if err != nil {
+		return agent_yaml.ContainerAgent{}, false
+	}
+	data, err := os.ReadFile(agentYamlPath) //nolint:gosec // path from azd project config
+	if err != nil {
+		return agent_yaml.ContainerAgent{}, false
+	}
+	var def agent_yaml.ContainerAgent
+	if err := yaml.Unmarshal(data, &def); err != nil {
+		return agent_yaml.ContainerAgent{}, false
+	}
+	return def, true
+}
+
+// anyDigitalWorkerService reports whether any hosted agent service resolves to an
+// activity profile for which want(profile) is true (e.g. M365Provision or
+// M365Publish). hasBlueprintEnv enables the env-var fallback when agent.yaml does
+// not set activity.use_case.
+func anyDigitalWorkerService(
+	proj *azdext.ProjectConfig,
+	hasBlueprintEnv bool,
+	want func(agent_yaml.ActivityProfile) bool,
+) bool {
+	for _, svc := range proj.Services {
+		if svc.Host != AiAgentHost {
+			continue
+		}
+		def, ok := loadContainerAgentForService(proj, svc)
+		if !ok {
+			continue
+		}
+		if want(def.ResolveActivityProfile(hasBlueprintEnv)) {
+			return true
+		}
+	}
+	return false
 }
 
 // runBlueprintM365Provisioning performs the post-provision M365 registration for
@@ -314,9 +366,15 @@ func postdeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *a
 
 	agentClient := agent_api.NewAgentClient(endpointResp.Value, cred)
 
+	// Whether the environment provisioned a digital-worker blueprint, used as the
+	// fallback when agent.yaml does not set activity.use_case.
+	hasBlueprintEnv := getEnvValueOrEmpty(ctx, azdClient, envName, "AGENT_IDENTITY_BLUEPRINT_ID") != "" ||
+		getEnvValueOrEmpty(ctx, azdClient, envName, "MAIB_NAME") != ""
+
 	// Build name→principalID map by fetching the agent version for each hosted service.
 	agentIdentities := make(map[string]string)
 	// Track agent GUIDs per service for activity-protocol M365 publish (post-deploy).
+	// Only digital-worker agents are added here; simple activity agents are skipped.
 	agentGUIDs := make(map[string]string)
 	for _, svc := range hostedAgents {
 		serviceKey := toServiceKey(svc.Name)
@@ -362,8 +420,13 @@ func postdeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *a
 		}
 
 		agentIdentities[agentName] = principalID
+		// Only collect the GUID for digital-worker agents — simple activity agents
+		// are not published to M365.
 		if versionObj.AgentGUID != "" {
-			agentGUIDs[agentName] = versionObj.AgentGUID
+			if def, ok := loadContainerAgentForService(args.Project, svc); ok &&
+				def.ResolveActivityProfile(hasBlueprintEnv).M365Publish {
+				agentGUIDs[agentName] = versionObj.AgentGUID
+			}
 		}
 	}
 
@@ -583,8 +646,51 @@ func kindEnvUpdate(ctx context.Context, azdClient *azdext.AzdClient, project *az
 		if err := setEnvVar(ctx, azdClient, envName, "ENABLE_CAPABILITY_HOST", "false"); err != nil {
 			return err
 		}
+
+		// For activity-protocol digital workers, signal the infra template to
+		// create the MAIB + Bot Service by setting ENABLE_DIGITAL_WORKER and
+		// AGENT_NAME. The starter-basic infra gates the digital-worker modules on
+		// these (off by default, so other agents are unaffected).
+		if err := digitalWorkerEnvUpdate(ctx, azdClient, data, envName); err != nil {
+			return err
+		}
 	}
 
+	return nil
+}
+
+// digitalWorkerEnvUpdate inspects the agent.yaml and, when it declares an
+// activity-protocol digital worker, sets ENABLE_DIGITAL_WORKER=true and AGENT_NAME
+// so the infra template provisions the MAIB + Bot Service. For non-digital-worker
+// agents it is a no-op.
+func digitalWorkerEnvUpdate(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	agentYaml []byte,
+	envName string,
+) error {
+	var def agent_yaml.ContainerAgent
+	if err := yaml.Unmarshal(agentYaml, &def); err != nil {
+		// Non-fatal: a parse issue here shouldn't block provision; the agent.yaml
+		// was already validated above for the kind field.
+		return nil
+	}
+
+	// hasBlueprintEnv is false here: at preprovision the blueprint env vars don't
+	// exist yet. The profile therefore relies on agent.yaml's activity.use_case.
+	profile := def.ResolveActivityProfile(false)
+	if !profile.IsActivity || profile.UseCase != agent_yaml.ActivityUseCaseDigitalWorker {
+		return nil
+	}
+
+	if err := setEnvVar(ctx, azdClient, envName, "ENABLE_DIGITAL_WORKER", "true"); err != nil {
+		return err
+	}
+	if def.Name != "" {
+		if err := setEnvVar(ctx, azdClient, envName, "AGENT_NAME", def.Name); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
@@ -243,9 +243,10 @@ func (d *HostedAgentDefinition) UnmarshalJSON(data []byte) error {
 
 // CreateAgentVersionRequest represents a request to create an agent version
 type CreateAgentVersionRequest struct {
-	Description *string           `json:"description,omitempty"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
-	Definition  any               `json:"definition"` // Can be any of the agent definition types
+	Description        *string             `json:"description,omitempty"`
+	Metadata           map[string]string   `json:"metadata,omitempty"`
+	Definition         any                 `json:"definition"` // Can be any of the agent definition types
+	BlueprintReference *BlueprintReference `json:"blueprint_reference,omitempty"`
 }
 
 // CreateAgentRequest represents a request to create an agent

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
@@ -146,6 +146,10 @@ func (c *AgentClient) CreateAgent(ctx context.Context, request *CreateAgentReque
 		return nil, fmt.Errorf("failed to set request body: %w", err)
 	}
 
+	// AgentEndpoints feature must be enabled for agent_endpoint (protocols,
+	// authorization_schemes) in the request body to be honored by the service.
+	req.Raw().Header.Set("Foundry-Features", "HostedAgents=V1Preview,AgentEndpoints=V1Preview")
+
 	resp, err := c.pipeline.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
@@ -233,6 +237,10 @@ func (c *AgentClient) PatchAgent(
 	if err := req.SetBody(streaming.NopCloser(bytes.NewReader(payload)), "application/json"); err != nil {
 		return nil, fmt.Errorf("failed to set request body: %w", err)
 	}
+
+	// AgentEndpoints feature must be enabled for agent_endpoint (protocols,
+	// authorization_schemes) patches to be honored by the service.
+	req.Raw().Header.Set("Foundry-Features", "HostedAgents=V1Preview,AgentEndpoints=V1Preview")
 
 	resp, err := c.pipeline.Do(req)
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
@@ -648,6 +648,31 @@ func TestPatchAgent_Success(t *testing.T) {
 	require.Equal(t, "my-agent", result.Name)
 }
 
+// TestPatchAgent_SetsAgentEndpointsFeatureHeader verifies the agent_endpoint
+// patch is sent with the AgentEndpoints feature enabled. Without this header the
+// service ignores agent_endpoint protocols/authorization_schemes (e.g. the
+// BotServiceRbac scheme required by activity-protocol agents).
+func TestPatchAgent_SetsAgentEndpointsFeatureHeader(t *testing.T) {
+	client, transport := newCaptureClient(http.StatusOK, "{}")
+
+	req := &PatchAgentRequest{
+		AgentEndpoint: &AgentEndpoint{
+			Protocols: []AgentEndpointProtocol{AgentEndpointProtocolActivity},
+			AuthorizationSchemes: []AgentEndpointAuthorizationScheme{
+				{Type: AgentEndpointAuthSchemeBotServiceRbac},
+			},
+		},
+	}
+
+	_, err := client.PatchAgent(t.Context(), "my-agent", req, "v1")
+	require.NoError(t, err)
+	require.Len(t, transport.requests, 1)
+	require.Equal(t,
+		"HostedAgents=V1Preview,AgentEndpoints=V1Preview",
+		transport.requests[0].Header.Get("Foundry-Features"),
+	)
+}
+
 func TestPatchAgent_400ReturnsError(t *testing.T) {
 	client := newTestClient(
 		"https://test.example.com/api/projects/proj",

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/activity_profile_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/activity_profile_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package agent_yaml
+
+import "testing"
+
+func activityAgent(useCase string, protocols ...string) ContainerAgent {
+	recs := make([]ProtocolVersionRecord, 0, len(protocols))
+	for _, p := range protocols {
+		recs = append(recs, ProtocolVersionRecord{Protocol: p, Version: "1.0.0"})
+	}
+	c := ContainerAgent{Protocols: recs}
+	if useCase != "" {
+		c.Activity = &ActivityConfig{UseCase: useCase}
+	}
+	return c
+}
+
+func TestContainerAgent_IsActivityProtocol(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		protocols []string
+		want      bool
+	}{
+		{"friendly activity", []string{"activity"}, true},
+		{"wire activity_protocol", []string{"activity_protocol"}, true},
+		{"mixed case + spaces", []string{"  Activity_Protocol "}, true},
+		{"responses only", []string{"responses"}, false},
+		{"none", nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := activityAgent("", tc.protocols...).IsActivityProtocol()
+			if got != tc.want {
+				t.Errorf("IsActivityProtocol() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestContainerAgent_ResolveActivityProfile(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		useCase         string
+		protocols       []string
+		hasBlueprintEnv bool
+		wantIsActivity  bool
+		wantUseCase     ActivityUseCase
+		wantEndpoint    bool
+		wantRbac        bool
+		wantBlueprint   bool
+		wantProvision   bool
+		wantPublish     bool
+	}{
+		{
+			name:           "non-activity agent",
+			protocols:      []string{"responses"},
+			wantIsActivity: false,
+		},
+		{
+			name:           "explicit digital_worker",
+			useCase:        "digital_worker",
+			protocols:      []string{"activity"},
+			wantIsActivity: true,
+			wantUseCase:    ActivityUseCaseDigitalWorker,
+			wantEndpoint:   true,
+			wantRbac:       true,
+			wantBlueprint:  true,
+			wantProvision:  true,
+			wantPublish:    true,
+		},
+		{
+			name:           "explicit simple",
+			useCase:        "simple",
+			protocols:      []string{"activity"},
+			wantIsActivity: true,
+			wantUseCase:    ActivityUseCaseSimple,
+			wantEndpoint:   true,
+			// no rbac/blueprint/m365
+		},
+		{
+			name:            "explicit simple wins over blueprint env",
+			useCase:         "simple",
+			protocols:       []string{"activity"},
+			hasBlueprintEnv: true,
+			wantIsActivity:  true,
+			wantUseCase:     ActivityUseCaseSimple,
+			wantEndpoint:    true,
+		},
+		{
+			name:            "unset falls back to digital_worker when blueprint env present",
+			protocols:       []string{"activity"},
+			hasBlueprintEnv: true,
+			wantIsActivity:  true,
+			wantUseCase:     ActivityUseCaseDigitalWorker,
+			wantEndpoint:    true,
+			wantRbac:        true,
+			wantBlueprint:   true,
+			wantProvision:   true,
+			wantPublish:     true,
+		},
+		{
+			name:           "unset falls back to simple without blueprint env",
+			protocols:      []string{"activity"},
+			wantIsActivity: true,
+			wantUseCase:    ActivityUseCaseSimple,
+			wantEndpoint:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := activityAgent(tc.useCase, tc.protocols...).ResolveActivityProfile(tc.hasBlueprintEnv)
+			if p.IsActivity != tc.wantIsActivity {
+				t.Fatalf("IsActivity = %v, want %v", p.IsActivity, tc.wantIsActivity)
+			}
+			if !tc.wantIsActivity {
+				return
+			}
+			if p.UseCase != tc.wantUseCase {
+				t.Errorf("UseCase = %q, want %q", p.UseCase, tc.wantUseCase)
+			}
+			if p.InjectActivityEndpoint != tc.wantEndpoint {
+				t.Errorf("InjectActivityEndpoint = %v, want %v", p.InjectActivityEndpoint, tc.wantEndpoint)
+			}
+			if p.InjectBotServiceRbac != tc.wantRbac {
+				t.Errorf("InjectBotServiceRbac = %v, want %v", p.InjectBotServiceRbac, tc.wantRbac)
+			}
+			if p.InjectBlueprintReference != tc.wantBlueprint {
+				t.Errorf("InjectBlueprintReference = %v, want %v", p.InjectBlueprintReference, tc.wantBlueprint)
+			}
+			if p.M365Provision != tc.wantProvision {
+				t.Errorf("M365Provision = %v, want %v", p.M365Provision, tc.wantProvision)
+			}
+			if p.M365Publish != tc.wantPublish {
+				t.Errorf("M365Publish = %v, want %v", p.M365Publish, tc.wantPublish)
+			}
+		})
+	}
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
@@ -110,6 +110,7 @@ func MapEndpointAndCard(
 		nil,
 		agentEndpoint,
 		agentCard,
+		nil,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -381,12 +382,18 @@ func CreateHostedAgentAPIRequest(hostedAgent ContainerAgent, buildConfig *AgentB
 		}
 	}
 
-	// Map protocol versions from the hosted agent definition
+	// Map protocol versions from the hosted agent definition.
+	// "activity" in agent.yaml is the endpoint-level name; the definition-level
+	// field (container_protocol_versions) requires the canonical name "activity_protocol".
 	protocolVersions := make([]agent_api.ProtocolVersionRecord, 0)
 	if len(hostedAgent.Protocols) > 0 {
 		for _, protocol := range hostedAgent.Protocols {
+			apiProtocol := agent_api.AgentProtocol(protocol.Protocol)
+			if apiProtocol == "activity" {
+				apiProtocol = agent_api.AgentProtocolActivityProtocol
+			}
 			protocolVersions = append(protocolVersions, agent_api.ProtocolVersionRecord{
-				Protocol: agent_api.AgentProtocol(protocol.Protocol),
+				Protocol: apiProtocol,
 				Version:  protocol.Version,
 			})
 		}
@@ -422,8 +429,16 @@ func CreateHostedAgentAPIRequest(hostedAgent ContainerAgent, buildConfig *AgentB
 			},
 		}
 
+		// Map blueprint reference if present in agent.yaml
+		var blueprintRef *agent_api.BlueprintReference
+		if hostedAgent.BlueprintReference != nil {
+			blueprintRef = &agent_api.BlueprintReference{
+				Type:        hostedAgent.BlueprintReference.Type,
+				BlueprintID: hostedAgent.BlueprintReference.BlueprintID,
+			}
+		}
 		return createAgentAPIRequest(hostedAgent.AgentDefinition, codeDef,
-			hostedAgent.AgentEndpoint, hostedAgent.AgentCard)
+			hostedAgent.AgentEndpoint, hostedAgent.AgentCard, blueprintRef)
 	}
 
 	// Container/image deploy path
@@ -443,18 +458,27 @@ func CreateHostedAgentAPIRequest(hostedAgent ContainerAgent, buildConfig *AgentB
 		Image:                imageURL,
 	}
 
+	// Map blueprint reference if present in agent.yaml
+	var blueprintRef *agent_api.BlueprintReference
+	if hostedAgent.BlueprintReference != nil {
+		blueprintRef = &agent_api.BlueprintReference{
+			Type:        hostedAgent.BlueprintReference.Type,
+			BlueprintID: hostedAgent.BlueprintReference.BlueprintID,
+		}
+	}
 	return createAgentAPIRequest(hostedAgent.AgentDefinition, imageDef,
-		hostedAgent.AgentEndpoint, hostedAgent.AgentCard)
+		hostedAgent.AgentEndpoint, hostedAgent.AgentCard, blueprintRef)
 }
 
 // createAgentAPIRequest is a helper function to create the final request with common fields.
-// The optional agentEndpoint and agentCard parameters are mapped to the corresponding
-// request-level fields when non-nil.
+// The optional agentEndpoint, agentCard, and blueprintRef parameters are mapped to the
+// corresponding request-level fields when non-nil.
 func createAgentAPIRequest(
 	agentDefinition AgentDefinition,
 	agentDef any,
 	agentEndpoint *AgentEndpoint,
 	agentCard *AgentCard,
+	blueprintRef *agent_api.BlueprintReference,
 ) (*agent_api.CreateAgentRequest, error) {
 	// Prepare metadata
 	metadata := make(map[string]string)
@@ -491,7 +515,8 @@ func createAgentAPIRequest(
 	request := &agent_api.CreateAgentRequest{
 		Name: agentName,
 		CreateAgentVersionRequest: agent_api.CreateAgentVersionRequest{
-			Definition: agentDef,
+			Definition:         agentDef,
+			BlueprintReference: blueprintRef,
 		},
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
@@ -732,7 +732,7 @@ func TestCreateAgentAPIRequest_AllFields(t *testing.T) {
 		Metadata:    &meta,
 	}
 
-	req, err := createAgentAPIRequest(agentDef, "placeholder-definition", nil, nil)
+	req, err := createAgentAPIRequest(agentDef, "placeholder-definition", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -757,7 +757,7 @@ func TestCreateAgentAPIRequest_DefaultName(t *testing.T) {
 	t.Parallel()
 	agentDef := AgentDefinition{Kind: AgentKindHosted}
 
-	req, err := createAgentAPIRequest(agentDef, nil, nil, nil)
+	req, err := createAgentAPIRequest(agentDef, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -770,7 +770,7 @@ func TestCreateAgentAPIRequest_NilMetadata(t *testing.T) {
 	t.Parallel()
 	agentDef := AgentDefinition{Kind: AgentKindHosted, Name: "test"}
 
-	req, err := createAgentAPIRequest(agentDef, nil, nil, nil)
+	req, err := createAgentAPIRequest(agentDef, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -788,7 +788,7 @@ func TestCreateAgentAPIRequest_EmptyDescription(t *testing.T) {
 		Description: &empty,
 	}
 
-	req, err := createAgentAPIRequest(agentDef, nil, nil, nil)
+	req, err := createAgentAPIRequest(agentDef, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -809,7 +809,7 @@ func TestCreateAgentAPIRequest_MetadataWithNonStringValues(t *testing.T) {
 		Metadata: &meta,
 	}
 
-	req, err := createAgentAPIRequest(agentDef, nil, nil, nil)
+	req, err := createAgentAPIRequest(agentDef, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -832,7 +832,7 @@ func TestCreateAgentAPIRequest_AuthorsSingleAuthor(t *testing.T) {
 		Metadata: &meta,
 	}
 
-	req, err := createAgentAPIRequest(agentDef, nil, nil, nil)
+	req, err := createAgentAPIRequest(agentDef, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
@@ -1599,6 +1599,126 @@ func TestCreateAgentAPIRequest_CodeDeploy_WithRaiConfig(t *testing.T) {
 	}
 }
 
+// TestCreateAgentAPIRequest_ActivityProtocol_NameNormalized verifies that the
+// endpoint-level "activity" protocol name in agent.yaml is normalized to the
+// definition-level "activity_protocol" name required by container_protocol_versions.
+func TestCreateAgentAPIRequest_ActivityProtocol_NameNormalized(t *testing.T) {
+	t.Parallel()
+	agent := ContainerAgent{
+		AgentDefinition: AgentDefinition{
+			Kind: AgentKindHosted,
+			Name: "echo-agent",
+		},
+		Protocols: []ProtocolVersionRecord{
+			{Protocol: "activity", Version: "1.0.0"},
+		},
+		Image: "acr.azurecr.io/echo-agent:latest",
+	}
+
+	req, err := CreateAgentAPIRequestFromDefinition(agent, WithImageURL("acr.azurecr.io/echo-agent:latest"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	def, ok := req.Definition.(agent_api.HostedAgentDefinition)
+	if !ok {
+		t.Fatalf("expected HostedAgentDefinition, got %T", req.Definition)
+	}
+
+	if len(def.ProtocolVersions) != 1 {
+		t.Fatalf("expected 1 protocol version, got %d", len(def.ProtocolVersions))
+	}
+	if def.ProtocolVersions[0].Protocol != agent_api.AgentProtocolActivityProtocol {
+		t.Errorf("Protocol = %q, want %q", def.ProtocolVersions[0].Protocol, agent_api.AgentProtocolActivityProtocol)
+	}
+}
+
+// TestCreateAgentAPIRequest_ActivityProtocol_CanonicalNamePassedThrough verifies that
+// "activity_protocol" (already canonical) is preserved unchanged.
+func TestCreateAgentAPIRequest_ActivityProtocol_CanonicalNamePassedThrough(t *testing.T) {
+	t.Parallel()
+	agent := ContainerAgent{
+		AgentDefinition: AgentDefinition{
+			Kind: AgentKindHosted,
+			Name: "echo-agent",
+		},
+		Protocols: []ProtocolVersionRecord{
+			{Protocol: "activity_protocol", Version: "1.0.0"},
+		},
+		Image: "acr.azurecr.io/echo-agent:latest",
+	}
+
+	req, err := CreateAgentAPIRequestFromDefinition(agent, WithImageURL("acr.azurecr.io/echo-agent:latest"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	def := req.Definition.(agent_api.HostedAgentDefinition)
+	if def.ProtocolVersions[0].Protocol != agent_api.AgentProtocolActivityProtocol {
+		t.Errorf("Protocol = %q, want %q", def.ProtocolVersions[0].Protocol, agent_api.AgentProtocolActivityProtocol)
+	}
+}
+
+// TestCreateAgentAPIRequest_BlueprintReference_FromAgentYaml verifies that a
+// blueprint_reference declared in agent.yaml is mapped into the API request.
+func TestCreateAgentAPIRequest_BlueprintReference_FromAgentYaml(t *testing.T) {
+	t.Parallel()
+	agent := ContainerAgent{
+		AgentDefinition: AgentDefinition{
+			Kind: AgentKindHosted,
+			Name: "echo-agent",
+		},
+		Protocols: []ProtocolVersionRecord{
+			{Protocol: "activity_protocol", Version: "1.0.0"},
+		},
+		Image: "acr.azurecr.io/echo-agent:latest",
+		BlueprintReference: &BlueprintReference{
+			Type:        "ManagedAgentIdentityBlueprint",
+			BlueprintID: "echo-agent-maib",
+		},
+	}
+
+	req, err := CreateAgentAPIRequestFromDefinition(agent, WithImageURL("acr.azurecr.io/echo-agent:latest"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if req.BlueprintReference == nil {
+		t.Fatal("expected BlueprintReference to be set, got nil")
+	}
+	if req.BlueprintReference.Type != "ManagedAgentIdentityBlueprint" {
+		t.Errorf("BlueprintReference.Type = %q, want %q", req.BlueprintReference.Type, "ManagedAgentIdentityBlueprint")
+	}
+	if req.BlueprintReference.BlueprintID != "echo-agent-maib" {
+		t.Errorf("BlueprintReference.BlueprintID = %q, want %q", req.BlueprintReference.BlueprintID, "echo-agent-maib")
+	}
+}
+
+// TestCreateAgentAPIRequest_BlueprintReference_NilWhenNotSet verifies that the
+// blueprint_reference field is nil when not declared in agent.yaml (non-MAIB agents).
+func TestCreateAgentAPIRequest_BlueprintReference_NilWhenNotSet(t *testing.T) {
+	t.Parallel()
+	agent := ContainerAgent{
+		AgentDefinition: AgentDefinition{
+			Kind: AgentKindHosted,
+			Name: "invocations-agent",
+		},
+		Protocols: []ProtocolVersionRecord{
+			{Protocol: "invocations", Version: "1.0.0"},
+		},
+		Image: "acr.azurecr.io/invocations-agent:latest",
+	}
+
+	req, err := CreateAgentAPIRequestFromDefinition(agent, WithImageURL("acr.azurecr.io/invocations-agent:latest"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if req.BlueprintReference != nil {
+		t.Errorf("expected BlueprintReference to be nil for non-MAIB agent, got %+v", req.BlueprintReference)
+	}
+}
+
 func TestCreateHostedAgentAPIRequest_NoRaiConfig(t *testing.T) {
 	t.Parallel()
 	agent := ContainerAgent{

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
@@ -6,6 +6,7 @@ package agent_yaml
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"go.yaml.in/yaml/v3"
 )
@@ -230,6 +231,7 @@ type ContainerAgent struct {
 	CodeConfiguration    *CodeConfiguration      `json:"codeConfiguration,omitempty" yaml:"code_configuration,omitempty"`
 	Policies             []Policy                `json:"policies,omitempty" yaml:"policies,omitempty"`
 	BlueprintReference   *BlueprintReference     `json:"blueprintReference,omitempty" yaml:"blueprint_reference,omitempty"`
+	Activity             *ActivityConfig         `json:"activity,omitempty" yaml:"activity,omitempty"`
 }
 
 // AgentManifest The following represents a manifest that can be used to create agents dynamically.
@@ -688,6 +690,116 @@ type AgentEndpoint struct {
 	VersionSelector      *VersionSelector      `json:"versionSelector,omitempty" yaml:"version_selector,omitempty"`
 	Protocols            []string              `json:"protocols,omitempty" yaml:"protocols,omitempty"`
 	AuthorizationSchemes []AuthorizationScheme `json:"authorizationSchemes,omitempty" yaml:"authorization_schemes,omitempty"`
+}
+
+// ActivityUseCase identifies how an activity-protocol agent is consumed, which
+// determines the additional deployment operations azd performs.
+type ActivityUseCase string
+
+const (
+	// ActivityUseCaseSimple is a plain activity-protocol agent: it receives
+	// pushed activities but is not registered as an M365 digital worker. Only
+	// the activity protocol + endpoint are configured.
+	ActivityUseCaseSimple ActivityUseCase = "simple"
+	// ActivityUseCaseDigitalWorker is an activity agent published into M365 as a
+	// digital worker. In addition to the activity endpoint, azd injects the
+	// BotServiceRbac auth scheme and blueprint reference, and runs the M365
+	// registration steps (OAuth2 grants, blueprint owner, digital-worker
+	// publish, Teams backend configuration).
+	ActivityUseCaseDigitalWorker ActivityUseCase = "digital_worker"
+)
+
+// ActivityConfig holds activity-protocol specific configuration in agent.yaml.
+type ActivityConfig struct {
+	// UseCase selects the activity deployment profile: "simple" or
+	// "digital_worker". When empty, the profile is inferred from the
+	// environment (see ResolveActivityProfile).
+	UseCase string `json:"useCase,omitempty" yaml:"use_case,omitempty"`
+}
+
+// ActivityProfile describes which activity-specific deployment operations apply
+// to an agent. It is the single source of truth shared by the deploy path and
+// the provision/deploy lifecycle handlers.
+type ActivityProfile struct {
+	// IsActivity is true when the agent declares the activity protocol.
+	IsActivity bool
+	// UseCase is the resolved use case (simple or digital_worker). Only
+	// meaningful when IsActivity is true.
+	UseCase ActivityUseCase
+	// InjectActivityEndpoint registers agent_endpoint.protocols=["activity"].
+	InjectActivityEndpoint bool
+	// InjectBotServiceRbac adds the BotServiceRbac authorization scheme so a Bot
+	// Service channel can authenticate to the agent.
+	InjectBotServiceRbac bool
+	// InjectBlueprintReference injects blueprint_reference from MAIB_NAME.
+	InjectBlueprintReference bool
+	// M365Provision runs the post-provision M365 registration (OAuth2 grants +
+	// blueprint owner).
+	M365Provision bool
+	// M365Publish runs the post-deploy M365 publish (digital-worker publish +
+	// Teams backend configuration).
+	M365Publish bool
+}
+
+// IsActivityProtocol reports whether the agent declares the activity protocol,
+// accepting both the friendly name "activity" and the wire name
+// "activity_protocol".
+func (c ContainerAgent) IsActivityProtocol() bool {
+	for _, p := range c.Protocols {
+		switch strings.ToLower(strings.TrimSpace(p.Protocol)) {
+		case "activity", "activity_protocol":
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveActivityProfile resolves the activity deployment profile for the agent.
+//
+// The use case is taken from agent.yaml's activity.use_case when set. When it is
+// unset, the profile falls back to the environment: if a blueprint/MAIB is
+// present (hasBlueprintEnv), the agent is treated as a digital worker for
+// backward compatibility; otherwise it is a simple activity agent.
+//
+// hasBlueprintEnv should be true when MAIB_NAME or AGENT_IDENTITY_BLUEPRINT_ID is
+// set in the azd environment (i.e. the infra provisioned a digital-worker
+// blueprint).
+func (c ContainerAgent) ResolveActivityProfile(hasBlueprintEnv bool) ActivityProfile {
+	if !c.IsActivityProtocol() {
+		return ActivityProfile{IsActivity: false}
+	}
+
+	useCase := ActivityUseCase(strings.ToLower(strings.TrimSpace(activityUseCaseOf(c))))
+	if useCase == "" {
+		if hasBlueprintEnv {
+			useCase = ActivityUseCaseDigitalWorker
+		} else {
+			useCase = ActivityUseCaseSimple
+		}
+	}
+
+	profile := ActivityProfile{
+		IsActivity:             true,
+		UseCase:                useCase,
+		InjectActivityEndpoint: true, // all activity agents receive pushed activities
+	}
+
+	if useCase == ActivityUseCaseDigitalWorker {
+		profile.InjectBotServiceRbac = true
+		profile.InjectBlueprintReference = true
+		profile.M365Provision = true
+		profile.M365Publish = true
+	}
+
+	return profile
+}
+
+// activityUseCaseOf returns the configured activity use case, or "" when unset.
+func activityUseCaseOf(c ContainerAgent) string {
+	if c.Activity == nil {
+		return ""
+	}
+	return c.Activity.UseCase
 }
 
 // AgentCardSkill describes a single capability that an agent can perform.

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
@@ -229,6 +229,7 @@ type ContainerAgent struct {
 	AgentCard            *AgentCard              `json:"agentCard,omitempty" yaml:"agent_card,omitempty"`
 	CodeConfiguration    *CodeConfiguration      `json:"codeConfiguration,omitempty" yaml:"code_configuration,omitempty"`
 	Policies             []Policy                `json:"policies,omitempty" yaml:"policies,omitempty"`
+	BlueprintReference   *BlueprintReference     `json:"blueprintReference,omitempty" yaml:"blueprint_reference,omitempty"`
 }
 
 // AgentManifest The following represents a manifest that can be used to create agents dynamically.
@@ -647,6 +648,16 @@ func (ps PropertySchema) MarshalYAML() (any, error) {
 type ProtocolVersionRecord struct {
 	Protocol string `json:"protocol" yaml:"protocol"`
 	Version  string `json:"version" yaml:"version"`
+}
+
+// BlueprintReference identifies the Managed Agent Identity Blueprint (MAIB)
+// backing an agent version. When set in agent.yaml, it is forwarded verbatim
+// to the Foundry CreateAgentVersion API as the blueprint_reference field.
+// For activity-protocol agents, the MAIB_NAME azd environment variable is used
+// as a fallback when this field is omitted.
+type BlueprintReference struct {
+	Type        string `json:"type" yaml:"type"`
+	BlueprintID string `json:"blueprint_id" yaml:"blueprint_id"`
 }
 
 // VersionSelectionRule describes how traffic is routed to an agent version in agent.yaml.

--- a/cli/azd/extensions/azure.ai.agents/internal/project/m365_registration.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/m365_registration.go
@@ -1,0 +1,425 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+)
+
+// M365 registration moves the work the legacy activity-protocol PowerShell
+// scripts performed (post-provision OAuth2 grants + blueprint owner, post-deploy
+// digital-worker publish + Teams backend configuration) into the native azd
+// deploy lifecycle. These are Microsoft Graph / AzureML / Teams Developer Portal
+// data-plane operations that register the activity agent's blueprint into M365 so
+// the agent is reachable from channels (e.g. Teams).
+//
+// All steps are best-effort: they require elevated Graph / admin permissions that
+// not every developer has, so a failure is surfaced as a warning and does not fail
+// `azd provision` / `azd deploy`. This mirrors the existing agent-identity RBAC
+// step, which also warns (rather than fails) on a 403.
+
+const (
+	graphBaseURL = "https://graph.microsoft.com/v1.0"
+	graphScope   = "https://graph.microsoft.com/.default"
+	aiAzureScope = "https://ai.azure.com/.default"
+	teamsScope   = "https://dev.teams.microsoft.com/.default"
+
+	// Well-known first-party app IDs that the blueprint service principal must be
+	// granted delegated access to for inheritable tool scopes to work.
+	apexAppID    = "5a807f24-c9de-44ee-a3a7-329e88a00ffc"
+	prodMCPAppID = "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1"
+
+	// Delegated scopes granted to the blueprint SP on the prod MCP server SP.
+	mcpGrantScopes = "McpServers.M365Admin.All McpServers.DASearch.All McpServers.WebSearch.All " +
+		"McpServers.Files.All AgentTools.MOSEvents.All McpServers.Admin365Graph.All " +
+		"McpServers.ERPAnalytics.All McpServers.DataverseCustom.All McpServers.Dataverse.All " +
+		"McpServers.D365Service.All McpServers.D365Sales.All McpServers.Management.All " +
+		"McpServersMetadata.Read.All McpServers.Developer.All McpServers.CopilotMCP.All " +
+		"McpServers.OneDriveSharepoint.All McpServers.Mail.All McpServers.Teams.All " +
+		"McpServers.Me.All McpServers.Calendar.All McpServers.SharepointLists.All " +
+		"McpServers.Knowledge.All McpServers.Excel.All McpServers.Word.All " +
+		"McpServers.PowerPoint.All"
+
+	// Delegated scope granted to the blueprint SP on the APEX (AgentData) SP.
+	apexGrantScope = "AgentData.ReadWrite"
+)
+
+// m365Client performs authenticated JSON requests against the Graph, AzureML and
+// Teams Developer Portal data planes using credential-scoped bearer tokens.
+type m365Client struct {
+	cred azcore.TokenCredential
+	http *http.Client
+}
+
+func newM365Client(cred azcore.TokenCredential) *m365Client {
+	return &m365Client{
+		cred: cred,
+		http: &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+// httpResult is the decoded outcome of an authenticated request.
+type httpResult struct {
+	statusCode int
+	body       string
+}
+
+// ok reports whether the status code is a 2xx success.
+func (r httpResult) ok() bool { return r.statusCode >= 200 && r.statusCode < 300 }
+
+// do issues an authenticated request for the given token scope. A nil body sends
+// no payload. The response body is always read so callers can string-match
+// service error messages for idempotency.
+func (c *m365Client) do(
+	ctx context.Context,
+	method, url, scope string,
+	body any,
+) (httpResult, error) {
+	token, err := c.cred.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{scope}})
+	if err != nil {
+		return httpResult{}, fmt.Errorf("failed to acquire token for %s: %w", scope, err)
+	}
+
+	var reader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return httpResult{}, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		reader = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, reader)
+	if err != nil {
+		return httpResult{}, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token.Token)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return httpResult{}, fmt.Errorf("request to %s failed: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	return httpResult{statusCode: resp.StatusCode, body: string(raw)}, nil
+}
+
+// servicePrincipalObjectID resolves a service principal's object ID from its app
+// (client) ID via Graph.
+func (c *m365Client) servicePrincipalObjectID(ctx context.Context, appID string) (string, error) {
+	url := fmt.Sprintf("%s/servicePrincipals(appId='%s')", graphBaseURL, appID)
+	res, err := c.do(ctx, http.MethodGet, url, graphScope, nil)
+	if err != nil {
+		return "", err
+	}
+	if !res.ok() {
+		return "", fmt.Errorf("graph returned %d resolving service principal for appId %s: %s",
+			res.statusCode, appID, res.body)
+	}
+	var obj struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(res.body), &obj); err != nil {
+		return "", fmt.Errorf("failed to parse service principal response: %w", err)
+	}
+	if obj.ID == "" {
+		return "", fmt.Errorf("service principal object ID not found for appId %s", appID)
+	}
+	return obj.ID, nil
+}
+
+// applicationObjectID resolves an application's object ID from its app (client) ID.
+func (c *m365Client) applicationObjectID(ctx context.Context, appID string) (string, error) {
+	url := fmt.Sprintf("%s/applications(appId='%s')", graphBaseURL, appID)
+	res, err := c.do(ctx, http.MethodGet, url, graphScope, nil)
+	if err != nil {
+		return "", err
+	}
+	if !res.ok() {
+		return "", fmt.Errorf("graph returned %d resolving application for appId %s: %s",
+			res.statusCode, appID, res.body)
+	}
+	var obj struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(res.body), &obj); err != nil {
+		return "", fmt.Errorf("failed to parse application response: %w", err)
+	}
+	if obj.ID == "" {
+		return "", fmt.Errorf("application object ID not found for appId %s", appID)
+	}
+	return obj.ID, nil
+}
+
+// createOAuth2Grant creates a delegated (AllPrincipals) OAuth2 permission grant
+// from the blueprint SP (clientID) to a resource SP (resourceID). Existing grants
+// are treated as success (idempotent).
+func (c *m365Client) createOAuth2Grant(ctx context.Context, clientSPID, resourceSPID, scope string) error {
+	body := map[string]any{
+		"clientId":    clientSPID,
+		"consentType": "AllPrincipals",
+		"principalId": nil,
+		"resourceId":  resourceSPID,
+		"scope":       scope,
+	}
+	res, err := c.do(ctx, http.MethodPost, graphBaseURL+"/oauth2PermissionGrants", graphScope, body)
+	if err != nil {
+		return err
+	}
+	if res.ok() {
+		return nil
+	}
+	if strings.Contains(res.body, "Permission entry already exists") {
+		return nil
+	}
+	return fmt.Errorf("graph returned %d creating OAuth2 grant: %s", res.statusCode, res.body)
+}
+
+// EnsureBlueprintM365Provisioning performs the post-provision M365 setup for an
+// activity-protocol agent's blueprint: delegated OAuth2 grants for inheritable tool
+// scopes and adding the current user as an owner of the blueprint application.
+//
+// Best-effort: any failure is reported as a warning and nil is returned so that a
+// missing Graph permission does not fail `azd provision`.
+func EnsureBlueprintM365Provisioning(
+	ctx context.Context,
+	cred azcore.TokenCredential,
+	blueprintAppID string,
+) error {
+	if strings.TrimSpace(blueprintAppID) == "" {
+		return nil
+	}
+
+	fmt.Println()
+	fmt.Println("Blueprint M365 registration (post-provision)")
+	fmt.Printf("  Blueprint app ID: %s\n", blueprintAppID)
+
+	client := newM365Client(cred)
+
+	blueprintSPID, err := client.servicePrincipalObjectID(ctx, blueprintAppID)
+	if err != nil {
+		warnM365("resolve blueprint service principal", err)
+		// Without the blueprint SP object ID neither grant can proceed; the owner
+		// step is independent, so fall through to it.
+	} else {
+		ensureOAuth2Grants(ctx, client, blueprintSPID)
+	}
+
+	ensureBlueprintOwner(ctx, client, blueprintAppID)
+
+	fmt.Println("✓ Blueprint M365 registration (post-provision) complete")
+	return nil
+}
+
+// ensureOAuth2Grants grants the blueprint SP delegated access to the prod MCP and
+// APEX service principals. Each grant is best-effort.
+func ensureOAuth2Grants(ctx context.Context, client *m365Client, blueprintSPID string) {
+	mcpSPID, err := client.servicePrincipalObjectID(ctx, prodMCPAppID)
+	if err != nil {
+		warnM365("resolve prod MCP service principal", err)
+	} else if err := client.createOAuth2Grant(ctx, blueprintSPID, mcpSPID, mcpGrantScopes); err != nil {
+		warnM365("create MCP OAuth2 grant", err)
+	} else {
+		fmt.Println("    ✓ MCP delegated scopes granted to blueprint SP")
+	}
+
+	apexSPID, err := client.servicePrincipalObjectID(ctx, apexAppID)
+	if err != nil {
+		warnM365("resolve APEX service principal", err)
+	} else if err := client.createOAuth2Grant(ctx, blueprintSPID, apexSPID, apexGrantScope); err != nil {
+		warnM365("create APEX OAuth2 grant", err)
+	} else {
+		fmt.Println("    ✓ APEX delegated scope granted to blueprint SP")
+	}
+}
+
+// ensureBlueprintOwner adds the current signed-in user as an owner of the blueprint
+// application. Best-effort; requires user-delegated auth (not a service principal).
+func ensureBlueprintOwner(ctx context.Context, client *m365Client, blueprintAppID string) {
+	meRes, err := client.do(ctx, http.MethodGet, graphBaseURL+"/me", graphScope, nil)
+	if err != nil {
+		warnM365("resolve current user", err)
+		return
+	}
+	if !meRes.ok() {
+		warnM365("resolve current user", fmt.Errorf("graph returned %d: %s", meRes.statusCode, meRes.body))
+		return
+	}
+	var me struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(meRes.body), &me); err != nil || me.ID == "" {
+		warnM365("resolve current user", fmt.Errorf("could not parse /me response: %s", meRes.body))
+		return
+	}
+
+	appObjectID, err := client.applicationObjectID(ctx, blueprintAppID)
+	if err != nil {
+		warnM365("resolve blueprint application", err)
+		return
+	}
+
+	body := map[string]any{
+		"@odata.id": fmt.Sprintf("%s/directoryObjects/%s", graphBaseURL, me.ID),
+	}
+	url := fmt.Sprintf("%s/applications/%s/owners/$ref", graphBaseURL, appObjectID)
+	res, err := client.do(ctx, http.MethodPost, url, graphScope, body)
+	if err != nil {
+		warnM365("add current user as blueprint owner", err)
+		return
+	}
+	if res.ok() || strings.Contains(res.body, "One or more added object references already exist") {
+		fmt.Println("    ✓ Current user is an owner of the blueprint application")
+		return
+	}
+	warnM365("add current user as blueprint owner",
+		fmt.Errorf("graph returned %d: %s", res.statusCode, res.body))
+}
+
+// PublishDigitalWorkerParams holds the inputs required to publish an activity agent
+// as an M365 digital worker and configure its Teams backend.
+type PublishDigitalWorkerParams struct {
+	BlueprintAppID string
+	AgentGUID      string
+	AgentName      string
+	SubscriptionID string
+	ResourceGroup  string
+	Location       string
+	AccountName    string
+	ProjectName    string
+}
+
+// PublishDigitalWorker publishes the deployed activity agent as an M365 digital
+// worker (tenant scope) and configures the blueprint's Teams backend so it is
+// reachable from channels. Best-effort: failures are surfaced as warnings and nil
+// is returned so a missing permission does not fail `azd deploy`.
+func PublishDigitalWorker(
+	ctx context.Context,
+	cred azcore.TokenCredential,
+	p PublishDigitalWorkerParams,
+) error {
+	if strings.TrimSpace(p.BlueprintAppID) == "" || strings.TrimSpace(p.AgentGUID) == "" {
+		return nil
+	}
+
+	fmt.Println()
+	fmt.Println("Publish digital worker (post-deploy)")
+	fmt.Printf("  Agent: %s | Blueprint: %s | GUID: %s\n", p.AgentName, p.BlueprintAppID, p.AgentGUID)
+
+	client := newM365Client(cred)
+
+	if err := publishDigitalWorkerRequest(ctx, client, p); err != nil {
+		warnM365("publish digital worker to M365", err)
+	} else {
+		fmt.Println("    ✓ Digital worker published to M365 (tenant scope)")
+	}
+
+	if err := configureBlueprintBackend(ctx, client, p.BlueprintAppID); err != nil {
+		warnM365("configure blueprint backend in Teams Developer Portal", err)
+	} else {
+		fmt.Println("    ✓ Blueprint backend configured in Teams Developer Portal")
+	}
+
+	fmt.Println("✓ Publish digital worker (post-deploy) complete")
+	fmt.Println()
+	fmt.Println("Next steps:")
+	fmt.Println("  1. Approve the agent in M365 Admin Center: " +
+		"https://admin.cloud.microsoft/#/agents/all/requested")
+	fmt.Printf("  2. Blueprint ID: %s\n", p.BlueprintAppID)
+	return nil
+}
+
+// publishDigitalWorkerRequest POSTs the M365 publish request to the AzureML
+// agent-asset data plane. Existing published versions are treated as success.
+func publishDigitalWorkerRequest(ctx context.Context, client *m365Client, p PublishDigitalWorkerParams) error {
+	workspaceName := fmt.Sprintf("%s@%s@AML", p.AccountName, p.ProjectName)
+	url := fmt.Sprintf(
+		"https://%s.api.azureml.ms/agent-asset/v2.0/subscriptions/%s/resourceGroups/%s/"+
+			"providers/Microsoft.MachineLearningServices/workspaces/%s/microsoft365/publish",
+		p.Location, p.SubscriptionID, p.ResourceGroup, workspaceName,
+	)
+
+	body := map[string]any{
+		"agentGuid":              p.AgentGUID,
+		"botId":                  p.BlueprintAppID,
+		"publishAsDigitalWorker": true,
+		"appPublishScope":        "Tenant",
+		"subscriptionId":         p.SubscriptionID,
+		"agentName":              p.AgentName,
+		"appVersion":             "1.0.0",
+		"shortDescription":       "Foundry A365 Agent deployed via Azure Developer CLI",
+		"fullDescription": "A Foundry A365 agent example that demonstrates integration with " +
+			"Microsoft 365 and Azure Cognitive Services.",
+		"developerName":          "Azure Developer",
+		"developerWebsiteUrl":    "https://azure.microsoft.com",
+		"privacyUrl":             "https://privacy.microsoft.com",
+		"termsOfUseUrl":          "https://www.microsoft.com/legal/terms-of-use",
+		"useAgenticUserTemplate": true,
+		"agenticUserTemplate": map[string]any{
+			"Id":                       "digitalWorkerTemplate",
+			"File":                     "agenticUserTemplateManifest.json",
+			"SchemaVersion":            "0.1.0-preview",
+			"AgentIdentityBlueprintId": p.BlueprintAppID,
+			"CommunicationProtocol":    "activityProtocol",
+		},
+	}
+
+	res, err := client.do(ctx, http.MethodPost, url, aiAzureScope, body)
+	if err != nil {
+		return err
+	}
+	if res.ok() || strings.Contains(res.body, "version already exists") {
+		return nil
+	}
+	return fmt.Errorf("publish API returned %d: %s", res.statusCode, res.body)
+}
+
+// configureBlueprintBackend configures the blueprint's bot-based backend in the
+// Teams Developer Portal. The bot ID is the same as the blueprint app ID.
+func configureBlueprintBackend(ctx context.Context, client *m365Client, blueprintAppID string) error {
+	url := fmt.Sprintf(
+		"https://dev.teams.microsoft.com/api/v1.0/agentblueprints/%s/backendConfiguration",
+		blueprintAppID,
+	)
+	body := map[string]any{
+		"type": "botBased",
+		"botBased": map[string]any{
+			"botId": blueprintAppID,
+		},
+	}
+	res, err := client.do(ctx, http.MethodPut, url, teamsScope, body)
+	if err != nil {
+		return err
+	}
+	if res.ok() {
+		return nil
+	}
+	return fmt.Errorf("teams developer portal returned %d: %s", res.statusCode, res.body)
+}
+
+// warnM365 prints a non-fatal warning for a failed best-effort M365 step.
+func warnM365(action string, err error) {
+	fmt.Printf("%s\n", output.WithWarningFormat(
+		"    Could not %s: %v\n"+
+			"      This step requires elevated Microsoft Graph / admin permissions and is best-effort.\n"+
+			"      The agent was still deployed; complete this step manually if channel access is required.",
+		action, err,
+	))
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/m365_registration_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/m365_registration_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTokenCredential is a no-op TokenCredential for tests.
+type fakeTokenCredential struct {
+	token string
+}
+
+func (f fakeTokenCredential) GetToken(
+	context.Context, policy.TokenRequestOptions,
+) (azcore.AccessToken, error) {
+	tok := f.token
+	if tok == "" {
+		tok = "test-token"
+	}
+	return azcore.AccessToken{Token: tok, ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func TestHTTPResultOK(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, httpResult{statusCode: 200}.ok())
+	require.True(t, httpResult{statusCode: 201}.ok())
+	require.True(t, httpResult{statusCode: 299}.ok())
+	require.False(t, httpResult{statusCode: 199}.ok())
+	require.False(t, httpResult{statusCode: 300}.ok())
+	require.False(t, httpResult{statusCode: 400}.ok())
+	require.False(t, httpResult{statusCode: 500}.ok())
+}
+
+func TestM365Client_Do_SetsBearerTokenAndParsesResponse(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth, gotAccept, gotContentType, gotMethod string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotAccept = r.Header.Get("Accept")
+		gotContentType = r.Header.Get("Content-Type")
+		gotMethod = r.Method
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"abc"}`))
+	}))
+	defer server.Close()
+
+	client := newM365Client(fakeTokenCredential{token: "secret-token"})
+	res, err := client.do(
+		t.Context(), http.MethodPost, server.URL, graphScope,
+		map[string]any{"hello": "world"},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, res.statusCode)
+	require.Equal(t, `{"id":"abc"}`, res.body)
+	require.True(t, res.ok())
+
+	require.Equal(t, "Bearer secret-token", gotAuth)
+	require.Equal(t, "application/json", gotAccept)
+	require.Equal(t, "application/json", gotContentType)
+	require.Equal(t, http.MethodPost, gotMethod)
+	require.JSONEq(t, `{"hello":"world"}`, string(gotBody))
+}
+
+func TestM365Client_Do_NoBodyOmitsContentType(t *testing.T) {
+	t.Parallel()
+
+	var gotContentType string
+	hadBody := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		b, _ := io.ReadAll(r.Body)
+		hadBody = len(b) > 0
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := newM365Client(fakeTokenCredential{})
+	res, err := client.do(t.Context(), http.MethodGet, server.URL, graphScope, nil)
+	require.NoError(t, err)
+	require.True(t, res.ok())
+	require.Empty(t, gotContentType)
+	require.False(t, hadBody)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -60,7 +60,8 @@ type displayableProtocolEntry struct {
 }
 
 // displayableProtocols is the single source of truth for protocols that produce
-// user-facing invocation endpoints and env vars.
+// user-facing endpoint configuration and env vars.
+// Note: activity_protocol is push-based (not invocable) but is displayable for endpoint configuration.
 var displayableProtocols = []displayableProtocolEntry{
 	{
 		Protocol:  agent_api.AgentProtocolResponses,
@@ -76,6 +77,11 @@ var displayableProtocols = []displayableProtocolEntry{
 		Protocol:  agent_api.AgentProtocolInvocationsWS,
 		EnvSuffix: "INVOCATIONS_WS",
 		BuildURL:  buildInvocationsWSProtocolURL,
+	},
+	{
+		Protocol:  agent_api.AgentProtocolActivityProtocol,
+		EnvSuffix: "ACTIVITY",
+		BuildURL:  buildActivityProtocolURL,
 	},
 }
 
@@ -120,6 +126,17 @@ func buildInvocationsWSProtocolURL(projectEndpoint, agentName string) string {
 	return fmt.Sprintf(
 		"wss://%s/api/projects/agents/endpoint/protocols/invocations_ws?%s",
 		u.Host, q.Encode(),
+	)
+}
+
+// buildActivityProtocolURL builds the per-agent URL reference for the "activity_protocol".
+// Activity is push-based (Foundry pushes activities to the agent), not pull-based like
+// responses/invocations. This returns a declarative reference URL used in endpoint
+// configuration, not an HTTP invocation endpoint.
+func buildActivityProtocolURL(projectEndpoint, agentName string) string {
+	return fmt.Sprintf(
+		"%s/agents/%s/endpoint/protocols/activity?api-version=%s",
+		projectEndpoint, agentName, agent_api.AgentEndpointAPIVersion,
 	)
 }
 
@@ -1224,6 +1241,26 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 
 	applyAgentMetadata(request)
 
+	// For activity-protocol agents, inject BlueprintReference from MAIB_NAME env var
+	// when not already specified in agent.yaml. MAIB_NAME is a Bicep output that
+	// identifies the Managed Agent Identity Blueprint backing this agent.
+	if request.BlueprintReference == nil && azdEnv["MAIB_NAME"] != "" {
+		request.BlueprintReference = &agent_api.BlueprintReference{
+			Type:        "ManagedAgentIdentityBlueprint",
+			BlueprintID: azdEnv["MAIB_NAME"],
+		}
+	}
+
+	// For activity-protocol agents, ensure the agent endpoint advertises the
+	// "activity" protocol and registers a BotServiceRbac authorization scheme so
+	// the Bot Service channel can authenticate to the push-based agent endpoint.
+	// This mirrors the unconditional endpoint patch the legacy activity scripts
+	// perform, making activity agents work out of the box without sample authors
+	// hand-writing agent_endpoint. Existing user-specified values are preserved.
+	if agentDefDeclaresActivity(agentDef) {
+		ensureActivityEndpointDefaults(request)
+	}
+
 	// Default to "responses" protocol when none specified in agent.yaml.
 	protocols := agentDef.Protocols
 	if len(protocols) == 0 {
@@ -1237,6 +1274,60 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 		request:         request,
 		protocols:       protocols,
 	}, nil
+}
+
+// agentDefDeclaresActivity reports whether the agent definition declares the
+// activity protocol. agent.yaml may use either the endpoint-level name
+// "activity" or the canonical definition-level name "activity_protocol".
+func agentDefDeclaresActivity(agentDef agent_yaml.ContainerAgent) bool {
+	for _, p := range agentDef.Protocols {
+		switch strings.ToLower(strings.TrimSpace(p.Protocol)) {
+		case string(agent_api.AgentEndpointProtocolActivity),
+			string(agent_api.AgentProtocolActivityProtocol):
+			return true
+		}
+	}
+	return false
+}
+
+// ensureActivityEndpointDefaults makes sure an activity agent's endpoint is
+// configured for push-based delivery: the "activity" endpoint protocol must be
+// present and a BotServiceRbac authorization scheme must be registered so the
+// Bot Service channel can authenticate. Existing values are preserved; this only
+// adds what is missing.
+func ensureActivityEndpointDefaults(request *agent_api.CreateAgentRequest) {
+	if request.AgentEndpoint == nil {
+		request.AgentEndpoint = &agent_api.AgentEndpoint{}
+	}
+
+	hasActivity := false
+	for _, p := range request.AgentEndpoint.Protocols {
+		if p == agent_api.AgentEndpointProtocolActivity {
+			hasActivity = true
+			break
+		}
+	}
+	if !hasActivity {
+		request.AgentEndpoint.Protocols = append(
+			request.AgentEndpoint.Protocols, agent_api.AgentEndpointProtocolActivity,
+		)
+	}
+
+	hasBotServiceRbac := false
+	for _, s := range request.AgentEndpoint.AuthorizationSchemes {
+		if s.Type == agent_api.AgentEndpointAuthSchemeBotServiceRbac {
+			hasBotServiceRbac = true
+			break
+		}
+	}
+	if !hasBotServiceRbac {
+		request.AgentEndpoint.AuthorizationSchemes = append(
+			request.AgentEndpoint.AuthorizationSchemes,
+			agent_api.AgentEndpointAuthorizationScheme{
+				Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac,
+			},
+		)
+	}
 }
 
 // deployResult holds the intermediate results from a deploy method (code or container)
@@ -2256,9 +2347,10 @@ func (p *AgentServiceTargetProvider) createAgent(
 
 	// Extract CreateAgentVersionRequest from CreateAgentRequest
 	versionRequest := &agent_api.CreateAgentVersionRequest{
-		Description: request.Description,
-		Metadata:    request.Metadata,
-		Definition:  request.Definition,
+		Description:        request.Description,
+		Metadata:           request.Metadata,
+		Definition:         request.Definition,
+		BlueprintReference: request.BlueprintReference,
 	}
 
 	// Create agent version

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -52,6 +52,11 @@ type displayableProtocolEntry struct {
 	Protocol  agent_api.AgentProtocol
 	URLPath   string // path suffix in the invocation URL (empty when BuildURL is set)
 	EnvSuffix string // suffix used in AGENT_{KEY}_{SUFFIX}_ENDPOINT env vars
+	// DisplayLabel optionally overrides the user-facing protocol name. When empty,
+	// string(Protocol) is used. This lets the wire-level name (e.g.
+	// "activity_protocol", required by the service) differ from the friendly name
+	// shown to users (e.g. "activity").
+	DisplayLabel string
 	// BuildURL optionally builds a custom invocation URL for this protocol.
 	// When set, it overrides the generic URL template that uses URLPath.
 	// projectEndpoint is the Foundry project root
@@ -79,9 +84,10 @@ var displayableProtocols = []displayableProtocolEntry{
 		BuildURL:  buildInvocationsWSProtocolURL,
 	},
 	{
-		Protocol:  agent_api.AgentProtocolActivityProtocol,
-		EnvSuffix: "ACTIVITY",
-		BuildURL:  buildActivityProtocolURL,
+		Protocol:     agent_api.AgentProtocolActivityProtocol,
+		EnvSuffix:    "ACTIVITY",
+		DisplayLabel: string(agent_api.AgentEndpointProtocolActivity),
+		BuildURL:     buildActivityProtocolURL,
 	},
 }
 
@@ -153,8 +159,12 @@ type ProtocolEnvSuffix struct {
 func DisplayableProtocolEnvSuffixes() []ProtocolEnvSuffix {
 	result := make([]ProtocolEnvSuffix, len(displayableProtocols))
 	for i, dp := range displayableProtocols {
+		label := dp.DisplayLabel
+		if label == "" {
+			label = string(dp.Protocol)
+		}
 		result[i] = ProtocolEnvSuffix{
-			Label:  string(dp.Protocol),
+			Label:  label,
 			Suffix: dp.EnvSuffix,
 		}
 	}
@@ -1241,10 +1251,18 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 
 	applyAgentMetadata(request)
 
-	// For activity-protocol agents, inject BlueprintReference from MAIB_NAME env var
+	// Resolve the activity deployment profile. The use case comes from
+	// agent.yaml's activity.use_case when set; otherwise it falls back to the
+	// environment (a provisioned blueprint/MAIB implies a digital worker).
+	hasBlueprintEnv := azdEnv["MAIB_NAME"] != "" || azdEnv["AGENT_IDENTITY_BLUEPRINT_ID"] != ""
+	activityProfile := agentDef.ResolveActivityProfile(hasBlueprintEnv)
+
+	// For digital-worker agents, inject BlueprintReference from MAIB_NAME env var
 	// when not already specified in agent.yaml. MAIB_NAME is a Bicep output that
-	// identifies the Managed Agent Identity Blueprint backing this agent.
-	if request.BlueprintReference == nil && azdEnv["MAIB_NAME"] != "" {
+	// identifies the Managed Agent Identity Blueprint backing this agent. Simple
+	// activity agents are not backed by a blueprint and skip this.
+	if activityProfile.InjectBlueprintReference &&
+		request.BlueprintReference == nil && azdEnv["MAIB_NAME"] != "" {
 		request.BlueprintReference = &agent_api.BlueprintReference{
 			Type:        "ManagedAgentIdentityBlueprint",
 			BlueprintID: azdEnv["MAIB_NAME"],
@@ -1252,13 +1270,11 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 	}
 
 	// For activity-protocol agents, ensure the agent endpoint advertises the
-	// "activity" protocol and registers a BotServiceRbac authorization scheme so
-	// the Bot Service channel can authenticate to the push-based agent endpoint.
-	// This mirrors the unconditional endpoint patch the legacy activity scripts
-	// perform, making activity agents work out of the box without sample authors
-	// hand-writing agent_endpoint. Existing user-specified values are preserved.
-	if agentDefDeclaresActivity(agentDef) {
-		ensureActivityEndpointDefaults(request)
+	// "activity" protocol. Digital-worker agents additionally register a
+	// BotServiceRbac authorization scheme so the Bot Service channel can
+	// authenticate. Existing user-specified values are preserved.
+	if activityProfile.IsActivity {
+		ensureActivityEndpointDefaults(request, activityProfile)
 	}
 
 	// Default to "responses" protocol when none specified in agent.yaml.
@@ -1280,53 +1296,50 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 // activity protocol. agent.yaml may use either the endpoint-level name
 // "activity" or the canonical definition-level name "activity_protocol".
 func agentDefDeclaresActivity(agentDef agent_yaml.ContainerAgent) bool {
-	for _, p := range agentDef.Protocols {
-		switch strings.ToLower(strings.TrimSpace(p.Protocol)) {
-		case string(agent_api.AgentEndpointProtocolActivity),
-			string(agent_api.AgentProtocolActivityProtocol):
-			return true
-		}
-	}
-	return false
+	return agentDef.IsActivityProtocol()
 }
 
-// ensureActivityEndpointDefaults makes sure an activity agent's endpoint is
-// configured for push-based delivery: the "activity" endpoint protocol must be
-// present and a BotServiceRbac authorization scheme must be registered so the
-// Bot Service channel can authenticate. Existing values are preserved; this only
-// adds what is missing.
-func ensureActivityEndpointDefaults(request *agent_api.CreateAgentRequest) {
+// ensureActivityEndpointDefaults configures an activity agent's endpoint for
+// push-based delivery per the resolved profile: the "activity" endpoint protocol
+// is added when missing, and (for digital-worker agents) a BotServiceRbac
+// authorization scheme is registered so the Bot Service channel can
+// authenticate. Existing values are preserved; this only adds what is missing.
+func ensureActivityEndpointDefaults(request *agent_api.CreateAgentRequest, profile agent_yaml.ActivityProfile) {
 	if request.AgentEndpoint == nil {
 		request.AgentEndpoint = &agent_api.AgentEndpoint{}
 	}
 
-	hasActivity := false
-	for _, p := range request.AgentEndpoint.Protocols {
-		if p == agent_api.AgentEndpointProtocolActivity {
-			hasActivity = true
-			break
+	if profile.InjectActivityEndpoint {
+		hasActivity := false
+		for _, p := range request.AgentEndpoint.Protocols {
+			if p == agent_api.AgentEndpointProtocolActivity {
+				hasActivity = true
+				break
+			}
 		}
-	}
-	if !hasActivity {
-		request.AgentEndpoint.Protocols = append(
-			request.AgentEndpoint.Protocols, agent_api.AgentEndpointProtocolActivity,
-		)
+		if !hasActivity {
+			request.AgentEndpoint.Protocols = append(
+				request.AgentEndpoint.Protocols, agent_api.AgentEndpointProtocolActivity,
+			)
+		}
 	}
 
-	hasBotServiceRbac := false
-	for _, s := range request.AgentEndpoint.AuthorizationSchemes {
-		if s.Type == agent_api.AgentEndpointAuthSchemeBotServiceRbac {
-			hasBotServiceRbac = true
-			break
+	if profile.InjectBotServiceRbac {
+		hasBotServiceRbac := false
+		for _, s := range request.AgentEndpoint.AuthorizationSchemes {
+			if s.Type == agent_api.AgentEndpointAuthSchemeBotServiceRbac {
+				hasBotServiceRbac = true
+				break
+			}
 		}
-	}
-	if !hasBotServiceRbac {
-		request.AgentEndpoint.AuthorizationSchemes = append(
-			request.AgentEndpoint.AuthorizationSchemes,
-			agent_api.AgentEndpointAuthorizationScheme{
-				Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac,
-			},
-		)
+		if !hasBotServiceRbac {
+			request.AgentEndpoint.AuthorizationSchemes = append(
+				request.AgentEndpoint.AuthorizationSchemes,
+				agent_api.AgentEndpointAuthorizationScheme{
+					Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac,
+				},
+			)
+		}
 	}
 }
 
@@ -1417,6 +1430,13 @@ func (p *AgentServiceTargetProvider) finalizeDeploy(
 		}
 		augmentDeployNote(state, artifacts, projectRoot, configDir)
 	}
+
+	// For activity digital-worker agents, append the M365 onboarding
+	// "Next steps" (admin-center approval, blueprint ID, Teams instance) to
+	// the visible deploy note. These are tenant-admin actions azd cannot
+	// perform automatically; the helper self-gates and is a no-op for
+	// non-digital-worker agents.
+	appendDigitalWorkerNextSteps(artifacts, azdEnv, protocols)
 
 	return &azdext.ServiceDeployResult{
 		Artifacts: artifacts,
@@ -2120,6 +2140,61 @@ func lastNoteArtifact(artifacts []*azdext.Artifact) *azdext.Artifact {
 	return nil
 }
 
+// appendDigitalWorkerNextSteps appends the M365 onboarding "Next steps"
+// guidance to the visible deploy note for activity digital-worker agents.
+// These steps — admin-center approval, blueprint ID, and creating a Teams
+// instance — are tenant-admin actions azd cannot perform automatically, so
+// they are surfaced in the deploy output the same way the legacy post-deploy
+// script printed them. The block is attached to the last note-bearing
+// artifact (the same artifact augmentDeployNote enriches) so it renders in
+// the deploy summary rather than the extension's listen-process stdout, which
+// is not shown by `azd deploy`.
+//
+// No-op when no blueprint identity is present (the "simple" activity profile
+// is never published to M365) or when the agent does not speak the activity
+// protocol.
+func appendDigitalWorkerNextSteps(
+	artifacts []*azdext.Artifact,
+	azdEnv map[string]string,
+	protocols []agent_yaml.ProtocolVersionRecord,
+) {
+	blueprintID := strings.TrimSpace(azdEnv["AGENT_IDENTITY_BLUEPRINT_ID"])
+	if blueprintID == "" || !protocolsIncludeActivity(protocols) {
+		return
+	}
+
+	target := lastNoteArtifact(artifacts)
+	if target == nil {
+		return
+	}
+
+	block := "Next steps to finish onboarding your digital worker:\n" +
+		"  1. Approve the agent in the M365 Admin Center: " +
+		output.WithLinkFormat("https://admin.cloud.microsoft/#/agents/all/requested") + "\n" +
+		fmt.Sprintf("  2. Blueprint ID: %s\n", blueprintID) +
+		"  3. Create a Teams instance of the agent in the Teams Developer Portal: " +
+		output.WithLinkFormat("https://dev.teams.microsoft.com/tools/agent-blueprint")
+
+	if existing := target.Metadata["note"]; existing != "" {
+		target.Metadata["note"] = existing + "\n\n" + block
+	} else {
+		target.Metadata["note"] = block
+	}
+}
+
+// protocolsIncludeActivity reports whether any record names the activity
+// protocol, accepting both the user-facing "activity" alias and the internal
+// "activity_protocol" wire value.
+func protocolsIncludeActivity(protocols []agent_yaml.ProtocolVersionRecord) bool {
+	for _, p := range protocols {
+		switch strings.ToLower(strings.TrimSpace(p.Protocol)) {
+		case string(agent_api.AgentEndpointProtocolActivity), "activity_protocol":
+			return true
+		}
+	}
+	return false
+}
+
 // suggestionsIncludeReadme reports whether any suggestion is a local-README
 // pointer (ResolveAfterDeploy emits these as "see <relPath>/README.md").
 // Used by augmentDeployNote to decide whether to replace or append to the
@@ -2157,13 +2232,25 @@ type protocolEndpointInfo struct {
 
 // displayableProtocolFor returns the displayable protocol entry matching the given
 // protocol string, or nil if the protocol does not produce a user-visible endpoint.
+// The friendly endpoint-level name "activity" and the wire-level name
+// "activity_protocol" both resolve to the same entry.
 func displayableProtocolFor(protocol string) *displayableProtocolEntry {
+	normalized := normalizeDisplayProtocol(protocol)
 	for i, dp := range displayableProtocols {
-		if agent_api.AgentProtocol(protocol) == dp.Protocol {
+		if normalized == dp.Protocol {
 			return &displayableProtocols[i]
 		}
 	}
 	return nil
+}
+
+// normalizeDisplayProtocol maps the endpoint-level alias "activity" to the
+// canonical definition-level protocol "activity_protocol" used by the registry.
+func normalizeDisplayProtocol(protocol string) agent_api.AgentProtocol {
+	if strings.EqualFold(strings.TrimSpace(protocol), string(agent_api.AgentEndpointProtocolActivity)) {
+		return agent_api.AgentProtocolActivityProtocol
+	}
+	return agent_api.AgentProtocol(protocol)
 }
 
 // agentInvocationEndpoints builds the list of displayable invocation endpoints
@@ -2178,6 +2265,14 @@ func agentInvocationEndpoints(
 		dp := displayableProtocolFor(p.Protocol)
 		if dp == nil {
 			continue
+		}
+
+		// Prefer the friendly display label (e.g. "activity") over the raw
+		// agent.yaml value so endpoint output is consistent regardless of whether
+		// the user wrote "activity" or "activity_protocol".
+		displayProtocol := p.Protocol
+		if dp.DisplayLabel != "" {
+			displayProtocol = dp.DisplayLabel
 		}
 
 		var endpointURL string
@@ -2200,7 +2295,7 @@ func agentInvocationEndpoints(
 		}
 
 		endpoints = append(endpoints, protocolEndpointInfo{
-			Protocol: p.Protocol,
+			Protocol: displayProtocol,
 			URL:      endpointURL,
 		})
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -590,7 +590,14 @@ func TestDisplayableProtocolFor(t *testing.T) {
 			wantURLScheme:    "wss",
 			wantURLOmitAgent: true,
 		},
-		{name: "activity_protocol excluded", protocol: "activity_protocol", wantNil: true},
+		{
+			name:            "activity_protocol",
+			protocol:        "activity_protocol",
+			wantProtocol:    agent_api.AgentProtocolActivityProtocol,
+			wantEnvSuffix:   "ACTIVITY",
+			wantURLContains: "/agents/my-agent/endpoint/protocols/activity",
+			wantURLScheme:   "https",
+		},
 		{name: "unknown excluded", protocol: "unknown_proto", wantNil: true},
 	}
 
@@ -680,7 +687,7 @@ func TestAgentInvocationEndpoints(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple protocols with activity_protocol excluded",
+			name: "multiple protocols with all types",
 			protocols: []agent_yaml.ProtocolVersionRecord{
 				{Protocol: "responses", Version: "1.0.0"},
 				{Protocol: "activity_protocol", Version: "1.0.0"},
@@ -693,6 +700,10 @@ func TestAgentInvocationEndpoints(t *testing.T) {
 					URL:      baseURL + "openai/responses?api-version=v1",
 				},
 				{
+					Protocol: "activity_protocol",
+					URL:      baseURL + "activity?api-version=v1",
+				},
+				{
 					Protocol: "invocations",
 					URL:      baseURL + "invocations?api-version=v1",
 				},
@@ -703,11 +714,16 @@ func TestAgentInvocationEndpoints(t *testing.T) {
 			},
 		},
 		{
-			name: "only activity_protocol yields empty",
+			name: "only activity_protocol yields single endpoint",
 			protocols: []agent_yaml.ProtocolVersionRecord{
 				{Protocol: "activity_protocol", Version: "1.0.0"},
 			},
-			expected: nil,
+			expected: []protocolEndpointInfo{
+				{
+					Protocol: "activity_protocol",
+					URL:      baseURL + "activity?api-version=v1",
+				},
+			},
 		},
 		{
 			name:      "nil protocols yields empty",
@@ -849,6 +865,30 @@ func TestDeployArtifacts_EmptyProtocols_NoEndpoints(t *testing.T) {
 	require.Empty(t, artifacts)
 }
 
+// TestDeployArtifacts_ActivityProtocol_SingleEndpoint verifies that an activity-protocol
+// agent produces a single activity endpoint artifact.
+func TestDeployArtifacts_ActivityProtocol_SingleEndpoint(t *testing.T) {
+	t.Parallel()
+
+	p := &AgentServiceTargetProvider{}
+	const ep = "https://myproject.services.ai.azure.com/api/projects/proj"
+
+	protocols := []agent_yaml.ProtocolVersionRecord{
+		{Protocol: "activity_protocol", Version: "1.0.0"},
+	}
+
+	artifacts := p.deployArtifacts(
+		"echo-agent", "1.0.0",
+		"", ep,
+		protocols,
+	)
+
+	require.Len(t, artifacts, 1)
+	wantURL := ep + "/agents/echo-agent/endpoint/protocols/activity?api-version=v1"
+	require.Equal(t, wantURL, artifacts[0].Location)
+	require.Equal(t, "Agent endpoint (activity_protocol)", artifacts[0].Metadata["label"])
+}
+
 // TestPackage_NoEarlyFailureWithoutACR is a regression test ensuring that
 // Package for a hosted agent does not fail early when
 // AZURE_CONTAINER_REGISTRY_ENDPOINT is unset. The ACR endpoint is resolved
@@ -952,6 +992,113 @@ func TestLoadContainerAgentDefinition_MalformedYAMLReturnsError(t *testing.T) {
 	_, _, err := provider.loadContainerAgentDefinition()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "agent.yaml is not valid")
+}
+
+func TestAgentDefDeclaresActivity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		protocols []agent_yaml.ProtocolVersionRecord
+		want      bool
+	}{
+		{
+			name:      "endpoint-level activity name",
+			protocols: []agent_yaml.ProtocolVersionRecord{{Protocol: "activity", Version: "1.0.0"}},
+			want:      true,
+		},
+		{
+			name:      "definition-level activity_protocol name",
+			protocols: []agent_yaml.ProtocolVersionRecord{{Protocol: "activity_protocol", Version: "1.0.0"}},
+			want:      true,
+		},
+		{
+			name:      "case-insensitive and whitespace tolerant",
+			protocols: []agent_yaml.ProtocolVersionRecord{{Protocol: "  Activity_Protocol ", Version: "1.0.0"}},
+			want:      true,
+		},
+		{
+			name:      "non-activity protocol",
+			protocols: []agent_yaml.ProtocolVersionRecord{{Protocol: "responses", Version: "1.0.0"}},
+			want:      false,
+		},
+		{
+			name:      "no protocols",
+			protocols: nil,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := agentDefDeclaresActivity(agent_yaml.ContainerAgent{Protocols: tt.protocols})
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEnsureActivityEndpointDefaults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil endpoint gets activity protocol and BotServiceRbac", func(t *testing.T) {
+		req := &agent_api.CreateAgentRequest{}
+		ensureActivityEndpointDefaults(req)
+
+		require.NotNil(t, req.AgentEndpoint)
+		require.Equal(t,
+			[]agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolActivity},
+			req.AgentEndpoint.Protocols,
+		)
+		require.Len(t, req.AgentEndpoint.AuthorizationSchemes, 1)
+		require.Equal(t,
+			agent_api.AgentEndpointAuthSchemeBotServiceRbac,
+			req.AgentEndpoint.AuthorizationSchemes[0].Type,
+		)
+	})
+
+	t.Run("preserves existing activity and BotServiceRbac without duplicates", func(t *testing.T) {
+		req := &agent_api.CreateAgentRequest{
+			AgentEndpoint: &agent_api.AgentEndpoint{
+				Protocols: []agent_api.AgentEndpointProtocol{
+					agent_api.AgentEndpointProtocolActivity,
+				},
+				AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
+					{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
+				},
+			},
+		}
+		ensureActivityEndpointDefaults(req)
+
+		require.Equal(t,
+			[]agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolActivity},
+			req.AgentEndpoint.Protocols,
+		)
+		require.Len(t, req.AgentEndpoint.AuthorizationSchemes, 1)
+	})
+
+	t.Run("adds activity and BotServiceRbac alongside existing values", func(t *testing.T) {
+		req := &agent_api.CreateAgentRequest{
+			AgentEndpoint: &agent_api.AgentEndpoint{
+				Protocols: []agent_api.AgentEndpointProtocol{
+					agent_api.AgentEndpointProtocolResponses,
+				},
+				AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
+					{Type: agent_api.AgentEndpointAuthSchemeEntra},
+				},
+			},
+		}
+		ensureActivityEndpointDefaults(req)
+
+		require.Contains(t, req.AgentEndpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
+		require.Contains(t, req.AgentEndpoint.Protocols, agent_api.AgentEndpointProtocolResponses)
+
+		var schemeTypes []agent_api.AgentEndpointAuthorizationSchemeType
+		for _, s := range req.AgentEndpoint.AuthorizationSchemes {
+			schemeTypes = append(schemeTypes, s.Type)
+		}
+		require.Contains(t, schemeTypes, agent_api.AgentEndpointAuthSchemeBotServiceRbac)
+		require.Contains(t, schemeTypes, agent_api.AgentEndpointAuthSchemeEntra)
+	})
 }
 
 func TestShouldUsePreBuiltImage_NoImageDefaultsToBuild(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -700,7 +700,7 @@ func TestAgentInvocationEndpoints(t *testing.T) {
 					URL:      baseURL + "openai/responses?api-version=v1",
 				},
 				{
-					Protocol: "activity_protocol",
+					Protocol: "activity",
 					URL:      baseURL + "activity?api-version=v1",
 				},
 				{
@@ -720,7 +720,19 @@ func TestAgentInvocationEndpoints(t *testing.T) {
 			},
 			expected: []protocolEndpointInfo{
 				{
-					Protocol: "activity_protocol",
+					Protocol: "activity",
+					URL:      baseURL + "activity?api-version=v1",
+				},
+			},
+		},
+		{
+			name: "friendly activity name yields single endpoint",
+			protocols: []agent_yaml.ProtocolVersionRecord{
+				{Protocol: "activity", Version: "1.0.0"},
+			},
+			expected: []protocolEndpointInfo{
+				{
+					Protocol: "activity",
 					URL:      baseURL + "activity?api-version=v1",
 				},
 			},
@@ -886,7 +898,7 @@ func TestDeployArtifacts_ActivityProtocol_SingleEndpoint(t *testing.T) {
 	require.Len(t, artifacts, 1)
 	wantURL := ep + "/agents/echo-agent/endpoint/protocols/activity?api-version=v1"
 	require.Equal(t, wantURL, artifacts[0].Location)
-	require.Equal(t, "Agent endpoint (activity_protocol)", artifacts[0].Metadata["label"])
+	require.Equal(t, "Agent endpoint (activity)", artifacts[0].Metadata["label"])
 }
 
 // TestPackage_NoEarlyFailureWithoutACR is a regression test ensuring that
@@ -1040,9 +1052,19 @@ func TestAgentDefDeclaresActivity(t *testing.T) {
 func TestEnsureActivityEndpointDefaults(t *testing.T) {
 	t.Parallel()
 
-	t.Run("nil endpoint gets activity protocol and BotServiceRbac", func(t *testing.T) {
+	digitalWorker := agent_yaml.ActivityProfile{
+		IsActivity:             true,
+		InjectActivityEndpoint: true,
+		InjectBotServiceRbac:   true,
+	}
+	simple := agent_yaml.ActivityProfile{
+		IsActivity:             true,
+		InjectActivityEndpoint: true,
+	}
+
+	t.Run("digital worker: nil endpoint gets activity protocol and BotServiceRbac", func(t *testing.T) {
 		req := &agent_api.CreateAgentRequest{}
-		ensureActivityEndpointDefaults(req)
+		ensureActivityEndpointDefaults(req, digitalWorker)
 
 		require.NotNil(t, req.AgentEndpoint)
 		require.Equal(t,
@@ -1056,7 +1078,20 @@ func TestEnsureActivityEndpointDefaults(t *testing.T) {
 		)
 	})
 
-	t.Run("preserves existing activity and BotServiceRbac without duplicates", func(t *testing.T) {
+	t.Run("simple: gets activity protocol but NO BotServiceRbac", func(t *testing.T) {
+		req := &agent_api.CreateAgentRequest{}
+		ensureActivityEndpointDefaults(req, simple)
+
+		require.NotNil(t, req.AgentEndpoint)
+		require.Equal(t,
+			[]agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolActivity},
+			req.AgentEndpoint.Protocols,
+		)
+		require.Empty(t, req.AgentEndpoint.AuthorizationSchemes,
+			"simple activity agents must not get a BotServiceRbac scheme")
+	})
+
+	t.Run("digital worker: preserves existing activity and BotServiceRbac without duplicates", func(t *testing.T) {
 		req := &agent_api.CreateAgentRequest{
 			AgentEndpoint: &agent_api.AgentEndpoint{
 				Protocols: []agent_api.AgentEndpointProtocol{
@@ -1067,7 +1102,7 @@ func TestEnsureActivityEndpointDefaults(t *testing.T) {
 				},
 			},
 		}
-		ensureActivityEndpointDefaults(req)
+		ensureActivityEndpointDefaults(req, digitalWorker)
 
 		require.Equal(t,
 			[]agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolActivity},
@@ -1076,7 +1111,7 @@ func TestEnsureActivityEndpointDefaults(t *testing.T) {
 		require.Len(t, req.AgentEndpoint.AuthorizationSchemes, 1)
 	})
 
-	t.Run("adds activity and BotServiceRbac alongside existing values", func(t *testing.T) {
+	t.Run("digital worker: adds activity and BotServiceRbac alongside existing values", func(t *testing.T) {
 		req := &agent_api.CreateAgentRequest{
 			AgentEndpoint: &agent_api.AgentEndpoint{
 				Protocols: []agent_api.AgentEndpointProtocol{
@@ -1087,7 +1122,7 @@ func TestEnsureActivityEndpointDefaults(t *testing.T) {
 				},
 			},
 		}
-		ensureActivityEndpointDefaults(req)
+		ensureActivityEndpointDefaults(req, digitalWorker)
 
 		require.Contains(t, req.AgentEndpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
 		require.Contains(t, req.AgentEndpoint.Protocols, agent_api.AgentEndpointProtocolResponses)
@@ -1679,6 +1714,77 @@ func TestAugmentDeployNote_NoReadme_AppendsBelowAkaMsLink(t *testing.T) {
 	require.Contains(t, got, "Next:", "Next: block should be appended")
 	require.Contains(t, got, "azd ai agent invoke ", "should suggest invoking the deployed agent")
 	require.Equal(t, 1, strings.Count(got, "Next:"), "Next: header should appear exactly once")
+}
+
+func TestAppendDigitalWorkerNextSteps(t *testing.T) {
+	t.Parallel()
+
+	activityProtocols := []agent_yaml.ProtocolVersionRecord{{Protocol: "activity", Version: "1.0.0"}}
+
+	t.Run("digital worker appends onboarding steps to existing note", func(t *testing.T) {
+		t.Parallel()
+		artifact := &azdext.Artifact{
+			Kind:     azdext.ArtifactKind_ARTIFACT_KIND_ENDPOINT,
+			Metadata: map[string]string{"label": "Agent endpoint (activity)", "note": "static aka.ms link"},
+		}
+
+		appendDigitalWorkerNextSteps(
+			[]*azdext.Artifact{artifact},
+			map[string]string{"AGENT_IDENTITY_BLUEPRINT_ID": "bp-123"},
+			activityProtocols,
+		)
+
+		got := artifact.Metadata["note"]
+		require.Contains(t, got, "static aka.ms link", "existing note should be preserved")
+		require.Contains(t, got, "onboarding your digital worker", "should append digital-worker next steps")
+		require.Contains(t, got, "admin.cloud.microsoft", "should include the M365 admin center link")
+		require.Contains(t, got, "bp-123", "should surface the blueprint ID")
+		require.Contains(t, got, "Teams Developer Portal", "should include the Teams instance step")
+	})
+
+	t.Run("internal activity_protocol wire value is recognized", func(t *testing.T) {
+		t.Parallel()
+		artifact := &azdext.Artifact{
+			Kind:     azdext.ArtifactKind_ARTIFACT_KIND_ENDPOINT,
+			Metadata: map[string]string{"note": "n"},
+		}
+
+		appendDigitalWorkerNextSteps(
+			[]*azdext.Artifact{artifact},
+			map[string]string{"AGENT_IDENTITY_BLUEPRINT_ID": "bp-9"},
+			[]agent_yaml.ProtocolVersionRecord{{Protocol: "activity_protocol", Version: "1.0.0"}},
+		)
+
+		require.Contains(t, artifact.Metadata["note"], "onboarding your digital worker")
+	})
+
+	t.Run("no blueprint env is a no-op (simple activity profile)", func(t *testing.T) {
+		t.Parallel()
+		artifact := &azdext.Artifact{
+			Kind:     azdext.ArtifactKind_ARTIFACT_KIND_ENDPOINT,
+			Metadata: map[string]string{"note": "untouched"},
+		}
+
+		appendDigitalWorkerNextSteps([]*azdext.Artifact{artifact}, map[string]string{}, activityProtocols)
+
+		require.Equal(t, "untouched", artifact.Metadata["note"], "should not modify note when no blueprint is present")
+	})
+
+	t.Run("non-activity protocol is a no-op", func(t *testing.T) {
+		t.Parallel()
+		artifact := &azdext.Artifact{
+			Kind:     azdext.ArtifactKind_ARTIFACT_KIND_ENDPOINT,
+			Metadata: map[string]string{"note": "untouched"},
+		}
+
+		appendDigitalWorkerNextSteps(
+			[]*azdext.Artifact{artifact},
+			map[string]string{"AGENT_IDENTITY_BLUEPRINT_ID": "bp-123"},
+			[]agent_yaml.ProtocolVersionRecord{{Protocol: "invocations", Version: "1.0.0"}},
+		)
+
+		require.Equal(t, "untouched", artifact.Metadata["note"], "should not modify note for non-activity agents")
+	})
 }
 
 func TestAugmentDeployNote_WithReadme_ReplacesAkaMsLink(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/version.txt
+++ b/cli/azd/extensions/azure.ai.agents/version.txt
@@ -1,1 +1,1 @@
-0.1.40-preview
+0.1.41-preview


### PR DESCRIPTION
## Summary

Adds native Activity-protocol support to the `azure.ai.agents` extension, so activity agents (including M365 "digital workers") work end-to-end with `azd ai agent init` → `azd provision` → `azd deploy` without external scripts.

## What's included

**Native activity protocol (commit 1)**
- Set `Foundry-Features: HostedAgents=V1Preview,AgentEndpoints=V1Preview` on CreateAgent/PatchAgent so the agent endpoint patch (protocols + authorization_schemes) is accepted.
- Auto-inject the agent endpoint with `protocols: [activity]` and `authorization_schemes: [BotServiceRbac]` for activity agents (additive; does not override user config).
- Normalize user-facing `activity` ↔ internal `activity_protocol` wire value in `map.go`.
- New `m365_registration.go`: best-effort M365 onboarding (OAuth2 grants for MCP/APEX, blueprint owner, digital-worker publish, Teams backend config) wired into the postprovision/postdeploy hooks.

**Use-case profiles + init + onboarding next-steps (commit 2)**
- `agent.yaml` gains `activity.use_case` (`simple` | `digital_worker`). `ResolveActivityProfile` gates activity-endpoint injection, BotServiceRbac, blueprint reference, and M365 provision/publish.
- `azd ai agent init` round-trips `use_case` from the manifest; adds `--activity-use-case` and an `AZD_AI_STARTER_TEMPLATE` override. The preprovision hook sets `ENABLE_DIGITAL_WORKER` + `AGENT_NAME` so the starter template provisions the MAIB + Bot Service.
- `azd deploy` now prints the digital-worker onboarding next steps (M365 admin-center approval, blueprint ID, Teams instance) in the visible deploy summary.

## Testing

- `go vet ./...` clean.
- `go test ./...` green across all packages (cmd, project, agent_yaml, nextstep, doctor, ...).
- Validated end-to-end against a live Foundry project: init → provision (creates MAIB + Bot Service) → deploy (agent active, activity endpoint + BotServiceRbac, bot messaging endpoint correct, Teams channel enabled).

> Note: the digital-worker `init` path depends on companion infra in `Azure-Samples/azd-ai-starter-basic` (separate PR).