### PR TITLE
fix: warn when agent services share a Foundry agent name

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `azd provision` now connects to an existing Foundry project when the `azure.ai.project` service sets `endpoint:` (bring-your-own) instead of failing with a brownfield error, and `azd down` leaves a bring-your-own project in place because azd did not create it.
 - Add a `--call-id` flag to `azd ai agent invoke` that sends the `x-agent-foundry-call-id` header on `--local` invocations only. It is ignored for remote Foundry requests.
 - Replace the per-command Foundry isolation-key flags (`--user-isolation-key`, `--chat-isolation-key`, and the session-ownership `--isolation-key`) with a single `--user-identity` flag. The value is sent as the `x-agent-user-id` header for `--local` invocations and as `x-ms-user-identity` for all remote Foundry requests. This is a breaking change with no backward-compatible flag retention.
+- `azd deploy`/`azd up` now warn when two or more `azure.ai.agent` services resolve to the same Foundry agent `name`. Foundry identifies an agent by its name, so such services deploy to the same agent and overwrite each other; the warning names the colliding services so each can be given a unique name in `azure.yaml`. Deploy still proceeds.
 
 ## 0.1.41-preview (2026-06-19)
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 
@@ -20,6 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
 // configureExtensionHost wires the service target and event handlers on the
@@ -164,8 +166,22 @@ var (
 	developerRBACErr  error
 )
 
