### PR TITLE
fix: add omitempty to yaml tags to prevent empty strings in azure.yaml

### DIFF
--- a/cli/azd/pkg/project/project_config.go
+++ b/cli/azd/pkg/project/project_config.go
@@ -56,9 +56,9 @@ type RequiredVersions struct {
 
 // options supported in azure.yaml
 type PipelineOptions struct {
-	Provider  string   `yaml:"provider"`
-	Variables []string `yaml:"variables"`
-	Secrets   []string `yaml:"secrets"`
+	Provider  string   `yaml:"provider,omitempty"`
+	Variables []string `yaml:"variables,omitempty"`
+	Secrets   []string `yaml:"secrets,omitempty"`
 }
 
 // Project lifecycle event arguments

--- a/cli/azd/pkg/project/project_config_test.go
+++ b/cli/azd/pkg/project/project_config_test.go
@@ -737,3 +737,42 @@ func Test_HooksConfig_RoundTrip(t *testing.T) {
 	require.Len(t, restored["postprovision"], 1)
 	assert.Equal(t, "echo bye", restored["postprovision"][0].Run)
 }
+
+func TestServiceConfig_MarshalYAML_OmitsEmptyOptionalFields(t *testing.T) {
+	svc := &ServiceConfig{
+		Host: ContainerAppTarget,
+	}
+
+	data, err := yaml.Marshal(svc)
+	require.NoError(t, err)
+	output := string(data)
+
+	// host is required and must always be present
+	assert.Contains(t, output, "host: containerapp")
+
+	// optional fields with zero values should be omitted
+	assert.NotContains(t, output, "project:")
+	assert.NotContains(t, output, "language:")
+}
+
+func TestPipelineOptions_MarshalYAML_OmitsEmptyFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		options PipelineOptions
+	}{
+		{"all zero values", PipelineOptions{}},
+		{"empty slices", PipelineOptions{Variables: []string{}, Secrets: []string{}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := yaml.Marshal(tt.options)
+			require.NoError(t, err)
+			output := string(data)
+
+			assert.NotContains(t, output, "provider:")
+			assert.NotContains(t, output, "variables:")
+			assert.NotContains(t, output, "secrets:")
+		})
+	}
+}

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -35,11 +35,11 @@ type ServiceConfig struct {
 	// The ARM api version to use for the service. If not specified, the latest version is used.
 	ApiVersion string `yaml:"apiVersion,omitempty"`
 	// The relative path to the project folder from the project root
-	RelativePath string `yaml:"project"`
+	RelativePath string `yaml:"project,omitempty"`
 	// The azure hosting model to use, ex) appservice, function, containerapp
-	Host ServiceTargetKind `yaml:"host"`
+	Host ServiceTargetKind `yaml:"host,omitempty"`
 	// The programming language of the project
-	Language ServiceLanguageKind `yaml:"language"`
+	Language ServiceLanguageKind `yaml:"language,omitempty"`
 	// The output path for build artifacts
 	OutputPath string `yaml:"dist,omitempty"`
 	// The source image to use for container based applications

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -37,7 +37,7 @@ type ServiceConfig struct {
 	// The relative path to the project folder from the project root
 	RelativePath string `yaml:"project,omitempty"`
 	// The azure hosting model to use, ex) appservice, function, containerapp
-	Host ServiceTargetKind `yaml:"host,omitempty"`
+	Host ServiceTargetKind `yaml:"host"`
 	// The programming language of the project
 	Language ServiceLanguageKind `yaml:"language,omitempty"`
 	// The output path for build artifacts


### PR DESCRIPTION
When `azd` serializes project configuration back to `azure.yaml`, fields with zero values (empty strings, nil slices) were being written as empty strings or empty arrays. This produces noisy, confusing output -- particularly for fields like `host`, `language`, and `project` on services, and `provider`/`variables`/`secrets` on pipeline options.

## Approach

Added `omitempty` to the yaml struct tags on the affected fields so they are omitted from the serialized output when empty:

- **`ServiceConfig`** (`service_config.go`): `project`, `host`, `language`
- **`PipelineOptions`** (`project_config.go`): `provider`, `variables`, `secrets`

This is consistent with how all other optional fields in these structs are already tagged.

Fixes: #8862