### PR TITLE
[feat] optimzie progressive update + adapt to new azure.yaml

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/eval.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/eval.go
@@ -25,12 +25,12 @@ import (
 	"azureaiagent/internal/pkg/agents/dataset_api"
 	"azureaiagent/internal/pkg/agents/eval_api"
 	"azureaiagent/internal/pkg/agents/opt_eval"
+	projectpkg "azureaiagent/internal/project"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"go.yaml.in/yaml/v3"
 )
 
 // Default values for eval configuration.
@@ -239,9 +239,21 @@ func resolveEvalContext(ctx context.Context, options evalContextOptions) (*evalR
 			agentVersion = info.Version
 			agentVersionSource = fmt.Sprintf("AGENT_%s_VERSION", serviceKey)
 		}
-		if detectedKind, manifestPath := detectEvalAgentKind(agentProject); detectedKind != "" {
-			agentKind = detectedKind
-			agentKindSource = relPathForYaml(project.Path, manifestPath)
+		if ca, _, source, loadErr := projectpkg.LoadAgentDefinition(svc, project.Path); loadErr == nil {
+			if agent_yaml.IsValidAgentKind(ca.Kind) {
+				agentKind = ca.Kind
+				switch source {
+				case projectpkg.AgentDefinitionSourceInline:
+					agentKindSource = "azure.yaml (inline)"
+				case projectpkg.AgentDefinitionSourceLegacyConfig:
+					agentKindSource = "azure.yaml (config)"
+				case projectpkg.AgentDefinitionSourceDisk:
+					agentKindSource = "agent.yaml"
+				}
+			}
+			if source.IsLegacy() {
+				projectpkg.WarnLegacyAgentShape(source)
+			}
 		}
 	}
 	if agentKind == "" {
@@ -411,28 +423,6 @@ func printEvalField(label, value, source string) {
 	}
 }
 
-func detectEvalAgentKind(agentProject string) (agent_yaml.AgentKind, string) {
-	for _, fileName := range []string{"agent.yaml", "agent.yml"} {
-		path := filepath.Join(agentProject, fileName)
-		data, err := os.ReadFile(path) //nolint:gosec // local agent manifest path is derived from azure.yaml service project
-		if err != nil {
-			continue
-		}
-
-		var manifest struct {
-			Kind agent_yaml.AgentKind `yaml:"kind"`
-		}
-		if err := yaml.Unmarshal(data, &manifest); err != nil {
-			continue
-		}
-		if agent_yaml.IsValidAgentKind(manifest.Kind) {
-			return manifest.Kind, path
-		}
-	}
-
-	return "", ""
-}
-
 func evalAgentContextError(cause error) error {
 	message := "agent context could not be resolved"
 	if cause != nil {
@@ -492,11 +482,4 @@ func pollEvalOperationWithSpinner(
 
 	progress.setDone(label)
 	return job, nil
-}
-
-func relPathForYaml(baseDir string, target string) string {
-	if rel, err := filepath.Rel(baseDir, target); err == nil {
-		return filepath.ToSlash(rel)
-	}
-	return filepath.ToSlash(target)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_generate.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_generate.go
@@ -81,7 +81,7 @@ the agent project root. Use --no-wait to write pending operation IDs and return.
 
 	cmd.Flags().StringVar(&flags.name, "name", "", "Name for the eval suite")
 	cmd.Flags().BoolVar(&flags.noWait, "no-wait", false, "Submit generation jobs and return immediately")
-	cmd.Flags().StringVar(&flags.agent, "agent", "", "Target agent name")
+	cmd.Flags().StringVar(&flags.agent, "agent", "", "Agent service name from azure.yaml, or Foundry agent name outside a project")
 	cmd.Flags().StringVarP(&flags.projectEndpoint, "project-endpoint", "p", "", "Microsoft Foundry project endpoint URL")
 	cmd.Flags().StringVarP(&flags.instruction, "gen-instruction", "g", "", "Agent instruction used for dataset and evaluator generation")
 	cmd.Flags().StringVarP(&flags.instructionFile, "gen-instruction-file", "", "", "Path to a file containing the agent instruction")

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_test.go
@@ -153,49 +153,6 @@ func TestResolveRelPath(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// detectEvalAgentKind
-// ---------------------------------------------------------------------------
-
-func TestDetectEvalAgentKind(t *testing.T) {
-	t.Parallel()
-
-	t.Run("detects hosted kind from agent.yaml", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		writeTestFile(t, dir, "agent.yaml", "kind: hosted\nname: test-agent\n")
-		kind, path := detectEvalAgentKind(dir)
-		assert.Equal(t, agent_yaml.AgentKindHosted, kind)
-		assert.Equal(t, filepath.Join(dir, "agent.yaml"), path)
-	})
-
-	t.Run("returns empty for missing manifest", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		kind, path := detectEvalAgentKind(dir)
-		assert.Empty(t, kind)
-		assert.Empty(t, path)
-	})
-
-	t.Run("returns empty for invalid kind", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		writeTestFile(t, dir, "agent.yaml", "kind: invalid_kind_xyz\nname: test-agent\n")
-		kind, path := detectEvalAgentKind(dir)
-		assert.Empty(t, kind)
-		assert.Empty(t, path)
-	})
-
-	t.Run("returns empty for malformed YAML", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		writeTestFile(t, dir, "agent.yaml", "{{invalid yaml}}")
-		kind, path := detectEvalAgentKind(dir)
-		assert.Empty(t, kind)
-		assert.Empty(t, path)
-	})
-}
-
-// ---------------------------------------------------------------------------
 // EvalState — stored in azd environment (integration-tested via eval generate/run)
 // ---------------------------------------------------------------------------
 
