### PR TITLE
fix: add environmentVariables to azure.ai.agent schema

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- [[#8935]](https://github.com/Azure/azure-dev/pull/8935) `azd ai agent init` writes an agent service `environmentVariables` list that the `azure.ai.agent` schema did not define. Add the `environmentVariables` property (a list of `name`/`value` pairs) to the schema so the generated `azure.yaml` validates and editors complete it.
+- [[#8935]](https://github.com/Azure/azure-dev/pull/8935) `azd ai agent init` writes an agent service `environmentVariables` list that the `azure.ai.agent` schema did not define. Add the `environmentVariables` property (a list of `name`/`value` pairs) to the schema so the generated `azure.yaml` validates and editors complete it, and disallow service-level `env` for `azure.ai.agent` services because azd core does not forward it to extensions.
 
 ### Other Changes
 

--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 1.0.0-beta.3 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+- `azd ai agent init` writes an agent service `environmentVariables` list that the `azure.ai.agent` schema did not define. Add the `environmentVariables` property (a list of `name`/`value` pairs) to the schema so the generated `azure.yaml` validates and editors complete it.
+
+### Other Changes
+
 ## 1.0.0-beta.2 (2026-07-01)
 
 ### Bugs Fixed

--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- `azd ai agent init` writes an agent service `environmentVariables` list that the `azure.ai.agent` schema did not define. Add the `environmentVariables` property (a list of `name`/`value` pairs) to the schema so the generated `azure.yaml` validates and editors complete it.
+- [[#8935]](https://github.com/Azure/azure-dev/pull/8935) `azd ai agent init` writes an agent service `environmentVariables` list that the `azure.ai.agent` schema did not define. Add the `environmentVariables` property (a list of `name`/`value` pairs) to the schema so the generated `azure.yaml` validates and editors complete it.
 
 ### Other Changes
 

--- a/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
@@ -4,13 +4,6 @@
   "description": "Custom configuration for the Azure AI Agent Service target",
   "type": "object",
   "properties": {
-    "env": {
-      "type": "object",
-      "description": "Environment variables as key-value pairs",
-      "additionalProperties": {
-        "type": "string"
-      }
-    },
     "environmentVariables": {
       "type": "array",
       "description": "Environment variables for the hosted agent container, as a list of name/value pairs. Values support ${ENV_VAR} substitution resolved from the azd environment at deploy time.",

--- a/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
@@ -11,6 +11,11 @@
         "type": "string"
       }
     },
+    "environmentVariables": {
+      "type": "array",
+      "description": "Environment variables for the hosted agent container, as a list of name/value pairs. Values support ${ENV_VAR} substitution resolved from the azd environment at deploy time.",
+      "items": { "$ref": "#/definitions/EnvironmentVariable" }
+    },
     "container": {
       "$ref": "#/definitions/ContainerSettings"
     },
@@ -101,6 +106,16 @@
   },
   "additionalProperties": true,
   "definitions": {
+    "EnvironmentVariable": {
+      "type": "object",
+      "description": "A single environment variable for the hosted agent container.",
+      "properties": {
+        "name": { "type": "string", "description": "Environment variable name." },
+        "value": { "type": "string", "description": "Environment variable value. Supports ${ENV_VAR} substitution resolved from the azd environment at deploy time." }
+      },
+      "required": ["name", "value"],
+      "additionalProperties": false
+    },
     "ProtocolVersionRecord": {
       "type": "object",
       "description": "A protocol the agent implements, with its version.",

--- a/cli/azd/extensions/azure.ai.agents/schemas/examples/complex.azure.yaml
+++ b/cli/azd/extensions/azure.ai.agents/schemas/examples/complex.azure.yaml
@@ -106,9 +106,11 @@ services:
     startupCommand: python main.py
     toolboxes:
       - research-tools
-    env:
-      LOG_LEVEL: info
-      MODEL_ENDPOINT: ${{project.endpoint}}
+    environmentVariables:
+      - name: LOG_LEVEL
+        value: info
+      - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+        value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}
     protocols:
       - protocol: a2a
         version: "0.2"

--- a/cli/azd/extensions/azure.ai.agents/schemas/examples/simple.azure.yaml
+++ b/cli/azd/extensions/azure.ai.agents/schemas/examples/simple.azure.yaml
@@ -25,3 +25,8 @@ services:
     kind: hosted
     name: assistant
     description: A simple assistant.
+    environmentVariables:
+      - name: LOG_LEVEL
+        value: info
+      - name: MODEL_ENDPOINT
+        value: ${FOUNDRY_PROJECT_ENDPOINT}

--- a/cli/azd/extensions/azure.ai.agents/schemas/examples/simple.azure.yaml
+++ b/cli/azd/extensions/azure.ai.agents/schemas/examples/simple.azure.yaml
@@ -28,5 +28,5 @@ services:
     environmentVariables:
       - name: LOG_LEVEL
         value: info
-      - name: MODEL_ENDPOINT
-        value: ${FOUNDRY_PROJECT_ENDPOINT}
+      - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+        value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -436,6 +436,7 @@
                                 },
                                 "k8s": false,
                                 "apiVersion": false,
+                                "env": false,
                                 "network": false
                             }
                         }

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -396,6 +396,7 @@
                                 },
                                 "k8s": false,
                                 "apiVersion": false,
+                                "env": false,
                                 "network": false
                             }
                         }


### PR DESCRIPTION
## Problem

`azd ai agent init` writes an agent service entry to `azure.yaml` that includes an `environmentVariables` property — a list of `name`/`value` pairs carried on the inline agent definition (`AgentDefinitionInline.EnvironmentVariables`, JSON key `environmentVariables`). This value is both written at init and read back at deploy (`prepareDeploy` resolves each entry against the azd environment).

However, the `azure.ai.agent` service schema (`cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json`) never defined `environmentVariables`, so the generated manifest didn't match the schema definition.

Also, the existing `env` property in the schema was misleading for `azure.ai.agent`: azd core parses service-level `env` into `project.ServiceConfig.Environment`, but the core-to-extension mapper does not forward that field to `azdext.ServiceConfig`, and the extension-facing proto has no `env`/`Environment` field. As a result, `env` on an `azure.ai.agent` service does not reach the extension or the hosted agent container.

## Fix

- Add the `environmentVariables` array property to `azure.ai.agent.json`, plus an `EnvironmentVariable` definition (`{ name, value }`, both required, `additionalProperties: false`) that mirrors the Go `agent_yaml.EnvironmentVariable` shape.
- Remove the misleading `env` property from `azure.ai.agent.json`.
- Explicitly disallow service-level `env` for `azure.ai.agent` in both root schemas (`schemas/v1.0/azure.yaml.json` and `schemas/alpha/azure.yaml.json`) so editors reject a field that azd core does not pass to extensions.
- Update examples to use `environmentVariables` with the actual model deployment env var shape.

## Validation

- Local AJV validation confirms `environmentVariables` is accepted for `azure.ai.agent` and service-level `env` is rejected.
- JSON parse validation passes for the changed schema files.
- `cspell` passes on the updated `CHANGELOG.md`.
- Existing `TestAgentDefinitionRoundTrip` already confirms the code round-trips `environmentVariables` through the inline service properties — the shape the schema now describes.

No Go code changed; this is a schema/example correction.