### PR TITLE
fix: auto-detect foundry provisioning provider for unified yaml

### DIFF
--- a/cli/azd/pkg/azd/default.go
+++ b/cli/azd/pkg/azd/default.go
@@ -6,11 +6,13 @@ package azd
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk/storage"
 	"github.com/azure/azure-dev/cli/azd/pkg/cosmosdb"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
+	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	infraBicep "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/bicep"
 	infraTerraform "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/terraform"
@@ -86,9 +88,17 @@ func (p *DefaultPlatform) ConfigureContainer(container *ioc.NestedContainer) err
 		container.MustRegisterNamedTransient(string(provider), constructor)
 	}
 
-	// Function to determine the default IaC provider when provisioning
+	// DefaultProviderResolver picks the IaC provider when azure.yaml doesn't set
+	// infra.provider. If the project has no on-disk IaC but uses service hosts owned by an
+	// installed extension that also ships a provisioning provider, route to that provider
+	// (e.g. a Foundry azure.yaml -> microsoft.foundry, no infra/ directory needed).
+	// Otherwise default to bicep.
 	container.MustRegisterSingleton(func() provisioning.DefaultProviderResolver {
 		return func() (provisioning.ProviderKind, error) {
+			if provider, ok := defaultProviderFromExtensions(container); ok {
+				return provider, nil
+			}
+
 			return provisioning.Bicep, nil
 		}
 	})
@@ -152,4 +162,85 @@ func (p *DefaultPlatform) ConfigureContainer(container *ioc.NestedContainer) err
 	})
 
 	return nil
+}
+
+// defaultProviderFromExtensions returns the provisioning provider an installed extension
+// supplies for the loaded project's service hosts. It returns false (so the caller falls
+// back to bicep) when there's no project, no extension manager, or no matching extension.
+func defaultProviderFromExtensions(serviceLocator ioc.ServiceLocator) (provisioning.ProviderKind, bool) {
+	var projectConfig *project.ProjectConfig
+	if err := serviceLocator.Resolve(&projectConfig); err != nil || projectConfig == nil {
+		return "", false
+	}
+
+	var extensionManager *extensions.Manager
+	if err := serviceLocator.Resolve(&extensionManager); err != nil || extensionManager == nil {
+		return "", false
+	}
+
+	installed, err := extensionManager.ListInstalled()
+	if err != nil {
+		return "", false
+	}
+
+	return providerFromInstalledExtensions(projectConfig.Services, installed)
+}
+
+// providerFromInstalledExtensions finds an installed extension that both registers a
+// provisioning provider and serves one of the project's service hosts, and returns that
+// provisioning provider (for example, the Foundry extension serves azure.ai.project and
+// registers microsoft.foundry). It returns false when nothing matches. Extension ids are
+// sorted so the choice is deterministic when more than one extension qualifies.
+func providerFromInstalledExtensions(
+	services map[string]*project.ServiceConfig,
+	installed map[string]*extensions.Extension,
+) (provisioning.ProviderKind, bool) {
+	if len(services) == 0 || len(installed) == 0 {
+		return "", false
+	}
+
+	hosts := make(map[string]struct{}, len(services))
+	for _, svc := range services {
+		if svc != nil && svc.Host != "" {
+			hosts[string(svc.Host)] = struct{}{}
+		}
+	}
+
+	if len(hosts) == 0 {
+		return "", false
+	}
+
+	ids := make([]string, 0, len(installed))
+	for id := range installed {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+
+	for _, id := range ids {
+		ext := installed[id]
+		if ext == nil || !ext.HasCapability(extensions.ProvisioningProviderCapability) {
+			continue
+		}
+
+		var provisioningProvider string
+		servesHost := false
+		for _, provider := range ext.Providers {
+			switch provider.Type {
+			case extensions.ProvisioningProviderType:
+				if provisioningProvider == "" {
+					provisioningProvider = provider.Name
+				}
+			case extensions.ServiceTargetProviderType:
+				if _, ok := hosts[provider.Name]; ok {
+					servesHost = true
+				}
+			}
+		}
+
+		if provisioningProvider != "" && servesHost {
+			return provisioning.ProviderKind(provisioningProvider), true
+		}
+	}
+
+	return "", false
 }

--- a/cli/azd/pkg/azd/default_test.go
+++ b/cli/azd/pkg/azd/default_test.go
@@ -6,8 +6,10 @@ package azd
 import (
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
+	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,4 +37,101 @@ func Test_DefaultPlatform_ConfigureContainer(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expected, actual)
 	})