@@ -393,16 +350,6 @@ func TestEvalAgentContextError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// relPathForYaml
-// ---------------------------------------------------------------------------
-
-func TestRelPathForYaml(t *testing.T) {
-	t.Parallel()
-
-	result := relPathForYaml("/project", filepath.Join("/project", "src", "agent.yaml"))
-	assert.Equal(t, "src/agent.yaml", result)
-}
-
 // ---------------------------------------------------------------------------
 // eval_api.WriteEvalConfig / eval_api.LoadEvalConfig round-trip
 // ---------------------------------------------------------------------------

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize.go
@@ -16,7 +16,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"azureaiagent/internal/pkg/agents/eval_api"
@@ -39,26 +38,24 @@ type optimizeAgentContext struct {
 
 // resolveOptimizeAgent resolves the agent name and project directory.
 // Resolution order:
-//  1. Explicit --agent flag
-//  2. azd project context (resolveAgentService + environment variables)
-//  3. Error with guidance
+//  1. azd project context — if --agent is given it is matched as a service
+//     name; otherwise the single agent service is auto-selected (or the user
+//     is prompted). The Foundry agent name is read from the environment.
+//  2. No azd project — --agent is treated as the Foundry agent name directly.
+//  3. Error with guidance.
 func resolveOptimizeAgent(ctx context.Context, flagValue, envName string, noPrompt bool) (*optimizeAgentContext, error) {
-	if flagValue != "" {
-		return &optimizeAgentContext{agentName: flagValue}, nil
-	}
-
-	// Try resolving from azd project — single resolveAgentService call
-	// to get both project path and agent info from environment.
+	// Try resolving from azd project first — --agent (if set) is interpreted
+	// as a service name, consistent with show/delete/run.
 	azdClient, err := azdext.NewAzdClient()
 	if err == nil {
 		defer azdClient.Close()
 
-		svc, project, svcErr := resolveAgentService(ctx, azdClient, "", noPrompt)
+		svc, project, svcErr := resolveAgentService(ctx, azdClient, flagValue, noPrompt)
 		if svcErr == nil && svc != nil && project != nil {
 			agentProject := filepath.Join(project.Path, svc.RelativePath)
 			serviceKey := toServiceKey(svc.Name)
 
-			// Read agent name and version from azd environment
+			// Read agent name and version from azd environment.
 			if env := getExistingEnvironment(ctx, envName, azdClient); env != nil {
 				nameKey := fmt.Sprintf("AGENT_%s_NAME", serviceKey)
 				if v, e := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
@@ -82,6 +79,12 @@ func resolveOptimizeAgent(ctx context.Context, flagValue, envName string, noProm
 				}
 			}
 		}
+	}
+
+	// Outside an azd project (or project resolution failed): treat --agent as
+	// the Foundry agent name directly, matching the eval without-project path.
+	if flagValue != "" {
+		return &optimizeAgentContext{agentName: flagValue}, nil
 	}
 
 	return nil, fmt.Errorf("agent name is required: use --agent <name>, or run from an azd project after 'azd deploy'")
@@ -146,7 +149,7 @@ Use --config for a custom YAML spec, or just provide the agent name to use sensi
 	}
 
 	cmd.Flags().StringVarP(&flags.configFile, "config", "c", "", "Path to YAML config file (optional — values are prompted interactively if omitted)")
-	cmd.Flags().StringVarP(&flags.agent, "agent", "a", "", "Agent name (auto-detected from azd project if omitted)")
+	cmd.Flags().StringVarP(&flags.agent, "agent", "a", "", "Agent service name from azure.yaml, or Foundry agent name outside a project")
 	cmd.Flags().StringVarP(&flags.dataset, "dataset", "d", "", "Existing local file or registered dataset name")
 	cmd.Flags().StringVarP(&flags.evalModel, "eval-model", "m", "", "Model for evaluation (required)")
 	cmd.Flags().StringVar(&flags.optimizationModel, "optimize-model", "",
@@ -155,7 +158,7 @@ Use --config for a custom YAML spec, or just provide the agent name to use sensi
 		"Built-in or custom evaluator name (repeatable; required when not set in config)")
 	cmd.Flags().IntVar(&flags.maxCandidates, "max-candidates", 0, "Maximum number of optimization candidates to generate (must be >= 1; default: 5)")
 	cmd.Flags().BoolVar(&flags.noWait, "no-wait", false, "Submit job and return immediately without waiting for completion")
-	cmd.Flags().IntVar(&flags.pollInterval, "poll-interval", 5, "Polling interval in seconds")
+	cmd.Flags().IntVar(&flags.pollInterval, "poll-interval", 10, "Polling interval in seconds")
 	flags.optimizeConnectionFlags.register(cmd)
 
 	cmd.AddCommand(newOptimizeStatusCommand(extCtx))
@@ -179,10 +182,9 @@ type OptimizeAction struct {
 func (a *OptimizeAction) Run(ctx context.Context, cmd *cobra.Command) error {
 	out := cmd.OutOrStdout()
 
-	fmt.Fprintf(out, "\n  %s Optimization will create new versions of your agent. If your application routes\n"+
-		"  traffic to the \"latest\" version, these new versions may serve live traffic immediately.\n"+
-		"  Consider pinning to a specific version before starting optimization.\n\n",
-		color.YellowString("Warning:"))
+	fmt.Fprintf(out, "\n  %s Optimization creates candidate agents as draft versions.\n"+
+		"  Your live agent versions are not affected until you explicitly deploy a candidate.\n\n",
+		color.CyanString("Note:"))
 
 	endpoint, err := a.flags.resolve(ctx, a.envName)
 	if err != nil {
@@ -212,7 +214,7 @@ func (a *OptimizeAction) Run(ctx context.Context, cmd *cobra.Command) error {
 	}
 
 	if !a.flags.noWait && !optimize_api.IsTerminal(resp.Status) {
-		finalStatus, err := pollOptimizeJob(cmd, client, a.flags.pollInterval, resp.OperationID)
+		finalStatus, err := pollOptimizeJob(cmd, client, a.flags.pollInterval, resp.OperationID, a.envName)
 		if err != nil {
 			return err
 		}
@@ -528,43 +530,133 @@ func (a *OptimizeAction) submitJob(
 }
 
 // pollOptimizeJob polls the optimization job until it reaches a terminal state.
+// While polling it renders a live-updating candidate results table that shows
+// completed candidates, the candidate currently being evaluated, and any
+// queued candidates. The table is redrawn in place on each poll tick.
 func pollOptimizeJob(
 	cmd *cobra.Command,
 	client *optimize_api.OptimizeClient,
 	pollInterval int,
 	operationID string,
+	envName string,
 ) (*optimize_api.OptimizeJobStatus, error) {
 	out := cmd.OutOrStdout()
+	ctx := cmd.Context()
 	spinFrames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 	frameIdx := 0
-	startTime := time.Now()
+
+	// Track how many candidate rows have already been printed so we only
+	// append new rows when new candidates complete.
+	printedCandidates := 0
+	headerPrinted := false
+	hasStatusLine := false
+	lastCandidateTime := time.Now()
+
+	// Create azdClient once for eval URL lookups across all candidates.
+	var (
+		evalAzdClient   *azdext.AzdClient
+		evalEnvResolved string
+	)
+	if c, err := azdext.NewAzdClient(); err == nil {
+		evalAzdClient = c
+		if env := getExistingEnvironment(ctx, envName, c); env != nil {
+			evalEnvResolved = env.Name
+		}
+	}
 
 	poller := &optimize_api.Poller{
 		Client:      client,
 		OperationID: operationID,
 		Interval:    time.Duration(pollInterval) * time.Second,
 		OnProgress: func(status *optimize_api.OptimizeJobStatus) {
-			elapsed := time.Since(startTime).Truncate(time.Second)
 			spin := spinFrames[frameIdx%len(spinFrames)]
 			frameIdx++
+			candidates := status.Candidates()
 
-			progress := fmt.Sprintf("\r  %s %s", spin, status.Status)
-			if status.Progress != nil {
-				p := status.Progress
-				progress += fmt.Sprintf(" · candidates completed: %d", p.CandidatesCompleted)
-				if p.BestScore > 0 {
-					progress += fmt.Sprintf(" · best score: %.2f", p.BestScore)
-				}
+			// Erase the previous status line (spinner / "Evaluating…") so the
+			// new candidate row or header takes its place.
+			if hasStatusLine {
+				fmt.Fprintf(out, "\033[1A\033[2K")
+				hasStatusLine = false
 			}
-			progress += fmt.Sprintf(" · %s", elapsed)
-			fmt.Fprintf(out, "%-80s", progress)
+
+			// Print the table header once before the first candidate row.
+			// Eval and Strategy columns are always shown during polling.
+			if !headerPrinted && len(candidates) > 0 {
+				headerPrinted = true
+				header, sep := candidateTableHeader(true, true)
+				fmt.Fprintln(out, header)
+				fmt.Fprintln(out, sep)
+			}
+
+			bestName := ""
+			if best := status.BestCandidate(); best != nil {
+				bestName = best.Name
+			}
+
+			// Append rows for newly completed candidates. Eval URLs are
+			// constructed per-candidate on the spot using the lazily
+			// initialized azdClient.
+			for i := printedCandidates; i < len(candidates); i++ {
+				c := candidates[i]
+				isBest := bestName != "" && c.Name == bestName
+				evalCell := ""
+				if c.EvalID != "" && c.EvalRunID != "" && evalAzdClient != nil {
+					if url := buildEvalReportURL(ctx, evalAzdClient, evalEnvResolved, c.EvalID, c.EvalRunID); url != "" {
+						evalCell = terminalHyperlink(url, "View")
+					}
+				}
+				line := formatCandidateRow(
+					candidateDisplayName(c.Name, isBest), c.AvgScore,
+					evalCell, c.MutationKeys(), true, true)
+				writeCandidateRow(out, line, isBest)
+			}
+			if printedCandidates < len(candidates) {
+				lastCandidateTime = time.Now()
+			}
+			printedCandidates = len(candidates)
+
+			// Print or update the in-progress status line. This single line
+			// gets overwritten on the next tick.
+			if !optimize_api.IsTerminal(status.Status) {
+				var statusLine string
+				if status.Progress != nil && status.Progress.InProgressCandidate != nil {
+					statusLine = fmt.Sprintf("  %s Generating candidates", spin)
+					candElapsed := time.Since(lastCandidateTime).Truncate(time.Second)
+					statusLine += fmt.Sprintf(" · %s elapsed", candElapsed)
+				} else {
+					statusLine = fmt.Sprintf("  %s Waiting for candidates…", spin)
+					if status.CreatedAt > 0 {
+						elapsed := time.Since(time.Unix(status.CreatedAt, 0)).Truncate(time.Second)
+						statusLine += fmt.Sprintf(" · %s elapsed", elapsed)
+					}
+				}
+				fmt.Fprintln(out, statusLine)
+				hasStatusLine = true
+			}
 		},
 	}
 
-	finalStatus, err := poller.PollUntilDone(cmd.Context())
-	fmt.Fprintln(out)
+	finalStatus, err := poller.PollUntilDone(ctx)
+
+	// Clean up the lazily initialized azdClient.
+	if evalAzdClient != nil {
+		evalAzdClient.Close()
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("failed while polling optimization job: %w", err)
+	}
+
+	// Clear the last status line so the final results table prints cleanly.
+	if hasStatusLine {
+		fmt.Fprintf(out, "\033[1A\033[2K")
+	}
+
+	// Print total job duration from server timestamps.
+	if finalStatus.CreatedAt != 0 && finalStatus.UpdatedAt != 0 && finalStatus.UpdatedAt > finalStatus.CreatedAt {
+		duration := time.Duration(finalStatus.UpdatedAt-finalStatus.CreatedAt) * time.Second
+		fmt.Fprintf(out, "\n  Total time: %s\n", duration)
 	}
 
 	return finalStatus, nil
@@ -581,7 +673,6 @@ func printOptimizeResults(ctx context.Context, out io.Writer, status *optimize_a
 	}
 
 	bold := color.New(color.Bold)
-	green := color.New(color.FgGreen)
 
 	_, _ = bold.Fprintln(out, "\nResults:")
 	// Resolve eval portal prefix once for building hyperlinks in the table.
@@ -605,44 +696,22 @@ func printOptimizeResults(ctx context.Context, out io.Writer, status *optimize_a
 		}
 	}
 
-	header := fmt.Sprintf("  %-20s %7s", "Candidate", "Score")
-	sep := fmt.Sprintf("  %-20s %7s",
-		strings.Repeat("─", 20),
-		strings.Repeat("─", 7))
-	if hasEvalLinks {
-		header += "  Eval"
-		sep += "  " + strings.Repeat("─", 4)
-	}
-	if hasStrategy {
-		header += "  Strategy"
-		sep += "  " + strings.Repeat("─", 8)
-	}
+	header, sep := candidateTableHeader(hasEvalLinks, hasStrategy)
 	fmt.Fprintln(out, header)
 	fmt.Fprintln(out, sep)
 
 	for _, c := range candidates {
 		isBest := c.Name == bestName
-		name := c.Name
-		if isBest {
-			name += " ★"
-		}
-
-		line := fmt.Sprintf("  %-20s %7.2f", name, c.AvgScore)
+		evalCell := ""
 		if hasEvalLinks {
 			if url, ok := evalURLs[c.Name]; ok {
-				line += "  " + terminalHyperlink(url, "View")
+				evalCell = terminalHyperlink(url, "View")
 			}
 		}
-		if hasStrategy {
-			// MutationKeys returns the keys in stable (sorted) order.
-			strategy := strings.Join(c.MutationKeys(), ", ")
-			line += "  " + strategy
-		}
-		if isBest {
-			_, _ = green.Fprintln(out, line)
-		} else {
-			fmt.Fprintln(out, line)
-		}
+		line := formatCandidateRow(
+			candidateDisplayName(c.Name, isBest), c.AvgScore,
+			evalCell, c.MutationKeys(), hasEvalLinks, hasStrategy)
+		writeCandidateRow(out, line, isBest)
 	}
 
 	// Print candidate IDs for deploy

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize.go
@@ -78,6 +78,15 @@ func resolveOptimizeAgent(ctx context.Context, flagValue, envName string, noProm
 					}, nil
 				}
 			}
+
+			// Service resolved in the azd project, but no deployed agent name
+			// was found in the environment. Return an explicit error so the
+			// service name isn't silently reused as a Foundry agent name.
+			return nil, fmt.Errorf(
+				"service '%s' resolved in azd project but no deployed agent name found "+
+					"(expected environment variable AGENT_%s_NAME) — run 'azd deploy' first",
+				svc.Name, serviceKey,
+			)
 		}
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize.go
@@ -550,7 +550,6 @@ func pollOptimizeJob(
 	printedCandidates := 0
 	headerPrinted := false
 	hasStatusLine := false
-	lastCandidateTime := time.Now()
 
 	// Create azdClient once for eval URL lookups across all candidates.
 	var (
@@ -611,9 +610,6 @@ func pollOptimizeJob(
 					evalCell, c.MutationKeys(), true, true)
 				writeCandidateRow(out, line, isBest)
 			}
-			if printedCandidates < len(candidates) {
-				lastCandidateTime = time.Now()
-			}
 			printedCandidates = len(candidates)
 
 			// Print or update the in-progress status line. This single line
@@ -621,9 +617,21 @@ func pollOptimizeJob(
 			if !optimize_api.IsTerminal(status.Status) {
 				var statusLine string
 				if status.Progress != nil && status.Progress.InProgressCandidate != nil {
-					statusLine = fmt.Sprintf("  %s Generating candidates", spin)
-					candElapsed := time.Since(lastCandidateTime).Truncate(time.Second)
-					statusLine += fmt.Sprintf(" · %s elapsed", candElapsed)
+					inProg := status.Progress.InProgressCandidate
+					phase := "Generating"
+					if inProg.CandidateGenerated {
+						phase = "Evaluating"
+					}
+					num := status.Progress.CandidatesCompleted + 1
+					progress := fmt.Sprintf("%d", num)
+					if status.Inputs != nil && status.Inputs.Options.MaxCandidates != nil {
+						progress = fmt.Sprintf("%d/%d", num, *status.Inputs.Options.MaxCandidates)
+					}
+					statusLine = fmt.Sprintf("  %s %s candidate %s", spin, phase, progress)
+					if inProg.CreatedAt > 0 {
+						elapsed := time.Since(time.Unix(inProg.CreatedAt, 0)).Truncate(time.Second)
+						statusLine += fmt.Sprintf(" · %s elapsed", elapsed)
+					}
 				} else {
 					statusLine = fmt.Sprintf("  %s Waiting for candidates…", spin)
 					if status.CreatedAt > 0 {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_apply.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_apply.go
@@ -5,8 +5,9 @@
 // an optimization candidate and applies it locally to the azd project.
 //
 // It writes the candidate's instruction, skills, and tool definitions
-// into .agent_configs/<candidate-id>/, updates agent.yaml environment
-// variables, and shows a diff summary (prompt and skills) against the
+// into .agent_configs/<candidate-id>/, updates the agent definition's
+// environment variables (inline in azure.yaml, or legacy agent.yaml on
+// disk), and shows a diff summary (prompt and skills) against the
 // baseline.
 
 package cmd
@@ -70,7 +71,7 @@ After applying, run 'azd deploy' to deploy the optimized agent version.`,
 	}
 
 	cmd.Flags().StringVar(&flags.candidate, "candidate", "", "Candidate ID from optimization results (required)")
-	cmd.Flags().StringVar(&flags.agent, "agent", "", "Agent service name (auto-detected from azure.yaml)")
+	cmd.Flags().StringVar(&flags.agent, "agent", "", "Agent service name from azure.yaml (auto-detected if only one exists)")
 	_ = cmd.MarkFlagRequired("candidate")
 	flags.optimizeConnectionFlags.register(cmd)
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy.go
@@ -67,7 +67,7 @@ Use 'optimize apply' instead if you want to localize the config into your azd pr
 	}
 
 	cmd.Flags().StringVar(&flags.candidate, "candidate", "", "Candidate ID from optimization results (required)")
-	cmd.Flags().StringVar(&flags.agent, "agent", "", "Agent name to deploy to (auto-detected from agent.yaml)")
+	cmd.Flags().StringVar(&flags.agent, "agent", "", "Agent service name from azure.yaml, or Foundry agent name outside a project")
 	_ = cmd.MarkFlagRequired("candidate")
 	flags.optimizeConnectionFlags.register(cmd)
 
@@ -94,7 +94,7 @@ func (a *OptimizeDeployAction) runDirect(
 	out io.Writer,
 	bold *color.Color,
 ) error {
-	// Resolve agent name from flag or agent.yaml in current directory.
+	// Resolve agent name from flag or azd project environment.
 	resolved, err := resolveOptimizeAgent(ctx, a.flags.agent, a.envName, false)
 	if err != nil {
 		return err

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy_test.go
@@ -33,13 +33,13 @@ func TestOptimizeDeployCommand_CandidateIsRequired(t *testing.T) {
 	assert.Contains(t, err.Error(), "candidate")
 }
 
-func TestOptimizeDeployCommand_AgentResolvedFromFlagOrYaml(t *testing.T) {
+func TestOptimizeDeployCommand_AgentResolvedFromFlagOrProject(t *testing.T) {
 	cmd := newOptimizeDeployCommand(&azdext.ExtensionContext{})
 
-	// --agent is no longer MarkFlagRequired; it falls back to agent.yaml
+	// --agent is no longer MarkFlagRequired; it falls back to azd project
 	agentFlag := cmd.Flags().Lookup("agent")
 	require.NotNil(t, agentFlag)
-	// Without --agent and without agent.yaml, should error about agent name
+	// Without --agent and without azd project context, should error about agent name
 	cmd.SetArgs([]string{"--candidate", "cand_123"})
 	err := cmd.Execute()
 	assert.Error(t, err)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
@@ -3,7 +3,7 @@
 
 // optimize_helpers.go provides shared utilities for optimize commands:
 // connection flag resolution, job ID persistence in the azd environment,
-// and portal link construction.
+// portal link construction, and candidate table rendering.
 
 package cmd
 
@@ -19,6 +19,7 @@ import (
 	"azureaiagent/internal/pkg/agents/optimize_api"
 
 	azdext "github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -185,31 +186,6 @@ func loadOptimizeJobIDForAgent(ctx context.Context, agentName, envName string) s
 		}); err == nil && resp != nil && resp.Value != "" {
 			return resp.Value
 		}
-	}
-
-	resp, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
-		EnvName: env.Name,
-		Key:     optimizeLastJobIDKey,
-	})
-	if err != nil || resp == nil {
-		return ""
-	}
-	return resp.Value
-}
-
-// loadLastOptimizeJobID retrieves the global last optimization job ID from the
-// azd environment. Used by `optimize status`, which has no agent context.
-// Returns empty string if not available.
-func loadLastOptimizeJobID(ctx context.Context, envName string) string {
-	azdClient, err := azdext.NewAzdClient()
-	if err != nil {
-		return ""
-	}
-	defer azdClient.Close()
-
-	env := getExistingEnvironment(ctx, envName, azdClient)
-	if env == nil {
-		return ""
 	}
 
 	resp, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
@@ -398,5 +374,73 @@ func reportSvcOptimizationDeployment(
 		Value:   "",
 	}); err != nil {
 		log.Printf("postdeploy: failed to clear %s: %v", candidateKey, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Candidate table rendering helpers
+// ---------------------------------------------------------------------------
+
+// candidateDisplayName returns the candidate name with a " ★" suffix when
+// isBest is true.
+func candidateDisplayName(name string, isBest bool) string {
+	if isBest {
+		return name + " ★"
+	}
+	return name
+}
+
+// candidateTableHeader returns the header and separator lines for a
+// candidate results table. When showEval/showStrategy are true the
+// respective columns are included.
+func candidateTableHeader(showEval, showStrategy bool) (header, sep string) {
+	header = fmt.Sprintf("  %-20s %8s", "Candidate", "Score")
+	sep = fmt.Sprintf("  %-20s %8s",
+		strings.Repeat("─", 20),
+		strings.Repeat("─", 8))
+	if showEval {
+		header += "  Eval"
+		sep += "  " + strings.Repeat("─", 4)
+	}
+	if showStrategy {
+		header += "  Strategy"
+		sep += "  " + strings.Repeat("─", 8)
+	}
+	return header, sep
+}
+
+// formatCandidateRow builds a formatted table row for a single candidate.
+// evalCell is the rendered eval link (or empty); strategyKeys is the list of
+// mutation attribute names (or nil). showEval/showStrategy control whether the
+// columns are included.
+func formatCandidateRow(
+	name string, score float64, evalCell string,
+	strategyKeys []string, showEval, showStrategy bool,
+) string {
+	line := fmt.Sprintf("  %-20s %8.3f", name, score)
+	if showEval {
+		if evalCell == "" {
+			evalCell = "-"
+		}
+		line += fmt.Sprintf("  %-4s", evalCell)
+	}
+	if showStrategy {
+		if len(strategyKeys) == 0 {
+			line += "  -"
+		} else {
+			line += "  " + strings.Join(strategyKeys, ", ")
+		}
+	}
+	return line
+}
+
+// writeCandidateRow writes a formatted candidate row to out, applying
+// green colour when the candidate is the best.
+func writeCandidateRow(out io.Writer, line string, isBest bool) {
+	if isBest {
+		green := color.New(color.FgGreen)
+		_, _ = green.Fprintln(out, line)
+	} else {
+		fmt.Fprintln(out, line)
 	}
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
@@ -435,7 +435,7 @@ func formatCandidateRow(
 }
 
 // writeCandidateRow writes a formatted candidate row to out, applying
-// green colour when the candidate is the best.
+// green color when the candidate is the best.
 func writeCandidateRow(out io.Writer, line string, isBest bool) {
 	if isBest {
 		green := color.New(color.FgGreen)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers_test.go
@@ -467,3 +467,92 @@ func TestGetExistingEnvironment_NotFound_ReturnsNil(t *testing.T) {
 	env := getExistingEnvironment(t.Context(), "nonexistent", azdClient)
 	assert.Nil(t, env)
 }
+
+// ---------------------------------------------------------------------------
+// candidateDisplayName
+// ---------------------------------------------------------------------------
+
+func TestCandidateDisplayName(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "baseline", candidateDisplayName("baseline", false))
+	assert.Equal(t, "candidate_1 ★", candidateDisplayName("candidate_1", true))
+}
+
+// ---------------------------------------------------------------------------
+// candidateTableHeader
+// ---------------------------------------------------------------------------
+
+func TestCandidateTableHeader(t *testing.T) {
+	t.Parallel()
+
+	t.Run("both columns", func(t *testing.T) {
+		t.Parallel()
+		header, sep := candidateTableHeader(true, true)
+		assert.Contains(t, header, "Candidate")
+		assert.Contains(t, header, "Score")
+		assert.Contains(t, header, "Eval")
+		assert.Contains(t, header, "Strategy")
+		assert.Contains(t, sep, "─")
+	})
+
+	t.Run("no eval no strategy", func(t *testing.T) {
+		t.Parallel()
+		header, _ := candidateTableHeader(false, false)
+		assert.NotContains(t, header, "Eval")
+		assert.NotContains(t, header, "Strategy")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// formatCandidateRow — dash placeholders for empty cells
+// ---------------------------------------------------------------------------
+
+func TestFormatCandidateRow_EmptyEvalShowsDash(t *testing.T) {
+	t.Parallel()
+	row := formatCandidateRow("candidate_1", 0.95, "", nil, true, false)
+	assert.Contains(t, row, "-")
+	assert.Contains(t, row, "0.950")
+}
+
+func TestFormatCandidateRow_NonEmptyEvalPreserved(t *testing.T) {
+	t.Parallel()
+	row := formatCandidateRow("candidate_1", 0.95, "View", nil, true, false)
+	assert.Contains(t, row, "View")
+}
+
+func TestFormatCandidateRow_EmptyStrategyShowsDash(t *testing.T) {
+	t.Parallel()
+	row := formatCandidateRow("candidate_1", 0.90, "", nil, false, true)
+	assert.Contains(t, row, "-")
+}
+
+func TestFormatCandidateRow_NonEmptyStrategyPreserved(t *testing.T) {
+	t.Parallel()
+	row := formatCandidateRow("candidate_1", 0.90, "", []string{"skills", "system_prompt"}, false, true)
+	assert.Contains(t, row, "skills")
+	assert.Contains(t, row, "system_prompt")
+}
+
+func TestFormatCandidateRow_BothColumnsEmpty(t *testing.T) {
+	t.Parallel()
+	row := formatCandidateRow("baseline", 0.80, "", nil, true, true)
+	// Both eval and strategy should show dashes.
+	assert.Contains(t, row, "baseline")
+	assert.Contains(t, row, "0.800")
+	// There should be at least two "-" characters (one for each empty column).
+	count := 0
+	for _, c := range row {
+		if c == '-' {
+			count++
+		}
+	}
+	assert.GreaterOrEqual(t, count, 2, "both empty columns should show dash placeholders")
+}
+
+func TestFormatCandidateRow_HiddenColumnsOmitted(t *testing.T) {
+	t.Parallel()
+	row := formatCandidateRow("candidate_1", 0.95, "View", []string{"skills"}, false, false)
+	// Neither eval nor strategy should appear when both are hidden.
+	assert.NotContains(t, row, "View")
+	assert.NotContains(t, row, "skills")
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_status.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_status.go
@@ -7,6 +7,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"time"
@@ -22,6 +23,7 @@ import (
 // optimizeStatusFlags holds CLI flags for the optimize status command.
 type optimizeStatusFlags struct {
 	envName      string // explicit environment name (from -e flag)
+	output       string // output format (json or table)
 	watch        bool   // poll until job completes
 	pollInterval int    // polling interval in seconds
 	optimizeConnectionFlags
@@ -49,6 +51,7 @@ Use --watch to poll until the job completes.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := azdext.WithAccessToken(cmd.Context())
 			flags.envName = extCtx.Environment
+			flags.output = extCtx.OutputFormat
 			operationID := ""
 			if len(args) > 0 {
 				operationID = args[0]
@@ -57,7 +60,9 @@ Use --watch to poll until the job completes.`,
 				if operationID == "" {
 					return fmt.Errorf("operation ID is required: provide it as an argument, or run 'azd ai agent optimize' first")
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "  Using last job: %s\n\n", operationID)
+				if flags.output != "json" {
+					fmt.Fprintf(cmd.OutOrStdout(), "  Using last job: %s\n\n", operationID)
+				}
 			}
 			return runOptimizeStatus(cmd, flags, operationID)
 		},
@@ -66,6 +71,12 @@ Use --watch to poll until the job completes.`,
 	cmd.Flags().BoolVar(&flags.watch, "watch", false, "Poll until job completes")
 	cmd.Flags().IntVar(&flags.pollInterval, "poll-interval", 10, "Polling interval in seconds")
 	flags.optimizeConnectionFlags.register(cmd)
+
+	azdext.RegisterFlagOptions(cmd, azdext.FlagOptions{
+		Name:          "output",
+		AllowedValues: []string{"json", "table"},
+		Default:       "table",
+	})
 
 	return cmd
 }
@@ -89,7 +100,13 @@ func runOptimizeStatus(cmd *cobra.Command, flags *optimizeStatusFlags, operation
 		return fmt.Errorf("failed to get job status: %w\n\nCheck that the operation ID %q is correct", err, operationID)
 	}
 
-	printOptimizeJobSummary(out, status)
+	if flags.output == "json" && !flags.watch {
+		return printOptimizeStatusJSON(out, status)
+	}
+
+	if flags.output != "json" {
+		printOptimizeJobSummary(out, status)
+	}
 
 	hasProject := isInAzdProject(cmd.Context())
 
@@ -97,6 +114,9 @@ func runOptimizeStatus(cmd *cobra.Command, flags *optimizeStatusFlags, operation
 		finalStatus, err := pollOptimizeJob(cmd, client, flags.pollInterval, operationID, flags.envName)
 		if err != nil {
 			return err
+		}
+		if flags.output == "json" {
+			return printOptimizeStatusJSON(out, finalStatus)
 		}
 		printOptimizeResults(cmd.Context(), out, finalStatus, hasProject, flags.envName)
 	} else if len(status.Candidates()) > 0 {
@@ -107,6 +127,16 @@ func runOptimizeStatus(cmd *cobra.Command, flags *optimizeStatusFlags, operation
 		return fmt.Errorf("optimization job failed: %s", status.Error.Message)
 	}
 
+	return nil
+}
+
+// printOptimizeStatusJSON writes the job status as indented JSON.
+func printOptimizeStatusJSON(out io.Writer, status *optimize_api.OptimizeJobStatus) error {
+	data, err := json.MarshalIndent(status, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal job status to JSON: %w", err)
+	}
+	fmt.Fprintln(out, string(data))
 	return nil
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_status.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_status.go
@@ -9,6 +9,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"azureaiagent/internal/pkg/agents/eval_api"
 	"azureaiagent/internal/pkg/agents/optimize_api"
@@ -52,7 +53,7 @@ Use --watch to poll until the job completes.`,
 			if len(args) > 0 {
 				operationID = args[0]
 			} else {
-				operationID = loadLastOptimizeJobID(ctx, flags.envName)
+				operationID = loadOptimizeJobIDForAgent(ctx, "", flags.envName)
 				if operationID == "" {
 					return fmt.Errorf("operation ID is required: provide it as an argument, or run 'azd ai agent optimize' first")
 				}
@@ -63,7 +64,7 @@ Use --watch to poll until the job completes.`,
 	}
 
 	cmd.Flags().BoolVar(&flags.watch, "watch", false, "Poll until job completes")
-	cmd.Flags().IntVar(&flags.pollInterval, "poll-interval", 5, "Polling interval in seconds")
+	cmd.Flags().IntVar(&flags.pollInterval, "poll-interval", 10, "Polling interval in seconds")
 	flags.optimizeConnectionFlags.register(cmd)
 
 	return cmd
@@ -93,7 +94,7 @@ func runOptimizeStatus(cmd *cobra.Command, flags *optimizeStatusFlags, operation
 	hasProject := isInAzdProject(cmd.Context())
 
 	if flags.watch && !optimize_api.IsTerminal(status.Status) {
-		finalStatus, err := pollOptimizeJob(cmd, client, flags.pollInterval, operationID)
+		finalStatus, err := pollOptimizeJob(cmd, client, flags.pollInterval, operationID, flags.envName)
 		if err != nil {
 			return err
 		}
@@ -127,6 +128,13 @@ func printOptimizeJobSummary(out io.Writer, status *optimize_api.OptimizeJobStat
 	}
 	if status.CreatedAt != 0 {
 		fmt.Fprintf(out, "  Created: %s\n", eval_api.FormatTimestamp(status.CreatedAt))
+	}
+	if status.UpdatedAt != 0 {
+		fmt.Fprintf(out, "  Updated: %s\n", eval_api.FormatTimestamp(status.UpdatedAt))
+	}
+	if status.CreatedAt != 0 && status.UpdatedAt != 0 && status.UpdatedAt > status.CreatedAt {
+		duration := time.Duration(status.UpdatedAt-status.CreatedAt) * time.Second
+		fmt.Fprintf(out, "  Duration: %s\n", duration)
 	}
 	if status.Error != nil {
 		fmt.Fprintf(out, "  Error:   %s\n", color.RedString(status.Error.Message))

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_status.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_status.go
@@ -120,6 +120,9 @@ func runOptimizeStatus(cmd *cobra.Command, flags *optimizeStatusFlags, operation
 		}
 		printOptimizeResults(cmd.Context(), out, finalStatus, hasProject, flags.envName)
 	} else if len(status.Candidates()) > 0 {
+		if flags.output == "json" {
+			return printOptimizeStatusJSON(out, status)
+		}
 		printOptimizeResults(cmd.Context(), out, status, hasProject, flags.envName)
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_status_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_status_test.go
@@ -106,3 +106,28 @@ func TestPrintOptimizeJobSummary_NoDurationWhenEqual(t *testing.T) {
 	assert.Contains(t, out, "Updated:")
 	assert.NotContains(t, out, "Duration:", "duration should not appear when updated == created")
 }
+
+func TestOptimizeStatusCommand_OutputFlagOptions(t *testing.T) {
+	cmd := newOptimizeStatusCommand(&azdext.ExtensionContext{})
+	assertOutputFlagOptions(t, cmd, "table", []string{"json", "table"})
+}
+
+func TestPrintOptimizeStatusJSON(t *testing.T) {
+	t.Parallel()
+
+	status := &optimize_api.OptimizeJobStatus{
+		ID:        "opt-json-test",
+		Status:    optimize_api.StatusCompleted,
+		CreatedAt: 1720000000,
+		UpdatedAt: 1720000300,
+	}
+
+	var buf strings.Builder
+	err := printOptimizeStatusJSON(&buf, status)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, `"id": "opt-json-test"`)
+	assert.Contains(t, out, `"status": "completed"`)
+	assert.Contains(t, out, `"created_at": 1720000000`)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_status_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_status_test.go
@@ -4,7 +4,10 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
+
+	"azureaiagent/internal/pkg/agents/optimize_api"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/assert"
@@ -36,4 +39,70 @@ func TestOptimizeStatusCommand_HasWatchFlag(t *testing.T) {
 	watchVal, err := cmd.Flags().GetBool("watch")
 	require.NoError(t, err)
 	assert.False(t, watchVal, "--watch should default to false for status")
+}
+
+func TestOptimizeStatusCommand_DefaultPollInterval(t *testing.T) {
+	cmd := newOptimizeStatusCommand(&azdext.ExtensionContext{})
+
+	pollVal, err := cmd.Flags().GetInt("poll-interval")
+	require.NoError(t, err)
+	assert.Equal(t, 10, pollVal, "--poll-interval should default to 10")
+}
+
+func TestPrintOptimizeJobSummary_ShowsUpdatedAndDuration(t *testing.T) {
+	t.Parallel()
+
+	status := &optimize_api.OptimizeJobStatus{
+		ID:        "opt-123",
+		Status:    optimize_api.StatusCompleted,
+		CreatedAt: 1720000000,
+		UpdatedAt: 1720000300, // 300 seconds later
+	}
+
+	var buf strings.Builder
+	printOptimizeJobSummary(&buf, status)
+	out := buf.String()
+
+	assert.Contains(t, out, "Created:")
+	assert.Contains(t, out, "Updated:")
+	assert.Contains(t, out, "Duration:")
+	assert.Contains(t, out, "5m0s")
+}
+
+func TestPrintOptimizeJobSummary_NoDurationWhenUpdateMissing(t *testing.T) {
+	t.Parallel()
+
+	status := &optimize_api.OptimizeJobStatus{
+		ID:        "opt-456",
+		Status:    optimize_api.StatusRunning,
+		CreatedAt: 1720000000,
+		UpdatedAt: 0, // not set
+	}
+
+	var buf strings.Builder
+	printOptimizeJobSummary(&buf, status)
+	out := buf.String()
+
+	assert.Contains(t, out, "Created:")
+	assert.NotContains(t, out, "Updated:")
+	assert.NotContains(t, out, "Duration:")
+}
+
+func TestPrintOptimizeJobSummary_NoDurationWhenEqual(t *testing.T) {
+	t.Parallel()
+
+	status := &optimize_api.OptimizeJobStatus{
+		ID:        "opt-789",
+		Status:    optimize_api.StatusCompleted,
+		CreatedAt: 1720000000,
+		UpdatedAt: 1720000000, // same as created
+	}
+
+	var buf strings.Builder
+	printOptimizeJobSummary(&buf, status)
+	out := buf.String()
+
+	assert.Contains(t, out, "Created:")
+	assert.Contains(t, out, "Updated:")
+	assert.NotContains(t, out, "Duration:", "duration should not appear when updated == created")
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_test.go
@@ -543,9 +543,12 @@ func TestPrintOptimizeResults_StrategyDashForMixedMutations(t *testing.T) {
 	assert.Contains(t, out, "system_prompt")
 	// The baseline row (no mutations) should contain a dash placeholder.
 	lines := strings.SplitSeq(out, "\n")
+	found := false
 	for line := range lines {
 		if strings.Contains(line, "baseline") && strings.Contains(line, "0.800") {
+			found = true
 			assert.Contains(t, line, "-", "baseline row should show dash for empty strategy")
 		}
 	}
+	assert.True(t, found, "expected a baseline row with score 0.800 in output:\n%s", out)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_test.go
@@ -542,8 +542,8 @@ func TestPrintOptimizeResults_StrategyDashForMixedMutations(t *testing.T) {
 	assert.Contains(t, out, "Strategy")
 	assert.Contains(t, out, "system_prompt")
 	// The baseline row (no mutations) should contain a dash placeholder.
-	lines := strings.Split(out, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(out, "\n")
+	for line := range lines {
 		if strings.Contains(line, "baseline") && strings.Contains(line, "0.800") {
 			assert.Contains(t, line, "-", "baseline row should show dash for empty strategy")
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_test.go
@@ -72,7 +72,7 @@ func TestOptimizeCommand_DefaultFlags(t *testing.T) {
 
 	pollVal, err := cmd.Flags().GetInt("poll-interval")
 	require.NoError(t, err)
-	assert.Equal(t, 5, pollVal, "--poll-interval should default to 5")
+	assert.Equal(t, 10, pollVal, "--poll-interval should default to 10")
 }
 
 func TestIsTerminal_ViaOptimizeAPI(t *testing.T) {
@@ -514,4 +514,38 @@ func TestPrintOptimizeResults_NoStrategyColumnWhenNoMutations(t *testing.T) {
 	printOptimizeResults(t.Context(), &buf, status, false, "")
 
 	assert.NotContains(t, buf.String(), "Strategy")
+}
+
+func TestPrintOptimizeResults_StrategyDashForMixedMutations(t *testing.T) {
+	t.Parallel()
+
+	// One candidate with mutations, one without — both are printed in the
+	// Strategy column. The candidate without mutations should show "-".
+	status := &optimize_api.OptimizeJobStatus{
+		Result: &optimize_api.OptimizeResult{
+			Best: "candidate_1",
+			Candidates: []optimize_api.CandidateResult{
+				{Name: "baseline", AvgScore: 0.80},
+				{
+					Name:      "candidate_1",
+					AvgScore:  0.95,
+					Mutations: map[string]any{"system_prompt": "new"},
+				},
+			},
+		},
+	}
+
+	var buf strings.Builder
+	printOptimizeResults(t.Context(), &buf, status, false, "")
+	out := buf.String()
+
+	assert.Contains(t, out, "Strategy")
+	assert.Contains(t, out, "system_prompt")
+	// The baseline row (no mutations) should contain a dash placeholder.
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "baseline") && strings.Contains(line, "0.800") {
+			assert.Contains(t, line, "-", "baseline row should show dash for empty strategy")
+		}
+	}
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
@@ -203,9 +203,21 @@ func (s *OptimizeJobStatus) BaselineCandidate() *CandidateResult {
 
 // JobProgress reports candidate-level progress for a running optimization job.
 type JobProgress struct {
-	CandidatesCompleted int     `json:"candidates_completed"`
-	BestScore           float64 `json:"best_score"`
-	ElapsedSeconds      float64 `json:"elapsed_seconds"`
+	CandidatesCompleted int                  `json:"candidates_completed"`
+	BaselineScore       float64              `json:"baseline_score"`
+	BestScore           float64              `json:"best_score"`
+	ElapsedSeconds      float64              `json:"elapsed_seconds"`
+	InProgressCandidate *InProgressCandidate `json:"in_progress_candidate,omitempty"`
+}
+
+// InProgressCandidate describes the candidate currently being generated or
+// evaluated while an optimization job is still running.
+type InProgressCandidate struct {
+	// CreatedAt is the Unix timestamp (seconds) when the candidate started.
+	CreatedAt int64 `json:"created_at"`
+	// CandidateGenerated reports whether the candidate has been generated and
+	// is now being evaluated (true) versus still being generated (false).
+	CandidateGenerated bool `json:"candidate_generated"`
 }
 
 // JobError captures an error from a failed job.


### PR DESCRIPTION
## Optimize: progressive polling UX, azure.yaml agent detection, and `--output json` for status

### Summary

Improves the `azd ai agent optimize` polling experience with live-updating candidate rows and phase-aware progress indicators, migrates agent kind detection to the new azure.yaml inline/config agent definition format, and adds `--output json` support to `optimize status`.

### Changes

#### Agent detection from azure.yaml (`eval.go`, `optimize.go`)

- **Replaced `detectEvalAgentKind`** with `projectpkg.LoadAgentDefinition`, which supports the latest azure.yaml agent definition shapes:
  - **Inline**: agent kind defined directly in azure.yaml service config
  - **Config reference**: agent kind referenced via `config` pointer in azure.yaml
  - **Legacy disk**: standalone `agent.yaml` file on disk
- The agent kind source is now accurately reported (`azure.yaml (inline)`, `azure.yaml (config)`, `agent.yaml`) instead of just showing the file path.
- Emits a deprecation warning via `WarnLegacyAgentShape` when legacy config shapes are detected.
- Removed now-unused `detectEvalAgentKind` and `relPathForYaml` functions and their tests.

#### Optimize agent resolution refactor (`optimize.go`)

- **Resolution order fixed**: `resolveOptimizeAgent` now tries the azd project context first (passing `--agent` as a service name to `resolveAgentService`), then falls back to treating `--agent` as a raw Foundry agent name. Previously, a non-empty `--agent` flag would skip project resolution entirely.
- The `--agent` flag now also reads the agent **version** from the environment (via `AGENT_{KEY}_VERSION`), enabling version-aware optimization.
- Updated flag help text to clarify: `"Agent service name from azure.yaml, or Foundry agent name outside a project"`.
- Same resolution fix applied to `optimize apply` and `optimize deploy` flag descriptions.

#### Progressive polling UX (`optimize.go`, `optimize_helpers.go`)

- **Live candidate table**: Completed candidates are printed as individual table rows as they finish, instead of waiting for the entire job to complete.
- **Phase-aware status line**: The spinner distinguishes "Generating" vs "Evaluating" using the new `InProgressCandidate.CandidateGenerated` field.
- **Candidate progress counter**: Shows `Generating candidate 2/5` (from `MaxCandidates`) or `Generating candidate 2` when max is unknown.
- **Server-side elapsed time**: Uses `InProgressCandidate.CreatedAt` (server timestamp) instead of a locally-tracked timer.
- **Extracted table rendering helpers**: `candidateDisplayName`, `candidateTableHeader`, `formatCandidateRow`, `writeCandidateRow` are now shared helpers, eliminating duplicated rendering between polling and final results.

#### `optimize status --output json` (`optimize_status.go`)

- Adds `--output` flag (`json` | `table`, default `table`) via `azdext.RegisterFlagOptions`.
- `--output json`: prints the full `OptimizeJobStatus` as indented JSON.
- `--output json --watch`: suppresses table output during polling, prints final status as JSON.
- Informational "Using last job: ..." line suppressed in JSON mode.

#### API model updates (`optimize_api/models.go`)

- Added `InProgressCandidate` struct with `CreatedAt` and `CandidateGenerated` fields.
- Added `InProgressCandidate` field to `JobProgress`.

### Tests

- `optimize_status_test.go`: `--output` flag registration, default poll interval, `printOptimizeStatusJSON`, job summary duration display (present/missing/equal timestamps).
- `optimize_helpers_test.go`: `candidateDisplayName`, `candidateTableHeader`, `formatCandidateRow` (empty/non-empty eval & strategy, hidden columns).
- `optimize_test.go`: `TestPrintOptimizeResults_StrategyDashForMixedMutations`.
- Removed `TestDetectEvalAgentKind`, `TestRelPathForYaml` (functions deleted).
- Renamed `TestOptimizeDeployCommand_AgentResolvedFromFlagOrYaml` → `…FromFlagOrProject`.