### PR TITLE
fix: avoid double agent service prompt in `azd ai agent invoke`

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -785,7 +785,9 @@ func resolveStartupCommandForInit(
 }
 
 // resolveAgentProtocol loads the agent.yaml manifest for the service and returns the
-// protocol that the agent implements (e.g. "responses", "invocations").
+// protocol that the agent implements (e.g. "responses", "invocations") along with
+// the resolved service name. The service name is useful for callers that need to
+// avoid a redundant resolveAgentService call (and its interactive prompt) later.
 // Returns an error when the protocol cannot be determined, with a contextual
 // suggestion guiding the user to fix the underlying issue.
 func resolveAgentProtocol(
@@ -793,10 +795,10 @@ func resolveAgentProtocol(
 	azdClient *azdext.AzdClient,
 	name string,
 	noPrompt bool,
-) (agent_api.AgentProtocol, error) {
+) (agent_api.AgentProtocol, string, error) {
 	svc, project, err := resolveAgentService(ctx, azdClient, name, noPrompt)
 	if err != nil {
-		return "", exterrors.Validation(
+		return "", "", exterrors.Validation(
 			exterrors.CodeInvalidParameter,
 			fmt.Sprintf(
 				"could not resolve agent service in azd project: %s", err,
@@ -808,13 +810,17 @@ func resolveAgentProtocol(
 
 	agentYamlPath, err := paths.JoinAllowRoot(project.Path, svc.RelativePath, "agent.yaml")
 	if err != nil {
-		return "", exterrors.Validation(
+		return "", "", exterrors.Validation(
 			exterrors.CodeInvalidServiceConfig,
 			fmt.Sprintf("invalid service path for %s: %s", svc.Name, err),
 			"update azure.yaml so the agent service path stays within the project directory",
 		)
 	}
-	return protocolFromAgentYaml(agentYamlPath)
+	protocol, err := protocolFromAgentYaml(agentYamlPath)
+	if err != nil {
+		return "", "", err
+	}
+	return protocol, svc.Name, nil
 }
 
 // protocolFromAgentYaml reads and parses the agent.yaml file at the given path

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -379,13 +380,13 @@ func (s *helpersProjectServer) Get(
 type helpersPromptServer struct {
 	azdext.UnimplementedPromptServiceServer
 	selectIndex int32
-	selectCalls int
+	selectCalls atomic.Int32
 }
 
 func (s *helpersPromptServer) Select(
 	_ context.Context, req *azdext.SelectRequest,
 ) (*azdext.SelectResponse, error) {
-	s.selectCalls++
+	s.selectCalls.Add(1)
 	idx := s.selectIndex
 	return &azdext.SelectResponse{Value: &idx}, nil
 }
@@ -407,7 +408,10 @@ func newHelpersTestAzdClient(
 	require.NoError(t, err)
 
 	go func() { _ = grpcServer.Serve(listener) }()
-	t.Cleanup(func() { grpcServer.Stop() })
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		_ = listener.Close()
+	})
 
 	azdClient, err := azdext.NewAzdClient(azdext.WithAddress(listener.Addr().String()))
 	require.NoError(t, err)
@@ -522,6 +526,6 @@ func TestResolveAgentProtocol_MultipleServicesPromptsOnce(t *testing.T) {
 	_, serviceName, err := resolveAgentProtocol(t.Context(), azdClient, "", false)
 	require.NoError(t, err)
 	require.Equal(t, "svc-a", serviceName)
-	require.Equal(t, 1, promptServer.selectCalls,
+	require.Equal(t, int32(1), promptServer.selectCalls.Load(),
 		"resolveAgentProtocol should trigger exactly one prompt")
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
@@ -4,6 +4,8 @@
 package cmd
 
 import (
+	"context"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +13,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
 func TestDetectStartupCommand(t *testing.T) {
@@ -357,4 +360,168 @@ func TestIsTerminal_NonTTY(t *testing.T) {
 	if isTerminal(r.Fd()) {
 		t.Errorf("isTerminal(pipe read end) = true, want false")
 	}
+}
+
+// helpersProjectServer is a fake ProjectServiceServer that returns a fixed project config.
+type helpersProjectServer struct {
+	azdext.UnimplementedProjectServiceServer
+	project *azdext.ProjectConfig
+}
+
+func (s *helpersProjectServer) Get(
+	_ context.Context, _ *azdext.EmptyRequest,
+) (*azdext.GetProjectResponse, error) {
+	return &azdext.GetProjectResponse{Project: s.project}, nil
+}
+
+// helpersPromptServer is a fake PromptServiceServer that records Select calls
+// and returns a canned choice index.
+type helpersPromptServer struct {
+	azdext.UnimplementedPromptServiceServer
+	selectIndex int32
+	selectCalls int
+}
+
+func (s *helpersPromptServer) Select(
+	_ context.Context, req *azdext.SelectRequest,
+) (*azdext.SelectResponse, error) {
+	s.selectCalls++
+	idx := s.selectIndex
+	return &azdext.SelectResponse{Value: &idx}, nil
+}
+
+// newHelpersTestAzdClient spins up a gRPC server with the supplied Project and
+// Prompt stubs and returns a client wired to its address.
+func newHelpersTestAzdClient(
+	t *testing.T,
+	projectServer *helpersProjectServer,
+	promptServer *helpersPromptServer,
+) *azdext.AzdClient {
+	t.Helper()
+
+	grpcServer := grpc.NewServer()
+	azdext.RegisterProjectServiceServer(grpcServer, projectServer)
+	azdext.RegisterPromptServiceServer(grpcServer, promptServer)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() { _ = grpcServer.Serve(listener) }()
+	t.Cleanup(func() { grpcServer.Stop() })
+
+	azdClient, err := azdext.NewAzdClient(azdext.WithAddress(listener.Addr().String()))
+	require.NoError(t, err)
+	t.Cleanup(func() { azdClient.Close() })
+
+	return azdClient
+}
+
+// TestResolveAgentProtocol_ReturnsServiceName verifies that resolveAgentProtocol
+// returns the resolved service name alongside the protocol, so callers can cache
+// it and avoid a redundant prompt.
+func TestResolveAgentProtocol_ReturnsServiceName(t *testing.T) {
+	t.Parallel()
+
+	// Create a temp dir with agent.yaml declaring the "responses" protocol.
+	svcDir := t.TempDir()
+	agentYaml := "protocols:\n  - protocol: responses\n    version: \"1.0\"\n"
+	require.NoError(t, os.WriteFile(filepath.Join(svcDir, "agent.yaml"), []byte(agentYaml), 0600))
+
+	tests := []struct {
+		name        string
+		inputName   string // name passed to resolveAgentProtocol
+		services    map[string]*azdext.ServiceConfig
+		selectIndex int32 // which service the prompt returns (0-based)
+		wantName    string
+	}{
+		{
+			name:      "single service auto-resolved",
+			inputName: "",
+			services: map[string]*azdext.ServiceConfig{
+				"my-agent": {Name: "my-agent", Host: AiAgentHost, RelativePath: "."},
+			},
+			wantName: "my-agent",
+		},
+		{
+			name:      "explicit name returns that service",
+			inputName: "agent-b",
+			services: map[string]*azdext.ServiceConfig{
+				"agent-a": {Name: "agent-a", Host: AiAgentHost, RelativePath: "."},
+				"agent-b": {Name: "agent-b", Host: AiAgentHost, RelativePath: "."},
+			},
+			wantName: "agent-b",
+		},
+		{
+			name:      "multiple services prompt selects first",
+			inputName: "",
+			services: map[string]*azdext.ServiceConfig{
+				"alpha": {Name: "alpha", Host: AiAgentHost, RelativePath: "."},
+				"beta":  {Name: "beta", Host: AiAgentHost, RelativePath: "."},
+			},
+			selectIndex: 0,
+			wantName:    "alpha",
+		},
+		{
+			name:      "multiple services prompt selects second",
+			inputName: "",
+			services: map[string]*azdext.ServiceConfig{
+				"alpha": {Name: "alpha", Host: AiAgentHost, RelativePath: "."},
+				"beta":  {Name: "beta", Host: AiAgentHost, RelativePath: "."},
+			},
+			selectIndex: 1,
+			wantName:    "beta",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			projectServer := &helpersProjectServer{
+				project: &azdext.ProjectConfig{
+					Path:     svcDir,
+					Services: tt.services,
+				},
+			}
+			promptServer := &helpersPromptServer{selectIndex: tt.selectIndex}
+			azdClient := newHelpersTestAzdClient(t, projectServer, promptServer)
+
+			protocol, serviceName, err := resolveAgentProtocol(
+				t.Context(), azdClient, tt.inputName, false,
+			)
+			require.NoError(t, err)
+			require.Equal(t, "responses", string(protocol))
+			require.Equal(t, tt.wantName, serviceName,
+				"resolveAgentProtocol should return the resolved service name")
+		})
+	}
+}
+
+// TestResolveAgentProtocol_MultipleServicesPromptsOnce verifies that a single
+// call to resolveAgentProtocol triggers exactly one prompt when there are
+// multiple agent services and no name is provided.
+func TestResolveAgentProtocol_MultipleServicesPromptsOnce(t *testing.T) {
+	t.Parallel()
+
+	svcDir := t.TempDir()
+	agentYaml := "protocols:\n  - protocol: responses\n    version: \"1.0\"\n"
+	require.NoError(t, os.WriteFile(filepath.Join(svcDir, "agent.yaml"), []byte(agentYaml), 0600))
+
+	projectServer := &helpersProjectServer{
+		project: &azdext.ProjectConfig{
+			Path: svcDir,
+			Services: map[string]*azdext.ServiceConfig{
+				"svc-a": {Name: "svc-a", Host: AiAgentHost, RelativePath: "."},
+				"svc-b": {Name: "svc-b", Host: AiAgentHost, RelativePath: "."},
+			},
+		},
+	}
+	promptServer := &helpersPromptServer{selectIndex: 0}
+	azdClient := newHelpersTestAzdClient(t, projectServer, promptServer)
+
+	_, serviceName, err := resolveAgentProtocol(t.Context(), azdClient, "", false)
+	require.NoError(t, err)
+	require.Equal(t, "svc-a", serviceName)
+	require.Equal(t, 1, promptServer.selectCalls,
+		"resolveAgentProtocol should trigger exactly one prompt")
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -444,6 +444,10 @@ func (a *InvokeAction) emitInvokeFailureNextStep(mode nextstep.InvokeMode, agent
 // resolveProtocol returns the protocol to use for this invocation.
 // The explicit --protocol flag takes priority; otherwise the protocol
 // is auto-detected from agent.yaml (local or remote).
+// When the protocol is auto-detected and the agent name was not already
+// set, the resolved service name is cached in a.flags.name so that
+// downstream calls (resolveRemoteContext, resolveLocalAgentKey) do an
+// exact lookup instead of prompting the user a second time.
 func (a *InvokeAction) resolveProtocol(
 	ctx context.Context,
 ) (agent_api.AgentProtocol, error) {
@@ -457,14 +461,28 @@ func (a *InvokeAction) resolveProtocol(
 	}
 	defer azdClient.Close()
 
+	var protocol agent_api.AgentProtocol
+	var serviceName string
+
 	if a.flags.local {
-		return resolveAgentProtocol(
+		protocol, serviceName, err = resolveAgentProtocol(
 			ctx, azdClient, "", a.noPrompt,
 		)
+	} else {
+		protocol, serviceName, err = resolveAgentProtocol(
+			ctx, azdClient, a.flags.name, a.noPrompt,
+		)
 	}
-	return resolveAgentProtocol(
-		ctx, azdClient, a.flags.name, a.noPrompt,
-	)
+	if err != nil {
+		return "", err
+	}
+
+	// Cache the resolved service name so downstream calls avoid re-prompting.
+	if a.flags.name == "" && serviceName != "" {
+		a.flags.name = serviceName
+	}
+
+	return protocol, nil
 }
 
 func (a *InvokeAction) httpTimeout() time.Duration {


### PR DESCRIPTION
## Problem

When running `azd ai agent invoke hello` with multiple agent services defined in `azure.yaml`, the user is prompted to select an agent service **twice**.

The root cause is that the invoke flow calls `resolveAgentService()` independently in two places:

1. `resolveProtocol()` -- to auto-detect the protocol from `agent.yaml`
2. `resolveRemoteContext()` (or `resolveLocalAgentKey()` for `--local`) -- to resolve the agent name and endpoint

Each call sees an empty name and multiple services, so each triggers an interactive prompt.

## Approach

- Modified `resolveAgentProtocol()` in `helpers.go` to return the resolved service name as a second return value alongside the protocol. This is a minimal signature change; the function already had the service info in hand but was discarding it.
- Updated `resolveProtocol()` in `invoke.go` to cache the returned service name into `a.flags.name` when the name was not already set. Downstream calls (`resolveRemoteContext`, `resolveLocalAgentKey`) then find a non-empty name and perform an exact lookup instead of re-prompting.

## Tests

Added two new test functions in `helpers_test.go`:

- `TestResolveAgentProtocol_ReturnsServiceName` -- table-driven test covering single-service auto-resolve, explicit name, and multi-service prompt selection (first and second choice)
- `TestResolveAgentProtocol_MultipleServicesPromptsOnce` -- asserts exactly one prompt call occurs when multiple services exist and no name is provided

Fixes: #7782