### PR TITLE
Add resource group location mismatch provision validation check (azure.ai.agents)

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/extension.yaml
+++ b/cli/azd/extensions/azure.ai.agents/extension.yaml
@@ -17,6 +17,7 @@ capabilities:
   - mcp-server
   - service-target-provider
   - provisioning-provider
+  - validation-provider
   - metadata
 providers:
   - name: azure.ai.agent

--- a/cli/azd/extensions/azure.ai.agents/extension.yaml
+++ b/cli/azd/extensions/azure.ai.agents/extension.yaml
@@ -6,7 +6,7 @@ description: Ship agents with Microsoft Foundry from your terminal. (Beta)
 usage: azd ai agent <command> [options]
 # NOTE: Make sure version.txt is in sync with this version.
 version: 1.0.0-beta.5
-requiredAzdVersion: ">=1.27.0"
+requiredAzdVersion: ">=1.27.1"
 dependencies:
   - id: azure.ai.inspector
     version: "~1.0.0-beta.1"

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
@@ -38,6 +38,13 @@ func configureExtensionHost(host *azdext.ExtensionHost) {
 		WithProvisioningProvider(project.FoundryProviderName, func() azdext.ProvisioningProvider {
 			return project.NewFoundryProvisioningProvider(azdClient)
 		}).
+		WithValidationCheck(azdext.ValidationCheckRegistration{
+			CheckType: "local-preflight",
+			RuleID:    project.ResourceGroupLocationRuleID,
+			Factory: func() azdext.ValidationCheckProvider {
+				return project.NewResourceGroupLocationCheck(azdClient)
+			},
+		}).
 		WithProjectEventHandler("preprovision", func(ctx context.Context, args *azdext.ProjectEventArgs) error {
 			return preprovisionHandler(ctx, azdClient, args)
 		}).

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
@@ -39,7 +39,11 @@ func configureExtensionHost(host *azdext.ExtensionHost) {
 			return project.NewFoundryProvisioningProvider(azdClient)
 		}).
 		WithValidationCheck(azdext.ValidationCheckRegistration{
-			CheckType: "local-preflight",
+			// Provider-agnostic check: runs before provisioning regardless of the
+			// provisioning provider. This matters because the azure.ai.agents
+			// extension provisions through its own microsoft.foundry provider,
+			// which never triggers the Bicep-only "local-preflight" checks.
+			CheckType: azdext.ValidationCheckTypeProvision,
 			RuleID:    project.ResourceGroupLocationRuleID,
 			Factory: func() azdext.ValidationCheckProvider {
 				return project.NewResourceGroupLocationCheck(azdClient)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check.go
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"azureaiagent/internal/pkg/azure"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+)
+
+// ResourceGroupLocationRuleID is the stable identifier for the resource-group
+// location-mismatch local-preflight check.
+const ResourceGroupLocationRuleID = "resource_group_location_mismatch"
+
+// ResourceGroupLocationCheck is a local-preflight validation check that detects an
+// immutable resource-group region conflict before provisioning starts.
+//
+// The azure.ai.agents extension writes a stable, salted resource group name to
+// AZURE_RESOURCE_GROUP at init. If AZURE_LOCATION is later changed (for example by
+// re-running init, adopting a Foundry project in a different region, or a manual
+// `azd env set`) while that resource group already exists in the original region,
+// the subscription-scoped provisioning deployment fails with the ARM error
+// "InvalidResourceGroupLocation" — a resource group's region cannot be changed.
+//
+// Surfacing the conflict here turns a slow, cryptic deploy-time failure into fast,
+// actionable guidance during azd's validation phase.
+type ResourceGroupLocationCheck struct {
+	azdClient *azdext.AzdClient
+}
+
+// NewResourceGroupLocationCheck creates a new ResourceGroupLocationCheck.
+func NewResourceGroupLocationCheck(azdClient *azdext.AzdClient) *ResourceGroupLocationCheck {
+	return &ResourceGroupLocationCheck{azdClient: azdClient}
+}
+
+// Validate implements azdext.ValidationCheckProvider.
+//
+// The check is best-effort: any inability to determine the situation (missing
+// environment values, auth failure, resource group not found, or an API error)
+// yields no results so that validation is never blocked by the check itself.
+// Only a definitive mismatch — the resource group exists in a different region —
+// produces a blocking error result.
+func (c *ResourceGroupLocationCheck) Validate(
+	ctx context.Context,
+	valCtx *azdext.ValidationContext,
+	_ *azdext.ValidationCheckRequest,
+) (*azdext.ValidationCheckResponse, error) {
+	empty := &azdext.ValidationCheckResponse{}
+
+	envClient := c.azdClient.Environment()
+	envResp, err := envClient.GetCurrent(ctx, &azdext.EmptyRequest{})
+	if err != nil {
+		return empty, nil // Non-critical: can't resolve the environment.
+	}
+	envName := envResp.Environment.Name
+
+	subscriptionID := envValue(ctx, envClient, envName, "AZURE_SUBSCRIPTION_ID")
+
+	// Prefer the location supplied in the validation context; fall back to the env value.
+	location, ok := valCtx.EnvLocation()
+	if !ok || location == "" {
+		location = envValue(ctx, envClient, envName, "AZURE_LOCATION")
+	}
+	if subscriptionID == "" || location == "" {
+		// Without both values there is nothing to compare; provision will prompt for them.
+		return empty, nil
+	}
+
+	resourceGroup := envValue(ctx, envClient, envName, "AZURE_RESOURCE_GROUP")
+	if resourceGroup == "" {
+		// Mirror azd's default when AZURE_RESOURCE_GROUP is unset.
+		resourceGroup = fmt.Sprintf("rg-%s", envName)
+	}
+
+	tenantResponse, err := c.azdClient.Account().LookupTenant(ctx, &azdext.LookupTenantRequest{
+		SubscriptionId: subscriptionID,
+	})
+	if err != nil {
+		return empty, nil // Non-critical: can't resolve tenant.
+	}
+
+	cred, err := azidentity.NewAzureDeveloperCLICredential(&azidentity.AzureDeveloperCLICredentialOptions{
+		TenantID:                   tenantResponse.TenantId,
+		AdditionallyAllowedTenants: []string{"*"},
+	})
+	if err != nil {
+		return empty, nil // Non-critical: auth issues will surface during provision.
+	}
+
+	rgClient, err := armresources.NewResourceGroupsClient(subscriptionID, cred, azure.NewArmClientOptions())
+	if err != nil {
+		return empty, nil // Non-critical: can't create the client.
+	}
+
+	getResp, err := rgClient.Get(ctx, resourceGroup, nil)
+	if err != nil {
+		// A 404 means the resource group does not exist yet — provision will create it in
+		// AZURE_LOCATION, so there is no conflict. Any other error is treated as non-blocking.
+		return empty, nil
+	}
+
+	if getResp.Location == nil {
+		return empty, nil
+	}
+
+	return evaluateResourceGroupLocation(resourceGroup, *getResp.Location, location, subscriptionID), nil
+}
+
+// evaluateResourceGroupLocation compares an existing resource group's region against the
+// requested AZURE_LOCATION. It returns an empty response when the regions match
+// (case-insensitively) and a blocking error result with remediation guidance when they
+// differ. The comparison and message construction are isolated here so they can be
+// unit-tested without Azure access.
+func evaluateResourceGroupLocation(
+	resourceGroup, existingLocation, requestedLocation, subscriptionID string,
+) *azdext.ValidationCheckResponse {
+	if strings.EqualFold(existingLocation, requestedLocation) {
+		return &azdext.ValidationCheckResponse{}
+	}
+
+	message := fmt.Sprintf(
+		"Resource group %q already exists in region %q, but AZURE_LOCATION is set to %q. "+
+			"A resource group's region cannot be changed, so provisioning would fail with "+
+			"the ARM error \"InvalidResourceGroupLocation\".",
+		resourceGroup, existingLocation, requestedLocation,
+	)
+
+	suggestion := fmt.Sprintf(
+		"Resolve the conflict before provisioning by choosing one of the following:\n"+
+			"  • Use the existing region:          azd env set AZURE_LOCATION %s\n"+
+			"  • Target a different resource group: azd env set AZURE_RESOURCE_GROUP <new-name>\n"+
+			"  • Delete the resource group if it is no longer needed: "+
+			"az group delete --name %s --subscription %s",
+		existingLocation, resourceGroup, subscriptionID,
+	)
+
+	return &azdext.ValidationCheckResponse{
+		Results: []*azdext.ValidationCheckResult{
+			{
+				Severity:     azdext.ValidationCheckSeverity_VALIDATION_CHECK_SEVERITY_ERROR,
+				DiagnosticId: ResourceGroupLocationRuleID,
+				Message:      message,
+				Suggestion:   suggestion,
+			},
+		},
+	}
+}
+
+// envValue returns the value of key in the named azd environment, or an empty string when
+// it is unset or cannot be read.
+func envValue(ctx context.Context, envClient azdext.EnvironmentServiceClient, envName, key string) string {
+	resp, err := envClient.GetValue(ctx, &azdext.GetEnvRequest{EnvName: envName, Key: key})
+	if err != nil {
+		return ""
+	}
+	return resp.Value
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check.go
@@ -18,8 +18,15 @@ import (
 )
 
 // ResourceGroupLocationRuleID is the stable identifier for the resource-group
-// location-mismatch provision validation check.
-const ResourceGroupLocationRuleID = "resource_group_location_mismatch"
+// location-mismatch provision validation check. It doubles as both the
+// registration RuleID and the result DiagnosticId.
+//
+// The identifier is prefixed with the owning extension id (azure.ai.agents)
+// because the provision validation rule namespace is global — core enforces
+// uniqueness on check_type + rule_id across every installed extension. Namespacing
+// keeps the rule unambiguously mappable back to this extension for future
+// features such as suppressions and rule sets.
+const ResourceGroupLocationRuleID = "azure.ai.agents.resource_group_location_mismatch"
 
 // ResourceGroupLocationCheck is a provider-agnostic "provision" validation check
 // (azdext.ValidationCheckTypeProvision) that detects an immutable resource-group
@@ -39,11 +46,27 @@ const ResourceGroupLocationRuleID = "resource_group_location_mismatch"
 // actionable guidance during azd's validation phase.
 type ResourceGroupLocationCheck struct {
 	azdClient *azdext.AzdClient
+
+	// resourceGroupLocation resolves the region of an existing resource group.
+	// It is a field so tests can inject a fake without Azure access; production
+	// code uses armResourceGroupLocation (set by the constructor).
+	resourceGroupLocation resourceGroupLocationLookup
 }
+
+// resourceGroupLocationLookup resolves the Azure region of an existing resource
+// group. It returns (location, found, err): found=false means the group does not
+// exist (or its region is unknown), which is not a conflict; a non-nil err is
+// treated as non-blocking by the caller (the check never blocks on its own
+// inability to determine the situation).
+type resourceGroupLocationLookup func(
+	ctx context.Context, subscriptionID, resourceGroup string,
+) (location string, found bool, err error)
 
 // NewResourceGroupLocationCheck creates a new ResourceGroupLocationCheck.
 func NewResourceGroupLocationCheck(azdClient *azdext.AzdClient) *ResourceGroupLocationCheck {
-	return &ResourceGroupLocationCheck{azdClient: azdClient}
+	c := &ResourceGroupLocationCheck{azdClient: azdClient}
+	c.resourceGroupLocation = c.armResourceGroupLocation
+	return c
 }
 
 // Validate implements azdext.ValidationCheckProvider.
@@ -96,12 +119,22 @@ func (c *ResourceGroupLocationCheck) Validate(
 	// fall back to reading the azd environment directly. Context values are
 	// best-effort and may be empty on a cold first run (dispatch happens before
 	// the provider resolves and prompts for subscription/location/resource group).
+	//
+	// The context accessors return the environment value verbatim
+	// (provisionValidationContext sources them from Environment.Getenv without
+	// trimming), so trim here too. Otherwise a persisted value with surrounding
+	// whitespace would bypass the trimmed envValueOrEmpty fallback and either
+	// produce a false mismatch (AZURE_LOCATION) or target the wrong resource
+	// group name and silently skip the check — while the Foundry provider, which
+	// trims, provisions into the real group.
 	subscriptionID, ok := valCtx.SubscriptionID()
+	subscriptionID = strings.TrimSpace(subscriptionID)
 	if !ok || subscriptionID == "" {
 		subscriptionID = envValueOrEmpty(ctx, envClient, envName, "AZURE_SUBSCRIPTION_ID")
 	}
 
 	location, ok := valCtx.EnvLocation()
+	location = strings.TrimSpace(location)
 	if !ok || location == "" {
 		location = envValueOrEmpty(ctx, envClient, envName, "AZURE_LOCATION")
 	}
@@ -111,6 +144,7 @@ func (c *ResourceGroupLocationCheck) Validate(
 	}
 
 	resourceGroup, ok := valCtx.ResourceGroup()
+	resourceGroup = strings.TrimSpace(resourceGroup)
 	if !ok || resourceGroup == "" {
 		resourceGroup = envValueOrEmpty(ctx, envClient, envName, "AZURE_RESOURCE_GROUP")
 	}
@@ -121,11 +155,30 @@ func (c *ResourceGroupLocationCheck) Validate(
 		resourceGroup = defaultResourceGroupName(envName)
 	}
 
+	existingLocation, found, err := c.resourceGroupLocation(ctx, subscriptionID, resourceGroup)
+	if err != nil || !found {
+		// Non-critical: a missing resource group (404), auth/tenant failure, or any
+		// other lookup error is treated as non-blocking so the check never blocks
+		// provisioning on its own inability to determine the situation.
+		return empty, nil
+	}
+
+	return evaluateResourceGroupLocation(resourceGroup, existingLocation, location, subscriptionID), nil
+}
+
+// armResourceGroupLocation is the production resourceGroupLocationLookup. It
+// resolves the resource group's region via ARM, using the azd credential scoped
+// to the subscription's tenant. Every failure mode is non-blocking: it returns
+// found=false (or an error the caller ignores) so the check never blocks
+// provisioning on its own inability to determine the situation.
+func (c *ResourceGroupLocationCheck) armResourceGroupLocation(
+	ctx context.Context, subscriptionID, resourceGroup string,
+) (string, bool, error) {
 	tenantResponse, err := c.azdClient.Account().LookupTenant(ctx, &azdext.LookupTenantRequest{
 		SubscriptionId: subscriptionID,
 	})
 	if err != nil {
-		return empty, nil // Non-critical: can't resolve tenant.
+		return "", false, err // Non-critical: can't resolve tenant.
 	}
 
 	cred, err := azidentity.NewAzureDeveloperCLICredential(&azidentity.AzureDeveloperCLICredentialOptions{
@@ -133,26 +186,26 @@ func (c *ResourceGroupLocationCheck) Validate(
 		AdditionallyAllowedTenants: []string{"*"},
 	})
 	if err != nil {
-		return empty, nil // Non-critical: auth issues will surface during provision.
+		return "", false, err // Non-critical: auth issues will surface during provision.
 	}
 
 	rgClient, err := armresources.NewResourceGroupsClient(subscriptionID, cred, azure.NewArmClientOptions())
 	if err != nil {
-		return empty, nil // Non-critical: can't create the client.
+		return "", false, err // Non-critical: can't create the client.
 	}
 
 	getResp, err := rgClient.Get(ctx, resourceGroup, nil)
 	if err != nil {
 		// A 404 means the resource group does not exist yet — provision will create it in
 		// AZURE_LOCATION, so there is no conflict. Any other error is treated as non-blocking.
-		return empty, nil
+		return "", false, err
 	}
 
 	if getResp.Location == nil {
-		return empty, nil
+		return "", false, nil
 	}
 
-	return evaluateResourceGroupLocation(resourceGroup, *getResp.Location, location, subscriptionID), nil
+	return *getResp.Location, true, nil
 }
 
 // evaluateResourceGroupLocation compares an existing resource group's region against the
@@ -179,7 +232,7 @@ func evaluateResourceGroupLocation(
 			"  • Use the existing region:          azd env set AZURE_LOCATION %s\n"+
 			"  • Target a different resource group: azd env set AZURE_RESOURCE_GROUP <new-name>\n"+
 			"  • Delete the resource group if it is no longer needed: "+
-			"az group delete --name %s --subscription %s",
+			"az group delete --name %q --subscription %s",
 		existingLocation, resourceGroup, subscriptionID,
 	)
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check.go
@@ -16,11 +16,15 @@ import (
 )
 
 // ResourceGroupLocationRuleID is the stable identifier for the resource-group
-// location-mismatch local-preflight check.
+// location-mismatch provision validation check.
 const ResourceGroupLocationRuleID = "resource_group_location_mismatch"
 
-// ResourceGroupLocationCheck is a local-preflight validation check that detects an
-// immutable resource-group region conflict before provisioning starts.
+// ResourceGroupLocationCheck is a provider-agnostic "provision" validation check
+// (azdext.ValidationCheckTypeProvision) that detects an immutable resource-group
+// region conflict before provisioning starts. It is registered under the
+// provision check type — rather than the Bicep-only "local-preflight" type —
+// because the azure.ai.agents extension provisions through its own
+// microsoft.foundry provider, which never triggers local-preflight checks.
 //
 // The azure.ai.agents extension writes a stable, salted resource group name to
 // AZURE_RESOURCE_GROUP at init. If AZURE_LOCATION is later changed (for example by
@@ -54,6 +58,19 @@ func (c *ResourceGroupLocationCheck) Validate(
 ) (*azdext.ValidationCheckResponse, error) {
 	empty := &azdext.ValidationCheckResponse{}
 
+	// The "provision" check type is dispatched for every project whenever this
+	// extension is installed, but the InvalidResourceGroupLocation conflict this
+	// check guards against is specific to the microsoft.foundry provisioning
+	// provider — it runs a subscription-scoped deployment that CREATES the
+	// resource group at AZURE_LOCATION. For any other provider (core Bicep,
+	// Terraform, or an unrelated project that merely has this extension
+	// installed) an existing resource group in a different region is perfectly
+	// valid, so running the check there would raise a false positive. Skip
+	// unless the current project actually provisions through microsoft.foundry.
+	if !c.usesFoundryProvider(ctx) {
+		return empty, nil
+	}
+
 	envClient := c.azdClient.Environment()
 	envResp, err := envClient.GetCurrent(ctx, &azdext.EmptyRequest{})
 	if err != nil {
@@ -61,9 +78,15 @@ func (c *ResourceGroupLocationCheck) Validate(
 	}
 	envName := envResp.Environment.Name
 
-	subscriptionID := envValue(ctx, envClient, envName, "AZURE_SUBSCRIPTION_ID")
+	// Prefer the values supplied in the lean "provision" validation context;
+	// fall back to reading the azd environment directly. Context values are
+	// best-effort and may be empty on a cold first run (dispatch happens before
+	// the provider resolves and prompts for subscription/location/resource group).
+	subscriptionID, ok := valCtx.SubscriptionID()
+	if !ok || subscriptionID == "" {
+		subscriptionID = envValue(ctx, envClient, envName, "AZURE_SUBSCRIPTION_ID")
+	}
 
-	// Prefer the location supplied in the validation context; fall back to the env value.
 	location, ok := valCtx.EnvLocation()
 	if !ok || location == "" {
 		location = envValue(ctx, envClient, envName, "AZURE_LOCATION")
@@ -73,7 +96,10 @@ func (c *ResourceGroupLocationCheck) Validate(
 		return empty, nil
 	}
 
-	resourceGroup := envValue(ctx, envClient, envName, "AZURE_RESOURCE_GROUP")
+	resourceGroup, ok := valCtx.ResourceGroup()
+	if !ok || resourceGroup == "" {
+		resourceGroup = envValue(ctx, envClient, envName, "AZURE_RESOURCE_GROUP")
+	}
 	if resourceGroup == "" {
 		// Mirror azd's default when AZURE_RESOURCE_GROUP is unset.
 		resourceGroup = fmt.Sprintf("rg-%s", envName)
@@ -151,6 +177,19 @@ func evaluateResourceGroupLocation(
 			},
 		},
 	}
+}
+
+// usesFoundryProvider reports whether the current azd project provisions through
+// the microsoft.foundry provider (azure.yaml `infra.provider: microsoft.foundry`).
+// It is best-effort: when the project configuration cannot be read it returns
+// false so the check is skipped rather than risk a false positive on a project
+// that has nothing to do with Foundry agents.
+func (c *ResourceGroupLocationCheck) usesFoundryProvider(ctx context.Context) bool {
+	resp, err := c.azdClient.Project().Get(ctx, &azdext.EmptyRequest{})
+	if err != nil || resp.GetProject() == nil {
+		return false
+	}
+	return resp.GetProject().GetInfra().GetProvider() == FoundryProviderName
 }
 
 // envValue returns the value of key in the named azd environment, or an empty string when

--- a/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check.go
@@ -84,12 +84,12 @@ func (c *ResourceGroupLocationCheck) Validate(
 	// the provider resolves and prompts for subscription/location/resource group).
 	subscriptionID, ok := valCtx.SubscriptionID()
 	if !ok || subscriptionID == "" {
-		subscriptionID = envValue(ctx, envClient, envName, "AZURE_SUBSCRIPTION_ID")
+		subscriptionID = envValueOrEmpty(ctx, envClient, envName, "AZURE_SUBSCRIPTION_ID")
 	}
 
 	location, ok := valCtx.EnvLocation()
 	if !ok || location == "" {
-		location = envValue(ctx, envClient, envName, "AZURE_LOCATION")
+		location = envValueOrEmpty(ctx, envClient, envName, "AZURE_LOCATION")
 	}
 	if subscriptionID == "" || location == "" {
 		// Without both values there is nothing to compare; provision will prompt for them.
@@ -98,11 +98,13 @@ func (c *ResourceGroupLocationCheck) Validate(
 
 	resourceGroup, ok := valCtx.ResourceGroup()
 	if !ok || resourceGroup == "" {
-		resourceGroup = envValue(ctx, envClient, envName, "AZURE_RESOURCE_GROUP")
+		resourceGroup = envValueOrEmpty(ctx, envClient, envName, "AZURE_RESOURCE_GROUP")
 	}
 	if resourceGroup == "" {
-		// Mirror azd's default when AZURE_RESOURCE_GROUP is unset.
-		resourceGroup = fmt.Sprintf("rg-%s", envName)
+		// Mirror azd's default when AZURE_RESOURCE_GROUP is unset, reusing the
+		// same helper the foundry provisioning path uses so the check stays in
+		// sync if the default naming convention ever changes.
+		resourceGroup = defaultResourceGroupName(envName)
 	}
 
 	tenantResponse, err := c.azdClient.Account().LookupTenant(ctx, &azdext.LookupTenantRequest{
@@ -192,12 +194,18 @@ func (c *ResourceGroupLocationCheck) usesFoundryProvider(ctx context.Context) bo
 	return resp.GetProject().GetInfra().GetProvider() == FoundryProviderName
 }
 
-// envValue returns the value of key in the named azd environment, or an empty string when
-// it is unset or cannot be read.
-func envValue(ctx context.Context, envClient azdext.EnvironmentServiceClient, envName, key string) string {
+// envValueOrEmpty returns the trimmed value of key in the named azd environment,
+// or an empty string when it is unset or cannot be read. Trimming matches
+// FoundryProvisioningProvider.envValue and prevents a stray leading/trailing
+// space in AZURE_LOCATION or AZURE_RESOURCE_GROUP from producing a
+// false-positive region mismatch (the comparison uses strings.EqualFold, which
+// does not trim). The distinct name avoids confusion with that method, which
+// has different error semantics (it propagates the error rather than swallowing
+// it).
+func envValueOrEmpty(ctx context.Context, envClient azdext.EnvironmentServiceClient, envName, key string) string {
 	resp, err := envClient.GetValue(ctx, &azdext.GetEnvRequest{EnvName: envName, Key: key})
 	if err != nil {
 		return ""
 	}
-	return resp.Value
+	return strings.TrimSpace(resp.Value)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check.go
@@ -6,6 +6,8 @@ package project
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"azureaiagent/internal/pkg/azure"
@@ -68,6 +70,18 @@ func (c *ResourceGroupLocationCheck) Validate(
 	// valid, so running the check there would raise a false positive. Skip
 	// unless the current project actually provisions through microsoft.foundry.
 	if !c.usesFoundryProvider(ctx) {
+		return empty, nil
+	}
+
+	// Skip brownfield (bring-your-own) projects. When the Foundry service sets
+	// `endpoint:`, the microsoft.foundry provider connects to that existing
+	// project and provisions nothing — it creates no resource group and derives
+	// its target from AZURE_AI_PROJECT_ID, ignoring AZURE_RESOURCE_GROUP. Running
+	// this check there would compare AZURE_LOCATION against an unrelated, stale
+	// resource group of the same name and could wrongly block provisioning while
+	// suggesting the deletion of a resource group that has nothing to do with the
+	// deployment.
+	if c.isBrownfieldFoundryProject(ctx) {
 		return empty, nil
 	}
 
@@ -192,6 +206,34 @@ func (c *ResourceGroupLocationCheck) usesFoundryProvider(ctx context.Context) bo
 		return false
 	}
 	return resp.GetProject().GetInfra().GetProvider() == FoundryProviderName
+}
+
+// isBrownfieldFoundryProject reports whether the current project's Foundry
+// service is brownfield — i.e. it sets `endpoint:` to connect to an existing
+// Foundry project. It reuses the same helpers the provider uses so the two stay
+// in sync: findFoundryProjectService locates the service and foundryServiceEndpoint
+// reports whether `endpoint:` is set. It is best-effort: if the project or
+// azure.yaml cannot be read, or no Foundry service is found, it returns false so
+// the check proceeds (the greenfield path, which is where the region conflict can
+// actually occur).
+func (c *ResourceGroupLocationCheck) isBrownfieldFoundryProject(ctx context.Context) bool {
+	resp, err := c.azdClient.Project().Get(ctx, &azdext.EmptyRequest{})
+	if err != nil || resp.GetProject() == nil {
+		return false
+	}
+
+	// ProjectConfig.Path is the project directory that contains azure.yaml.
+	rawYAML, err := os.ReadFile(filepath.Join(resp.GetProject().GetPath(), "azure.yaml"))
+	if err != nil {
+		return false
+	}
+
+	svcName, err := findFoundryProjectService(rawYAML)
+	if err != nil {
+		return false
+	}
+
+	return foundryServiceEndpoint(rawYAML, svcName) != ""
 }
 
 // envValueOrEmpty returns the trimmed value of key in the named azd environment,

--- a/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvaluateResourceGroupLocation(t *testing.T) {
+	const (
+		resourceGroup  = "rg-myenv-abc123"
+		subscriptionID = "00000000-0000-0000-0000-000000000000"
+	)
+
+	t.Run("matching regions produce no results", func(t *testing.T) {
+		resp := evaluateResourceGroupLocation(resourceGroup, "eastus", "eastus", subscriptionID)
+		require.NotNil(t, resp)
+		assert.Empty(t, resp.Results)
+	})
+
+	t.Run("region comparison is case-insensitive", func(t *testing.T) {
+		resp := evaluateResourceGroupLocation(resourceGroup, "EastUS", "eastus", subscriptionID)
+		require.NotNil(t, resp)
+		assert.Empty(t, resp.Results)
+	})
+
+	t.Run("mismatched regions produce a blocking error result with guidance", func(t *testing.T) {
+		resp := evaluateResourceGroupLocation(resourceGroup, "eastus", "westus2", subscriptionID)
+		require.NotNil(t, resp)
+		require.Len(t, resp.Results, 1)
+
+		result := resp.Results[0]
+		assert.Equal(t,
+			azdext.ValidationCheckSeverity_VALIDATION_CHECK_SEVERITY_ERROR,
+			result.Severity,
+		)
+		assert.Equal(t, ResourceGroupLocationRuleID, result.DiagnosticId)
+
+		// The message should surface the immutable-region ARM failure and both regions.
+		assert.Contains(t, result.Message, resourceGroup)
+		assert.Contains(t, result.Message, "eastus")
+		assert.Contains(t, result.Message, "westus2")
+		assert.Contains(t, result.Message, "InvalidResourceGroupLocation")
+
+		// The suggestion should offer all three remediation paths.
+		assert.Contains(t, result.Suggestion, "azd env set AZURE_LOCATION eastus")
+		assert.Contains(t, result.Suggestion, "azd env set AZURE_RESOURCE_GROUP")
+		assert.Contains(t, result.Suggestion, "az group delete --name "+resourceGroup)
+		assert.Contains(t, result.Suggestion, subscriptionID)
+	})
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check_test.go
@@ -50,7 +50,19 @@ func TestEvaluateResourceGroupLocation(t *testing.T) {
 		// The suggestion should offer all three remediation paths.
 		assert.Contains(t, result.Suggestion, "azd env set AZURE_LOCATION eastus")
 		assert.Contains(t, result.Suggestion, "azd env set AZURE_RESOURCE_GROUP")
-		assert.Contains(t, result.Suggestion, "az group delete --name "+resourceGroup)
+		// The resource-group name is shell-quoted (%q) so a name containing shell
+		// metacharacters (parentheses are valid in Azure RG names) stays copy-pasteable.
+		assert.Contains(t, result.Suggestion, `az group delete --name "`+resourceGroup+`"`)
 		assert.Contains(t, result.Suggestion, subscriptionID)
+	})
+
+	t.Run("resource group name with shell metacharacters is quoted in the delete command", func(t *testing.T) {
+		const parenRG = "rg(test)"
+		resp := evaluateResourceGroupLocation(parenRG, "eastus", "westus2", subscriptionID)
+		require.NotNil(t, resp)
+		require.Len(t, resp.Results, 1)
+
+		// Without quoting, "az group delete --name rg(test)" is a shell syntax error.
+		assert.Contains(t, resp.Results[0].Suggestion, `az group delete --name "rg(test)"`)
 	})
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check_validate_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/resource_group_location_check_validate_test.go
@@ -1,0 +1,298 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// validateStubProjectServer serves a fixed ProjectConfig for Validate's provider
+// and brownfield gates.
+type validateStubProjectServer struct {
+	azdext.UnimplementedProjectServiceServer
+	project *azdext.ProjectConfig
+	err     error
+}
+
+func (s *validateStubProjectServer) Get(
+	context.Context, *azdext.EmptyRequest,
+) (*azdext.GetProjectResponse, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &azdext.GetProjectResponse{Project: s.project}, nil
+}
+
+// validateStubEnvServer serves a fixed env name and keyed values for Validate's
+// environment fallback.
+type validateStubEnvServer struct {
+	azdext.UnimplementedEnvironmentServiceServer
+	envName string
+	get     map[string]string
+}
+
+func (s *validateStubEnvServer) GetCurrent(
+	context.Context, *azdext.EmptyRequest,
+) (*azdext.EnvironmentResponse, error) {
+	return &azdext.EnvironmentResponse{Environment: &azdext.Environment{Name: s.envName}}, nil
+}
+
+func (s *validateStubEnvServer) GetValue(
+	_ context.Context, req *azdext.GetEnvRequest,
+) (*azdext.KeyValueResponse, error) {
+	return &azdext.KeyValueResponse{Value: s.get[req.Key]}, nil
+}
+
+// newValidateTestClient spins up a gRPC server exposing the given project and
+// environment stubs and returns an AzdClient connected to it.
+func newValidateTestClient(
+	t *testing.T,
+	projSrv azdext.ProjectServiceServer,
+	envSrv azdext.EnvironmentServiceServer,
+) *azdext.AzdClient {
+	t.Helper()
+
+	srv := grpc.NewServer()
+	azdext.RegisterProjectServiceServer(srv, projSrv)
+	azdext.RegisterEnvironmentServiceServer(srv, envSrv)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+	})
+
+	client, err := azdext.NewAzdClient(azdext.WithAddress(lis.Addr().String()))
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	return client
+}
+
+// writeAzureYAML writes an azure.yaml with a single Foundry project service to a
+// fresh temp dir and returns the dir. When endpoint is non-empty the service is
+// brownfield (bring-your-own).
+func writeAzureYAML(t *testing.T, endpoint string) string {
+	t.Helper()
+	dir := t.TempDir()
+	body := "name: rgloc-test\nservices:\n  ai-project:\n    host: " + FoundryProjectHost + "\n"
+	if endpoint != "" {
+		body += "    endpoint: " + endpoint + "\n"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte(body), 0o600))
+	return dir
+}
+
+// provisionContext builds a "provision" ValidationContext from the given values.
+// Empty values are omitted so the accessor reports (‑, false), exercising the
+// environment fallback.
+func provisionContext(subscriptionID, location, resourceGroup string) *azdext.ValidationContext {
+	data := map[string][]byte{}
+	if subscriptionID != "" {
+		data[azdext.ValidationContextSubscriptionID] = []byte(subscriptionID)
+	}
+	if location != "" {
+		data[azdext.ValidationContextEnvLocation] = []byte(location)
+	}
+	if resourceGroup != "" {
+		data[azdext.ValidationContextResourceGroup] = []byte(resourceGroup)
+	}
+	return &azdext.ValidationContext{CheckType: azdext.ValidationCheckTypeProvision, Data: data}
+}
+
+func TestValidate_Gates(t *testing.T) {
+	const sub = "00000000-0000-0000-0000-000000000000"
+
+	t.Run("skips non-foundry provider without looking up the resource group", func(t *testing.T) {
+		proj := &validateStubProjectServer{project: &azdext.ProjectConfig{
+			Path:  writeAzureYAML(t, ""),
+			Infra: &azdext.InfraOptions{Provider: "bicep"},
+		}}
+		env := &validateStubEnvServer{envName: "rgloc-test", get: map[string]string{}}
+		client := newValidateTestClient(t, proj, env)
+
+		var called bool
+		c := &ResourceGroupLocationCheck{azdClient: client}
+		c.resourceGroupLocation = func(context.Context, string, string) (string, bool, error) {
+			called = true
+			return "eastus", true, nil
+		}
+
+		resp, err := c.Validate(t.Context(), provisionContext(sub, "westus2", "rg-x"), &azdext.ValidationCheckRequest{})
+		require.NoError(t, err)
+		assert.Empty(t, resp.Results)
+		assert.False(t, called, "resource group lookup must not run for a non-foundry provider")
+	})
+
+	t.Run("skips brownfield (endpoint) foundry project", func(t *testing.T) {
+		proj := &validateStubProjectServer{project: &azdext.ProjectConfig{
+			Path:  writeAzureYAML(t, "https://acct.services.ai.azure.com/api/projects/p"),
+			Infra: &azdext.InfraOptions{Provider: FoundryProviderName},
+		}}
+		env := &validateStubEnvServer{envName: "rgloc-test", get: map[string]string{}}
+		client := newValidateTestClient(t, proj, env)
+
+		var called bool
+		c := &ResourceGroupLocationCheck{azdClient: client}
+		c.resourceGroupLocation = func(context.Context, string, string) (string, bool, error) {
+			called = true
+			return "eastus", true, nil
+		}
+
+		resp, err := c.Validate(t.Context(), provisionContext(sub, "westus2", "rg-x"), &azdext.ValidationCheckRequest{})
+		require.NoError(t, err)
+		assert.Empty(t, resp.Results)
+		assert.False(t, called, "resource group lookup must not run for a brownfield project")
+	})
+
+	t.Run("skips when required values are missing", func(t *testing.T) {
+		proj := &validateStubProjectServer{project: &azdext.ProjectConfig{
+			Path:  writeAzureYAML(t, ""),
+			Infra: &azdext.InfraOptions{Provider: FoundryProviderName},
+		}}
+		// Subscription present but no location, and none in the env: nothing to compare.
+		env := &validateStubEnvServer{envName: "rgloc-test", get: map[string]string{}}
+		client := newValidateTestClient(t, proj, env)
+
+		var called bool
+		c := &ResourceGroupLocationCheck{azdClient: client}
+		c.resourceGroupLocation = func(context.Context, string, string) (string, bool, error) {
+			called = true
+			return "eastus", true, nil
+		}
+
+		resp, err := c.Validate(t.Context(), provisionContext(sub, "", "rg-x"), &azdext.ValidationCheckRequest{})
+		require.NoError(t, err)
+		assert.Empty(t, resp.Results)
+		assert.False(t, called, "lookup must not run without both subscription and location")
+	})
+}
+
+func TestValidate_GreenfieldFoundry(t *testing.T) {
+	const sub = "00000000-0000-0000-0000-000000000000"
+
+	newCheck := func(t *testing.T, env *validateStubEnvServer, lookup resourceGroupLocationLookup,
+	) *ResourceGroupLocationCheck {
+		proj := &validateStubProjectServer{project: &azdext.ProjectConfig{
+			Path:  writeAzureYAML(t, ""),
+			Infra: &azdext.InfraOptions{Provider: FoundryProviderName},
+		}}
+		client := newValidateTestClient(t, proj, env)
+		c := &ResourceGroupLocationCheck{azdClient: client}
+		c.resourceGroupLocation = lookup
+		return c
+	}
+
+	t.Run("mismatched region produces a blocking error", func(t *testing.T) {
+		env := &validateStubEnvServer{envName: "rgloc-test", get: map[string]string{}}
+		c := newCheck(t, env, func(context.Context, string, string) (string, bool, error) {
+			return "eastus", true, nil
+		})
+
+		resp, err := c.Validate(t.Context(), provisionContext(sub, "westus2", "rg-x"), &azdext.ValidationCheckRequest{})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 1)
+		assert.Equal(t,
+			azdext.ValidationCheckSeverity_VALIDATION_CHECK_SEVERITY_ERROR, resp.Results[0].Severity)
+		assert.Equal(t, ResourceGroupLocationRuleID, resp.Results[0].DiagnosticId)
+	})
+
+	t.Run("matching region produces no results", func(t *testing.T) {
+		env := &validateStubEnvServer{envName: "rgloc-test", get: map[string]string{}}
+		c := newCheck(t, env, func(context.Context, string, string) (string, bool, error) {
+			return "eastus", true, nil
+		})
+
+		resp, err := c.Validate(t.Context(), provisionContext(sub, "eastus", "rg-x"), &azdext.ValidationCheckRequest{})
+		require.NoError(t, err)
+		assert.Empty(t, resp.Results)
+	})
+
+	t.Run("lookup failure is non-blocking", func(t *testing.T) {
+		env := &validateStubEnvServer{envName: "rgloc-test", get: map[string]string{}}
+		c := newCheck(t, env, func(context.Context, string, string) (string, bool, error) {
+			return "", false, errors.New("boom")
+		})
+
+		resp, err := c.Validate(t.Context(), provisionContext(sub, "westus2", "rg-x"), &azdext.ValidationCheckRequest{})
+		require.NoError(t, err)
+		assert.Empty(t, resp.Results, "an error-severity result must not be produced when the lookup fails")
+	})
+
+	t.Run("resource group not found is non-blocking", func(t *testing.T) {
+		env := &validateStubEnvServer{envName: "rgloc-test", get: map[string]string{}}
+		c := newCheck(t, env, func(context.Context, string, string) (string, bool, error) {
+			return "", false, nil
+		})
+
+		resp, err := c.Validate(t.Context(), provisionContext(sub, "westus2", "rg-x"), &azdext.ValidationCheckRequest{})
+		require.NoError(t, err)
+		assert.Empty(t, resp.Results)
+	})
+
+	t.Run("trims context values before comparing", func(t *testing.T) {
+		env := &validateStubEnvServer{envName: "rgloc-test", get: map[string]string{}}
+		var gotRG string
+		c := newCheck(t, env, func(_ context.Context, _, rg string) (string, bool, error) {
+			gotRG = rg
+			return "eastus", true, nil
+		})
+
+		// Whitespace-padded context values must be trimmed: location " eastus "
+		// should match ARM's "eastus" (no false mismatch), and the resource group
+		// must reach the lookup without surrounding spaces.
+		resp, err := c.Validate(
+			t.Context(), provisionContext("  "+sub+"  ", " eastus ", "  rg-x  "), &azdext.ValidationCheckRequest{})
+		require.NoError(t, err)
+		assert.Empty(t, resp.Results)
+		assert.Equal(t, "rg-x", gotRG)
+	})
+
+	t.Run("falls back to environment values when the context is empty", func(t *testing.T) {
+		env := &validateStubEnvServer{envName: "rgloc-test", get: map[string]string{
+			"AZURE_SUBSCRIPTION_ID": sub,
+			"AZURE_LOCATION":        "westus2",
+			"AZURE_RESOURCE_GROUP":  "rg-from-env",
+		}}
+		var gotRG string
+		c := newCheck(t, env, func(_ context.Context, _, rg string) (string, bool, error) {
+			gotRG = rg
+			return "eastus", true, nil
+		})
+
+		// Empty context => accessors report (‑, false) => the env fallback supplies
+		// all three values.
+		resp, err := c.Validate(t.Context(), provisionContext("", "", ""), &azdext.ValidationCheckRequest{})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 1)
+		assert.Equal(t, "rg-from-env", gotRG)
+	})
+
+	t.Run("defaults the resource group name when none is provided", func(t *testing.T) {
+		env := &validateStubEnvServer{envName: "rgloc-test", get: map[string]string{}}
+		var gotRG string
+		c := newCheck(t, env, func(_ context.Context, _, rg string) (string, bool, error) {
+			gotRG = rg
+			return "eastus", true, nil
+		})
+
+		resp, err := c.Validate(t.Context(), provisionContext(sub, "westus2", ""), &azdext.ValidationCheckRequest{})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 1)
+		assert.Equal(t, defaultResourceGroupName("rgloc-test"), gotRG)
+	})
+}


### PR DESCRIPTION
## What

Adds a **provider-agnostic provision validation check** to the `azure.ai.agents` extension that detects an **immutable resource-group region conflict** before provisioning and stops `azd` with a clear note + remediation suggestion.

This is the **#1 production ARM error** (`InvalidResourceGroupLocation`, 87 operations in the top-5 report): provisioning fails because the target resource group already exists in a different region than `AZURE_LOCATION`. A resource group's region cannot be changed, so proceeding is a guaranteed failure — the check is a **blocking Error**, surfaced during `azd`'s validation phase instead of at deploy time.

## How

- New `internal/project/resource_group_location_check.go` — `ResourceGroupLocationCheck` implementing `azdext.ValidationCheckProvider`.
- Registered in `internal/cmd/listen.go` via the `validation-provider` extension capability (`CheckType: provision`, `RuleID: azure.ai.agents.resource_group_location_mismatch`). Uses the provider-agnostic `provision` check type (**not** `local-preflight`), because the Foundry provider never dispatches Bicep local-preflight — so the check runs regardless of the provisioning provider (Bicep, Terraform, or extension-provided), dispatched once per run by `RunProvisionValidation`, introduced in **azd 1.27.1**.
- The rule ID is **namespaced with the extension id** (`azure.ai.agents.…`) because the provision validation rule namespace is global (core enforces uniqueness on `check_type` + `rule_id` across all installed extensions); this keeps the rule mappable to its owning extension for future suppressions / rule sets. Core follow-up tracked in #9060.
- Reads `AZURE_LOCATION` (prefers `ValidationContext.EnvLocation()`), `AZURE_SUBSCRIPTION_ID`, `AZURE_RESOURCE_GROUP` (fallback `defaultResourceGroupName(envName)`); all context **and** environment values are trimmed before comparison so a stray-whitespace value can't cause a false mismatch or silently skip the check. Resolves credential via `LookupTenant` → `AzureDeveloperCLICredential`; `GET`s the resource group and compares regions (case-insensitive).
- **Skips non-Foundry projects**: the `provision` check type is dispatched for every project when the extension is installed, so the check no-ops unless the project actually provisions through `microsoft.foundry`.
- **Skips brownfield projects**: when the Foundry service has `endpoint:` set, the provider connects to an existing project and creates no resource group — the guard reuses `findFoundryProjectService` + `foundryServiceEndpoint` to stay in sync with the provider's own brownfield detection.
- **Best-effort / non-blocking:** skips silently on missing env values, auth failure, a 404 (RG not created yet), or any API error — it never blocks validation itself. Only a definitive mismatch emits a blocking result.
- `extension.yaml` `requiredAzdVersion` bumped to `>=1.27.1`, the first release containing the provider-agnostic provision validation dispatch (#9019).

### What the user sees

> Resource group "rg-myenv-abc123" already exists in region "eastus", but AZURE_LOCATION is set to "westus2". A resource group's region cannot be changed, so provisioning would fail with the ARM error "InvalidResourceGroupLocation".

…with a suggestion offering 3 remediation paths (`azd env set AZURE_LOCATION`, a different resource group, or a shell-quoted `az group delete`).

## Testing

- **Unit tests** for the pure comparison/message logic (region match, case-insensitivity, mismatch guidance, shell-quoting of the resource-group name in the `az group delete` command).
- **Provider-level `Validate` tests** using in-process gRPC stubs for the project/environment services plus an injectable resource-group lookup, covering: the non-Foundry provider gate, the brownfield (`endpoint:`) gate, the missing-values skip, region mismatch → blocking error, region match → no result, best-effort no-op on lookup failure / RG-not-found, context-value trimming, environment fallback, and the default resource-group name.
- **End-to-end**: verified against a live subscription — a greenfield Foundry project with a region mismatch surfaces the error and aborts provisioning (exit 0, like a user-chosen abort); a brownfield (`endpoint:`) project skips the check and provisioning proceeds.
- `go build`, `go test ./internal/project ./internal/cmd` (incl. `-race`), `go vet`, `golangci-lint` (0 issues), `gofmt`, cspell — all pass. Repro steps are in the linked issue.
