### PR TITLE
feat: generalize $ref resolver + shared $ref-aware azure.yaml edit helper

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/project/includes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/includes.go
@@ -37,9 +37,9 @@ var remoteRefPattern = regexp.MustCompile(`(?i)^[a-z][a-z0-9+.-]*://`)
 // map[string]any. The core ServiceConfig fields (host, the service key, uses) are stripped by
 // core and never appear here. cfg therefore takes any of these shapes:
 //
-//   - A service-entry-level $ref. The $ref sits at the top level of the inline map, beside the
-//     host and service key that core already removed (e.g. an agent or skill entry whose body
-//     lives in ./agents/research-agent.yaml). The map itself is the $ref directive.
+//   - A service-entry-level $ref. In azure.yaml the service entry can be authored with host:
+//     plus $ref (and optional overlay keys). Core removes ServiceConfig fields such as host
+//     before the extension sees the config, so the cfg map passed here has $ref at its top level.
 //   - A deployment array-item $ref. Deployments stay an array on the project service, so each
 //     item in deployments may be its own $ref (e.g. ./deployments/gpt-4o.yaml).
 //   - Any nested $ref reached while walking the entry (a $ref inside a loaded file, or a sibling

--- a/cli/azd/extensions/azure.ai.agents/internal/project/includes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/includes.go
@@ -29,13 +29,24 @@ const maxRefDepth = 32
 // are rejected for now; only local YAML/JSON files are supported.
 var remoteRefPattern = regexp.MustCompile(`(?i)^[a-z][a-z0-9+.-]*://`)
 
-// ResolveFileRefs resolves $ref file includes within a parsed Foundry service configuration.
+// ResolveFileRefs resolves $ref file includes within a Foundry resource service configuration.
 //
-// cfg is the Foundry service entry as already-parsed data (the inline azure.yaml keys that
+// In the separate-services azure.yaml shape every Foundry resource is its own service entry, so
+// each owning extension calls ResolveFileRefs on its resource's inline map: the entry keys that
 // reach the extension over gRPC, where they arrive as a structpb.Struct decoded to
-// map[string]any). projectRoot is the directory that holds azure.yaml; relative $ref targets
-// at the top level resolve against it, and rebased project/instructions paths are anchored to
-// it.
+// map[string]any. The core ServiceConfig fields (host, the service key, uses) are stripped by
+// core and never appear here. cfg therefore takes any of these shapes:
+//
+//   - A service-entry-level $ref. The $ref sits at the top level of the inline map, beside the
+//     host and service key that core already removed (e.g. an agent or skill entry whose body
+//     lives in ./agents/research-agent.yaml). The map itself is the $ref directive.
+//   - A deployment array-item $ref. Deployments stay an array on the project service, so each
+//     item in deployments may be its own $ref (e.g. ./deployments/gpt-4o.yaml).
+//   - Any nested $ref reached while walking the entry (a $ref inside a loaded file, or a sibling
+//     value), since resolution is recursive over every map and sequence node.
+//
+// projectRoot is the directory that holds azure.yaml; relative $ref targets at the top level
+// resolve against it, and rebased project/instructions paths are anchored to it.
 //
 // Any object that contains a "$ref" string is replaced by the referenced YAML or JSON file,
 // with the object's remaining keys overlaid on top. The overlay is a shallow, top-level merge:

