### PR TITLE
Increase default deployment capacity from 10 to 50 for agents

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/docs/private-networking.md
+++ b/cli/azd/extensions/azure.ai.agents/docs/private-networking.md
@@ -23,7 +23,7 @@ services:
     deployments:
       - name: gpt-4o-mini
         model: { format: OpenAI, name: gpt-4o-mini, version: "2024-07-18" }
-        sku: { name: GlobalStandard, capacity: 10 }
+        sku: { name: GlobalStandard, capacity: 50 }
     network:
       # ----- Egress: agent runtime network (pick ONE) -----
       #

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -1175,7 +1175,7 @@ func resolveModelDeployments(
 		ModelName:    model.Name,
 		Options: &azdext.AiModelDeploymentOptions{
 			Locations: []string{location},
-			Capacity:  new(int32(defaultDeploymentCapacity)),
+			Capacity:  new(defaultDeploymentCapacity),
 		},
 		Quota: &azdext.QuotaCheckOptions{
 			MinRemainingCapacity: 1,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -1175,6 +1175,7 @@ func resolveModelDeployments(
 		ModelName:    model.Name,
 		Options: &azdext.AiModelDeploymentOptions{
 			Locations: []string{location},
+			Capacity:  new(int32(defaultDeploymentCapacity)),
 		},
 		Quota: &azdext.QuotaCheckOptions{
 			MinRemainingCapacity: 1,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
@@ -37,7 +37,7 @@ services:
           version: "2024-07-18"
         sku:
           name: GlobalStandard
-          capacity: 10
+          capacity: 50
     agents:
       - name: my-agent
         docker:

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
@@ -27,6 +27,10 @@ import (
 
 var defaultSkuPriority = []string{"GlobalStandard", "DataZoneStandard", "Standard"}
 
+// defaultDeploymentCapacity is the preferred deployment capacity for agent model deployments.
+// This overrides the lower SKU default (typically 10) which is insufficient for agents.
+const defaultDeploymentCapacity int32 = 50
+
 // errModelSkipped is a sentinel error returned by getModelDetails when the
 // user explicitly chooses "Skip this model" from the model-selection prompt.
 // Callers MUST use errors.Is to detect this case and drop the model from the
@@ -521,6 +525,7 @@ func (a *modelSelector) getModelDetails(
 			ModelName:    model.Name,
 			Options: &azdext.AiModelDeploymentOptions{
 				Locations: []string{currentLocation},
+				Capacity:  new(int32(defaultDeploymentCapacity)),
 			},
 			Quota: &azdext.QuotaCheckOptions{
 				MinRemainingCapacity: 1,
@@ -560,7 +565,7 @@ func (a *modelSelector) getModelDetails(
 func resolveNoPromptCapacity(candidate *azdext.AiModelDeployment) (int32, bool) {
 	capacity := candidate.Capacity
 	if capacity <= 0 {
-		capacity = max(candidate.Sku.MinCapacity, int32(1))
+		capacity = defaultDeploymentCapacity
 	}
 
 	if candidate.Sku.CapacityStep > 0 && capacity%candidate.Sku.CapacityStep != 0 {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
@@ -525,7 +525,7 @@ func (a *modelSelector) getModelDetails(
 			ModelName:    model.Name,
 			Options: &azdext.AiModelDeploymentOptions{
 				Locations: []string{currentLocation},
-				Capacity:  new(int32(defaultDeploymentCapacity)),
+				Capacity:  new(defaultDeploymentCapacity),
 			},
 			Quota: &azdext.QuotaCheckOptions{
 				MinRemainingCapacity: 1,
@@ -564,7 +564,8 @@ func (a *modelSelector) getModelDetails(
 
 func resolveNoPromptCapacity(candidate *azdext.AiModelDeployment) (int32, bool) {
 	capacity := candidate.Capacity
-	if capacity <= 0 {
+	defaulted := capacity <= 0
+	if defaulted {
 		capacity = defaultDeploymentCapacity
 	}
 
@@ -577,7 +578,17 @@ func resolveNoPromptCapacity(candidate *azdext.AiModelDeployment) (int32, bool) 
 		capacity = candidate.Sku.MinCapacity
 	}
 	if candidate.Sku.MaxCapacity > 0 && capacity > candidate.Sku.MaxCapacity {
-		return 0, false
+		if !defaulted {
+			return 0, false
+		}
+		// Clamp down to the highest step-aligned capacity within max.
+		capacity = candidate.Sku.MaxCapacity
+		if step := candidate.Sku.CapacityStep; step > 0 && capacity%step != 0 {
+			capacity = (capacity / step) * step
+		}
+		if capacity < candidate.Sku.MinCapacity || capacity <= 0 {
+			return 0, false
+		}
 	}
 
 	if candidate.RemainingQuota != nil && float64(capacity) > *candidate.RemainingQuota {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models_test.go
@@ -33,30 +33,30 @@ func TestResolveNoPromptCapacity(t *testing.T) {
 			wantOk:       true,
 		},
 		{
-			name: "zero capacity defaults to max(minCapacity, 1)",
+			name: "zero capacity defaults to defaultDeploymentCapacity",
 			candidate: &azdext.AiModelDeployment{
 				Capacity: 0,
 				Sku:      &azdext.AiModelSku{MinCapacity: 5},
 			},
-			wantCapacity: 5,
+			wantCapacity: defaultDeploymentCapacity,
 			wantOk:       true,
 		},
 		{
-			name: "zero capacity with zero minCapacity defaults to 1",
+			name: "zero capacity with zero minCapacity defaults to defaultDeploymentCapacity",
 			candidate: &azdext.AiModelDeployment{
 				Capacity: 0,
 				Sku:      &azdext.AiModelSku{MinCapacity: 0},
 			},
-			wantCapacity: 1,
+			wantCapacity: defaultDeploymentCapacity,
 			wantOk:       true,
 		},
 		{
-			name: "negative capacity defaults to max(minCapacity, 1)",
+			name: "negative capacity defaults to defaultDeploymentCapacity",
 			candidate: &azdext.AiModelDeployment{
 				Capacity: -3,
 				Sku:      &azdext.AiModelSku{MinCapacity: 2},
 			},
-			wantCapacity: 2,
+			wantCapacity: defaultDeploymentCapacity,
 			wantOk:       true,
 		},
 		{
@@ -78,12 +78,12 @@ func TestResolveNoPromptCapacity(t *testing.T) {
 			wantOk:       true,
 		},
 		{
-			name: "enforces minCapacity then step alignment",
+			name: "enforces step alignment on defaultDeploymentCapacity",
 			candidate: &azdext.AiModelDeployment{
 				Capacity: 0,
 				Sku:      &azdext.AiModelSku{MinCapacity: 10, CapacityStep: 3},
 			},
-			wantCapacity: 12, // min=10, rounded up to next step of 3
+			wantCapacity: 51, // default=50, rounded up to next step of 3
 			wantOk:       true,
 		},
 		{
@@ -91,6 +91,15 @@ func TestResolveNoPromptCapacity(t *testing.T) {
 			candidate: &azdext.AiModelDeployment{
 				Capacity: 20,
 				Sku:      &azdext.AiModelSku{MaxCapacity: 10},
+			},
+			wantCapacity: 0,
+			wantOk:       false,
+		},
+		{
+			name: "defaultDeploymentCapacity exceeds maxCapacity returns false",
+			candidate: &azdext.AiModelDeployment{
+				Capacity: 0,
+				Sku:      &azdext.AiModelSku{MaxCapacity: 30},
 			},
 			wantCapacity: 0,
 			wantOk:       false,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models_test.go
@@ -96,13 +96,22 @@ func TestResolveNoPromptCapacity(t *testing.T) {
 			wantOk:       false,
 		},
 		{
-			name: "defaultDeploymentCapacity exceeds maxCapacity returns false",
+			name: "defaultDeploymentCapacity clamped to maxCapacity",
 			candidate: &azdext.AiModelDeployment{
 				Capacity: 0,
 				Sku:      &azdext.AiModelSku{MaxCapacity: 30},
 			},
-			wantCapacity: 0,
-			wantOk:       false,
+			wantCapacity: 30,
+			wantOk:       true,
+		},
+		{
+			name: "defaultDeploymentCapacity clamped and step-aligned down",
+			candidate: &azdext.AiModelDeployment{
+				Capacity: 0,
+				Sku:      &azdext.AiModelSku{MaxCapacity: 50, CapacityStep: 7},
+			},
+			wantCapacity: 49, // 50/7=7*7=49
+			wantOk:       true,
 		},
 		{
 			name: "exceeds remaining quota returns false",

--- a/cli/azd/extensions/azure.ai.agents/schemas/examples/simple.azure.yaml
+++ b/cli/azd/extensions/azure.ai.agents/schemas/examples/simple.azure.yaml
@@ -15,7 +15,7 @@ services:
           version: "2024-07-18"
         sku:
           name: GlobalStandard
-          capacity: 10
+          capacity: 50
 
   assistant:
     host: azure.ai.agent


### PR DESCRIPTION
## Motivation

The Azure SKU default capacity for model deployments is typically 10, which is too low for AI agent workloads. Users see "10" pre-filled in the capacity prompt during `azd ai agent init`, requiring manual adjustment every time. The recommendation from bug bash feedback is 30-50.

## Approach

Introduces a `defaultDeploymentCapacity` constant (50) in the agents extension and passes it as the preferred capacity through all deployment resolution paths:

- **Interactive path** (`PromptAiDeployment`): Sets `Options.Capacity` so the capacity prompt defaults to 50 instead of the SKU default.
- **Non-interactive path** (`ResolveModelDeployments`): Sets `Options.Capacity` so resolved deployments use 50.
- **No-prompt fallback** (`resolveNoPromptCapacity`): Uses 50 when the candidate has no capacity set, instead of `max(minCapacity, 1)`.

The preferred capacity still respects SKU constraints -- if the SKU's max capacity is below 50, or remaining quota is insufficient, the system will clamp or reject as before.

## Notes

- User-provided capacity values in `azure.yaml` are unaffected (they take precedence).
- Existing deployments with capacity already set are also unaffected.

Fixes: #8858