### PR TITLE
Update default responses protocol version to 2.0.0

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -665,7 +665,7 @@ func synthesizeImageManifestFile(agentName, image string) (string, func(), error
 			"name":        agentName,
 			"description": fmt.Sprintf("Hosted container agent using pre-built image %s", image),
 			"protocols": []map[string]any{
-				{"protocol": "responses", "version": "1.0.0"},
+				{"protocol": "responses", "version": "2.0.0"},
 			},
 		},
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -891,13 +891,13 @@ type protocolInfo struct {
 
 // knownProtocols lists the protocols offered during init, in display order.
 var knownProtocols = []protocolInfo{
-	{Name: "responses", Version: "1.0.0"},
+	{Name: "responses", Version: "2.0.0"},
 	{Name: "invocations", Version: "1.0.0"},
 }
 
 // promptProtocols asks the user which protocols their agent supports.
 // When flagProtocols is non-empty the prompt is skipped and those values are used directly.
-// When noPrompt is true and no flag values are provided, defaults to [responses/1.0.0].
+// When noPrompt is true and no flag values are provided, defaults to [responses/2.0.0].
 func promptProtocols(
 	ctx context.Context,
 	promptClient azdext.PromptServiceClient,
@@ -940,7 +940,7 @@ func promptProtocols(
 	// Non-interactive mode: default to responses.
 	if noPrompt {
 		return []agent_yaml.ProtocolVersionRecord{
-			{Protocol: "responses", Version: "1.0.0"},
+			{Protocol: "responses", Version: "2.0.0"},
 		}, nil
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go
@@ -587,7 +587,7 @@ func TestPromptProtocols_FlagValues(t *testing.T) {
 			name:          "responses only",
 			flagProtocols: []string{"responses"},
 			wantProtocols: []agent_yaml.ProtocolVersionRecord{
-				{Protocol: "responses", Version: "1.0.0"},
+				{Protocol: "responses", Version: "2.0.0"},
 			},
 		},
 		{
@@ -601,7 +601,7 @@ func TestPromptProtocols_FlagValues(t *testing.T) {
 			name:          "both protocols",
 			flagProtocols: []string{"responses", "invocations"},
 			wantProtocols: []agent_yaml.ProtocolVersionRecord{
-				{Protocol: "responses", Version: "1.0.0"},
+				{Protocol: "responses", Version: "2.0.0"},
 				{Protocol: "invocations", Version: "1.0.0"},
 			},
 		},
@@ -615,7 +615,7 @@ func TestPromptProtocols_FlagValues(t *testing.T) {
 			name:          "duplicates are removed",
 			flagProtocols: []string{"responses", "responses", "invocations"},
 			wantProtocols: []agent_yaml.ProtocolVersionRecord{
-				{Protocol: "responses", Version: "1.0.0"},
+				{Protocol: "responses", Version: "2.0.0"},
 				{Protocol: "invocations", Version: "1.0.0"},
 			},
 		},
@@ -666,8 +666,8 @@ func TestPromptProtocols_NoPromptDefault(t *testing.T) {
 	if got[0].Protocol != "responses" {
 		t.Errorf("protocol = %q, want %q", got[0].Protocol, "responses")
 	}
-	if got[0].Version != "1.0.0" {
-		t.Errorf("version = %q, want %q", got[0].Version, "1.0.0")
+	if got[0].Version != "2.0.0" {
+		t.Errorf("version = %q, want %q", got[0].Version, "2.0.0")
 	}
 }
 
@@ -722,7 +722,7 @@ func TestPromptProtocols_Interactive(t *testing.T) {
 				}, nil
 			},
 			wantProtocols: []agent_yaml.ProtocolVersionRecord{
-				{Protocol: "responses", Version: "1.0.0"},
+				{Protocol: "responses", Version: "2.0.0"},
 				{Protocol: "invocations", Version: "1.0.0"},
 			},
 		},
@@ -737,7 +737,7 @@ func TestPromptProtocols_Interactive(t *testing.T) {
 				}, nil
 			},
 			wantProtocols: []agent_yaml.ProtocolVersionRecord{
-				{Protocol: "responses", Version: "1.0.0"},
+				{Protocol: "responses", Version: "2.0.0"},
 			},
 		},
 		{

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -336,7 +336,7 @@ func TestSynthesizeImageManifestFile(t *testing.T) {
 	require.Empty(t, containerAgent.Image)
 	require.Len(t, containerAgent.Protocols, 1)
 	require.Equal(t, "responses", containerAgent.Protocols[0].Protocol)
-	require.Equal(t, "1.0.0", containerAgent.Protocols[0].Version)
+	require.Equal(t, "2.0.0", containerAgent.Protocols[0].Version)
 
 	// cleanup removes the temp directory.
 	cleanup()
@@ -362,7 +362,7 @@ func TestAddToProjectPreBuiltImageWritesServiceImage(t *testing.T) {
 				Description: &description,
 			},
 			Protocols: []agent_yaml.ProtocolVersionRecord{
-				{Protocol: "responses", Version: "1.0.0"},
+				{Protocol: "responses", Version: "2.0.0"},
 			},
 		},
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
@@ -393,7 +393,7 @@ func CreateHostedAgentAPIRequest(hostedAgent ContainerAgent, buildConfig *AgentB
 	} else {
 		// Set default protocol versions if none specified
 		protocolVersions = []agent_api.ProtocolVersionRecord{
-			{Protocol: agent_api.AgentProtocolResponses, Version: "1.0.0"},
+			{Protocol: agent_api.AgentProtocolResponses, Version: "2.0.0"},
 		}
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
@@ -932,7 +932,7 @@ func TestCreateHostedAgentAPIRequest_DefaultProtocols(t *testing.T) {
 	if imgDef.ProtocolVersions[0].Protocol != agent_api.AgentProtocolResponses {
 		t.Errorf("default protocol = %q", imgDef.ProtocolVersions[0].Protocol)
 	}
-	if imgDef.ProtocolVersions[0].Version != "1.0.0" {
+	if imgDef.ProtocolVersions[0].Version != "2.0.0" {
 		t.Errorf("default version = %q", imgDef.ProtocolVersions[0].Version)
 	}
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agent_definition_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agent_definition_test.go
@@ -24,7 +24,7 @@ func sampleContainerAgent() agent_yaml.ContainerAgent {
 			Description: new("A basic agent hosted by Foundry."),
 		},
 		Protocols: []agent_yaml.ProtocolVersionRecord{
-			{Protocol: "responses", Version: "1.0.0"},
+			{Protocol: "responses", Version: "2.0.0"},
 		},
 		EnvironmentVariables: &[]agent_yaml.EnvironmentVariable{
 			{Name: "FOUNDRY_MODEL_DEPLOYMENT_NAME", Value: "gpt-4.1-mini"},

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1273,7 +1273,7 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 	protocols := agentDef.Protocols
 	if len(protocols) == 0 {
 		protocols = []agent_yaml.ProtocolVersionRecord{
-			{Protocol: string(agent_api.AgentProtocolResponses), Version: "1.0.0"},
+			{Protocol: string(agent_api.AgentProtocolResponses), Version: "2.0.0"},
 		}
 	}
 


### PR DESCRIPTION
## Why

Due to a change in MAF (Microsoft AI Foundry), the responses protocol version should default to `2.0.0` instead of `1.0.0`. This aligns the agents extension with the updated MAF contract.

## Approach

Updated the three source locations where the default responses protocol version is set:

- **`agent_yaml/map.go`** -- default when no protocols are specified in agent YAML
- **`init_from_code.go`** -- `knownProtocols` lookup table, comment, and no-prompt fallback
- **`service_target_agent.go`** -- deploy-time default in `prepareForDeploy`

Other protocol versions (invocations, a2a, activity_protocol, invocations_ws) remain at `1.0.0` -- only the responses protocol default changes.

## Testing

Updated all corresponding test expectations across 3 test files. All tests pass (the only failures are pre-existing ARM template staleness in `synthesis/`, unrelated to this change).

Fixes: #8894