--- a/cli/azd/extensions/azure.ai.agents/internal/project/includes_edit.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/includes_edit.go
@@ -1,0 +1,342 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/yamlnode"
+	"github.com/braydonk/yaml"
+
+	"azureaiagent/internal/exterrors"
+)
+
+// ErrServiceNotFound is returned when a named service entry is absent and creation was not
+// requested. It mirrors yamlnode.ErrNodeNotFound so callers can branch on a sentinel.
+var ErrServiceNotFound = errors.New("service entry not found")
+
+// EditTarget selects where a write to a service entry lands.
+type EditTarget int
+
+const (
+	// EditInline writes the field on the service entry in the holding document, beside any
+	// $ref. This is the spec §2.4 default (append inline): ResolveFileRefs reads such a key as
+	// an overlay override layered on top of the referenced file, so the write is read back as
+	// the winning value.
+	EditInline EditTarget = iota
+
+	// EditRefFile follows the entry's $ref and writes the field into the referenced split file
+	// instead. If the entry is not $ref-backed it falls back to an inline write.
+	EditRefFile
+)
+
+// YAMLDocument is an editable, comment-preserving azure.yaml (or a referenced split file). It
+// wraps a braydonk yaml.Node tree so edits keep comments, key order, and block-scalar style,
+// matching how azd core round-trips azure.yaml.
+//
+// It is the $ref-aware write counterpart to ResolveFileRefs: EntryRef recognizes a $ref entry
+// with the same key the resolver uses, and EditRefFile resolves the split-file path with the
+// resolver's shared path logic, so reads and writes of $ref entries agree. The composition
+// commands tracked by #8049 share this helper.
+//
+// Edits mutate the tree in memory; call Save to persist. Writes through EditRefFile lazily load
+// the referenced file, and Save persists every file touched this way alongside the main one.
+type YAMLDocument struct {
+	path    string
+	root    yaml.Node
+	refDocs map[string]*YAMLDocument
+}
+
+// LoadYAMLDocument reads and parses the YAML file at path into an editable document.
+func LoadYAMLDocument(path string) (*YAMLDocument, error) {
+	// #nosec G304 -- azure.yaml and its $ref split files are trusted config input, the same
+	// trust level as azure.yaml itself (design spec §2.4 treats includes as trusted input).
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidFileRef,
+			fmt.Sprintf("cannot read YAML file %q: %v", path, err),
+			"Check that the path is correct and the file exists and is readable.",
+		)
+	}
+	return ParseYAMLDocument(path, data)
+}
+
+// ParseYAMLDocument parses data as the YAML document located (logically) at path. path is used
+// to resolve relative $ref split-file targets and as the destination for Save; it need not
+// exist on disk yet. Empty input yields an empty document whose root is created on first edit.
+func ParseYAMLDocument(path string, data []byte) (*YAMLDocument, error) {
+	doc := &YAMLDocument{path: path, refDocs: map[string]*YAMLDocument{}}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return doc, nil
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.SetScanBlockScalarAsLiteral(true)
+	if err := decoder.Decode(&doc.root); err != nil {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidFileRef,
+			fmt.Sprintf("YAML file %q is not valid: %v", path, err),
+			"Fix the file so it parses as a YAML document.",
+		)
+	}
+	return doc, nil
+}
+
+// Bytes serializes the document, preserving comments, key order, and block-scalar style with
+// two-space indentation (the azure.yaml convention used by azd core).
+func (d *YAMLDocument) Bytes() ([]byte, error) {
+	if d.root.Kind == 0 {
+		return []byte{}, nil
+	}
+
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	// preserve multi-line block scalar style
+	encoder.SetAssumeBlockAsLiteral(true)
+	if err := encoder.Encode(&d.root); err != nil {
+		_ = encoder.Close()
+		return nil, fmt.Errorf("encoding YAML: %w", err)
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, fmt.Errorf("closing YAML encoder: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// Save writes the document back to its path, then persists every referenced split file edited
+// through EditRefFile.
+func (d *YAMLDocument) Save() error {
+	data, err := d.Bytes()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(d.path, data, osutil.PermissionFile); err != nil {
+		return fmt.Errorf("writing %q: %w", d.path, err)
+	}
+	for _, sub := range d.refDocs {
+		if err := sub.Save(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ServiceEntry returns the mapping node for services.<name>. When create is true a missing
+// services mapping and/or entry are added (and returned); when false a missing entry returns
+// ErrServiceNotFound.
+func (d *YAMLDocument) ServiceEntry(name string, create bool) (*yaml.Node, error) {
+	if name == "" {
+		return nil, errors.New("service name must not be empty")
+	}
+
+	services, err := d.servicesNode(create)
+	if err != nil {
+		return nil, err
+	}
+	if services != nil {
+		if entry := mappingValue(services, name); entry != nil {
+			if entry.Kind != yaml.MappingNode {
+				return nil, fmt.Errorf("%w: service %q is not a mapping", yamlnode.ErrNodeWrongKind, name)
+			}
+			return entry, nil
+		}
+	}
+
+	if !create {
+		return nil, fmt.Errorf("%w: %s", ErrServiceNotFound, name)
+	}
+
+	entry := &yaml.Node{Kind: yaml.MappingNode}
+	services.Content = append(services.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: name},
+		entry,
+	)
+	return entry, nil
+}
+
+// SetServiceField sets services.<name>.<key> to value, creating the service entry if missing.
+// It is $ref-aware:
+//
+//   - EditInline writes the key on the entry node beside any $ref. ResolveFileRefs reads it as
+//     an overlay override on top of the referenced file.
+//   - EditRefFile writes the key into the file named by the entry's $ref instead (resolved
+//     relative to this document with the resolver's shared path logic). If the entry has no
+//     $ref it falls back to an inline write.
+//
+// value may be any value yamlnode.Encode accepts (scalars, sequences, mappings).
+func (d *YAMLDocument) SetServiceField(name, key string, value any, target EditTarget) error {
+	if key == "" {
+		return errors.New("field key must not be empty")
+	}
+
+	entry, err := d.ServiceEntry(name, true)
+	if err != nil {
+		return err
+	}
+
+	valueNode, err := yamlnode.Encode(value)
+	if err != nil {
+		return err
+	}
+
+	if target == EditRefFile {
+		if ref, isRef := EntryRef(entry); isRef {
+			return d.setRefFileField(ref, key, valueNode)
+		}
+		// No split file to target; fall back to an inline write.
+	}
+
+	return setEntryField(entry, key, valueNode)
+}
+
+// EntryRef reports the $ref target of a service entry and whether the entry is $ref-backed. It
+// recognizes the same directive key as ResolveFileRefs, so a writer and the resolver agree on
+// which entries are file includes.
+func EntryRef(entry *yaml.Node) (string, bool) {
+	value := mappingValue(entry, refKey)
+	if value == nil || value.Kind != yaml.ScalarNode {
+		return "", false
+	}
+	ref := strings.TrimSpace(value.Value)
+	if ref == "" {
+		return "", false
+	}
+	return ref, true
+}
+
+// setRefFileField loads (and caches) the split file named by ref and sets key on its root
+// mapping. The file is persisted by Save.
+func (d *YAMLDocument) setRefFileField(ref, key string, valueNode *yaml.Node) error {
+	target, err := refTargetPath(ref, d.dir())
+	if err != nil {
+		return err
+	}
+
+	sub, err := d.refDoc(target)
+	if err != nil {
+		return err
+	}
+
+	subRoot, err := sub.rootMapping(true)
+	if err != nil {
+		return err
+	}
+	return setEntryField(subRoot, key, valueNode)
+}
+
+// refDoc returns the cached editable document for the split file at target, loading it once.
+func (d *YAMLDocument) refDoc(target string) (*YAMLDocument, error) {
+	if sub, ok := d.refDocs[target]; ok {
+		return sub, nil
+	}
+	sub, err := LoadYAMLDocument(target)
+	if err != nil {
+		return nil, err
+	}
+	d.refDocs[target] = sub
+	return sub, nil
+}
+
+// dir returns the directory that holds the document, used to resolve relative $ref targets.
+func (d *YAMLDocument) dir() string {
+	if d.path == "" {
+		return "."
+	}
+	return filepath.Dir(d.path)
+}
+
+// servicesNode returns the top-level services mapping, optionally creating it.
+func (d *YAMLDocument) servicesNode(create bool) (*yaml.Node, error) {
+	root, err := d.rootMapping(create)
+	if err != nil || root == nil {
+		return nil, err
+	}
+
+	if services := mappingValue(root, "services"); services != nil {
+		if services.Kind != yaml.MappingNode {
+			return nil, fmt.Errorf("%w: services is not a mapping", yamlnode.ErrNodeWrongKind)
+		}
+		return services, nil
+	}
+
+	if !create {
+		return nil, nil
+	}
+
+	services := &yaml.Node{Kind: yaml.MappingNode}
+	root.Content = append(root.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "services"},
+		services,
+	)
+	return services, nil
+}
+
+// rootMapping returns the document's root mapping node, optionally initializing an empty
+// document and root mapping.
+func (d *YAMLDocument) rootMapping(create bool) (*yaml.Node, error) {
+	if d.root.Kind == 0 {
+		if !create {
+			return nil, nil
+		}
+		d.root = yaml.Node{Kind: yaml.DocumentNode}
+	}
+	if d.root.Kind != yaml.DocumentNode {
+		return nil, fmt.Errorf("%w: YAML root is not a document", yamlnode.ErrNodeWrongKind)
+	}
+
+	if len(d.root.Content) == 0 {
+		if !create {
+			return nil, nil
+		}
+		d.root.Content = []*yaml.Node{{Kind: yaml.MappingNode}}
+	}
+
+	root := d.root.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("%w: YAML root is not a mapping", yamlnode.ErrNodeWrongKind)
+	}
+	return root, nil
+}
+
+// mappingValue returns the value node for key in a mapping node, or nil when absent.
+func mappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// setEntryField sets key on the mapping node via yamlnode.Set, first transferring the comments
+// of any replaced value onto the new node so an inline annotation survives an in-place update.
+// A new key is appended (preserving existing key order).
+func setEntryField(entry *yaml.Node, key string, valueNode *yaml.Node) error {
+	if old := mappingValue(entry, key); old != nil {
+		valueNode.HeadComment = old.HeadComment
+		valueNode.LineComment = old.LineComment
+		valueNode.FootComment = old.FootComment
+	}
+	return yamlnode.Set(entry, quotePathSegment(key), valueNode)
+}
+
+// quotePathSegment escapes a single yamlnode dotted-path segment so a key containing the path
+// syntax's special characters (. [ ] ? ") is treated literally.
+func quotePathSegment(segment string) string {
+	if !strings.ContainsAny(segment, `.[]?"`) {
+		return segment
+	}
+	return `"` + strings.ReplaceAll(segment, `"`, `\"`) + `"`
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/includes_edit.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/includes_edit.go
@@ -43,8 +43,8 @@ const (
 //
 // It is the $ref-aware write counterpart to ResolveFileRefs: EntryRef recognizes a $ref entry
 // with the same key the resolver uses, and EditRefFile resolves the split-file path with the
-// resolver's shared path logic, so reads and writes of $ref entries agree. The composition
-// commands tracked by #8049 share this helper.
+// resolver's shared path logic, so reads and writes of $ref entries agree. It is also intended
+// for the #8049 composition command write path.
 //
 // Edits mutate the tree in memory; call Save to persist. Writes through EditRefFile lazily load
 // the referenced file, and Save persists every file touched this way alongside the main one.

--- a/cli/azd/extensions/azure.ai.agents/internal/project/includes_edit_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/includes_edit_test.go
@@ -1,0 +1,265 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readFile reads dir-relative or absolute path content as a string.
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	// #nosec G304 -- tests read files they just wrote under a t.TempDir() root.
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(data)
+}
+
+// serviceEntryMap parses an azure.yaml document and returns services.<name> as a map, matching
+// the already-parsed inline map a provider would feed to ResolveFileRefs.
+func serviceEntryMap(t *testing.T, doc, name string) map[string]any {
+	t.Helper()
+	parsed := parseYAML(t, doc)
+	services, ok := parsed["services"].(map[string]any)
+	require.True(t, ok, "services mapping missing")
+	entry, ok := services[name].(map[string]any)
+	require.True(t, ok, "service %q missing", name)
+	return entry
+}
+
+func TestYAMLDocument_RoundTripPreservesCommentsAndOrder(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "azure.yaml")
+	src := `name: my-project # inline project name
+# a standalone comment about services
+services:
+  research-agent:
+    # the agent host
+    host: azure.ai.agent
+    $ref: ./agents/research-agent.yaml
+`
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o600))
+
+	doc, err := LoadYAMLDocument(path)
+	require.NoError(t, err)
+	out, err := doc.Bytes()
+	require.NoError(t, err)
+	first := string(out)
+
+	// Comments survive the round trip.
+	assert.Contains(t, first, "# inline project name")
+	assert.Contains(t, first, "# a standalone comment about services")
+	assert.Contains(t, first, "# the agent host")
+	// Key order within the entry is preserved (host before $ref).
+	assert.Less(t, strings.Index(first, "host:"), strings.Index(first, "$ref:"))
+
+	// Re-encoding is stable (idempotent).
+	doc2, err := ParseYAMLDocument(path, out)
+	require.NoError(t, err)
+	out2, err := doc2.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, first, string(out2))
+}
+
+func TestYAMLDocument_ServiceEntry_FindMissingCreate(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "azure.yaml")
+	src := `name: p
+services:
+  existing:
+    host: azure.ai.agent
+`
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o600))
+	doc, err := LoadYAMLDocument(path)
+	require.NoError(t, err)
+
+	entry, err := doc.ServiceEntry("existing", false)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.Equal(t, "azure.ai.agent", mappingValue(entry, "host").Value)
+
+	_, err = doc.ServiceEntry("missing", false)
+	require.ErrorIs(t, err, ErrServiceNotFound)
+
+	created, err := doc.ServiceEntry("missing", true)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	// The created entry is now findable and is the same node.
+	again, err := doc.ServiceEntry("missing", false)
+	require.NoError(t, err)
+	assert.Same(t, created, again)
+}
+
+func TestYAMLDocument_ServiceEntry_CreatesServicesMapping(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "azure.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("name: p\n"), 0o600))
+
+	doc, err := LoadYAMLDocument(path)
+	require.NoError(t, err)
+	entry, err := doc.ServiceEntry("svc", true)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	require.NoError(t, doc.Save())
+
+	saved := readFile(t, path)
+	assert.Contains(t, saved, "services:")
+	assert.Contains(t, saved, "svc:")
+}
+
+func TestEntryRef(t *testing.T) {
+	doc, err := ParseYAMLDocument("azure.yaml", []byte(`
+services:
+  ref-svc:
+    host: azure.ai.agent
+    $ref: ./agents/a.yaml
+  inline-svc:
+    host: azure.ai.agent
+    kind: prompt
+`))
+	require.NoError(t, err)
+
+	refEntry, err := doc.ServiceEntry("ref-svc", false)
+	require.NoError(t, err)
+	target, isRef := EntryRef(refEntry)
+	assert.True(t, isRef)
+	assert.Equal(t, "./agents/a.yaml", target)
+
+	inlineEntry, err := doc.ServiceEntry("inline-svc", false)
+	require.NoError(t, err)
+	_, isRef = EntryRef(inlineEntry)
+	assert.False(t, isRef)
+}
+
+func TestYAMLDocument_SetServiceField_InlineOverlayAndAgreement(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "agents/research-agent.yaml", `
+kind: hosted
+project: ../src/research-agent
+`)
+	path := filepath.Join(root, "azure.yaml")
+	src := `services:
+  research-agent:
+    host: azure.ai.agent
+    $ref: ./agents/research-agent.yaml
+`
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o600))
+
+	doc, err := LoadYAMLDocument(path)
+	require.NoError(t, err)
+	require.NoError(t, doc.SetServiceField("research-agent", "kind", "prompt", EditInline))
+	require.NoError(t, doc.Save())
+
+	saved := readFile(t, path)
+	// $ref is preserved and the overlay key is added beside it.
+	assert.Contains(t, saved, "$ref: ./agents/research-agent.yaml")
+	assert.Contains(t, saved, "kind: prompt")
+
+	// Reads and writes agree: the resolver overlays the inline key over the loaded file, so the
+	// inline value wins while the file's other (rebased) fields come through.
+	resolved, err := ResolveFileRefs(serviceEntryMap(t, saved, "research-agent"), root)
+	require.NoError(t, err)
+	assert.Equal(t, "prompt", resolved["kind"])
+	assert.Equal(t, "src/research-agent", resolved["project"])
+}
+
+func TestYAMLDocument_SetServiceField_InlineUpdateInPlace(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "azure.yaml")
+	src := `services:
+  agent-project:
+    host: azure.ai.project
+    endpoint: https://old.example.com # current endpoint
+`
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o600))
+
+	doc, err := LoadYAMLDocument(path)
+	require.NoError(t, err)
+	require.NoError(t, doc.SetServiceField("agent-project", "endpoint", "https://new.example.com", EditInline))
+	require.NoError(t, doc.Save())
+
+	saved := readFile(t, path)
+	assert.Contains(t, saved, "https://new.example.com")
+	assert.NotContains(t, saved, "https://old.example.com")
+	// The replaced value's inline comment is preserved.
+	assert.Contains(t, saved, "# current endpoint")
+	// Existing key order is preserved (host before endpoint).
+	assert.Less(t, strings.Index(saved, "host:"), strings.Index(saved, "endpoint:"))
+}
+
+func TestYAMLDocument_SetServiceField_EditRefFile(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "agents/research-agent.yaml", `
+kind: hosted
+project: ../src/research-agent
+`)
+	path := filepath.Join(root, "azure.yaml")
+	src := `services:
+  research-agent:
+    host: azure.ai.agent
+    $ref: ./agents/research-agent.yaml
+`
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o600))
+
+	doc, err := LoadYAMLDocument(path)
+	require.NoError(t, err)
+	require.NoError(t, doc.SetServiceField("research-agent", "kind", "prompt", EditRefFile))
+	require.NoError(t, doc.Save())
+
+	// The azure.yaml entry is untouched: still just host + $ref.
+	savedMain := readFile(t, path)
+	assert.Contains(t, savedMain, "$ref: ./agents/research-agent.yaml")
+	assert.NotContains(t, savedMain, "kind:")
+
+	// The split file received the new value.
+	savedRef := readFile(t, filepath.Join(root, "agents", "research-agent.yaml"))
+	assert.Contains(t, savedRef, "kind: prompt")
+	assert.NotContains(t, savedRef, "hosted")
+
+	// The resolver now reads the new value from the file.
+	resolved, err := ResolveFileRefs(serviceEntryMap(t, savedMain, "research-agent"), root)
+	require.NoError(t, err)
+	assert.Equal(t, "prompt", resolved["kind"])
+}
+
+func TestYAMLDocument_SetServiceField_EditRefFileFallsBackInline(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "azure.yaml")
+	src := `services:
+  agent-project:
+    host: azure.ai.project
+`
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o600))
+
+	doc, err := LoadYAMLDocument(path)
+	require.NoError(t, err)
+	// The entry has no $ref, so EditRefFile falls back to an inline write.
+	require.NoError(t, doc.SetServiceField("agent-project", "endpoint", "https://e.example.com", EditRefFile))
+	require.NoError(t, doc.Save())
+
+	assert.Contains(t, readFile(t, path), "endpoint: https://e.example.com")
+}
+
+func TestYAMLDocument_SetServiceField_EditRefFileMissing(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "azure.yaml")
+	src := `services:
+  research-agent:
+    host: azure.ai.agent
+    $ref: ./agents/missing.yaml
+`
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o600))
+
+	doc, err := LoadYAMLDocument(path)
+	require.NoError(t, err)
+	err = doc.SetServiceField("research-agent", "kind", "prompt", EditRefFile)
+	requireFileRefError(t, err, "cannot read")
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/includes_edit_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/includes_edit_test.go
@@ -34,6 +34,15 @@ func serviceEntryMap(t *testing.T, doc, name string) map[string]any {
 	return entry
 }
 
