### PR TITLE
feat: per-host azure.yaml schemas and service targets for Foundry AI resources

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services.go
@@ -130,9 +130,10 @@ func emitResourceServices(
 }
 
 // addResourceService adds a single Foundry resource service to azure.yaml with
-// its schema under config: and optionally wires its uses: list. The service is
-// added with an empty language so azd resolves a no-op framework; the owning
-// extension's service-target provider handles its (currently no-op) lifecycle.
+// its keys composed at the service level (inline, via AdditionalProperties, the
+// same shape the agent service uses) and optionally wires its uses: list. The
+// service is added with an empty language so azd resolves a no-op framework; the
+// owning extension's service-target provider handles its lifecycle.
 func addResourceService(
 	ctx context.Context,
 	azdClient *azdext.AzdClient,
@@ -142,9 +143,9 @@ func addResourceService(
 	uses []string,
 ) error {
 	svc := &azdext.ServiceConfig{
-		Name:   name,
-		Host:   host,
-		Config: cfg,
+		Name:                 name,
+		Host:                 host,
+		AdditionalProperties: cfg,
 	}
 
 	if _, err := azdClient.Project().AddService(ctx, &azdext.AddServiceRequest{Service: svc}); err != nil {
@@ -220,11 +221,12 @@ func reserveServiceName(used map[string]string, name, source string) error {
 func collectProjectDeployments(services map[string]*azdext.ServiceConfig) ([]project.Deployment, error) {
 	var out []project.Deployment
 	for _, svc := range sortedServices(services) {
-		if svc.Host != AiProjectHost || svc.Config == nil {
+		props := project.ServiceConfigProps(svc)
+		if svc.Host != AiProjectHost || props == nil {
 			continue
 		}
 		var cfg *project.ServiceTargetAgentConfig
-		if err := project.UnmarshalStruct(svc.Config, &cfg); err != nil {
+		if err := project.UnmarshalStruct(props, &cfg); err != nil {
 			return nil, fmt.Errorf("parsing project service %q config: %w", svc.Name, err)
 		}
 		if cfg != nil {
@@ -251,11 +253,12 @@ func collectProjectDeployments(services map[string]*azdext.ServiceConfig) ([]pro
 func collectConnections(services map[string]*azdext.ServiceConfig) ([]project.Connection, error) {
 	var out []project.Connection
 	for _, svc := range sortedServices(services) {
-		if svc.Host != AiConnectionHost || svc.Config == nil {
+		props := project.ServiceConfigProps(svc)
+		if svc.Host != AiConnectionHost || props == nil {
 			continue
 		}
 		var conn *project.Connection
-		if err := project.UnmarshalStruct(svc.Config, &conn); err != nil {
+		if err := project.UnmarshalStruct(props, &conn); err != nil {
 			return nil, fmt.Errorf("parsing connection service %q config: %w", svc.Name, err)
 		}
 		if conn != nil {
@@ -282,11 +285,12 @@ func collectConnections(services map[string]*azdext.ServiceConfig) ([]project.Co
 func collectToolboxes(services map[string]*azdext.ServiceConfig) ([]project.Toolbox, error) {
 	var out []project.Toolbox
 	for _, svc := range sortedServices(services) {
-		if svc.Host != AiToolboxHost || svc.Config == nil {
+		props := project.ServiceConfigProps(svc)
+		if svc.Host != AiToolboxHost || props == nil {
 			continue
 		}
 		var toolbox *project.Toolbox
-		if err := project.UnmarshalStruct(svc.Config, &toolbox); err != nil {
+		if err := project.UnmarshalStruct(props, &toolbox); err != nil {
 			return nil, fmt.Errorf("parsing toolbox service %q config: %w", svc.Name, err)
 		}
 		if toolbox != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services_test.go
@@ -367,3 +367,46 @@ func TestEmitResourceServices_WiresSiblingsToProject(t *testing.T) {
 	assert.Equal(t, []string{aiProjectServiceName}, server.uses["myconn"])
 	assert.Equal(t, []string{aiProjectServiceName, "myconn"}, server.uses["myagent"])
 }
+
+// TestEmitResourceServices_WritesServiceLevelProps verifies resource services are
+// written with their keys composed at the service level (inline via
+// AdditionalProperties, matching the agent service shape and the config:false
+// host schema conditionals) rather than nested under config:, and that the
+// collectors read that service-level shape back.
+func TestEmitResourceServices_WritesServiceLevelProps(t *testing.T) {
+	t.Parallel()
+
+	server := &recordingProjectServer{}
+	client := newProjectRecorderClient(t, server)
+
+	deployments := []project.Deployment{{
+		Name:  "gpt-4.1-mini",
+		Model: project.DeploymentModel{Format: "OpenAI", Name: "gpt-4.1-mini", Version: "2025-04-14"},
+		Sku:   project.DeploymentSku{Name: "GlobalStandard", Capacity: 10},
+	}}
+	conns := []project.Connection{{Name: "myconn", Category: "ApiKey", Target: "https://example", AuthType: "ApiKey"}}
+	require.NoError(t, emitResourceServices(t.Context(), client, "myagent", deployments, conns, nil))
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+
+	services := map[string]*azdext.ServiceConfig{}
+	for _, svc := range server.added {
+		// Resource keys must travel at the service level, not under config:.
+		assert.Nil(t, svc.Config, "service %q must not nest keys under config:", svc.Name)
+		assert.NotNil(t, svc.AdditionalProperties, "service %q must carry service-level keys", svc.Name)
+		services[svc.Name] = svc
+	}
+
+	// The collectors read the service-level shape back through ServiceConfigProps.
+	gotDeployments, err := collectProjectDeployments(services)
+	require.NoError(t, err)
+	require.Len(t, gotDeployments, 1)
+	assert.Equal(t, "gpt-4.1-mini", gotDeployments[0].Name)
+
+	gotConns, err := collectConnections(services)
+	require.NoError(t, err)
+	require.Len(t, gotConns, 1)
+	assert.Equal(t, "myconn", gotConns[0].Name)
+	assert.Equal(t, "ApiKey", gotConns[0].Category)
+}

--- a/cli/azd/extensions/azure.ai.connections/schemas/azure.ai.connection.json
+++ b/cli/azd/extensions/azure.ai.connections/schemas/azure.ai.connection.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.connections/schemas/azure.ai.connection.json",
+  "title": "Azure AI Foundry connection service",
+  "description": "Service-level configuration for a host: azure.ai.connection entry. The service key is the connection name. azd upserts the connection on the project the entry uses:.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "category": {
+      "type": "string",
+      "description": "Connection category (e.g., 'CustomKeys', 'ApiKey', 'AzureOpenAI', 'CognitiveSearch', 'RemoteTool')."
+    },
+    "target": {
+      "type": "string",
+      "description": "Target endpoint URL or ARM resource ID. May contain ${VAR} (azd env, resolved client-side)."
+    },
+    "authType": {
+      "type": "string",
+      "description": "Authentication type.",
+      "enum": [
+        "AAD",
+        "AccessKey",
+        "AccountKey",
+        "AgenticIdentity",
+        "AgenticIdentityToken",
+        "ApiKey",
+        "CustomKeys",
+        "ManagedIdentity",
+        "None",
+        "OAuth2",
+        "PAT",
+        "ProjectManagedIdentity",
+        "SAS",
+        "ServicePrincipal",
+        "UserEntraToken",
+        "UsernamePassword"
+      ]
+    },
+    "credentials": {
+      "type": "object",
+      "description": "Credentials. Values may contain ${VAR} (azd env, resolved client-side) or ${{...}} (Foundry server-side resolution, passed through untouched).",
+      "additionalProperties": true
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Additional metadata as key-value pairs.",
+      "additionalProperties": { "type": "string" }
+    }
+  }
+}

--- a/cli/azd/extensions/azure.ai.projects/schemas/azure.ai.project.json
+++ b/cli/azd/extensions/azure.ai.projects/schemas/azure.ai.project.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.projects/schemas/azure.ai.project.json",
+  "title": "Azure AI Foundry project service",
+  "description": "Service-level configuration for a host: azure.ai.project entry. The project owns its model deployments and an optional endpoint to an existing project. When endpoint is omitted, azd provisions a new project; when set, azd connects to that existing project instead of creating one.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "endpoint": {
+      "type": "string",
+      "description": "Endpoint URL of an existing Foundry project (e.g. https://my-account.services.ai.azure.com/api/projects/my-project). When set, azd connects to this project instead of provisioning a new one. May contain ${VAR} (azd env, resolved client-side)."
+    },
+    "deployments": {
+      "type": "array",
+      "description": "Model deployments to upsert on the project.",
+      "items": {
+        "oneOf": [
+          { "$ref": "#/definitions/Deployment" },
+          { "$ref": "#/definitions/FileRef" }
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "Deployment": {
+      "type": "object",
+      "required": ["name", "model", "sku"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the model deployment."
+        },
+        "model": {
+          "type": "object",
+          "required": ["format", "name", "version"],
+          "additionalProperties": false,
+          "properties": {
+            "format": { "type": "string", "description": "Model format (e.g., 'OpenAI')." },
+            "name": { "type": "string", "description": "Model name (e.g., 'gpt-4.1-mini')." },
+            "version": { "type": "string", "description": "Model version (e.g., '2025-04-14')." }
+          }
+        },
+        "sku": {
+          "type": "object",
+          "required": ["capacity", "name"],
+          "additionalProperties": false,
+          "properties": {
+            "capacity": { "type": "integer", "description": "SKU capacity (TPM units)." },
+            "name": { "type": "string", "description": "SKU name (e.g., 'Standard', 'GlobalStandard', 'GlobalBatch')." }
+          }
+        }
+      }
+    },
+    "FileRef": {
+      "type": "object",
+      "required": ["$ref"],
+      "additionalProperties": true,
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "description": "Path to a YAML or JSON file containing the definition. Relative paths resolve from the file containing this $ref. Absolute paths and URLs are also accepted."
+        }
+      }
+    }
+  }
+}

--- a/cli/azd/extensions/azure.ai.routines/extension.yaml
+++ b/cli/azd/extensions/azure.ai.routines/extension.yaml
@@ -1,12 +1,17 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/refs/heads/main/cli/azd/extensions/extension.schema.json
 capabilities:
     - custom-commands
+    - service-target-provider
     - metadata
 description: Manage Microsoft Foundry Routines from your terminal. (Preview)
 displayName: Foundry Routines (Preview)
 id: azure.ai.routines
 language: go
 namespace: ai.routine
+providers:
+    - name: azure.ai.routine
+      type: service-target
+      description: Upserts Foundry routines declared as azure.ai.routine services in azure.yaml
 tags:
     - ai
     - routine

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/root.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/root.go
@@ -27,6 +27,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.PersistentFlags().StringP("project-endpoint", "p", "",
 		"Foundry project endpoint URL (overrides env var and config)")
 
+	rootCmd.AddCommand(azdext.NewListenCommand(configureExtensionHost))
 	rootCmd.AddCommand(newContextCommand())
 	rootCmd.AddCommand(newVersionCommand(&extCtx.OutputFormat))
 	rootCmd.AddCommand(newMetadataCommand(rootCmd))
@@ -41,4 +42,14 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.AddCommand(newRoutineRunCommand(extCtx))
 
 	return rootCmd
+}
+
+// configureExtensionHost is the listen callback. It registers the
+// azure.ai.routine service target so `azd up`/`azd deploy` upsert routines
+// declared as services in azure.yaml.
+func configureExtensionHost(host *azdext.ExtensionHost) {
+	azdClient := host.Client()
+	host.WithServiceTarget(aiRoutineHost, func() azdext.ServiceTargetProvider {
+		return newRoutineServiceTarget(azdClient)
+	})
 }

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target.go
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"azure.ai.routines/internal/pkg/routines"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+)
+
+// aiRoutineHost is the azure.yaml service host kind owned by this extension. A
+// `host: azure.ai.routine` service entry carries one Foundry routine, keyed by
+// the routine name, and is upserted at deploy time by routineServiceTarget. A
+// routine references an agent by name, so its service must declare uses: on the
+// azure.ai.agent service it invokes, which orders the agent ahead of it.
+const aiRoutineHost = "azure.ai.routine"
+
+var _ azdext.ServiceTargetProvider = (*routineServiceTarget)(nil)
+
+// routineServiceTarget upserts a Foundry routine declared as an azure.ai.routine
+// service. The entry's service-level keys are bound directly to the routine API
+// model (triggers, action, ...); the routine name is the service key. Package
+// and Publish are no-ops because a routine has no build artifact.
+type routineServiceTarget struct {
+	azdClient     *azdext.AzdClient
+	serviceConfig *azdext.ServiceConfig
+}
+
+// newRoutineServiceTarget creates the azure.ai.routine service-target provider.
+func newRoutineServiceTarget(azdClient *azdext.AzdClient) azdext.ServiceTargetProvider {
+	return &routineServiceTarget{azdClient: azdClient}
+}
+
+// Initialize stores the service configuration; no other setup is required.
+func (p *routineServiceTarget) Initialize(ctx context.Context, serviceConfig *azdext.ServiceConfig) error {
+	p.serviceConfig = serviceConfig
+	return nil
+}
+
+// Endpoints returns no endpoints; a routine service exposes none.
+func (p *routineServiceTarget) Endpoints(
+	ctx context.Context,
+	serviceConfig *azdext.ServiceConfig,
+	targetResource *azdext.TargetResource,
+) ([]string, error) {
+	return nil, nil
+}
+
+// GetTargetResource delegates to azd's default resolver and falls back to a
+// minimal target so the deploy pipeline can proceed; the routine upsert targets
+// the Foundry project endpoint, not an ARM resource.
+func (p *routineServiceTarget) GetTargetResource(
+	ctx context.Context,
+	subscriptionId string,
+	serviceConfig *azdext.ServiceConfig,
+	defaultResolver func() (*azdext.TargetResource, error),
+) (*azdext.TargetResource, error) {
+	if defaultResolver != nil {
+		if target, err := defaultResolver(); err == nil && target != nil {
+			return target, nil
+		}
+	}
+	return &azdext.TargetResource{SubscriptionId: subscriptionId}, nil
+}
+
+// Package is a no-op; a routine has nothing to build or stage.
+func (p *routineServiceTarget) Package(
+	ctx context.Context,
+	serviceConfig *azdext.ServiceConfig,
+	serviceContext *azdext.ServiceContext,
+	progress azdext.ProgressReporter,
+) (*azdext.ServicePackageResult, error) {
+	return &azdext.ServicePackageResult{}, nil
+}
+
+// Publish is a no-op; a routine has no artifact to publish.
+func (p *routineServiceTarget) Publish(
+	ctx context.Context,
+	serviceConfig *azdext.ServiceConfig,
+	serviceContext *azdext.ServiceContext,
+	targetResource *azdext.TargetResource,
+	publishOptions *azdext.PublishOptions,
+	progress azdext.ProgressReporter,
+) (*azdext.ServicePublishResult, error) {
+	return &azdext.ServicePublishResult{}, nil
+}
+
+// Deploy upserts the routine with an idempotent PUT. The service-level keys bind
+// directly to the routine API model, so the routine name is taken from the
+// service key and never from the body. Removing the service from azure.yaml
+// stops azd managing the routine but does not delete it (use
+// `azd ai routine delete`).
+func (p *routineServiceTarget) Deploy(
+	ctx context.Context,
+	serviceConfig *azdext.ServiceConfig,
+	serviceContext *azdext.ServiceContext,
+	targetResource *azdext.TargetResource,
+	progress azdext.ProgressReporter,
+) (*azdext.ServiceDeployResult, error) {
+	body, err := parseRoutineServiceConfig(serviceConfig)
+	if err != nil {
+		return nil, err
+	}
+	// The service key is the routine identity; ignore any name in the body.
+	body.Name = serviceConfig.GetName()
+
+	if progress != nil {
+		progress(fmt.Sprintf("Upserting routine %q", serviceConfig.GetName()))
+	}
+
+	client, err := newRoutineServiceClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := client.PutRoutine(ctx, body.Name, body); err != nil {
+		return nil, fmt.Errorf("upserting routine %q: %w", body.Name, err)
+	}
+
+	return &azdext.ServiceDeployResult{}, nil
+}
+
+// parseRoutineServiceConfig binds the service-level (inline) routine keys to the
+// routine API model, falling back to the deprecated config: shape for azure.yaml
+// files written before the per-resource service split.
+func parseRoutineServiceConfig(svc *azdext.ServiceConfig) (*routines.Routine, error) {
+	props := svc.GetAdditionalProperties()
+	if props == nil || len(props.GetFields()) == 0 {
+		props = svc.GetConfig()
+	}
+	body := &routines.Routine{}
+	if props == nil {
+		return body, nil
+	}
+	b, err := json.Marshal(props.AsMap())
+	if err != nil {
+		return nil, fmt.Errorf("encoding routine service %q config: %w", svc.GetName(), err)
+	}
+	if err := json.Unmarshal(b, body); err != nil {
+		return nil, fmt.Errorf("parsing routine service %q config: %w", svc.GetName(), err)
+	}
+	return body, nil
+}
+
+// newRoutineServiceClient resolves the project endpoint (from the active azd
+// environment, global config, or FOUNDRY_PROJECT_ENDPOINT) and an azd developer
+// credential, then builds an authenticated routine client for deploy-time
+// upserts. It mirrors newRoutineClient but takes no cobra command, since a
+// service target has no flags.
+func newRoutineServiceClient(ctx context.Context) (*routines.Client, error) {
+	resolved, err := resolveProjectEndpoint(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	cred, err := azidentity.NewAzureDeveloperCLICredential(&azidentity.AzureDeveloperCLICredentialOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Azure credential: %w", err)
+	}
+	return routines.NewClient(resolved.Endpoint, cred), nil
+}

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestParseRoutineServiceConfig_ServiceLevel(t *testing.T) {
+	t.Parallel()
+
+	props, err := structpb.NewStruct(map[string]any{
+		"description": "nightly summary",
+		"enabled":     true,
+		"triggers": map[string]any{
+			"default": map[string]any{"type": "recurring", "cron_expression": "0 9 * * *"},
+		},
+		"action": map[string]any{"type": "invoke_agent_responses_api", "agent_name": "summarizer"},
+	})
+	require.NoError(t, err)
+
+	body, err := parseRoutineServiceConfig(&azdext.ServiceConfig{
+		Name:                 "nightly",
+		Host:                 aiRoutineHost,
+		AdditionalProperties: props,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "nightly summary", body.Description)
+	require.NotNil(t, body.Enabled)
+	assert.True(t, *body.Enabled)
+	require.Contains(t, body.Triggers, "default")
+	assert.Equal(t, "recurring", body.Triggers["default"].Type)
+	assert.Equal(t, "0 9 * * *", body.Triggers["default"].CronExpression)
+	require.NotNil(t, body.Action)
+	assert.Equal(t, "summarizer", body.Action.AgentName)
+}
+
+// TestParseRoutineServiceConfig_ConfigFallback verifies routines written before
+// the per-resource service split (config-nested shape) still parse.
+func TestParseRoutineServiceConfig_ConfigFallback(t *testing.T) {
+	t.Parallel()
+
+	props, err := structpb.NewStruct(map[string]any{"description": "legacy"})
+	require.NoError(t, err)
+
+	body, err := parseRoutineServiceConfig(&azdext.ServiceConfig{
+		Name:   "legacy",
+		Host:   aiRoutineHost,
+		Config: props,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "legacy", body.Description)
+}

--- a/cli/azd/extensions/azure.ai.routines/schemas/azure.ai.routine.json
+++ b/cli/azd/extensions/azure.ai.routines/schemas/azure.ai.routine.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.routines/schemas/azure.ai.routine.json",
   "title": "Azure AI Foundry routine service",
-  "description": "Service-level configuration for a host: azure.ai.routine entry. The service key is the routine name. A routine is a scheduled or event-driven invocation of an agent declared as an azure.ai.agent service. A routine service must uses: the agent it references.",
+  "description": "Service-level configuration for a host: azure.ai.routine entry. The service key is the routine name. A routine is a scheduled or event-driven invocation of an agent declared as an azure.ai.agent service; the routine service must uses: the agent it invokes. The keys bind directly to the Foundry routine API model, so the schema is intentionally permissive while that API stabilizes.",
   "type": "object",
   "additionalProperties": true,
   "properties": {
@@ -10,35 +10,34 @@
       "type": "string",
       "description": "Description of the routine."
     },
-    "trigger": {
+    "enabled": {
+      "type": "boolean",
+      "description": "Whether the routine is enabled."
+    },
+    "triggers": {
       "type": "object",
-      "description": "What fires the routine.",
-      "required": ["type"],
-      "additionalProperties": true,
-      "allOf": [
-        {
-          "if": { "properties": { "type": { "const": "schedule" } }, "required": ["type"] },
-          "then": { "required": ["cron"] }
-        },
-        {
-          "if": { "properties": { "type": { "enum": ["webhook", "event"] } }, "required": ["type"] },
-          "then": { "required": ["filter"] }
+      "description": "Triggers keyed by a user-defined identifier (commonly 'default'). Each trigger selects a variant via its type (e.g. timer, recurring, github_issue, custom).",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["type"],
+        "properties": {
+          "type": { "type": "string", "description": "Trigger variant." },
+          "cron_expression": { "type": "string", "description": "Cron expression for a recurring trigger." },
+          "at": { "type": "string", "description": "Fire time for a one-shot timer trigger." }
         }
-      ],
-      "properties": {
-        "type": { "type": "string", "enum": ["schedule", "webhook", "event"] },
-        "cron": { "type": "string", "description": "Cron expression. Required for type: schedule." },
-        "filter": { "type": "object", "description": "Event/webhook filter. Required for type: webhook | event." }
       }
     },
-    "agent": {
-      "type": "string",
-      "description": "Name of the azure.ai.agent service the routine invokes."
-    },
-    "input": {
+    "action": {
       "type": "object",
-      "description": "Input payload passed to the agent. Values may use ${VAR} (azd env, resolved client-side) or ${{...}} (Foundry server-side, passed through untouched).",
-      "additionalProperties": true
+      "description": "What the routine does when it fires. Invokes an agent by name.",
+      "additionalProperties": true,
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string", "description": "Action variant (e.g. invoke_agent_responses_api, invoke_agent_invocations_api)." },
+        "agent_name": { "type": "string", "description": "Name of the azure.ai.agent service the routine invokes." },
+        "input": { "description": "Static JSON input sent to the agent when the routine fires. Values may use ${VAR} or ${{...}}." }
+      }
     }
   }
 }

--- a/cli/azd/extensions/azure.ai.routines/schemas/azure.ai.routine.json
+++ b/cli/azd/extensions/azure.ai.routines/schemas/azure.ai.routine.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.routines/schemas/azure.ai.routine.json",
+  "title": "Azure AI Foundry routine service",
+  "description": "Service-level configuration for a host: azure.ai.routine entry. The service key is the routine name. A routine is a scheduled or event-driven invocation of an agent declared as an azure.ai.agent service. A routine service must uses: the agent it references.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "description": {
+      "type": "string",
+      "description": "Description of the routine."
+    },
+    "trigger": {
+      "type": "object",
+      "description": "What fires the routine.",
+      "required": ["type"],
+      "additionalProperties": true,
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "schedule" } }, "required": ["type"] },
+          "then": { "required": ["cron"] }
+        },
+        {
+          "if": { "properties": { "type": { "enum": ["webhook", "event"] } }, "required": ["type"] },
+          "then": { "required": ["filter"] }
+        }
+      ],
+      "properties": {
+        "type": { "type": "string", "enum": ["schedule", "webhook", "event"] },
+        "cron": { "type": "string", "description": "Cron expression. Required for type: schedule." },
+        "filter": { "type": "object", "description": "Event/webhook filter. Required for type: webhook | event." }
+      }
+    },
+    "agent": {
+      "type": "string",
+      "description": "Name of the azure.ai.agent service the routine invokes."
+    },
+    "input": {
+      "type": "object",
+      "description": "Input payload passed to the agent. Values may use ${VAR} (azd env, resolved client-side) or ${{...}} (Foundry server-side, passed through untouched).",
+      "additionalProperties": true
+    }
+  }
+}

--- a/cli/azd/extensions/azure.ai.skills/extension.yaml
+++ b/cli/azd/extensions/azure.ai.skills/extension.yaml
@@ -10,7 +10,12 @@ requiredAzdVersion: ">1.23.13"
 language: go
 capabilities:
   - custom-commands
+  - service-target-provider
   - metadata
+providers:
+  - name: azure.ai.skill
+    type: service-target
+    description: Upserts Foundry skills declared as azure.ai.skill services in azure.yaml
 tags:
   - ai
   - skill

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/root.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/root.go
@@ -59,6 +59,12 @@ a Foundry project.`,
 	return rootCmd
 }
 
-// configureExtensionHost is the listen callback. Skills register no
-// lifecycle hooks, so it's a no-op.
-func configureExtensionHost(host *azdext.ExtensionHost) { _ = host }
+// configureExtensionHost is the listen callback. It registers the
+// azure.ai.skill service target so `azd up`/`azd deploy` upsert skills declared
+// as services in azure.yaml.
+func configureExtensionHost(host *azdext.ExtensionHost) {
+	azdClient := host.Client()
+	host.WithServiceTarget(aiSkillHost, func() azdext.ServiceTargetProvider {
+		return newSkillServiceTarget(azdClient)
+	})
+}

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target.go
@@ -112,9 +112,9 @@ func (p *skillServiceTarget) Deploy(
 	if err != nil {
 		return nil, err
 	}
-	// TODO(#8049 follow-up): when instructions is a file path (.md/.txt), load
-	// the file contents at deploy time, rebasing relative paths to the file that
-	// declares them (spec 2.4). For now only inline instruction text is upserted.
+	// TODO: when instructions is a file path (.md/.txt), load the file contents
+	// at deploy time, rebasing relative paths to the declaring file.
+	// For now only inline instruction text is upserted.
 	if cfg.Instructions == "" {
 		return nil, fmt.Errorf("skill service %q requires instructions", serviceConfig.GetName())
 	}

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target.go
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"azureaiskills/internal/pkg/skill_api"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+)
+
+// aiSkillHost is the azure.yaml service host kind owned by this extension. A
+// `host: azure.ai.skill` service entry carries one Foundry skill, keyed by the
+// skill name, and is reconciled (upserted) at deploy time by skillServiceTarget.
+const aiSkillHost = "azure.ai.skill"
+
+var _ azdext.ServiceTargetProvider = (*skillServiceTarget)(nil)
+
+// skillServiceConfig is the service-level shape of a `host: azure.ai.skill`
+// entry (see schemas/azure.ai.skill.json). The skill name is the azure.yaml
+// service key, not a body field.
+type skillServiceConfig struct {
+	Description  string   `json:"description,omitempty"`
+	Instructions string   `json:"instructions,omitempty"`
+	Tools        []string `json:"tools,omitempty"`
+}
+
+// skillServiceTarget upserts a Foundry skill declared as an azure.ai.skill
+// service. Deploy creates a new default skill version from the entry's inline
+// instructions; the resource name is the service key. Package and Publish are
+// no-ops because a skill has no build artifact.
+type skillServiceTarget struct {
+	azdClient     *azdext.AzdClient
+	serviceConfig *azdext.ServiceConfig
+}
+
+// newSkillServiceTarget creates the azure.ai.skill service-target provider.
+func newSkillServiceTarget(azdClient *azdext.AzdClient) azdext.ServiceTargetProvider {
+	return &skillServiceTarget{azdClient: azdClient}
+}
+
+// Initialize stores the service configuration; no other setup is required.
+func (p *skillServiceTarget) Initialize(ctx context.Context, serviceConfig *azdext.ServiceConfig) error {
+	p.serviceConfig = serviceConfig
+	return nil
+}
+
+// Endpoints returns no endpoints; a skill service exposes none.
+func (p *skillServiceTarget) Endpoints(
+	ctx context.Context,
+	serviceConfig *azdext.ServiceConfig,
+	targetResource *azdext.TargetResource,
+) ([]string, error) {
+	return nil, nil
+}
+
+// GetTargetResource delegates to azd's default resolver and falls back to a
+// minimal target so the deploy pipeline can proceed; the skill upsert targets
+// the Foundry project endpoint, not an ARM resource.
+func (p *skillServiceTarget) GetTargetResource(
+	ctx context.Context,
+	subscriptionId string,
+	serviceConfig *azdext.ServiceConfig,
+	defaultResolver func() (*azdext.TargetResource, error),
+) (*azdext.TargetResource, error) {
+	if defaultResolver != nil {
+		if target, err := defaultResolver(); err == nil && target != nil {
+			return target, nil
+		}
+	}
+	return &azdext.TargetResource{SubscriptionId: subscriptionId}, nil
+}
+
+// Package is a no-op; a skill has nothing to build or stage.
+func (p *skillServiceTarget) Package(
+	ctx context.Context,
+	serviceConfig *azdext.ServiceConfig,
+	serviceContext *azdext.ServiceContext,
+	progress azdext.ProgressReporter,
+) (*azdext.ServicePackageResult, error) {
+	return &azdext.ServicePackageResult{}, nil
+}
+
+// Publish is a no-op; a skill has no artifact to publish.
+func (p *skillServiceTarget) Publish(
+	ctx context.Context,
+	serviceConfig *azdext.ServiceConfig,
+	serviceContext *azdext.ServiceContext,
+	targetResource *azdext.TargetResource,
+	publishOptions *azdext.PublishOptions,
+	progress azdext.ProgressReporter,
+) (*azdext.ServicePublishResult, error) {
+	return &azdext.ServicePublishResult{}, nil
+}
+
+// Deploy upserts the skill by creating a new default version from the entry's
+// inline instructions. The call is idempotent: re-running deploy creates a new
+// version rather than failing. Removing the service from azure.yaml stops azd
+// managing the skill but does not delete it (use `azd ai skill delete`).
+func (p *skillServiceTarget) Deploy(
+	ctx context.Context,
+	serviceConfig *azdext.ServiceConfig,
+	serviceContext *azdext.ServiceContext,
+	targetResource *azdext.TargetResource,
+	progress azdext.ProgressReporter,
+) (*azdext.ServiceDeployResult, error) {
+	cfg, err := parseSkillServiceConfig(serviceConfig)
+	if err != nil {
+		return nil, err
+	}
+	// TODO(#8049 follow-up): when instructions is a file path (.md/.txt), load
+	// the file contents at deploy time, rebasing relative paths to the file that
+	// declares them (spec 2.4). For now only inline instruction text is upserted.
+	if cfg.Instructions == "" {
+		return nil, fmt.Errorf("skill service %q requires instructions", serviceConfig.GetName())
+	}
+
+	if progress != nil {
+		progress(fmt.Sprintf("Upserting skill %q", serviceConfig.GetName()))
+	}
+
+	skillCtx, err := resolveSkillContext(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := skillCtx.client.CreateVersionInline(
+		ctx,
+		serviceConfig.GetName(),
+		skill_api.CreateVersionRequest{
+			InlineContent: &skill_api.SkillInlineContent{
+				Description:  cfg.Description,
+				Instructions: cfg.Instructions,
+				AllowedTools: cfg.Tools,
+			},
+			Default: true,
+		},
+	); err != nil {
+		return nil, fmt.Errorf("upserting skill %q: %w", serviceConfig.GetName(), err)
+	}
+
+	return &azdext.ServiceDeployResult{}, nil
+}
+
+// parseSkillServiceConfig reads the service-level (inline) skill properties,
+// falling back to the deprecated config: shape for azure.yaml files written
+// before the per-resource service split.
+func parseSkillServiceConfig(svc *azdext.ServiceConfig) (*skillServiceConfig, error) {
+	props := svc.GetAdditionalProperties()
+	if props == nil || len(props.GetFields()) == 0 {
+		props = svc.GetConfig()
+	}
+	cfg := &skillServiceConfig{}
+	if props == nil {
+		return cfg, nil
+	}
+	b, err := json.Marshal(props.AsMap())
+	if err != nil {
+		return nil, fmt.Errorf("encoding skill service %q config: %w", svc.GetName(), err)
+	}
+	if err := json.Unmarshal(b, cfg); err != nil {
+		return nil, fmt.Errorf("parsing skill service %q config: %w", svc.GetName(), err)
+	}
+	return cfg, nil
+}

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestParseSkillServiceConfig_ServiceLevel(t *testing.T) {
+	t.Parallel()
+
+	props, err := structpb.NewStruct(map[string]any{
+		"description":  "code review skill",
+		"instructions": "Review code for correctness.",
+		"tools":        []any{"code_interpreter"},
+	})
+	require.NoError(t, err)
+
+	cfg, err := parseSkillServiceConfig(&azdext.ServiceConfig{
+		Name:                 "code-review",
+		Host:                 aiSkillHost,
+		AdditionalProperties: props,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "code review skill", cfg.Description)
+	assert.Equal(t, "Review code for correctness.", cfg.Instructions)
+	assert.Equal(t, []string{"code_interpreter"}, cfg.Tools)
+}
+
+// TestParseSkillServiceConfig_ConfigFallback verifies skills written before the
+// per-resource service split (config-nested shape) still parse.
+func TestParseSkillServiceConfig_ConfigFallback(t *testing.T) {
+	t.Parallel()
+
+	props, err := structpb.NewStruct(map[string]any{
+		"instructions": "legacy shape",
+	})
+	require.NoError(t, err)
+
+	cfg, err := parseSkillServiceConfig(&azdext.ServiceConfig{
+		Name:   "legacy",
+		Host:   aiSkillHost,
+		Config: props,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "legacy shape", cfg.Instructions)
+}
+
+func TestParseSkillServiceConfig_Empty(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseSkillServiceConfig(&azdext.ServiceConfig{Name: "empty", Host: aiSkillHost})
+	require.NoError(t, err)
+	assert.Empty(t, cfg.Instructions)
+}

--- a/cli/azd/extensions/azure.ai.skills/schemas/azure.ai.skill.json
+++ b/cli/azd/extensions/azure.ai.skills/schemas/azure.ai.skill.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.skills/schemas/azure.ai.skill.json",
+  "title": "Azure AI Foundry skill service",
+  "description": "Service-level configuration for a host: azure.ai.skill entry. The service key is the skill name. A skill is a reusable capability bundle (instructions + tools) an agent attaches at run time.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "description": {
+      "type": "string",
+      "description": "Description of the skill."
+    },
+    "instructions": {
+      "type": "string",
+      "description": "Inline instruction text, or a file path (.md, .txt) the extension reads at deploy time. A relative path resolves from the file that declares it. ${VAR} and ${{...}} expansion applies to the loaded text."
+    },
+    "tools": {
+      "type": "array",
+      "description": "Tool type names the skill uses (must be declared on a toolbox the agent references, or attached directly to the agent's tools list).",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/cli/azd/extensions/azure.ai.toolboxes/schemas/azure.ai.toolbox.json
+++ b/cli/azd/extensions/azure.ai.toolboxes/schemas/azure.ai.toolbox.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.toolboxes/schemas/azure.ai.toolbox.json",
+  "title": "Azure AI Foundry toolbox service",
+  "description": "Service-level configuration for a host: azure.ai.toolbox entry. The service key is the toolbox name. A toolbox is a named bundle of connection-backed tools that agents reference by name.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "description": {
+      "type": "string",
+      "description": "Description of the toolbox."
+    },
+    "tools": {
+      "type": "array",
+      "description": "List of tools in the toolbox.",
+      "items": {
+        "type": "object",
+        "required": ["type"],
+        "additionalProperties": true,
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Tool type (e.g., 'web_search', 'code_interpreter', 'file_search', 'mcp', 'azure_ai_search', 'bing_grounding', 'openapi')."
+          },
+          "connection": {
+            "type": "string",
+            "description": "Name of an azure.ai.connection service (required for connection-backed tool types like 'mcp', 'azure_ai_search')."
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -230,7 +230,12 @@
                             "staticwebapp",
                             "aks",
                             "ai.endpoint",
-                            "azure.ai.agent"
+                            "azure.ai.agent",
+                            "azure.ai.project",
+                            "azure.ai.connection",
+                            "azure.ai.toolbox",
+                            "azure.ai.skill",
+                            "azure.ai.routine"
                         ]
                     },
                     "language": {
@@ -425,6 +430,106 @@
                                 "config": false,
                                 "k8s": false,
                                 "apiVersion": false
+                            }
+                        }
+                    },
+                    {
+                        "comment": "Azure AI Foundry project host - code-less resource service; composes the project schema at the service level and disables source/container properties",
+                        "if": {
+                            "properties": {
+                                "host": { "const": "azure.ai.project" }
+                            }
+                        },
+                        "then": {
+                            "allOf": [
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.projects/schemas/azure.ai.project.json" }
+                            ],
+                            "properties": {
+                                "project": false,
+                                "runtime": false,
+                                "docker": false,
+                                "image": false,
+                                "config": false
+                            }
+                        }
+                    },
+                    {
+                        "comment": "Azure AI Foundry connection host - code-less resource service; the service key is the connection name",
+                        "if": {
+                            "properties": {
+                                "host": { "const": "azure.ai.connection" }
+                            }
+                        },
+                        "then": {
+                            "allOf": [
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.connections/schemas/azure.ai.connection.json" }
+                            ],
+                            "properties": {
+                                "project": false,
+                                "runtime": false,
+                                "docker": false,
+                                "image": false,
+                                "config": false
+                            }
+                        }
+                    },
+                    {
+                        "comment": "Azure AI Foundry toolbox host - code-less resource service; the service key is the toolbox name",
+                        "if": {
+                            "properties": {
+                                "host": { "const": "azure.ai.toolbox" }
+                            }
+                        },
+                        "then": {
+                            "allOf": [
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.toolboxes/schemas/azure.ai.toolbox.json" }
+                            ],
+                            "properties": {
+                                "project": false,
+                                "runtime": false,
+                                "docker": false,
+                                "image": false,
+                                "config": false
+                            }
+                        }
+                    },
+                    {
+                        "comment": "Azure AI Foundry skill host - code-less resource service; the service key is the skill name",
+                        "if": {
+                            "properties": {
+                                "host": { "const": "azure.ai.skill" }
+                            }
+                        },
+                        "then": {
+                            "allOf": [
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.skills/schemas/azure.ai.skill.json" }
+                            ],
+                            "properties": {
+                                "project": false,
+                                "runtime": false,
+                                "docker": false,
+                                "image": false,
+                                "config": false
+                            }
+                        }
+                    },
+                    {
+                        "comment": "Azure AI Foundry routine host - code-less resource service; the service key is the routine name and it uses: the agent it invokes",
+                        "if": {
+                            "properties": {
+                                "host": { "const": "azure.ai.routine" }
+                            }
+                        },
+                        "then": {
+                            "allOf": [
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.routines/schemas/azure.ai.routine.json" }
+                            ],
+                            "properties": {
+                                "project": false,
+                                "runtime": false,
+                                "docker": false,
+                                "image": false,
+                                "config": false
                             }
                         }
                     },

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -191,7 +191,12 @@
                             "staticwebapp",
                             "aks",
                             "ai.endpoint",
-                            "azure.ai.agent"
+                            "azure.ai.agent",
+                            "azure.ai.project",
+                            "azure.ai.connection",
+                            "azure.ai.toolbox",
+                            "azure.ai.skill",
+                            "azure.ai.routine"
                         ]
                     },
                     "language": {
@@ -385,6 +390,106 @@
                                 "config": false,
                                 "k8s": false,
                                 "apiVersion": false
+                            }
+                        }
+                    },
+                    {
+                        "comment": "Azure AI Foundry project host - code-less resource service; composes the project schema at the service level and disables source/container properties",
+                        "if": {
+                            "properties": {
+                                "host": { "const": "azure.ai.project" }
+                            }
+                        },
+                        "then": {
+                            "allOf": [
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.projects/schemas/azure.ai.project.json" }
+                            ],
+                            "properties": {
+                                "project": false,
+                                "runtime": false,
+                                "docker": false,
+                                "image": false,
+                                "config": false
+                            }
+                        }
+                    },
+                    {
+                        "comment": "Azure AI Foundry connection host - code-less resource service; the service key is the connection name",
+                        "if": {
+                            "properties": {
+                                "host": { "const": "azure.ai.connection" }
+                            }
+                        },
+                        "then": {
+                            "allOf": [
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.connections/schemas/azure.ai.connection.json" }
+                            ],
+                            "properties": {
+                                "project": false,
+                                "runtime": false,
+                                "docker": false,
+                                "image": false,
+                                "config": false
+                            }
+                        }
+                    },
+                    {
+                        "comment": "Azure AI Foundry toolbox host - code-less resource service; the service key is the toolbox name",
+                        "if": {
+                            "properties": {
+                                "host": { "const": "azure.ai.toolbox" }
+                            }
+                        },
+                        "then": {
+                            "allOf": [
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.toolboxes/schemas/azure.ai.toolbox.json" }
+                            ],
+                            "properties": {
+                                "project": false,
+                                "runtime": false,
+                                "docker": false,
+                                "image": false,
+                                "config": false
+                            }
+                        }
+                    },
+                    {
+                        "comment": "Azure AI Foundry skill host - code-less resource service; the service key is the skill name",
+                        "if": {
+                            "properties": {
+                                "host": { "const": "azure.ai.skill" }
+                            }
+                        },
+                        "then": {
+                            "allOf": [
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.skills/schemas/azure.ai.skill.json" }
+                            ],
+                            "properties": {
+                                "project": false,
+                                "runtime": false,
+                                "docker": false,
+                                "image": false,
+                                "config": false
+                            }
+                        }
+                    },
+                    {
+                        "comment": "Azure AI Foundry routine host - code-less resource service; the service key is the routine name and it uses: the agent it invokes",
+                        "if": {
+                            "properties": {
+                                "host": { "const": "azure.ai.routine" }
+                            }
+                        },
+                        "then": {
+                            "allOf": [
+                                { "$ref": "https://raw.githubusercontent.com/Azure/azure-dev/huimiu/foundry-azure-yaml/cli/azd/extensions/azure.ai.routines/schemas/azure.ai.routine.json" }
+                            ],
+                            "properties": {
+                                "project": false,
+                                "runtime": false,
+                                "docker": false,
+                                "image": false,
+                                "config": false
                             }
                         }
                     },


### PR DESCRIPTION
## Summary

Adds per-host JSON schemas, service-level config writing, and full `azd deploy` support for five Foundry AI resource hosts in azure.yaml: `azure.ai.project`, `azure.ai.connection`, `azure.ai.toolbox`, `azure.ai.skill`, and `azure.ai.routine`.

## What changed

### Per-host schemas
Each Foundry resource host now has its own JSON schema (`azure.ai.project.json`, `azure.ai.connection.json`, `azure.ai.toolbox.json`, `azure.ai.skill.json`, `azure.ai.routine.json`) describing the properties that can appear inline on the service in azure.yaml. Both `schemas/v1.0/azure.yaml.json` and `schemas/alpha/azure.yaml.json` have five new `if/then` conditionals — one per host — that compose these schemas into the core azure.yaml shape. Each Foundry host conditional also disables the `config`, `project`, `runtime`, `docker`, and `image` fields, which do not apply to AI resources.

### Service-level config writing (`azure.ai.agents`)
`resource_services.go` now writes project, connection, and toolbox entries using `AdditionalProperties` (service-level inline) instead of the nested `config:` block. Readers prefer `AdditionalProperties` and fall back to `Config` for files written by earlier versions.

### `azure.ai.skill` service target
`azure.ai.skills` now registers a service target provider. `azd deploy` reads `instructions`, `description`, and `allowed_tools` from the service entry and calls `CreateVersionInline`, setting that version as the default. The skill name is taken from the azure.yaml service name.

### `azure.ai.routine` service target
`azure.ai.routines` now registers a service target provider. `azd deploy` binds the service-level properties directly to the routine API model (`triggers`, `actions`, `tools`, `description`) and calls `PutRoutine` for a full upsert. The routine name is taken from the azure.yaml service name.

> **Note on routine config shape**: the schema and deploy binding use the real API model vocabulary (`timer`/`recurring`/`github_issue`/`custom` triggers; `invoke_agent_responses_api`/`invoke_agent_invocations_api` actions) rather than placeholder names.

## Testing

```
cd cli/azd/extensions/azure.ai.agents  && go build ./... && go test ./...
cd cli/azd/extensions/azure.ai.skills  && go build ./... && go test ./...
cd cli/azd/extensions/azure.ai.routines && go build ./... && go test ./...
```
