### PR TITLE
fix: prompt for subscription and location on foundry azd up

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Add a `--call-id` flag to `azd ai agent invoke` that sends the `x-agent-foundry-call-id` header on `--local` invocations only. It is ignored for remote Foundry requests.
 - Replace the per-command Foundry isolation-key flags (`--user-isolation-key`, `--chat-isolation-key`, and the session-ownership `--isolation-key`) with a single `--user-identity` flag. The value is sent as the `x-agent-user-id` header for `--local` invocations and as `x-ms-user-identity` for all remote Foundry requests. This is a breaking change with no backward-compatible flag retention.
 
+### Bugs Fixed
+
+- [[#8859]](https://github.com/Azure/azure-dev/issues/8859) `azd up` now prompts for an Azure subscription and location when `AZURE_SUBSCRIPTION_ID` or `AZURE_LOCATION` is not set, matching core `azd up`, instead of failing. Under `--no-prompt` it still returns an actionable `azd env set ...` error.
+
 ## 0.1.41-preview (2026-06-19)
 
 - [[#8731]](https://github.com/Azure/azure-dev/pull/8731) Improve the post-deploy `Next:` guidance with a stacked layout that puts each command on its own line above its description, adds a blank line between suggestions, and highlights `azd` commands. The new layout applies across deploy, `azd ai agent show`, `init`, and `doctor`. Thanks @therealjohn for the contribution!

--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider.go
@@ -386,7 +386,17 @@ func (p *FoundryProvisioningProvider) resolveEnv(ctx context.Context) error {
 		return strings.TrimSpace(resp.Value), nil
 	}
 
-	if p.subID, err = get(envKeySubscriptionID); err != nil || p.subID == "" {
+	// A read error (env not found / corrupted / transport) is distinct from a
+	// key that is simply unset: GetValue returns ("", nil) for an absent key.
+	// Surface read failures; only prompt when the value is present-but-empty.
+	if p.subID, err = get(envKeySubscriptionID); err != nil {
+		return exterrors.Dependency(
+			exterrors.CodeEnvironmentValuesFailed,
+			fmt.Sprintf("read %s from azd environment %q: %s", envKeySubscriptionID, p.envName, err),
+			"verify the azd environment is accessible, then retry",
+		)
+	}
+	if p.subID == "" {
 		// Not set yet: prompt for a subscription (matching core `azd up`) and
 		// persist it, instead of failing. Under `--no-prompt` this surfaces an
 		// actionable "run `azd env set ...`" error so CI/scripts stay deterministic.
@@ -395,7 +405,14 @@ func (p *FoundryProvisioningProvider) resolveEnv(ctx context.Context) error {
 		}
 	}
 
-	if p.location, err = get(envKeyLocation); err != nil || p.location == "" {
+	if p.location, err = get(envKeyLocation); err != nil {
+		return exterrors.Dependency(
+			exterrors.CodeEnvironmentValuesFailed,
+			fmt.Sprintf("read %s from azd environment %q: %s", envKeyLocation, p.envName, err),
+			"verify the azd environment is accessible, then retry",
+		)
+	}
+	if p.location == "" {
 		// Not set yet: prompt for a location and persist it, instead of failing.
 		if err := p.promptLocation(ctx); err != nil {
 			return err
@@ -457,7 +474,15 @@ func (p *FoundryProvisioningProvider) promptSubscription(ctx context.Context) er
 		)
 	}
 
-	p.subID = resp.GetSubscription().GetId()
+	subID := strings.TrimSpace(resp.GetSubscription().GetId())
+	if subID == "" {
+		return exterrors.Dependency(
+			exterrors.CodeMissingAzureSubscription,
+			"subscription selection returned an empty subscription id",
+			fmt.Sprintf("retry, or run `azd env set %s <subscription-id>`", envKeySubscriptionID),
+		)
+	}
+	p.subID = subID
 	return p.setEnv(ctx, envKeySubscriptionID, p.subID)
 }
 
@@ -490,7 +515,15 @@ func (p *FoundryProvisioningProvider) promptLocation(ctx context.Context) error 
 		)
 	}
 
-	p.location = resp.GetLocation().GetName()
+	location := strings.TrimSpace(resp.GetLocation().GetName())
+	if location == "" {
+		return exterrors.Dependency(
+			exterrors.CodeMissingAzureLocation,
+			"location selection returned an empty location name",
+			fmt.Sprintf("retry, or run `azd env set %s <region>`", envKeyLocation),
+		)
+	}
+	p.location = location
 	return p.setEnv(ctx, envKeyLocation, p.location)
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider.go
@@ -387,19 +387,19 @@ func (p *FoundryProvisioningProvider) resolveEnv(ctx context.Context) error {
 	}
 
 	if p.subID, err = get(envKeySubscriptionID); err != nil || p.subID == "" {
-		return exterrors.Dependency(
-			exterrors.CodeMissingAzureSubscription,
-			fmt.Sprintf("%s is required but not set in azd environment %q", envKeySubscriptionID, p.envName),
-			fmt.Sprintf("run `azd env set %s <subscription-id>`", envKeySubscriptionID),
-		)
+		// Not set yet: prompt for a subscription (matching core `azd up`) and
+		// persist it, instead of failing. Under `--no-prompt` this surfaces an
+		// actionable "run `azd env set ...`" error so CI/scripts stay deterministic.
+		if err := p.promptSubscription(ctx); err != nil {
+			return err
+		}
 	}
 
 	if p.location, err = get(envKeyLocation); err != nil || p.location == "" {
-		return exterrors.Dependency(
-			exterrors.CodeMissingAzureLocation,
-			fmt.Sprintf("%s is required but not set in azd environment %q", envKeyLocation, p.envName),
-			fmt.Sprintf("run `azd env set %s <region>`", envKeyLocation),
-		)
+		// Not set yet: prompt for a location and persist it, instead of failing.
+		if err := p.promptLocation(ctx); err != nil {
+			return err
+		}
 	}
 
 	if p.rgName, err = get(envKeyResourceGroup); err != nil || p.rgName == "" {
@@ -424,6 +424,85 @@ func (p *FoundryProvisioningProvider) resolveEnv(ctx context.Context) error {
 		log.Printf("[debug] %s not set; skipping developer role assignment", envKeyPrincipalID)
 	}
 
+	return nil
+}
+
+// promptSubscription asks the user to select an Azure subscription when
+// AZURE_SUBSCRIPTION_ID is not set, then persists the choice to the azd
+// environment and updates p.subID. This mirrors core `azd up`, which prompts
+// for a subscription instead of failing.
+//
+// Under `--no-prompt` the azd host returns a "prompt required" error; that case
+// is surfaced as an actionable Dependency error naming the env var to set so
+// headless callers stay deterministic. Tenant resolution is left to
+// ensureCredential, which looks up the user access tenant from the subscription.
+func (p *FoundryProvisioningProvider) promptSubscription(ctx context.Context) error {
+	resp, err := p.azdClient.Prompt().PromptSubscription(ctx, &azdext.PromptSubscriptionRequest{})
+	if err != nil {
+		if exterrors.IsCancellation(err) {
+			return exterrors.Cancelled("subscription selection was cancelled")
+		}
+		if exterrors.IsPromptRequired(err) {
+			return exterrors.Dependency(
+				exterrors.CodeMissingAzureSubscription,
+				fmt.Sprintf("%s is required but not set in azd environment %q", envKeySubscriptionID, p.envName),
+				fmt.Sprintf("run `azd env set %s <subscription-id>`, or run interactively to pick one",
+					envKeySubscriptionID),
+			)
+		}
+		return exterrors.Dependency(
+			exterrors.CodeMissingAzureSubscription,
+			fmt.Sprintf("failed to select an Azure subscription: %s", err),
+			"retry, or run interactively to pick one",
+		)
+	}
+
+	p.subID = resp.GetSubscription().GetId()
+	return p.setEnv(ctx, envKeySubscriptionID, p.subID)
+}
+
+// promptLocation asks the user to select an Azure location when AZURE_LOCATION
+// is not set, then persists the choice and updates p.location. It mirrors
+// promptSubscription's cancellation and `--no-prompt` handling. The prompt is
+// scoped to the resolved subscription; no region allow-list is applied, matching
+// core `azd up`.
+func (p *FoundryProvisioningProvider) promptLocation(ctx context.Context) error {
+	resp, err := p.azdClient.Prompt().PromptLocation(ctx, &azdext.PromptLocationRequest{
+		AzureContext: &azdext.AzureContext{
+			Scope: &azdext.AzureScope{SubscriptionId: p.subID, TenantId: p.tenantID},
+		},
+	})
+	if err != nil {
+		if exterrors.IsCancellation(err) {
+			return exterrors.Cancelled("location selection was cancelled")
+		}
+		if exterrors.IsPromptRequired(err) {
+			return exterrors.Dependency(
+				exterrors.CodeMissingAzureLocation,
+				fmt.Sprintf("%s is required but not set in azd environment %q", envKeyLocation, p.envName),
+				fmt.Sprintf("run `azd env set %s <region>`, or run interactively to pick one", envKeyLocation),
+			)
+		}
+		return exterrors.Dependency(
+			exterrors.CodeMissingAzureLocation,
+			fmt.Sprintf("failed to select an Azure location: %s", err),
+			"retry, or run interactively to pick one",
+		)
+	}
+
+	p.location = resp.GetLocation().GetName()
+	return p.setEnv(ctx, envKeyLocation, p.location)
+}
+
+// setEnv persists a single key/value to the active azd environment.
+func (p *FoundryProvisioningProvider) setEnv(ctx context.Context, key, value string) error {
+	if _, err := p.azdClient.Environment().SetValue(ctx, &azdext.SetEnvRequest{
+		EnvName: p.envName,
+		Key:     key,
+		Value:   value,
+	}); err != nil {
+		return fmt.Errorf("persist %s to azd environment %q: %w", key, p.envName, err)
+	}
 	return nil
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_resolveenv_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_resolveenv_test.go
@@ -25,6 +25,7 @@ type resolveEnvStubEnvServer struct {
 	azdext.UnimplementedEnvironmentServiceServer
 	envName string
 	get     map[string]string
+	getErr  map[string]error
 	set     map[string]string
 }
 
@@ -37,6 +38,9 @@ func (s *resolveEnvStubEnvServer) GetCurrent(
 func (s *resolveEnvStubEnvServer) GetValue(
 	_ context.Context, req *azdext.GetEnvRequest,
 ) (*azdext.KeyValueResponse, error) {
+	if err := s.getErr[req.Key]; err != nil {
+		return nil, err
+	}
 	return &azdext.KeyValueResponse{Value: s.get[req.Key]}, nil
 }
 
@@ -199,4 +203,64 @@ func TestResolveEnv_CancelledSubscriptionPromptReturnsCancelled(t *testing.T) {
 	var local *azdext.LocalError
 	require.ErrorAs(t, err, &local)
 	assert.Equal(t, exterrors.CodeCancelled, local.Code)
+}
+
+func TestResolveEnv_CancelledLocationPromptReturnsCancelled(t *testing.T) {
+	// Subscription resolves, but the user cancels the location prompt. resolveEnv
+	// must return a cancellation error and not persist partial state.
+	env := &resolveEnvStubEnvServer{
+		envName: "foundry-bugbash",
+		get:     map[string]string{envKeySubscriptionID: "00000000-0000-0000-0000-000000000001"},
+	}
+	prompt := &resolveEnvStubPromptServer{
+		locationErr: status.Error(codes.Canceled, "user cancelled"),
+	}
+	client := newResolveEnvTestClient(t, env, prompt)
+
+	p := &FoundryProvisioningProvider{azdClient: client}
+	err := p.resolveEnv(t.Context())
+	require.Error(t, err)
+
+	var local *azdext.LocalError
+	require.ErrorAs(t, err, &local)
+	assert.Equal(t, exterrors.CodeCancelled, local.Code)
+}
+
+func TestResolveEnv_SubscriptionReadErrorSurfaces(t *testing.T) {
+	// A genuine environment read failure must be surfaced, not masked by a
+	// prompt: GetValue returns ("", nil) for an unset key, so an error here
+	// means the environment itself could not be read.
+	env := &resolveEnvStubEnvServer{
+		envName: "foundry-bugbash",
+		get:     map[string]string{},
+		getErr:  map[string]error{envKeySubscriptionID: status.Error(codes.Internal, "env read failed")},
+	}
+	prompt := &resolveEnvStubPromptServer{}
+	client := newResolveEnvTestClient(t, env, prompt)
+
+	p := &FoundryProvisioningProvider{azdClient: client}
+	err := p.resolveEnv(t.Context())
+	require.Error(t, err)
+
+	assert.Equal(t, 0, prompt.subscriptionN, "a read failure must not trigger a prompt")
+	var local *azdext.LocalError
+	require.ErrorAs(t, err, &local)
+	assert.Equal(t, exterrors.CodeEnvironmentValuesFailed, local.Code)
+}
+
+func TestResolveEnv_EmptySubscriptionResponseReturnsError(t *testing.T) {
+	// Defensive: a subscription response with a blank id must not be persisted;
+	// fail with an actionable error instead of writing an empty value.
+	env := &resolveEnvStubEnvServer{envName: "foundry-bugbash", get: map[string]string{}}
+	prompt := &resolveEnvStubPromptServer{subscriptionID: "   "}
+	client := newResolveEnvTestClient(t, env, prompt)
+
+	p := &FoundryProvisioningProvider{azdClient: client}
+	err := p.resolveEnv(t.Context())
+	require.Error(t, err)
+
+	var local *azdext.LocalError
+	require.ErrorAs(t, err, &local)
+	assert.Equal(t, exterrors.CodeMissingAzureSubscription, local.Code)
+	assert.Empty(t, env.set, "an empty subscription id must not be persisted")
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_resolveenv_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_resolveenv_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"azureaiagent/internal/exterrors"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// resolveEnvStubEnvServer is an EnvironmentService stub for resolveEnv tests. It
+// serves a fixed env name, returns values from a keyed map (absent keys read as
+// empty, which is what triggers the prompt path), and records SetValue writes.
+type resolveEnvStubEnvServer struct {
+	azdext.UnimplementedEnvironmentServiceServer
+	envName string
+	get     map[string]string
+	set     map[string]string
+}
+
+func (s *resolveEnvStubEnvServer) GetCurrent(
+	context.Context, *azdext.EmptyRequest,
+) (*azdext.EnvironmentResponse, error) {
+	return &azdext.EnvironmentResponse{Environment: &azdext.Environment{Name: s.envName}}, nil
+}
+
+func (s *resolveEnvStubEnvServer) GetValue(
+	_ context.Context, req *azdext.GetEnvRequest,
+) (*azdext.KeyValueResponse, error) {
+	return &azdext.KeyValueResponse{Value: s.get[req.Key]}, nil
+}
+
+func (s *resolveEnvStubEnvServer) SetValue(
+	_ context.Context, req *azdext.SetEnvRequest,
+) (*azdext.EmptyResponse, error) {
+	if s.set == nil {
+		s.set = map[string]string{}
+	}
+	s.set[req.Key] = req.Value
+	return &azdext.EmptyResponse{}, nil
+}
+
+// resolveEnvStubPromptServer is a PromptService stub for resolveEnv tests. Each
+// prompt returns its configured value, or its configured error when set.
+type resolveEnvStubPromptServer struct {
+	azdext.UnimplementedPromptServiceServer
+	subscriptionID  string
+	subscriptionErr error
+	subscriptionN   int
+	location        string
+	locationErr     error
+	locationN       int
+}
+
+func (s *resolveEnvStubPromptServer) PromptSubscription(
+	context.Context, *azdext.PromptSubscriptionRequest,
+) (*azdext.PromptSubscriptionResponse, error) {
+	s.subscriptionN++
+	if s.subscriptionErr != nil {
+		return nil, s.subscriptionErr
+	}
+	return &azdext.PromptSubscriptionResponse{
+		Subscription: &azdext.Subscription{Id: s.subscriptionID},
+	}, nil
+}
+
+func (s *resolveEnvStubPromptServer) PromptLocation(
+	context.Context, *azdext.PromptLocationRequest,
+) (*azdext.PromptLocationResponse, error) {
+	s.locationN++
+	if s.locationErr != nil {
+		return nil, s.locationErr
+	}
+	return &azdext.PromptLocationResponse{Location: &azdext.Location{Name: s.location}}, nil
+}
+
+// newResolveEnvTestClient spins up a gRPC server exposing the given environment
+// and prompt stubs and returns an AzdClient connected to it.
+func newResolveEnvTestClient(
+	t *testing.T,
+	envSrv azdext.EnvironmentServiceServer,
+	promptSrv azdext.PromptServiceServer,
+) *azdext.AzdClient {
+	t.Helper()
+
+	srv := grpc.NewServer()
+	azdext.RegisterEnvironmentServiceServer(srv, envSrv)
+	azdext.RegisterPromptServiceServer(srv, promptSrv)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+	})
+
+	client, err := azdext.NewAzdClient(azdext.WithAddress(lis.Addr().String()))
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	return client
+}
+
+func TestResolveEnv_PromptsAndPersistsSubscriptionAndLocation(t *testing.T) {
+	// Neither AZURE_SUBSCRIPTION_ID nor AZURE_LOCATION is set: resolveEnv must
+	// prompt for both (matching core `azd up`) and persist the choices, instead
+	// of failing the way it used to (#8859).
+	env := &resolveEnvStubEnvServer{envName: "foundry-bugbash", get: map[string]string{}}
+	prompt := &resolveEnvStubPromptServer{
+		subscriptionID: "00000000-0000-0000-0000-000000000001",
+		location:       "westus2",
+	}
+	client := newResolveEnvTestClient(t, env, prompt)
+
+	p := &FoundryProvisioningProvider{azdClient: client}
+	require.NoError(t, p.resolveEnv(t.Context()))
+
+	assert.Equal(t, 1, prompt.subscriptionN, "expected a subscription prompt")
+	assert.Equal(t, 1, prompt.locationN, "expected a location prompt")
+	assert.Equal(t, "00000000-0000-0000-0000-000000000001", p.subID)
+	assert.Equal(t, "westus2", p.location)
+	assert.Equal(t, "00000000-0000-0000-0000-000000000001", env.set[envKeySubscriptionID],
+		"subscription should be persisted to the azd environment")
+	assert.Equal(t, "westus2", env.set[envKeyLocation],
+		"location should be persisted to the azd environment")
+}
+
+func TestResolveEnv_NoPromptSubscriptionReturnsActionableError(t *testing.T) {
+	// Under `--no-prompt` the azd host returns a "prompt required" error. The
+	// provider must surface an actionable suggestion naming the env var so CI
+	// and scripts stay deterministic.
+	env := &resolveEnvStubEnvServer{envName: "foundry-bugbash", get: map[string]string{}}
+	prompt := &resolveEnvStubPromptServer{
+		subscriptionErr: status.Error(codes.FailedPrecondition, "prompt required: no terminal"),
+	}
+	client := newResolveEnvTestClient(t, env, prompt)
+
+	p := &FoundryProvisioningProvider{azdClient: client}
+	err := p.resolveEnv(t.Context())
+	require.Error(t, err)
+
+	var local *azdext.LocalError
+	require.ErrorAs(t, err, &local)
+	assert.Equal(t, exterrors.CodeMissingAzureSubscription, local.Code)
+	assert.Equal(t, azdext.LocalErrorCategoryDependency, local.Category)
+	assert.Contains(t, local.Suggestion, envKeySubscriptionID)
+	assert.Empty(t, env.set, "nothing should be persisted when the prompt fails")
+}
+
+func TestResolveEnv_NoPromptLocationReturnsActionableError(t *testing.T) {
+	// Subscription is already set, but AZURE_LOCATION is not. Under `--no-prompt`
+	// the location prompt fails and must yield an actionable AZURE_LOCATION error.
+	env := &resolveEnvStubEnvServer{
+		envName: "foundry-bugbash",
+		get:     map[string]string{envKeySubscriptionID: "00000000-0000-0000-0000-000000000001"},
+	}
+	prompt := &resolveEnvStubPromptServer{
+		locationErr: status.Error(codes.FailedPrecondition, "prompt required: no terminal"),
+	}
+	client := newResolveEnvTestClient(t, env, prompt)
+
+	p := &FoundryProvisioningProvider{azdClient: client}
+	err := p.resolveEnv(t.Context())
+	require.Error(t, err)
+
+	assert.Equal(t, 0, prompt.subscriptionN, "subscription was already set; no prompt expected")
+	var local *azdext.LocalError
+	require.ErrorAs(t, err, &local)
+	assert.Equal(t, exterrors.CodeMissingAzureLocation, local.Code)
+	assert.Equal(t, azdext.LocalErrorCategoryDependency, local.Category)
+	assert.Contains(t, local.Suggestion, envKeyLocation)
+}
+
+func TestResolveEnv_CancelledSubscriptionPromptReturnsCancelled(t *testing.T) {
+	// A user-cancelled subscription prompt must map to the cancellation category,
+	// not a missing-dependency error.
+	env := &resolveEnvStubEnvServer{envName: "foundry-bugbash", get: map[string]string{}}
+	prompt := &resolveEnvStubPromptServer{
+		subscriptionErr: status.Error(codes.Canceled, "user cancelled"),
+	}
+	client := newResolveEnvTestClient(t, env, prompt)
+
+	p := &FoundryProvisioningProvider{azdClient: client}
+	err := p.resolveEnv(t.Context())
+	require.Error(t, err)
+
+	var local *azdext.LocalError
+	require.ErrorAs(t, err, &local)
+	assert.Equal(t, exterrors.CodeCancelled, local.Code)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_resolveenv_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_resolveenv_test.go
@@ -264,3 +264,45 @@ func TestResolveEnv_EmptySubscriptionResponseReturnsError(t *testing.T) {
 	assert.Equal(t, exterrors.CodeMissingAzureSubscription, local.Code)
 	assert.Empty(t, env.set, "an empty subscription id must not be persisted")
 }
+
+func TestResolveEnv_LocationReadErrorSurfaces(t *testing.T) {
+	// A location read failure is distinct from an unset AZURE_LOCATION value and
+	// must be surfaced instead of falling through to the location prompt.
+	env := &resolveEnvStubEnvServer{
+		envName: "foundry-bugbash",
+		get:     map[string]string{envKeySubscriptionID: "00000000-0000-0000-0000-000000000001"},
+		getErr:  map[string]error{envKeyLocation: status.Error(codes.Internal, "env read failed")},
+	}
+	prompt := &resolveEnvStubPromptServer{}
+	client := newResolveEnvTestClient(t, env, prompt)
+
+	p := &FoundryProvisioningProvider{azdClient: client}
+	err := p.resolveEnv(t.Context())
+	require.Error(t, err)
+
+	assert.Equal(t, 0, prompt.subscriptionN, "subscription was already set; no prompt expected")
+	assert.Equal(t, 0, prompt.locationN, "a read failure must not trigger a prompt")
+	var local *azdext.LocalError
+	require.ErrorAs(t, err, &local)
+	assert.Equal(t, exterrors.CodeEnvironmentValuesFailed, local.Code)
+}
+
+func TestResolveEnv_EmptyLocationResponseReturnsError(t *testing.T) {
+	// Defensive: a location response with a blank name must not be persisted;
+	// fail with an actionable error instead of writing an empty value.
+	env := &resolveEnvStubEnvServer{
+		envName: "foundry-bugbash",
+		get:     map[string]string{envKeySubscriptionID: "00000000-0000-0000-0000-000000000001"},
+	}
+	prompt := &resolveEnvStubPromptServer{location: "   "}
+	client := newResolveEnvTestClient(t, env, prompt)
+
+	p := &FoundryProvisioningProvider{azdClient: client}
+	err := p.resolveEnv(t.Context())
+	require.Error(t, err)
+
+	var local *azdext.LocalError
+	require.ErrorAs(t, err, &local)
+	assert.Equal(t, exterrors.CodeMissingAzureLocation, local.Code)
+	assert.Empty(t, env.set, "an empty location name must not be persisted")
+}


### PR DESCRIPTION
Fixes #8859

### Problem

Running `azd up` in a Foundry (`azure.ai.agents`) project fails immediately when `AZURE_SUBSCRIPTION_ID` (or `AZURE_LOCATION`) is not set in the azd environment:

```
ERROR: AZURE_SUBSCRIPTION_ID is required but not set in azd environment "foundry-bugbash"
Suggestion: run `azd env set AZURE_SUBSCRIPTION_ID <subscription-id>`
```

Core `azd up` prompts the user to pick a subscription/location when they aren't set; the extension's provisioning provider instead hard-failed.

### Root cause

`FoundryProvisioningProvider.resolveEnv` read `AZURE_SUBSCRIPTION_ID` / `AZURE_LOCATION` from the environment and returned a `Dependency` error when either was empty, rather than prompting. The extension already prompts in its `init` flow (`PromptSubscription` / `PromptLocation`), but the provision path (`azd up` / `azd provision`) never adopted it.

### Fix

When `AZURE_SUBSCRIPTION_ID` / `AZURE_LOCATION` are missing, `resolveEnv` now prompts via the azdext Prompt service and persists the chosen values to the azd environment, matching core `azd up`.

- New `promptSubscription` / `promptLocation` / `setEnv` helpers on the provider.
- Deterministic `--no-prompt` / CI behavior preserved: when the host returns a "prompt required" error, the original actionable `azd env set ...` suggestion is still surfaced.
- User cancellation maps to the cancellation category.
- Tenant/credential resolution is unchanged (`ensureCredential` + `withTenantOutput`).
- Brownfield (`endpoint:`) path is untouched — it uses `resolveEnvName` and needs no subscription/location.

### Tests

Added `foundry_provisioning_provider_resolveenv_test.go` covering: prompt-and-persist for both values; `--no-prompt` actionable errors for missing subscription and location; and user-cancellation handling. Full `internal/project` suite and `go build ./...` pass; `gofmt`, `golangci-lint`, and `cspell` are clean.