### PR TITLE
Fix agents init --image azure.yaml output

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -66,9 +66,10 @@ type initFlags struct {
 	// image specifies a pre-built container image URL (e.g., "myacr.azurecr.io/agent:v1").
 	// When set without --manifest, init synthesizes a minimal hosted container manifest and
 	// routes through the manifest flow, skipping template/language selection and code
-	// scaffolding (there is no source to scaffold). It also writes the image field to
-	// agent.yaml, skips Dockerfile generation, and skips ACR connection prompts. Requires
-	// --agent-name when no --manifest is given. Incompatible with --deploy-mode code.
+	// scaffolding (there is no source to scaffold). The image is written to the generated
+	// azure.yaml service's top-level image field, skips Dockerfile generation, and skips ACR
+	// connection prompts. Requires --agent-name when no --manifest is given. Incompatible
+	// with --deploy-mode code.
 	image string
 	// force, when true, lets headless callers (--no-prompt) pre-consent to
 	// overwrite prompts that would otherwise return a structured error. It
@@ -619,46 +620,30 @@ func updateAgentDefinition(
 	}
 }
 
-// setImageOnTemplate sets the Image field on a ContainerAgent template.
-// When --image is provided, this function updates the manifest so the image URL
-// is persisted in agent.yaml and used during deployment instead of building from Dockerfile.
-func setImageOnTemplate(agentManifest *agent_yaml.AgentManifest, image string) error {
-	if image == "" {
-		return nil
+// preBuiltImageForInit returns the pre-built image that should be written to the
+// azure.yaml service image field. The --image flag wins over any image carried by
+// a user-provided manifest because it is the explicit CLI override.
+func preBuiltImageForInit(agentManifest *agent_yaml.AgentManifest, flagImage string) string {
+	if image := strings.TrimSpace(flagImage); image != "" {
+		return image
 	}
 	if agentManifest == nil {
-		return fmt.Errorf("agent manifest is nil")
-	}
-
-	hostedAgent, ok := agentManifest.Template.(agent_yaml.ContainerAgent)
-	if !ok {
-		return fmt.Errorf("--image is only supported for hosted container agents, got %T", agentManifest.Template)
-	}
-
-	hostedAgent.Image = image
-	agentManifest.Template = hostedAgent
-	return nil
-}
-
-// agentUsesPreBuiltImage reports whether the manifest's template is a hosted
-// container agent that references a pre-built image. For such agents azd does
-// not build from source, so build-time concerns like the startup command and
-// ACR setup do not apply. Covers both the --image flag (synthesized manifest)
-// and a user-provided -m manifest that already specifies an image.
-func agentUsesPreBuiltImage(agentManifest *agent_yaml.AgentManifest) bool {
-	if agentManifest == nil {
-		return false
+		return ""
 	}
 	ca, ok := agentManifest.Template.(agent_yaml.ContainerAgent)
-	return ok && strings.TrimSpace(ca.Image) != ""
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(ca.Image)
 }
 
 // synthesizeImageManifestFile writes a minimal hosted container agent manifest to a
 // temporary file for the bring-your-own-image flow (--image without --manifest).
 // Routing through the manifest path lets init skip template/language selection and code
 // scaffolding, since a pre-built image needs none of those. The returned cleanup removes
-// the temp directory; callers should defer it. The image is also persisted by
-// setImageOnTemplate during Run, but is included here so the manifest is self-describing.
+// the temp directory; callers should defer it. The image is intentionally not embedded
+// in the temporary manifest; init writes --image to the generated azure.yaml service's
+// top-level image field.
 func synthesizeImageManifestFile(agentName, image string) (string, func(), error) {
 	noop := func() {}
 
@@ -674,7 +659,6 @@ func synthesizeImageManifestFile(agentName, image string) (string, func(), error
 			"kind":        string(agent_yaml.AgentKindHosted),
 			"name":        agentName,
 			"description": fmt.Sprintf("Hosted container agent using pre-built image %s", image),
-			"image":       image,
 			"protocols": []map[string]any{
 				{"protocol": "responses", "version": "1.0.0"},
 			},
@@ -1086,7 +1070,7 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 			// there is no source to scaffold and no template/language to choose.
 			// Synthesize a minimal hosted container manifest and route it through the
 			// manifest flow, which skips the init-mode / template / language prompts
-			// and code scaffolding. The image is wired into agent.yaml and ACR is
+			// and code scaffolding. The image is wired into azure.yaml and ACR is
 			// skipped by the existing --image handling in InitAction.Run.
 			if flags.image != "" && flags.manifestPointer == "" {
 				// Validate early so we fail before initializing a project/template.
@@ -1671,11 +1655,6 @@ func (a *InitAction) Run(ctx context.Context) error {
 			return err
 		}
 		if err := setAgentNameOnTemplate(agentManifest, agentName); err != nil {
-			return err
-		}
-
-		// Set pre-built image if --image was provided
-		if err := setImageOnTemplate(agentManifest, a.flags.image); err != nil {
 			return err
 		}
 
@@ -2933,10 +2912,12 @@ func (a *InitAction) addToProject(ctx context.Context, targetDir string, agentMa
 		}
 	}
 
+	preBuiltImage := preBuiltImageForInit(agentManifest, a.flags.image)
+
 	// Detect startup command. Skipped for code deploy (uses ZIP packaging) and
 	// when the agent uses a pre-built container image, since the image's own
 	// entrypoint runs and no startup command applies.
-	if !a.isCodeDeploy && !agentUsesPreBuiltImage(agentManifest) {
+	if !a.isCodeDeploy && preBuiltImage == "" {
 		startupCmd, err := resolveStartupCommandForInit(ctx, a.azdClient, a.projectConfig.Path, targetDir, a.flags.noPrompt)
 		if err != nil {
 			return err
@@ -2981,7 +2962,7 @@ func (a *InitAction) addToProject(ctx context.Context, targetDir string, agentMa
 		RelativePath:         targetDir,
 		Host:                 AiAgentHost,
 		Language:             "docker",
-		Image:                containerDef.Image,
+		Image:                preBuiltImage,
 		AdditionalProperties: agentProps,
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -216,58 +216,46 @@ func TestValidateImageFlag(t *testing.T) {
 	}
 }
 
-func TestSetImageOnTemplate(t *testing.T) {
+func TestPreBuiltImageForInit(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		manifest  *agent_yaml.AgentManifest
-		image     string
-		wantImage string
-		wantErr   bool
+		name     string
+		manifest *agent_yaml.AgentManifest
+		flag     string
+		want     string
 	}{
+		{name: "empty", manifest: &agent_yaml.AgentManifest{Template: agent_yaml.ContainerAgent{}}, want: ""},
+		{name: "nil manifest", manifest: nil, want: ""},
+		{name: "non-container agent", manifest: &agent_yaml.AgentManifest{Template: agent_yaml.Workflow{}}, want: ""},
 		{
-			name:      "empty image is noop",
-			manifest:  &agent_yaml.AgentManifest{Template: agent_yaml.ContainerAgent{}},
-			image:     "",
-			wantImage: "",
+			name:     "manifest image",
+			manifest: &agent_yaml.AgentManifest{Template: agent_yaml.ContainerAgent{Image: "myacr.azurecr.io/agent:v1"}},
+			want:     "myacr.azurecr.io/agent:v1",
 		},
 		{
-			name:      "sets image on container agent",
-			manifest:  &agent_yaml.AgentManifest{Template: agent_yaml.ContainerAgent{}},
-			image:     "myacr.azurecr.io/agent:v1",
-			wantImage: "myacr.azurecr.io/agent:v1",
+			name:     "flag image wins",
+			manifest: &agent_yaml.AgentManifest{Template: agent_yaml.ContainerAgent{Image: "myacr.azurecr.io/agent:v1"}},
+			flag:     "override.azurecr.io/agent:v2",
+			want:     "override.azurecr.io/agent:v2",
 		},
 		{
-			name:     "nil manifest returns error",
-			manifest: nil,
-			image:    "myacr.azurecr.io/agent:v1",
-			wantErr:  true,
+			name:     "trims flag image",
+			manifest: &agent_yaml.AgentManifest{Template: agent_yaml.ContainerAgent{}},
+			flag:     "  myacr.azurecr.io/agent:v1  ",
+			want:     "myacr.azurecr.io/agent:v1",
 		},
 		{
-			name:     "non-container agent returns error",
-			manifest: &agent_yaml.AgentManifest{Template: agent_yaml.Workflow{}},
-			image:    "myacr.azurecr.io/agent:v1",
-			wantErr:  true,
+			name:     "trims manifest image",
+			manifest: &agent_yaml.AgentManifest{Template: agent_yaml.ContainerAgent{Image: "  myacr.azurecr.io/agent:v1  "}},
+			want:     "myacr.azurecr.io/agent:v1",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			err := setImageOnTemplate(tt.manifest, tt.image)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-
-			if tt.image != "" {
-				hostedAgent, ok := tt.manifest.Template.(agent_yaml.ContainerAgent)
-				require.True(t, ok)
-				require.Equal(t, tt.wantImage, hostedAgent.Image)
-			}
+			require.Equal(t, tt.want, preBuiltImageForInit(tt.manifest, tt.flag))
 		})
 	}
 }
@@ -345,7 +333,7 @@ func TestSynthesizeImageManifestFile(t *testing.T) {
 	require.True(t, ok, "synthesized template should be a ContainerAgent, got %T", template)
 	require.Equal(t, agent_yaml.AgentKindHosted, containerAgent.Kind)
 	require.Equal(t, agentName, containerAgent.Name)
-	require.Equal(t, image, containerAgent.Image)
+	require.Empty(t, containerAgent.Image)
 	require.Len(t, containerAgent.Protocols, 1)
 	require.Equal(t, "responses", containerAgent.Protocols[0].Protocol)
 	require.Equal(t, "1.0.0", containerAgent.Protocols[0].Version)
@@ -355,43 +343,53 @@ func TestSynthesizeImageManifestFile(t *testing.T) {
 	require.NoFileExists(t, manifestPath)
 }
 
-func TestAgentUsesPreBuiltImage(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		manifest *agent_yaml.AgentManifest
-		want     bool
-	}{
-		{name: "nil manifest", manifest: nil, want: false},
-		{
-			name:     "container agent with image",
-			manifest: &agent_yaml.AgentManifest{Template: agent_yaml.ContainerAgent{Image: "myacr.azurecr.io/a:v1"}},
-			want:     true,
-		},
-		{
-			name:     "container agent without image",
-			manifest: &agent_yaml.AgentManifest{Template: agent_yaml.ContainerAgent{}},
-			want:     false,
-		},
-		{
-			name:     "container agent with whitespace-only image",
-			manifest: &agent_yaml.AgentManifest{Template: agent_yaml.ContainerAgent{Image: "   "}},
-			want:     false,
-		},
-		{
-			name:     "non-container agent",
-			manifest: &agent_yaml.AgentManifest{Template: agent_yaml.Workflow{}},
-			want:     false,
+func TestAddToProjectPreBuiltImageWritesServiceImage(t *testing.T) {
+	const image = "myacr.azurecr.io/agents/my-agent:v1"
+	server := &recordingProjectServer{}
+	client := newProjectRecorderClient(t, server)
+	action := &InitAction{
+		azdClient:           client,
+		environment:         &azdext.Environment{Name: "test-env"},
+		flags:               &initFlags{image: image, noPrompt: true},
+		serviceNameOverride: "my-agent",
+	}
+	description := "Hosted container agent using a pre-built image"
+	manifest := &agent_yaml.AgentManifest{
+		Template: agent_yaml.ContainerAgent{
+			AgentDefinition: agent_yaml.AgentDefinition{
+				Kind:        agent_yaml.AgentKindHosted,
+				Name:        "my-agent",
+				Description: &description,
+			},
+			Protocols: []agent_yaml.ProtocolVersionRecord{
+				{Protocol: "responses", Version: "1.0.0"},
+			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			require.Equal(t, tt.want, agentUsesPreBuiltImage(tt.manifest))
-		})
+	_, err := captureStdout(t, func() error {
+		return action.addToProject(t.Context(), "src/my-agent", manifest)
+	})
+	require.NoError(t, err)
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+
+	var agentService *azdext.ServiceConfig
+	for _, service := range server.added {
+		if service.GetName() == "my-agent" {
+			agentService = service
+			break
+		}
 	}
+	require.NotNil(t, agentService)
+	require.Equal(t, image, agentService.GetImage())
+	require.Equal(t, "docker", agentService.GetLanguage())
+	require.NotNil(t, agentService.GetDocker())
+	require.NotNil(t, agentService.GetAdditionalProperties())
+
+	_, hasInlineImage := agentService.GetAdditionalProperties().GetFields()["image"]
+	require.False(t, hasInlineImage, "pre-built image must ride on the top-level service image field")
 }
 
 func TestValidateInitAgentName(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1095,11 +1095,13 @@ func (p *AgentServiceTargetProvider) Deploy(
 // shouldUsePreBuiltImage determines whether to use a pre-built image.
 //
 // Behavior:
-//   - If no image is configured in agent.yaml, always build from Dockerfile.
+//   - If no image is configured in the loaded agent definition, always build from Dockerfile.
+//     The image usually comes from the azure.yaml service image field, but can come from
+//     a legacy agent.yaml fallback.
 //   - In non-interactive mode (--no-prompt), the prompt returns the default
 //     selection (index 0 = build from Dockerfile) automatically.
 //   - In interactive mode, prompt the user. The default is to build, so users
-//     who happen to have an image in agent.yaml are not silently switched onto
+//     who happen to have an image configured are not silently switched onto
 //     the pre-built path.
 func (p *AgentServiceTargetProvider) shouldUsePreBuiltImage(
 	ctx context.Context,
@@ -1111,7 +1113,7 @@ func (p *AgentServiceTargetProvider) shouldUsePreBuiltImage(
 	}
 
 	if p.shouldSkipACRForEnvironment(ctx) {
-		log.Printf("AZD_AGENT_SKIP_ACR=true: using pre-built image from agent.yaml")
+		log.Printf("AZD_AGENT_SKIP_ACR=true: using pre-built image from agent definition")
 		return true, nil
 	}
 
@@ -1414,7 +1416,7 @@ func (p *AgentServiceTargetProvider) deployHostedAgent(
 				exterrors.CodeMissingPublishedContainer,
 				"published container artifact not found: no remote container artifact was found in service "+
 					"publish artifacts and no pre-built image was specified",
-				"either set 'image' in agent.yaml, "+
+				"either set 'image' on the azure.yaml agent service, "+
 					"or run 'azd package' and 'azd publish' to build from a Dockerfile",
 			)
 		}

--- a/cli/azd/pkg/osutil/expandable_string.go
+++ b/cli/azd/pkg/osutil/expandable_string.go
@@ -25,6 +25,11 @@ func (e ExpandableString) Empty() bool {
 	return e.template == ""
 }
 
+// IsZero reports whether the template is empty for YAML omitempty handling.
+func (e ExpandableString) IsZero() bool {
+	return e.Empty()
+}
+
 // Envsubst evaluates the template, substituting values as [envsubst.Eval] would.
 func (e ExpandableString) Envsubst(mapping func(string) string) (string, error) {
 	return envsubst.Eval(e.template, mapping)

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -484,6 +484,39 @@ postbuild:
 	})
 }
 
+func TestServiceImageSavedToYaml(t *testing.T) {
+	t.Parallel()
+
+	projectConfig := &ProjectConfig{
+		Name: "test-project",
+		Services: map[string]*ServiceConfig{
+			"agent": {
+				RelativePath: "src/agent",
+				Host:         "azure.ai.agent",
+				Language:     "docker",
+				Image:        osutil.NewExpandableString("myacr.azurecr.io/agent:v1"),
+			},
+		},
+	}
+	projectFile := filepath.Join(t.TempDir(), "azure.yaml")
+
+	err := Save(t.Context(), projectConfig, projectFile)
+	require.NoError(t, err)
+
+	fileContent, err := os.ReadFile(projectFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(fileContent), "image: myacr.azurecr.io/agent:v1")
+
+	loadedProject, err := Load(t.Context(), projectFile)
+	require.NoError(t, err)
+	require.Contains(t, loadedProject.Services, "agent")
+	assert.Equal(
+		t,
+		"myacr.azurecr.io/agent:v1",
+		loadedProject.Services["agent"].Image.MustEnvsubst(func(string) string { return "" }),
+	)
+}
+
 func TestInfraDefaultsNotSavedToYaml(t *testing.T) {
 	t.Run("DefaultValuesNotWritten", func(t *testing.T) {
 		// Create a minimal project config with no infra settings


### PR DESCRIPTION
Fixes #8878

## Summary

- Keep `azd ai agent init --image` aligned with the unified `azure.yaml` shape by writing the pre-built image to the agent service's top-level `image:` field.
- Stop embedding the `--image` value into the synthesized temporary agent manifest / generated agent definition path.
- Fix YAML `omitempty` handling for `osutil.ExpandableString` so non-empty service fields such as `image:` survive `project.Save` / extension `AddService`.
- Add regression coverage that verifies the service image rides on `ServiceConfig.Image` and is not carried in inline agent properties.
- Update pre-built-image deploy guidance to refer to the `azure.yaml` agent service instead of `agent.yaml`.
