### PR TITLE
fix(update): trust azure/azd Homebrew cask source so macOS update banner and azd update work

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ powershell -ex AllSigned -c "Invoke-RestMethod 'https://aka.ms/install-azd.ps1' 
 ### macOS
 
 ```bash
-brew install --cask azure/azd/azd
+brew trust azure/azd && brew install --cask azure/azd/azd
 ```
 
+> **Note:** `brew trust azure/azd` trusts azd's Homebrew source (the `azure/azd` tap for `github.com/Azure/homebrew-azd`). Homebrew requires this before it will install casks from third-party sources.
+>
 > **Note:** If upgrading from a non-Homebrew installation, remove the existing `azd` binary first.
 
 ### Linux

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+- [[#8683]](https://github.com/Azure/azure-dev/issues/8683) Fix the macOS Homebrew update banner and `azd update` suggesting/running cask commands that fail with `Refusing to load cask azure/azd/azd from untrusted tap` on current Homebrew. The banner now suggests `brew trust azure/azd && brew upgrade --cask azure/azd/azd`, and `azd update` trusts the `azure/azd` tap before any cask operation.
 - [[#8649]](https://github.com/Azure/azure-dev/pull/8649) Fix interactive prompts (for example the `azd init` environment-name prompt) rendering twice on Windows terminals by rendering prompts with azd's own UX components instead of the archived survey library.
 
 ### Other Changes

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- [[#8683]](https://github.com/Azure/azure-dev/issues/8683) Fix the macOS Homebrew update banner and `azd update` suggesting/running cask commands that fail with `Refusing to load cask azure/azd/azd from untrusted tap` on current Homebrew. The banner now suggests `brew trust azure/azd && brew upgrade --cask azure/azd/azd`, and `azd update` trusts the `azure/azd` tap before any cask operation.
+- [[#8776]](https://github.com/Azure/azure-dev/pull/8776) Fix the macOS Homebrew update banner and `azd update` suggesting/running cask commands that fail with `Refusing to load cask azure/azd/azd from untrusted tap` on current Homebrew. azd now trusts its Homebrew source (`brew trust azure/azd`) before the cask install/upgrade in both the update banner and `azd update`, and the install instructions show the trust step.
 - [[#8649]](https://github.com/Azure/azure-dev/pull/8649) Fix interactive prompts (for example the `azd init` environment-name prompt) rendering twice on Windows terminals by rendering prompts with azd's own UX components instead of the archived survey library.
 
 ### Other Changes

--- a/cli/azd/docs/design/azd-update.md
+++ b/cli/azd/docs/design/azd-update.md
@@ -237,11 +237,14 @@ Homebrew updates use cask operations for both stable and daily channels:
 ```
 1. Check which cask is currently installed via `brew list --cask`
    - `azd` = stable cask, `azd@daily` = daily cask
-2. If no cask installed (formula or other install) → uninstall and reinstall as correct cask
-3. If switching channels → uninstall current cask, install target cask
+2. Trust the azure/azd tap (`brew tap azure/azd` then `brew trust azure/azd`,
+   best-effort) so Homebrew's untrusted-tap guard doesn't block the cask
+   operations below (see issue #8683)
+3. If no cask installed (formula or other install) → uninstall and reinstall as correct cask
+4. If switching channels → uninstall current cask, install target cask
    - daily→stable: `brew uninstall --cask azd@daily` then `brew install --cask azure/azd/azd`
    - stable→daily: `brew uninstall --cask azd` then `brew install --cask azure/azd/azd@daily`
-4. If same channel → `brew upgrade --cask azure/azd/azd` (or `azure/azd/azd@daily`)
+5. If same channel → `brew upgrade --cask azure/azd/azd` (or `azure/azd/azd@daily`)
 ```
 
 #### Elevation Handling

--- a/cli/azd/docs/design/azd-update.md
+++ b/cli/azd/docs/design/azd-update.md
@@ -175,7 +175,7 @@ All flags persist their values to config, which can also be set directly via `az
 
 | Install Method | Strategy |
 |----------------|----------|
-| `brew` | Homebrew cask: `brew install/upgrade --cask azure/azd/azd` (stable) or `azure/azd/azd@daily` (daily). Handles channel switching by uninstalling the current formula or cask and installing the target. |
+| `brew` | Homebrew cask: trust azd's source (`brew trust azure/azd`), then `brew install/upgrade --cask azure/azd/azd` (stable) or `azure/azd/azd@daily` (daily). Handles channel switching by uninstalling the current formula or cask and installing the target. |
 | `winget` | Shell out: `winget upgrade Microsoft.Azd` |
 | `choco` | Shell out: `choco upgrade azd` |
 | `install-azd.ps1`, `msi` (Windows) | Shell out: `install-azd.ps1` with backup/restore of running executable |
@@ -237,9 +237,11 @@ Homebrew updates use cask operations for both stable and daily channels:
 ```
 1. Check which cask is currently installed via `brew list --cask`
    - `azd` = stable cask, `azd@daily` = daily cask
-2. Trust the azure/azd tap (`brew tap azure/azd` then `brew trust azure/azd`,
-   best-effort) so Homebrew's untrusted-tap guard doesn't block the cask
-   operations below (see issue #8683)
+2. Trust azd's Homebrew source so the cask operations below aren't blocked:
+   run `brew trust azure/azd`.
+   - `azure/azd` is azd's own source — the Homebrew tap name for
+     `github.com/Azure/homebrew-azd`, which publishes the `azd` (stable) and `azd@daily` casks.
+   - Homebrew treats third-party sources as untrusted and refuses to load their casks until trusted, which would otherwise block install upgrade, and even uninstall. Trusting the source unblocks the cask install/upgrade that follows.
 3. If no cask installed (formula or other install) → uninstall and reinstall as correct cask
 4. If switching channels → uninstall current cask, install target cask
    - daily→stable: `brew uninstall --cask azd@daily` then `brew install --cask azure/azd/azd`

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -302,7 +302,11 @@ func platformUpgradeHintFor(goos string, installedBy installer.InstallType, chan
 	case "darwin":
 		switch installedBy {
 		case installer.InstallTypeBrew:
-			return update.RunUpdateHint("brew uninstall azd && brew install --cask azure/azd/azd")
+			// Homebrew treats the azure/azd tap as untrusted and blocks every cask
+			// operation (install/upgrade/uninstall) until the tap is trusted, so
+			// prepend `brew trust azure/azd` to keep the suggested command working.
+			// See https://github.com/Azure/azure-dev/issues/8683.
+			return update.RunUpdateHint("brew uninstall azd && brew trust azure/azd && brew install --cask azure/azd/azd")
 		case installer.InstallTypeSh:
 			return shInstallerHint(isDaily, "https://aka.ms/azd/upgrade/mac")
 		default:

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -303,8 +303,9 @@ func platformUpgradeHintFor(goos string, installedBy installer.InstallType, chan
 		switch installedBy {
 		case installer.InstallTypeBrew:
 			// Homebrew refuses to load casks from the untrusted azure/azd source,
-			// blocking install, upgrade, and even uninstall
-			return update.RunUpdateHint("brew uninstall azd && brew trust azure/azd && brew install --cask azure/azd/azd")
+			// blocking install, upgrade, and even uninstall, so trust the source
+			// first so the uninstall + reinstall that follow aren't blocked.
+			return update.RunUpdateHint("brew trust azure/azd && brew uninstall azd && brew install --cask azure/azd/azd")
 		case installer.InstallTypeSh:
 			return shInstallerHint(isDaily, "https://aka.ms/azd/upgrade/mac")
 		default:

--- a/cli/azd/main.go
+++ b/cli/azd/main.go
@@ -302,10 +302,8 @@ func platformUpgradeHintFor(goos string, installedBy installer.InstallType, chan
 	case "darwin":
 		switch installedBy {
 		case installer.InstallTypeBrew:
-			// Homebrew treats the azure/azd tap as untrusted and blocks every cask
-			// operation (install/upgrade/uninstall) until the tap is trusted, so
-			// prepend `brew trust azure/azd` to keep the suggested command working.
-			// See https://github.com/Azure/azure-dev/issues/8683.
+			// Homebrew refuses to load casks from the untrusted azure/azd source,
+			// blocking install, upgrade, and even uninstall
 			return update.RunUpdateHint("brew uninstall azd && brew trust azure/azd && brew install --cask azure/azd/azd")
 		case installer.InstallTypeSh:
 			return shInstallerHint(isDaily, "https://aka.ms/azd/upgrade/mac")

--- a/cli/azd/main_test.go
+++ b/cli/azd/main_test.go
@@ -126,7 +126,7 @@ func TestPlatformUpgradeHintFor(t *testing.T) {
 			goos:            "darwin",
 			installedBy:     installer.InstallTypeBrew,
 			channel:         update.ChannelDaily,
-			wantContains:    []string{"brew trust azure/azd && brew upgrade --cask azure/azd/azd"},
+			wantContains:    []string{"brew trust azure/azd && brew uninstall azd && brew install --cask azure/azd/azd"},
 			wantNotContains: []string{detailsMarker},
 		},
 		{

--- a/cli/azd/main_test.go
+++ b/cli/azd/main_test.go
@@ -126,7 +126,7 @@ func TestPlatformUpgradeHintFor(t *testing.T) {
 			goos:            "darwin",
 			installedBy:     installer.InstallTypeBrew,
 			channel:         update.ChannelDaily,
-			wantContains:    []string{"brew uninstall azd && brew install --cask azure/azd/azd"},
+			wantContains:    []string{"brew trust azure/azd && brew upgrade --cask azure/azd/azd"},
 			wantNotContains: []string{detailsMarker},
 		},
 		{

--- a/cli/azd/pkg/update/manager.go
+++ b/cli/azd/pkg/update/manager.go
@@ -326,6 +326,12 @@ func (m *Manager) updateViaBrew(ctx context.Context, cfg *UpdateConfig, writer i
 
 	targetChannel := cfg.Channel
 
+	// Homebrew (6.0+) refuses to load casks from the third-party azure/azd tap
+	// until it is explicitly trusted, which blocks install, upgrade, and even
+	// uninstall. Trust the tap up front so the cask operations below succeed.
+	// See https://github.com/Azure/azure-dev/issues/8683.
+	m.ensureBrewTapTrusted(ctx, writer)
+
 	if !hasAzd && !hasAzdDaily {
 		// azd is not installed as a cask (formula install or other).
 		// Uninstall the non-cask version and install the correct cask.
@@ -375,6 +381,33 @@ func (m *Manager) updateViaBrew(ctx context.Context, cfg *UpdateConfig, writer i
 		return m.updateViaPackageManager(ctx, "brew", []string{"upgrade", "--cask", "azure/azd/azd@daily"}, writer)
 	default:
 		return fmt.Errorf("unsupported channel: %s", targetChannel)
+	}
+}
+
+// ensureBrewTapTrusted taps and trusts the azure/azd Homebrew tap so that the
+// cask operations performed by updateViaBrew aren't blocked by Homebrew's
+// untrusted-tap guard, which refuses to load casks from third-party taps until
+// they are trusted (see https://github.com/Azure/azure-dev/issues/8683).
+//
+// The tap must exist before it can be trusted (Homebrew no longer auto-taps
+// untrusted taps), so the tap is ensured first. Both steps are best-effort and
+// idempotent: failures are logged rather than returned so that older Homebrew
+// versions without the trust guard (and therefore without a `brew trust`
+// command) still work, and so the subsequent cask command surfaces the real
+// error if trust is genuinely required but missing.
+func (m *Manager) ensureBrewTapTrusted(ctx context.Context, writer io.Writer) {
+	fmt.Fprintf(writer, "Trusting Homebrew tap azure/azd...\n")
+
+	tapArgs := exec.NewRunArgs("brew", "tap", "azure/azd").
+		WithStdOut(writer).WithStdErr(writer).WithInteractive(true)
+	if _, err := m.commandRunner.Run(ctx, tapArgs); err != nil {
+		log.Printf("brew tap azure/azd failed: %v", err)
+	}
+
+	trustArgs := exec.NewRunArgs("brew", "trust", "azure/azd").
+		WithStdOut(writer).WithStdErr(writer).WithInteractive(true)
+	if _, err := m.commandRunner.Run(ctx, trustArgs); err != nil {
+		log.Printf("brew trust azure/azd failed: %v", err)
 	}
 }
 

--- a/cli/azd/pkg/update/manager.go
+++ b/cli/azd/pkg/update/manager.go
@@ -962,7 +962,9 @@ func IsPackageManagerInstall() bool {
 func PackageManagerUninstallCmd(installedBy installer.InstallType) string {
 	switch installedBy {
 	case installer.InstallTypeBrew:
-		return "brew uninstall azd"
+		// `brew uninstall azd` reads the azure/azd cask metadata, which Homebrew
+		// blocks until the source is trusted, so trust it first.
+		return "brew trust azure/azd && brew uninstall azd"
 	case installer.InstallTypeWinget:
 		return "winget uninstall Microsoft.Azd"
 	case installer.InstallTypeChoco:

--- a/cli/azd/pkg/update/manager.go
+++ b/cli/azd/pkg/update/manager.go
@@ -326,11 +326,17 @@ func (m *Manager) updateViaBrew(ctx context.Context, cfg *UpdateConfig, writer i
 
 	targetChannel := cfg.Channel
 
-	// Homebrew (6.0+) refuses to load casks from the third-party azure/azd tap
-	// until it is explicitly trusted, which blocks install, upgrade, and even
-	// uninstall. Trust the tap up front so the cask operations below succeed.
-	// See https://github.com/Azure/azure-dev/issues/8683.
-	m.ensureBrewTapTrusted(ctx, writer)
+	// `azure/azd` is azd's own Homebrew source (the `azure/azd` tap for
+	// github.com/Azure/homebrew-azd, which publishes the `azd` and `azd@daily`
+	// casks). Homebrew refuses to load casks from untrusted third-party sources —
+	// blocking install, upgrade, and even uninstall — so trust azd's source before
+	// the cask operations below.
+	fmt.Fprintf(writer, "Trusting azd's Homebrew source (azure/azd)...\n")
+	trustArgs := exec.NewRunArgs("brew", "trust", "azure/azd").
+		WithStdOut(writer).WithStdErr(writer).WithInteractive(true)
+	if _, err := m.commandRunner.Run(ctx, trustArgs); err != nil {
+		log.Printf("brew trust azure/azd failed: %v", err)
+	}
 
 	if !hasAzd && !hasAzdDaily {
 		// azd is not installed as a cask (formula install or other).
@@ -381,33 +387,6 @@ func (m *Manager) updateViaBrew(ctx context.Context, cfg *UpdateConfig, writer i
 		return m.updateViaPackageManager(ctx, "brew", []string{"upgrade", "--cask", "azure/azd/azd@daily"}, writer)
 	default:
 		return fmt.Errorf("unsupported channel: %s", targetChannel)
-	}
-}
-
-// ensureBrewTapTrusted taps and trusts the azure/azd Homebrew tap so that the
-// cask operations performed by updateViaBrew aren't blocked by Homebrew's
-// untrusted-tap guard, which refuses to load casks from third-party taps until
-// they are trusted (see https://github.com/Azure/azure-dev/issues/8683).
-//
-// The tap must exist before it can be trusted (Homebrew no longer auto-taps
-// untrusted taps), so the tap is ensured first. Both steps are best-effort and
-// idempotent: failures are logged rather than returned so that older Homebrew
-// versions without the trust guard (and therefore without a `brew trust`
-// command) still work, and so the subsequent cask command surfaces the real
-// error if trust is genuinely required but missing.
-func (m *Manager) ensureBrewTapTrusted(ctx context.Context, writer io.Writer) {
-	fmt.Fprintf(writer, "Trusting Homebrew tap azure/azd...\n")
-
-	tapArgs := exec.NewRunArgs("brew", "tap", "azure/azd").
-		WithStdOut(writer).WithStdErr(writer).WithInteractive(true)
-	if _, err := m.commandRunner.Run(ctx, tapArgs); err != nil {
-		log.Printf("brew tap azure/azd failed: %v", err)
-	}
-
-	trustArgs := exec.NewRunArgs("brew", "trust", "azure/azd").
-		WithStdOut(writer).WithStdErr(writer).WithInteractive(true)
-	if _, err := m.commandRunner.Run(ctx, trustArgs); err != nil {
-		log.Printf("brew trust azure/azd failed: %v", err)
 	}
 }
 

--- a/cli/azd/pkg/update/manager_test.go
+++ b/cli/azd/pkg/update/manager_test.go
@@ -651,9 +651,22 @@ func (t *urlRewriteTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	return t.base.RoundTrip(newReq)
 }
 
+// mockBrewTapTrust registers success responses for the best-effort
+// `brew tap azure/azd` and `brew trust azure/azd` steps that updateViaBrew runs
+// before any cask operation so the third-party tap is trusted (see #8683).
+func mockBrewTapTrust(runner *mockexec.MockCommandRunner) {
+	runner.When(func(args exec.RunArgs, command string) bool {
+		return command == "brew tap azure/azd"
+	}).Respond(exec.NewRunResult(0, "", ""))
+	runner.When(func(args exec.RunArgs, command string) bool {
+		return command == "brew trust azure/azd"
+	}).Respond(exec.NewRunResult(0, "", ""))
+}
+
 func TestUpdateViaBrew(t *testing.T) {
 	t.Run("NotCask_Stable", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
+		mockBrewTapTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "some-other-cask\n", ""))
@@ -673,6 +686,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("NotCask_Daily", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
+		mockBrewTapTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "some-other-cask\n", ""))
@@ -692,6 +706,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("NotCask_UnsupportedChannel", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
+		mockBrewTapTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "some-other-cask\n", ""))
@@ -708,6 +723,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("SwitchDailyToStable", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
+		mockBrewTapTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "azd@daily\n", ""))
@@ -727,6 +743,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("SwitchStableToDaily", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
+		mockBrewTapTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "azd\n", ""))
@@ -746,6 +763,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("SwitchDailyToStable_UninstallFails", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
+		mockBrewTapTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "azd@daily\n", ""))
@@ -764,6 +782,32 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("UpgradeStable", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
+		mockBrewTapTrust(mockRunner)
+		mockRunner.When(func(args exec.RunArgs, command string) bool {
+			return command == "brew list --cask"
+		}).Respond(exec.NewRunResult(0, "azd\n", ""))
+		mockRunner.When(func(args exec.RunArgs, command string) bool {
+			return command == "brew upgrade --cask azure/azd/azd"
+		}).Respond(exec.NewRunResult(0, "Updated", ""))
+
+		m := NewManager(mockRunner, nil)
+		var buf bytes.Buffer
+		err := m.updateViaBrew(t.Context(), &UpdateConfig{Channel: ChannelStable}, &buf)
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "Trusting Homebrew tap azure/azd")
+		require.Contains(t, buf.String(), "Updating azd (stable channel)")
+	})
+
+	t.Run("TrustFails_StillUpgrades", func(t *testing.T) {
+		// Trust is best-effort: a failure (e.g. older Homebrew without the
+		// `brew trust` command) must not abort the upgrade. See #8683.
+		mockRunner := mockexec.NewMockCommandRunner()
+		mockRunner.When(func(args exec.RunArgs, command string) bool {
+			return command == "brew tap azure/azd"
+		}).Respond(exec.NewRunResult(0, "", ""))
+		mockRunner.When(func(args exec.RunArgs, command string) bool {
+			return command == "brew trust azure/azd"
+		}).SetError(fmt.Errorf("Unknown command: trust"))
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "azd\n", ""))
@@ -780,6 +824,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("UpgradeDaily", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
+		mockBrewTapTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "azd@daily\n", ""))
@@ -796,6 +841,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("UpgradeStable_Fails", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
+		mockBrewTapTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "azd\n", ""))
@@ -814,6 +860,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("UpgradeUnsupportedChannel", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
+		mockBrewTapTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "azd\n", ""))
@@ -827,6 +874,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("ListFails_FallsBackToInstall", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
+		mockBrewTapTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).SetError(fmt.Errorf("brew not found"))
@@ -845,6 +893,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("UninstallFails_StillInstallsCask", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
+		mockBrewTapTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "other-cask\n", ""))

--- a/cli/azd/pkg/update/manager_test.go
+++ b/cli/azd/pkg/update/manager_test.go
@@ -651,13 +651,10 @@ func (t *urlRewriteTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	return t.base.RoundTrip(newReq)
 }
 
-// mockBrewTapTrust registers success responses for the best-effort
-// `brew tap azure/azd` and `brew trust azure/azd` steps that updateViaBrew runs
-// before any cask operation so the third-party tap is trusted (see #8683).
-func mockBrewTapTrust(runner *mockexec.MockCommandRunner) {
-	runner.When(func(args exec.RunArgs, command string) bool {
-		return command == "brew tap azure/azd"
-	}).Respond(exec.NewRunResult(0, "", ""))
+// mockBrewTrust registers a success response for the best-effort
+// `brew trust azure/azd` step that updateViaBrew runs before any cask operation
+// so azd's Homebrew source is trusted.
+func mockBrewTrust(runner *mockexec.MockCommandRunner) {
 	runner.When(func(args exec.RunArgs, command string) bool {
 		return command == "brew trust azure/azd"
 	}).Respond(exec.NewRunResult(0, "", ""))
@@ -666,7 +663,7 @@ func mockBrewTapTrust(runner *mockexec.MockCommandRunner) {
 func TestUpdateViaBrew(t *testing.T) {
 	t.Run("NotCask_Stable", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
-		mockBrewTapTrust(mockRunner)
+		mockBrewTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "some-other-cask\n", ""))
@@ -686,7 +683,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("NotCask_Daily", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
-		mockBrewTapTrust(mockRunner)
+		mockBrewTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "some-other-cask\n", ""))
@@ -706,7 +703,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("NotCask_UnsupportedChannel", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
-		mockBrewTapTrust(mockRunner)
+		mockBrewTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "some-other-cask\n", ""))
@@ -723,7 +720,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("SwitchDailyToStable", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
-		mockBrewTapTrust(mockRunner)
+		mockBrewTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "azd@daily\n", ""))
@@ -743,7 +740,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("SwitchStableToDaily", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
-		mockBrewTapTrust(mockRunner)
+		mockBrewTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "azd\n", ""))
@@ -763,7 +760,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("SwitchDailyToStable_UninstallFails", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
-		mockBrewTapTrust(mockRunner)
+		mockBrewTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "azd@daily\n", ""))
@@ -782,7 +779,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("UpgradeStable", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
-		mockBrewTapTrust(mockRunner)
+		mockBrewTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "azd\n", ""))
@@ -794,7 +791,7 @@ func TestUpdateViaBrew(t *testing.T) {
 		var buf bytes.Buffer
 		err := m.updateViaBrew(t.Context(), &UpdateConfig{Channel: ChannelStable}, &buf)
 		require.NoError(t, err)
-		require.Contains(t, buf.String(), "Trusting Homebrew tap azure/azd")
+		require.Contains(t, buf.String(), "Trusting azd's Homebrew source (azure/azd)")
 		require.Contains(t, buf.String(), "Updating azd (stable channel)")
 	})
 
@@ -802,9 +799,6 @@ func TestUpdateViaBrew(t *testing.T) {
 		// Trust is best-effort: a failure (e.g. older Homebrew without the
 		// `brew trust` command) must not abort the upgrade. See #8683.
 		mockRunner := mockexec.NewMockCommandRunner()
-		mockRunner.When(func(args exec.RunArgs, command string) bool {
-			return command == "brew tap azure/azd"
-		}).Respond(exec.NewRunResult(0, "", ""))
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew trust azure/azd"
 		}).SetError(fmt.Errorf("Unknown command: trust"))
@@ -824,7 +818,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("UpgradeDaily", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
-		mockBrewTapTrust(mockRunner)
+		mockBrewTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "azd@daily\n", ""))
@@ -841,7 +835,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("UpgradeStable_Fails", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
-		mockBrewTapTrust(mockRunner)
+		mockBrewTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "azd\n", ""))
@@ -860,7 +854,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("UpgradeUnsupportedChannel", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
-		mockBrewTapTrust(mockRunner)
+		mockBrewTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "azd\n", ""))
@@ -874,7 +868,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("ListFails_FallsBackToInstall", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
-		mockBrewTapTrust(mockRunner)
+		mockBrewTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).SetError(fmt.Errorf("brew not found"))
@@ -893,7 +887,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 	t.Run("UninstallFails_StillInstallsCask", func(t *testing.T) {
 		mockRunner := mockexec.NewMockCommandRunner()
-		mockBrewTapTrust(mockRunner)
+		mockBrewTrust(mockRunner)
 		mockRunner.When(func(args exec.RunArgs, command string) bool {
 			return command == "brew list --cask"
 		}).Respond(exec.NewRunResult(0, "other-cask\n", ""))

--- a/cli/azd/pkg/update/manager_test.go
+++ b/cli/azd/pkg/update/manager_test.go
@@ -120,7 +120,7 @@ func TestPackageManagerUninstallCmd(t *testing.T) {
 		installedBy installer.InstallType
 		want        string
 	}{
-		{"brew", installer.InstallTypeBrew, "brew uninstall azd"},
+		{"brew", installer.InstallTypeBrew, "brew trust azure/azd && brew uninstall azd"},
 		{"winget", installer.InstallTypeWinget, "winget uninstall Microsoft.Azd"},
 		{"choco", installer.InstallTypeChoco, "choco uninstall azd"},
 		{"unknown", installer.InstallTypeUnknown, "your package manager"},

--- a/cli/installer/README.md
+++ b/cli/installer/README.md
@@ -35,8 +35,10 @@ See [MSI configuration](#msi-configuration) for advanced install scenarios.
 #### Homebrew (recommended)
 
 ```bash
-brew install --cask azure/azd/azd
+brew trust azure/azd && brew install --cask azure/azd/azd
 ```
+
+`brew trust azure/azd` trusts azd's Homebrew source (the `azure/azd` tap for `github.com/Azure/homebrew-azd`); Homebrew requires this before it will install casks from third-party sources.
 
 If using `brew` to upgrade `azd` from a version not installed using `brew`, remove the existing version of `azd` using the uninstall script (if installed to the default location) or by deleting the `azd` binary manually.
 


### PR DESCRIPTION
Fixes #8683

## Problem

On macOS, the `azd` update banner suggests a Homebrew command that fails:

```
Update available: 1.25.4 -> 1.25.6
To update, run `brew uninstall azd && brew install --cask azure/azd/azd`
```

```
$ brew uninstall azd && brew install --cask azure/azd/azd
Error: Refusing to load cask azure/azd/azd from untrusted tap azure/azd.
```

Homebrew treats the third-party `azure/azd` source as **untrusted** and blocks
**every** operation that reads its cask metadata — install, upgrade, *and even
uninstall* — until it is trusted with `brew trust azure/azd`. The banner sends
users in a circle, and `azd update`'s Homebrew path (`updateViaBrew`) runs the
same blocked cask commands.

## Fix

Keep azd on its existing `azure/azd` Homebrew **cask** and run `brew trust
azure/azd` **before** any cask install/upgrade/uninstall so the commands aren't
blocked by Homebrew's untrusted-source guard.

We verified by testing that a separate `brew tap` step isn't needed: `brew trust`
records trust against the source *name* (`azure/azd`) as durable Homebrew state
(it even survives `brew untap`), so `brew trust azure/azd && brew install --cask
azure/azd/azd` works on its own — the install resolves the now-trusted source.

- **Update banner** (`cli/azd/main.go`): now suggests `brew trust azure/azd &&
  brew uninstall azd && brew install --cask azure/azd/azd`. `brew trust` runs
  **first** so even the `uninstall` — which also reads cask metadata and is
  otherwise blocked — succeeds.
- **`azd update`** (`cli/azd/pkg/update/manager.go`): `updateViaBrew` runs
  `brew trust azure/azd` before any cask install/upgrade/uninstall (stable and
  daily). Best-effort and idempotent, so older Homebrew without the untrusted-
  source guard (and therefore without a `brew trust` command) still works.
- **`PackageManagerUninstallCmd`**: the brew uninstall hint is now
  `brew trust azure/azd && brew uninstall azd`.
- **Install docs** (`README.md`, `cli/installer/README.md`): updated to
  `brew trust azure/azd && brew install --cask azure/azd/azd`.

## Testing

- `main_test.go` darwin/brew banner expectation and `TestPackageManagerUninstallCmd`
  updated to the trust-first commands.
- `TestUpdateViaBrew` sub-tests mock the `brew trust azure/azd` step, and
  `TrustFails_StillUpgrades` proves a trust failure does not abort the update.
- `go build ./...`, `go test .` / `go test ./pkg/update/...`, `golangci-lint`,
  `gofmt`, and `go vet` are clean.

## Notes

- `installer.InstalledBy()` only returns `InstallTypeBrew` (it can't distinguish a
  cask install from a formula install), so the banner targets the cask path.
