### PR TITLE
training: show Foundry Portal Uri in 'azd ai training job show'

### DIFF
--- a/cli/azd/extensions/azure.ai.training/internal/cmd/job_show.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/job_show.go
@@ -306,7 +306,7 @@ func printJobDetails(d *jobDetails) {
 	if props.Description != "" {
 		fmt.Fprintf(w, "Description:\t%s\n", props.Description)
 	}
-	fmt.Fprintf(w, "Foundry Portal Uri:\t%s\n", valueOrDash(utils.ServiceEndpoint(props.Services, "Studio")))
+	fmt.Fprintf(w, "Foundry Portal URI:\t%s\n", valueOrDash(utils.ServiceEndpoint(props.Services, "Studio")))
 	_ = w.Flush()
 	fmt.Println()
 

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/job_show.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/job_show.go
@@ -306,6 +306,9 @@ func printJobDetails(d *jobDetails) {
 	if props.Description != "" {
 		fmt.Fprintf(w, "Description:\t%s\n", props.Description)
 	}
+	if portalURL := utils.ServiceEndpoint(props.Services, "Studio"); portalURL != "" {
+		fmt.Fprintf(w, "Foundry Portal Uri:\t%s\n", portalURL)
+	}
 	_ = w.Flush()
 	fmt.Println()
 

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/job_show.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/job_show.go
@@ -306,9 +306,7 @@ func printJobDetails(d *jobDetails) {
 	if props.Description != "" {
 		fmt.Fprintf(w, "Description:\t%s\n", props.Description)
 	}
-	if portalURL := utils.ServiceEndpoint(props.Services, "Studio"); portalURL != "" {
-		fmt.Fprintf(w, "Foundry Portal Uri:\t%s\n", portalURL)
-	}
+	fmt.Fprintf(w, "Foundry Portal Uri:\t%s\n", valueOrDash(utils.ServiceEndpoint(props.Services, "Studio")))
 	_ = w.Flush()
 	fmt.Println()
 

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/job_show_test.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/job_show_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"azure.ai.training/pkg/models"
+)
+
+// captureStdout runs fn while redirecting os.Stdout to a pipe, then returns
+// everything fn wrote. Used because printJobDetails writes directly to stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	fn()
+
+	_ = w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+func TestPrintJobDetails_FoundryPortalUri(t *testing.T) {
+	const portal = "https://ai.azure.com/build/jobs/test-job"
+
+	tests := []struct {
+		name        string
+		services    map[string]any
+		wantContain bool
+	}{
+		{
+			name: "Studio service present prints Foundry Portal Uri",
+			services: map[string]any{
+				"Studio": map[string]any{
+					"endpoint":       portal,
+					"jobServiceType": "Studio",
+					"status":         "Running",
+				},
+			},
+			wantContain: true,
+		},
+		{
+			name:        "no services map omits line",
+			services:    nil,
+			wantContain: false,
+		},
+		{
+			name: "services without Studio entry omits line",
+			services: map[string]any{
+				"Tracking": map[string]any{"endpoint": "https://tracking/x"},
+			},
+			wantContain: false,
+		},
+		{
+			name: "Studio entry with empty endpoint omits line",
+			services: map[string]any{
+				"Studio": map[string]any{"endpoint": ""},
+			},
+			wantContain: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &jobDetails{
+				Job: &models.JobResource{
+					Name: "test-job",
+					Properties: models.CommandJob{
+						JobType:     "Command",
+						DisplayName: "Test Job",
+						Description: "unit-test job",
+						Status:      "Completed",
+						Services:    tc.services,
+					},
+				},
+				Metrics: map[string]*models.MetricsFullResponse{},
+			}
+
+			out := captureStdout(t, func() { printJobDetails(d) })
+
+			hasLine := strings.Contains(out, "Foundry Portal Uri:") &&
+				strings.Contains(out, portal)
+			if tc.wantContain && !hasLine {
+				t.Errorf("expected Foundry Portal Uri line with %q, got:\n%s", portal, out)
+			}
+			if !tc.wantContain && strings.Contains(out, "Foundry Portal Uri:") {
+				t.Errorf("did not expect Foundry Portal Uri line, got:\n%s", out)
+			}
+		})
+	}
+}

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/job_show_test.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/job_show_test.go
@@ -40,12 +40,12 @@ func TestPrintJobDetails_FoundryPortalUri(t *testing.T) {
 	const portal = "https://ai.azure.com/build/jobs/test-job"
 
 	tests := []struct {
-		name        string
-		services    map[string]any
-		wantContain bool
+		name     string
+		services map[string]any
+		wantURL  string // expected value after "Foundry Portal Uri:"
 	}{
 		{
-			name: "Studio service present prints Foundry Portal Uri",
+			name: "Studio service present prints URL",
 			services: map[string]any{
 				"Studio": map[string]any{
 					"endpoint":       portal,
@@ -53,26 +53,26 @@ func TestPrintJobDetails_FoundryPortalUri(t *testing.T) {
 					"status":         "Running",
 				},
 			},
-			wantContain: true,
+			wantURL: portal,
 		},
 		{
-			name:        "no services map omits line",
-			services:    nil,
-			wantContain: false,
+			name:     "no services map prints dash",
+			services: nil,
+			wantURL:  "-",
 		},
 		{
-			name: "services without Studio entry omits line",
+			name: "services without Studio entry prints dash",
 			services: map[string]any{
 				"Tracking": map[string]any{"endpoint": "https://tracking/x"},
 			},
-			wantContain: false,
+			wantURL: "-",
 		},
 		{
-			name: "Studio entry with empty endpoint omits line",
+			name: "Studio entry with empty endpoint prints dash",
 			services: map[string]any{
 				"Studio": map[string]any{"endpoint": ""},
 			},
-			wantContain: false,
+			wantURL: "-",
 		},
 	}
 
@@ -94,13 +94,18 @@ func TestPrintJobDetails_FoundryPortalUri(t *testing.T) {
 
 			out := captureStdout(t, func() { printJobDetails(d) })
 
-			hasLine := strings.Contains(out, "Foundry Portal Uri:") &&
-				strings.Contains(out, portal)
-			if tc.wantContain && !hasLine {
-				t.Errorf("expected Foundry Portal Uri line with %q, got:\n%s", portal, out)
+			if !strings.Contains(out, "Foundry Portal Uri:") {
+				t.Fatalf("expected Foundry Portal Uri line to always be present, got:\n%s", out)
 			}
-			if !tc.wantContain && strings.Contains(out, "Foundry Portal Uri:") {
-				t.Errorf("did not expect Foundry Portal Uri line, got:\n%s", out)
+			var got string
+			for _, line := range strings.Split(out, "\n") {
+				if i := strings.Index(line, "Foundry Portal Uri:"); i >= 0 {
+					got = strings.TrimSpace(line[i+len("Foundry Portal Uri:"):])
+					break
+				}
+			}
+			if got != tc.wantURL {
+				t.Errorf("Foundry Portal Uri value = %q, want %q\nfull output:\n%s", got, tc.wantURL, out)
 			}
 		})
 	}

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/job_show_test.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/job_show_test.go
@@ -13,34 +13,41 @@ import (
 )
 
 // captureStdout runs fn while redirecting os.Stdout to a pipe, then returns
-// everything fn wrote. The write end is closed (so the reader unblocks) and
-// the original stdout is restored even if fn panics, via t.Cleanup, so the
-// helper is safe to use in table-driven tests.
+// everything fn wrote. A goroutine drains the pipe into a strings.Builder so
+// large writes can't deadlock on the OS pipe buffer; os.Stdout is restored and
+// the read end closed via t.Cleanup so the helper is safe even if fn panics.
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 	r, w, err := os.Pipe()
 	if err != nil {
-		t.Fatalf("pipe: %v", err)
+		t.Fatalf("os.Pipe: %v", err)
 	}
 	orig := os.Stdout
 	os.Stdout = w
+
+	// Drain in a goroutine so large output can't deadlock on a full pipe buffer.
+	var sb strings.Builder
+	copyDone := make(chan error, 1)
+	go func() {
+		_, copyErr := io.Copy(&sb, r)
+		_ = r.Close()
+		copyDone <- copyErr
+	}()
+
 	t.Cleanup(func() {
 		os.Stdout = orig
-		_ = r.Close()
+		_ = w.Close()
 	})
-
-	done := make(chan string, 1)
-	go func() {
-		b, _ := io.ReadAll(r)
-		done <- string(b)
-	}()
 
 	func() {
 		defer func() { _ = w.Close() }()
 		fn()
 	}()
 
-	return <-done
+	if err := <-copyDone; err != nil {
+		t.Fatalf("capture stdout: %v", err)
+	}
+	return sb.String()
 }
 
 func TestPrintJobDetails_FoundryPortalURI(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/job_show_test.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/job_show_test.go
@@ -13,15 +13,21 @@ import (
 )
 
 // captureStdout runs fn while redirecting os.Stdout to a pipe, then returns
-// everything fn wrote. Used because printJobDetails writes directly to stdout.
+// everything fn wrote. The write end is closed (so the reader unblocks) and
+// the original stdout is restored even if fn panics, via t.Cleanup, so the
+// helper is safe to use in table-driven tests.
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
-	orig := os.Stdout
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("pipe: %v", err)
 	}
+	orig := os.Stdout
 	os.Stdout = w
+	t.Cleanup(func() {
+		os.Stdout = orig
+		_ = r.Close()
+	})
 
 	done := make(chan string, 1)
 	go func() {
@@ -29,20 +35,21 @@ func captureStdout(t *testing.T, fn func()) string {
 		done <- string(b)
 	}()
 
-	fn()
+	func() {
+		defer func() { _ = w.Close() }()
+		fn()
+	}()
 
-	_ = w.Close()
-	os.Stdout = orig
 	return <-done
 }
 
-func TestPrintJobDetails_FoundryPortalUri(t *testing.T) {
+func TestPrintJobDetails_FoundryPortalURI(t *testing.T) {
 	const portal = "https://ai.azure.com/build/jobs/test-job"
 
 	tests := []struct {
 		name     string
 		services map[string]any
-		wantURL  string // expected value after "Foundry Portal Uri:"
+		wantURL  string // expected value after "Foundry Portal URI:"
 	}{
 		{
 			name: "Studio service present prints URL",
@@ -94,18 +101,18 @@ func TestPrintJobDetails_FoundryPortalUri(t *testing.T) {
 
 			out := captureStdout(t, func() { printJobDetails(d) })
 
-			if !strings.Contains(out, "Foundry Portal Uri:") {
-				t.Fatalf("expected Foundry Portal Uri line to always be present, got:\n%s", out)
+			if !strings.Contains(out, "Foundry Portal URI:") {
+				t.Fatalf("expected Foundry Portal URI line to always be present, got:\n%s", out)
 			}
 			var got string
-			for _, line := range strings.Split(out, "\n") {
-				if i := strings.Index(line, "Foundry Portal Uri:"); i >= 0 {
-					got = strings.TrimSpace(line[i+len("Foundry Portal Uri:"):])
+			for line := range strings.SplitSeq(out, "\n") {
+				if _, after, ok := strings.Cut(line, "Foundry Portal URI:"); ok {
+					got = strings.TrimSpace(after)
 					break
 				}
 			}
 			if got != tc.wantURL {
-				t.Errorf("Foundry Portal Uri value = %q, want %q\nfull output:\n%s", got, tc.wantURL, out)
+				t.Errorf("Foundry Portal URI value = %q, want %q\nfull output:\n%s", got, tc.wantURL, out)
 			}
 		})
 	}

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/job_show_test.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/job_show_test.go
@@ -14,8 +14,10 @@ import (
 
 // captureStdout runs fn while redirecting os.Stdout to a pipe, then returns
 // everything fn wrote. A goroutine drains the pipe into a strings.Builder so
-// large writes can't deadlock on the OS pipe buffer; os.Stdout is restored and
-// the read end closed via t.Cleanup so the helper is safe even if fn panics.
+// large writes can't deadlock on the OS pipe buffer. os.Stdout is restored
+// immediately after fn returns so any subsequent writes in the same test
+// (e.g. debug logging, a second captureStdout call) behave normally; t.Cleanup
+// remains as a panic safety net.
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 	r, w, err := os.Pipe()
@@ -34,6 +36,7 @@ func captureStdout(t *testing.T, fn func()) string {
 		copyDone <- copyErr
 	}()
 
+	// Panic safety net only; the happy path restores stdout below.
 	t.Cleanup(func() {
 		os.Stdout = orig
 		_ = w.Close()
@@ -43,6 +46,7 @@ func captureStdout(t *testing.T, fn func()) string {
 		defer func() { _ = w.Close() }()
 		fn()
 	}()
+	os.Stdout = orig
 
 	if err := <-copyDone; err != nil {
 		t.Fatalf("capture stdout: %v", err)


### PR DESCRIPTION
Adds a 'Foundry Portal Uri:' line to the job show output, sourced from properties.services['Studio'].endpoint via utils.ServiceEndpoint.
<img width="1899" height="997" alt="image" src="https://github.com/user-attachments/assets/b336cc70-d72f-4c10-ac4d-55150ba15252" />