+func assertSubstringOrder(t *testing.T, s, before, after string) {
+	t.Helper()
+	beforeIndex := strings.Index(s, before)
+	afterIndex := strings.Index(s, after)
+	require.NotEqual(t, -1, beforeIndex, "%q missing", before)
+	require.NotEqual(t, -1, afterIndex, "%q missing", after)
+	assert.Less(t, beforeIndex, afterIndex)
+}
+
 func TestYAMLDocument_RoundTripPreservesCommentsAndOrder(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "azure.yaml")
@@ -58,7 +67,7 @@ services:
 	assert.Contains(t, first, "# a standalone comment about services")
 	assert.Contains(t, first, "# the agent host")
 	// Key order within the entry is preserved (host before $ref).
-	assert.Less(t, strings.Index(first, "host:"), strings.Index(first, "$ref:"))
+	assertSubstringOrder(t, first, "host:", "$ref:")
 
 	// Re-encoding is stable (idempotent).
 	doc2, err := ParseYAMLDocument(path, out)
@@ -244,7 +253,7 @@ func TestYAMLDocument_SetServiceField_InlineUpdateInPlace(t *testing.T) {
 	// The replaced value's inline comment is preserved.
 	assert.Contains(t, saved, "# current endpoint")
 	// Existing key order is preserved (host before endpoint).
-	assert.Less(t, strings.Index(saved, "host:"), strings.Index(saved, "endpoint:"))
+	assertSubstringOrder(t, saved, "host:", "endpoint:")
 }
 
 func TestYAMLDocument_SetServiceField_EditRefFile(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/includes_edit_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/includes_edit_test.go
@@ -139,6 +139,58 @@ services:
 	assert.False(t, isRef)
 }
 
