### PR TITLE
Add uksouth hosted agent region

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/hosted-agent-regions.json
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/hosted-agent-regions.json
@@ -18,6 +18,7 @@
         "spaincentral",
         "swedencentral",
         "switzerlandnorth",
+        "uksouth",
         "westus",
         "westus3"
     ]


### PR DESCRIPTION
Add `uksouth` to the supported regions for hosted agents.
Fixes: #8970 