### PR TITLE
docs: Add documentation comment for ConsoleMessage

### DIFF
--- a/cli/azd/pkg/contracts/console_message.go
+++ b/cli/azd/pkg/contracts/console_message.go
@@ -3,6 +3,7 @@
 
 package contracts
 
+// ConsoleMessage represents a message to be displayed in the console.
 type ConsoleMessage struct {
 	Message string `json:"message"`
 }


### PR DESCRIPTION
### 问题背景
`ConsoleMessage` 类型在 `cli/azd/pkg/contracts/console_message.go` 中缺少文档注释，这降低了代码的可读性和可维护性。添加文档注释可以帮助开发者快速理解类型用途，符合 Go 语言的最佳实践。

### 修改内容
- **修改了什么**：为 `ConsoleMessage` 结构体添加了一个 Go 文档注释，说明它代表在控制台显示的消息。
- **为什么这样改**：为了提供清晰的类型描述，改善代码自文档性，便于维护和协作。
- **对代码质量的提升**：增强了代码的可读性和可维护性，无性能、安全性或功能影响。

### 验证方式
- 由于此修改仅添加注释，不改变代码逻辑，所有现有测试应继续通过。可以通过运行 `go test ./cli/azd/pkg/contracts/...` 来验证。
- 无需添加新测试。
- 手动验证：检查文件 `cli/azd/pkg/contracts/console_message.go` 中的注释是否正确无误。

### 其他信息
- 无 breaking changes。
- 此 PR 本身就是文档改进，无需更新其他文档。
- 无已知限制。