+// TestEntryRef_EdgeCases documents the intentional divergence from the resolver for
+// degenerate $ref values: EntryRef falls back to (false) rather than erroring, so the
+// write path treats the entry as inline. The read path (ResolveFileRefs) will surface
+// CodeInvalidFileRef on these same inputs — the divergence is safe because the write
+// still lands somewhere, and the read failure gives a clear diagnostic.
+func TestEntryRef_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantRef bool
+		wantVal string
+	}{
+		{
+			name: "empty $ref falls back to not-a-ref",
+			yaml: "services:\n  svc:\n    $ref: \"\"\n",
+		},
+		{
+			name: "whitespace-only $ref falls back to not-a-ref",
+			yaml: "services:\n  svc:\n    $ref: \"   \"\n",
+		},
+		{
+			name: "no $ref key at all",
+			yaml: "services:\n  svc:\n    kind: prompt\n",
+		},
+		{
+			name:    "numeric $ref value is coerced to string — treated as ref",
+			yaml:    "services:\n  svc:\n    $ref: 123\n",
+			wantRef: true,
+			wantVal: "123",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			doc, err := ParseYAMLDocument("azure.yaml", []byte(tc.yaml))
+			require.NoError(t, err)
+			entry, err := doc.ServiceEntry("svc", false)
+			require.NoError(t, err)
+			got, isRef := EntryRef(entry)
+			assert.Equal(t, tc.wantRef, isRef)
+			if tc.wantRef {
+				assert.Equal(t, tc.wantVal, got)
+			}
+		})
+	}
+}
+
+// TestEntryRef_NilEntry documents that EntryRef is nil-safe.
+func TestEntryRef_NilEntry(t *testing.T) {
+	_, isRef := EntryRef(nil)
+	assert.False(t, isRef)
+}
+
 func TestYAMLDocument_SetServiceField_InlineOverlayAndAgreement(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "agents/research-agent.yaml", `

--- a/cli/azd/extensions/azure.ai.agents/internal/project/includes_edit_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/includes_edit_test.go
@@ -148,11 +148,9 @@ services:
 	assert.False(t, isRef)
 }
 
-// TestEntryRef_EdgeCases documents the intentional divergence from the resolver for
-// degenerate $ref values: EntryRef falls back to (false) rather than erroring, so the
-// write path treats the entry as inline. The read path (ResolveFileRefs) will surface
-// CodeInvalidFileRef on these same inputs — the divergence is safe because the write
-// still lands somewhere, and the read failure gives a clear diagnostic.
+// TestEntryRef_EdgeCases documents EntryRef's narrow detection behavior: empty or whitespace-only
+// $ref values fall back to not-a-ref so the write helper treats the entry as inline, while scalar
+// values such as 123 are reported as refs and fail later if the referenced file is invalid.
 func TestEntryRef_EdgeCases(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -173,7 +171,7 @@ func TestEntryRef_EdgeCases(t *testing.T) {
 			yaml: "services:\n  svc:\n    kind: prompt\n",
 		},
 		{
-			name:    "numeric $ref value is coerced to string — treated as ref",
+			name:    "numeric $ref value parses as scalar string - treated as ref",
 			yaml:    "services:\n  svc:\n    $ref: 123\n",
 			wantRef: true,
 			wantVal: "123",

--- a/cli/azd/extensions/azure.ai.agents/internal/project/includes_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/includes_test.go
@@ -386,3 +386,161 @@ agents:
 	_, err := ResolveFileRefs(cfg, root)
 	requireFileRefError(t, err, "must not be empty")
 }
+
+// In the separate-services shape an agent's body lives in its own file and the inline map is
+// itself the $ref directive (the host and service key are stripped by core before the entry
+// reaches the extension), so the whole entry resolves from the file.
+func TestResolveFileRefs_ServiceEntryTopLevelRef(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "agents/research-agent.yaml", `
+kind: hosted
+project: ../src/research-agent
+docker:
+  path: Dockerfile
+`)
+	cfg := parseYAML(t, `
+$ref: ./agents/research-agent.yaml
+`)
+
+	got, err := ResolveFileRefs(cfg, root)
+	require.NoError(t, err)
+
+	// project rebased from the agents/ directory to the project root; docker.path is not a
+	// path-bearing key and is left untouched.
+	want := parseYAML(t, `
+kind: hosted
+project: src/research-agent
+docker:
+  path: Dockerfile
+`)
+	assert.Equal(t, want, got)
+}
+
+// A service-entry-level $ref may carry sibling overrides authored inline in azure.yaml, which
+// overlay the loaded file shallowly. Inline values are left exactly as written; only the file's
+// own paths rebase.
+func TestResolveFileRefs_ServiceEntryTopLevelRefWithOverlay(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "agents/research-agent.yaml", `
+kind: hosted
+project: ../src/research-agent
+env:
+  A: "1"
+`)
+	cfg := parseYAML(t, `
+$ref: ./agents/research-agent.yaml
+kind: prompt
+instructions: Do the thing inline.
+env:
+  B: "2"
+`)
+
+	got, err := ResolveFileRefs(cfg, root)
+	require.NoError(t, err)
+
+	// kind scalar overridden, env map replaced wholesale (shallow), inline instructions prose
+	// kept as-is (not a .md/.txt path, so not rebased), and the file's project still rebases.
+	want := parseYAML(t, `
+kind: prompt
+project: src/research-agent
+instructions: Do the thing inline.
+env:
+  B: "2"
+`)
+	assert.Equal(t, want, got)
+}
+
+// Deployments stay an array on the project service, so a deployment $ref sits at the array-item
+// level. Each item resolves independently; inline items pass through unchanged.
+func TestResolveFileRefs_ProjectDeploymentsArrayItemRef(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "deployments/gpt-4o.yaml", `
+name: gpt-4o
+model:
+  name: gpt-4o
+  format: OpenAI
+  version: "2024-08-06"
+sku:
+  name: GlobalStandard
+  capacity: 10
+`)
+	cfg := parseYAML(t, `
+endpoint: https://my-account.services.ai.azure.com/api/projects/my-project
+deployments:
+  - $ref: ./deployments/gpt-4o.yaml
+  - name: text-embedding-3-large
+    model:
+      name: text-embedding-3-large
+      format: OpenAI
+      version: "1"
+    sku:
+      name: Standard
+      capacity: 50
+`)
+
+	got, err := ResolveFileRefs(cfg, root)
+	require.NoError(t, err)
+
+	want := parseYAML(t, `
+endpoint: https://my-account.services.ai.azure.com/api/projects/my-project
+deployments:
+  - name: gpt-4o
+    model:
+      name: gpt-4o
+      format: OpenAI
+      version: "2024-08-06"
+    sku:
+      name: GlobalStandard
+      capacity: 10
+  - name: text-embedding-3-large
+    model:
+      name: text-embedding-3-large
+      format: OpenAI
+      version: "1"
+    sku:
+      name: Standard
+      capacity: 50
+`)
+	assert.Equal(t, want, got)
+}
+
+// A deployment array-item $ref may carry sibling overrides, which overlay the loaded file
+// shallowly: scalars replace, and a sibling map replaces the loaded map wholesale.
+func TestResolveFileRefs_DeploymentRefOverlay(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "deployments/base.yaml", `
+name: base-name
+model:
+  name: gpt-4o
+  format: OpenAI
+  version: "2024-08-06"
+sku:
+  name: Standard
+  capacity: 10
+`)
+	cfg := parseYAML(t, `
+deployments:
+  - $ref: ./deployments/base.yaml
+    name: overridden
+    sku:
+      name: GlobalStandard
+      capacity: 100
+`)
+
+	got, err := ResolveFileRefs(cfg, root)
+	require.NoError(t, err)
+
+	// name scalar overridden, sku map replaced wholesale, model left untouched.
+	want := parseYAML(t, `
+deployments:
+  - name: overridden
+    model:
+      name: gpt-4o
+      format: OpenAI
+      version: "2024-08-06"
+    sku:
+      name: GlobalStandard
+      capacity: 100
+`)
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
Part of #8775 · Design spec PR #8590 (`docs/specs/unify-azure-yaml/spec.md` §2.4).

Base branch is `huimiu/foundry-azure-yaml` (the Foundry `azure.yaml` integration branch). This PR is intentionally independent of #8675.

## What

PR3 of the "unify Foundry config in `azure.yaml`" follow-up.

### Resolver generalization (`includes.go` — docs + tests only)

The `$ref` resolver from #8627 already resolves `$ref` at any map/sequence node, so the separate-services shapes need **no new resolution logic** — only a generalized documented contract and coverage:

- Service-entry-level `$ref` (top-level inline map, beside `host:` / the service key, which core strips).
- Deployment array-item `$ref` on the project service.
- Per-file rebasing of `project` / `instructions` / nested `$ref` (already implemented).

### Shared `$ref`-aware YAML edit helper (`includes_edit.go` — new)

A comment-preserving writer that the #8049 composition commands also use, so reads and writes of `$ref` entries agree:

- `YAMLDocument` load / parse / save / bytes — braydonk round-trip with two-space indent and block-scalar style, matching how azd core writes `azure.yaml`.
- `ServiceEntry(name, create)`, `EntryRef(entry)`, `SetServiceField(name, key, value, EditTarget)`.
- `EditInline` overlays a key beside `$ref` (the §2.4 default); `EditRefFile` follows the `$ref` into the split file (path resolved with the resolver's shared logic), falling back to inline when the entry is not `$ref`-backed.
- Reuses core `pkg/yamlnode` for node ops and the resolver's `refKey` / `refTargetPath`, so the writer and resolver agree on what a `$ref` entry is and where it points.

## Out of scope

Wiring the resolver into each provider's parse path (rides with PR2), remote URL `$ref` fetching, and JSON-Schema validation of loaded entries. No azd-core changes; no dependency on #8675.

## Tests

`go test ./internal/project/...`

- Resolver shapes: service-entry top-level `$ref` (+ overlay), project `deployments:` array-item `$ref` (+ inline item, + overlay).
- Edit helper: round-trip comment/order preservation, find / create / missing, `$ref` detection, inline overlay + read-back agreement via `ResolveFileRefs`, in-place update (comment preserved), `EditRefFile` split-file write, non-`$ref` fallback, and missing ref-file error.

`gofmt -s`, `golangci-lint`, and `cspell` are clean.
