### PR TITLE
fix(ci): build azure.ai.inspector from source in test workflow

### DIFF
--- a/.github/workflows/test-ext-azure-ai-agents.yml
+++ b/.github/workflows/test-ext-azure-ai-agents.yml
@@ -45,8 +45,9 @@ jobs:
       - name: Build & install inspector dependency from source
         working-directory: cli/azd/extensions/azure.ai.inspector
         run: |
-          # The azure.ai.inspector extension has not been published to the registry
-          # at 1.0.0-beta.1+ yet — build from source to satisfy the dependency.
+          # Build azure.ai.inspector from source to ensure PR CI always has a
+          # compatible version — dependency releases are post-merge, but PRs may
+          # include inspector changes from this same repo.
           pwsh -File ci-build.ps1 -OutputFileName azure-ai-inspector-linux-amd64 -Version $(cat version.txt | tr -d '\r\n')
           mkdir -p bin
           mv azure-ai-inspector-linux-amd64 bin/

--- a/.github/workflows/test-ext-azure-ai-agents.yml
+++ b/.github/workflows/test-ext-azure-ai-agents.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "cli/azd/extensions/azure.ai.agents/**"
+      - "cli/azd/extensions/azure.ai.inspector/**"
       - "cli/azd/test/functional/ai_agents/**"
       - ".github/workflows/test-ext-azure-ai-agents.yml"
     branches: [main]
@@ -40,8 +41,18 @@ jobs:
           # Install the developer extension (provides 'azd x' commands).
           # The built-in 'azd' source is auto-registered, so no source-add needed.
           azd extension install microsoft.azd.extensions --no-prompt
-          # Pre-install the inspector dependency so the local install can resolve it.
-          azd extension install azure.ai.inspector --no-prompt
+
+      - name: Build & install inspector dependency from source
+        working-directory: cli/azd/extensions/azure.ai.inspector
+        run: |
+          # The azure.ai.inspector extension has not been published to the registry
+          # at 1.0.0-beta.1+ yet — build from source to satisfy the dependency.
+          pwsh -File ci-build.ps1 -OutputFileName azure-ai-inspector-linux-amd64 -Version $(cat version.txt | tr -d '\r\n')
+          mkdir -p bin
+          mv azure-ai-inspector-linux-amd64 bin/
+          azd x pack
+          azd x publish
+          azd extension install azure.ai.inspector --source local --force --no-prompt
 
       - name: Build extension (ci-build.ps1)
         working-directory: cli/azd/extensions/azure.ai.agents


### PR DESCRIPTION
## Problem

All runs of `test-ext-azure-ai-agents.yml` are failing since the 1.0.0-beta.1 version bump (#8896):

```
ERROR: failed to install extension: installed dependency azure.ai.inspector version 0.0.1-preview does not satisfy constraint "~1.0.0-beta.1"
```

**Root cause**: The workflow installs `azure.ai.inspector` from the registry, but only `0.0.1-preview` has been published there. The source was bumped to `1.0.0-beta.1` but never released to the registry.

This blocks **all PRs** touching the agents extension (8 different branches affected today).

Fixes #8916

## Fix

Build and install `azure.ai.inspector` from source using `ci-build.ps1` + `azd x pack/publish` -- the same approach already used for `azure.ai.agents` itself.

Also adds `cli/azd/extensions/azure.ai.inspector/**` to the workflow path trigger so inspector source changes trigger the test.

## Verification

- Confirmed all 8 failed runs from Jun 30-Jul 1 show the identical error
- The fix mirrors the existing pattern for building azure.ai.agents from source
- CI `test` job passes on this PR