+// duplicateAgentNameWarnOnce ensures the duplicate agent-name warning is emitted
+// at most once per extension process lifetime. Service-level predeploy handlers
+// fire per-service, but the check is project-scoped — a single pass over every
+// azure.ai.agent service surfaces all collisions without repeating the warning
+// for each colliding service.
+var duplicateAgentNameWarnOnce sync.Once
+
 func predeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *azdext.ServiceEventArgs) error {
 	svc := args.Service
+
+	// Warn (once) when multiple agent services resolve to the same Foundry agent
+	// name. Foundry identifies an agent by its name, so such services overwrite
+	// each other on deploy. Advisory only — deploy continues.
+	duplicateAgentNameWarnOnce.Do(func() {
+		warnDuplicateAgentNames(args.Project)
+	})
 
 	deployments, err := collectProjectDeployments(args.Project.Services)
 	if err != nil {
@@ -204,6 +220,71 @@ func predeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *az
 func isHostedAgentService(svc *azdext.ServiceConfig, proj *azdext.ProjectConfig) bool {
 	_, isHosted, _, err := project.LoadAgentDefinition(svc, proj.Path)
 	return err == nil && isHosted
+}
+
+// duplicateAgentNameGroup is a Foundry agent name referenced by more than one
+// azure.ai.agent service, with the colliding azure.yaml service keys sorted for
+// stable output.
+type duplicateAgentNameGroup struct {
+	agentName    string
+	serviceNames []string
+}
+
+// findDuplicateAgentNames groups hosted azure.ai.agent services by their resolved
+// Foundry agent name and returns the groups referenced by two or more services.
+// Foundry uses the agent name as an agent's unique identifier, so services that
+// share a name deploy to the same agent and overwrite each other.
+//
+// Services whose definition can't be resolved, that aren't hosted agents, or that
+// carry an empty name are skipped — their own deploy surfaces any real error. The
+// returned groups (and the service keys within each) are sorted for deterministic
+// output.
+func findDuplicateAgentNames(proj *azdext.ProjectConfig) []duplicateAgentNameGroup {
+	if proj == nil {
+		return nil
+	}
+
+	servicesByAgentName := map[string][]string{}
+	for serviceName, svc := range proj.Services {
+		if svc.GetHost() != AiAgentHost {
+			continue
+		}
+		ca, isHosted, _, err := project.LoadAgentDefinition(svc, proj.Path)
+		if err != nil || !isHosted {
+			continue
+		}
+		agentName := strings.TrimSpace(ca.Name)
+		if agentName == "" {
+			continue
+		}
+		servicesByAgentName[agentName] = append(servicesByAgentName[agentName], serviceName)
+	}
+
+	var groups []duplicateAgentNameGroup
+	for agentName, serviceNames := range servicesByAgentName {
+		if len(serviceNames) < 2 {
+			continue
+		}
+		sort.Strings(serviceNames)
+		groups = append(groups, duplicateAgentNameGroup{agentName: agentName, serviceNames: serviceNames})
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].agentName < groups[j].agentName })
+	return groups
+}
+
+// warnDuplicateAgentNames prints one warning per agent name shared by multiple
+// azure.ai.agent services. The warning names the colliding service keys and the
+// shared agent name so the user can give each agent a unique name in azure.yaml.
+// It is advisory: deploy continues.
+func warnDuplicateAgentNames(proj *azdext.ProjectConfig) {
+	for _, group := range findDuplicateAgentNames(proj) {
+		fmt.Fprintf(os.Stderr, "%s", output.WithWarningFormat(
+			"WARNING: agent name %q is used by multiple services (%s). Foundry identifies an agent "+
+				"by its name, so these services deploy to the same agent and overwrite each other. "+
+				"Give each agent a unique name in azure.yaml.\n",
+			group.agentName, strings.Join(group.serviceNames, ", "),
+		))
+	}
 }
 
 func postdeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *azdext.ServiceEventArgs) error {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_test.go
@@ -4,9 +4,11 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"azureaiagent/internal/pkg/agents/agent_yaml"
@@ -767,4 +769,44 @@ func TestFindDuplicateAgentNames(t *testing.T) {
 func TestFindDuplicateAgentNames_NilProject(t *testing.T) {
 	t.Parallel()
 	require.Nil(t, findDuplicateAgentNames(nil))
+}
+
+func TestWarnDuplicateAgentNames_WritesWarningOnce(t *testing.T) {
+	// Do not run in parallel: this test temporarily redirects process stderr.
+	proj := &azdext.ProjectConfig{
+		Path: t.TempDir(),
+		Services: map[string]*azdext.ServiceConfig{
+			"toolbox-agent-4": inlineAgentService(t, "toolbox-agent-4", "toolbox-agent-2"),
+			"toolbox-agent-2": inlineAgentService(t, "toolbox-agent-2", "toolbox-agent-2"),
+			"other":           inlineAgentService(t, "other", "other-agent"),
+		},
+	}
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	var once sync.Once
+	once.Do(func() { warnDuplicateAgentNames(proj) })
+	once.Do(func() { warnDuplicateAgentNames(proj) })
+
+	require.NoError(t, w.Close())
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+
+	warning := buf.String()
+	assert.Equal(t, 1, strings.Count(warning, "WARNING: agent name"))
+	assert.Contains(t, warning, `agent name "toolbox-agent-2"`)
+	assert.Contains(t, warning, "toolbox-agent-2, toolbox-agent-4")
+	assert.Contains(t, warning, "azure.yaml")
+	assert.NotContains(t, warning, "other-agent")
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"azureaiagent/internal/pkg/agents/agent_yaml"
 	"azureaiagent/internal/project"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -658,4 +659,112 @@ func TestEnrichToolboxFromConnections_EmptyTarget(t *testing.T) {
 	assert.False(t, hasURL)
 	// server_label should still be set.
 	assert.Equal(t, "no-target", tb.Tools[0]["server_label"])
+}
+
+// ---------------------------------------------------------------------------
+// findDuplicateAgentNames
+// ---------------------------------------------------------------------------
+
+// inlineAgentService builds an azure.ai.agent service whose inline definition
+// resolves to a hosted agent with the given Foundry agent name. serviceName is
+// the azure.yaml service key; agentName is the unique Foundry identifier.
+func inlineAgentService(t *testing.T, serviceName, agentName string) *azdext.ServiceConfig {
+	t.Helper()
+	ca := agent_yaml.ContainerAgent{
+		AgentDefinition: agent_yaml.AgentDefinition{
+			Kind:        agent_yaml.AgentKindHosted,
+			Name:        agentName,
+			Description: new("test agent"),
+		},
+		Protocols: []agent_yaml.ProtocolVersionRecord{
+			{Protocol: "responses", Version: "1.0.0"},
+		},
+	}
+	props, err := project.AgentDefinitionToServiceProperties(ca, nil)
+	require.NoError(t, err)
+	return &azdext.ServiceConfig{Name: serviceName, Host: AiAgentHost, AdditionalProperties: props}
+}
+
+func TestFindDuplicateAgentNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		services map[string]*azdext.ServiceConfig
+		want     []duplicateAgentNameGroup
+	}{
+		{
+			name:     "no services",
+			services: nil,
+			want:     nil,
+		},
+		{
+			name: "unique agent names",
+			services: map[string]*azdext.ServiceConfig{
+				"svc-a": inlineAgentService(t, "svc-a", "agent-a"),
+				"svc-b": inlineAgentService(t, "svc-b", "agent-b"),
+			},
+			want: nil,
+		},
+		{
+			name: "two services share one name",
+			services: map[string]*azdext.ServiceConfig{
+				// Mirrors the issue: two service keys, same agent name.
+				"toolbox-agent-4": inlineAgentService(t, "toolbox-agent-4", "toolbox-agent-2"),
+				"toolbox-agent-2": inlineAgentService(t, "toolbox-agent-2", "toolbox-agent-2"),
+				"other":           inlineAgentService(t, "other", "other-agent"),
+			},
+			want: []duplicateAgentNameGroup{
+				{agentName: "toolbox-agent-2", serviceNames: []string{"toolbox-agent-2", "toolbox-agent-4"}},
+			},
+		},
+		{
+			name: "three services share one name",
+			services: map[string]*azdext.ServiceConfig{
+				"svc-c": inlineAgentService(t, "svc-c", "shared"),
+				"svc-a": inlineAgentService(t, "svc-a", "shared"),
+				"svc-b": inlineAgentService(t, "svc-b", "shared"),
+			},
+			want: []duplicateAgentNameGroup{
+				{agentName: "shared", serviceNames: []string{"svc-a", "svc-b", "svc-c"}},
+			},
+		},
+		{
+			name: "multiple duplicate groups sorted by agent name",
+			services: map[string]*azdext.ServiceConfig{
+				"z1": inlineAgentService(t, "z1", "zebra"),
+				"z2": inlineAgentService(t, "z2", "zebra"),
+				"a1": inlineAgentService(t, "a1", "alpha"),
+				"a2": inlineAgentService(t, "a2", "alpha"),
+			},
+			want: []duplicateAgentNameGroup{
+				{agentName: "alpha", serviceNames: []string{"a1", "a2"}},
+				{agentName: "zebra", serviceNames: []string{"z1", "z2"}},
+			},
+		},
+		{
+			name: "non-agent host and unresolvable services are skipped",
+			services: map[string]*azdext.ServiceConfig{
+				// Same name as the agent but a different host — not a collision.
+				"web":   {Name: "web", Host: "containerapp", RelativePath: "."},
+				"agent": inlineAgentService(t, "agent", "shared-name"),
+				// azure.ai.agent host but no resolvable definition — skipped.
+				"empty": {Name: "empty", Host: AiAgentHost, RelativePath: "."},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			proj := &azdext.ProjectConfig{Path: t.TempDir(), Services: tt.services}
+			require.Equal(t, tt.want, findDuplicateAgentNames(proj))
+		})
+	}
+}
+
+func TestFindDuplicateAgentNames_NilProject(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, findDuplicateAgentNames(nil))
 }


