### PR TITLE
fix: point foundry beta.1 agents dep to 1.0.0-beta.2

### DIFF
--- a/cli/azd/extensions/registry.json
+++ b/cli/azd/extensions/registry.json
@@ -6715,7 +6715,7 @@
           "dependencies": [
             {
               "id": "azure.ai.agents",
-              "version": "~1.0.0-beta.1"
+              "version": "~1.0.0-beta.2"
             },
             {
               "id": "azure.ai.connections",


### PR DESCRIPTION
Updates the `microsoft.foundry` `1.0.0-beta.1` dependency on `azure.ai.agents` from `~1.0.0-beta.1` to `~1.0.0-beta.2`.

`azure.ai.agents` `1.0.0-beta.1` was removed from the registry (#8912) because it shipped duplicate providers and was superseded by `1.0.0-beta.2`. The umbrella `microsoft.foundry` `1.0.0-beta.1` entry still referenced the removed `~1.0.0-beta.1` agents version; this points it at the version that actually exists in the registry.

The other six sub-extension references (`connections`/`inspector`/`projects`/`routines`/`skills`/`toolboxes`) remain `~1.0.0-beta.1` and are unchanged.