### PR TITLE
Bump requiredAzdVersion to >=1.27.0 for some AI/Foundry extensions

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/extension.yaml
+++ b/cli/azd/extensions/azure.ai.agents/extension.yaml
@@ -6,7 +6,7 @@ description: Ship agents with Microsoft Foundry from your terminal. (Preview)
 usage: azd ai agent <command> [options]
 # NOTE: Make sure version.txt is in sync with this version.
 version: 0.1.42-preview
-requiredAzdVersion: ">1.25.2"
+requiredAzdVersion: ">=1.27.0"
 dependencies:
   - id: azure.ai.inspector
     version: "~0.0.1-preview"

--- a/cli/azd/extensions/azure.ai.connections/extension.yaml
+++ b/cli/azd/extensions/azure.ai.connections/extension.yaml
@@ -17,3 +17,4 @@ tags:
     - connection
 usage: azd ai connection <command> [options]
 version: 0.1.3-preview
+requiredAzdVersion: ">=1.27.0"

--- a/cli/azd/extensions/azure.ai.inspector/extension.yaml
+++ b/cli/azd/extensions/azure.ai.inspector/extension.yaml
@@ -6,7 +6,7 @@ description: Browser-based inspector UI for locally running Foundry agents. (Pre
 usage: azd ai inspector <command> [options]
 # NOTE: Make sure version.txt is in sync with this version.
 version: 0.0.1-preview
-requiredAzdVersion: ">1.23.13"
+requiredAzdVersion: ">=1.27.0"
 language: go
 capabilities:
   - custom-commands

--- a/cli/azd/extensions/azure.ai.projects/extension.yaml
+++ b/cli/azd/extensions/azure.ai.projects/extension.yaml
@@ -17,3 +17,4 @@ tags:
     - project
 usage: azd ai project <command> [options]
 version: 0.1.1-preview
+requiredAzdVersion: ">=1.27.0"

--- a/cli/azd/extensions/azure.ai.routines/extension.yaml
+++ b/cli/azd/extensions/azure.ai.routines/extension.yaml
@@ -17,3 +17,4 @@ tags:
     - routine
 usage: azd ai routine <command> [options]
 version: 0.1.1-preview
+requiredAzdVersion: ">=1.27.0"

--- a/cli/azd/extensions/azure.ai.skills/extension.yaml
+++ b/cli/azd/extensions/azure.ai.skills/extension.yaml
@@ -6,7 +6,7 @@ description: Manage Microsoft Foundry skills (reusable agent behavioral guidelin
 usage: azd ai skill <command> [options]
 # NOTE: Make sure version.txt is in sync with this version.
 version: 0.1.1-preview
-requiredAzdVersion: ">1.23.13"
+requiredAzdVersion: ">=1.27.0"
 language: go
 capabilities:
   - custom-commands

--- a/cli/azd/extensions/azure.ai.toolboxes/extension.yaml
+++ b/cli/azd/extensions/azure.ai.toolboxes/extension.yaml
@@ -17,3 +17,4 @@ tags:
     - toolbox
 usage: azd ai toolbox <command> [options]
 version: 0.1.2-preview
+requiredAzdVersion: ">=1.27.0"

--- a/cli/azd/extensions/microsoft.foundry/extension.yaml
+++ b/cli/azd/extensions/microsoft.foundry/extension.yaml
@@ -6,7 +6,7 @@ tags:
     - ai
     - foundry
 version: 0.1.0-preview
-requiredAzdVersion: ">1.25.2"
+requiredAzdVersion: ">=1.27.0"
 dependencies:
   - id: azure.ai.agents
     version: "~0.1.0-preview"


### PR DESCRIPTION
## Why

The AI and Foundry extensions need to require azd core 1.27.0 as the minimum version to ensure compatibility with newer core APIs and behaviors.

## What changed

Updated `requiredAzdVersion` to `">=1.27.0"` across 8 extension manifests:

- **Updated existing field:** `azure.ai.agents`, `azure.ai.inspector`, `azure.ai.skills`, `microsoft.foundry`
- **Added new field:** `azure.ai.connections`, `azure.ai.projects`, `azure.ai.routines`, `azure.ai.toolboxes`

For extensions that previously lacked `requiredAzdVersion`, the field was placed immediately after the `version:` line, consistent with the convention in other extension manifests.