### PR TITLE
fix: set brownfield Foundry projectName without ACR

### DIFF
--- a/.impeccable/hook.cache.json
+++ b/.impeccable/hook.cache.json
@@ -1,0 +1,1 @@
+{"version":1,"sessions":{}}

--- a/.impeccable/hook.cache.json
+++ b/.impeccable/hook.cache.json
@@ -1,1 +1,0 @@
-{"version":1,"sessions":{}}

--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs Fixed
 
+- [[#8917]](https://github.com/Azure/azure-dev/pull/8917) Fix an `InvalidTemplate` error when deploying a brownfield (`endpoint:`) Foundry project that declares model deployments without creating a container registry. The `projectName` ARM parameter is now always set, so the referenced `Microsoft.CognitiveServices/accounts/projects` resource gets a valid two-segment name.
 - [[#8901]](https://github.com/Azure/azure-dev/pull/8901) Remove duplicate service-target provider claims from the `azure.ai.agents` extension manifest for hosts now owned by the split Foundry extensions (`azure.ai.projects`, `azure.ai.connections`, `azure.ai.toolboxes`). Thanks @huimiu for the contribution!
 
 ## 1.0.0-beta.1 (2026-06-30)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider.go
@@ -810,11 +810,15 @@ func (p *FoundryProvisioningProvider) brownfieldParams(
 	params := map[string]any{
 		"accountName": map[string]any{"value": account},
 		"deployments": map[string]any{"value": p.brownfieldDeployments},
+		// projectName is always required: the template unconditionally references
+		// the existing accounts/projects resource, whose ARM name is
+		// '<accountName>/<projectName>'. Leaving it empty yields a single-segment
+		// name and an InvalidTemplate error even when no ACR is created.
+		"projectName": map[string]any{"value": p.brownfieldProjectName()},
 	}
 	if createACR {
 		params["includeAcr"] = map[string]any{"value": true}
 		params["acrName"] = map[string]any{"value": p.brownfieldACRName(account)}
-		params["projectName"] = map[string]any{"value": p.brownfieldProjectName()}
 		params["tags"] = map[string]any{"value": map[string]string{"azd-env-name": p.envName}}
 		// Only set location when resolved; an empty value would override the
 		// template default (resourceGroup().location) and fail the deployment.

--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_brownfield_acr_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_brownfield_acr_test.go
@@ -172,13 +172,20 @@ func TestBrownfieldParams(t *testing.T) {
 
 	deployments := []synthesis.Deployment{{Name: "gpt-4o-mini"}}
 
-	t.Run("without ACR carries only account and deployments", func(t *testing.T) {
+	t.Run("without ACR carries account, deployments and projectName", func(t *testing.T) {
 		t.Parallel()
-		p := &FoundryProvisioningProvider{envName: "dev", brownfieldDeployments: deployments}
+		p := &FoundryProvisioningProvider{
+			envName:               "dev",
+			brownfieldDeployments: deployments,
+			brownfieldEndpoint:    "https://acct.services.ai.azure.com/api/projects/my-project",
+		}
 		params := p.brownfieldParams(t.Context(), "acct", "rg", false)
 
 		assert.Equal(t, map[string]any{"value": "acct"}, params["accountName"])
 		assert.Equal(t, map[string]any{"value": deployments}, params["deployments"])
+		// projectName is always required so the existing accounts/projects
+		// resource gets a valid two-segment ARM name.
+		assert.Equal(t, map[string]any{"value": "my-project"}, params["projectName"])
 		assert.NotContains(t, params, "includeAcr")
 		assert.NotContains(t, params, "acrName")
 	})


### PR DESCRIPTION
Fixes #8920 

## TL;DR

Running `azd provision` / `azd deploy` on an **existing** Foundry project that adds model deployments **without** creating a container registry failed with an ARM `InvalidTemplate` error. The required `projectName` value was only passed to the template when a registry was *also* being created. This PR always passes it.

## Who hits this

Any brownfield Foundry project service (`host: azure.ai.project` with an `endpoint:`) that:

- declares model `deployments:`, **and**
- deploys its agent as code/ZIP (`codeConfiguration`) — so **no** container registry (ACR) is created.

## Symptom

```
InvalidTemplate: The template resource 'hui-proj-ncus-resource/' of type
'Microsoft.CognitiveServices/accounts/projects' ... contains '1' name
segment(s) separated by '/', but '2' segment(s) were expected.
```

The resource name is missing its second segment: it should be `<account>/<project>` but came out as just `<account>/`.

## Root cause

`brownfield.arm.json` **always** references the existing project resource, whose ARM name is `format('{0}/{1}', accountName, projectName)`. But `brownfieldParams` only set the `projectName` parameter **inside the `if createACR` branch**. With no ACR, `projectName` fell back to the template default `''`, producing the invalid single-segment name `<accountName>/`.

## Fix

Move `projectName` out of the `createACR` branch so it is **always** set (resolved from the project endpoint). ACR-only params (`includeAcr`, `acrName`, `tags`, `location`) stay gated on `createACR`.

```go
params := map[string]any{
    "accountName": {"value": account},
    "deployments": {"value": p.brownfieldDeployments},
    "projectName": {"value": p.brownfieldProjectName()}, // always set now
}
if createACR {
    // includeAcr / acrName / tags / location only here
}
```

## How to verify

`azd provision --preview` on such a project runs an ARM what-if through the same code path (and creates nothing):

- **Before:** fails with the `InvalidTemplate` error above.
- **After:** the what-if succeeds and the plan shows the model deployment on the existing `<account>/<project>` resource.

## Tests

`TestBrownfieldParams` now asserts `projectName` is present in the no-ACR case.

## Related

A separate azure.yaml serialization issue for code-less hosts (invalid `project: ""` / `language: ""`) surfaced during this work and is tracked in #8919.