### PR TITLE
fix: wire container registry for adopted agent container deploy

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.5 (Unreleased)
+
+### Bugs Fixed
+
+- [[#8981]](https://github.com/Azure/azure-dev/pull/8981) Fix `azd ai agent init -m <azure.yaml> --deploy-mode container` not resolving a container registry when adopting a unified Foundry `azure.yaml` on an existing Foundry project, which made `azd deploy` fail with `could not determine container registry endpoint`. The deploy mode is now resolved before Foundry project setup, so a container agent wires `AZURE_CONTAINER_REGISTRY_ENDPOINT` (or is signaled to create one on provision) while code deploy and `--image` still skip ACR.
+
 ## 1.0.0-beta.4 (2026-07-03)
 
 ### Bugs Fixed

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -787,10 +787,26 @@ func runInitFromAzureYaml(
 		return err
 	}
 
+	// Apply deploy-mode configuration to the adopted agent
+	// service(s) before configuring the Foundry project. Whether an
+	// Azure Container Registry must be wired (skipACR) depends on the
+	// resolved deploy mode: a container agent on an existing project
+	// needs AZURE_CONTAINER_REGISTRY_ENDPOINT set here, while a code
+	// agent (or a user-supplied --image) does not.
+	usesContainer, err := applyDeployModeToAdoptedProject(ctx, flags, azdClient)
+	if err != nil {
+		return err
+	}
+
+	// skipACR is false only for a container deploy whose registry azd
+	// manages. Code deploy and --image (bring your own registry) both
+	// skip ACR.
+	skipACR := !usesContainer || flags.image != ""
+
 	result, err := configureFoundryProject(
 		ctx, azdClient, azureContext, env.Name,
 		flags.projectResourceId, flags.noPrompt,
-		true, // skipACR — unified azure.yaml does not use container builds
+		skipACR,
 	)
 	if err != nil {
 		if exterrors.IsCancellation(err) {
@@ -844,14 +860,6 @@ func runInitFromAzureYaml(
 		if err := persistFirstDeploymentName(ctx, setEnv, referencedDeployments); err != nil {
 			return fmt.Errorf("failed to set AZURE_AI_MODEL_DEPLOYMENT_NAME: %w", err)
 		}
-	}
-
-	// Apply deploy-mode configuration to the adopted agent service (#8923).
-	// When the user passes --deploy-mode (and optionally --runtime /
-	// --entry-point), or when the service doesn't already specify its deploy
-	// mode, resolve code vs container configuration and update the service.
-	if err := applyDeployModeToAdoptedProject(ctx, flags, azdClient); err != nil {
-		return err
 	}
 
 	fmt.Printf(
@@ -1176,19 +1184,24 @@ func printAdoptionNextSteps(ctx context.Context, azdClient *azdext.AzdClient, fo
 // based on the --deploy-mode, --runtime, and --entry-point flags. When no
 // explicit flag is passed and the service already has a codeConfiguration or
 // docker property, the service is left unchanged (the sample is pre-configured).
+//
+// It reports whether any agent service resolved to a container
+// (Docker) deploy so the caller can decide whether an Azure
+// Container Registry must be wired (existing project) or created
+// on provision.
 func applyDeployModeToAdoptedProject(
 	ctx context.Context,
 	flags *initFlags,
 	azdClient *azdext.AzdClient,
-) error {
+) (bool, error) {
 	// Validate --image flag early (incompatible with --deploy-mode code).
 	if err := validateImageFlag(flags.image, flags.deployMode); err != nil {
-		return err
+		return false, err
 	}
 
 	resp, err := azdClient.Project().Get(ctx, &azdext.EmptyRequest{})
 	if err != nil {
-		return fmt.Errorf("reading adopted project: %w", err)
+		return false, fmt.Errorf("reading adopted project: %w", err)
 	}
 
 	// Collect all agent services in the adopted project.
@@ -1204,53 +1217,68 @@ func applyDeployModeToAdoptedProject(
 	}
 	if len(agentServices) == 0 {
 		// No agent service found -- nothing to configure.
-		return nil
+		return false, nil
 	}
 
-	// Apply configuration to each agent service.
+	// Apply configuration to each agent service, tracking whether any
+	// resolves to a container deploy so the caller can wire an ACR.
+	usesContainer := false
 	for _, agent := range agentServices {
-		if err := applyDeployModeToService(ctx, flags, azdClient, agent.name, agent.svc); err != nil {
-			return err
+		container, err := applyDeployModeToService(ctx, flags, azdClient, agent.name, agent.svc)
+		if err != nil {
+			return false, err
+		}
+		if container {
+			usesContainer = true
 		}
 	}
-	return nil
+	return usesContainer, nil
 }
 
-// applyDeployModeToService applies deploy-mode configuration to a single agent service.
+// applyDeployModeToService applies deploy-mode configuration to a
+// single agent service and reports whether the resolved mode is a
+// container (Docker) deploy. A container deploy that azd builds
+// requires an Azure Container Registry; a code (ZIP) deploy does
+// not. A user-provided --image is a container deploy but uses the
+// caller's own registry, so callers treat --image as skip-ACR.
 func applyDeployModeToService(
 	ctx context.Context,
 	flags *initFlags,
 	azdClient *azdext.AzdClient,
 	serviceName string,
 	svc *azdext.ServiceConfig,
-) error {
+) (bool, error) {
 	// Apply --image override to the agent service when provided.
 	if flags.image != "" {
 		imageValue, err := structpb.NewValue(flags.image)
 		if err != nil {
-			return fmt.Errorf("encoding image value: %w", err)
+			return false, fmt.Errorf("encoding image value: %w", err)
 		}
 		if _, err := azdClient.Project().SetServiceConfigValue(ctx, &azdext.SetServiceConfigValueRequest{
 			ServiceName: serviceName,
 			Path:        "image",
 			Value:       imageValue,
 		}); err != nil {
-			return fmt.Errorf("writing image to agent service %q: %w", serviceName, err)
+			return false, fmt.Errorf("writing image to agent service %q: %w", serviceName, err)
 		}
 		log.Printf("Applied --image %q to agent service %q", flags.image, serviceName)
 
 		// --image implies container deploy; apply container config and return.
-		return applyContainerDeployToService(ctx, azdClient, serviceName, svc)
+		if err := applyContainerDeployToService(ctx, azdClient, serviceName, svc); err != nil {
+			return false, err
+		}
+		return true, nil
 	}
 
 	// Check whether the service already specifies its deploy mode.
 	hasCodeConfig := adoptedServiceHasCodeConfig(svc)
 	hasDocker := adoptedServiceHasDocker(svc)
 
-	// When no explicit --deploy-mode flag is passed and the service is
-	// already configured, respect the sample's existing configuration.
+	// When no explicit --deploy-mode flag is passed and the service
+	// is already configured, respect the sample's existing config. A
+	// pre-configured docker property means container deploy.
 	if flags.deployMode == "" && (hasCodeConfig || hasDocker) {
-		return nil
+		return hasDocker, nil
 	}
 
 	// Use the service's subdirectory for language detection (not project root).
@@ -1262,13 +1290,16 @@ func applyDeployModeToService(
 	// userProvidedManifest is true: -m was explicitly provided.
 	deployMode, err := promptDeployMode(ctx, azdClient, flags.noPrompt, showCodeDeploy, flags.deployMode, true)
 	if err != nil {
-		return fmt.Errorf("resolving deploy mode for adopted project: %w", err)
+		return false, fmt.Errorf("resolving deploy mode for adopted project: %w", err)
 	}
 
 	if deployMode == "code" {
-		return applyCodeDeployToService(ctx, flags, azdClient, serviceName, targetDir, svc)
+		return false, applyCodeDeployToService(ctx, flags, azdClient, serviceName, targetDir, svc)
 	}
-	return applyContainerDeployToService(ctx, azdClient, serviceName, svc)
+	if err := applyContainerDeployToService(ctx, azdClient, serviceName, svc); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // adoptedServiceHasCodeConfig checks whether the adopted agent service already

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_deploymode_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_deploymode_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// deployModeProjectServer is a minimal ProjectService stub that
+// serves a fixed set of services and records the config writes
+// applyDeployModeToService makes.
+type deployModeProjectServer struct {
+	azdext.UnimplementedProjectServiceServer
+
+	mu       sync.Mutex
+	services map[string]*azdext.ServiceConfig
+	sets     map[string]map[string]any // serviceName -> path -> value
+	unsets   map[string][]string       // serviceName -> unset paths
+}
+
+func (s *deployModeProjectServer) Get(
+	_ context.Context, _ *azdext.EmptyRequest,
+) (*azdext.GetProjectResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return &azdext.GetProjectResponse{Project: &azdext.ProjectConfig{Services: s.services}}, nil
+}
+
+func (s *deployModeProjectServer) SetServiceConfigValue(
+	_ context.Context, req *azdext.SetServiceConfigValueRequest,
+) (*azdext.EmptyResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sets == nil {
+		s.sets = map[string]map[string]any{}
+	}
+	if s.sets[req.ServiceName] == nil {
+		s.sets[req.ServiceName] = map[string]any{}
+	}
+	var v any
+	if req.Value != nil {
+		v = req.Value.AsInterface()
+	}
+	s.sets[req.ServiceName][req.Path] = v
+	return &azdext.EmptyResponse{}, nil
+}
+
+func (s *deployModeProjectServer) UnsetServiceConfig(
+	_ context.Context, req *azdext.UnsetServiceConfigRequest,
+) (*azdext.EmptyResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.unsets == nil {
+		s.unsets = map[string][]string{}
+	}
+	s.unsets[req.ServiceName] = append(s.unsets[req.ServiceName], req.Path)
+	return &azdext.EmptyResponse{}, nil
+}
+
+// agentServiceConfig builds an azure.ai.agent ServiceConfig whose
+// additionalProperties carry the supplied deploy-mode block (e.g.
+// "docker" or "codeConfiguration"). Pass a nil block for an
+// unconfigured service.
+func agentServiceConfig(t *testing.T, name string, props map[string]any) *azdext.ServiceConfig {
+	t.Helper()
+	sc := &azdext.ServiceConfig{Name: name, Host: AiAgentHost}
+	if props != nil {
+		st, err := structpb.NewStruct(props)
+		require.NoError(t, err)
+		sc.AdditionalProperties = st
+	}
+	return sc
+}
+
+// TestApplyDeployModeToAdoptedProject verifies that the adopt flow
+// reports whether the resolved deploy mode is a container (Docker)
+// deploy so the caller can wire an Azure Container Registry. A
+// container agent that never reported itself would leave
+// AZURE_CONTAINER_REGISTRY_ENDPOINT unset and fail deploy.
+func TestApplyDeployModeToAdoptedProject(t *testing.T) {
+	const svcName = "agent"
+
+	dockerProps := map[string]any{"docker": map[string]any{"remoteBuild": true}}
+	codeProps := map[string]any{
+		"codeConfiguration": map[string]any{"runtime": "python_3_13", "entryPoint": "app.py"},
+	}
+
+	tests := []struct {
+		name          string
+		flags         *initFlags
+		service       *azdext.ServiceConfig
+		wantContainer bool
+		wantLanguage  any
+		wantDockerSet bool
+		wantCodeSet   bool
+	}{
+		{
+			name:          "explicit container flag wires ACR",
+			flags:         &initFlags{deployMode: "container"},
+			service:       agentServiceConfig(t, svcName, nil),
+			wantContainer: true,
+			wantLanguage:  "docker",
+			wantDockerSet: true,
+		},
+		{
+			name:          "explicit code flag skips ACR",
+			flags:         &initFlags{deployMode: "code", runtime: "python_3_13", entryPoint: "app.py"},
+			service:       agentServiceConfig(t, svcName, nil),
+			wantContainer: false,
+			wantLanguage:  "python",
+			wantCodeSet:   true,
+		},
+		{
+			name:          "prebuilt image is container deploy",
+			flags:         &initFlags{image: "myacr.azurecr.io/agent:v1"},
+			service:       agentServiceConfig(t, svcName, nil),
+			wantContainer: true,
+			wantLanguage:  "docker",
+			wantDockerSet: true,
+		},
+		{
+			name:          "respects sample docker config",
+			flags:         &initFlags{},
+			service:       agentServiceConfig(t, svcName, dockerProps),
+			wantContainer: true,
+		},
+		{
+			name:          "respects sample code config",
+			flags:         &initFlags{},
+			service:       agentServiceConfig(t, svcName, codeProps),
+			wantContainer: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := &deployModeProjectServer{
+				services: map[string]*azdext.ServiceConfig{svcName: tc.service},
+			}
+			client := newProjectRecorderClient(t, server)
+
+			usesContainer, err := applyDeployModeToAdoptedProject(t.Context(), tc.flags, client)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantContainer, usesContainer)
+
+			sets := server.sets[svcName]
+			if tc.wantLanguage != nil {
+				assert.Equal(t, tc.wantLanguage, sets["language"])
+			}
+			if tc.wantDockerSet {
+				assert.Contains(t, sets, "docker")
+			}
+			if tc.wantCodeSet {
+				assert.Contains(t, sets, "codeConfiguration")
+			}
+			// A respected sample config must not be rewritten.
+			if !tc.wantDockerSet && !tc.wantCodeSet && tc.wantLanguage == nil {
+				assert.Empty(t, sets)
+			}
+		})
+	}
+}
+
+// TestApplyDeployModeToAdoptedProject_NoAgentServices verifies that
+// a project without any azure.ai.agent service reports no container
+// deploy (so ACR is skipped) rather than erroring.
+func TestApplyDeployModeToAdoptedProject_NoAgentServices(t *testing.T) {
+	server := &deployModeProjectServer{
+		services: map[string]*azdext.ServiceConfig{
+			"web": {Name: "web", Host: "containerapp"},
+		},
+	}
+	client := newProjectRecorderClient(t, server)
+
+	usesContainer, err := applyDeployModeToAdoptedProject(t.Context(), &initFlags{}, client)
+	require.NoError(t, err)
+	assert.False(t, usesContainer)
+}


### PR DESCRIPTION
Fixes: #8982 

## Problem

`azd ai agent init -m <azure.yaml> --deploy-mode container` on an existing Foundry project finished without resolving a container registry. `azd deploy` then failed:

```
could not determine container registry endpoint, ensure 'registry' has been set in the docker
options or 'AZURE_CONTAINER_REGISTRY_ENDPOINT' environment variable has been set
```

## Root cause

When adopting a unified `azure.yaml`, init configured the Foundry project (including the container-registry step) **before** it knew the deploy mode, and always assumed no registry was needed. So a container agent skipped registry setup and `AZURE_CONTAINER_REGISTRY_ENDPOINT` was never set.

## Fix

Resolve the deploy mode first, then configure the Foundry project. A container deploy now sets up a registry (wire an existing ACR or signal one to be created on provision), while code deploy and a user-supplied `--image` continue to skip it.
