### PR TITLE
fix: always pass projectName to brownfield Foundry provisioning

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider.go
@@ -810,11 +810,15 @@ func (p *FoundryProvisioningProvider) brownfieldParams(
 	params := map[string]any{
 		"accountName": map[string]any{"value": account},
 		"deployments": map[string]any{"value": p.brownfieldDeployments},
+		// projectName feeds the unconditional existing `foundryAccountPreview::project`
+		// resource, so it must always be set -- even on the model-deployments-only
+		// reconcile path. Omitting it collapses the resource name to "<account>/"
+		// and fails ARM template validation with InvalidTemplate.
+		"projectName": map[string]any{"value": p.brownfieldProjectName()},
 	}
 	if createACR {
 		params["includeAcr"] = map[string]any{"value": true}
 		params["acrName"] = map[string]any{"value": p.brownfieldACRName(account)}
-		params["projectName"] = map[string]any{"value": p.brownfieldProjectName()}
 		params["tags"] = map[string]any{"value": map[string]string{"azd-env-name": p.envName}}
 		// Only set location when resolved; an empty value would override the
 		// template default (resourceGroup().location) and fail the deployment.

--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_brownfield_acr_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_brownfield_acr_test.go
@@ -172,13 +172,23 @@ func TestBrownfieldParams(t *testing.T) {
 
 	deployments := []synthesis.Deployment{{Name: "gpt-4o-mini"}}
 
-	t.Run("without ACR carries only account and deployments", func(t *testing.T) {
+	t.Run("without ACR still carries projectName for the existing project resource", func(t *testing.T) {
 		t.Parallel()
-		p := &FoundryProvisioningProvider{envName: "dev", brownfieldDeployments: deployments}
+		// The brownfield template declares `foundryAccountPreview::project` as an
+		// unconditional existing resource, so projectName must be supplied even
+		// when no ACR is created (model-deployments-only reconcile). Regression
+		// test for the InvalidTemplate failure where the name collapsed to
+		// "<account>/" because projectName was omitted.
+		p := &FoundryProvisioningProvider{
+			envName:               "dev",
+			brownfieldEndpoint:    "https://acct.services.ai.azure.com/api/projects/my-project",
+			brownfieldDeployments: deployments,
+		}
 		params := p.brownfieldParams(t.Context(), "acct", "rg", false)
 
 		assert.Equal(t, map[string]any{"value": "acct"}, params["accountName"])
 		assert.Equal(t, map[string]any{"value": deployments}, params["deployments"])
+		assert.Equal(t, map[string]any{"value": "my-project"}, params["projectName"])
 		assert.NotContains(t, params, "includeAcr")
 		assert.NotContains(t, params, "acrName")
 	})


### PR DESCRIPTION
## Summary

Brownfield Foundry provisioning (`azd provision` / `azd up` against an existing Foundry project referenced via a service `endpoint:`) failed with `InvalidTemplate` whenever the deploy reconciled model deployments but did not create a container registry.

The brownfield ARM template (`brownfield.arm.json`, compiled from `brownfield.bicep`) declares `foundryAccountPreview::project` as an **unconditional** `existing` resource named `format('{0}/{1}', accountName, projectName)`. `brownfieldParams` only supplied `projectName` on the ACR branch (`createACR=true`). On a model-deployment-only reconcile (`createACR=false`), `projectName` was omitted and defaulted to `''`, so the resource name collapsed to `<account>/` and ARM rejected the whole deployment before provisioning anything:

```
ERROR CODE: InvalidTemplate
The template resource '<account>/' of type 'Microsoft.CognitiveServices/accounts/projects'
... has an invalid name. The name '<account>/' contains '1' name segment(s) separated by
'/', but '2' segment(s) were expected.
path: properties.template.resources.foundryAccountPreview::project.type
```

This is surprising for users on the code-deploy path (`codeConfiguration.dependencyResolution: remote_build`), which does not need an ACR: the ACR resources are correctly skipped (`includeAcr=false`), but the dead project reference still tripped template validation. Regression introduced in #8880, which added the ACR-only project reference to the template while gating `projectName` behind the ACR branch.

## Change

`brownfieldParams` now always sets `projectName` (parsed from the project endpoint, with a fallback to the resolved Foundry name), not just on the ACR branch. `Deploy` and `Preview` share this function, so both paths are covered. The unconditional project reference is now valid and inert on non-ACR deploys, and no ACR is created on that path.

## Testing

- Added a regression test (`TestBrownfieldParams`, "without ACR still carries projectName for the existing project resource") asserting `projectName` is present on the non-ACR path.
- `go test ./internal/project/...` passes, `go build ./...` succeeds, `gofmt` clean.

## Follow-up

Fixes #8946.

This is the minimal fix. The deeper cleanup - removing the ACR-only `foundryAccountPreview` / `foundryAccountPreview::project` references from non-ACR deploys entirely by inlining them into the `includeAcr`-conditional resources - can be done as a separate follow-up.
