### PR TITLE
fix: allow --local with a named agent in azd ai agent invoke

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -452,11 +452,6 @@ func (a *InvokeAction) resolveProtocol(
 	}
 	defer azdClient.Close()
 
-	if a.flags.local {
-		return resolveAgentProtocol(
-			ctx, azdClient, a.flags.name, a.noPrompt,
-		)
-	}
 	return resolveAgentProtocol(
 		ctx, azdClient, a.flags.name, a.noPrompt,
 	)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -120,6 +120,9 @@ suppressed in raw mode.`,
   # Invoke locally (agent must be running via 'azd ai agent run')
   azd ai agent invoke --local "Hello!"
 
+  # Invoke a specific agent locally (useful in multi-agent projects)
+  azd ai agent invoke my-agent --local "Hello!"
+
   # Start a new session (discard conversation history)
   azd ai agent invoke --new-session "Hello!"
 
@@ -192,14 +195,6 @@ suppressed in raw mode.`,
 
 			if err := validateInvokeVersionFlags(cmd, flags); err != nil {
 				return err
-			}
-
-			if flags.name != "" && flags.local {
-				return exterrors.Validation(
-					exterrors.CodeInvalidParameter,
-					"cannot use --local with a named agent; named agents are always invoked remotely on Foundry",
-					"omit the agent name for local invocation, or remove --local for remote",
-				)
 			}
 
 			if flags.protocol != "" {
@@ -459,7 +454,7 @@ func (a *InvokeAction) resolveProtocol(
 
 	if a.flags.local {
 		return resolveAgentProtocol(
-			ctx, azdClient, "", a.noPrompt,
+			ctx, azdClient, a.flags.name, a.noPrompt,
 		)
 	}
 	return resolveAgentProtocol(

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
@@ -436,6 +436,24 @@ func TestInvokeCommandIsolationFlags(t *testing.T) {
 	}
 }
 
+// TestInvokeLocalWithNamedAgent verifies that --local combined with a
+// positional agent name passes validation (no "cannot use --local with a
+// named agent" error). The command will still fail at Run time (no azd
+// project), but the validation stage must not reject it.
+func TestInvokeLocalWithNamedAgent(t *testing.T) {
+	t.Parallel()
+
+	cmd := newInvokeCommand(nil)
+	cmd.SetArgs([]string{"my-agent", "--local", "Hello!"})
+	err := cmd.Execute()
+
+	// The command will error because there is no azd project or local server,
+	// but the error must NOT be the old validation rejection.
+	if err != nil && strings.Contains(err.Error(), "cannot use --local with a named agent") {
+		t.Fatalf("unexpected validation rejection: %v", err)
+	}
+}
+
 func TestIsolationHeaderFlags_SessionRequestOptions(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
@@ -445,11 +445,14 @@ func TestInvokeLocalWithNamedAgent(t *testing.T) {
 
 	cmd := newInvokeCommand(nil)
 	cmd.SetArgs([]string{"my-agent", "--local", "Hello!"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 	err := cmd.Execute()
 
-	// The command will error because there is no azd project or local server,
-	// but the error must NOT be the old validation rejection.
-	if err != nil && strings.Contains(err.Error(), "cannot use --local with a named agent") {
+	if err == nil {
+		t.Fatal("expected an error (no azd project), got nil")
+	}
+	if strings.Contains(err.Error(), "cannot use --local with a named agent") {
 		t.Fatalf("unexpected validation rejection: %v", err)
 	}
 }


### PR DESCRIPTION
## Why

In multi-agent projects, `azd ai agent invoke my-agent --local "message"` fails with:

> cannot use --local with a named agent; named agents are always invoked remotely on Foundry

This forces users to go through the interactive picker every time, even when they already know the agent name. The downstream local code paths (`responsesLocal`, `invocationsLocal`) already accept and correctly use the agent name for session key resolution, so the validation guard was unnecessarily restrictive.

## What changed

- **Removed the validation block** that rejected `--local` combined with a positional agent name.
- **Fixed `resolveProtocol()`** to pass `a.flags.name` (instead of empty string) when `--local` is set, so protocol auto-detection reads the correct agent's `agent.yaml` in multi-agent projects.
- **Added a command example** showing `azd ai agent invoke my-agent --local "Hello!"`.
- **Added `TestInvokeLocalWithNamedAgent`** verifying the combination passes validation.

All existing tests pass.

Fixes: #7928