+}
+
+func Test_providerFromInstalledExtensions(t *testing.T) {
+	foundryExt := func() *extensions.Extension {
+		return &extensions.Extension{
+			Id:           "azure.ai.agents",
+			Capabilities: []extensions.CapabilityType{extensions.ProvisioningProviderCapability},
+			Providers: []extensions.Provider{
+				{Name: "azure.ai.agent", Type: extensions.ServiceTargetProviderType},
+				{Name: "azure.ai.project", Type: extensions.ServiceTargetProviderType},
+				{Name: "microsoft.foundry", Type: extensions.ProvisioningProviderType},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		services  map[string]*project.ServiceConfig
+		installed map[string]*extensions.Extension
+		want      provisioning.ProviderKind
+		wantOk    bool
+	}{
+		{
+			name: "foundry project routes to microsoft.foundry",
+			services: map[string]*project.ServiceConfig{
+				"ai-project": {Host: "azure.ai.project"},
+				"assistant":  {Host: "azure.ai.agent"},
+			},
+			installed: map[string]*extensions.Extension{"azure.ai.agents": foundryExt()},
+			want:      provisioning.ProviderKind("microsoft.foundry"),
+			wantOk:    true,
+		},
+		{
+			name: "extension without provisioning capability is ignored",
+			services: map[string]*project.ServiceConfig{
+				"ai-project": {Host: "azure.ai.project"},
+			},
+			installed: map[string]*extensions.Extension{
+				"azure.ai.agents": {
+					Id:        "azure.ai.agents",
+					Providers: foundryExt().Providers,
+				},
+			},
+			wantOk: false,
+		},
+		{
+			name: "no installed extensions falls back",
+			services: map[string]*project.ServiceConfig{
+				"ai-project": {Host: "azure.ai.project"},
+			},
+			installed: map[string]*extensions.Extension{},
+			wantOk:    false,
+		},
+		{
+			name: "host not served by the provisioning extension falls back",
+			services: map[string]*project.ServiceConfig{
+				"web": {Host: "containerapp"},
+			},
+			installed: map[string]*extensions.Extension{"azure.ai.agents": foundryExt()},
+			wantOk:    false,
+		},
+		{
+			name:      "no services falls back",
+			services:  map[string]*project.ServiceConfig{},
+			installed: map[string]*extensions.Extension{"azure.ai.agents": foundryExt()},
+			wantOk:    false,
+		},
+		{
+			name: "multiple qualifying extensions selects lowest id",
+			services: map[string]*project.ServiceConfig{
+				"ai-project": {Host: "azure.ai.project"},
+			},
+			installed: map[string]*extensions.Extension{
+				"zzz.ext": {
+					Id:           "zzz.ext",
+					Capabilities: []extensions.CapabilityType{extensions.ProvisioningProviderCapability},
+					Providers: []extensions.Provider{
+						{Name: "azure.ai.project", Type: extensions.ServiceTargetProviderType},
+						{Name: "zzz.provider", Type: extensions.ProvisioningProviderType},
+					},
+				},
+				"azure.ai.agents": foundryExt(),
+			},
+			want:   provisioning.ProviderKind("microsoft.foundry"),
+			wantOk: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := providerFromInstalledExtensions(tt.services, tt.installed)
+			require.Equal(t, tt.wantOk, ok)
+			if tt.wantOk {
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
 }

--- a/cli/azd/pkg/extensions/registry.go
+++ b/cli/azd/pkg/extensions/registry.go
@@ -64,6 +64,8 @@ type ProviderType string
 const (
 	// Service target provider type for custom deployment targets
 	ServiceTargetProviderType ProviderType = "service-target"
+	// Provisioning provider type for custom infrastructure provisioning
+	ProvisioningProviderType ProviderType = "provisioning-provider"
 )
 
 // Extension represents an extension in the registry

--- a/cli/azd/pkg/infra/provisioning/manager.go
+++ b/cli/azd/pkg/infra/provisioning/manager.go
@@ -530,6 +530,11 @@ func (m *Manager) newProvider(ctx context.Context) (Provider, error) {
 		providerKey = defaultProvider
 	}
 
+	// Record the resolved provider on the options so it reaches Provider.Initialize.
+	// Extension providers receive this over gRPC and reject an empty value; the built-in
+	// bicep/terraform providers ignore it.
+	m.options.Provider = providerKey
+
 	var provider Provider
 	err = m.serviceLocator.ResolveNamed(string(providerKey), &provider)
 	if err != nil {

--- a/cli/azd/pkg/infra/provisioning/manager_test.go
+++ b/cli/azd/pkg/infra/provisioning/manager_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/test"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockaccount"
@@ -394,4 +395,80 @@ func registerContainerDependencies(mockContext *mocks.MockContext, env *environm
 
 func defaultProvider() (provisioning.ProviderKind, error) {
 	return provisioning.Bicep, nil
+}
+
+// recordingProvider records the options passed to Initialize.
+type recordingProvider struct {
+	initializedProvider provisioning.ProviderKind
+}
+
+func (p *recordingProvider) Name() string { return "recording" }
+
+func (p *recordingProvider) Initialize(
+	ctx context.Context, projectPath string, options provisioning.Options,
+) error {
+	p.initializedProvider = options.Provider
+	return nil
+}
+
+func (p *recordingProvider) State(
+	ctx context.Context, options *provisioning.StateOptions,
+) (*provisioning.StateResult, error) {
+	return nil, nil
+}
+
+func (p *recordingProvider) Deploy(ctx context.Context) (*provisioning.DeployResult, error) {
+	return nil, nil
+}
+
+func (p *recordingProvider) Preview(ctx context.Context) (*provisioning.DeployPreviewResult, error) {
+	return nil, nil
+}
+
+func (p *recordingProvider) Destroy(
+	ctx context.Context, options provisioning.DestroyOptions,
+) (*provisioning.DestroyResult, error) {
+	return nil, nil
+}
+
+func (p *recordingProvider) EnsureEnv(ctx context.Context) error { return nil }
+
+func (p *recordingProvider) Parameters(ctx context.Context) ([]provisioning.Parameter, error) {
+	return nil, nil
+}
+
+func (p *recordingProvider) PlannedOutputs(ctx context.Context) ([]provisioning.PlannedOutput, error) {
+	return nil, nil
+}
+
+// An unspecified provider is resolved by the default resolver; the manager must hand the
+// resolved name to Provider.Initialize (extension providers validate it).
+func TestManagerForwardsResolvedProviderToInitialize(t *testing.T) {
+	env := environment.NewWithValues("test-env", nil)
+
+	mockContext := mocks.NewMockContext(t.Context())
+	registerContainerDependencies(mockContext, env)
+
+	recording := &recordingProvider{}
+	ioc.RegisterNamedInstance[provisioning.Provider](mockContext.Container, "writeback", recording)
+
+	resolver := func() (provisioning.ProviderKind, error) {
+		return provisioning.ProviderKind("writeback"), nil
+	}
+
+	envManager := &mockenv.MockEnvManager{}
+	mgr := provisioning.NewManager(
+		mockContext.Container,
+		resolver,
+		envManager,
+		env,
+		mockContext.Console,
+		mockContext.AlphaFeaturesManager,
+		nil,
+		cloud.AzurePublic(),
+	)
+
+	err := mgr.Initialize(*mockContext.Context, "", provisioning.Options{})
+	require.NoError(t, err)
+	require.Equal(t, provisioning.ProviderKind("writeback"), recording.initializedProvider)
 }


### PR DESCRIPTION
## Summary

Fixes #8819. With a unified `azure.yaml` that declares Foundry services (`host: azure.ai.project`, `azure.ai.agent`, …) but no `infra.provider` and no on-disk `infra/` directory, `azd provision` (including `--preview`) failed with:

```
ERROR: initializing provisioning manager: failed to compile bicep template: ... Could not find ... infra\main.bicep
```

## Root cause

When `infra.provider` is unset and no IaC files are found, the provisioning manager's `DefaultProviderResolver` unconditionally returned `bicep`, so core's Bicep provider tried to compile a non-existent `infra/main.bicep`. The extension's `microsoft.foundry` provider (which synthesizes Bicep in-memory, no `infra/` needed) was never reached, because core only routes to it when `infra.provider: microsoft.foundry` is set.

## Fix

Core-level auto-detection — generic, with no hard-coded provider/host names:

- **`pkg/azd/default.go`** — the `DefaultProviderResolver` now lazily resolves the project config and installed extensions. When `infra.provider` is unset and no on-disk IaC is present, it defaults to an installed extension's provisioning provider whose service host the project uses. This maps a unified Foundry `azure.yaml` to `microsoft.foundry` and generalizes to any extension that registers both a `service-target` and a `provisioning-provider`. Falls back to `bicep` when nothing applies or no project/extension context is available.
- **`pkg/extensions/registry.go`** — add the `ProvisioningProviderType` provider-type constant.
- **`pkg/infra/provisioning/manager.go`** — `newProvider` writes the resolved provider name back onto the options so the provider's `Initialize` (the extension validates it over gRPC) receives the concrete name instead of an unspecified value.

## Tests

- `pkg/azd/default_test.go` — table tests for the host → provider mapping helper (foundry → `microsoft.foundry`; missing capability / extension / host → fallback; deterministic multi-extension selection).
- `pkg/infra/provisioning/manager_test.go` — asserts the resolved provider reaches `Provider.Initialize`.

## Validation

`go build ./...`, `go vet`, `gofmt`, `cspell`, and `golangci-lint` are clean; tests pass for `pkg/azd`, `pkg/infra/provisioning`, `pkg/extensions`, and `internal/cmd`.

## Out of scope

The example `azure.yaml` files are unchanged (auto-detect only).