### PR DESCRIPTION
Fixes #8872

## Problem

In an `azure.yaml` with multiple `host: azure.ai.agent` services, two or more services can carry the same agent `name`. Foundry uses the agent `name` as an agent's unique identifier, so deploying both services creates/updates the **same** Foundry agent — they silently overwrite each other, and azd gives no signal.

Example from the issue: services `toolbox-agent-2` and `toolbox-agent-4` both set `name: toolbox-agent-2`.

## Change

`azd deploy`/`azd up` now emits a non-blocking warning when two or more `azure.ai.agent` services resolve to the same Foundry agent `name`, naming the colliding services so the user can give each a unique name. Deploy still proceeds.

- `findDuplicateAgentNames` scans the `azure.ai.agent` services, resolves each via `project.LoadAgentDefinition` (covers the unified inline shape, the legacy config shape, and a legacy on-disk `agent.yaml`), groups the azure.yaml service keys by resolved agent name, and returns groups shared by ≥2 services (deterministically sorted). Services that aren't hosted agents, can't be resolved, or have an empty name are skipped.
- `warnDuplicateAgentNames` prints one yellow warning per group to stderr via `output.WithWarningFormat`, matching the existing init / legacy-shape warning style.
- Wired into `predeployHandler` behind a new `duplicateAgentNameWarnOnce sync.Once`, so the project-wide scan warns at most once per process even though the handler fires per agent service — mirroring the existing `developerRBACOnce` pattern.

## Tests

`TestFindDuplicateAgentNames` covers: no services, unique names, the issue's two-service collision, a three-way collision, multiple groups sorted by agent name, and non-agent-host / unresolvable services being skipped, plus a nil-project case.

## Validation

From `cli/azd/extensions/azure.ai.agents`: `gofmt` clean, `go build ./...`, `go vet ./internal/cmd/`, and the full `internal/cmd` test suite all pass.