### PR TITLE
fix(agents): update container deploy schema to use protocol_versions and container_configuration

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy.go
@@ -340,13 +340,20 @@ func buildDeployDefinition(currentDef map[string]any, envVars map[string]string)
 	return newDef
 }
 
-// normalizeProtocolVersions ensures container_protocol_versions use the
-// canonical "1.0.0" format instead of the legacy "v1" format that the
+// normalizeProtocolVersions ensures protocol_versions (or legacy container_protocol_versions)
+// use the canonical "1.0.0" format instead of the legacy "v1" format that the
 // platform no longer accepts for new versions.
 func normalizeProtocolVersions(def map[string]any) {
-	raw, ok := def["container_protocol_versions"]
+	// Try new field name first, fall back to legacy
+	raw, ok := def["protocol_versions"]
 	if !ok {
-		return
+		raw, ok = def["container_protocol_versions"]
+		if !ok {
+			return
+		}
+		// Migrate legacy field to new name
+		def["protocol_versions"] = raw
+		delete(def, "container_protocol_versions")
 	}
 	protocols, ok := raw.([]any)
 	if !ok {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy.go
@@ -337,6 +337,7 @@ func buildDeployDefinition(currentDef map[string]any, envVars map[string]string)
 	}
 	newDef["environment_variables"] = envVars
 	normalizeProtocolVersions(newDef)
+	normalizeContainerImage(newDef)
 	return newDef
 }
 
@@ -368,6 +369,27 @@ func normalizeProtocolVersions(def map[string]any) {
 			pMap["version"] = "1.0.0"
 		}
 	}
+}
+
+// normalizeContainerImage migrates the legacy top-level "image" field to
+// "container_configuration.image" on raw definition maps. This is needed because
+// service responses stored as map[string]any bypass HostedAgentDefinition.UnmarshalJSON.
+func normalizeContainerImage(def map[string]any) {
+	// Already using new schema
+	if _, ok := def["container_configuration"]; ok {
+		return
+	}
+	// Migrate legacy top-level image
+	image, ok := def["image"]
+	if !ok {
+		return
+	}
+	imageStr, ok := image.(string)
+	if !ok || imageStr == "" {
+		return
+	}
+	def["container_configuration"] = map[string]any{"image": imageStr}
+	delete(def, "image")
 }
 
 // pollVersionActive polls the agent version until its status is "active" or a timeout occurs.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy_test.go
@@ -161,6 +161,36 @@ func TestNormalizeProtocolVersions_MissingField(t *testing.T) {
 	normalizeProtocolVersions(def) // should not panic
 }
 
