### PR TITLE
Change ms.topic from 'conceptual' to 'reference'

### DIFF
--- a/cli/azd/docs/docgen.go
+++ b/cli/azd/docs/docgen.go
@@ -31,7 +31,7 @@ author: alexwolfmsft
 ms.author: alexwolf
 ms.date: %v
 ms.service: azure-dev-cli
-ms.topic: conceptual
+ms.topic: reference
 ms.custom: devx-track-azdevcli
 ---
 


### PR DESCRIPTION
This pull request makes a small update to the metadata in the documentation generation code to fix an ongoing build error. The change updates the topic type from "conceptual" to "reference" in the documentation front matter.

Fixes #8823