### PR TITLE
fix: omit empty project and language keys in azure.yaml

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Omit empty `project` and `language` keys when saving `azure.yaml`, so code-less resource hosts such as `azure.ai.project` no longer emit an invalid `project: ""` that fails schema validation.
+- [[#8918]](https://github.com/Azure/azure-dev/pull/8918) Omit empty `project` and `language` keys when saving `azure.yaml`, so code-less resource hosts such as `azure.ai.project` no longer emit an invalid `project: ""` that fails schema validation.
 
 ### Other Changes
 

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Omit empty `project` and `language` keys when saving `azure.yaml`, so code-less resource hosts such as `azure.ai.project` no longer emit an invalid `project: ""` that fails schema validation.
+
 ### Other Changes
 
 ## 1.27.0 (2026-06-30)

--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -517,6 +517,33 @@ func TestServiceImageSavedToYaml(t *testing.T) {
 	)
 }
 
+// TestCodelessServiceOmitsProjectAndLanguage verifies that a code-less resource
+// host (e.g. azure.ai.project) does not emit empty "project:" or "language:"
+// keys. The azure.yaml schema disallows "project" for these hosts, so writing
+// an empty value produces an invalid file that fails schema validation.
+func TestCodelessServiceOmitsProjectAndLanguage(t *testing.T) {
+	t.Parallel()
+
+	projectConfig := &ProjectConfig{
+		Name: "test-project",
+		Services: map[string]*ServiceConfig{
+			"foundry": {
+				Host: "azure.ai.project",
+			},
+		},
+	}
+	projectFile := filepath.Join(t.TempDir(), "azure.yaml")
+
+	err := Save(t.Context(), projectConfig, projectFile)
+	require.NoError(t, err)
+
+	fileContent, err := os.ReadFile(projectFile)
+	require.NoError(t, err)
+	assert.NotContains(t, string(fileContent), "project:")
+	assert.NotContains(t, string(fileContent), "language:")
+	assert.Contains(t, string(fileContent), "host: azure.ai.project")
+}
+
 func TestInfraDefaultsNotSavedToYaml(t *testing.T) {
 	t.Run("DefaultValuesNotWritten", func(t *testing.T) {
 		// Create a minimal project config with no infra settings

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -34,12 +34,14 @@ type ServiceConfig struct {
 	ResourceName osutil.ExpandableString `yaml:"resourceName,omitempty"`
 	// The ARM api version to use for the service. If not specified, the latest version is used.
 	ApiVersion string `yaml:"apiVersion,omitempty"`
-	// The relative path to the project folder from the project root
-	RelativePath string `yaml:"project"`
+	// The relative path to the project folder from the project root.
+	// Omitted for code-less resource hosts (e.g. azure.ai.project) that have no source.
+	RelativePath string `yaml:"project,omitempty"`
 	// The azure hosting model to use, ex) appservice, function, containerapp
 	Host ServiceTargetKind `yaml:"host"`
-	// The programming language of the project
-	Language ServiceLanguageKind `yaml:"language"`
+	// The programming language of the project.
+	// Omitted for code-less resource hosts (e.g. azure.ai.project) that have no source.
+	Language ServiceLanguageKind `yaml:"language,omitempty"`
 	// The output path for build artifacts
 	OutputPath string `yaml:"dist,omitempty"`
 	// The source image to use for container based applications


### PR DESCRIPTION
## Problem

`azd ai agent init` generates an `azure.yaml` where the code-less resource service (`host: azure.ai.project`) is written with `project: ""` and `language: ""`:

```yaml
services:
  hui-proj-ncus:
    project: ""
    host: azure.ai.project
    language: ""
    ...
```

The `azure.yaml` schema disables `project` for these code-less hosts (`"project": false` for `azure.ai.project`, `azure.ai.connection`, `azure.ai.toolbox`, `azure.ai.skill`, `azure.ai.routine`), so the generated file fails validation with **"Property project is not allowed."**

## Root cause

`ServiceConfig.RelativePath` (`yaml:"project"`) and `ServiceConfig.Language` (`yaml:"language"`) had no `omitempty`, so `project.Save` always emitted them — even for code-less resource hosts that legitimately have no source path or language.

## Fix

Add `omitempty` to `RelativePath` and `Language`. Traditional/container hosts always set these, so their output is unchanged; only empty values (code-less hosts) are now omitted.

## Tests

Added `TestCodelessServiceOmitsProjectAndLanguage` verifying an `azure.ai.project` service serializes without `project:`/`language:` keys. Full `pkg/project` and `internal/grpcserver` suites pass.