+func TestNormalizeContainerImage_MigratesLegacy(t *testing.T) {
+	def := map[string]any{
+		"kind":  "hosted",
+		"image": "myimage:latest",
+	}
+	normalizeContainerImage(def)
+
+	containerConfig, ok := def["container_configuration"].(map[string]any)
+	require.True(t, ok, "container_configuration should be set")
+	assert.Equal(t, "myimage:latest", containerConfig["image"])
+	assert.Nil(t, def["image"], "legacy image field should be removed")
+}
+
+func TestNormalizeContainerImage_NoOpWhenNewSchema(t *testing.T) {
+	def := map[string]any{
+		"kind":                    "hosted",
+		"container_configuration": map[string]any{"image": "existing:v1"},
+	}
+	normalizeContainerImage(def)
+
+	containerConfig := def["container_configuration"].(map[string]any)
+	assert.Equal(t, "existing:v1", containerConfig["image"])
+}
+
+func TestNormalizeContainerImage_NoOpWhenNoImage(t *testing.T) {
+	def := map[string]any{"kind": "hosted"}
+	normalizeContainerImage(def) // should not panic
+	assert.Nil(t, def["container_configuration"])
+}
+
 // ---- upsertAgentYamlEnvVar ----
 
 func TestUpsertAgentYamlEnvVar_InsertsNew(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy_test.go
@@ -121,10 +121,10 @@ func TestBuildDeployDefinition_PreservesFieldsAndOverridesEnvVars(t *testing.T) 
 
 func TestBuildDeployDefinition_NormalizesProtocolVersion(t *testing.T) {
 	currentDef := map[string]any{
-		"kind":   "hosted",
+		"kind":                    "hosted",
 		"container_configuration": map[string]any{"image": "myimage:latest"},
-		"cpu":    "1.0",
-		"memory": "2Gi",
+		"cpu":                     "1.0",
+		"memory":                  "2Gi",
 		"container_protocol_versions": []any{
 			map[string]any{"protocol": "responses", "version": "v1"},
 		},

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy_test.go
@@ -91,10 +91,10 @@ func TestExtractEnvVars_WithVars(t *testing.T) {
 
 func TestBuildDeployDefinition_PreservesFieldsAndOverridesEnvVars(t *testing.T) {
 	currentDef := map[string]any{
-		"kind":   "hosted",
-		"image":  "myimage:latest",
-		"cpu":    "1.0",
-		"memory": "2Gi",
+		"kind":                    "hosted",
+		"container_configuration": map[string]any{"image": "myimage:latest"},
+		"cpu":                     "1.0",
+		"memory":                  "2Gi",
 		"environment_variables": map[string]any{
 			"EXISTING_VAR": "keep_me",
 		},
@@ -108,7 +108,8 @@ func TestBuildDeployDefinition_PreservesFieldsAndOverridesEnvVars(t *testing.T) 
 	newDef := buildDeployDefinition(currentDef, envVars)
 
 	assert.Equal(t, "hosted", newDef["kind"])
-	assert.Equal(t, "myimage:latest", newDef["image"])
+	containerConfig := newDef["container_configuration"].(map[string]any)
+	assert.Equal(t, "myimage:latest", containerConfig["image"])
 	assert.Equal(t, "1.0", newDef["cpu"])
 	assert.Equal(t, "2Gi", newDef["memory"])
 
@@ -121,7 +122,7 @@ func TestBuildDeployDefinition_PreservesFieldsAndOverridesEnvVars(t *testing.T) 
 func TestBuildDeployDefinition_NormalizesProtocolVersion(t *testing.T) {
 	currentDef := map[string]any{
 		"kind":   "hosted",
-		"image":  "myimage:latest",
+		"container_configuration": map[string]any{"image": "myimage:latest"},
 		"cpu":    "1.0",
 		"memory": "2Gi",
 		"container_protocol_versions": []any{
@@ -132,22 +133,25 @@ func TestBuildDeployDefinition_NormalizesProtocolVersion(t *testing.T) {
 
 	newDef := buildDeployDefinition(currentDef, map[string]string{"FOO": "bar"})
 
-	protocols := newDef["container_protocol_versions"].([]any)
+	// Legacy field should be migrated to protocol_versions
+	protocols := newDef["protocol_versions"].([]any)
 	p := protocols[0].(map[string]any)
 	assert.Equal(t, "1.0.0", p["version"], "v1 should be normalized to 1.0.0")
 	assert.Equal(t, "responses", p["protocol"])
+	// Legacy field should be removed
+	assert.Nil(t, newDef["container_protocol_versions"])
 }
 
 func TestNormalizeProtocolVersions_NoOp(t *testing.T) {
-	// Already 1.0.0 — should not change
+	// Already using new field name with 1.0.0 — should not change
 	def := map[string]any{
-		"container_protocol_versions": []any{
+		"protocol_versions": []any{
 			map[string]any{"protocol": "responses", "version": "1.0.0"},
 		},
 	}
 	normalizeProtocolVersions(def)
 
-	protocols := def["container_protocol_versions"].([]any)
+	protocols := def["protocol_versions"].([]any)
 	p := protocols[0].(map[string]any)
 	assert.Equal(t, "1.0.0", p["version"])
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
@@ -211,54 +211,34 @@ type CodeConfigurationAPI struct {
 	DependencyResolution string   `json:"dependency_resolution,omitempty"`
 }
 
-// HostedAgentDefinition represents a hosted agent that can be either container-based
-// (with Image) or code-based (with CodeConfiguration). The protocol versions JSON
-// field name differs: container uses "container_protocol_versions" while code uses
-// "protocol_versions". Custom marshaling handles this automatically.
-type HostedAgentDefinition struct {
-	AgentDefinition
-	ProtocolVersions     []ProtocolVersionRecord `json:"-"` // marshaled dynamically based on deploy mode
-	CPU                  string                  `json:"cpu"`
-	Memory               string                  `json:"memory"`
-	EnvironmentVariables map[string]string       `json:"environment_variables,omitempty"`
-	Image                string                  `json:"image,omitempty"`              // container deploy only
-	CodeConfiguration    *CodeConfigurationAPI   `json:"code_configuration,omitempty"` // code deploy only
+// ContainerConfigurationAPI represents the container_configuration block in the API request.
+// Used for container deploy mode to specify the pre-built container image.
+type ContainerConfigurationAPI struct {
+	Image string `json:"image"`
 }
 
-// MarshalJSON implements custom JSON marshaling for HostedAgentDefinition.
-// Code deploy agents use "protocol_versions"; container agents use "container_protocol_versions".
-func (d HostedAgentDefinition) MarshalJSON() ([]byte, error) {
-	type Alias HostedAgentDefinition
-
-	if d.CodeConfiguration != nil {
-		// Code deploy: use protocol_versions
-		return json.Marshal(struct {
-			Alias
-			ProtocolVersions []ProtocolVersionRecord `json:"protocol_versions"`
-		}{
-			Alias:            Alias(d),
-			ProtocolVersions: d.ProtocolVersions,
-		})
-	}
-
-	// Container deploy: use container_protocol_versions
-	return json.Marshal(struct {
-		Alias
-		ContainerProtocolVersions []ProtocolVersionRecord `json:"container_protocol_versions"`
-	}{
-		Alias:                     Alias(d),
-		ContainerProtocolVersions: d.ProtocolVersions,
-	})
+// HostedAgentDefinition represents a hosted agent that can be either container-based
+// (with ContainerConfiguration) or code-based (with CodeConfiguration).
+// Both deploy modes now use "protocol_versions" in the serialized JSON.
+type HostedAgentDefinition struct {
+	AgentDefinition
+	ProtocolVersions       []ProtocolVersionRecord    `json:"protocol_versions,omitempty"`
+	CPU                    string                     `json:"cpu"`
+	Memory                 string                     `json:"memory"`
+	EnvironmentVariables   map[string]string          `json:"environment_variables,omitempty"`
+	ContainerConfiguration *ContainerConfigurationAPI `json:"container_configuration,omitempty"` // container deploy only
+	CodeConfiguration      *CodeConfigurationAPI      `json:"code_configuration,omitempty"`      // code deploy only
+	Image                  string                     `json:"image,omitempty"`                   // deprecated: for backward compat deserialization only
 }
 
 // UnmarshalJSON implements custom JSON unmarshaling for HostedAgentDefinition.
-// It reads protocol versions from either "protocol_versions" or "container_protocol_versions".
+// It reads protocol versions from either "protocol_versions" or legacy "container_protocol_versions",
+// and image from either "container_configuration.image" or legacy top-level "image".
 func (d *HostedAgentDefinition) UnmarshalJSON(data []byte) error {
 	type Alias HostedAgentDefinition
 
 	var raw struct {
 		Alias
-		ProtocolVersions          []ProtocolVersionRecord `json:"protocol_versions"`
 		ContainerProtocolVersions []ProtocolVersionRecord `json:"container_protocol_versions"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -266,11 +246,18 @@ func (d *HostedAgentDefinition) UnmarshalJSON(data []byte) error {
 	}
 
 	*d = HostedAgentDefinition(raw.Alias)
-	if len(raw.ProtocolVersions) > 0 {
-		d.ProtocolVersions = raw.ProtocolVersions
-	} else {
+
+	// Backward compat: if protocol_versions is empty, fall back to legacy container_protocol_versions
+	if len(d.ProtocolVersions) == 0 && len(raw.ContainerProtocolVersions) > 0 {
 		d.ProtocolVersions = raw.ContainerProtocolVersions
 	}
+
+	// Backward compat: if container_configuration is not set but legacy top-level image is, migrate it
+	if d.ContainerConfiguration == nil && d.Image != "" {
+		d.ContainerConfiguration = &ContainerConfigurationAPI{Image: d.Image}
+		d.Image = "" // clear deprecated field
+	}
+
 	return nil
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
@@ -127,7 +127,7 @@ func TestHostedAgentDefinition_RoundTrip(t *testing.T) {
 
 	s := string(data)
 	for _, field := range []string{
-		`"container_protocol_versions"`, `"cpu"`, `"memory"`, `"environment_variables"`,
+		`"protocol_versions"`, `"cpu"`, `"memory"`, `"environment_variables"`,
 	} {
 		if !strings.Contains(s, field) {
 			t.Errorf("expected JSON to contain %s", field)
@@ -160,7 +160,9 @@ func TestHostedAgentDefinition_ContainerImage_RoundTrip(t *testing.T) {
 		},
 		CPU:    "0.5",
 		Memory: "1Gi",
-		Image:  "myregistry.azurecr.io/agent:latest",
+		ContainerConfiguration: &ContainerConfigurationAPI{
+			Image: "myregistry.azurecr.io/agent:latest",
+		},
 	}
 
 	data, err := json.Marshal(original)
@@ -169,11 +171,15 @@ func TestHostedAgentDefinition_ContainerImage_RoundTrip(t *testing.T) {
 	}
 
 	s := string(data)
-	if !strings.Contains(s, `"image"`) {
-		t.Error("expected JSON to contain \"image\"")
+	if !strings.Contains(s, `"container_configuration"`) {
+		t.Error("expected JSON to contain \"container_configuration\"")
 	}
-	if !strings.Contains(s, `"container_protocol_versions"`) {
-		t.Error("expected JSON to contain \"container_protocol_versions\"")
+	if !strings.Contains(s, `"protocol_versions"`) {
+		t.Error("expected JSON to contain \"protocol_versions\"")
+	}
+	// Should NOT contain legacy top-level "image" or "container_protocol_versions"
+	if strings.Contains(s, `"container_protocol_versions"`) {
+		t.Error("unexpected legacy \"container_protocol_versions\" in JSON")
 	}
 
 	var got HostedAgentDefinition
@@ -181,11 +187,45 @@ func TestHostedAgentDefinition_ContainerImage_RoundTrip(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 
-	if got.Image != original.Image {
-		t.Errorf("Image = %q, want %q", got.Image, original.Image)
+	if got.ContainerConfiguration == nil || got.ContainerConfiguration.Image != original.ContainerConfiguration.Image {
+		t.Errorf("ContainerConfiguration.Image = %v, want %q", got.ContainerConfiguration, original.ContainerConfiguration.Image)
 	}
 	if got.CPU != "0.5" {
 		t.Errorf("CPU = %q, want %q", got.CPU, "0.5")
+	}
+}
+
+func TestHostedAgentDefinition_LegacyUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	// Simulate legacy API response with old schema
+	legacyJSON := `{
+		"kind": "hosted",
+		"image": "myregistry.azurecr.io/agent:latest",
+		"container_protocol_versions": [{"protocol": "responses", "version": "1.0.0"}],
+		"cpu": "0.5",
+		"memory": "1Gi"
+	}`
+
+	var got HostedAgentDefinition
+	if err := json.Unmarshal([]byte(legacyJSON), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Legacy image should be migrated to container_configuration
+	if got.ContainerConfiguration == nil {
+		t.Fatal("expected ContainerConfiguration to be set from legacy image field")
+	}
+	if got.ContainerConfiguration.Image != "myregistry.azurecr.io/agent:latest" {
+		t.Errorf("ContainerConfiguration.Image = %q, want %q", got.ContainerConfiguration.Image, "myregistry.azurecr.io/agent:latest")
+	}
+	// Legacy image field should be cleared
+	if got.Image != "" {
+		t.Errorf("legacy Image field should be cleared, got %q", got.Image)
+	}
+	// Legacy container_protocol_versions should be migrated to protocol_versions
+	if len(got.ProtocolVersions) != 1 || got.ProtocolVersions[0].Protocol != AgentProtocolResponses {
+		t.Errorf("ProtocolVersions not migrated from legacy container_protocol_versions: %+v", got.ProtocolVersions)
 	}
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
@@ -170,16 +170,23 @@ func TestHostedAgentDefinition_ContainerImage_RoundTrip(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	s := string(data)
-	if !strings.Contains(s, `"container_configuration"`) {
-		t.Error("expected JSON to contain \"container_configuration\"")
+	// Parse into raw map to verify schema structure
+	var rawMap map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMap); err != nil {
+		t.Fatalf("unmarshal to map: %v", err)
 	}
-	if !strings.Contains(s, `"protocol_versions"`) {
-		t.Error("expected JSON to contain \"protocol_versions\"")
+	if _, ok := rawMap["container_configuration"]; !ok {
+		t.Error("expected top-level \"container_configuration\" key")
+	}
+	if _, ok := rawMap["protocol_versions"]; !ok {
+		t.Error("expected top-level \"protocol_versions\" key")
 	}
 	// Should NOT contain legacy top-level "image" or "container_protocol_versions"
-	if strings.Contains(s, `"container_protocol_versions"`) {
-		t.Error("unexpected legacy \"container_protocol_versions\" in JSON")
+	if _, ok := rawMap["container_protocol_versions"]; ok {
+		t.Error("unexpected legacy \"container_protocol_versions\" key")
+	}
+	if _, ok := rawMap["image"]; ok {
+		t.Error("unexpected legacy top-level \"image\" key")
 	}
 
 	var got HostedAgentDefinition

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
@@ -440,7 +440,9 @@ func CreateHostedAgentAPIRequest(hostedAgent ContainerAgent, buildConfig *AgentB
 		CPU:                  cpu,
 		Memory:               memory,
 		EnvironmentVariables: envVars,
-		Image:                imageURL,
+		ContainerConfiguration: &agent_api.ContainerConfigurationAPI{
+			Image: imageURL,
+		},
 	}
 
 	return createAgentAPIRequest(hostedAgent.AgentDefinition, imageDef,

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
@@ -885,8 +885,8 @@ func TestCreateHostedAgentAPIRequest_FullConfig(t *testing.T) {
 	if imgDef.Kind != agent_api.AgentKindHosted {
 		t.Errorf("Kind = %q", imgDef.Kind)
 	}
-	if imgDef.Image != "myregistry.azurecr.io/agent:v1" {
-		t.Errorf("Image = %q", imgDef.Image)
+	if imgDef.ContainerConfiguration == nil || imgDef.ContainerConfiguration.Image != "myregistry.azurecr.io/agent:v1" {
+		t.Errorf("ContainerConfiguration.Image = %v", imgDef.ContainerConfiguration)
 	}
 	if imgDef.CPU != "4" {
 		t.Errorf("CPU = %q", imgDef.CPU)
@@ -977,8 +977,8 @@ func TestCreateHostedAgentAPIRequest_UsesAgentImage(t *testing.T) {
 	}
 
 	imgDef := req.Definition.(agent_api.HostedAgentDefinition)
-	if imgDef.Image != "myregistry.azurecr.io/agent-image:v1" {
-		t.Errorf("Image = %q", imgDef.Image)
+	if imgDef.ContainerConfiguration == nil || imgDef.ContainerConfiguration.Image != "myregistry.azurecr.io/agent-image:v1" {
+		t.Errorf("ContainerConfiguration.Image = %v", imgDef.ContainerConfiguration)
 	}
 }
 
@@ -1001,8 +1001,8 @@ func TestCreateHostedAgentAPIRequest_BuildConfigImageOverridesAgentImage(t *test
 	}
 
 	imgDef := req.Definition.(agent_api.HostedAgentDefinition)
-	if imgDef.Image != "myregistry.azurecr.io/published:v2" {
-		t.Errorf("Image = %q", imgDef.Image)
+	if imgDef.ContainerConfiguration == nil || imgDef.ContainerConfiguration.Image != "myregistry.azurecr.io/published:v2" {
+		t.Errorf("ContainerConfiguration.Image = %v", imgDef.ContainerConfiguration)
 	}
 }
 
@@ -1105,8 +1105,8 @@ func TestCreateAgentAPIRequestFromDefinition_HostedWithBuildOptions(t *testing.T
 	}
 
 	imgDef := req.Definition.(agent_api.HostedAgentDefinition)
-	if imgDef.Image != "myimg:v2" {
-		t.Errorf("Image = %q", imgDef.Image)
+	if imgDef.ContainerConfiguration == nil || imgDef.ContainerConfiguration.Image != "myimg:v2" {
+		t.Errorf("ContainerConfiguration.Image = %v", imgDef.ContainerConfiguration)
 	}
 	if imgDef.CPU != "2" {
 		t.Errorf("CPU = %q", imgDef.CPU)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -2294,8 +2294,8 @@ func (p *AgentServiceTargetProvider) displayAgentInfo(request *agent_api.CreateA
 
 	// Display agent-specific information
 	if hostedDef, ok := request.Definition.(agent_api.HostedAgentDefinition); ok {
-		if hostedDef.Image != "" {
-			fmt.Fprintf(os.Stderr, "Image: %s\n", hostedDef.Image)
+		if hostedDef.ContainerConfiguration != nil {
+			fmt.Fprintf(os.Stderr, "Image: %s\n", hostedDef.ContainerConfiguration.Image)
 		}
 		fmt.Fprintf(os.Stderr, "CPU: %s\n", hostedDef.CPU)
 		fmt.Fprintf(os.Stderr, "Memory: %s\n", hostedDef.Memory)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -2294,7 +2294,7 @@ func (p *AgentServiceTargetProvider) displayAgentInfo(request *agent_api.CreateA
 
 	// Display agent-specific information
 	if hostedDef, ok := request.Definition.(agent_api.HostedAgentDefinition); ok {
-		if hostedDef.ContainerConfiguration != nil {
+		if hostedDef.ContainerConfiguration != nil && hostedDef.ContainerConfiguration.Image != "" {
 			fmt.Fprintf(os.Stderr, "Image: %s\n", hostedDef.ContainerConfiguration.Image)
 		}
 		fmt.Fprintf(os.Stderr, "CPU: %s\n", hostedDef.CPU)


### PR DESCRIPTION
## Summary

Migrate container deploy API schema to match the latest service-side TypeSpec definition:
- `container_protocol_versions` → `protocol_versions` (unified with code deploy)
- top-level `image` → `container_configuration.image`

## Reference

Schema change is documented in the official REST API reference:
https://learn.microsoft.com/en-us/azure/foundry/agents/how-to/deploy-hosted-agent?pivots=rest#create-an-agent

The documented create-agent payload uses:
`json
{
  "definition": {
    "kind": "hosted",
    "container_configuration": {
      "image": "myacr.azurecr.io/my-agent:v1"
    },
    "protocol_versions": [
      {"protocol": "responses", "version": "1.0.0"}
    ],
    "cpu": "1",
    "memory": "2Gi"
  }
}
`

## Changes

- **models.go**: Added `ContainerConfigurationAPI` struct, updated `HostedAgentDefinition` to use `protocol_versions` (via struct tag) and `container_configuration` for container image. Removed custom `MarshalJSON`. Updated `UnmarshalJSON` for backward compat with legacy fields.
- **map.go**: Container deploy path now populates `ContainerConfiguration` instead of bare `Image`.
- **optimize_deploy.go**: `normalizeProtocolVersions` handles both new and legacy field names. Added `normalizeContainerImage` to migrate legacy top-level `image` on raw maps (service responses bypass UnmarshalJSON).
- **service_target_agent.go**: Display code reads from `ContainerConfiguration.Image` with empty-string guard.
- **Tests**: All updated and passing, including legacy unmarshal backward compat test.

## Backward Compatibility

`UnmarshalJSON` still reads legacy API responses that use `container_protocol_versions` and top-level `image`, migrating them to the new schema in memory. The optimize-deploy path also normalizes raw definition maps via `normalizeContainerImage` and `normalizeProtocolVersions`.

Fixes #8828
