### PR TITLE
Standardize responsive table layouts across azd commands

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -4,12 +4,15 @@ words:
   - agentdetect
   - Authenticode
   - azdignore
+  - borderless
   - gofmt
   - golangci
   - golangtools
   - lightspeed
   - runewidth
   - toplevel
+  - truncatable
+  - wrappable
   - azcloud
   - azdext
   - azdxignore

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -12,8 +12,6 @@
 
 ### Other Changes
 
-- [[#8667]](https://github.com/Azure/azure-dev/issues/8667) Standardize the responsive table layouts for `azd extension list`, `azd tool check`, `azd tool list`, and `azd template list`. The list commands now adapt to terminal width with consistent column ordering and labels: at full width all columns are shown (truncating lower-priority values with an ellipsis when needed), at medium width lower-priority columns are hidden behind a `...` indicator with a "Showing N of M columns" hint, and at narrow width rows render as readable cards. `azd extension list` now shows separate `INSTALLED` and `LATEST` version columns, and `azd template list` renders as cards with a dedicated `SOURCE` field.
-
 ## 1.25.6 (2026-06-12)
 
 ### Bugs Fixed

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- [[#8667]](https://github.com/Azure/azure-dev/issues/8667) Standardize the responsive table layouts for `azd extension list`, `azd tool check`, `azd tool list`, and `azd template list`. The list commands now adapt to terminal width with consistent column ordering and labels: at full width all columns are shown (truncating lower-priority values with an ellipsis when needed), at medium width lower-priority columns are hidden behind a `...` indicator with a "Showing N of M columns" hint, and at narrow width rows render as readable cards. `azd extension list` now shows separate `INSTALLED` and `LATEST` version columns, and `azd template list` renders as cards with a dedicated `SOURCE` field.
+
 ## 1.25.6 (2026-06-12)
 
 ### Bugs Fixed

--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -180,7 +180,7 @@ $ azd config set defaults.location eastus`,
 			Footer: getCmdConfigOptionsHelpFooter,
 		},
 		ActionResolver: newConfigOptionsAction,
-		OutputFormats:  []output.Format{output.JsonFormat, output.TableFormat, output.NoneFormat},
+		OutputFormats:  []output.Format{output.JsonFormat, output.NoneFormat},
 		DefaultFormat:  output.NoneFormat,
 	})
 
@@ -539,9 +539,6 @@ func getCmdConfigOptionsHelpFooter(*cobra.Command) string {
 		"List all available configuration settings in JSON format": output.WithHighLightFormat(
 			"azd config options -o json",
 		),
-		"List all available configuration settings in table format": output.WithHighLightFormat(
-			"azd config options -o table",
-		),
 	})
 }
 
@@ -589,108 +586,6 @@ func (a *configOptionsAction) Run(ctx context.Context) (*actions.ActionResult, e
 		if err != nil {
 			return nil, fmt.Errorf("failed formatting config options: %w", err)
 		}
-		return nil, nil
-	}
-
-	if a.formatter.Kind() == output.TableFormat {
-		// Table format
-		type tableRow struct {
-			Key           string
-			Description   string
-			Type          string
-			CurrentValue  string
-			AllowedValues string
-			EnvVar        string
-			Example       string
-		}
-
-		var rows []tableRow
-		for _, option := range options {
-			allowedValues := ""
-			if len(option.AllowedValues) > 0 {
-				allowedValues = strings.Join(option.AllowedValues, ", ")
-			}
-
-			// Get current value from config
-			currentValue := ""
-			// Skip environment-only variables (those with keys starting with EnvOnlyPrefix)
-			if !strings.HasPrefix(option.Key, config.EnvOnlyPrefix) {
-				if val, ok := currentConfig.Get(option.Key); ok {
-					// Convert value to string representation
-					switch v := val.(type) {
-					case string:
-						currentValue = v
-					case map[string]any:
-						currentValue = "<object>"
-					case []any:
-						currentValue = "<array>"
-					default:
-						currentValue = fmt.Sprintf("%v", v)
-					}
-				}
-			}
-
-			rows = append(rows, tableRow{
-				Key:           option.Key,
-				Description:   option.Description,
-				Type:          option.Type,
-				CurrentValue:  currentValue,
-				AllowedValues: allowedValues,
-				EnvVar:        option.EnvVar,
-				Example:       option.Example,
-			})
-		}
-
-		columns := []output.PrettyColumn{
-			{
-				Column:   output.Column{Heading: "KEY", ValueTemplate: "{{.Key}}"},
-				Priority: 1,
-			},
-			{
-				Column:   output.Column{Heading: "DESCRIPTION", ValueTemplate: "{{.Description}}"},
-				Priority: 1,
-			},
-			{
-				Column:   output.Column{Heading: "TYPE", ValueTemplate: "{{.Type}}"},
-				Priority: 2,
-			},
-			{
-				Column: output.Column{
-					Heading:       "CURRENT VALUE",
-					ValueTemplate: "{{.CurrentValue}}",
-				},
-				Priority: 2,
-			},
-			{
-				Column: output.Column{
-					Heading:       "ALLOWED VALUES",
-					ValueTemplate: "{{.AllowedValues}}",
-				},
-				Priority: 3,
-			},
-			{
-				Column: output.Column{
-					Heading:       "ENVIRONMENT VARIABLE",
-					ValueTemplate: "{{.EnvVar}}",
-				},
-				Priority: 3,
-			},
-			{
-				Column:   output.Column{Heading: "EXAMPLE", ValueTemplate: "{{.Example}}"},
-				Priority: 3,
-			},
-		}
-
-		prettyFormatter := &output.PrettyTableFormatter{}
-		err = prettyFormatter.Format(rows, a.writer, output.PrettyTableFormatterOptions{
-			Columns:              columns,
-			CardGroupColumn:      "KEY",
-			ResponsiveColumnHint: true,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed formatting config options: %w", err)
-		}
-
 		return nil, nil
 	}
 

--- a/cli/azd/cmd/config.go
+++ b/cli/azd/cmd/config.go
@@ -683,8 +683,9 @@ func (a *configOptionsAction) Run(ctx context.Context) (*actions.ActionResult, e
 
 		prettyFormatter := &output.PrettyTableFormatter{}
 		err = prettyFormatter.Format(rows, a.writer, output.PrettyTableFormatterOptions{
-			Columns:         columns,
-			CardGroupColumn: "KEY",
+			Columns:              columns,
+			CardGroupColumn:      "KEY",
+			ResponsiveColumnHint: true,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed formatting config options: %w", err)

--- a/cli/azd/cmd/config_options_test.go
+++ b/cli/azd/cmd/config_options_test.go
@@ -91,44 +91,6 @@ func TestConfigOptionsAction_JSON(t *testing.T) {
 	require.True(t, foundAgentModelType, agentcopilot.ConfigKeyModelType+" should be present")
 }
 
-func TestConfigOptionsAction_Table(t *testing.T) {
-	t.Parallel()
-	buf := &bytes.Buffer{}
-	mockContext := mocks.NewMockContext(t.Context())
-	console := mockContext.Console
-
-	tempDir := t.TempDir()
-	configPath := tempDir + "/config.json"
-	manager := config.NewManager()
-	fileConfigManager := config.NewFileConfigManager(manager)
-	userConfigManager := config.NewUserConfigManager(fileConfigManager)
-
-	err := fileConfigManager.Save(config.NewEmptyConfig(), configPath)
-	require.NoError(t, err)
-
-	action := newConfigOptionsAction(
-		console,
-		&output.TableFormatter{},
-		buf,
-		userConfigManager,
-		[]string{},
-	)
-
-	_, err = action.Run(*mockContext.Context)
-	require.NoError(t, err)
-
-	outputStr := buf.String()
-	require.Contains(t, outputStr, "KEY")
-	require.Contains(t, outputStr, "DESCRIPTION")
-	require.Contains(t, outputStr, "defaults.subscription")
-	require.Contains(t, outputStr, "alpha.all")
-	require.Contains(t, outputStr, "auth.useAzCliAuth")
-	require.Contains(t, outputStr, "platform.type")
-	require.Contains(t, outputStr, "platform.config")
-	require.Contains(t, outputStr, "cloud.name")
-	require.Contains(t, outputStr, agentcopilot.ConfigKeyModelType)
-}
-
 func TestConfigOptionsAction_DefaultFormat(t *testing.T) {
 	t.Parallel()
 	buf := &bytes.Buffer{}

--- a/cli/azd/cmd/copilot.go
+++ b/cli/azd/cmd/copilot.go
@@ -288,34 +288,23 @@ func (a *copilotConsentListAction) Run(ctx context.Context) (*actions.ActionResu
 
 	// Convert rules to display format
 	type ruleDisplay struct {
-		Target           string `json:"target"`
-		Context          string `json:"context"`
-		Action           string `json:"action"`
-		Permission       string `json:"permission"`
-		PermissionSymbol string `json:"-"`
-		Scope            string `json:"scope"`
-		GrantedAt        string `json:"grantedAt"`
+		Target     string `json:"target"`
+		Context    string `json:"context"`
+		Action     string `json:"action"`
+		Permission string `json:"permission"`
+		Scope      string `json:"scope"`
+		GrantedAt  string `json:"grantedAt"`
 	}
 
 	var displayRules []ruleDisplay
 	for _, rule := range rules {
-		perm := string(rule.Permission)
-		symbol := "?"
-		switch perm {
-		case "allow":
-			symbol = "✓"
-		case "deny":
-			symbol = "✗"
-		}
-
 		displayRules = append(displayRules, ruleDisplay{
-			Target:           string(rule.Target),
-			Context:          string(rule.Operation),
-			Action:           string(rule.Action),
-			Permission:       perm,
-			PermissionSymbol: symbol,
-			Scope:            string(rule.Scope),
-			GrantedAt:        rule.GrantedAt.Format("2006-01-02 15:04:05"),
+			Target:     string(rule.Target),
+			Context:    string(rule.Operation),
+			Action:     string(rule.Action),
+			Permission: string(rule.Permission),
+			Scope:      string(rule.Scope),
+			GrantedAt:  rule.GrantedAt.Format("2006-01-02 15:04:05"),
 		})
 	}
 
@@ -332,10 +321,9 @@ func (a *copilotConsentListAction) Run(ctx context.Context) (*actions.ActionResu
 				Priority: 1,
 			},
 			{
-				Column:             output.Column{Heading: "PERMISSION", ValueTemplate: "{{.Permission}}"},
-				Priority:           1,
-				ShortValueTemplate: "{{.PermissionSymbol}}",
-				ColorFunc:          consentPermissionColor,
+				Column:    output.Column{Heading: "PERMISSION", ValueTemplate: "{{.Permission}}"},
+				Priority:  1,
+				ColorFunc: consentPermissionColor,
 			},
 			{
 				Column:   output.Column{Heading: "SCOPE", ValueTemplate: "{{.Scope}}"},
@@ -356,8 +344,9 @@ func (a *copilotConsentListAction) Run(ctx context.Context) (*actions.ActionResu
 		}
 
 		return nil, prettyFormatter.Format(displayRules, a.writer, output.PrettyTableFormatterOptions{
-			Columns:         columns,
-			CardGroupColumn: "SCOPE",
+			Columns:              columns,
+			CardGroupColumn:      "SCOPE",
+			ResponsiveColumnHint: true,
 		})
 	}
 
@@ -649,11 +638,11 @@ func formatConsentRuleDescription(rule consent.ConsentRule) string {
 // consentPermissionColor applies color formatting based on permission value.
 func consentPermissionColor(s string) string {
 	switch s {
-	case "allow", "✓":
+	case "allow":
 		return output.WithSuccessFormat(s)
-	case "deny", "✗":
+	case "deny":
 		return output.WithErrorFormat(s)
-	case "prompt", "?":
+	case "prompt":
 		return output.WithWarningFormat(s)
 	default:
 		return output.WithGrayFormat(s)

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -237,13 +237,9 @@ type extensionListItem struct {
 	UpdateAvailable  bool   `json:"updateAvailable"`
 	Incompatible     bool   `json:"-"`
 	Source           string `json:"source"`
-	// DisplayVersion is installed version or "Not installed" for table rendering.
-	DisplayVersion string `json:"-"`
 	// Status is a human-readable installation/update status indicator.
 	// Populated only for pretty-table rendering; omitted from JSON.
 	Status string `json:"-"`
-	// StatusSymbol is the symbol-only status (✓, ↑, ⚠, -) for medium/narrow widths.
-	StatusSymbol string `json:"-"`
 }
 
 func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, error) {
@@ -319,10 +315,6 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 		}
 
 		status := extensionStatus(installed, updateAvailable && !updateIncompatible, updateIncompatible)
-		displayVersion := installedVersion
-		if displayVersion == "" {
-			displayVersion = "Not installed"
-		}
 
 		extensionRows = append(extensionRows, extensionListItem{
 			Id:               extension.Id,
@@ -333,9 +325,7 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 			UpdateAvailable:  updateAvailable && !updateIncompatible,
 			Incompatible:     updateIncompatible,
 			Source:           extension.Source,
-			DisplayVersion:   displayVersion,
 			Status:           status,
-			StatusSymbol:     extensionStatusSymbol(status),
 		})
 	}
 
@@ -364,9 +354,7 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 			Version:          ext.Version,
 			InstalledVersion: ext.Version,
 			Source:           ext.Source,
-			DisplayVersion:   ext.Version,
 			Status:           statusUpToDate,
-			StatusSymbol:     extensionStatusSymbol(statusUpToDate),
 		})
 	}
 
@@ -407,14 +395,9 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 					Heading:       "NAME",
 					ValueTemplate: "{{.Name}}",
 				},
-				Priority: 3,
-			},
-			{
-				Column: output.Column{
-					Heading:       "VERSION",
-					ValueTemplate: "{{.DisplayVersion}}",
-				},
-				Priority: 1,
+				Priority:    3,
+				CardTitle:   true,
+				Truncatable: true,
 			},
 			{
 				Column: output.Column{
@@ -422,8 +405,26 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 					ValueTemplate: "{{.Status}}",
 				},
 				Priority:           1,
-				ShortValueTemplate: "{{.StatusSymbol}}",
+				Truncatable:        true,
+				AlignLeadingSymbol: true,
 				ColorFunc:          extensionStatusColor,
+			},
+			{
+				Column: output.Column{
+					Heading:       "INSTALLED",
+					ValueTemplate: `{{if .InstalledVersion}}{{.InstalledVersion}}{{else}}-{{end}}`,
+				},
+				CardValueTemplate: `{{if .InstalledVersion}}{{.InstalledVersion}}{{end}}`,
+				Priority:          1,
+			},
+			{
+				Column: output.Column{
+					Heading:       "LATEST",
+					ValueTemplate: "{{.Version}}",
+				},
+				CardValueTemplate: `{{if or .UpdateAvailable (not .InstalledVersion)}}{{.Version}}{{end}}`,
+				Priority:          3,
+				Truncatable:       true,
 			},
 			{
 				Column: output.Column{
@@ -435,8 +436,9 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 		}
 
 		formatErr = prettyFormatter.Format(extensionRows, a.writer, output.PrettyTableFormatterOptions{
-			Columns:         columns,
-			CardGroupColumn: "SOURCE",
+			Columns:              columns,
+			CardGroupColumn:      "SOURCE",
+			ResponsiveColumnHint: true,
 		})
 
 		if formatErr == nil {
@@ -475,10 +477,10 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 
 // Status indicator constants for extension list display.
 const (
-	statusUpToDate   = "✓ Up to date"
-	statusUpdate     = "↑ Update available"
+	statusUpToDate   = "Up to date"
+	statusUpdate     = "⟳ Update available"
 	statusIncompat   = "⚠ Incompatible"
-	statusNotInstall = "-"
+	statusNotInstall = "Not installed"
 )
 
 // extensionStatus returns a human-readable status string for the extension list table.
@@ -495,36 +497,16 @@ func extensionStatus(installed, updateAvailable, incompatible bool) string {
 	}
 }
 
-// Status symbol constants for medium/narrow display.
-const (
-	symbolUpToDate   = "✓"
-	symbolUpdate     = "↑"
-	symbolIncompat   = "⚠"
-	symbolNotInstall = "-"
-)
-
-// extensionStatusSymbol returns the symbol-only version of a status string.
-func extensionStatusSymbol(status string) string {
-	switch status {
-	case statusUpToDate:
-		return symbolUpToDate
-	case statusUpdate:
-		return symbolUpdate
-	case statusIncompat:
-		return symbolIncompat
-	default:
-		return symbolNotInstall
-	}
-}
-
 // extensionStatusColor applies color formatting based on the status indicator text.
+// Leading/trailing whitespace (e.g. from column alignment padding) is ignored
+// when matching, but preserved in the returned, colored string.
 func extensionStatusColor(s string) string {
-	switch s {
-	case statusUpToDate, symbolUpToDate:
+	switch strings.TrimSpace(s) {
+	case statusUpToDate:
 		return output.WithSuccessFormat(s)
-	case statusUpdate, symbolUpdate:
+	case statusUpdate:
 		return output.WithWarningFormat(s)
-	case statusIncompat, symbolIncompat:
+	case statusIncompat:
 		return output.WithErrorFormat(s)
 	default:
 		return output.WithGrayFormat(s)

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -475,10 +475,9 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 }
 
 // Status indicator constants for extension list display.
-// Only "Update available" carries a leading symbol; the others are plain text.
 const (
 	statusUpToDate   = "Up to date"
-	statusUpdate     = "⟳ Update available"
+	statusUpdate     = "Update available"
 	statusIncompat   = "Incompatible"
 	statusNotInstall = "Not installed"
 )
@@ -498,10 +497,8 @@ func extensionStatus(installed, updateAvailable, incompatible bool) string {
 }
 
 // extensionStatusColor applies color formatting based on the status indicator text.
-// Leading/trailing whitespace (e.g. from column alignment padding) is ignored
-// when matching, but preserved in the returned, colored string.
 func extensionStatusColor(s string) string {
-	switch strings.TrimSpace(s) {
+	switch s {
 	case statusUpToDate:
 		return output.WithSuccessFormat(s)
 	case statusUpdate:

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -476,10 +476,11 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 }
 
 // Status indicator constants for extension list display.
+// Only "Update available" carries a leading symbol; the others are plain text.
 const (
 	statusUpToDate   = "Up to date"
 	statusUpdate     = "⟳ Update available"
-	statusIncompat   = "⚠ Incompatible"
+	statusIncompat   = "Incompatible"
 	statusNotInstall = "Not installed"
 )
 
@@ -2316,8 +2317,9 @@ func (a *extensionSourceListAction) Run(ctx context.Context) (*actions.ActionRes
 		}
 
 		err = prettyFormatter.Format(sourceConfigs, a.writer, output.PrettyTableFormatterOptions{
-			Columns:         columns,
-			CardGroupColumn: "TYPE",
+			Columns:              columns,
+			CardGroupColumn:      "TYPE",
+			ResponsiveColumnHint: true,
 		})
 	} else {
 		err = a.formatter.Format(sourceConfigs, a.writer, nil)

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -404,10 +404,9 @@ func (a *extensionListAction) Run(ctx context.Context) (*actions.ActionResult, e
 					Heading:       "STATUS",
 					ValueTemplate: "{{.Status}}",
 				},
-				Priority:           1,
-				Truncatable:        true,
-				AlignLeadingSymbol: true,
-				ColorFunc:          extensionStatusColor,
+				Priority:    1,
+				Truncatable: true,
+				ColorFunc:   extensionStatusColor,
 			},
 			{
 				Column: output.Column{

--- a/cli/azd/cmd/extension_test.go
+++ b/cli/azd/cmd/extension_test.go
@@ -660,36 +660,17 @@ func TestExtensionStatus(t *testing.T) {
 	}
 }
 
-func TestExtensionStatusSymbol(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		status string
-		want   string
-	}{
-		{statusUpToDate, symbolUpToDate},
-		{statusUpdate, symbolUpdate},
-		{statusIncompat, symbolIncompat},
-		{statusNotInstall, symbolNotInstall},
-	}
-	for _, tt := range tests {
-		t.Run(tt.status, func(t *testing.T) {
-			t.Parallel()
-			got := extensionStatusSymbol(tt.status)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestExtensionStatusColor(t *testing.T) {
 	// Force color output on — fatih/color disables in non-TTY environments.
 	originalNoColor := color.NoColor
 	color.NoColor = false
 	defer func() { color.NoColor = originalNoColor }()
 
-	// Verify no panics and non-empty output for each status (full and symbol forms)
+	// Verify no panics and non-empty output for each status, including values
+	// with leading alignment padding (which the color function tolerates).
 	for _, s := range []string{
 		statusUpToDate, statusUpdate, statusIncompat, statusNotInstall,
-		symbolUpToDate, symbolUpdate, symbolIncompat, symbolNotInstall,
+		"  " + statusUpToDate, "  " + statusNotInstall,
 	} {
 		result := extensionStatusColor(s)
 		assert.NotEmpty(t, result, "color function should return non-empty for %q", s)

--- a/cli/azd/cmd/extension_test.go
+++ b/cli/azd/cmd/extension_test.go
@@ -666,11 +666,9 @@ func TestExtensionStatusColor(t *testing.T) {
 	color.NoColor = false
 	defer func() { color.NoColor = originalNoColor }()
 
-	// Verify no panics and non-empty output for each status, including values
-	// with leading alignment padding (which the color function tolerates).
+	// Verify no panics and non-empty colored output for each status value.
 	for _, s := range []string{
 		statusUpToDate, statusUpdate, statusIncompat, statusNotInstall,
-		"  " + statusUpToDate, "  " + statusNotInstall,
 	} {
 		result := extensionStatusColor(s)
 		assert.NotEmpty(t, result, "color function should return non-empty for %q", s)

--- a/cli/azd/cmd/finish55_coverage3_test.go
+++ b/cli/azd/cmd/finish55_coverage3_test.go
@@ -44,8 +44,7 @@ func Test_ConfigListAlpha_HappyPath_Finish(t *testing.T) {
 }
 
 // ──────────────────────────────────────────────────────────────
-// configOptionsAction.Run — table format with complex config values
-// Exercises switch cases at lines 621-626 (map/array/default)
+// configOptionsAction.Run — shared config manager fake
 // ──────────────────────────────────────────────────────────────
 
 type finishConfigMgr struct {
@@ -56,59 +55,9 @@ type finishConfigMgr struct {
 func (m *finishConfigMgr) Load() (config.Config, error) { return m.cfg, m.err }
 func (m *finishConfigMgr) Save(_ config.Config) error   { return nil }
 
-func Test_ConfigOptions_TableFormat_MapValue_Finish(t *testing.T) {
-	t.Parallel()
-	// Set a known config key to a map value to hit case map[string]any
-	cfg := config.NewConfig(map[string]any{
-		"defaults": map[string]any{
-			"subscription": map[string]any{"nested": "value"},
-		},
-	})
-	mgr := &finishConfigMgr{cfg: cfg}
-	console := mockinput.NewMockConsole()
-	buf := &bytes.Buffer{}
-	formatter := &output.TableFormatter{}
-	action := newConfigOptionsAction(console, formatter, buf, mgr, nil)
-	_, err := action.Run(t.Context())
-	require.NoError(t, err)
-}
-
-func Test_ConfigOptions_TableFormat_ArrayValue_Finish(t *testing.T) {
-	t.Parallel()
-	cfg := config.NewConfig(map[string]any{
-		"defaults": map[string]any{
-			"subscription": []any{"sub1", "sub2"},
-		},
-	})
-	mgr := &finishConfigMgr{cfg: cfg}
-	console := mockinput.NewMockConsole()
-	buf := &bytes.Buffer{}
-	formatter := &output.TableFormatter{}
-	action := newConfigOptionsAction(console, formatter, buf, mgr, nil)
-	_, err := action.Run(t.Context())
-	require.NoError(t, err)
-}
-
-func Test_ConfigOptions_TableFormat_IntValue_Finish(t *testing.T) {
-	t.Parallel()
-	// Set a known config key to an integer to hit the default case
-	cfg := config.NewConfig(map[string]any{
-		"defaults": map[string]any{
-			"subscription": 42,
-		},
-	})
-	mgr := &finishConfigMgr{cfg: cfg}
-	console := mockinput.NewMockConsole()
-	buf := &bytes.Buffer{}
-	formatter := &output.TableFormatter{}
-	action := newConfigOptionsAction(console, formatter, buf, mgr, nil)
-	_, err := action.Run(t.Context())
-	require.NoError(t, err)
-}
-
 // ──────────────────────────────────────────────────────────────
 // configOptionsAction.Run — default (none) format with complex values
-// Exercises switch cases at lines 697-702 (map/array/default)
+// Exercises the value-conversion switch cases (map/array/default)
 // ──────────────────────────────────────────────────────────────
 
 func Test_ConfigOptions_DefaultFormat_MapValue_Finish(t *testing.T) {
@@ -422,23 +371,6 @@ func Test_ConfigOptions_JsonFormatError_Finish(t *testing.T) {
 	console := mockinput.NewMockConsole()
 	w := &errWriter{}
 	formatter := &output.JsonFormatter{}
-	action := newConfigOptionsAction(console, formatter, w, mgr, nil)
-	_, err := action.Run(t.Context())
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed formatting config options")
-}
-
-// ──────────────────────────────────────────────────────────────
-// configOptionsAction.Run — table format error (line 676-678)
-// ──────────────────────────────────────────────────────────────
-
-func Test_ConfigOptions_TableFormatError_Finish(t *testing.T) {
-	t.Parallel()
-	cfg := config.NewEmptyConfig()
-	mgr := &finishConfigMgr{cfg: cfg}
-	console := mockinput.NewMockConsole()
-	w := &errWriter{}
-	formatter := &output.TableFormatter{}
 	action := newConfigOptionsAction(console, formatter, w, mgr, nil)
 	_, err := action.Run(t.Context())
 	require.Error(t, err)

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -145,36 +145,32 @@ func (tl *templateListAction) Run(ctx context.Context) (*actions.ActionResult, e
 			{
 				Column: output.Column{
 					Heading:       "NAME",
-					ValueTemplate: `{{if ne .Name ""}}{{.Name}}{{else}}{{.Title}}{{end}}`,
+					ValueTemplate: `{{if ne .Title ""}}{{.Title}}{{else}}{{.Name}}{{end}}`,
 				},
-				Priority: 1,
-			},
-			{
-				Column:   output.Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"},
-				Priority: 1,
-			},
-			{
-				Column:   output.Column{Heading: "TAGS", ValueTemplate: "{{.DisplayTags}}"},
-				Priority: 2,
-			},
-			{
-				Column:   output.Column{Heading: "DESCRIPTION", ValueTemplate: "{{.Description}}"},
-				Priority: 3,
+				CardTitle: true,
 			},
 			{
 				Column: output.Column{
-					Heading: "REPOSITORY PATH",
+					Heading: "REPOSITORY",
 					ValueTemplate: `{{if ne .RepositoryPath ""}}` +
 						`{{.RepositoryPath}}{{else}}{{.RepoSource}}{{end}}`,
 					Transformer: templates.Hyperlink,
 				},
-				Priority: 3,
+			},
+			{
+				Column: output.Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"},
+			},
+			{
+				Column: output.Column{Heading: "TAGS", ValueTemplate: "{{.DisplayTags}}"},
+			},
+			{
+				Column: output.Column{Heading: "DESCRIPTION", ValueTemplate: "{{.Description}}"},
 			},
 		}
 
 		err = prettyFormatter.Format(rows, tl.writer, output.PrettyTableFormatterOptions{
-			Columns:         columns,
-			CardGroupColumn: "SOURCE",
+			Columns:    columns,
+			ForceCards: true,
 		})
 
 		if err == nil {

--- a/cli/azd/cmd/templates.go
+++ b/cli/azd/cmd/templates.go
@@ -397,8 +397,9 @@ func (a *templateSourceListAction) Run(ctx context.Context) (*actions.ActionResu
 		}
 
 		err = prettyFormatter.Format(sourceConfigs, a.writer, output.PrettyTableFormatterOptions{
-			Columns:         columns,
-			CardGroupColumn: "TYPE",
+			Columns:              columns,
+			CardGroupColumn:      "TYPE",
+			ResponsiveColumnHint: true,
 		})
 	} else {
 		err = a.formatter.Format(sourceConfigs, a.writer, nil)

--- a/cli/azd/cmd/testdata/TestUsage-azd-config-options.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-config-options.snap
@@ -19,7 +19,4 @@ Examples
   List all available configuration settings in JSON format
     azd config options -o json
 
-  List all available configuration settings in table format
-    azd config options -o table
-
 

--- a/cli/azd/cmd/tool.go
+++ b/cli/azd/cmd/tool.go
@@ -1554,10 +1554,9 @@ func writeDryRunTable(w io.Writer, rows []toolDryRunItem) error {
 }
 
 // toolStatusColor applies color formatting based on install status text.
-// Leading/trailing whitespace is ignored when matching but preserved in output.
 func toolStatusColor(s string) string {
-	switch strings.TrimSpace(s) {
-	case "Installed", "✓":
+	switch s {
+	case "Installed":
 		return output.WithSuccessFormat(s)
 	default:
 		// "Not installed" and any other state render in gray.

--- a/cli/azd/cmd/tool.go
+++ b/cli/azd/cmd/tool.go
@@ -315,13 +315,12 @@ func (a *toolAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 // ---------------------------------------------------------------------------
 
 type toolListItem struct {
-	Id           string `json:"id"`
-	Name         string `json:"name"`
-	Category     string `json:"category"`
-	Priority     string `json:"priority"`
-	Status       string `json:"status"`
-	StatusSymbol string `json:"-"`
-	Version      string `json:"version"`
+	Id       string `json:"id"`
+	Name     string `json:"name"`
+	Category string `json:"category"`
+	Priority string `json:"priority"`
+	Status   string `json:"status"`
+	Version  string `json:"version"`
 }
 
 type toolListAction struct {
@@ -369,23 +368,20 @@ func (a *toolListAction) Run(ctx context.Context) (*actions.ActionResult, error)
 
 	rows := make([]toolListItem, 0, len(statuses))
 	for _, s := range statuses {
-		status := "Not Installed"
-		statusSymbol := "✗"
+		status := "Not installed"
 		version := ""
 		if s.Installed {
 			status = "Installed"
-			statusSymbol = "✓"
 			version = s.InstalledVersion
 		}
 
 		rows = append(rows, toolListItem{
-			Id:           s.Tool.Id,
-			Name:         s.Tool.Name,
-			Category:     string(s.Tool.Category),
-			Priority:     string(s.Tool.Priority),
-			Status:       status,
-			StatusSymbol: statusSymbol,
-			Version:      version,
+			Id:       s.Tool.Id,
+			Name:     s.Tool.Name,
+			Category: string(s.Tool.Category),
+			Priority: string(s.Tool.Priority),
+			Status:   status,
+			Version:  version,
 		})
 	}
 
@@ -400,36 +396,46 @@ func (a *toolListAction) Run(ctx context.Context) (*actions.ActionResult, error)
 		prettyFormatter := &output.PrettyTableFormatter{}
 		columns := []output.PrettyColumn{
 			{
-				Column:   output.Column{Heading: "NAME", ValueTemplate: "{{.Name}}"},
+				Column:   output.Column{Heading: "ID", ValueTemplate: "{{.Id}}"},
 				Priority: 1,
 			},
 			{
-				Column:             output.Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
-				Priority:           1,
-				ShortValueTemplate: "{{.StatusSymbol}}",
-				ColorFunc:          toolStatusColor,
+				Column:      output.Column{Heading: "NAME", ValueTemplate: "{{.Name}}"},
+				Priority:    2,
+				CardTitle:   true,
+				Wrappable:   true,
+				Truncatable: true,
 			},
 			{
-				Column:   output.Column{Heading: "VERSION", ValueTemplate: "{{.Version}}"},
-				Priority: 2,
+				Column:      output.Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+				Priority:    1,
+				Truncatable: true,
+				ColorFunc:   toolStatusColor,
 			},
 			{
-				Column:   output.Column{Heading: "CATEGORY", ValueTemplate: "{{.Category}}"},
-				Priority: 2,
+				Column: output.Column{
+					Heading:       "INSTALLED",
+					ValueTemplate: `{{if .Version}}{{.Version}}{{else}}-{{end}}`,
+				},
+				CardValueTemplate: `{{if .Version}}{{.Version}}{{end}}`,
+				Priority:          1,
 			},
 			{
-				Column:   output.Column{Heading: "ID", ValueTemplate: "{{.Id}}"},
-				Priority: 3,
+				Column:      output.Column{Heading: "CATEGORY", ValueTemplate: "{{.Category}}"},
+				Priority:    3,
+				Truncatable: true,
 			},
 			{
-				Column:   output.Column{Heading: "PRIORITY", ValueTemplate: "{{.Priority}}"},
-				Priority: 3,
+				Column:      output.Column{Heading: "PRIORITY", ValueTemplate: "{{.Priority}}"},
+				Priority:    3,
+				Truncatable: true,
 			},
 		}
 
 		formatErr = prettyFormatter.Format(rows, a.writer, output.PrettyTableFormatterOptions{
-			Columns:         columns,
-			CardGroupColumn: "CATEGORY",
+			Columns:              columns,
+			CardGroupColumn:      "CATEGORY",
+			ResponsiveColumnHint: true,
 		})
 	} else {
 		formatErr = a.formatter.Format(rows, a.writer, nil)
@@ -942,6 +948,9 @@ type toolCheckItem struct {
 	InstalledVersion string `json:"installedVersion"`
 	LatestVersion    string `json:"latestVersion"`
 	UpdateAvailable  bool   `json:"updateAvailable"`
+	// Status is a human-readable installation/update status indicator.
+	// Populated only for pretty-table rendering; omitted from JSON.
+	Status string `json:"-"`
 }
 
 type toolCheckAction struct {
@@ -999,6 +1008,7 @@ func (a *toolCheckAction) Run(ctx context.Context) (*actions.ActionResult, error
 			InstalledVersion: r.CurrentVersion,
 			LatestVersion:    r.LatestVersion,
 			UpdateAvailable:  r.UpdateAvailable,
+			Status:           toolCheckStatus(r.CurrentVersion != "", r.UpdateAvailable),
 		})
 	}
 	tracing.SetUsageAttributes(
@@ -1016,40 +1026,47 @@ func (a *toolCheckAction) Run(ctx context.Context) (*actions.ActionResult, error
 		prettyFormatter := &output.PrettyTableFormatter{}
 		columns := []output.PrettyColumn{
 			{
-				Column:   output.Column{Heading: "NAME", ValueTemplate: "{{.Name}}"},
+				Column:   output.Column{Heading: "ID", ValueTemplate: "{{.Id}}"},
 				Priority: 1,
 			},
 			{
-				Column: output.Column{
-					Heading:       "UPDATE AVAILABLE",
-					ValueTemplate: `{{if .UpdateAvailable}}Yes{{else}}No{{end}}`,
-				},
+				Column:      output.Column{Heading: "NAME", ValueTemplate: "{{.Name}}"},
+				Priority:    2,
+				CardTitle:   true,
+				Wrappable:   true,
+				Truncatable: true,
+			},
+			{
+				Column:             output.Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
 				Priority:           1,
-				ShortValueTemplate: `{{if .UpdateAvailable}}⬆{{else}}✓{{end}}`,
-				ColorFunc:          updateAvailableColor,
+				Truncatable:        true,
+				AlignLeadingSymbol: true,
+				ColorFunc:          extensionStatusColor,
 			},
 			{
 				Column: output.Column{
-					Heading:       "INSTALLED VERSION",
-					ValueTemplate: "{{.InstalledVersion}}",
+					Heading:       "INSTALLED",
+					ValueTemplate: `{{if .InstalledVersion}}{{.InstalledVersion}}{{else}}-{{end}}`,
 				},
-				Priority: 2,
+				CardValueTemplate: `{{if .InstalledVersion}}{{.InstalledVersion}}{{end}}`,
+				Priority:          1,
 			},
 			{
 				Column: output.Column{
-					Heading:       "LATEST VERSION",
+					Heading:       "LATEST",
 					ValueTemplate: "{{.LatestVersion}}",
 				},
-				Priority: 2,
-			},
-			{
-				Column:   output.Column{Heading: "ID", ValueTemplate: "{{.Id}}"},
-				Priority: 3,
+				CardValueTemplate: `{{if or .UpdateAvailable (not .InstalledVersion)}}{{.LatestVersion}}{{end}}`,
+				Priority:          3,
+				Truncatable:       true,
 			},
 		}
 
 		formatErr = prettyFormatter.Format(
-			rows, a.writer, output.PrettyTableFormatterOptions{Columns: columns, CardGroupColumn: "NAME"},
+			rows, a.writer, output.PrettyTableFormatterOptions{
+				Columns:              columns,
+				ResponsiveColumnHint: true,
+			},
 		)
 
 		if formatErr == nil {
@@ -1538,25 +1555,26 @@ func writeDryRunTable(w io.Writer, rows []toolDryRunItem) error {
 }
 
 // toolStatusColor applies color formatting based on install status text.
+// Leading/trailing whitespace is ignored when matching but preserved in output.
 func toolStatusColor(s string) string {
-	switch s {
+	switch strings.TrimSpace(s) {
 	case "Installed", "✓":
 		return output.WithSuccessFormat(s)
-	case "Not Installed", "✗":
-		return output.WithWarningFormat(s)
 	default:
+		// "Not installed" and any other state render in gray.
 		return output.WithGrayFormat(s)
 	}
 }
 
-// updateAvailableColor applies color formatting based on update availability text.
-func updateAvailableColor(s string) string {
-	switch s {
-	case "No", "✓":
-		return output.WithSuccessFormat(s)
-	case "Yes", "⬆":
-		return output.WithWarningFormat(s)
+// toolCheckStatus returns a human-readable status string for the tool check
+// table, reusing the extension status vocabulary for consistency.
+func toolCheckStatus(installed, updateAvailable bool) string {
+	switch {
+	case !installed:
+		return statusNotInstall
+	case updateAvailable:
+		return statusUpdate
 	default:
-		return output.WithGrayFormat(s)
+		return statusUpToDate
 	}
 }

--- a/cli/azd/cmd/tool.go
+++ b/cli/azd/cmd/tool.go
@@ -1232,7 +1232,7 @@ func (a *toolShowAction) displayToolDetails(
 	}
 
 	// Tool Information
-	installedVersion := "Not Installed"
+	installedVersion := "Not installed"
 	if status.Installed {
 		installedVersion = status.InstalledVersion
 		if installedVersion == "" {

--- a/cli/azd/cmd/tool.go
+++ b/cli/azd/cmd/tool.go
@@ -1037,11 +1037,10 @@ func (a *toolCheckAction) Run(ctx context.Context) (*actions.ActionResult, error
 				Truncatable: true,
 			},
 			{
-				Column:             output.Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
-				Priority:           1,
-				Truncatable:        true,
-				AlignLeadingSymbol: true,
-				ColorFunc:          extensionStatusColor,
+				Column:      output.Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+				Priority:    1,
+				Truncatable: true,
+				ColorFunc:   extensionStatusColor,
 			},
 			{
 				Column: output.Column{

--- a/cli/azd/pkg/output/pretty_table.go
+++ b/cli/azd/pkg/output/pretty_table.go
@@ -11,7 +11,7 @@ import (
 )
 
 // emptyTemplate renders an empty string for any data row. It backs the
-// header-only "..." placeholder column at the compact breakpoint.
+// header-only "···" placeholder column at the compact breakpoint.
 var emptyTemplate = template.Must(template.New("empty").Parse(""))
 
 // PrettyTableFormatter renders tabular data with responsive breakpoints.
@@ -103,13 +103,6 @@ func parseColumns(columns []PrettyColumn) ([]resolvedColumn, error) {
 			return nil, fmt.Errorf("column %q: %w", c.Heading, err)
 		}
 		rc := resolvedColumn{col: c, tmpl: t}
-		if c.ShortValueTemplate != "" {
-			st, err := template.New(c.Heading + "_short").Parse(c.ShortValueTemplate)
-			if err != nil {
-				return nil, fmt.Errorf("column %q short template: %w", c.Heading, err)
-			}
-			rc.shortTmpl = st
-		}
 		if c.CardValueTemplate != "" {
 			ct, err := template.New(c.Heading + "_card").Parse(c.CardValueTemplate)
 			if err != nil {

--- a/cli/azd/pkg/output/pretty_table.go
+++ b/cli/azd/pkg/output/pretty_table.go
@@ -4,81 +4,19 @@
 package output
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
-	"regexp"
-	"strings"
 	"text/template"
-
-	"github.com/fatih/color"
-	"github.com/mattn/go-runewidth"
 )
 
-// Width breakpoint constants for responsive layout selection.
-const (
-	// DefaultFullThreshold is the terminal width at or above which all columns
-	// are shown with full text values.
-	DefaultFullThreshold = 100
-
-	// DefaultCompactThreshold is the terminal width at or above which only
-	// high-priority columns (Priority ≤ 2) are shown with ShortValueTemplate.
-	// Below this value the card layout is used.
-	DefaultCompactThreshold = 60
-
-	// columnPadding is the whitespace gap between columns (no box-drawing separators).
-	columnPadding = 3
-)
-
-// PrettyColumn extends Column with priority for responsive column dropping.
-type PrettyColumn struct {
-	Column
-
-	// Priority controls column visibility at compact widths.
-	// 1 = always shown in compact, 2 = always shown in compact,
-	// 3+ = full table only. 0 is treated as 1.
-	Priority int
-
-	// ShortValueTemplate is an alternative Go template used at compact
-	// widths. If empty, the regular ValueTemplate is used.
-	ShortValueTemplate string
-
-	// ColorFunc applies color formatting to the cell value.
-	// If nil, no color formatting is applied.
-	ColorFunc func(string) string
-}
-
-// PrettyTableFormatterOptions configures the pretty table formatter.
-type PrettyTableFormatterOptions struct {
-	Columns []PrettyColumn
-
-	// CardGroupColumn is the heading name of the column to group cards by
-	// in the card layout. Each distinct value becomes a section header.
-	// If empty, cards are rendered ungrouped with the first column as card title.
-	CardGroupColumn string
-
-	// FullThreshold is the terminal width at or above which the full layout
-	// is used (all columns, full text). Defaults to DefaultFullThreshold (100).
-	FullThreshold int
-
-	// CompactThreshold is the terminal width at or above which the compact
-	// layout is used (Priority ≤ 2 columns, ShortValueTemplate).
-	// Below this the card layout is used.
-	// Defaults to DefaultCompactThreshold (60).
-	CompactThreshold int
-}
-
-// parsedCol pairs a PrettyColumn with its compiled templates.
-type parsedCol struct {
-	col       PrettyColumn
-	tmpl      *template.Template
-	shortTmpl *template.Template // nil when ShortValueTemplate is empty
-}
+// emptyTemplate renders an empty string for any data row. It backs the
+// header-only "..." placeholder column at the compact breakpoint.
+var emptyTemplate = template.Must(template.New("empty").Parse(""))
 
 // PrettyTableFormatter renders tabular data with responsive breakpoints.
-// It supports 3 layout modes based on terminal width: full table,
-// compact table (fewer columns), and card layout.
+// It supports three layout modes based on terminal width: full table, compact
+// table (fewer columns), and card layout.
 type PrettyTableFormatter struct {
 	// ConsoleWidthFn returns the current terminal width. Defaults to getConsoleWidth.
 	ConsoleWidthFn func() int
@@ -103,28 +41,9 @@ func (f *PrettyTableFormatter) Format(obj any, writer io.Writer, opts any) error
 		return err
 	}
 
-	// Parse templates upfront
-	parsed := make([]parsedCol, len(options.Columns))
-	seenHeadings := make(map[string]bool, len(options.Columns))
-	for i, c := range options.Columns {
-		if seenHeadings[c.Heading] {
-			return fmt.Errorf("duplicate column heading %q", c.Heading)
-		}
-		seenHeadings[c.Heading] = true
-
-		t, err := template.New(c.Heading).Parse(c.ValueTemplate)
-		if err != nil {
-			return fmt.Errorf("column %q: %w", c.Heading, err)
-		}
-		pc := parsedCol{col: c, tmpl: t}
-		if c.ShortValueTemplate != "" {
-			st, err := template.New(c.Heading + "_short").Parse(c.ShortValueTemplate)
-			if err != nil {
-				return fmt.Errorf("column %q short template: %w", c.Heading, err)
-			}
-			pc.shortTmpl = st
-		}
-		parsed[i] = pc
+	parsed, err := parseColumns(options.Columns)
+	if err != nil {
+		return err
 	}
 
 	widthFn := f.ConsoleWidthFn
@@ -133,6 +52,22 @@ func (f *PrettyTableFormatter) Format(obj any, writer io.Writer, opts any) error
 	}
 	termWidth := widthFn()
 
+	if options.ForceCards {
+		return f.formatGroupedCards(parsed, rows, termWidth, writer, options)
+	}
+
+	switch resolveBreakpoint(termWidth, options) {
+	case breakpointFull:
+		return f.renderFullTable(parsed, rows, termWidth, writer, options)
+	case breakpointCompact:
+		return f.renderCompactTable(parsed, rows, termWidth, writer, options)
+	default:
+		return f.formatGroupedCards(parsed, rows, termWidth, writer, options)
+	}
+}
+
+// resolveBreakpoint maps a terminal width to a responsive layout breakpoint.
+func resolveBreakpoint(termWidth int, options PrettyTableFormatterOptions) breakpoint {
 	fullT := options.FullThreshold
 	if fullT <= 0 {
 		fullT = DefaultFullThreshold
@@ -144,337 +79,47 @@ func (f *PrettyTableFormatter) Format(obj any, writer io.Writer, opts any) error
 
 	switch {
 	case termWidth >= fullT:
-		return f.renderFullTable(parsed, rows, termWidth, writer)
+		return breakpointFull
 	case termWidth >= compactT:
-		return f.renderCompactTable(parsed, rows, termWidth, writer, options)
+		return breakpointCompact
 	default:
-		return f.formatGroupedCards(parsed, rows, termWidth, writer, options)
+		return breakpointCard
 	}
 }
 
-// renderFullTable renders all columns with full text values and whitespace padding.
-func (f *PrettyTableFormatter) renderFullTable(
-	parsed []parsedCol, rows []any, termWidth int, writer io.Writer,
-) error {
-	return f.renderPaddedTable(parsed, rows, termWidth, writer, false)
-}
-
-// renderCompactTable renders only Priority ≤ 2 columns with ShortValueTemplate.
-func (f *PrettyTableFormatter) renderCompactTable(
-	parsed []parsedCol, rows []any, termWidth int, writer io.Writer, options PrettyTableFormatterOptions,
-) error {
-	filtered := make([]parsedCol, 0, len(parsed))
-	for _, pc := range parsed {
-		p := pc.col.Priority
-		if p == 0 {
-			p = 1
+// parseColumns compiles the value templates for each column and validates that
+// headings are unique.
+func parseColumns(columns []PrettyColumn) ([]resolvedColumn, error) {
+	parsed := make([]resolvedColumn, len(columns))
+	seenHeadings := make(map[string]bool, len(columns))
+	for i, c := range columns {
+		if seenHeadings[c.Heading] {
+			return nil, fmt.Errorf("duplicate column heading %q", c.Heading)
 		}
-		if p <= 2 {
-			filtered = append(filtered, pc)
+		seenHeadings[c.Heading] = true
+
+		t, err := template.New(c.Heading).Parse(c.ValueTemplate)
+		if err != nil {
+			return nil, fmt.Errorf("column %q: %w", c.Heading, err)
 		}
-	}
-	if len(filtered) == 0 {
-		return f.formatGroupedCards(parsed, rows, termWidth, writer, options)
-	}
-	return f.renderPaddedTable(filtered, rows, termWidth, writer, true)
-}
-
-// renderPaddedTable builds a whitespace-padded table with a header underline.
-// When useShort is true, ShortValueTemplate is used where available.
-func (f *PrettyTableFormatter) renderPaddedTable(
-	cols []parsedCol, rows []any, termWidth int, writer io.Writer, useShort bool,
-) error {
-	// Resolve cell values
-	type cellGrid struct {
-		values [][]string // [row][col]
-	}
-	grid := cellGrid{values: make([][]string, len(rows))}
-
-	for ri, row := range rows {
-		grid.values[ri] = make([]string, len(cols))
-		for ci, pc := range cols {
-			tmpl := pc.tmpl
-			if useShort && pc.shortTmpl != nil {
-				tmpl = pc.shortTmpl
-			}
-			val, err := prettyExecTemplate(tmpl, row)
+		rc := resolvedColumn{col: c, tmpl: t}
+		if c.ShortValueTemplate != "" {
+			st, err := template.New(c.Heading + "_short").Parse(c.ShortValueTemplate)
 			if err != nil {
-				return fmt.Errorf("row %d, column %q: %w", ri, pc.col.Heading, err)
+				return nil, fmt.Errorf("column %q short template: %w", c.Heading, err)
 			}
-			if pc.col.Transformer != nil {
-				val = pc.col.Transformer(val)
-			}
-			grid.values[ri][ci] = val
+			rc.shortTmpl = st
 		}
-	}
-
-	// Compute natural column widths (max of heading and all cell values)
-	colWidths := make([]int, len(cols))
-	for ci, pc := range cols {
-		colWidths[ci] = displayWidth(pc.col.Heading)
-	}
-	for _, rowVals := range grid.values {
-		for ci, val := range rowVals {
-			if dw := displayWidth(val); dw > colWidths[ci] {
-				colWidths[ci] = dw
-			}
-		}
-	}
-
-	boldHeader := color.New(color.Bold, color.FgHiWhite)
-	var buf bytes.Buffer
-
-	// Header row
-	for ci, pc := range cols {
-		if ci > 0 {
-			buf.WriteString(strings.Repeat(" ", columnPadding))
-		}
-		heading := pc.col.Heading
-		hdw := displayWidth(heading)
-		padNeeded := max(colWidths[ci]-hdw, 0)
-		buf.WriteString(boldHeader.Sprint(heading))
-		if ci < len(cols)-1 {
-			buf.WriteString(strings.Repeat(" ", padNeeded))
-		}
-	}
-	buf.WriteByte('\n')
-
-	// Header underline
-	lineWidth := min(sumWidths(colWidths)+max(0, len(cols)-1)*columnPadding, termWidth)
-	buf.WriteString(WithGrayFormat(strings.Repeat("─", lineWidth)))
-	buf.WriteByte('\n')
-
-	// Data rows
-	for _, rowVals := range grid.values {
-		for ci, val := range rowVals {
-			if ci > 0 {
-				buf.WriteString(strings.Repeat(" ", columnPadding))
-			}
-
-			// Apply color
-			colored := val
-			if cols[ci].col.ColorFunc != nil {
-				colored = cols[ci].col.ColorFunc(val)
-			}
-
-			// Pad based on display width, not byte length
-			padNeeded := max(colWidths[ci]-displayWidth(val), 0)
-			buf.WriteString(colored)
-			// Don't pad the last column
-			if ci < len(cols)-1 {
-				buf.WriteString(strings.Repeat(" ", padNeeded))
-			}
-		}
-		buf.WriteByte('\n')
-	}
-
-	_, err := fmt.Fprint(writer, buf.String())
-	return err
-}
-
-// formatGroupedCards renders rows as cards grouped by CardGroupColumn.
-// If CardGroupColumn is empty, cards are rendered ungrouped.
-func (f *PrettyTableFormatter) formatGroupedCards(
-	parsed []parsedCol, rows []any, termWidth int, writer io.Writer, options PrettyTableFormatterOptions,
-) error {
-	groupColIdx := -1
-	if options.CardGroupColumn != "" {
-		for i, pc := range parsed {
-			if pc.col.Heading == options.CardGroupColumn {
-				groupColIdx = i
-				break
-			}
-		}
-		if groupColIdx < 0 {
-			return fmt.Errorf("CardGroupColumn %q does not match any column heading", options.CardGroupColumn)
-		}
-	}
-
-	// Resolve all row values
-	type rowData struct {
-		values   map[string]string // heading -> value
-		groupVal string
-	}
-	allRows := make([]rowData, len(rows))
-	for ri, row := range rows {
-		rd := rowData{values: make(map[string]string)}
-		for _, pc := range parsed {
-			val, err := prettyExecTemplate(pc.tmpl, row)
+		if c.CardValueTemplate != "" {
+			ct, err := template.New(c.Heading + "_card").Parse(c.CardValueTemplate)
 			if err != nil {
-				return fmt.Errorf("row %d, column %q: %w", ri, pc.col.Heading, err)
+				return nil, fmt.Errorf("column %q card template: %w", c.Heading, err)
 			}
-			if pc.col.Transformer != nil {
-				val = pc.col.Transformer(val)
-			}
-			if pc.col.ColorFunc != nil {
-				rd.values[pc.col.Heading+"_colored"] = pc.col.ColorFunc(val)
-			}
-			rd.values[pc.col.Heading] = val
+			rc.cardTmpl = ct
 		}
-		if groupColIdx >= 0 {
-			rd.groupVal = rd.values[parsed[groupColIdx].col.Heading]
-		}
-		allRows[ri] = rd
+		parsed[i] = rc
 	}
-
-	// Determine card field order — exclude group column from card body
-	type cardField struct {
-		heading  string
-		hasColor bool
-	}
-	var cardFields []cardField
-	for _, pc := range parsed {
-		if groupColIdx >= 0 && pc.col.Heading == parsed[groupColIdx].col.Heading {
-			continue
-		}
-		cardFields = append(cardFields, cardField{
-			heading:  pc.col.Heading,
-			hasColor: pc.col.ColorFunc != nil,
-		})
-	}
-
-	// Find max heading length for alignment
-	maxHeadingLen := 0
-	for _, cf := range cardFields {
-		if len(cf.heading) > maxHeadingLen {
-			maxHeadingLen = len(cf.heading)
-		}
-	}
-
-	var buf bytes.Buffer
-
-	if groupColIdx >= 0 {
-		// Grouped cards: collect distinct group values in order
-		var groupOrder []string
-		groupRows := make(map[string][]rowData)
-		for _, rd := range allRows {
-			if _, exists := groupRows[rd.groupVal]; !exists {
-				groupOrder = append(groupOrder, rd.groupVal)
-			}
-			groupRows[rd.groupVal] = append(groupRows[rd.groupVal], rd)
-		}
-
-		for gi, group := range groupOrder {
-			// Group header: "── {label}: {value} ────────"
-			// Strip terminal escapes from group value — it comes from template execution.
-			strippedGroup := stripTerminalEscapes(group)
-			headerText := "── " + parsed[groupColIdx].col.Heading + ": " + strippedGroup + " "
-			remaining := max(termWidth-displayWidth(headerText), 1)
-			buf.WriteString(WithGrayFormat("%s", headerText+strings.Repeat("─", remaining)))
-			buf.WriteByte('\n')
-			buf.WriteByte('\n')
-
-			for ri, rd := range groupRows[group] {
-				for _, cf := range cardFields {
-					val := rd.values[cf.heading]
-					if val == "" {
-						continue
-					}
-					displayVal := val
-					if cf.hasColor {
-						if colored, ok := rd.values[cf.heading+"_colored"]; ok {
-							displayVal = colored
-						}
-					}
-					padding := maxHeadingLen - len(cf.heading)
-					buf.WriteString(cf.heading)
-					buf.WriteString(":")
-					buf.WriteString(strings.Repeat(" ", padding+2))
-					buf.WriteString(displayVal)
-					buf.WriteByte('\n')
-				}
-				if ri < len(groupRows[group])-1 {
-					buf.WriteByte('\n')
-				}
-			}
-
-			if gi < len(groupOrder)-1 {
-				buf.WriteByte('\n')
-			}
-		}
-	} else {
-		// Ungrouped cards — use first column as card title
-		boldTitle := color.New(color.Bold, color.FgHiWhite)
-
-		for ri, rd := range allRows {
-			titleHeading := parsed[0].col.Heading
-			titleVal := rd.values[titleHeading]
-
-			borderWidth := min(max(termWidth-2, 20), 76)
-
-			buf.WriteString(WithGrayFormat("┌" + strings.Repeat("─", borderWidth)))
-			buf.WriteByte('\n')
-			buf.WriteString("│ ")
-			buf.WriteString(boldTitle.Sprint(titleVal))
-			buf.WriteByte('\n')
-
-			for _, cf := range cardFields {
-				if cf.heading == titleHeading {
-					continue
-				}
-				val := rd.values[cf.heading]
-				if val == "" {
-					continue
-				}
-				if cf.hasColor {
-					if colored, ok := rd.values[cf.heading+"_colored"]; ok {
-						val = colored
-					}
-				}
-				padding := maxHeadingLen - len(cf.heading)
-				buf.WriteString("│ ")
-				buf.WriteString(cf.heading)
-				buf.WriteString(": ")
-				buf.WriteString(strings.Repeat(" ", padding))
-				buf.WriteString(val)
-				buf.WriteByte('\n')
-			}
-
-			buf.WriteString(WithGrayFormat("└" + strings.Repeat("─", borderWidth)))
-			buf.WriteByte('\n')
-			if ri < len(allRows)-1 {
-				buf.WriteByte('\n')
-			}
-		}
-	}
-
-	_, err := fmt.Fprint(writer, buf.String())
-	return err
-}
-
-// prettyExecTemplate renders a template against a data row and returns the string result.
-func prettyExecTemplate(tmpl *template.Template, data any) (string, error) {
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, data); err != nil {
-		return "", err
-	}
-	return buf.String(), nil
-}
-
-func sumWidths(widths []int) int {
-	total := 0
-	for _, w := range widths {
-		total += w
-	}
-	return total
-}
-
-// ansiRegex matches ANSI escape codes used for terminal coloring.
-var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
-
-// osc8Regex matches OSC-8 hyperlink escape sequences.
-// Format: \x1b]8;params;URI\x1b\  (ST terminator) or \x1b]8;params;URI\a (BEL terminator)
-var osc8Regex = regexp.MustCompile(`\x1b\]8;[^;]*;[^\x1b\a]*(?:\x1b\\|\a)`)
-
-// displayWidth returns the visible column width of s, ignoring ANSI escape
-// codes, OSC-8 hyperlink sequences, and accounting for wide Unicode characters (e.g. CJK).
-func displayWidth(s string) int {
-	return runewidth.StringWidth(stripTerminalEscapes(s))
-}
-
-func stripTerminalEscapes(s string) string {
-	stripped := osc8Regex.ReplaceAllString(s, "")
-	return ansiRegex.ReplaceAllString(stripped, "")
+	return parsed, nil
 }
 
 var _ Formatter = (*PrettyTableFormatter)(nil)

--- a/cli/azd/pkg/output/pretty_table_cards.go
+++ b/cli/azd/pkg/output/pretty_table_cards.go
@@ -1,0 +1,233 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+// cardRow holds the resolved values for a single row in the card layout.
+type cardRow struct {
+	values   map[string]string // heading -> value (Transformer applied)
+	colored  map[string]string // heading -> colored value (ColorFunc applied)
+	groupVal string
+}
+
+// formatGroupedCards renders rows as cards. When CardGroupColumn is set, cards
+// are grouped under a gray "── LABEL: value ──" header. A column flagged
+// CardTitle is rendered as the card's highlighted title line and excluded from
+// the labeled fields; without a CardTitle column the legacy boxed layout is used
+// for ungrouped cards.
+func (f *PrettyTableFormatter) formatGroupedCards(
+	parsed []resolvedColumn, rows []any, termWidth int, writer io.Writer, options PrettyTableFormatterOptions,
+) error {
+	groupColIdx := -1
+	if options.CardGroupColumn != "" {
+		for i, rc := range parsed {
+			if rc.col.Heading == options.CardGroupColumn {
+				groupColIdx = i
+				break
+			}
+		}
+		if groupColIdx < 0 {
+			return fmt.Errorf("CardGroupColumn %q does not match any column heading", options.CardGroupColumn)
+		}
+	}
+
+	titleColIdx := -1
+	for i, rc := range parsed {
+		if rc.col.CardTitle {
+			titleColIdx = i
+			break
+		}
+	}
+
+	allRows, err := resolveCardRows(parsed, rows, groupColIdx)
+	if err != nil {
+		return err
+	}
+
+	// Card field order excludes the group column and the title column.
+	var cardFields []resolvedColumn
+	for i, rc := range parsed {
+		if i == groupColIdx || i == titleColIdx {
+			continue
+		}
+		cardFields = append(cardFields, rc)
+	}
+	maxHeadingLen := 0
+	for _, cf := range cardFields {
+		maxHeadingLen = max(maxHeadingLen, len(cf.col.Heading))
+	}
+
+	titleHeading := ""
+	if titleColIdx >= 0 {
+		titleHeading = parsed[titleColIdx].col.Heading
+	}
+
+	var buf bytes.Buffer
+	if groupColIdx >= 0 {
+		f.writeGroupedCards(
+			&buf, allRows, cardFields, parsed[groupColIdx].col.Heading,
+			titleHeading, maxHeadingLen, termWidth,
+		)
+	} else if titleColIdx >= 0 {
+		f.writeTitledCards(&buf, allRows, cardFields, titleHeading, maxHeadingLen)
+	} else {
+		f.writeBoxedCards(&buf, allRows, parsed, maxHeadingLen, termWidth)
+	}
+
+	_, err = fmt.Fprint(writer, buf.String())
+	return err
+}
+
+// resolveCardRows executes the card templates (preferring CardValueTemplate) for
+// each row and applies Transformer/ColorFunc.
+func resolveCardRows(parsed []resolvedColumn, rows []any, groupColIdx int) ([]cardRow, error) {
+	allRows := make([]cardRow, len(rows))
+	for ri, row := range rows {
+		rd := cardRow{values: make(map[string]string), colored: make(map[string]string)}
+		for _, rc := range parsed {
+			tmpl := rc.tmpl
+			if rc.cardTmpl != nil {
+				tmpl = rc.cardTmpl
+			}
+			val, err := prettyExecTemplate(tmpl, row)
+			if err != nil {
+				return nil, fmt.Errorf("row %d, column %q: %w", ri, rc.col.Heading, err)
+			}
+			if rc.col.Transformer != nil {
+				val = rc.col.Transformer(val)
+			}
+			if rc.col.ColorFunc != nil {
+				rd.colored[rc.col.Heading] = rc.col.ColorFunc(val)
+			}
+			rd.values[rc.col.Heading] = val
+		}
+		if groupColIdx >= 0 {
+			rd.groupVal = rd.values[parsed[groupColIdx].col.Heading]
+		}
+		allRows[ri] = rd
+	}
+	return allRows, nil
+}
+
+// writeGroupedCards renders cards grouped under gray "── LABEL: value ──" headers.
+func (f *PrettyTableFormatter) writeGroupedCards(
+	buf *bytes.Buffer, allRows []cardRow, cardFields []resolvedColumn,
+	groupHeading, titleHeading string, maxHeadingLen, termWidth int,
+) {
+	var groupOrder []string
+	groupRows := make(map[string][]cardRow)
+	for _, rd := range allRows {
+		if _, ok := groupRows[rd.groupVal]; !ok {
+			groupOrder = append(groupOrder, rd.groupVal)
+		}
+		groupRows[rd.groupVal] = append(groupRows[rd.groupVal], rd)
+	}
+
+	for gi, group := range groupOrder {
+		headerText := "── " + groupHeading + ": " + stripTerminalEscapes(group) + " "
+		remaining := max(termWidth-displayWidth(headerText), 1)
+		buf.WriteString(WithGrayFormat("%s", headerText+strings.Repeat("─", remaining)))
+		buf.WriteString("\n\n")
+
+		rowsInGroup := groupRows[group]
+		for ri, rd := range rowsInGroup {
+			writeCardBody(buf, rd, cardFields, titleHeading, maxHeadingLen)
+			if ri < len(rowsInGroup)-1 {
+				buf.WriteByte('\n')
+			}
+		}
+		if gi < len(groupOrder)-1 {
+			buf.WriteByte('\n')
+		}
+	}
+}
+
+// writeTitledCards renders ungrouped, borderless cards with a highlighted title.
+func (f *PrettyTableFormatter) writeTitledCards(
+	buf *bytes.Buffer, allRows []cardRow, cardFields []resolvedColumn, titleHeading string, maxHeadingLen int,
+) {
+	for ri, rd := range allRows {
+		writeCardBody(buf, rd, cardFields, titleHeading, maxHeadingLen)
+		if ri < len(allRows)-1 {
+			buf.WriteByte('\n')
+		}
+	}
+}
+
+// writeCardBody writes a single card: an optional highlighted title line followed
+// by aligned "HEADING: value" fields, skipping empty values.
+func writeCardBody(
+	buf *bytes.Buffer, rd cardRow, cardFields []resolvedColumn, titleHeading string, maxHeadingLen int,
+) {
+	if titleHeading != "" {
+		if title := rd.values[titleHeading]; title != "" {
+			buf.WriteString(WithHighLightFormat("%s", stripTerminalEscapes(title)))
+			buf.WriteByte('\n')
+		}
+	}
+	for _, cf := range cardFields {
+		val := rd.values[cf.col.Heading]
+		if val == "" {
+			continue
+		}
+		if colored, ok := rd.colored[cf.col.Heading]; ok {
+			val = colored
+		}
+		buf.WriteString(cf.col.Heading)
+		buf.WriteString(":")
+		buf.WriteString(strings.Repeat(" ", maxHeadingLen-len(cf.col.Heading)+2))
+		buf.WriteString(val)
+		buf.WriteByte('\n')
+	}
+}
+
+// writeBoxedCards renders the legacy boxed ungrouped card layout used when no
+// CardTitle column is configured.
+func (f *PrettyTableFormatter) writeBoxedCards(
+	buf *bytes.Buffer, allRows []cardRow, parsed []resolvedColumn, maxHeadingLen, termWidth int,
+) {
+	boldTitle := color.New(color.Bold, color.FgHiWhite)
+	titleHeading := parsed[0].col.Heading
+	for ri, rd := range allRows {
+		borderWidth := min(max(termWidth-2, 20), 76)
+		buf.WriteString(WithGrayFormat("┌" + strings.Repeat("─", borderWidth)))
+		buf.WriteByte('\n')
+		buf.WriteString("│ ")
+		buf.WriteString(boldTitle.Sprint(rd.values[titleHeading]))
+		buf.WriteByte('\n')
+
+		for _, rc := range parsed {
+			if rc.col.Heading == titleHeading {
+				continue
+			}
+			val := rd.values[rc.col.Heading]
+			if val == "" {
+				continue
+			}
+			if colored, ok := rd.colored[rc.col.Heading]; ok {
+				val = colored
+			}
+			buf.WriteString("│ ")
+			buf.WriteString(rc.col.Heading)
+			buf.WriteString(": ")
+			buf.WriteString(strings.Repeat(" ", maxHeadingLen-len(rc.col.Heading)))
+			buf.WriteString(val)
+			buf.WriteByte('\n')
+		}
+
+		buf.WriteString(WithGrayFormat("└" + strings.Repeat("─", borderWidth)))
+		buf.WriteByte('\n')
+		if ri < len(allRows)-1 {
+			buf.WriteByte('\n')
+		}
+	}
+}

--- a/cli/azd/pkg/output/pretty_table_layout.go
+++ b/cli/azd/pkg/output/pretty_table_layout.go
@@ -148,8 +148,14 @@ func shrinkOrder(cols []resolvedColumn) []int {
 // layoutCell returns the display lines for a value rendered within width and
 // reports whether content was lost (truncated). Wrappable values wrap onto at
 // most maxWrapLines lines before truncating; others render on a single line,
-// truncating with an ellipsis when needed. Values that contain terminal escape
-// sequences are returned unchanged to avoid corrupting them.
+// truncating with an ellipsis when needed.
+//
+// Values that contain terminal escape sequences (ANSI color or OSC-8
+// hyperlinks) are returned unchanged: truncating mid-sequence would corrupt the
+// output, and escape-bearing columns are only configured as non-shrinkable
+// (e.g. LOCATION links), so they are never assigned a width below their content
+// and this branch is not reached in practice. Mark such a column Truncatable
+// only after teaching this function to truncate while preserving escapes.
 func layoutCell(value string, width int, wrappable bool) ([]string, bool) {
 	if value == "" {
 		return []string{""}, false
@@ -215,6 +221,13 @@ func wrapWords(words []string, width int) []string {
 				current = ""
 			}
 			head := takeWidth(word, width)
+			if head == "" {
+				// width is too narrow for even the first rune (e.g. width 1 with a
+				// width-2 rune). Take one rune anyway so the loop makes progress;
+				// the cell overflows by at most one rune, which only happens at
+				// degenerate widths.
+				head = string([]rune(word)[0])
+			}
 			lines = append(lines, head)
 			word = word[len(head):]
 		}

--- a/cli/azd/pkg/output/pretty_table_layout.go
+++ b/cli/azd/pkg/output/pretty_table_layout.go
@@ -1,0 +1,316 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+	"text/template"
+	"unicode"
+
+	"github.com/mattn/go-runewidth"
+)
+
+// ansiRegex matches ANSI escape codes used for terminal coloring.
+var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// osc8Regex matches OSC-8 hyperlink escape sequences.
+// Format: \x1b]8;params;URI\x1b\  (ST terminator) or \x1b]8;params;URI\a (BEL terminator)
+var osc8Regex = regexp.MustCompile(`\x1b\]8;[^;]*;[^\x1b\a]*(?:\x1b\\|\a)`)
+
+// displayWidth returns the visible column width of s, ignoring ANSI escape
+// codes, OSC-8 hyperlink sequences, and accounting for wide Unicode characters.
+func displayWidth(s string) int {
+	return runewidth.StringWidth(stripTerminalEscapes(s))
+}
+
+// stripTerminalEscapes removes OSC-8 hyperlink and ANSI color escape sequences.
+func stripTerminalEscapes(s string) string {
+	stripped := osc8Regex.ReplaceAllString(s, "")
+	return ansiRegex.ReplaceAllString(stripped, "")
+}
+
+// hasTerminalEscapes reports whether s contains ANSI or OSC-8 escape sequences.
+func hasTerminalEscapes(s string) bool {
+	return ansiRegex.MatchString(s) || osc8Regex.MatchString(s)
+}
+
+func sumWidths(widths []int) int {
+	total := 0
+	for _, w := range widths {
+		total += w
+	}
+	return total
+}
+
+// prettyExecTemplate renders a template against a data row and returns the string result.
+func prettyExecTemplate(tmpl *template.Template, data any) (string, error) {
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// rowWidth returns the total rendered width of a row given per-column widths,
+// including the padding between columns.
+func rowWidth(widths []int) int {
+	if len(widths) == 0 {
+		return 0
+	}
+	return sumWidths(widths) + (len(widths)-1)*columnPadding
+}
+
+// columnFloor returns the minimum width a column may be shrunk to. Non-shrinkable
+// columns return their natural width. The floor never drops below the heading
+// width, so headings are never truncated.
+func columnFloor(c resolvedColumn, natural int) int {
+	headingWidth := displayWidth(c.col.Heading)
+	switch {
+	case c.col.Truncatable:
+		// A truncatable column can shrink to a few characters plus the ellipsis.
+		// If it is also wrappable, it wraps across maxWrapLines lines and then
+		// truncates within them, so it can still reach this small floor — which
+		// lets it yield space to columns that cannot truncate.
+		target := minVisibleChars + displayWidth(ellipsis)
+		return clampWidth(target, headingWidth, natural)
+	case c.col.Wrappable:
+		// A wrap-only column spreads its content across maxWrapLines lines, so it
+		// needs roughly natural/maxWrapLines width to show everything.
+		target := (natural + maxWrapLines - 1) / maxWrapLines
+		return clampWidth(target, headingWidth, natural)
+	default:
+		return natural
+	}
+}
+
+// clampWidth returns target bounded to [floor, ceil], assuming floor ≤ ceil.
+func clampWidth(target, floor, ceil int) int {
+	return min(max(target, floor), ceil)
+}
+
+// fitColumns assigns a rendered width to each column so the row fits termWidth.
+// Overflow is reclaimed from shrinkable columns (Truncatable or Wrappable),
+// shrinking the least-important columns first (highest Priority, then right-most).
+// Non-shrinkable columns keep their natural width. The returned widths are never
+// smaller than each column's floor; if the row still overflows, it is left to
+// overflow rather than truncating headings.
+func fitColumns(cols []resolvedColumn, natural []int, termWidth int) []int {
+	widths := make([]int, len(natural))
+	copy(widths, natural)
+
+	if rowWidth(widths) <= termWidth || len(cols) == 0 {
+		return widths
+	}
+
+	order := shrinkOrder(cols)
+	for _, ci := range order {
+		if rowWidth(widths) <= termWidth {
+			break
+		}
+		floor := columnFloor(cols[ci], natural[ci])
+		if widths[ci] <= floor {
+			continue
+		}
+		over := rowWidth(widths) - termWidth
+		widths[ci] = max(widths[ci]-over, floor)
+	}
+
+	return widths
+}
+
+// shrinkOrder returns the indices of shrinkable columns in the order they should
+// be shrunk: least important first (highest Priority), ties broken right-to-left.
+func shrinkOrder(cols []resolvedColumn) []int {
+	order := make([]int, 0, len(cols))
+	for i, c := range cols {
+		if c.col.Truncatable || c.col.Wrappable {
+			order = append(order, i)
+		}
+	}
+	// Stable sort: higher priority value first; equal priority right-most first.
+	for i := 1; i < len(order); i++ {
+		for j := i; j > 0; j-- {
+			a, b := order[j-1], order[j]
+			swap := cols[a].priority() < cols[b].priority() ||
+				(cols[a].priority() == cols[b].priority() && a < b)
+			if !swap {
+				break
+			}
+			order[j-1], order[j] = order[j], order[j-1]
+		}
+	}
+	return order
+}
+
+// layoutCell returns the display lines for a value rendered within width and
+// reports whether content was lost (truncated). Wrappable values wrap onto at
+// most maxWrapLines lines before truncating; others render on a single line,
+// truncating with an ellipsis when needed. Values that contain terminal escape
+// sequences are returned unchanged to avoid corrupting them.
+func layoutCell(value string, width int, wrappable bool) ([]string, bool) {
+	if value == "" {
+		return []string{""}, false
+	}
+	if displayWidth(value) <= width || hasTerminalEscapes(value) || width <= 0 {
+		return []string{value}, false
+	}
+	if wrappable {
+		return wrapValue(value, width, maxWrapLines)
+	}
+	return []string{truncateWithEllipsis(value, width)}, true
+}
+
+// truncateWithEllipsis shortens s to fit within maxWidth display columns,
+// appending an ellipsis. At least minVisibleChars characters are kept.
+func truncateWithEllipsis(s string, maxWidth int) string {
+	if displayWidth(s) <= maxWidth {
+		return s
+	}
+	keep := max(maxWidth-displayWidth(ellipsis), minVisibleChars)
+	return takeWidth(s, keep) + ellipsis
+}
+
+// wrapValue word-wraps s onto at most maxLines lines of the given width. If
+// content remains after maxLines lines, the last line is truncated with an
+// ellipsis. It reports whether any content was lost.
+func wrapValue(s string, width, maxLines int) ([]string, bool) {
+	if maxLines <= 0 {
+		return []string{""}, true
+	}
+	if width <= 0 {
+		return []string{s}, true
+	}
+	words := strings.Fields(s)
+	if len(words) == 0 {
+		return []string{""}, false
+	}
+
+	all := wrapWords(words, width)
+	if len(all) <= maxLines {
+		return all, false
+	}
+
+	// Keep the first maxLines lines and mark the last one as truncated so the
+	// dropped content is visibly indicated.
+	kept := all[:maxLines:maxLines]
+	last := kept[len(kept)-1]
+	kept[len(kept)-1] = truncateWithEllipsis(last+" "+ellipsis, width)
+	return kept, true
+}
+
+// wrapWords greedily wraps words into lines no wider than width, hard-splitting
+// any single word that exceeds width. It applies no line limit; callers cap the
+// result as needed.
+func wrapWords(words []string, width int) []string {
+	var lines []string
+	var current string
+	for _, word := range words {
+		// Hard-split a word that is wider than a full line into width-sized chunks.
+		for displayWidth(word) > width {
+			if current != "" {
+				lines = append(lines, current)
+				current = ""
+			}
+			head := takeWidth(word, width)
+			lines = append(lines, head)
+			word = word[len(head):]
+		}
+		if word == "" {
+			continue
+		}
+		switch {
+		case current == "":
+			current = word
+		case displayWidth(current)+1+displayWidth(word) <= width:
+			current += " " + word
+		default:
+			lines = append(lines, current)
+			current = word
+		}
+	}
+	if current != "" {
+		lines = append(lines, current)
+	}
+	return lines
+}
+
+// takeWidth returns the longest prefix of s whose display width is ≤ width.
+func takeWidth(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	var b strings.Builder
+	used := 0
+	for _, r := range s {
+		rw := runewidth.RuneWidth(r)
+		if used+rw > width {
+			break
+		}
+		b.WriteRune(r)
+		used += rw
+	}
+	return b.String()
+}
+
+// buildColumnHint returns the responsive hint message shown after a table when
+// columns are hidden or values are truncated, or "" when no hint is needed.
+// When columns are hidden it is prefixed with "Showing N of M columns.".
+func buildColumnHint(visible, total int, truncated bool) string {
+	hidden := total - visible
+	if hidden <= 0 && !truncated {
+		return ""
+	}
+	resize := fmt.Sprintf(
+		"Resize the terminal or run with %s for full details.",
+		WithHighLightFormat("-o json"),
+	)
+	if hidden > 0 {
+		return fmt.Sprintf("Showing %d of %d columns. %s", visible, total, resize)
+	}
+	return resize
+}
+
+// alignLeadingSymbols left-pads values that lack a leading "symbol + space"
+// prefix so their text aligns with values that have one (e.g. so "Up to date"
+// aligns under the text of "⟳ Update available"). When no value has a leading
+// symbol, the values are returned unchanged (left-aligned).
+func alignLeadingSymbols(values []string) []string {
+	width := 0
+	for _, v := range values {
+		width = max(width, leadingSymbolWidth(v))
+	}
+	if width == 0 {
+		return values
+	}
+	out := make([]string, len(values))
+	for i, v := range values {
+		if v == "" {
+			out[i] = ""
+			continue
+		}
+		out[i] = strings.Repeat(" ", width-leadingSymbolWidth(v)) + v
+	}
+	return out
+}
+
+// leadingSymbolWidth returns the display width of a leading "symbol + space"
+// prefix (e.g. "⟳ "), or 0 when the value is empty or begins with a letter,
+// digit, or whitespace.
+func leadingSymbolWidth(v string) int {
+	if v == "" {
+		return 0
+	}
+	first := []rune(v)[0]
+	if unicode.IsLetter(first) || unicode.IsDigit(first) || unicode.IsSpace(first) {
+		return 0
+	}
+	idx := strings.IndexByte(v, ' ')
+	if idx < 0 {
+		return 0
+	}
+	return displayWidth(v[:idx+1])
+}

--- a/cli/azd/pkg/output/pretty_table_layout.go
+++ b/cli/azd/pkg/output/pretty_table_layout.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
-	"unicode"
 
 	"github.com/mattn/go-runewidth"
 )
@@ -272,45 +271,4 @@ func buildColumnHint(visible, total int, truncated bool) string {
 		return fmt.Sprintf("Showing %d of %d columns. %s", visible, total, resize)
 	}
 	return resize
-}
-
-// alignLeadingSymbols left-pads values that lack a leading "symbol + space"
-// prefix so their text aligns with values that have one (e.g. so "Up to date"
-// aligns under the text of "⟳ Update available"). When no value has a leading
-// symbol, the values are returned unchanged (left-aligned).
-func alignLeadingSymbols(values []string) []string {
-	width := 0
-	for _, v := range values {
-		width = max(width, leadingSymbolWidth(v))
-	}
-	if width == 0 {
-		return values
-	}
-	out := make([]string, len(values))
-	for i, v := range values {
-		if v == "" {
-			out[i] = ""
-			continue
-		}
-		out[i] = strings.Repeat(" ", width-leadingSymbolWidth(v)) + v
-	}
-	return out
-}
-
-// leadingSymbolWidth returns the display width of a leading "symbol + space"
-// prefix (e.g. "⟳ "), or 0 when the value is empty or begins with a letter,
-// digit, or whitespace.
-func leadingSymbolWidth(v string) int {
-	if v == "" {
-		return 0
-	}
-	first := []rune(v)[0]
-	if unicode.IsLetter(first) || unicode.IsDigit(first) || unicode.IsSpace(first) {
-		return 0
-	}
-	idx := strings.IndexByte(v, ' ')
-	if idx < 0 {
-		return 0
-	}
-	return displayWidth(v[:idx+1])
 }

--- a/cli/azd/pkg/output/pretty_table_responsive_test.go
+++ b/cli/azd/pkg/output/pretty_table_responsive_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/stretchr/testify/require"
@@ -154,6 +155,53 @@ func TestLayoutCellPreservesEscapedValues(t *testing.T) {
 	lines, trunc := layoutCell(value, 10, false)
 	require.False(t, trunc)
 	require.Equal(t, []string{value}, lines)
+}
+
+func TestWrapWordsTerminatesAtNarrowWidth(t *testing.T) {
+	// Regression: a width narrower than the leading rune's display width (e.g.
+	// width 1 with a width-2 CJK rune) must not loop forever. Each subtest runs
+	// in a bounded goroutine and fails if wrapping hangs.
+	cases := []struct {
+		name  string
+		words []string
+		width int
+	}{
+		{"wide rune at width 1", []string{"日本語"}, 1},
+		{"mixed ascii and wide rune at width 1", []string{"ab", "日"}, 1},
+		{"wide runes at width 0 via wrapValue", []string{"日本"}, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			done := make(chan []string, 1)
+			go func() { done <- wrapWords(tc.words, tc.width) }()
+			select {
+			case lines := <-done:
+				// Every input rune is preserved across the produced lines.
+				require.NotEmpty(t, lines)
+				require.Equal(t,
+					strings.Join(strings.Fields(strings.Join(tc.words, " ")), ""),
+					strings.ReplaceAll(strings.Join(lines, ""), " ", ""))
+			case <-time.After(2 * time.Second):
+				t.Fatal("wrapWords did not terminate")
+			}
+		})
+	}
+}
+
+func TestWrapValueNarrowWidthTerminates(t *testing.T) {
+	// layoutCell delegates to wrapValue for wrappable values; a degenerate width
+	// must still terminate and stay bounded to maxWrapLines.
+	done := make(chan []string, 1)
+	go func() {
+		lines, _ := layoutCell("日本語テスト", 1, true)
+		done <- lines
+	}()
+	select {
+	case lines := <-done:
+		require.LessOrEqual(t, len(lines), maxWrapLines)
+	case <-time.After(2 * time.Second):
+		t.Fatal("layoutCell did not terminate for a wrappable wide-rune value at width 1")
+	}
 }
 
 func TestShrinkOrderLeastImportantFirst(t *testing.T) {

--- a/cli/azd/pkg/output/pretty_table_responsive_test.go
+++ b/cli/azd/pkg/output/pretty_table_responsive_test.go
@@ -396,7 +396,7 @@ func TestAlignLeadingSymbols(t *testing.T) {
 func TestResponsiveStatusAlignment(t *testing.T) {
 	// dataLineContaining returns the stripped rendered line containing substr.
 	dataLineContaining := func(out, substr string) string {
-		for _, line := range strings.Split(out, "\n") {
+		for line := range strings.SplitSeq(out, "\n") {
 			if strings.Contains(line, substr) {
 				return line
 			}

--- a/cli/azd/pkg/output/pretty_table_responsive_test.go
+++ b/cli/azd/pkg/output/pretty_table_responsive_test.go
@@ -359,83 +359,6 @@ func TestCardTitleUngroupedBorderless(t *testing.T) {
 	require.NotContains(t, stripTerminalEscapes(out), "LATEST:")
 }
 
-func TestAlignLeadingSymbols(t *testing.T) {
-	tests := []struct {
-		name string
-		in   []string
-		want []string
-	}{
-		{
-			name: "no leading symbol leaves values untouched",
-			in:   []string{"Up to date", "Not installed", "Installed"},
-			want: []string{"Up to date", "Not installed", "Installed"},
-		},
-		{
-			name: "pads plain values to align under symbol text",
-			in:   []string{"⟳ Update available", "Up to date", "Not installed"},
-			want: []string{"⟳ Update available", "  Up to date", "  Not installed"},
-		},
-		{
-			name: "value that already has a symbol is unchanged",
-			in:   []string{"⟳ Update available", "⚠ Incompatible"},
-			want: []string{"⟳ Update available", "⚠ Incompatible"},
-		},
-		{
-			name: "empty values are not padded",
-			in:   []string{"⟳ Update available", ""},
-			want: []string{"⟳ Update available", ""},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, alignLeadingSymbols(tt.in))
-		})
-	}
-}
-
-func TestResponsiveStatusAlignment(t *testing.T) {
-	// dataLineContaining returns the stripped rendered line containing substr.
-	dataLineContaining := func(out, substr string) string {
-		for line := range strings.SplitSeq(out, "\n") {
-			if strings.Contains(line, substr) {
-				return line
-			}
-		}
-		return ""
-	}
-	textColumn := func(line, text string) int {
-		before, _, ok := strings.Cut(line, text)
-		require.True(t, ok, "text %q not found in %q", text, line)
-		return displayWidth(before)
-	}
-
-	columns := []PrettyColumn{
-		{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
-		{
-			Column:             Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
-			Priority:           1,
-			AlignLeadingSymbol: true,
-		},
-		{Column: Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"}, Priority: 1},
-	}
-
-	// When a symbol is present, the status text aligns: "Update available" and
-	// "Up to date" begin at the same display column (the no-padding case is
-	// covered directly by TestAlignLeadingSymbols).
-	rows := []responsiveInput{
-		{Id: "a", Status: "⟳ Update available", Source: "azd"},
-		{Id: "b", Status: "Up to date", Source: "azd"},
-	}
-	formatter := &PrettyTableFormatter{ConsoleWidthFn: func() int { return 120 }}
-	buf := &bytes.Buffer{}
-	require.NoError(t, formatter.Format(rows, buf, PrettyTableFormatterOptions{Columns: columns}))
-	out := stripTerminalEscapes(buf.String())
-
-	updateCol := textColumn(dataLineContaining(out, "Update available"), "Update available")
-	upToDateCol := textColumn(dataLineContaining(out, "Up to date"), "Up to date")
-	require.Equal(t, updateCol, upToDateCol)
-}
-
 func TestEllipsisAndHiddenColumnGlyphs(t *testing.T) {
 	// The package uses the single-character ellipsis for truncated values and
 	// three middle dots for the hidden-column placeholder header.
@@ -495,11 +418,10 @@ func TestResponsiveTruncatedStatusKeepsColor(t *testing.T) {
 	columns := []PrettyColumn{
 		{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
 		{
-			Column:             Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
-			Priority:           1,
-			Truncatable:        true,
-			AlignLeadingSymbol: true,
-			ColorFunc:          statusColor,
+			Column:      Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+			Priority:    1,
+			Truncatable: true,
+			ColorFunc:   statusColor,
 		},
 		{Column: Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"}, Priority: 1},
 	}

--- a/cli/azd/pkg/output/pretty_table_responsive_test.go
+++ b/cli/azd/pkg/output/pretty_table_responsive_test.go
@@ -1,0 +1,596 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/require"
+)
+
+// responsiveInput is the row type used by the responsive-layout tests.
+type responsiveInput struct {
+	Id               string
+	Name             string
+	Status           string
+	InstalledVersion string
+	LatestVersion    string
+	Category         string
+	Priority         string
+	Source           string
+	UpdateAvailable  bool
+}
+
+// toolCheckTestColumns mirrors the azd tool check column configuration:
+// wrapping NAME card title, truncatable STATUS/LATEST, card value omission.
+func toolCheckTestColumns() []PrettyColumn {
+	return []PrettyColumn{
+		{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+		{
+			Column:      Column{Heading: "NAME", ValueTemplate: "{{.Name}}"},
+			Priority:    2,
+			CardTitle:   true,
+			Wrappable:   true,
+			Truncatable: true,
+		},
+		{
+			Column:      Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+			Priority:    1,
+			Truncatable: true,
+		},
+		{
+			Column: Column{
+				Heading:       "INSTALLED",
+				ValueTemplate: `{{if .InstalledVersion}}{{.InstalledVersion}}{{else}}-{{end}}`,
+			},
+			CardValueTemplate: `{{if .InstalledVersion}}{{.InstalledVersion}}{{end}}`,
+			Priority:          1,
+		},
+		{
+			Column:            Column{Heading: "LATEST", ValueTemplate: "{{.LatestVersion}}"},
+			CardValueTemplate: `{{if or .UpdateAvailable (not .InstalledVersion)}}{{.LatestVersion}}{{end}}`,
+			Priority:          3,
+			Truncatable:       true,
+		},
+	}
+}
+
+func TestTruncateWithEllipsis(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		width int
+		want  string
+	}{
+		{"fits", "hello", 10, "hello"},
+		{"exact", "hello", 5, "hello"},
+		{"truncates", "0.1.20-preview", 9, "0.1.20-p…"},
+		{"keeps min five chars", "abcdefghij", 6, "abcde…"},
+		{"wide runes", "日本語テスト", 7, "日本語…"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateWithEllipsis(tt.input, tt.width)
+			require.Equal(t, tt.want, got)
+			ceiling := max(tt.width, minVisibleChars+displayWidth(ellipsis))
+			require.LessOrEqual(t, displayWidth(stripTerminalEscapes(got)), ceiling)
+		})
+	}
+}
+
+func TestWrapValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		width     int
+		maxLines  int
+		wantLines []string
+		wantTrunc bool
+	}{
+		{
+			name:      "two lines no truncation",
+			input:     "GitHub Copilot Chat VS Code Extension",
+			width:     20,
+			maxLines:  2,
+			wantLines: []string{"GitHub Copilot Chat", "VS Code Extension"},
+			wantTrunc: false,
+		},
+		{
+			name:      "truncates beyond max lines",
+			input:     "one two three four five six seven eight",
+			width:     10,
+			maxLines:  2,
+			wantTrunc: true,
+		},
+		{
+			name:      "single word longer than width",
+			input:     "supercalifragilistic",
+			width:     8,
+			maxLines:  2,
+			wantTrunc: true,
+		},
+		{
+			// Regression: multiple short words at a narrow width must still cap at
+			// maxLines (this previously produced 4 lines for "Bicep VS Code
+			// Extension" because a carried line plus a hard-split next word blew
+			// past the cap).
+			name:      "many short words capped at two lines",
+			input:     "Bicep VS Code Extension",
+			width:     6,
+			maxLines:  2,
+			wantLines: []string{"Bicep", "VS …"},
+			wantTrunc: true,
+		},
+		{
+			name:      "word wider than narrow column still caps",
+			input:     "GitHub Copilot Chat VS Code Extension",
+			width:     6,
+			maxLines:  2,
+			wantTrunc: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines, trunc := wrapValue(tt.input, tt.width, tt.maxLines)
+			require.LessOrEqual(t, len(lines), tt.maxLines)
+			for _, ln := range lines {
+				require.LessOrEqual(t, displayWidth(ln), tt.width, "line %q exceeds width", ln)
+			}
+			require.Equal(t, tt.wantTrunc, trunc)
+			if tt.wantLines != nil {
+				require.Equal(t, tt.wantLines, lines)
+			}
+		})
+	}
+}
+
+func TestLayoutCellPreservesEscapedValues(t *testing.T) {
+	// A value containing escape sequences must not be truncated/wrapped.
+	value := "\x1b[36mhttps://example.com/a-very-long-link\x1b[0m"
+	lines, trunc := layoutCell(value, 10, false)
+	require.False(t, trunc)
+	require.Equal(t, []string{value}, lines)
+}
+
+func TestShrinkOrderLeastImportantFirst(t *testing.T) {
+	cols, err := parseColumns([]PrettyColumn{
+		{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+		{Column: Column{Heading: "NAME", ValueTemplate: "{{.Name}}"}, Priority: 2, Wrappable: true},
+		{Column: Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"}, Priority: 1, Truncatable: true},
+		{Column: Column{Heading: "CATEGORY", ValueTemplate: "{{.Category}}"}, Priority: 3, Truncatable: true},
+		{Column: Column{Heading: "PRIORITY", ValueTemplate: "{{.Priority}}"}, Priority: 3, Truncatable: true},
+	})
+	require.NoError(t, err)
+
+	order := shrinkOrder(cols)
+	// Indices: 1=NAME(p2), 2=STATUS(p1), 3=CATEGORY(p3), 4=PRIORITY(p3).
+	// Highest priority first; equal priority right-most first → PRIORITY, CATEGORY, NAME, STATUS.
+	require.Equal(t, []int{4, 3, 1, 2}, order)
+}
+
+func TestFitColumnsTruncatesLeastImportantFirst(t *testing.T) {
+	cols, err := parseColumns(toolCheckTestColumns())
+	require.NoError(t, err)
+	// Natural widths for ID, NAME, STATUS, INSTALLED, LATEST.
+	natural := []int{19, 37, 18, 14, 14}
+
+	widths := fitColumns(cols, natural, 100)
+	require.LessOrEqual(t, rowWidth(widths), 100)
+	// ID is not shrinkable and keeps its natural width.
+	require.Equal(t, 19, widths[0])
+	// LATEST (least important truncatable) shrinks before STATUS (priority 1).
+	require.Less(t, widths[4], natural[4])
+	require.Equal(t, natural[2], widths[2], "STATUS should not shrink while LATEST can absorb the deficit")
+}
+
+func TestBuildColumnHint(t *testing.T) {
+	previousNoColor := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = previousNoColor })
+
+	require.Equal(t, "", buildColumnHint(5, 5, false))
+	require.Equal(t,
+		"Resize the terminal or run with -o json for full details.",
+		buildColumnHint(5, 5, true))
+	require.Equal(t,
+		"Showing 4 of 6 columns. Resize the terminal or run with -o json for full details.",
+		buildColumnHint(4, 6, false))
+}
+
+func TestResponsiveFullTableTruncatesAndHints(t *testing.T) {
+	rows := []responsiveInput{
+		{
+			Id: "GitHub.copilot-chat", Name: "GitHub Copilot Chat VS Code Extension",
+			Status: "Not installed", LatestVersion: "1.0.6-preview-build",
+		},
+	}
+	// Width 100 selects the full breakpoint, where overflow truncates values
+	// (no columns are dropped) and the hint omits the column count.
+	formatter := &PrettyTableFormatter{ConsoleWidthFn: func() int { return 100 }}
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns:              toolCheckTestColumns(),
+		ResponsiveColumnHint: true,
+	})
+	require.NoError(t, err)
+	out := stripTerminalEscapes(buf.String())
+
+	// All columns remain visible at the full breakpoint.
+	require.Contains(t, out, "LATEST")
+	// The hint appears without a column count (full breakpoint, values truncated).
+	require.Contains(t, out, "Resize the terminal or run with -o json for full details.")
+	require.NotContains(t, out, "Showing")
+	// No row exceeds the terminal width.
+	for line := range strings.SplitSeq(out, "\n") {
+		require.LessOrEqual(t, displayWidth(line), 100, "line exceeds width: %q", line)
+	}
+}
+
+func TestResponsiveCompactAddsHiddenColumnAndHint(t *testing.T) {
+	rows := []responsiveInput{
+		{Id: "az-cli", Name: "Azure CLI", Status: "Up to date", InstalledVersion: "1.0.0", LatestVersion: "1.0.0"},
+	}
+	formatter := &PrettyTableFormatter{ConsoleWidthFn: func() int { return 80 }}
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns:              toolCheckTestColumns(),
+		ResponsiveColumnHint: true,
+	})
+	require.NoError(t, err)
+	out := stripTerminalEscapes(buf.String())
+
+	// LATEST (priority 3) is hidden; the "⋯" placeholder column is present.
+	require.NotContains(t, out, "LATEST")
+	require.Contains(t, out, hiddenColumnHeading)
+	require.Contains(t, out,
+		"Showing 4 of 5 columns. Resize the terminal or run with -o json for full details.")
+}
+
+func TestResponsiveCompactNoHintWhenNoColumnsHidden(t *testing.T) {
+	rows := []responsiveInput{{Id: "az-cli", Status: "ok"}}
+	cols := []PrettyColumn{
+		{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+		{Column: Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"}, Priority: 1},
+	}
+	formatter := &PrettyTableFormatter{ConsoleWidthFn: func() int { return 80 }}
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns:              cols,
+		ResponsiveColumnHint: true,
+	})
+	require.NoError(t, err)
+	out := buf.String()
+	require.NotContains(t, out, "Showing")
+	require.NotContains(t, out, "Resize the terminal")
+	require.NotContains(t, out, hiddenColumnHeading)
+}
+
+func TestResponsiveColumnHintDisabledByDefault(t *testing.T) {
+	rows := []responsiveInput{{Id: "az-cli", Name: "Azure CLI", Status: "ok", LatestVersion: "1.0.0"}}
+	formatter := &PrettyTableFormatter{ConsoleWidthFn: func() int { return 80 }}
+	buf := &bytes.Buffer{}
+	// ResponsiveColumnHint defaults to false → no "⋯" column or hint message.
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{Columns: toolCheckTestColumns()})
+	require.NoError(t, err)
+	out := buf.String()
+	require.NotContains(t, out, "Showing")
+	require.NotContains(t, out, "Resize the terminal")
+}
+
+func TestCardTitleGroupedLayout(t *testing.T) {
+	previousNoColor := color.NoColor
+	color.NoColor = false
+	t.Cleanup(func() { color.NoColor = previousNoColor })
+
+	rows := []responsiveInput{
+		{
+			Id: "az-cli", Name: "Azure CLI", Status: "Installed",
+			InstalledVersion: "2.68.0", Category: "cli", Priority: "recommended",
+		},
+		{
+			Id: "vscode-azure-tools", Name: "Azure Tools VS Code Extension", Status: "Not installed",
+			Category: "vscode-extension", Priority: "recommended",
+		},
+	}
+	columns := []PrettyColumn{
+		{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+		{Column: Column{Heading: "NAME", ValueTemplate: "{{.Name}}"}, Priority: 2, CardTitle: true},
+		{Column: Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"}, Priority: 1},
+		{
+			Column: Column{
+				Heading:       "INSTALLED",
+				ValueTemplate: `{{if .InstalledVersion}}{{.InstalledVersion}}{{else}}-{{end}}`,
+			},
+			CardValueTemplate: `{{if .InstalledVersion}}{{.InstalledVersion}}{{end}}`,
+			Priority:          1,
+		},
+		{Column: Column{Heading: "CATEGORY", ValueTemplate: "{{.Category}}"}, Priority: 3},
+		{Column: Column{Heading: "PRIORITY", ValueTemplate: "{{.Priority}}"}, Priority: 3},
+	}
+	formatter := &PrettyTableFormatter{ConsoleWidthFn: func() int { return 40 }}
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
+		Columns:         columns,
+		CardGroupColumn: "CATEGORY",
+	})
+	require.NoError(t, err)
+	out := buf.String()
+	stripped := stripTerminalEscapes(out)
+
+	// Group headers retain the labeled, gray divider style.
+	require.Contains(t, stripped, "── CATEGORY: cli ")
+	require.Contains(t, stripped, "── CATEGORY: vscode-extension ")
+	// The NAME is rendered as a highlighted title (no "NAME:" label) and colored.
+	require.NotContains(t, stripped, "NAME:")
+	require.Regexp(t, sgrPrefixPattern("Azure CLI"), out)
+	// CATEGORY is the group header, not a card field: any "CATEGORY:" occurrence
+	// must be part of a "── CATEGORY:" divider line.
+	for line := range strings.SplitSeq(stripped, "\n") {
+		if strings.Contains(line, "CATEGORY:") {
+			require.True(t, strings.HasPrefix(line, "── CATEGORY:"),
+				"CATEGORY appeared as a card field: %q", line)
+		}
+	}
+	// Card value omission: the not-installed tool omits INSTALLED.
+	require.NotContains(t, stripped, "INSTALLED:  -")
+	// No box-drawing borders in the titled card layout.
+	require.NotContains(t, out, "┌")
+}
+
+func TestCardTitleUngroupedBorderless(t *testing.T) {
+	rows := []responsiveInput{
+		{Id: "az-cli", Name: "Azure CLI", Status: "Up to date", InstalledVersion: "1.0.0", LatestVersion: "1.0.0"},
+	}
+	formatter := &PrettyTableFormatter{ConsoleWidthFn: func() int { return 40 }}
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{Columns: toolCheckTestColumns()})
+	require.NoError(t, err)
+	out := buf.String()
+	// Ungrouped titled cards are borderless (no box-drawing characters).
+	require.NotContains(t, out, "┌")
+	require.NotContains(t, out, "│")
+	require.Contains(t, out, "Azure CLI")
+	require.Contains(t, out, "ID:")
+	// LATEST equals INSTALLED for an up-to-date tool → omitted from the card.
+	require.NotContains(t, stripTerminalEscapes(out), "LATEST:")
+}
+
+func TestAlignLeadingSymbols(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "no leading symbol leaves values untouched",
+			in:   []string{"Up to date", "Not installed", "Installed"},
+			want: []string{"Up to date", "Not installed", "Installed"},
+		},
+		{
+			name: "pads plain values to align under symbol text",
+			in:   []string{"⟳ Update available", "Up to date", "Not installed"},
+			want: []string{"⟳ Update available", "  Up to date", "  Not installed"},
+		},
+		{
+			name: "value that already has a symbol is unchanged",
+			in:   []string{"⟳ Update available", "⚠ Incompatible"},
+			want: []string{"⟳ Update available", "⚠ Incompatible"},
+		},
+		{
+			name: "empty values are not padded",
+			in:   []string{"⟳ Update available", ""},
+			want: []string{"⟳ Update available", ""},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, alignLeadingSymbols(tt.in))
+		})
+	}
+}
+
+func TestResponsiveStatusAlignment(t *testing.T) {
+	// dataLineContaining returns the stripped rendered line containing substr.
+	dataLineContaining := func(out, substr string) string {
+		for _, line := range strings.Split(out, "\n") {
+			if strings.Contains(line, substr) {
+				return line
+			}
+		}
+		return ""
+	}
+	textColumn := func(line, text string) int {
+		before, _, ok := strings.Cut(line, text)
+		require.True(t, ok, "text %q not found in %q", text, line)
+		return displayWidth(before)
+	}
+
+	columns := []PrettyColumn{
+		{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+		{
+			Column:             Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+			Priority:           1,
+			AlignLeadingSymbol: true,
+		},
+		{Column: Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"}, Priority: 1},
+	}
+
+	// When a symbol is present, the status text aligns: "Update available" and
+	// "Up to date" begin at the same display column (the no-padding case is
+	// covered directly by TestAlignLeadingSymbols).
+	rows := []responsiveInput{
+		{Id: "a", Status: "⟳ Update available", Source: "azd"},
+		{Id: "b", Status: "Up to date", Source: "azd"},
+	}
+	formatter := &PrettyTableFormatter{ConsoleWidthFn: func() int { return 120 }}
+	buf := &bytes.Buffer{}
+	require.NoError(t, formatter.Format(rows, buf, PrettyTableFormatterOptions{Columns: columns}))
+	out := stripTerminalEscapes(buf.String())
+
+	updateCol := textColumn(dataLineContaining(out, "Update available"), "Update available")
+	upToDateCol := textColumn(dataLineContaining(out, "Up to date"), "Up to date")
+	require.Equal(t, updateCol, upToDateCol)
+}
+
+func TestEllipsisAndHiddenColumnGlyphs(t *testing.T) {
+	// The package uses the single-character ellipsis for truncated values and
+	// three middle dots for the hidden-column placeholder header.
+	require.Equal(t, "…", ellipsis)
+	require.Equal(t, "···", hiddenColumnHeading)
+	require.Equal(t, 1, displayWidth(ellipsis))
+	require.Equal(t, 3, displayWidth(hiddenColumnHeading))
+
+	require.Equal(t, "0.1.2…", truncateWithEllipsis("0.1.20-preview", 6))
+}
+
+func TestColorLineLikeValue(t *testing.T) {
+	previousNoColor := color.NoColor
+	color.NoColor = false
+	t.Cleanup(func() { color.NoColor = previousNoColor })
+
+	// A ColorFunc that classifies by trimmed content (like extension status).
+	warn := func(s string) string {
+		if strings.TrimSpace(s) == "⟳ Update available" {
+			return WithWarningFormat(s)
+		}
+		return WithGrayFormat(s)
+	}
+
+	// Non-truncated: the full value keeps its classified color.
+	full := colorLineLikeValue(warn, "⟳ Update available", "⟳ Update available")
+	require.Equal(t, WithWarningFormat("⟳ Update available"), full)
+
+	// Truncated: classification stays based on the full value, but the visible
+	// (truncated) text is what gets wrapped — so it stays warning-colored even
+	// though the truncated text alone would classify as gray.
+	truncatedLine := "⟳ Update availa…"
+	got := colorLineLikeValue(warn, "⟳ Update available", truncatedLine)
+	require.Contains(t, got, truncatedLine)
+	require.NotEqual(t, WithGrayFormat(truncatedLine), got)
+	// It carries the same leading SGR prefix as the warning-colored full value.
+	warnPrefix := strings.SplitAfter(WithWarningFormat("x"), "m")[0]
+	require.True(t, strings.HasPrefix(got, warnPrefix),
+		"truncated line should keep the warning color prefix; got %q", got)
+}
+
+func TestResponsiveTruncatedStatusKeepsColor(t *testing.T) {
+	previousNoColor := color.NoColor
+	color.NoColor = false
+	t.Cleanup(func() { color.NoColor = previousNoColor })
+
+	statusColor := func(s string) string {
+		switch strings.TrimSpace(s) {
+		case "⟳ Update available":
+			return WithWarningFormat(s)
+		case "Up to date":
+			return WithSuccessFormat(s)
+		default:
+			return WithGrayFormat(s)
+		}
+	}
+	columns := []PrettyColumn{
+		{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+		{
+			Column:             Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+			Priority:           1,
+			Truncatable:        true,
+			AlignLeadingSymbol: true,
+			ColorFunc:          statusColor,
+		},
+		{Column: Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"}, Priority: 1},
+	}
+	rows := []responsiveInput{
+		{Id: "microsoft.azd.extensions.preview.longbuild", Status: "⟳ Update available", Source: "azd"},
+	}
+	// A narrow width (still in the compact table range) forces STATUS to truncate.
+	formatter := &PrettyTableFormatter{ConsoleWidthFn: func() int { return 60 }}
+	buf := &bytes.Buffer{}
+	require.NoError(t, formatter.Format(rows, buf, PrettyTableFormatterOptions{Columns: columns}))
+	out := buf.String()
+
+	// The status value is truncated…
+	require.Contains(t, stripTerminalEscapes(out), "…")
+	// …and the truncated status still carries the warning color prefix.
+	warnPrefix := strings.SplitAfter(WithWarningFormat("x"), "m")[0]
+	require.Contains(t, out, warnPrefix+"⟳")
+}
+
+func TestColumnFloorWrappableTruncatable(t *testing.T) {
+	cols, err := parseColumns([]PrettyColumn{
+		{Column: Column{Heading: "WRAPONLY", ValueTemplate: "{{.Name}}"}, Wrappable: true},
+		{Column: Column{Heading: "BOTH", ValueTemplate: "{{.Name}}"}, Wrappable: true, Truncatable: true},
+		{Column: Column{Heading: "TRUNC", ValueTemplate: "{{.Name}}"}, Truncatable: true},
+		{Column: Column{Heading: "FIXED", ValueTemplate: "{{.Name}}"}},
+	})
+	require.NoError(t, err)
+
+	natural := 40
+	truncFloor := minVisibleChars + displayWidth(ellipsis)
+	// Wrap-only floors near natural/maxWrapLines so all content fits in 2 lines.
+	require.Equal(t, (natural+maxWrapLines-1)/maxWrapLines, columnFloor(cols[0], natural))
+	// Wrappable+Truncatable can shrink all the way to the truncatable floor so it
+	// yields space to columns that cannot truncate.
+	require.Equal(t, truncFloor, columnFloor(cols[1], natural))
+	// Truncatable-only floors at the truncatable floor.
+	require.Equal(t, truncFloor, columnFloor(cols[2], natural))
+	// Non-shrinkable keeps its natural width.
+	require.Equal(t, natural, columnFloor(cols[3], natural))
+}
+
+func TestFitColumnsWrappableYieldsToHigherPriority(t *testing.T) {
+	// A wrappable+truncatable NAME (priority 2) should shrink aggressively so the
+	// higher-priority truncatable STATUS (priority 1) stays as readable as
+	// possible, rather than NAME hogging width and forcing STATUS to its floor.
+	cols, err := parseColumns([]PrettyColumn{
+		{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
+		{
+			Column:      Column{Heading: "NAME", ValueTemplate: "{{.Name}}"},
+			Priority:    2,
+			Wrappable:   true,
+			Truncatable: true,
+		},
+		{
+			Column:      Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+			Priority:    1,
+			Truncatable: true,
+		},
+		{Column: Column{Heading: "INSTALLED", ValueTemplate: "{{.V}}"}, Priority: 1},
+	})
+	require.NoError(t, err)
+
+	// ID and INSTALLED are not shrinkable.
+	natural := []int{19, 37, 18, 14}
+	widths := fitColumns(cols, natural, 66)
+
+	require.LessOrEqual(t, rowWidth(widths), 66)
+	require.Equal(t, 19, widths[0], "ID is not shrinkable")
+	require.Equal(t, 14, widths[3], "INSTALLED is not shrinkable")
+	// NAME is squeezed below its wrap floor (natural/2 = 19) to protect STATUS.
+	require.Less(t, widths[1], (37+maxWrapLines-1)/maxWrapLines)
+	// STATUS keeps more width than its minimum floor.
+	require.Greater(t, widths[2], minVisibleChars+displayWidth(ellipsis))
+	require.Greater(t, widths[2], widths[1], "STATUS should stay wider than the squeezed NAME")
+}
+
+func TestForceCardsIgnoresWidth(t *testing.T) {
+	rows := []responsiveInput{
+		{Id: "tmpl-a", Name: "Template A", Status: "x"},
+	}
+	columns := []PrettyColumn{
+		{Column: Column{Heading: "NAME", ValueTemplate: "{{.Name}}"}, CardTitle: true},
+		{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}},
+	}
+	// A very wide terminal would normally select the full table; ForceCards overrides.
+	formatter := &PrettyTableFormatter{ConsoleWidthFn: func() int { return 400 }}
+	buf := &bytes.Buffer{}
+	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{Columns: columns, ForceCards: true})
+	require.NoError(t, err)
+	out := buf.String()
+	// Card layout: a labeled field, not a header underline.
+	require.Contains(t, out, "ID:")
+	require.NotContains(t, out, "─")
+}

--- a/cli/azd/pkg/output/pretty_table_table.go
+++ b/cli/azd/pkg/output/pretty_table_table.go
@@ -1,0 +1,237 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+// renderTable renders cols and rows as a whitespace-padded table with a header
+// underline. When useShort is true, ShortValueTemplate is used where available.
+// It returns the rendered table and whether any value was truncated to fit.
+func (f *PrettyTableFormatter) renderTable(
+	cols []resolvedColumn, rows []any, termWidth int, useShort bool,
+) (string, bool, error) {
+	// Resolve plain cell values.
+	plain := make([][]string, len(rows))
+	for ri, row := range rows {
+		plain[ri] = make([]string, len(cols))
+		for ci, rc := range cols {
+			tmpl := rc.tmpl
+			if useShort && rc.shortTmpl != nil {
+				tmpl = rc.shortTmpl
+			}
+			val, err := prettyExecTemplate(tmpl, row)
+			if err != nil {
+				return "", false, fmt.Errorf("row %d, column %q: %w", ri, rc.col.Heading, err)
+			}
+			if rc.col.Transformer != nil {
+				val = rc.col.Transformer(val)
+			}
+			plain[ri][ci] = val
+		}
+	}
+
+	// Apply leading-symbol alignment per column where requested.
+	for ci, rc := range cols {
+		if !rc.col.AlignLeadingSymbol {
+			continue
+		}
+		column := make([]string, len(rows))
+		for ri := range rows {
+			column[ri] = plain[ri][ci]
+		}
+		column = alignLeadingSymbols(column)
+		for ri := range rows {
+			plain[ri][ci] = column[ri]
+		}
+	}
+
+	// Natural width = max of heading and all cell values.
+	natural := make([]int, len(cols))
+	for ci, rc := range cols {
+		natural[ci] = displayWidth(rc.col.Heading)
+	}
+	for _, rowVals := range plain {
+		for ci, val := range rowVals {
+			natural[ci] = max(natural[ci], displayWidth(val))
+		}
+	}
+
+	widths := fitColumns(cols, natural, termWidth)
+
+	// Lay out cells into (possibly multiple) colored lines, tracking truncation.
+	type cell struct {
+		lines []string
+	}
+	grid := make([][]cell, len(rows))
+	truncated := false
+	for ri, rowVals := range plain {
+		grid[ri] = make([]cell, len(cols))
+		for ci, val := range rowVals {
+			lines, lost := layoutCell(val, widths[ci], cols[ci].col.Wrappable)
+			truncated = truncated || lost
+			if cf := cols[ci].col.ColorFunc; cf != nil {
+				for li, ln := range lines {
+					if ln != "" {
+						// Classify the color from the full cell value, but apply it
+						// to the visible (possibly truncated) line so that a
+						// truncated value keeps the color of its underlying value.
+						lines[li] = colorLineLikeValue(cf, val, ln)
+					}
+				}
+			}
+			grid[ri][ci] = cell{lines: lines}
+		}
+	}
+
+	var buf bytes.Buffer
+	boldHeader := color.New(color.Bold, color.FgHiWhite)
+
+	// Header row.
+	for ci, rc := range cols {
+		if ci > 0 {
+			buf.WriteString(strings.Repeat(" ", columnPadding))
+		}
+		buf.WriteString(boldHeader.Sprint(rc.col.Heading))
+		if ci < len(cols)-1 {
+			buf.WriteString(strings.Repeat(" ", max(widths[ci]-displayWidth(rc.col.Heading), 0)))
+		}
+	}
+	buf.WriteByte('\n')
+
+	// Header underline.
+	lineWidth := min(rowWidth(widths), termWidth)
+	buf.WriteString(WithGrayFormat(strings.Repeat("─", lineWidth)))
+	buf.WriteByte('\n')
+
+	// Data rows, rendered line by line so wrapped cells expand the row height.
+	for ri := range rows {
+		height := 1
+		for ci := range cols {
+			height = max(height, len(grid[ri][ci].lines))
+		}
+		for li := range height {
+			for ci := range cols {
+				if ci > 0 {
+					buf.WriteString(strings.Repeat(" ", columnPadding))
+				}
+				line := ""
+				if li < len(grid[ri][ci].lines) {
+					line = grid[ri][ci].lines[li]
+				}
+				buf.WriteString(line)
+				if ci < len(cols)-1 {
+					buf.WriteString(strings.Repeat(" ", max(widths[ci]-displayWidth(line), 0)))
+				}
+			}
+			buf.WriteByte('\n')
+		}
+	}
+
+	return buf.String(), truncated, nil
+}
+
+// renderFullTable renders every column with full text values.
+func (f *PrettyTableFormatter) renderFullTable(
+	parsed []resolvedColumn, rows []any, termWidth int, writer io.Writer,
+	opts PrettyTableFormatterOptions,
+) error {
+	out, truncated, err := f.renderTable(parsed, rows, termWidth, false)
+	if err != nil {
+		return err
+	}
+	if _, err := writer.Write([]byte(out)); err != nil {
+		return err
+	}
+	if opts.ResponsiveColumnHint && truncated {
+		return writeColumnHint(writer, buildColumnHint(len(parsed), len(parsed), true))
+	}
+	return nil
+}
+
+// renderCompactTable renders only the columns visible at the compact breakpoint
+// (Priority ≤ compactPriorityThreshold). When ResponsiveColumnHint is set and
+// columns are dropped, a header-only "..." column and a hint message are added.
+func (f *PrettyTableFormatter) renderCompactTable(
+	parsed []resolvedColumn, rows []any, termWidth int,
+	writer io.Writer, opts PrettyTableFormatterOptions,
+) error {
+	visible := make([]resolvedColumn, 0, len(parsed))
+	for _, rc := range parsed {
+		if rc.priority() <= compactPriorityThreshold {
+			visible = append(visible, rc)
+		}
+	}
+	if len(visible) == 0 {
+		return f.formatGroupedCards(parsed, rows, termWidth, writer, opts)
+	}
+
+	dropped := len(parsed) - len(visible)
+	cols := visible
+	if opts.ResponsiveColumnHint && dropped > 0 {
+		cols = append(cols, hiddenColumnPlaceholder())
+	}
+
+	out, truncated, err := f.renderTable(cols, rows, termWidth, true)
+	if err != nil {
+		return err
+	}
+	if _, err := writer.Write([]byte(out)); err != nil {
+		return err
+	}
+	if opts.ResponsiveColumnHint {
+		if hint := buildColumnHint(len(visible), len(parsed), truncated); hint != "" {
+			return writeColumnHint(writer, hint)
+		}
+	}
+	return nil
+}
+
+// hiddenColumnPlaceholder returns a header-only "···" column with no values,
+// used to signal that lower-priority columns were hidden at compact width.
+func hiddenColumnPlaceholder() resolvedColumn {
+	// An empty template renders nothing for every row.
+	tmpl := emptyTemplate
+	return resolvedColumn{
+		col:  PrettyColumn{Column: Column{Heading: hiddenColumnHeading, ValueTemplate: ""}},
+		tmpl: tmpl,
+	}
+}
+
+// writeColumnHint writes a blank separator line followed by the hint message.
+func writeColumnHint(writer io.Writer, hint string) error {
+	_, err := writer.Write([]byte("\n" + hint + "\n"))
+	return err
+}
+
+// colorLineLikeValue applies the color that colorFunc assigns to the full cell
+// value to a single (possibly truncated) display line. Color classification
+// stays based on value while the visible text is line, so a truncated cell
+// keeps the color of its underlying value instead of being reclassified from
+// the truncated text (e.g. a shortened "Update available" status must stay
+// warning-colored).
+func colorLineLikeValue(colorFunc func(string) string, value, line string) string {
+	colored := colorFunc(value)
+	if colored == value {
+		// No color applied (e.g. NO_COLOR is set); nothing to transfer.
+		return line
+	}
+	if line == value {
+		return colored
+	}
+	// Transfer the leading/trailing escape sequences that wrap the value onto
+	// the visible line. colorFunc embeds value verbatim between a leading SGR
+	// prefix and a trailing reset.
+	if idx := strings.Index(colored, value); idx >= 0 {
+		return colored[:idx] + line + colored[idx+len(value):]
+	}
+	// Fallback: color the line directly.
+	return colorFunc(line)
+}

--- a/cli/azd/pkg/output/pretty_table_table.go
+++ b/cli/azd/pkg/output/pretty_table_table.go
@@ -225,8 +225,8 @@ func colorLineLikeValue(colorFunc func(string) string, value, line string) strin
 	// Transfer the leading/trailing escape sequences that wrap the value onto
 	// the visible line. colorFunc embeds value verbatim between a leading SGR
 	// prefix and a trailing reset.
-	if idx := strings.Index(colored, value); idx >= 0 {
-		return colored[:idx] + line + colored[idx+len(value):]
+	if before, after, ok := strings.Cut(colored, value); ok {
+		return before + line + after
 	}
 	// Fallback: color the line directly.
 	return colorFunc(line)

--- a/cli/azd/pkg/output/pretty_table_table.go
+++ b/cli/azd/pkg/output/pretty_table_table.go
@@ -13,21 +13,17 @@ import (
 )
 
 // renderTable renders cols and rows as a whitespace-padded table with a header
-// underline. When useShort is true, ShortValueTemplate is used where available.
-// It returns the rendered table and whether any value was truncated to fit.
+// underline. It returns the rendered table and whether any value was truncated
+// to fit.
 func (f *PrettyTableFormatter) renderTable(
-	cols []resolvedColumn, rows []any, termWidth int, useShort bool,
+	cols []resolvedColumn, rows []any, termWidth int,
 ) (string, bool, error) {
 	// Resolve plain cell values.
 	plain := make([][]string, len(rows))
 	for ri, row := range rows {
 		plain[ri] = make([]string, len(cols))
 		for ci, rc := range cols {
-			tmpl := rc.tmpl
-			if useShort && rc.shortTmpl != nil {
-				tmpl = rc.shortTmpl
-			}
-			val, err := prettyExecTemplate(tmpl, row)
+			val, err := prettyExecTemplate(rc.tmpl, row)
 			if err != nil {
 				return "", false, fmt.Errorf("row %d, column %q: %w", ri, rc.col.Heading, err)
 			}
@@ -143,7 +139,7 @@ func (f *PrettyTableFormatter) renderFullTable(
 	parsed []resolvedColumn, rows []any, termWidth int, writer io.Writer,
 	opts PrettyTableFormatterOptions,
 ) error {
-	out, truncated, err := f.renderTable(parsed, rows, termWidth, false)
+	out, truncated, err := f.renderTable(parsed, rows, termWidth)
 	if err != nil {
 		return err
 	}
@@ -158,7 +154,7 @@ func (f *PrettyTableFormatter) renderFullTable(
 
 // renderCompactTable renders only the columns visible at the compact breakpoint
 // (Priority ≤ compactPriorityThreshold). When ResponsiveColumnHint is set and
-// columns are dropped, a header-only "..." column and a hint message are added.
+// columns are dropped, a header-only "···" column and a hint message are added.
 func (f *PrettyTableFormatter) renderCompactTable(
 	parsed []resolvedColumn, rows []any, termWidth int,
 	writer io.Writer, opts PrettyTableFormatterOptions,
@@ -179,7 +175,7 @@ func (f *PrettyTableFormatter) renderCompactTable(
 		cols = append(cols, hiddenColumnPlaceholder())
 	}
 
-	out, truncated, err := f.renderTable(cols, rows, termWidth, true)
+	out, truncated, err := f.renderTable(cols, rows, termWidth)
 	if err != nil {
 		return err
 	}

--- a/cli/azd/pkg/output/pretty_table_table.go
+++ b/cli/azd/pkg/output/pretty_table_table.go
@@ -34,21 +34,6 @@ func (f *PrettyTableFormatter) renderTable(
 		}
 	}
 
-	// Apply leading-symbol alignment per column where requested.
-	for ci, rc := range cols {
-		if !rc.col.AlignLeadingSymbol {
-			continue
-		}
-		column := make([]string, len(rows))
-		for ri := range rows {
-			column[ri] = plain[ri][ci]
-		}
-		column = alignLeadingSymbols(column)
-		for ri := range rows {
-			plain[ri][ci] = column[ri]
-		}
-	}
-
 	// Natural width = max of heading and all cell values.
 	natural := make([]int, len(cols))
 	for ci, rc := range cols {

--- a/cli/azd/pkg/output/pretty_table_test.go
+++ b/cli/azd/pkg/output/pretty_table_test.go
@@ -14,12 +14,11 @@ import (
 )
 
 type prettyInput struct {
-	Name         string
-	Version      string
-	Status       string
-	StatusSymbol string
-	Source       string
-	Id           string
+	Name    string
+	Version string
+	Status  string
+	Source  string
+	Id      string
 }
 
 func sgrPrefixPattern(text string) *regexp.Regexp {
@@ -230,7 +229,7 @@ func TestPrettyHeaderUnderline(t *testing.T) {
 func TestPrettyFullBreakpoint(t *testing.T) {
 	rows := []prettyInput{
 		{Id: "azure.ai.agents", Name: "Foundry agents (Preview)", Version: "0.1.18-preview",
-			Status: "✓ Up to date", StatusSymbol: "✓", Source: "azd"},
+			Status: "✓ Up to date", Source: "azd"},
 	}
 
 	formatter := &PrettyTableFormatter{
@@ -258,7 +257,7 @@ func TestPrettyFullBreakpoint(t *testing.T) {
 func TestPrettyCompactBreakpoint(t *testing.T) {
 	rows := []prettyInput{
 		{Id: "azure.ai.agents", Name: "Foundry agents (Preview)", Version: "0.1.18-preview",
-			Status: "✓ Up to date", StatusSymbol: "✓", Source: "azd"},
+			Status: "✓ Up to date", Source: "azd"},
 	}
 
 	formatter := &PrettyTableFormatter{
@@ -273,23 +272,23 @@ func TestPrettyCompactBreakpoint(t *testing.T) {
 	require.NoError(t, err)
 	output := buf.String()
 
-	// Compact: Priority ≤ 2 columns, status uses ShortValueTemplate (symbol only)
+	// Compact: Priority ≤ 2 columns shown with their full values.
 	require.Contains(t, output, "ID")
 	require.Contains(t, output, "VERSION")
 	require.Contains(t, output, "STATUS")
 	require.Contains(t, output, "SOURCE")
 	// NAME (priority 3) dropped
 	require.NotContains(t, output, "NAME")
-	// Should use short status template (symbol only)
-	require.NotContains(t, output, "Up to date")
+	// Full status text is shown (no symbol substitution).
+	require.Contains(t, output, "Up to date")
 }
 
 func TestPrettyCardBreakpoint(t *testing.T) {
 	rows := []prettyInput{
 		{Id: "azure.ai.agents", Name: "Foundry agents (Preview)", Version: "0.1.18-preview",
-			Status: "✓ Up to date", StatusSymbol: "✓", Source: "azd"},
+			Status: "✓ Up to date", Source: "azd"},
 		{Id: "azure.coding-agent", Name: "Coding agent config", Version: "0.6.1",
-			Status: "⚠ Incompatible", StatusSymbol: "⚠", Source: "local"},
+			Status: "⚠ Incompatible", Source: "local"},
 	}
 
 	formatter := &PrettyTableFormatter{
@@ -357,70 +356,13 @@ func TestPrettyCardGroupingOrder(t *testing.T) {
 	require.Contains(t, output, "Third")
 }
 
-func TestPrettyShortValueTemplate(t *testing.T) {
+func TestPrettyColorFuncAtCompactWidth(t *testing.T) {
 	rows := []prettyInput{
-		{Id: "ext-a", Status: "✓ Up to date", StatusSymbol: "✓"},
-	}
-
-	// Width 70 is in compact range (60-99), should use short template
-	formatter := &PrettyTableFormatter{
-		ConsoleWidthFn: func() int { return 70 },
-	}
-
-	buf := &bytes.Buffer{}
-	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
-		Columns: []PrettyColumn{
-			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
-			{
-				Column:             Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
-				Priority:           1,
-				ShortValueTemplate: "{{.StatusSymbol}}",
-			},
-		},
-	})
-
-	require.NoError(t, err)
-	output := buf.String()
-
-	// At compact width, should use short template (symbol only)
-	require.NotContains(t, output, "Up to date")
-}
-
-func TestPrettyShortValueTemplateNotUsedAtFullWidth(t *testing.T) {
-	rows := []prettyInput{
-		{Id: "ext-a", Status: "✓ Up to date", StatusSymbol: "✓"},
-	}
-
-	formatter := &PrettyTableFormatter{
-		ConsoleWidthFn: func() int { return 120 },
-	}
-
-	buf := &bytes.Buffer{}
-	err := formatter.Format(rows, buf, PrettyTableFormatterOptions{
-		Columns: []PrettyColumn{
-			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
-			{
-				Column:             Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
-				Priority:           1,
-				ShortValueTemplate: "{{.StatusSymbol}}",
-			},
-		},
-	})
-
-	require.NoError(t, err)
-	output := buf.String()
-
-	// At full width, should use full template
-	require.Contains(t, output, "✓ Up to date")
-}
-
-func TestPrettyColorFuncWithShortValueTemplate(t *testing.T) {
-	rows := []prettyInput{
-		{Id: "ext-a", Status: "✓ Up to date", StatusSymbol: "✓"},
+		{Id: "ext-a", Status: "✓ Up to date"},
 	}
 
 	colorApplied := false
-	// Width 70 is compact range
+	// Width 70 is in the compact range (60-99).
 	formatter := &PrettyTableFormatter{
 		ConsoleWidthFn: func() int { return 70 },
 	}
@@ -430,9 +372,8 @@ func TestPrettyColorFuncWithShortValueTemplate(t *testing.T) {
 		Columns: []PrettyColumn{
 			{Column: Column{Heading: "ID", ValueTemplate: "{{.Id}}"}, Priority: 1},
 			{
-				Column:             Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
-				Priority:           1,
-				ShortValueTemplate: "{{.StatusSymbol}}",
+				Column:   Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+				Priority: 1,
 				ColorFunc: func(s string) string {
 					colorApplied = true
 					return "[" + s + "]"
@@ -442,11 +383,10 @@ func TestPrettyColorFuncWithShortValueTemplate(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	require.True(t, colorApplied, "ColorFunc should be applied to short value")
+	require.True(t, colorApplied, "ColorFunc should be applied at compact width")
 	output := buf.String()
-	// At compact width, should use short template AND apply color
-	require.NotContains(t, output, "Up to date")
-	require.Contains(t, output, "[✓]")
+	// Full status text is shown and colored (no symbol substitution).
+	require.Contains(t, output, "[✓ Up to date]")
 }
 
 // Breakpoint boundary transition tests
@@ -454,7 +394,7 @@ func TestPrettyColorFuncWithShortValueTemplate(t *testing.T) {
 func TestPrettyBreakpointTransitions(t *testing.T) {
 	rows := []prettyInput{
 		{Id: "azure.ai.agents", Name: "Foundry agents (Preview)", Version: "0.1.18-preview",
-			Status: "✓ Up to date", StatusSymbol: "✓", Source: "azd"},
+			Status: "✓ Up to date", Source: "azd"},
 	}
 
 	columns := extListTestColumns()
@@ -872,9 +812,8 @@ func extListTestColumns() []PrettyColumn {
 			Priority: 1,
 		},
 		{
-			Column:             Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
-			Priority:           2,
-			ShortValueTemplate: "{{.StatusSymbol}}",
+			Column:   Column{Heading: "STATUS", ValueTemplate: "{{.Status}}"},
+			Priority: 2,
 		},
 		{
 			Column:   Column{Heading: "SOURCE", ValueTemplate: "{{.Source}}"},

--- a/cli/azd/pkg/output/pretty_table_types.go
+++ b/cli/azd/pkg/output/pretty_table_types.go
@@ -59,10 +59,6 @@ type PrettyColumn struct {
 	// 1 and 2 are shown at compact; 3+ are full-table only. 0 is treated as 1.
 	Priority int
 
-	// ShortValueTemplate is an alternative Go template used at the compact
-	// breakpoint. If empty, the regular ValueTemplate is used.
-	ShortValueTemplate string
-
 	// CardValueTemplate is an alternative Go template used by the card layout.
 	// If empty, the regular ValueTemplate is used. It allows a column to omit
 	// redundant values in cards (e.g. a "latest" version that equals the
@@ -112,7 +108,7 @@ type PrettyTableFormatterOptions struct {
 	// Defaults to DefaultCompactThreshold (60).
 	CompactThreshold int
 
-	// ResponsiveColumnHint enables the header-only "..." column and the
+	// ResponsiveColumnHint enables the header-only "···" column and the
 	// "Showing N of M columns" / "Resize the terminal..." hint message in the
 	// table layouts when columns are hidden or values are truncated.
 	ResponsiveColumnHint bool
@@ -123,10 +119,9 @@ type PrettyTableFormatterOptions struct {
 
 // resolvedColumn pairs a PrettyColumn with its compiled templates.
 type resolvedColumn struct {
-	col       PrettyColumn
-	tmpl      *template.Template
-	shortTmpl *template.Template // nil when ShortValueTemplate is empty
-	cardTmpl  *template.Template // nil when CardValueTemplate is empty
+	col      PrettyColumn
+	tmpl     *template.Template
+	cardTmpl *template.Template // nil when CardValueTemplate is empty
 }
 
 // priority returns the effective compact-visibility priority (0 maps to 1).

--- a/cli/azd/pkg/output/pretty_table_types.go
+++ b/cli/azd/pkg/output/pretty_table_types.go
@@ -82,12 +82,6 @@ type PrettyColumn struct {
 	// title line (without a label) in the card layout, excluding it from the
 	// labeled card fields.
 	CardTitle bool
-
-	// AlignLeadingSymbol left-pads values that lack a leading "symbol + space"
-	// prefix (e.g. "⟳ Update available") so their text aligns with values that
-	// have one. When no value in the column has a leading symbol, values are
-	// left-aligned without padding. Applies to the table layouts only.
-	AlignLeadingSymbol bool
 }
 
 // PrettyTableFormatterOptions configures the pretty table formatter.

--- a/cli/azd/pkg/output/pretty_table_types.go
+++ b/cli/azd/pkg/output/pretty_table_types.go
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package output
+
+import "text/template"
+
+// Width breakpoint constants for responsive layout selection.
+const (
+	// DefaultFullThreshold is the terminal width at or above which all columns
+	// are shown with full text values.
+	DefaultFullThreshold = 100
+
+	// DefaultCompactThreshold is the terminal width at or above which only
+	// high-priority columns (Priority ≤ compactPriorityThreshold) are shown.
+	// Below this value the card layout is used.
+	DefaultCompactThreshold = 60
+
+	// columnPadding is the whitespace gap between columns (no box-drawing separators).
+	columnPadding = 3
+
+	// compactPriorityThreshold is the highest Priority value still shown at the
+	// compact breakpoint. Columns with a larger Priority are dropped.
+	compactPriorityThreshold = 2
+
+	// minVisibleChars is the minimum number of characters shown before the
+	// ellipsis when a value is truncated.
+	minVisibleChars = 5
+
+	// maxWrapLines is the maximum number of lines a Wrappable cell may occupy
+	// before its content is truncated.
+	maxWrapLines = 2
+
+	// ellipsis is appended to a value that has been shortened to fit.
+	ellipsis = "…"
+
+	// hiddenColumnHeading is the header-only placeholder column rendered at the
+	// compact breakpoint to signal that lower-priority columns were hidden.
+	hiddenColumnHeading = "···"
+)
+
+// breakpoint identifies which responsive layout the formatter renders.
+type breakpoint int
+
+const (
+	// breakpointCard renders one card per row (optionally grouped).
+	breakpointCard breakpoint = iota
+	// breakpointCompact renders a reduced set of columns.
+	breakpointCompact
+	// breakpointFull renders every column.
+	breakpointFull
+)
+
+// PrettyColumn extends Column with responsive layout metadata.
+type PrettyColumn struct {
+	Column
+
+	// Priority controls column visibility at the compact breakpoint.
+	// 1 and 2 are shown at compact; 3+ are full-table only. 0 is treated as 1.
+	Priority int
+
+	// ShortValueTemplate is an alternative Go template used at the compact
+	// breakpoint. If empty, the regular ValueTemplate is used.
+	ShortValueTemplate string
+
+	// CardValueTemplate is an alternative Go template used by the card layout.
+	// If empty, the regular ValueTemplate is used. It allows a column to omit
+	// redundant values in cards (e.g. a "latest" version that equals the
+	// installed one) while still rendering them in the table layouts.
+	CardValueTemplate string
+
+	// ColorFunc applies color formatting to the cell value. If nil, no color
+	// formatting is applied.
+	ColorFunc func(string) string
+
+	// Truncatable allows the value to be shortened with an ellipsis to fit the
+	// available width. At least minVisibleChars characters are kept.
+	Truncatable bool
+
+	// Wrappable allows the value to wrap onto at most maxWrapLines lines before
+	// being truncated. Used for identifier columns (e.g. NAME) where wrapping is
+	// preferred over truncation.
+	Wrappable bool
+
+	// CardTitle renders this column's value as the card's bold, highlighted
+	// title line (without a label) in the card layout, excluding it from the
+	// labeled card fields.
+	CardTitle bool
+
+	// AlignLeadingSymbol left-pads values that lack a leading "symbol + space"
+	// prefix (e.g. "⟳ Update available") so their text aligns with values that
+	// have one. When no value in the column has a leading symbol, values are
+	// left-aligned without padding. Applies to the table layouts only.
+	AlignLeadingSymbol bool
+}
+
+// PrettyTableFormatterOptions configures the pretty table formatter.
+type PrettyTableFormatterOptions struct {
+	Columns []PrettyColumn
+
+	// CardGroupColumn is the heading of the column to group cards by in the card
+	// layout. Each distinct value becomes a section header. If empty, cards are
+	// rendered ungrouped.
+	CardGroupColumn string
+
+	// FullThreshold is the terminal width at or above which the full layout is
+	// used. Defaults to DefaultFullThreshold (100).
+	FullThreshold int
+
+	// CompactThreshold is the terminal width at or above which the compact
+	// layout is used. Below this the card layout is used.
+	// Defaults to DefaultCompactThreshold (60).
+	CompactThreshold int
+
+	// ResponsiveColumnHint enables the header-only "..." column and the
+	// "Showing N of M columns" / "Resize the terminal..." hint message in the
+	// table layouts when columns are hidden or values are truncated.
+	ResponsiveColumnHint bool
+
+	// ForceCards renders the card layout regardless of terminal width.
+	ForceCards bool
+}
+
+// resolvedColumn pairs a PrettyColumn with its compiled templates.
+type resolvedColumn struct {
+	col       PrettyColumn
+	tmpl      *template.Template
+	shortTmpl *template.Template // nil when ShortValueTemplate is empty
+	cardTmpl  *template.Template // nil when CardValueTemplate is empty
+}
+
+// priority returns the effective compact-visibility priority (0 maps to 1).
+func (c resolvedColumn) priority() int {
+	if c.col.Priority == 0 {
+		return 1
+	}
+	return c.col.Priority
+}


### PR DESCRIPTION
Fixes #8667
Fixes #8634
Fixes #8669
Fixes #8670
Fixes #8686
Fixes #8772

This PR standardizes the responsive table experience for `azd extension list`, `azd tool check`, `azd tool list`, and `azd template list`, addressing the child issues (#8634, #8669, #8670, #8686) of the table-standardization epic (#8667). These commands previously had inconsistent column ordering, labels, and degraded poorly at narrower terminal widths.

The shared `PrettyTableFormatter` engine is refactored to drive a single, consistent responsive model with three width breakpoints: at full width all columns are shown (truncating lower-priority values with an ellipsis only when needed), at medium width the lowest-priority columns are hidden behind a `···` indicator with a "Showing N of M columns" hint, and at narrow width each row renders as a readable card. Column behavior is opt-in per command (truncation, two-line name wrapping, and card titles), so commands that don't adopt these behaviors are unaffected.

Alongside the redesign, `azd extension list` now shows separate `INSTALLED` and `LATEST` version columns, and `azd template list` renders as cards with a dedicated `SOURCE` field. Status values are simplified to plain text distinguished by colour only — there are no longer any status symbols, and "Up to date", "Update available", "Incompatible", and "Not installed" all render as plain coloured text with consistent casing across `tool list` and `tool show`. The `···` hidden-column indicator and "Showing N of M columns" hint are also extended to the other tabular commands (`extension source list`, `template source list`, and `copilot consent list`) so column dropping is never silent. The now-redundant `ShortValueTemplate` mechanism is removed; `copilot consent list` prints the full colour-coded permission text instead of a symbol. Finally, `azd config options` drops its `-o table` output, which rendered poorly and overflowed; it now supports the default stacked list and `-o json` only.

## Screenshots

### `azd extension list`

<img width="839" height="302" alt="image" src="https://github.com/user-attachments/assets/96e637c0-e3c0-41b3-bc4e-77fdecaf30b6" />

<img width="551" height="329" alt="image" src="https://github.com/user-attachments/assets/85d6f389-70a3-4f72-94f4-61171c245b39" />

<img width="242" height="272" alt="image" src="https://github.com/user-attachments/assets/653f5945-d45d-40c2-96cc-f8d4decf523d" />


### `azd tool check`

<img width="758" height="146" alt="image" src="https://github.com/user-attachments/assets/ea44cd1a-5713-4c40-9d61-ef5cd6b67b09" />

<img width="631" height="211" alt="image" src="https://github.com/user-attachments/assets/907218e0-ce72-4553-84c2-59e088a56860" />

<img width="265" height="320" alt="image" src="https://github.com/user-attachments/assets/97c20d30-61d4-4f8d-88ab-4518b62bb170" />

### `azd tool list`

<img width="707" height="182" alt="image" src="https://github.com/user-attachments/assets/6141d341-268a-4b9a-91fe-a4c272d4fb88" />

<img width="670" height="160" alt="image" src="https://github.com/user-attachments/assets/7d35c122-6b69-4d9e-a19e-bf8ba89130be" />

<img width="245" height="342" alt="image" src="https://github.com/user-attachments/assets/58796dde-f92e-4c5b-acb4-635969619acf" />

### `azd template list`

<img width="799" height="340" alt="image" src="https://github.com/user-attachments/assets/d18d71e3-be42-4b19-8895-1c7be0fccd75" />

### Other commands (`···` hint)

<img width="433" height="98" alt="image" src="https://github.com/user-attachments/assets/cc205a39-8026-4452-9436-70d6b58c8cc4" />

<img width="494" height="98" alt="image" src="https://github.com/user-attachments/assets/2c967d71-93e7-42b5-8060-eb1b18461061" />
