### PR TITLE
fix: omit empty service source fields

### DIFF
--- a/cli/azd/pkg/project/project_test.go
+++ b/cli/azd/pkg/project/project_test.go
@@ -1232,6 +1232,35 @@ func Test_Save(t *testing.T) {
 	assert.Equal(t, dir, prjConfig.Path)
 }
 
+func Test_Save_OmitsEmptyServiceSourceFields(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "azure.yaml")
+
+	prjConfig := &ProjectConfig{
+		Name: "test-save",
+		Services: map[string]*ServiceConfig{
+			"foundry": {
+				Host: ServiceTargetKind("azure.ai.project"),
+				AdditionalProperties: map[string]any{
+					"endpoint": "https://account.services.ai.azure.com/api/projects/project",
+				},
+			},
+		},
+	}
+
+	err := Save(t.Context(), prjConfig, filePath)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	content := string(data)
+	assert.Contains(t, content, "host: azure.ai.project")
+	assert.Contains(t, content, "endpoint: https://account.services.ai.azure.com/api/projects/project")
+	assert.NotContains(t, content, "project: \"\"")
+	assert.NotContains(t, content, "language: \"\"")
+}
+
 func Test_Save_CustomSchemaVersion(t *testing.T) {
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "azure.yaml")

--- a/cli/azd/pkg/project/service_config.go
+++ b/cli/azd/pkg/project/service_config.go
@@ -35,11 +35,11 @@ type ServiceConfig struct {
 	// The ARM api version to use for the service. If not specified, the latest version is used.
 	ApiVersion string `yaml:"apiVersion,omitempty"`
 	// The relative path to the project folder from the project root
-	RelativePath string `yaml:"project"`
+	RelativePath string `yaml:"project,omitempty"`
 	// The azure hosting model to use, ex) appservice, function, containerapp
 	Host ServiceTargetKind `yaml:"host"`
 	// The programming language of the project
-	Language ServiceLanguageKind `yaml:"language"`
+	Language ServiceLanguageKind `yaml:"language,omitempty"`
 	// The output path for build artifacts
 	OutputPath string `yaml:"dist,omitempty"`
 	// The source image to use for container based applications


### PR DESCRIPTION
Fixes #8938

## Problem

Services that use a code-less resource host such as `host: azure.ai.project` are written to `azure.yaml` with empty `project: ""` and `language: ""` fields:

```yaml
services:
  hui-proj-ncus:
    project: ""
    host: azure.ai.project
    language: ""
    deployments:
      - ...
    endpoint: https://...services.ai.azure.com/api/projects/hui-proj-ncus
```

These fields are invalid/meaningless for this host:
- The main `azure.yaml` schema explicitly disables `project` for `azure.ai.project` (`"project": false` in `schemas/v1.0/azure.yaml.json`), so `project: ""` is schema-invalid and the YAML language server flags it.
- The extension schema `azure.ai.project.json` only defines `endpoint`, `deployments`, and `network` — it never had `project` or `language`.

## Root cause

In `cli/azd/pkg/project/service_config.go`, these two fields are tagged without `omitempty`:

```go
RelativePath string              `yaml:"project"`
Language     ServiceLanguageKind `yaml:"language"`
```

Almost every other optional field on `ServiceConfig` (`resourceGroup`, `image`, `dist`, ...) already uses `omitempty`. `azure.yaml` is serialized with a plain `yaml.Marshal` in `project.Save()` (no custom marshaler), so any service with no source path/language emits the empty keys. This affects every code-less resource host (`azure.ai.project`, `azure.ai.connection`, `microsoft.foundry`, ...). The missing `omitempty` predates code-less resource hosts, when every service had a source path + language.

## Change

- Add `omitempty` to the `project` and `language` YAML tags on `ServiceConfig`.
- Add a regression test asserting empty source/language fields are omitted for a `host: azure.ai.project` service while `host`, `deployments`, and `endpoint` are preserved.

## Impact

Low. Only serialization of **empty** values changes:
- Populated services (`project: src/api`, `language: python`) serialize exactly as before.
- Empty values stop being written for code-less resource services.
- Runtime is unchanged: at load time, a missing field and an empty-string field both parse to the same Go zero value (`RelativePath == ""`, `ServiceLanguageNone`), and `ServiceLanguageNone` is already registered as the no-op framework service.
- Config mutations (`SetConfigValue` / `SetConfigSection` / `UnsetConfig`) re-save through the same path, so they no longer reintroduce `project: ""`.

## Tests

- `go test ./pkg/project -run Test_Save`
- `go test ./pkg/project`
- `go test ./internal/grpcserver -run "Save|Config|ProjectService"`