### PR TITLE
fix: reprompt on invalid agent name instead of crashing

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -269,7 +269,7 @@ func resolveInitAgentName(
 			if exterrors.IsCancellation(err) {
 				return "", exterrors.Cancelled("agent name prompt was cancelled")
 			}
-			return "", fmt.Errorf("failed to prompt for agent name: %w", err)
+			return "", exterrors.FromPrompt(err, "failed to prompt for agent name")
 		}
 
 		agentName := strings.TrimSpace(promptResp.Value)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -256,27 +256,35 @@ func resolveInitAgentName(
 		return defaultName, nil
 	}
 
-	promptResp, err := azdClient.Prompt().Prompt(ctx, &azdext.PromptRequest{
-		Options: &azdext.PromptOptions{
-			Message:      "Enter a name for your agent",
-			DefaultValue: defaultName,
-			HelpMessage: "Foundry agents are unique by name within a project. " +
-				"Reusing a name creates a new version of the existing agent.",
-		},
-	})
-	if err != nil {
-		if exterrors.IsCancellation(err) {
-			return "", exterrors.Cancelled("agent name prompt was cancelled")
+	for {
+		promptResp, err := azdClient.Prompt().Prompt(ctx, &azdext.PromptRequest{
+			Options: &azdext.PromptOptions{
+				Message:      "Enter a name for your agent",
+				DefaultValue: defaultName,
+				HelpMessage: "Foundry agents are unique by name within a project. " +
+					"Reusing a name creates a new version of the existing agent.",
+			},
+		})
+		if err != nil {
+			if exterrors.IsCancellation(err) {
+				return "", exterrors.Cancelled("agent name prompt was cancelled")
+			}
+			return "", fmt.Errorf("failed to prompt for agent name: %w", err)
 		}
-		return "", fmt.Errorf("failed to prompt for agent name: %w", err)
-	}
 
-	agentName := strings.TrimSpace(promptResp.Value)
-	if agentName == "" {
-		agentName = defaultName
-	}
+		agentName := strings.TrimSpace(promptResp.Value)
+		if agentName == "" {
+			agentName = defaultName
+		}
 
-	return validateInitAgentName(agentName)
+		validName, err := validateInitAgentName(agentName)
+		if err != nil {
+			writeValidationRetryError(err)
+			continue
+		}
+
+		return validName, nil
+	}
 }
 
 // resolveAgentNameFromManifestPointer resolves the agent name BEFORE any

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -123,6 +123,27 @@ func TestResolveInitAgentName_NoPromptUsesDefault(t *testing.T) {
 	}
 }
 
+func TestResolveInitAgentName_InvalidNameRepromptsUntilValid(t *testing.T) {
+	t.Parallel()
+
+	tooLong := strings.Repeat("a", 64) // 64 chars > 63 char limit
+	prompts := &testPromptServiceServer{
+		promptResponses: []string{tooLong, "valid-agent"},
+	}
+	azdClient := newTestAzdClient(t, &testEnvironmentServiceServer{}, &testWorkflowServiceServer{}, prompts)
+
+	name, err := resolveInitAgentName(t.Context(), azdClient, &initFlags{}, "default-agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "valid-agent" {
+		t.Fatalf("name = %q, want valid-agent", name)
+	}
+	if len(prompts.promptRequests) != 2 {
+		t.Fatalf("text prompts = %d, want 2 (first invalid, second valid)", len(prompts.promptRequests))
+	}
+}
+
 func TestAgentNameTemplateHelpers(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Why

When a user enters an agent name longer than 63 characters (or otherwise invalid) during `azd ai agent init`, the command crashes with a validation error. At that point, files may already be partially created, making it hard to undo.

## What changed

`resolveInitAgentName()` now wraps the interactive prompt in a retry loop. When validation fails, it prints the error and suggestion, then re-prompts -- matching the pattern already used by the sibling `promptForReplacementAgentName()` function.

- The `--agent-name` flag path still returns an error immediately (no interactive reprompt possible).
- The `--no-prompt` path is unchanged (it uses the already-validated default name).
- Only the interactive prompt path gains the retry loop.

A new test (`TestResolveInitAgentName_InvalidNameRepromptsUntilValid`) verifies that entering an invalid name followed by a valid one succeeds after exactly two prompts.

Fixes: #8381