### PR TITLE
Fix placeholder warning to reference azure.yaml instead of agent.yaml

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/format_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/format_test.go
@@ -202,8 +202,8 @@ func TestPrintAllNext(t *testing.T) {
 			// deploying. PrintAllNext must surface all three.
 			suggestions: []Suggestion{
 				{
-					Command:     "edit agent.yaml: replace {{TOOLBOX_ENDPOINT}} with the actual value",
-					Description: "agent.yaml has unresolved manifest placeholders",
+					Command:     "edit azure.yaml: replace {{TOOLBOX_ENDPOINT}} with the actual value",
+					Description: "azure.yaml has unresolved manifest placeholders",
 					Priority:    5,
 				},
 				{
@@ -220,8 +220,8 @@ func TestPrintAllNext(t *testing.T) {
 			},
 			want: "\n" +
 				"Next:\n" +
-				"  edit agent.yaml: replace {{TOOLBOX_ENDPOINT}} with the actual value\n" +
-				"  agent.yaml has unresolved manifest placeholders\n" +
+				"  edit azure.yaml: replace {{TOOLBOX_ENDPOINT}} with the actual value\n" +
+				"  azure.yaml has unresolved manifest placeholders\n" +
 				"\n" +
 				"  azd env set TOOLBOX_WEB_SEARCH_TOOLS_MCP_ENDPOINT <value>\n" +
 				"  supply the agent.yaml variable\n" +
@@ -234,9 +234,9 @@ func TestPrintAllNext(t *testing.T) {
 			// Worst-case shape from ResolveAfterInit when both
 			// maxFixupLines caps are saturated.
 			suggestions: []Suggestion{
-				{Command: "edit agent.yaml: replace {{A}} with the actual value", Description: "p1", Priority: 5},
-				{Command: "edit agent.yaml: replace {{B}} with the actual value", Description: "p1", Priority: 6},
-				{Command: "edit agent.yaml: replace {{C}} with the actual value", Description: "p1", Priority: 7},
+				{Command: "edit azure.yaml: replace {{A}} with the actual value", Description: "p1", Priority: 5},
+				{Command: "edit azure.yaml: replace {{B}} with the actual value", Description: "p1", Priority: 6},
+				{Command: "edit azure.yaml: replace {{C}} with the actual value", Description: "p1", Priority: 7},
 				{Command: "azd env set FOO <value>", Description: "p2", Priority: 8},
 				{Command: "azd env set BAR <value>", Description: "p2", Priority: 9},
 				{Command: "azd env set BAZ <value>", Description: "p2", Priority: 10},
@@ -244,13 +244,13 @@ func TestPrintAllNext(t *testing.T) {
 			},
 			want: "\n" +
 				"Next:\n" +
-				"  edit agent.yaml: replace {{A}} with the actual value\n" +
+				"  edit azure.yaml: replace {{A}} with the actual value\n" +
 				"  p1\n" +
 				"\n" +
-				"  edit agent.yaml: replace {{B}} with the actual value\n" +
+				"  edit azure.yaml: replace {{B}} with the actual value\n" +
 				"  p1\n" +
 				"\n" +
-				"  edit agent.yaml: replace {{C}} with the actual value\n" +
+				"  edit azure.yaml: replace {{C}} with the actual value\n" +
 				"  p1\n" +
 				"\n" +
 				"  azd env set FOO <value>\n" +
@@ -425,7 +425,7 @@ func TestFormatNextForNote_HostArtifactAlignment(t *testing.T) {
 
 // TestFormatNext_HighlightsOnlyAzdCommands verifies that runnable azd
 // commands are rendered in the highlight color while non-command pointers
-// ("see ..." / "edit agent.yaml: ...") and descriptions stay plain.
+// ("see ..." / "edit azure.yaml: ...") and descriptions stay plain.
 func TestFormatNext_HighlightsOnlyAzdCommands(t *testing.T) {
 	// Not parallel: toggles the process-global color.NoColor. Go runs
 	// non-parallel tests to completion before parallel tests resume, so

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/format_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/format_test.go
@@ -208,7 +208,7 @@ func TestPrintAllNext(t *testing.T) {
 				},
 				{
 					Command:     "azd env set TOOLBOX_WEB_SEARCH_TOOLS_MCP_ENDPOINT <value>",
-					Description: "supply the agent.yaml variable",
+					Description: "supply the azure.yaml variable",
 					Priority:    6,
 				},
 				{
@@ -224,7 +224,7 @@ func TestPrintAllNext(t *testing.T) {
 				"  azure.yaml has unresolved manifest placeholders\n" +
 				"\n" +
 				"  azd env set TOOLBOX_WEB_SEARCH_TOOLS_MCP_ENDPOINT <value>\n" +
-				"  supply the agent.yaml variable\n" +
+				"  supply the azure.yaml variable\n" +
 				"\n" +
 				"  azd deploy\n" +
 				"  when ready to deploy to Azure\n",

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
@@ -239,7 +239,7 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 			for _, key := range manual[:limit] {
 				out = append(out, Suggestion{
 					Command:     fmt.Sprintf("azd env set %s <value>", key),
-					Description: "referenced by agent.yaml but not set in azd env",
+					Description: "referenced by azure.yaml but not set in azd env",
 					Priority:    priority,
 				})
 				priority++

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
@@ -151,8 +151,8 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 	}
 
 	// Placeholder fix-ups always come first when present: they are broken
-	// state in agent.yaml itself and block both `run` and `deploy`. The
-	// user has to edit agent.yaml (or define a matching parameter in
+	// state in azure.yaml itself and block both `run` and `deploy`. The
+	// user has to edit azure.yaml (or define a matching parameter in
 	// agent.manifest.yaml) — `azd env set` cannot reach them.
 	hasPlaceholders := len(state.UnresolvedPlaceholders) > 0
 	if hasPlaceholders {
@@ -161,8 +161,8 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 		limit := min(len(placeholders), maxFixupLines)
 		for _, name := range placeholders[:limit] {
 			out = append(out, Suggestion{
-				Command:     fmt.Sprintf("edit agent.yaml: replace {{%s}} with the actual value", name),
-				Description: "agent.yaml has unresolved manifest placeholders",
+				Command:     fmt.Sprintf("edit azure.yaml: replace {{%s}} with the actual value", name),
+				Description: "azure.yaml has unresolved manifest placeholders",
 				Priority:    priority,
 			})
 			priority++

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
@@ -263,7 +263,7 @@ func TestResolveAfterInit_CreatedFolder(t *testing.T) {
 
 // TestResolveAfterInit_ManualVarsSingleEmitsEnrichedShape locks the
 // single-missing-manual-var case end-to-end. Three asserts: the env-set
-// line has the enriched "referenced by agent.yaml but not set in azd
+// line has the enriched "referenced by azure.yaml but not set in azd
 // env" description, the `azd ai agent run` follow-up immediately follows
 // the env-set lines, and the trailing `azd deploy` reminder is preserved.
 // This is the canonical B2 fix shape from issue #7975's "Example output
@@ -280,7 +280,7 @@ func TestResolveAfterInit_ManualVarsSingleEmitsEnrichedShape(t *testing.T) {
 	require.Len(t, out, 4)
 
 	assert.Equal(t, "azd env set MY_API_KEY <value>", out[0].Command)
-	assert.Equal(t, "referenced by agent.yaml but not set in azd env", out[0].Description,
+	assert.Equal(t, "referenced by azure.yaml but not set in azd env", out[0].Description,
 		"enriched description must explain WHY the env-set is needed")
 	assert.False(t, out[0].Trailing)
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
@@ -412,7 +412,7 @@ func TestResolveAfterInit_ToolboxReproRendersAllCategories(t *testing.T) {
 	rendered := buf.String()
 
 	assert.Contains(t, rendered,
-		"edit agent.yaml: replace {{TOOLBOX_ENDPOINT}} with the actual value",
+		"edit azure.yaml: replace {{TOOLBOX_ENDPOINT}} with the actual value",
 		"placeholder fix-up missing")
 	assert.Contains(t, rendered, "azd provision",
 		"toolbox-endpoint branch should route to azd provision")
@@ -552,7 +552,7 @@ func TestResolveAfterInit_ToolboxAndManualVarsCoexistWithPlaceholders(t *testing
 	rendered := buf.String()
 
 	assert.Contains(t, rendered,
-		"edit agent.yaml: replace {{AGENT_NAME}} with the actual value",
+		"edit azure.yaml: replace {{AGENT_NAME}} with the actual value",
 		"placeholder fix-up missing")
 	assert.Contains(t, rendered, "azd provision",
 		"coexistence+placeholders: toolbox sub-branch must still emit provision")
@@ -693,7 +693,7 @@ func TestResolveAfterInit_UnresolvedPlaceholders(t *testing.T) {
 			for i, name := range tt.wantPlaceholders {
 				require.Less(t, i, len(out))
 				assert.Equal(t,
-					"edit agent.yaml: replace {{"+name+"}} with the actual value",
+					"edit azure.yaml: replace {{"+name+"}} with the actual value",
 					out[i].Command,
 				)
 			}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state.go
@@ -530,11 +530,11 @@ func loadServiceProtocol(projectPath, relativePath string) string {
 //
 // {{NAME}} placeholders are reported separately because the user cannot
 // fix them with `azd env set` — the placeholder is literally inside
-// agent.yaml and would land in the container as `{{NAME}}` at deploy
+// azure.yaml and would land in the container as `{{NAME}}` at deploy
 // time. The resolver surfaces an "edit azure.yaml" suggestion for each.
 //
 // All three result lists are deduplicated and sorted ascending. Read
-// errors on individual agent.yaml files are silent: the resolver should
+// errors on individual azure.yaml files are silent: the resolver should
 // fall back to the default branch rather than emit guidance that
 // mentions variables we cannot prove are needed. Transport errors from
 // src.EnvValue are appended to errs so AssembleState's caller can

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state.go
@@ -531,7 +531,7 @@ func loadServiceProtocol(projectPath, relativePath string) string {
 // {{NAME}} placeholders are reported separately because the user cannot
 // fix them with `azd env set` — the placeholder is literally inside
 // agent.yaml and would land in the container as `{{NAME}}` at deploy
-// time. The resolver surfaces an "edit agent.yaml" suggestion for each.
+// time. The resolver surfaces an "edit azure.yaml" suggestion for each.
 //
 // All three result lists are deduplicated and sorted ascending. Read
 // errors on individual agent.yaml files are silent: the resolver should

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parameters.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parameters.go
@@ -58,8 +58,8 @@ func ProcessManifestParameters(
 	// either a parameter the manifest author forgot to declare under
 	// `parameters:` (typo / drift) or a literal `{{...}}` token the
 	// author intends to ship as-is. Either case warrants the warning,
-	// and the `Edit agent.yaml` advice is actionable from this point
-	// onward (the caller will write agent.yaml to disk moments later).
+	// and the `Edit azure.yaml` advice is actionable from this point
+	// onward (the caller will write the definition to azure.yaml).
 	//
 	// Earlier call sites of `InjectParameterValuesIntoManifest` (notably
 	// `ProcessModels` in init_models.go which substitutes only model
@@ -77,16 +77,16 @@ func ProcessManifestParameters(
 }
 
 // warnUnresolvedManifestPlaceholders re-marshals the template that will be
-// written to agent.yaml and prints a stdout warning naming any surviving
+// written to azure.yaml and prints a stdout warning naming any surviving
 // `{{NAME}}` placeholders. The nextstep guidance system uses the same
 // `PlaceholderPattern` so the warning names and the post-init `Next:` block
 // stay aligned (a placeholder reported in the warning must show up in the
 // Next: block, and vice versa).
 //
-// Scans only `manifest.Template` because that's what `writeAgentDefinitionFile`
-// marshals to agent.yaml; placeholders in other manifest sections (parameters,
+// Scans only `manifest.Template` because that's what gets written to
+// azure.yaml; placeholders in other manifest sections (parameters,
 // resources) never reach the on-disk file, so naming them in an
-// "Edit agent.yaml" warning would mislead the user.
+// "Edit azure.yaml" warning would mislead the user.
 func warnUnresolvedManifestPlaceholders(manifest *AgentManifest) error {
 	templateBytes, err := yaml.Marshal(manifest.Template)
 	if err != nil {
@@ -99,8 +99,8 @@ func warnUnresolvedManifestPlaceholders(manifest *AgentManifest) error {
 	}
 
 	fmt.Printf(
-		"Warning: agent.yaml has %d unresolved placeholder(s): %s. "+
-			"Edit agent.yaml and replace each `{{NAME}}` with the actual value before deploying.\n",
+		"Warning: azure.yaml has %d unresolved placeholder(s): %s. "+
+			"Edit azure.yaml and replace each `{{NAME}}` with the actual value before deploying.\n",
 		len(remaining),
 		strings.Join(remaining, ", "),
 	)

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/placeholders.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/placeholders.go
@@ -39,7 +39,7 @@ var PlaceholderPattern = regexp.MustCompile(`\{\{\s*([^\s{}][^{}]*?)\s*\}\}`)
 // Used by both injectParameterValues (to surface a specific warning
 // naming the unresolved placeholders) and by nextstep's fix-up
 // generator (to surface the same names in the `Next:` block as a
-// concrete "edit agent.yaml" hint). The two call sites must agree
+// concrete "edit azure.yaml" hint). The two call sites must agree
 // on what counts as a placeholder, hence the shared helper.
 func ExtractUnresolvedPlaceholders(template string) []string {
 	matches := PlaceholderPattern.FindAllStringSubmatch(template, -1)


### PR DESCRIPTION
The unresolved placeholder warning and nextstep suggestions still referenced `agent.yaml`, but agent definitions now live inline in `azure.yaml`. Users saw:

```
Warning: agent.yaml has 1 unresolved placeholder(s): TOOLBOX_ENDPOINT.
Edit agent.yaml and replace each `{{NAME}}` with the actual value before deploying.
```

This updates all user-facing strings (the warning message and the nextstep "edit ..." suggestions) to say `azure.yaml`, along with related code comments and test assertions.

**Files changed:**
- `parameters.go` -- warning `fmt.Printf` and function doc comments
- `nextstep/resolver.go` -- suggestion command/description strings and comments
- `nextstep/state.go` -- comment describing the suggestion text
- `nextstep/resolver_test.go` and `format_test.go` -- expected assertion strings

Fixes: #8855