### PR TITLE
Migrate predeploy/postdeploy to service-level event handlers in agents extension

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
@@ -155,7 +155,10 @@ func currentEnvName(ctx context.Context, azdClient *azdext.AzdClient) (string, e
 // process lifetime. Service-level predeploy handlers fire per-service, but the
 // RBAC pre-flight check is project-scoped and idempotent — running it once is
 // sufficient and avoids duplicate ARM/Graph calls and noisy output.
-var developerRBACOnce sync.Once
+var (
+	developerRBACOnce sync.Once
+	developerRBACErr  error
+)
 
 func predeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *azdext.ServiceEventArgs) error {
 	svc := args.Service
@@ -171,12 +174,11 @@ func predeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *az
 	// Guarded by sync.Once since this handler fires per-service but the check
 	// is project-scoped.
 	if isHostedAgentService(svc, args.Project) {
-		var rbacErr error
 		developerRBACOnce.Do(func() {
-			rbacErr = project.CheckDeveloperRBAC(ctx, azdClient)
+			developerRBACErr = project.CheckDeveloperRBAC(ctx, azdClient)
 		})
-		if rbacErr != nil {
-			return rbacErr
+		if developerRBACErr != nil {
+			return developerRBACErr
 		}
 	}
 
@@ -295,12 +297,19 @@ func postdeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *a
 		return fmt.Errorf("agent identity RBAC setup failed: %w", err)
 	}
 
-	// Report optimization candidate deployment to the optimization service.
-	reportSvcOptimizationDeployment(ctx, azdClient, svc, envName, endpointResp.Value,
-		func(endpoint string) *optimize_api.OptimizeClient {
-			return optimize_api.NewOptimizeClient(endpoint, cred)
-		},
-	)
+	// Report optimization candidate deployment (best-effort: panics are logged, not propagated).
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("postdeploy: optimization reporting panicked for %s: %v", svc.Name, r)
+			}
+		}()
+		reportSvcOptimizationDeployment(ctx, azdClient, svc, envName, endpointResp.Value,
+			func(endpoint string) *optimize_api.OptimizeClient {
+				return optimize_api.NewOptimizeClient(endpoint, cred)
+			},
+		)
+	}()
 
 	return nil
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
@@ -45,12 +45,12 @@ func configureExtensionHost(host *azdext.ExtensionHost) {
 		WithProjectEventHandler("postprovision", func(ctx context.Context, args *azdext.ProjectEventArgs) error {
 			return postprovisionHandler(ctx, azdClient, args)
 		}).
-		WithProjectEventHandler("predeploy", func(ctx context.Context, args *azdext.ProjectEventArgs) error {
+		WithServiceEventHandler("predeploy", func(ctx context.Context, args *azdext.ServiceEventArgs) error {
 			return predeployHandler(ctx, azdClient, args)
-		}).
-		WithProjectEventHandler("postdeploy", func(ctx context.Context, args *azdext.ProjectEventArgs) error {
+		}, &azdext.ServiceEventOptions{Host: AiAgentHost}).
+		WithServiceEventHandler("postdeploy", func(ctx context.Context, args *azdext.ServiceEventArgs) error {
 			return postdeployHandler(ctx, azdClient, args)
-		}).
+		}, &azdext.ServiceEventOptions{Host: AiAgentHost}).
 		WithProjectEventHandler("postdown", func(ctx context.Context, args *azdext.ProjectEventArgs) error {
 			return postdownHandler(ctx, azdClient, args)
 		})
@@ -150,27 +150,18 @@ func currentEnvName(ctx context.Context, azdClient *azdext.AzdClient) (string, e
 	return resp.Environment.Name, nil
 }
 
-func predeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *azdext.ProjectEventArgs) error {
-	hasHostedAgentService := false
-	for _, svc := range args.Project.Services {
-		if svc.Host != AiAgentHost {
-			continue
-		}
+func predeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *azdext.ServiceEventArgs) error {
+	svc := args.Service
 
-		if err := populateContainerSettings(ctx, azdClient, svc); err != nil {
-			return fmt.Errorf("failed to populate container settings for service %q: %w", svc.Name, err)
-		}
-		if err := envUpdate(ctx, azdClient, args.Project, svc); err != nil {
-			return fmt.Errorf("failed to update environment for service %q: %w", svc.Name, err)
-		}
-
-		if !hasHostedAgentService && isHostedAgentService(svc, args.Project) {
-			hasHostedAgentService = true
-		}
+	if err := populateContainerSettings(ctx, azdClient, svc); err != nil {
+		return fmt.Errorf("failed to populate container settings for service %q: %w", svc.Name, err)
+	}
+	if err := envUpdate(ctx, azdClient, args.Project, svc); err != nil {
+		return fmt.Errorf("failed to update environment for service %q: %w", svc.Name, err)
 	}
 
 	// Run developer RBAC pre-flight checks only for hosted agent deployments.
-	if hasHostedAgentService {
+	if isHostedAgentService(svc, args.Project) {
 		if err := project.CheckDeveloperRBAC(ctx, azdClient); err != nil {
 			return err
 		}
@@ -198,21 +189,15 @@ func isHostedAgentService(svc *azdext.ServiceConfig, proj *azdext.ProjectConfig)
 	return ok && kind == string(agent_yaml.AgentKindHosted)
 }
 
-func postdeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *azdext.ProjectEventArgs) error {
-	// Skip when the project has no hosted agent services. `postdeploy` fires on every
-	// `azd deploy`, so without this guard the FOUNDRY_PROJECT_ENDPOINT/AZURE_TENANT_ID
-	// reads below would fail for projects that don't use this extension. See #7373.
-	var hostedAgents []*azdext.ServiceConfig
-	for _, svc := range args.Project.Services {
-		if svc.Host == AiAgentHost && isHostedAgentService(svc, args.Project) {
-			hostedAgents = append(hostedAgents, svc)
-		}
-	}
-	if len(hostedAgents) == 0 {
+func postdeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *azdext.ServiceEventArgs) error {
+	svc := args.Service
+
+	// Skip when the service is not a hosted agent.
+	if !isHostedAgentService(svc, args.Project) {
 		return nil
 	}
 
-	// Collect agent identities from hosted agent services that were deployed.
+	// Collect agent identity from the hosted agent service that was deployed.
 	// After deploy, each hosted agent's name/version is stored as AGENT_{SERVICE_KEY}_NAME/VERSION.
 	// We fetch the full agent version object from the API to get the instance identity principal ID,
 	// which allows us to skip the slow Graph API discovery during RBAC assignment.
@@ -259,57 +244,46 @@ func postdeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *a
 
 	agentClient := agent_api.NewAgentClient(endpointResp.Value, cred)
 
-	// Build name→principalID map by fetching the agent version for each hosted service.
-	agentIdentities := make(map[string]string)
-	for _, svc := range hostedAgents {
-		serviceKey := toServiceKey(svc.Name)
+	// Fetch the agent version to get the instance identity principal ID.
+	serviceKey := toServiceKey(svc.Name)
 
-		versionResp, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
-			EnvName: envName,
-			Key:     fmt.Sprintf("AGENT_%s_VERSION", serviceKey),
-		})
-		if err != nil {
-			return fmt.Errorf(
-				"failed to read AGENT_%s_VERSION from environment: %w",
-				serviceKey, err,
-			)
-		}
-		if versionResp.Value == "" {
-			continue
-		}
-
-		// Fetch the agent version to get the instance identity principal ID.
-		versionObj, err := agentClient.GetAgentVersion(
-			ctx, svc.Name, versionResp.Value, DefaultAgentAPIVersion,
+	versionResp, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+		EnvName: envName,
+		Key:     fmt.Sprintf("AGENT_%s_VERSION", serviceKey),
+	})
+	if err != nil {
+		return fmt.Errorf(
+			"failed to read AGENT_%s_VERSION from environment: %w",
+			serviceKey, err,
 		)
-		if err != nil {
-			return fmt.Errorf(
-				"failed to fetch agent version for %s/%s: %w",
-				svc.Name, versionResp.Value, err,
-			)
-		}
-
-		principalID := ""
-		if versionObj.InstanceIdentity != nil {
-			principalID = versionObj.InstanceIdentity.PrincipalID
-		}
-
-		agentIdentities[svc.Name] = principalID
 	}
-
-	if len(agentIdentities) == 0 {
+	if versionResp.Value == "" {
 		return nil
 	}
+
+	versionObj, err := agentClient.GetAgentVersion(
+		ctx, svc.Name, versionResp.Value, DefaultAgentAPIVersion,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to fetch agent version for %s/%s: %w",
+			svc.Name, versionResp.Value, err,
+		)
+	}
+
+	principalID := ""
+	if versionObj.InstanceIdentity != nil {
+		principalID = versionObj.InstanceIdentity.PrincipalID
+	}
+
+	agentIdentities := map[string]string{svc.Name: principalID}
 
 	if err := project.EnsureAgentIdentityRBAC(ctx, azdClient, agentIdentities); err != nil {
 		return fmt.Errorf("agent identity RBAC setup failed: %w", err)
 	}
 
-	// Report optimization candidate deployments to the optimization service.
-	// If a service has AGENT_{KEY}_OPTIMIZATION_CANDIDATE_ID in the azd environment,
-	// the agent was deployed from an optimization candidate. We notify the
-	// optimization service so it can track which candidates have been deployed.
-	reportOptimizationDeployments(ctx, azdClient, hostedAgents, envName, endpointResp.Value,
+	// Report optimization candidate deployment to the optimization service.
+	reportSvcOptimizationDeployment(ctx, azdClient, svc, envName, endpointResp.Value,
 		func(endpoint string) *optimize_api.OptimizeClient {
 			return optimize_api.NewOptimizeClient(endpoint, cred)
 		},

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 
 	"azureaiagent/internal/exterrors"
 	"azureaiagent/internal/pkg/agents/agent_api"
@@ -150,6 +151,12 @@ func currentEnvName(ctx context.Context, azdClient *azdext.AzdClient) (string, e
 	return resp.Environment.Name, nil
 }
 
+// developerRBACOnce ensures CheckDeveloperRBAC runs at most once per extension
+// process lifetime. Service-level predeploy handlers fire per-service, but the
+// RBAC pre-flight check is project-scoped and idempotent — running it once is
+// sufficient and avoids duplicate ARM/Graph calls and noisy output.
+var developerRBACOnce sync.Once
+
 func predeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *azdext.ServiceEventArgs) error {
 	svc := args.Service
 
@@ -161,9 +168,15 @@ func predeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *az
 	}
 
 	// Run developer RBAC pre-flight checks only for hosted agent deployments.
+	// Guarded by sync.Once since this handler fires per-service but the check
+	// is project-scoped.
 	if isHostedAgentService(svc, args.Project) {
-		if err := project.CheckDeveloperRBAC(ctx, azdClient); err != nil {
-			return err
+		var rbacErr error
+		developerRBACOnce.Do(func() {
+			rbacErr = project.CheckDeveloperRBAC(ctx, azdClient)
+		})
+		if rbacErr != nil {
+			return rbacErr
 		}
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_test.go
@@ -16,26 +16,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPostdeployHandler_NoAgentService_NoOp verifies postdeployHandler returns nil
-// without any RPC calls when the project has no hosted agent services. Regression
-// guard for #7373.
-func TestPostdeployHandler_NoAgentService_NoOp(t *testing.T) {
+// TestPostdeployHandler_NonHostedAgent_NoOp verifies postdeployHandler returns nil
+// without any RPC calls when the service is an agent but not a hosted agent (no agent.yaml
+// with kind: hostedAgent). With service-level event handlers, the core filters by host type,
+// so this handler is only invoked for azure.ai.agent services.
+func TestPostdeployHandler_NonHostedAgent_NoOp(t *testing.T) {
 	t.Parallel()
 
 	// Use a temp dir + explicit RelativePath so isHostedAgentService deterministically
 	// returns false (no agent.yaml present) regardless of the test working directory.
-	args := &azdext.ProjectEventArgs{
+	args := &azdext.ServiceEventArgs{
 		Project: &azdext.ProjectConfig{
 			Path: t.TempDir(),
-			Services: map[string]*azdext.ServiceConfig{
-				"teams-bot": {Name: "teams-bot", Host: "containerapp", RelativePath: "."},
-			},
 		},
+		Service: &azdext.ServiceConfig{Name: "my-agent", Host: AiAgentHost, RelativePath: "."},
 	}
 
 	// nil azdClient — the early return must fire before any RPC call.
 	if err := postdeployHandler(t.Context(), nil, args); err != nil {
-		t.Fatalf("expected no error for project without agent services, got: %v", err)
+		t.Fatalf("expected no error for non-hosted agent service, got: %v", err)
 	}
 }
 
@@ -554,34 +553,19 @@ func TestToolboxConnectionsByName_MergesBothTypes(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// postdeployHandler — skips non-agent-host services
+// postdeployHandler — skips non-hosted agent services
 // ---------------------------------------------------------------------------
 
-func TestPostdeployHandler_SkipsNonAgentHostServices(t *testing.T) {
+func TestPostdeployHandler_SkipsNonHostedAgentService(t *testing.T) {
 	t.Parallel()
 
-	// Project has one service with a different host type — handler should
-	// return nil without making any RPC calls (azdClient is nil).
-	args := &azdext.ProjectEventArgs{
+	// Service is an agent host but not a hosted agent (no agent.yaml) — handler
+	// should return nil without making any RPC calls (azdClient is nil).
+	args := &azdext.ServiceEventArgs{
 		Project: &azdext.ProjectConfig{
 			Path: t.TempDir(),
-			Services: map[string]*azdext.ServiceConfig{
-				"api": {Name: "api", Host: "containerapp", RelativePath: "."},
-			},
 		},
-	}
-
-	assert.NoError(t, postdeployHandler(t.Context(), nil, args))
-}
-
-func TestPostdeployHandler_SkipsWhenNoServices(t *testing.T) {
-	t.Parallel()
-
-	args := &azdext.ProjectEventArgs{
-		Project: &azdext.ProjectConfig{
-			Path:     t.TempDir(),
-			Services: map[string]*azdext.ServiceConfig{},
-		},
+		Service: &azdext.ServiceConfig{Name: "my-agent", Host: AiAgentHost, RelativePath: "."},
 	}
 
 	assert.NoError(t, postdeployHandler(t.Context(), nil, args))

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_test.go
@@ -553,25 +553,6 @@ func TestToolboxConnectionsByName_MergesBothTypes(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// postdeployHandler — skips non-hosted agent services
-// ---------------------------------------------------------------------------
-
-func TestPostdeployHandler_SkipsNonHostedAgentService(t *testing.T) {
-	t.Parallel()
-
-	// Service is an agent host but not a hosted agent (no agent.yaml) — handler
-	// should return nil without making any RPC calls (azdClient is nil).
-	args := &azdext.ServiceEventArgs{
-		Project: &azdext.ProjectConfig{
-			Path: t.TempDir(),
-		},
-		Service: &azdext.ServiceConfig{Name: "my-agent", Host: AiAgentHost, RelativePath: "."},
-	}
-
-	assert.NoError(t, postdeployHandler(t.Context(), nil, args))
-}
-
-// ---------------------------------------------------------------------------
 // enrichToolboxFromConnections — server_url already set
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Motivation

The agents extension uses `WithProjectEventHandler` for all lifecycle events, which means each handler receives the full project config and must manually loop through services filtering by `svc.Host == AiAgentHost`. This is error-prone and unnecessary for events that fire at the service level.

## Approach

Switch `predeploy` and `postdeploy` from `WithProjectEventHandler` to `WithServiceEventHandler` with `&azdext.ServiceEventOptions{Host: AiAgentHost}`. The core now handles host-type filtering automatically, and each handler receives a single `*azdext.ServiceEventArgs` instead of needing to iterate all services.

Key changes:
- **Registration**: Two handlers use `WithServiceEventHandler` with the host filter
- **`predeployHandler`**: Operates directly on `args.Service` -- no loop, no host check
- **`postdeployHandler`**: Checks `isHostedAgentService` on the single service, fetches agent version and sets up RBAC for that one service, calls `reportSvcOptimizationDeployment` directly

`preprovision`, `postprovision`, and `postdown` remain as project-level handlers because the core only raises those events on the project config (not on individual service configs).

## Notes

- `reportOptimizationDeployments` (the multi-service wrapper) is no longer called from `postdeployHandler` but remains in `optimize_helpers.go` with its dedicated tests
- `CheckDeveloperRBAC` is idempotent so being called per-service (if multiple agent services exist) is safe
- Net: -103 lines, +61 lines

Fixes: #7989