### PR TITLE
Update agent models to match TypeSpec definition

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show.go
@@ -141,6 +141,8 @@ func resolveEndpointProtocols(endpoint *agent_api.AgentEndpoint) []string {
 	}
 
 	// Prefer protocol_configuration (newer API shape).
+	// A non-nil ProtocolConfiguration is authoritative even if empty,
+	// so we never fall through to the deprecated Protocols field.
 	if pc := endpoint.ProtocolConfiguration; pc != nil {
 		var protocols []string
 		if pc.Activity != nil {
@@ -161,9 +163,7 @@ func resolveEndpointProtocols(endpoint *agent_api.AgentEndpoint) []string {
 		if pc.InvocationsWS != nil {
 			protocols = append(protocols, "invocations_ws")
 		}
-		if len(protocols) > 0 {
-			return protocols
-		}
+		return protocols
 	}
 
 	// Fall back to deprecated Protocols field.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show.go
@@ -132,6 +132,52 @@ func printEndpointJSON(agent *agent_api.AgentObject) error {
 	return enc.Encode(out)
 }
 
+// resolveEndpointProtocols returns the list of enabled protocol names for display.
+// It prefers ProtocolConfiguration (where key presence declares enablement) and falls
+// back to the deprecated Protocols field for older API responses.
+func resolveEndpointProtocols(endpoint *agent_api.AgentEndpoint) []string {
+	if endpoint == nil {
+		return nil
+	}
+
+	// Prefer protocol_configuration (newer API shape).
+	if pc := endpoint.ProtocolConfiguration; pc != nil {
+		var protocols []string
+		if pc.Activity != nil {
+			protocols = append(protocols, "activity")
+		}
+		if pc.Responses != nil {
+			protocols = append(protocols, "responses")
+		}
+		if pc.A2A != nil {
+			protocols = append(protocols, "a2a")
+		}
+		if pc.MCP != nil {
+			protocols = append(protocols, "mcp")
+		}
+		if pc.Invocations != nil {
+			protocols = append(protocols, "invocations")
+		}
+		if pc.InvocationsWS != nil {
+			protocols = append(protocols, "invocations_ws")
+		}
+		if len(protocols) > 0 {
+			return protocols
+		}
+	}
+
+	// Fall back to deprecated Protocols field.
+	if len(endpoint.Protocols) > 0 {
+		protocols := make([]string, len(endpoint.Protocols))
+		for i, p := range endpoint.Protocols {
+			protocols[i] = string(p)
+		}
+		return protocols
+	}
+
+	return nil
+}
+
 func printEndpointTable(agent *agent_api.AgentObject) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 
@@ -140,11 +186,7 @@ func printEndpointTable(agent *agent_api.AgentObject) error {
 
 	// Protocols
 	fmt.Fprintf(w, "Protocols:\t")
-	if agent.AgentEndpoint != nil && len(agent.AgentEndpoint.Protocols) > 0 {
-		protocols := make([]string, len(agent.AgentEndpoint.Protocols))
-		for i, p := range agent.AgentEndpoint.Protocols {
-			protocols[i] = string(p)
-		}
+	if protocols := resolveEndpointProtocols(agent.AgentEndpoint); len(protocols) > 0 {
 		fmt.Fprintf(w, "%s\n", strings.Join(protocols, ", "))
 	} else {
 		fmt.Fprintf(w, "(not configured)\n")

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show_test.go
@@ -135,6 +135,70 @@ func TestPrintEndpointJSON(t *testing.T) {
 	t.Logf("=== endpoint show --output json ===\n%s", output)
 }
 
+func TestPrintEndpointTable_ProtocolConfiguration(t *testing.T) {
+	agent := &agent_api.AgentObject{
+		Name: "proto-config-agent",
+		AgentEndpoint: &agent_api.AgentEndpoint{
+			ProtocolConfiguration: &agent_api.ProtocolConfiguration{
+				Responses:   &agent_api.ResponsesProtocolConfiguration{},
+				A2A:         &agent_api.A2AProtocolConfiguration{},
+				Invocations: &agent_api.InvocationsProtocolConfiguration{},
+			},
+		},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := printEndpointTable(agent)
+	require.NoError(t, err)
+
+	_ = w.Close() //nolint:gosec
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	assert.Contains(t, output, "proto-config-agent")
+	assert.Contains(t, output, "responses")
+	assert.Contains(t, output, "a2a")
+	assert.Contains(t, output, "invocations")
+	// Should NOT contain "mcp" since it's not in protocol_configuration
+	assert.NotContains(t, output, "mcp")
+
+	t.Logf("=== endpoint show (protocol_configuration) ===\n%s", output)
+}
+
+func TestResolveEndpointProtocols(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint *agent_api.AgentEndpoint
+		want     []string
+	}{
+		{"nil endpoint", nil, nil},
+		{"empty endpoint", &agent_api.AgentEndpoint{}, nil},
+		{"protocol_configuration preferred over protocols", &agent_api.AgentEndpoint{
+			Protocols: []agent_api.AgentEndpointProtocol{"activity"},
+			ProtocolConfiguration: &agent_api.ProtocolConfiguration{
+				Responses: &agent_api.ResponsesProtocolConfiguration{},
+				MCP:       &agent_api.MCPProtocolConfiguration{},
+			},
+		}, []string{"responses", "mcp"}},
+		{"fallback to protocols", &agent_api.AgentEndpoint{
+			Protocols: []agent_api.AgentEndpointProtocol{"responses", "a2a"},
+		}, []string{"responses", "a2a"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveEndpointProtocols(tt.endpoint)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestGetIsolationKind(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show_test.go
@@ -186,6 +186,10 @@ func TestResolveEndpointProtocols(t *testing.T) {
 				MCP:       &agent_api.MCPProtocolConfiguration{},
 			},
 		}, []string{"responses", "mcp"}},
+		{"empty protocol_configuration is authoritative", &agent_api.AgentEndpoint{
+			Protocols:             []agent_api.AgentEndpointProtocol{"activity"},
+			ProtocolConfiguration: &agent_api.ProtocolConfiguration{},
+		}, nil},
 		{"fallback to protocols", &agent_api.AgentEndpoint{
 			Protocols: []agent_api.AgentEndpointProtocol{"responses", "a2a"},
 		}, []string{"responses", "a2a"}},

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
@@ -116,9 +116,10 @@ type VersionSelector struct {
 type AgentEndpointAuthorizationSchemeType string
 
 const (
-	AgentEndpointAuthSchemeEntra          AgentEndpointAuthorizationSchemeType = "Entra"
-	AgentEndpointAuthSchemeBotService     AgentEndpointAuthorizationSchemeType = "BotService"
-	AgentEndpointAuthSchemeBotServiceRbac AgentEndpointAuthorizationSchemeType = "BotServiceRbac"
+	AgentEndpointAuthSchemeEntra            AgentEndpointAuthorizationSchemeType = "Entra"
+	AgentEndpointAuthSchemeBotService       AgentEndpointAuthorizationSchemeType = "BotService"
+	AgentEndpointAuthSchemeBotServiceRbac   AgentEndpointAuthorizationSchemeType = "BotServiceRbac"
+	AgentEndpointAuthSchemeBotServiceTenant AgentEndpointAuthorizationSchemeType = "BotServiceTenant"
 )
 
 // IsolationKeySourceKind represents the kind of isolation key source.
@@ -142,11 +143,43 @@ type AgentEndpointAuthorizationScheme struct {
 	IsolationKeySource *IsolationKeySource                  `json:"isolation_key_source,omitempty"`
 }
 
+// ActivityProtocolConfiguration describes configuration specific to the activity protocol.
+type ActivityProtocolConfiguration struct {
+	EnableM365PublicEndpoint *bool `json:"enable_m365_public_endpoint,omitempty"`
+}
+
+// ResponsesProtocolConfiguration describes configuration specific to the responses protocol.
+type ResponsesProtocolConfiguration struct{}
+
+// A2AProtocolConfiguration describes configuration specific to the A2A protocol.
+type A2AProtocolConfiguration struct{}
+
+// McpProtocolConfiguration describes configuration specific to the MCP protocol.
+type McpProtocolConfiguration struct{}
+
+// InvocationsProtocolConfiguration describes configuration specific to the invocations protocol.
+type InvocationsProtocolConfiguration struct{}
+
+// InvocationsWsProtocolConfiguration describes configuration specific to the WebSocket-based invocations protocol.
+type InvocationsWsProtocolConfiguration struct{}
+
+// ProtocolConfiguration describes per-protocol configuration for the agent endpoint.
+// The presence of a key declares the protocol is enabled.
+type ProtocolConfiguration struct {
+	Activity      *ActivityProtocolConfiguration      `json:"activity,omitempty"`
+	Responses     *ResponsesProtocolConfiguration     `json:"responses,omitempty"`
+	A2A           *A2AProtocolConfiguration           `json:"a2a,omitempty"`
+	MCP           *McpProtocolConfiguration           `json:"mcp,omitempty"`
+	Invocations   *InvocationsProtocolConfiguration   `json:"invocations,omitempty"`
+	InvocationsWs *InvocationsWsProtocolConfiguration `json:"invocations_ws,omitempty"`
+}
+
 // AgentEndpoint describes the endpoint configuration for an agent.
 type AgentEndpoint struct {
-	VersionSelector      *VersionSelector                   `json:"version_selector,omitempty"`
-	Protocols            []AgentEndpointProtocol            `json:"protocols,omitempty"`
-	AuthorizationSchemes []AgentEndpointAuthorizationScheme `json:"authorization_schemes,omitempty"`
+	VersionSelector        *VersionSelector                   `json:"version_selector,omitempty"`
+	Protocols              []AgentEndpointProtocol            `json:"protocols,omitempty"`
+	ProtocolConfiguration  *ProtocolConfiguration             `json:"protocol_configuration,omitempty"`
+	AuthorizationSchemes   []AgentEndpointAuthorizationScheme `json:"authorization_schemes,omitempty"`
 }
 
 // AgentCardSkill describes a single capability that an agent can perform.
@@ -315,12 +348,16 @@ type AgentVersionError struct {
 
 // AgentObject represents an agent
 type AgentObject struct {
-	Object        string         `json:"object"`
-	ID            string         `json:"id"`
-	Name          string         `json:"name"`
-	AgentEndpoint *AgentEndpoint `json:"agent_endpoint,omitempty"`
-	AgentCard     *AgentCard     `json:"agent_card,omitempty"`
-	Versions      struct {
+	Object             string              `json:"object"`
+	ID                 string              `json:"id"`
+	Name               string              `json:"name"`
+	State              string              `json:"state,omitempty"`
+	AgentEndpoint      *AgentEndpoint      `json:"agent_endpoint,omitempty"`
+	AgentCard          *AgentCard          `json:"agent_card,omitempty"`
+	InstanceIdentity   *AgentIdentityInfo  `json:"instance_identity,omitempty"`
+	Blueprint          *BlueprintInfo      `json:"blueprint,omitempty"`
+	BlueprintReference *BlueprintReference `json:"blueprint_reference,omitempty"`
+	Versions           struct {
 		Latest AgentVersionObject `json:"latest"`
 	} `json:"versions"`
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
@@ -166,20 +166,20 @@ type InvocationsWSProtocolConfiguration struct{}
 // ProtocolConfiguration describes per-protocol configuration for the agent endpoint.
 // The presence of a key declares the protocol is enabled.
 type ProtocolConfiguration struct {
-	Activity      *ActivityProtocolConfiguration       `json:"activity,omitempty"`
-	Responses     *ResponsesProtocolConfiguration      `json:"responses,omitempty"`
-	A2A           *A2AProtocolConfiguration            `json:"a2a,omitempty"`
-	MCP           *MCPProtocolConfiguration            `json:"mcp,omitempty"`
-	Invocations   *InvocationsProtocolConfiguration    `json:"invocations,omitempty"`
-	InvocationsWS *InvocationsWSProtocolConfiguration  `json:"invocations_ws,omitempty"`
+	Activity      *ActivityProtocolConfiguration      `json:"activity,omitempty"`
+	Responses     *ResponsesProtocolConfiguration     `json:"responses,omitempty"`
+	A2A           *A2AProtocolConfiguration           `json:"a2a,omitempty"`
+	MCP           *MCPProtocolConfiguration           `json:"mcp,omitempty"`
+	Invocations   *InvocationsProtocolConfiguration   `json:"invocations,omitempty"`
+	InvocationsWS *InvocationsWSProtocolConfiguration `json:"invocations_ws,omitempty"`
 }
 
 // AgentEndpoint describes the endpoint configuration for an agent.
 type AgentEndpoint struct {
-	VersionSelector        *VersionSelector                   `json:"version_selector,omitempty"`
-	Protocols              []AgentEndpointProtocol            `json:"protocols,omitempty"`
-	ProtocolConfiguration  *ProtocolConfiguration             `json:"protocol_configuration,omitempty"`
-	AuthorizationSchemes   []AgentEndpointAuthorizationScheme `json:"authorization_schemes,omitempty"`
+	VersionSelector       *VersionSelector                   `json:"version_selector,omitempty"`
+	Protocols             []AgentEndpointProtocol            `json:"protocols,omitempty"`
+	ProtocolConfiguration *ProtocolConfiguration             `json:"protocol_configuration,omitempty"`
+	AuthorizationSchemes  []AgentEndpointAuthorizationScheme `json:"authorization_schemes,omitempty"`
 }
 
 // AgentCardSkill describes a single capability that an agent can perform.

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
@@ -154,24 +154,24 @@ type ResponsesProtocolConfiguration struct{}
 // A2AProtocolConfiguration describes configuration specific to the A2A protocol.
 type A2AProtocolConfiguration struct{}
 
-// McpProtocolConfiguration describes configuration specific to the MCP protocol.
-type McpProtocolConfiguration struct{}
+// MCPProtocolConfiguration describes configuration specific to the MCP protocol.
+type MCPProtocolConfiguration struct{}
 
 // InvocationsProtocolConfiguration describes configuration specific to the invocations protocol.
 type InvocationsProtocolConfiguration struct{}
 
-// InvocationsWsProtocolConfiguration describes configuration specific to the WebSocket-based invocations protocol.
-type InvocationsWsProtocolConfiguration struct{}
+// InvocationsWSProtocolConfiguration describes configuration specific to the WebSocket-based invocations protocol.
+type InvocationsWSProtocolConfiguration struct{}
 
 // ProtocolConfiguration describes per-protocol configuration for the agent endpoint.
 // The presence of a key declares the protocol is enabled.
 type ProtocolConfiguration struct {
-	Activity      *ActivityProtocolConfiguration      `json:"activity,omitempty"`
-	Responses     *ResponsesProtocolConfiguration     `json:"responses,omitempty"`
-	A2A           *A2AProtocolConfiguration           `json:"a2a,omitempty"`
-	MCP           *McpProtocolConfiguration           `json:"mcp,omitempty"`
-	Invocations   *InvocationsProtocolConfiguration   `json:"invocations,omitempty"`
-	InvocationsWs *InvocationsWsProtocolConfiguration `json:"invocations_ws,omitempty"`
+	Activity      *ActivityProtocolConfiguration       `json:"activity,omitempty"`
+	Responses     *ResponsesProtocolConfiguration      `json:"responses,omitempty"`
+	A2A           *A2AProtocolConfiguration            `json:"a2a,omitempty"`
+	MCP           *MCPProtocolConfiguration            `json:"mcp,omitempty"`
+	Invocations   *InvocationsProtocolConfiguration    `json:"invocations,omitempty"`
+	InvocationsWS *InvocationsWSProtocolConfiguration  `json:"invocations_ws,omitempty"`
 }
 
 // AgentEndpoint describes the endpoint configuration for an agent.

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
@@ -1378,9 +1378,9 @@ func TestAgentEndpoint_ProtocolConfiguration_RoundTrip(t *testing.T) {
 			Activity:      &ActivityProtocolConfiguration{EnableM365PublicEndpoint: new(true)},
 			Responses:     &ResponsesProtocolConfiguration{},
 			A2A:           &A2AProtocolConfiguration{},
-			MCP:           &McpProtocolConfiguration{},
+			MCP:           &MCPProtocolConfiguration{},
 			Invocations:   &InvocationsProtocolConfiguration{},
-			InvocationsWs: &InvocationsWsProtocolConfiguration{},
+			InvocationsWS: &InvocationsWSProtocolConfiguration{},
 		},
 	}
 
@@ -1426,7 +1426,7 @@ func TestAgentEndpoint_ProtocolConfiguration_RoundTrip(t *testing.T) {
 	if got.ProtocolConfiguration.Invocations == nil {
 		t.Error("Invocations is nil")
 	}
-	if got.ProtocolConfiguration.InvocationsWs == nil {
-		t.Error("InvocationsWs is nil")
+	if got.ProtocolConfiguration.InvocationsWS == nil {
+		t.Error("InvocationsWS is nil")
 	}
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
@@ -1284,3 +1284,149 @@ func TestAgentEndpoint_JSONRoundTrip(t *testing.T) {
 			got.AuthorizationSchemes[1].IsolationKeySource)
 	}
 }
+
+func TestAgentObject_RoundTrip_AllFields(t *testing.T) {
+	t.Parallel()
+
+	original := AgentObject{
+		Object: "agent",
+		ID:     "agent-456",
+		Name:   "full-agent",
+		State:  "enabled",
+		AgentEndpoint: &AgentEndpoint{
+			Protocols: []AgentEndpointProtocol{AgentEndpointProtocolResponses},
+		},
+		InstanceIdentity: &AgentIdentityInfo{
+			PrincipalID: "pid-111",
+			ClientID:    "cid-222",
+		},
+		Blueprint: &BlueprintInfo{
+			PrincipalID: "bp-pid-333",
+			ClientID:    "bp-cid-444",
+		},
+		BlueprintReference: &BlueprintReference{
+			Type:        "ManagedAgentIdentityBlueprint",
+			BlueprintID: "bp-id-555",
+		},
+		Versions: struct {
+			Latest AgentVersionObject `json:"latest"`
+		}{
+			Latest: AgentVersionObject{
+				Object:  "agent_version",
+				ID:      "ver-2",
+				Name:    "full-agent",
+				Version: "1",
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	s := string(data)
+	for _, field := range []string{
+		`"state"`, `"instance_identity"`, `"blueprint"`, `"blueprint_reference"`,
+		`"principal_id"`, `"client_id"`, `"blueprint_id"`,
+	} {
+		if !strings.Contains(s, field) {
+			t.Errorf("expected JSON to contain %s, got: %s", field, s)
+		}
+	}
+
+	var got AgentObject
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.State != "enabled" {
+		t.Errorf("State = %q, want %q", got.State, "enabled")
+	}
+	if got.InstanceIdentity == nil {
+		t.Fatal("InstanceIdentity is nil")
+	}
+	if got.InstanceIdentity.PrincipalID != "pid-111" {
+		t.Errorf("InstanceIdentity.PrincipalID = %q, want %q",
+			got.InstanceIdentity.PrincipalID, "pid-111")
+	}
+	if got.Blueprint == nil {
+		t.Fatal("Blueprint is nil")
+	}
+	if got.Blueprint.PrincipalID != "bp-pid-333" {
+		t.Errorf("Blueprint.PrincipalID = %q, want %q",
+			got.Blueprint.PrincipalID, "bp-pid-333")
+	}
+	if got.BlueprintReference == nil {
+		t.Fatal("BlueprintReference is nil")
+	}
+	if got.BlueprintReference.Type != "ManagedAgentIdentityBlueprint" {
+		t.Errorf("BlueprintReference.Type = %q, want %q",
+			got.BlueprintReference.Type, "ManagedAgentIdentityBlueprint")
+	}
+	if got.BlueprintReference.BlueprintID != "bp-id-555" {
+		t.Errorf("BlueprintReference.BlueprintID = %q, want %q",
+			got.BlueprintReference.BlueprintID, "bp-id-555")
+	}
+}
+
+func TestAgentEndpoint_ProtocolConfiguration_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := AgentEndpoint{
+		ProtocolConfiguration: &ProtocolConfiguration{
+			Activity:      &ActivityProtocolConfiguration{EnableM365PublicEndpoint: new(true)},
+			Responses:     &ResponsesProtocolConfiguration{},
+			A2A:           &A2AProtocolConfiguration{},
+			MCP:           &McpProtocolConfiguration{},
+			Invocations:   &InvocationsProtocolConfiguration{},
+			InvocationsWs: &InvocationsWsProtocolConfiguration{},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	s := string(data)
+	for _, field := range []string{
+		`"protocol_configuration"`, `"activity"`, `"responses"`, `"a2a"`,
+		`"mcp"`, `"invocations"`, `"invocations_ws"`, `"enable_m365_public_endpoint"`,
+	} {
+		if !strings.Contains(s, field) {
+			t.Errorf("expected JSON to contain %s, got: %s", field, s)
+		}
+	}
+
+	var got AgentEndpoint
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.ProtocolConfiguration == nil {
+		t.Fatal("ProtocolConfiguration is nil")
+	}
+	if got.ProtocolConfiguration.Activity == nil {
+		t.Fatal("Activity is nil")
+	}
+	if got.ProtocolConfiguration.Activity.EnableM365PublicEndpoint == nil ||
+		!*got.ProtocolConfiguration.Activity.EnableM365PublicEndpoint {
+		t.Error("Activity.EnableM365PublicEndpoint should be true")
+	}
+	if got.ProtocolConfiguration.Responses == nil {
+		t.Error("Responses is nil")
+	}
+	if got.ProtocolConfiguration.A2A == nil {
+		t.Error("A2A is nil")
+	}
+	if got.ProtocolConfiguration.MCP == nil {
+		t.Error("MCP is nil")
+	}
+	if got.ProtocolConfiguration.Invocations == nil {
+		t.Error("Invocations is nil")
+	}
+	if got.ProtocolConfiguration.InvocationsWs == nil {
+		t.Error("InvocationsWs is nil")
+	}
+}


### PR DESCRIPTION
## Motivation

Our Go agent model structs (`AgentObject`, `AgentEndpoint`) were outdated compared to the service TypeSpec at [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs/blob/feature/foundry-release/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp). Missing fields meant the CLI silently dropped properties returned by the API.

## Changes

**`AgentObject`** -- added fields present in the TypeSpec but missing from Go:
- `State` (operational state: enabled/disabled)
- `InstanceIdentity`, `Blueprint`, `BlueprintReference` (identity/blueprint info already on `AgentVersionObject` but missing at the agent level)

**`AgentEndpoint`** -- added `ProtocolConfiguration` field and supporting types:
- `ProtocolConfiguration` struct with per-protocol config pointers (activity, responses, a2a, mcp, invocations, invocations_ws)
- `ActivityProtocolConfiguration` with `EnableM365PublicEndpoint`
- Empty marker structs for the other protocols (matching the TypeSpec which reserves them for future fields)

**Constants** -- added `AgentEndpointAuthSchemeBotServiceTenant` to match the TypeSpec `AgentEndpointAuthorizationSchemeType` union.

**Tests** -- added two round-trip tests covering the new fields:
- `TestAgentObject_RoundTrip_AllFields`
- `TestAgentEndpoint_ProtocolConfiguration_RoundTrip`

## Notes

- `AgentVersionObject` was already aligned with TypeSpec -- no changes needed there.
- The `agent show` command calls `GetAgentVersion` (returns `AgentVersionObject`), so its output is unaffected. The `AgentObject` changes benefit commands that use `GetAgent` (e.g., list).

Fixes: #8338