### PR TITLE
Rename azure.ai.foundry to microsoft.foundry in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,6 @@
 /cli/azd/test/functional/ai_agents/         @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030
 /cli/azd/extensions/azure.ai.connections/   @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030
 /cli/azd/extensions/azure.ai.finetune/      @JeffreyCA @trangevi @achauhan-scc @kingernupur @saanikaguptamicrosoft
-/cli/azd/extensions/azure.ai.foundry/       @JeffreyCA @glharper @trangevi @trrwilson @therealjohn
 /cli/azd/extensions/azure.ai.inspector/     @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @anchenyi @XiaofuHuang
 /cli/azd/extensions/azure.ai.models/        @JeffreyCA @trangevi @achauhan-scc @kingernupur @saanikaguptamicrosoft
 /cli/azd/extensions/azure.ai.projects/      @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030
@@ -23,6 +22,7 @@
 /cli/azd/extensions/azure.ai.skills/        @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030
 /cli/azd/extensions/azure.ai.toolboxes/     @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030
 /cli/azd/extensions/azure.ai.training/      @JeffreyCA @trangevi @achauhan-scc @kingernupur @saanikaguptamicrosoft
+/cli/azd/extensions/microsoft.foundry/      @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030
 
 # ── Extensions ────────────────────────────────────────────────────────────────
 /ext/                                       @vhvb1989 @tg-msft @RickWinter @karolz-ms


### PR DESCRIPTION
The `microsoft.foundry` meta extension exists at `/cli/azd/extensions/microsoft.foundry/` but the CODEOWNERS entry still referenced the old `azure.ai.foundry` path. This renames the entry to match the actual extension directory, adds `@huimiu` and `@hund030` to align with the other foundry extension owner lists, and reorders it alphabetically (after all `azure.ai.*` entries).

Fixes: #8897