### PR TITLE
fix(azure.ai.skills): address follow-up items from skill commands PR

### DIFF
--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create.go
@@ -150,9 +150,12 @@ func (a *createAction) runFileMd(ctx context.Context, client *skill_api.Client) 
 
 	version, err := client.CreateVersionInline(ctx, a.flags.name, skill_api.CreateVersionRequest{
 		InlineContent: &skill_api.SkillInlineContent{
-			Description:  parsed.Description,
-			Instructions: parsed.Instructions,
-			Metadata:     parsed.Metadata,
+			Description:   parsed.Description,
+			Instructions:  parsed.Instructions,
+			Metadata:      parsed.Metadata,
+			License:       parsed.License,
+			Compatibility: parsed.Compatibility,
+			AllowedTools:  parsed.AllowedTools,
 		},
 		Default: true,
 	})
@@ -276,6 +279,7 @@ func (a *createAction) printCreateResult(ctx context.Context, client *skill_api.
 	if err != nil {
 		// Don't fail the create just because the follow-up GET failed; fall
 		// back to printing the version envelope instead.
+		fmt.Fprintf(os.Stderr, "Warning: could not fetch skill details: %v\n", err)
 		return printSkillVersionDetail(version, outputTable)
 	}
 	return printSkillDetail(skill, outputTable)

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_download.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_download.go
@@ -28,6 +28,7 @@ type downloadFlags struct {
 	projectEndpoint string
 
 	outputDirSet bool
+	versionSet   bool
 }
 
 type downloadAction struct{ flags *downloadFlags }
@@ -47,9 +48,10 @@ func (a *downloadAction) Run(ctx context.Context) error {
 		return err
 	}
 
-	// Reject whitespace-only --version to catch scripting bugs like
-	// --version "$UNSET_VAR" that would silently download the default.
-	if a.flags.version != "" && strings.TrimSpace(a.flags.version) == "" {
+	// Reject explicitly-provided but empty/whitespace --version to catch
+	// scripting bugs like --version "$UNSET_VAR" that would otherwise
+	// silently download the default version.
+	if a.flags.versionSet && strings.TrimSpace(a.flags.version) == "" {
 		return exterrors.Validation(
 			exterrors.CodeInvalidParameter,
 			"--version must not be empty or whitespace-only",
@@ -234,6 +236,7 @@ total uncompressed size.`,
 			flags.name = args[0]
 			flags.output = extCtx.OutputFormat
 			flags.outputDirSet = cmd.Flags().Changed("output-dir")
+			flags.versionSet = cmd.Flags().Changed("version")
 			flags.projectEndpoint, _ = cmd.Flags().GetString("project-endpoint")
 			return action.Run(azdext.WithAccessToken(cmd.Context()))
 		},

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_download.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_download.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"azureaiskills/internal/exterrors"
 	"azureaiskills/internal/pkg/skill_api"
@@ -44,6 +45,16 @@ type downloadResult struct {
 func (a *downloadAction) Run(ctx context.Context) error {
 	if err := validateSkillName(a.flags.name); err != nil {
 		return err
+	}
+
+	// Reject whitespace-only --version to catch scripting bugs like
+	// --version "$UNSET_VAR" that would silently download the default.
+	if a.flags.version != "" && strings.TrimSpace(a.flags.version) == "" {
+		return exterrors.Validation(
+			exterrors.CodeInvalidParameter,
+			"--version must not be empty or whitespace-only",
+			"pass an explicit version identifier, or omit --version to use the default",
+		)
 	}
 
 	outputDir := a.flags.outputDir

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_download_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_download_test.go
@@ -69,11 +69,20 @@ func TestDownloadAction_RejectsInvalidName(t *testing.T) {
 }
 
 func TestDownloadAction_RejectsWhitespaceOnlyVersion(t *testing.T) {
-	a := &downloadAction{flags: &downloadFlags{name: "my-skill", version: "   "}}
+	a := &downloadAction{flags: &downloadFlags{name: "my-skill", version: "   ", versionSet: true}}
 	err := a.Run(context.Background())
 	require.Error(t, err)
 	var le *azdext.LocalError
 	require.True(t, errors.As(err, &le))
 	require.Equal(t, exterrors.CodeInvalidParameter, le.Code)
 	require.Contains(t, le.Message, "whitespace")
+}
+
+func TestDownloadAction_RejectsEmptyVersionWhenFlagSet(t *testing.T) {
+	a := &downloadAction{flags: &downloadFlags{name: "my-skill", version: "", versionSet: true}}
+	err := a.Run(context.Background())
+	require.Error(t, err)
+	var le *azdext.LocalError
+	require.True(t, errors.As(err, &le))
+	require.Equal(t, exterrors.CodeInvalidParameter, le.Code)
 }

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_download_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_download_test.go
@@ -67,3 +67,13 @@ func TestDownloadAction_RejectsInvalidName(t *testing.T) {
 	require.True(t, errors.As(err, &le))
 	require.Equal(t, exterrors.CodeInvalidSkillName, le.Code)
 }
+
+func TestDownloadAction_RejectsWhitespaceOnlyVersion(t *testing.T) {
+	a := &downloadAction{flags: &downloadFlags{name: "my-skill", version: "   "}}
+	err := a.Run(context.Background())
+	require.Error(t, err)
+	var le *azdext.LocalError
+	require.True(t, errors.As(err, &le))
+	require.Equal(t, exterrors.CodeInvalidParameter, le.Code)
+	require.Contains(t, le.Message, "whitespace")
+}

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_update.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_update.go
@@ -203,6 +203,7 @@ func (a *updateAction) printUpdateResult(ctx context.Context, client *skill_api.
 	if err != nil {
 		// Don't fail the update just because the follow-up GET failed; fall
 		// back to printing the version envelope instead.
+		fmt.Fprintf(os.Stderr, "Warning: could not fetch skill details: %v\n", err)
 		return printSkillVersionDetail(version, outputTable)
 	}
 	return printSkillDetail(skill, outputTable)
@@ -230,6 +231,9 @@ func (a *updateAction) buildInlineContent() (*skill_api.SkillInlineContent, erro
 		content.Description = parsed.Description
 		content.Instructions = parsed.Instructions
 		content.Metadata = parsed.Metadata
+		content.License = parsed.License
+		content.Compatibility = parsed.Compatibility
+		content.AllowedTools = parsed.AllowedTools
 	}
 
 	if strings.TrimSpace(content.Description) == "" {

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_update_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_update_test.go
@@ -208,3 +208,40 @@ func TestUpdateAction_PackageFileIsDirectoryFails(t *testing.T) {
 	require.True(t, errors.As(err, &le))
 	require.Equal(t, exterrors.CodeInvalidSkillFile, le.Code)
 }
+
+// --- buildInlineContent validation (issue #8366) ---
+
+// TestUpdateAction_InlineDescriptionOnly_RejectsWithoutInstructions verifies
+// that passing --description alone (without --instructions) is rejected at
+// buildInlineContent time with CodeMissingRequiredField.
+func TestUpdateAction_InlineDescriptionOnly_RejectsWithoutInstructions(t *testing.T) {
+	a := &updateAction{flags: &updateFlags{
+		name:           "my-skill",
+		descriptionSet: true,
+		description:    "updated description",
+	}}
+	content, err := a.buildInlineContent()
+	require.Nil(t, content)
+	require.Error(t, err)
+	var le *azdext.LocalError
+	require.True(t, errors.As(err, &le))
+	require.Equal(t, exterrors.CodeMissingRequiredField, le.Code)
+	require.Contains(t, le.Message, "instructions")
+}
+
+// TestUpdateAction_InlineInstructionsOnly_RejectsWithoutDescription verifies
+// that passing --instructions alone (without --description) is rejected.
+func TestUpdateAction_InlineInstructionsOnly_RejectsWithoutDescription(t *testing.T) {
+	a := &updateAction{flags: &updateFlags{
+		name:            "my-skill",
+		instructionsSet: true,
+		instructions:    "updated instructions",
+	}}
+	content, err := a.buildInlineContent()
+	require.Nil(t, content)
+	require.Error(t, err)
+	var le *azdext.LocalError
+	require.True(t, errors.As(err, &le))
+	require.Equal(t, exterrors.CodeMissingRequiredField, le.Code)
+	require.Contains(t, le.Message, "description")
+}

--- a/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/archive.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/archive.go
@@ -4,10 +4,8 @@
 package skill_api
 
 import (
-	"archive/tar"
 	"archive/zip"
 	"bytes"
-	"compress/gzip"
 	"errors"
 	"fmt"
 	"io"
@@ -42,44 +40,7 @@ var (
 	ErrInvalidArchive = errors.New("invalid archive")
 )
 
-type ArchiveFormat int
-
-const (
-	ArchiveUnknown ArchiveFormat = iota
-	ArchiveZip
-	ArchiveTarGz
-)
-
-func (f ArchiveFormat) String() string {
-	switch f {
-	case ArchiveZip:
-		return "zip"
-	case ArchiveTarGz:
-		return "tar.gz"
-	default:
-		return "unknown"
-	}
-}
-
-// DetectArchiveFormat sniffs the first bytes of data. The Foundry Skills
-// download endpoints (GET /skills/{name}/content and
-// GET /skills/{name}/versions/{version}/content) return application/zip;
-// the gzip-tar branch remains for resilience against legacy or alternate
-// content paths.
-func DetectArchiveFormat(data []byte) ArchiveFormat {
-	switch {
-	case len(data) >= 4 && bytes.Equal(data[:4], []byte{'P', 'K', 0x03, 0x04}):
-		return ArchiveZip
-	case len(data) >= 4 && bytes.Equal(data[:4], []byte{'P', 'K', 0x05, 0x06}):
-		return ArchiveZip
-	case len(data) >= 2 && data[0] == 0x1f && data[1] == 0x8b:
-		return ArchiveTarGz
-	default:
-		return ArchiveUnknown
-	}
-}
-
-// SafeExtract extracts a ZIP or gzip-tar archive into opts.OutputDir.
+// SafeExtract extracts a ZIP archive into opts.OutputDir.
 //
 // Two-phase: entries are first written into a temp staging directory and
 // validated against the safety rules below; then symlink-escape checks run
@@ -106,26 +67,18 @@ func SafeExtract(data []byte, opts ExtractOptions) (*ExtractResult, error) {
 		maxBytes = DefaultMaxTotalUncompressed
 	}
 
+	// Validate ZIP magic bytes before attempting extraction.
+	if !isZipMagic(data) {
+		return nil, fmt.Errorf("%w: unrecognized archive format (expected ZIP)", ErrInvalidArchive)
+	}
+
 	staging, err := os.MkdirTemp("", "azd-skill-extract-*")
 	if err != nil {
 		return nil, fmt.Errorf("create staging directory: %w", err)
 	}
 	cleanupStaging := func() { _ = os.RemoveAll(staging) }
 
-	var (
-		files      []string
-		totalBytes int64
-		stageErr   error
-	)
-	switch DetectArchiveFormat(data) {
-	case ArchiveZip:
-		files, totalBytes, stageErr = stageFromZip(data, staging, maxEntries, maxBytes)
-	case ArchiveTarGz:
-		files, totalBytes, stageErr = stageFromTarGz(data, staging, maxEntries, maxBytes)
-	default:
-		cleanupStaging()
-		return nil, fmt.Errorf("%w: unrecognized magic bytes", ErrInvalidArchive)
-	}
+	files, totalBytes, stageErr := stageFromZip(data, staging, maxEntries, maxBytes)
 	if stageErr != nil {
 		cleanupStaging()
 		return nil, stageErr
@@ -138,6 +91,16 @@ func SafeExtract(data []byte, opts ExtractOptions) (*ExtractResult, error) {
 
 	cleanupStaging()
 	return &ExtractResult{Files: files, TotalBytes: totalBytes}, nil
+}
+
+// isZipMagic checks whether data starts with a valid ZIP magic number.
+func isZipMagic(data []byte) bool {
+	if len(data) < 4 {
+		return false
+	}
+	// PK\x03\x04 = local file header, PK\x05\x06 = empty archive (end of central dir)
+	return bytes.Equal(data[:4], []byte{'P', 'K', 0x03, 0x04}) ||
+		bytes.Equal(data[:4], []byte{'P', 'K', 0x05, 0x06})
 }
 
 func stageFromZip(data []byte, staging string, maxEntries int, maxBytes int64) ([]string, int64, error) {
@@ -177,62 +140,6 @@ func stageFromZip(data []byte, staging string, maxEntries int, maxBytes int64) (
 			defer rc.Close()
 			return io.Copy(w, io.LimitReader(rc, limit))
 		}, maxBytes-totalBytes, int64(entry.UncompressedSize64)) //nolint:gosec // bound-checked inside writeStagingEntry
-		if writeErr != nil {
-			return nil, 0, writeErr
-		}
-		totalBytes += written
-		files = append(files, cleaned)
-	}
-	return files, totalBytes, nil
-}
-
-func stageFromTarGz(data []byte, staging string, maxEntries int, maxBytes int64) ([]string, int64, error) {
-	gz, err := gzip.NewReader(bytes.NewReader(data))
-	if err != nil {
-		return nil, 0, fmt.Errorf("%w: %w", ErrInvalidArchive, err)
-	}
-	defer gz.Close()
-
-	tr := tar.NewReader(gz)
-	var files []string
-	var totalBytes int64
-	entryCount := 0
-
-	for {
-		hdr, hdrErr := tr.Next()
-		if errors.Is(hdrErr, io.EOF) {
-			break
-		}
-		if hdrErr != nil {
-			return nil, 0, fmt.Errorf("read tar entry: %w", hdrErr)
-		}
-		if entryCount >= maxEntries {
-			return nil, 0, fmt.Errorf("%w: entry count exceeds %d", ErrLimitExceeded, maxEntries)
-		}
-		entryCount++
-
-		cleaned, ok := validateEntryName(hdr.Name)
-		if !ok {
-			return nil, 0, fmt.Errorf("%w: %q", ErrUnsafeEntry, hdr.Name)
-		}
-
-		switch hdr.Typeflag {
-		case tar.TypeReg, tar.TypeRegA:
-			if hdr.Linkname != "" {
-				return nil, 0, fmt.Errorf("%w: %q regular-file entry has unexpected Linkname", ErrUnsafeEntry, hdr.Name)
-			}
-		case tar.TypeDir:
-			if mkErr := os.MkdirAll(filepath.Join(staging, filepath.FromSlash(cleaned)), 0700); mkErr != nil {
-				return nil, 0, fmt.Errorf("create staging dir %q: %w", cleaned, mkErr)
-			}
-			continue
-		default:
-			return nil, 0, fmt.Errorf("%w: %q has unsupported tar type %c", ErrUnsafeEntry, hdr.Name, hdr.Typeflag)
-		}
-
-		written, writeErr := writeStagingEntry(staging, cleaned, func(w io.Writer, limit int64) (int64, error) {
-			return io.Copy(w, io.LimitReader(tr, limit))
-		}, maxBytes-totalBytes, hdr.Size)
 		if writeErr != nil {
 			return nil, 0, writeErr
 		}

--- a/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/archive_create_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/archive_create_test.go
@@ -35,7 +35,7 @@ func TestArchiveDirectory_HappyPathRoundTrips(t *testing.T) {
 
 	data, err := ArchiveDirectory(src, ArchiveOptions{})
 	require.NoError(t, err)
-	require.Equal(t, ArchiveZip, DetectArchiveFormat(data))
+	require.True(t, isZipMagic(data))
 
 	// Round-trip through SafeExtract: every file should land in dst with the
 	// same content, using forward-slash paths regardless of the OS.
@@ -81,7 +81,7 @@ func TestArchiveDirectory_FollowsTopLevelSymlink(t *testing.T) {
 
 	data, err := ArchiveDirectory(link, ArchiveOptions{})
 	require.NoError(t, err)
-	require.Equal(t, ArchiveZip, DetectArchiveFormat(data))
+	require.True(t, isZipMagic(data))
 }
 
 func TestArchiveDirectory_RejectsInnerSymlink(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/archive_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/archive_test.go
@@ -4,10 +4,8 @@
 package skill_api
 
 import (
-	"archive/tar"
 	"archive/zip"
 	"bytes"
-	"compress/gzip"
 	"errors"
 	"os"
 	"path/filepath"
@@ -46,27 +44,6 @@ func makeZip(t *testing.T, entries []zipEntry) []byte {
 		}
 	}
 	require.NoError(t, zw.Close())
-	return buf.Bytes()
-}
-
-type tarEntry struct {
-	Name string
-	Body []byte
-}
-
-func makeTarGz(t *testing.T, entries []tarEntry) []byte {
-	t.Helper()
-	var buf bytes.Buffer
-	gz := gzip.NewWriter(&buf)
-	tw := tar.NewWriter(gz)
-	for _, e := range entries {
-		hdr := &tar.Header{Name: e.Name, Mode: 0644, Typeflag: tar.TypeReg, Size: int64(len(e.Body))}
-		require.NoError(t, tw.WriteHeader(hdr))
-		_, err := tw.Write(e.Body)
-		require.NoError(t, err)
-	}
-	require.NoError(t, tw.Close())
-	require.NoError(t, gz.Close())
 	return buf.Bytes()
 }
 
@@ -184,26 +161,20 @@ func TestSafeExtract_EmptyBody(t *testing.T) {
 	require.True(t, errors.Is(err, ErrInvalidArchive))
 }
 
-func TestSafeExtract_TarGzHappyPath(t *testing.T) {
-	archive := makeTarGz(t, []tarEntry{
-		{Name: "SKILL.md", Body: []byte("---\nname: foo\n---\nbody\n")},
-		{Name: "assets/icon.svg", Body: []byte("<svg/>")},
-	})
-	dir := t.TempDir()
-	res, err := SafeExtract(archive, ExtractOptions{OutputDir: dir})
-	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"SKILL.md", "assets/icon.svg"}, res.Files)
+func TestSafeExtract_RejectsNonZipArchive(t *testing.T) {
+	// gzip magic bytes — should be rejected now that tar.gz is removed.
+	gzipData := []byte{0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00}
+	_, err := SafeExtract(gzipData, ExtractOptions{OutputDir: t.TempDir()})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidArchive))
 }
 
-func TestDetectArchiveFormat(t *testing.T) {
+func TestIsZipMagic(t *testing.T) {
 	zipBytes := makeZip(t, []zipEntry{{Name: "SKILL.md", Body: []byte("body")}})
-	require.Equal(t, ArchiveZip, DetectArchiveFormat(zipBytes))
+	require.True(t, isZipMagic(zipBytes))
 
-	tarGzBytes := makeTarGz(t, []tarEntry{{Name: "SKILL.md", Body: []byte("body")}})
-	require.Equal(t, ArchiveTarGz, DetectArchiveFormat(tarGzBytes))
-
-	require.Equal(t, ArchiveUnknown, DetectArchiveFormat([]byte("not an archive")))
-	require.Equal(t, ArchiveUnknown, DetectArchiveFormat(nil))
+	require.False(t, isZipMagic([]byte("not an archive")))
+	require.False(t, isZipMagic(nil))
 }
 
 func TestValidateEntryName(t *testing.T) {
@@ -232,27 +203,4 @@ func TestValidateEntryName(t *testing.T) {
 		require.Equal(t, c.wantOK, ok, "input=%q", c.in)
 		require.Equal(t, c.want, got, "input=%q", c.in)
 	}
-}
-
-func TestSafeExtract_TarGzRejectsEntryWithLinkname(t *testing.T) {
-	var buf bytes.Buffer
-	gz := gzip.NewWriter(&buf)
-	tw := tar.NewWriter(gz)
-	// Regular-file entry with a non-empty Linkname field (should be rejected).
-	hdr := &tar.Header{
-		Name:     "SKILL.md",
-		Mode:     0644,
-		Typeflag: tar.TypeReg,
-		Size:     5,
-		Linkname: "/etc/passwd",
-	}
-	require.NoError(t, tw.WriteHeader(hdr))
-	_, err := tw.Write([]byte("hello"))
-	require.NoError(t, err)
-	require.NoError(t, tw.Close())
-	require.NoError(t, gz.Close())
-
-	_, extractErr := SafeExtract(buf.Bytes(), ExtractOptions{OutputDir: t.TempDir()})
-	require.Error(t, extractErr)
-	require.True(t, errors.Is(extractErr, ErrUnsafeEntry))
 }

--- a/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/client.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/client.go
@@ -48,19 +48,24 @@ const (
 	userAgentPrefix = "azd-ext-azure-ai-skills"
 )
 
-// downloadByteCap is the active per-response cap used by downloadContent.
-// Defaults to MaxDownloadBytes; tests may override it via withDownloadCap.
-var downloadByteCap int64 = MaxDownloadBytes
-
 type Client struct {
-	endpoint string
-	pipeline runtime.Pipeline
+	endpoint       string
+	pipeline       runtime.Pipeline
+	maxDownloadCap int64
 }
 
 // NewClient returns a Skills client rooted at endpoint, using cred for
 // bearer-token auth.
 func NewClient(endpoint string, cred azcore.TokenCredential, extensionVersion string) *Client {
 	return newClient(endpoint, cred, extensionVersion, false)
+}
+
+// WithMaxDownloadBytes overrides the per-response download size cap on the
+// client. Intended for testing; production callers use the default
+// MaxDownloadBytes value.
+func (c *Client) WithMaxDownloadBytes(cap int64) *Client {
+	c.maxDownloadCap = cap
+	return c
 }
 
 func newClient(endpoint string, cred azcore.TokenCredential, extensionVersion string, allowHTTP bool) *Client {
@@ -91,8 +96,9 @@ func newClient(endpoint string, cred azcore.TokenCredential, extensionVersion st
 	)
 
 	return &Client{
-		endpoint: strings.TrimRight(endpoint, "/"),
-		pipeline: pipeline,
+		endpoint:       strings.TrimRight(endpoint, "/"),
+		pipeline:       pipeline,
+		maxDownloadCap: MaxDownloadBytes,
 	}
 }
 
@@ -430,22 +436,24 @@ func (c *Client) downloadContent(ctx context.Context, fullURL string) ([]byte, e
 		}
 	}
 
+	cap := c.maxDownloadCap
+
 	// Fail fast on a server-declared oversize before reading the body.
-	if resp.ContentLength > downloadByteCap {
+	if resp.ContentLength > cap {
 		return nil, fmt.Errorf(
 			"download size %d exceeds the %d byte limit",
-			resp.ContentLength, downloadByteCap,
+			resp.ContentLength, cap,
 		)
 	}
 
 	// Read one extra byte so we can distinguish "exactly at limit" from
 	// "tried to send more than the limit".
-	body, err := io.ReadAll(io.LimitReader(resp.Body, downloadByteCap+1))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, cap+1))
 	if err != nil {
 		return nil, fmt.Errorf("read download body: %w", err)
 	}
-	if int64(len(body)) > downloadByteCap {
-		return nil, fmt.Errorf("download exceeds the %d byte limit", downloadByteCap)
+	if int64(len(body)) > cap {
+		return nil, fmt.Errorf("download exceeds the %d byte limit", cap)
 	}
 	return body, nil
 }

--- a/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/client_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/client_test.go
@@ -230,7 +230,6 @@ func TestClient_DownloadSkillContent_ReturnsZipBytes(t *testing.T) {
 }
 
 func TestClient_DownloadSkillContent_RejectsOversizeContentLength(t *testing.T) {
-	withDownloadCap(t, 16)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body := strings.Repeat("A", 17)
 		w.Header().Set("Content-Type", ContentTypeZip)
@@ -239,14 +238,13 @@ func TestClient_DownloadSkillContent_RejectsOversizeContentLength(t *testing.T) 
 	}))
 	defer srv.Close()
 
-	c := newTestClient(t, srv)
+	c := newTestClient(t, srv).WithMaxDownloadBytes(16)
 	_, err := c.DownloadSkillContent(context.Background(), "my-skill")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exceeds")
 }
 
 func TestClient_DownloadSkillContent_RejectsOversizeStreamingBody(t *testing.T) {
-	withDownloadCap(t, 16)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", ContentTypeZip)
 		// No Content-Length: force the streaming-limit path.
@@ -264,14 +262,13 @@ func TestClient_DownloadSkillContent_RejectsOversizeStreamingBody(t *testing.T) 
 	}))
 	defer srv.Close()
 
-	c := newTestClient(t, srv)
+	c := newTestClient(t, srv).WithMaxDownloadBytes(16)
 	_, err := c.DownloadSkillContent(context.Background(), "my-skill")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exceeds")
 }
 
 func TestClient_DownloadSkillContent_AcceptsAtLimit(t *testing.T) {
-	withDownloadCap(t, 16)
 	payload := []byte("PK\x03\x04tinybody")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", ContentTypeZip)
@@ -279,19 +276,10 @@ func TestClient_DownloadSkillContent_AcceptsAtLimit(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := newTestClient(t, srv)
+	c := newTestClient(t, srv).WithMaxDownloadBytes(16)
 	got, err := c.DownloadSkillContent(context.Background(), "my-skill")
 	require.NoError(t, err)
 	require.Equal(t, payload, got)
-}
-
-// withDownloadCap lowers downloadByteCap for the duration of a single test so
-// the cap can be exercised without writing MaxDownloadBytes through httptest.
-func withDownloadCap(t *testing.T, cap int64) {
-	t.Helper()
-	prev := downloadByteCap
-	downloadByteCap = cap
-	t.Cleanup(func() { downloadByteCap = prev })
 }
 
 func TestClient_DownloadVersionContent_TargetsVersionPath(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/skill_md.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/skill_md.go
@@ -20,7 +20,10 @@ const SkillMdFileName = "SKILL.md"
 type SkillMd struct {
 	Name           string
 	Description    string
+	License        string
+	Compatibility  string
 	Metadata       map[string]string
+	AllowedTools   []string
 	Instructions   string
 	RawFrontMatter map[string]any
 }
@@ -83,6 +86,27 @@ func ParseSkillMd(data []byte) (*SkillMd, error) {
 			return nil, err
 		}
 		out.Metadata = m
+	}
+	if v, ok := raw["license"]; ok {
+		s, err := frontMatterString("license", v)
+		if err != nil {
+			return nil, err
+		}
+		out.License = s
+	}
+	if v, ok := raw["compatibility"]; ok {
+		s, err := frontMatterString("compatibility", v)
+		if err != nil {
+			return nil, err
+		}
+		out.Compatibility = s
+	}
+	if v, ok := raw["allowed_tools"]; ok {
+		list, err := frontMatterStringSlice("allowed_tools", v)
+		if err != nil {
+			return nil, err
+		}
+		out.AllowedTools = list
 	}
 	return out, nil
 }
@@ -174,6 +198,28 @@ func frontMatterStringMap(field string, v any) (map[string]string, error) {
 			return nil, err
 		}
 		out[k] = s
+	}
+	return out, nil
+}
+
+func frontMatterStringSlice(field string, v any) ([]string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	raw, ok := v.([]any)
+	if !ok {
+		return nil, fmt.Errorf("SKILL.md front matter field %q must be a list", field)
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(raw))
+	for i, elem := range raw {
+		s, err := frontMatterString(fmt.Sprintf("%s[%d]", field, i), elem)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
 	}
 	return out, nil
 }

--- a/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/skill_md_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/skill_md_test.go
@@ -87,3 +87,37 @@ func TestParseSkillMd_CRLFLineEndings(t *testing.T) {
 	require.Equal(t, "my-skill", parsed.Name)
 	require.Equal(t, "works", parsed.Description)
 }
+
+func TestParseSkillMd_ExtractsLicenseCompatibilityAllowedTools(t *testing.T) {
+	doc := strings.Join([]string{
+		"---",
+		"name: my-skill",
+		"description: A skill",
+		"license: MIT",
+		"compatibility: gpt-4o",
+		"allowed_tools:",
+		"  - web_search",
+		"  - code_interpreter",
+		"metadata:",
+		"  owner: alice",
+		"---",
+		"Body text.",
+	}, "\n")
+
+	parsed, err := ParseSkillMd([]byte(doc))
+	require.NoError(t, err)
+	require.Equal(t, "my-skill", parsed.Name)
+	require.Equal(t, "A skill", parsed.Description)
+	require.Equal(t, "MIT", parsed.License)
+	require.Equal(t, "gpt-4o", parsed.Compatibility)
+	require.Equal(t, []string{"web_search", "code_interpreter"}, parsed.AllowedTools)
+	require.Equal(t, map[string]string{"owner": "alice"}, parsed.Metadata)
+	require.Equal(t, "Body text.", parsed.Instructions)
+}
+
+func TestParseSkillMd_AllowedToolsNotList(t *testing.T) {
+	doc := "---\nallowed_tools: not-a-list\n---\nbody\n"
+	_, err := ParseSkillMd([]byte(doc))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"allowed_tools" must be a list`)
+}


### PR DESCRIPTION
## Motivation

Issue #8366 tracked several follow-up items from the initial `azd ai skill` extension PR -- silent data loss on SKILL.md round-trips, dead code paths, test-unsafe mutable globals, and missing validation. This PR addresses the code-level fixes that don't require service-side coordination.

## Approach

Six focused fixes across the `azure.ai.skills` extension:

- **SKILL.md field propagation**: `ParseSkillMd` now extracts `license`, `compatibility`, and `allowed_tools` from front matter and both `create --file` and `update --file` flows propagate them into `SkillInlineContent`. Previously these fields were silently dropped on upload despite being declared in the wire model.

- **Dead tar.gz code removal**: The download endpoint always returns `application/zip` and the client hard-rejects other content types, making the `ArchiveTarGz` extraction branch unreachable. Replaced with a simple `isZipMagic` check and removed ~55 lines of dead code plus unused imports.

- **`downloadByteCap` promoted to instance field**: The package-level mutable global (only safe because tests never ran in parallel) is now a `Client` struct field initialized to `MaxDownloadBytes`, with a `WithMaxDownloadBytes` method for test overrides.

- **Stderr warnings for swallowed errors**: `printCreateResult` and `printUpdateResult` now emit a warning when the follow-up `GetSkill` call fails, instead of silently falling back to the version envelope.

- **Whitespace `--version` rejection**: `azd ai skill download my-skill --version "   "` now returns a clear validation error instead of silently downloading the default version.

- **New tests**: Covers inline update requiring both flags, `ParseSkillMd` field extraction, download version validation, and non-zip archive rejection.

## Items tracked separately

The following higher-impact items from #8366 need design decisions or service-team coordination and are not addressed here:

- `CreateVersionFromZip` memory buffering (io.Pipe streaming refactor)
- POST `/skills/{name}/versions` idempotency (needs Idempotency-Key header support)
- `--force` delete-then-create rollback safety (UX design decision)
- `--set-default-version` pre-flight check (error code coordination)

Fixes: #8366