### PR TITLE
fix(toolboxes): branch skill/connection mutations from latest version

### DIFF
--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_branch.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_branch.go
@@ -89,12 +89,13 @@ func resolveBranchVersion(
 		return res, nil
 	}
 
-	// Validate the requested version exists when we have a version list to
-	// check against. If the list is empty (edge case), trust the caller; a
-	// bad value surfaces as a not-found on the subsequent GetToolboxVersion.
-	if len(versions) > 0 && !slices.ContainsFunc(versions, func(v azure.ToolboxVersionObject) bool {
-		return v.Version == fromVersion
-	}) {
+	versionExists := fromVersion == tb.DefaultVersion
+	if len(versions) > 0 {
+		versionExists = slices.ContainsFunc(versions, func(v azure.ToolboxVersionObject) bool {
+			return v.Version == fromVersion
+		})
+	}
+	if !versionExists {
 		return branchResolution{}, exterrors.Validation(
 			exterrors.CodeToolboxVersionNotFound,
 			fmt.Sprintf("version %q does not exist for toolbox %q", fromVersion, toolboxName),

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_branch.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_branch.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
@@ -52,6 +53,13 @@ func registerFromVersionFlag(cmd *cobra.Command, fromVersion *string) {
 // An explicit --from-version overrides this (the prior default-snapshot behavior
 // is still reachable via --from-version <default>).
 //
+// "Latest" is the most recently created version: the toolbox API exposes no
+// canonical latest/head pointer (ToolboxObject carries only default_version), so
+// we derive it from the version list, preferring the newest CreatedAt and
+// falling back to the highest version number when CreatedAt is unavailable or
+// tied. Version numbers are monotonic, so this matches the true tip even if a
+// version is later deleted.
+//
 // When the toolbox reports no versions (an edge case; a real toolbox always has
 // its default), it falls back to the default version so the operation still
 // succeeds. A --from-version that does not exist is rejected.
@@ -70,9 +78,7 @@ func resolveBranchVersion(
 	latest := tb.DefaultVersion
 	if len(versions) > 0 {
 		sorted := slices.Clone(versions)
-		slices.SortFunc(sorted, func(a, b azure.ToolboxVersionObject) int {
-			return versionSortDescending(a.Version, b.Version)
-		})
+		slices.SortFunc(sorted, latestFirst)
 		latest = sorted[0].Version
 	}
 
@@ -98,6 +104,16 @@ func resolveBranchVersion(
 
 	res.Branch = fromVersion
 	return res, nil
+}
+
+// latestFirst orders two toolbox versions newest-first: by CreatedAt descending,
+// then by the numeric-aware version comparator as a deterministic tiebreaker
+// (and the sole signal when CreatedAt is not populated).
+func latestFirst(a, b azure.ToolboxVersionObject) int {
+	if a.CreatedAt != b.CreatedAt {
+		return cmp.Compare(b.CreatedAt, a.CreatedAt)
+	}
+	return versionSortDescending(a.Version, b.Version)
 }
 
 // printBranchNote surfaces, in text output only, that a new version was branched

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_branch.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_branch.go
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"azure.ai.toolboxes/internal/exterrors"
+	"azure.ai.toolboxes/internal/pkg/azure"
+
+	"github.com/spf13/cobra"
+)
+
+// branchResolution describes which existing toolbox version a mutation
+// (skill/connection add or remove) should branch its new immutable version from.
+type branchResolution struct {
+	// Branch is the version the new version is created from.
+	Branch string
+	// Latest is the highest existing version of the toolbox.
+	Latest string
+	// Default is the toolbox's current default version.
+	Default string
+}
+
+// branchedFromNonDefault reports whether the new version was branched from a
+// version other than the toolbox's default. When true, the default version's
+// contents are NOT the base of the new version, which is worth surfacing to the
+// user (the new version accumulates on top of Latest, not Default).
+func (b branchResolution) branchedFromNonDefault() bool {
+	return b.Branch != b.Default
+}
+
+// registerFromVersionFlag registers the shared --from-version flag used by the
+// add/remove verbs to override which version a new version branches from.
+func registerFromVersionFlag(cmd *cobra.Command, fromVersion *string) {
+	cmd.Flags().StringVar(
+		fromVersion, "from-version", "",
+		"Version to branch the new version from (defaults to the latest version).",
+	)
+}
+
+// resolveBranchVersion determines which existing toolbox version a new version
+// should branch from.
+//
+// By default it branches from the toolbox's LATEST version so sequential
+// add/remove operations accumulate (v3 = v2 + change), rather than repeatedly
+// forking from the default version and silently dropping earlier changes.
+// An explicit --from-version overrides this (the prior default-snapshot behavior
+// is still reachable via --from-version <default>).
+//
+// When the toolbox reports no versions (an edge case; a real toolbox always has
+// its default), it falls back to the default version so the operation still
+// succeeds. A --from-version that does not exist is rejected.
+func resolveBranchVersion(
+	ctx context.Context,
+	client toolboxClient,
+	toolboxName string,
+	tb *azure.ToolboxObject,
+	fromVersion string,
+) (branchResolution, error) {
+	versions, err := client.ListToolboxVersions(ctx, toolboxName)
+	if err != nil {
+		return branchResolution{}, exterrors.ServiceFromAzure(err, exterrors.OpListToolboxVersions)
+	}
+
+	latest := tb.DefaultVersion
+	if len(versions) > 0 {
+		sorted := slices.Clone(versions)
+		slices.SortFunc(sorted, func(a, b azure.ToolboxVersionObject) int {
+			return versionSortDescending(a.Version, b.Version)
+		})
+		latest = sorted[0].Version
+	}
+
+	res := branchResolution{Branch: latest, Latest: latest, Default: tb.DefaultVersion}
+
+	fromVersion = strings.TrimSpace(fromVersion)
+	if fromVersion == "" {
+		return res, nil
+	}
+
+	// Validate the requested version exists when we have a version list to
+	// check against. If the list is empty (edge case), trust the caller; a
+	// bad value surfaces as a not-found on the subsequent GetToolboxVersion.
+	if len(versions) > 0 && !slices.ContainsFunc(versions, func(v azure.ToolboxVersionObject) bool {
+		return v.Version == fromVersion
+	}) {
+		return branchResolution{}, exterrors.Validation(
+			exterrors.CodeToolboxVersionNotFound,
+			fmt.Sprintf("version %q does not exist for toolbox %q", fromVersion, toolboxName),
+			fmt.Sprintf("run `azd ai toolbox versions list %q` to see available versions", toolboxName),
+		)
+	}
+
+	res.Branch = fromVersion
+	return res, nil
+}
+
+// printBranchNote surfaces, in text output only, that a new version was branched
+// from a version other than the default so the user understands the new version
+// extends Latest (not Default) and the default is still unchanged. It is a no-op
+// when the branch is the default version or in JSON output.
+func printBranchNote(output string, branch branchResolution) {
+	if output == "json" || !branch.branchedFromNonDefault() {
+		return
+	}
+	if branch.Branch == branch.Latest {
+		fmt.Printf(
+			"Note: branched from version %s (the latest); the default version is still %s.\n",
+			branch.Branch, branch.Default,
+		)
+		return
+	}
+	fmt.Printf(
+		"Note: branched from version %s (--from-version); the latest is %s and the default is %s.\n",
+		branch.Branch, branch.Latest, branch.Default,
+	)
+}

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_branch_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_branch_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azure.ai.toolboxes/internal/exterrors"
+	"azure.ai.toolboxes/internal/foundry/connections"
+	"azure.ai.toolboxes/internal/pkg/azure"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tbWithVersions seeds a mock toolbox whose default is "1" but whose latest
+// version is "2" (v2 = v1 + a "greeting" skill), reproducing the #8674 setup
+// where default != latest.
+func tbWithDefaultOneLatestTwo(client *mockToolboxClient) {
+	client.getResults["tb"] = toolboxGetResult{obj: &azure.ToolboxObject{
+		Name: "tb", DefaultVersion: "1",
+	}}
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"},
+		{Name: "tb", Version: "2"},
+	}
+	client.versionResults["tb/1"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "1",
+		Tools:  []map[string]any{{"type": "mcp", "name": "a", "project_connection_id": "/c/a"}},
+		Skills: nil,
+	}}
+	client.versionResults["tb/2"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "2",
+		Tools:  []map[string]any{{"type": "mcp", "name": "a", "project_connection_id": "/c/a"}},
+		Skills: []map[string]any{{"type": "skill_reference", "name": "greeting"}},
+	}}
+}
+
+// Regression for #8674: `skill add` must branch from the LATEST version (v2),
+// so the new version accumulates greeting + code-review instead of silently
+// dropping greeting by forking from the default (v1).
+func TestRunSkillAddWith_BranchesFromLatestNotDefault(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	tbWithDefaultOneLatestTwo(client)
+
+	err := runSkillAddWith(t.Context(), client, "tb", "code-review", skillAddFlags{}, toolboxFlags{output: "json"})
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+
+	req := client.createVersionCalls[0].req
+	names := skillNames(req.Skills)
+	assert.Contains(t, names, "greeting", "skills from latest version must be carried forward")
+	assert.Contains(t, names, "code-review", "new skill must be attached")
+	assert.Len(t, req.Skills, 2)
+}
+
+// --from-version pins the branch source to an explicit version (here the default
+// v1), preserving the old default-snapshot behavior on demand.
+func TestRunSkillAddWith_FromVersionOverridesLatest(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	tbWithDefaultOneLatestTwo(client)
+
+	err := runSkillAddWith(
+		t.Context(), client, "tb", "code-review",
+		skillAddFlags{fromVersion: "1"}, toolboxFlags{output: "json"},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+
+	names := skillNames(client.createVersionCalls[0].req.Skills)
+	assert.NotContains(t, names, "greeting", "branching from v1 must not carry v2's skills")
+	assert.Contains(t, names, "code-review")
+	assert.Len(t, names, 1)
+}
+
+// A --from-version that does not exist is rejected with a clear error.
+func TestRunSkillAddWith_FromVersionNotFound(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	tbWithDefaultOneLatestTwo(client)
+
+	err := runSkillAddWith(
+		t.Context(), client, "tb", "code-review",
+		skillAddFlags{fromVersion: "99"}, toolboxFlags{output: "json"},
+	)
+	requireLocalError(t, err, exterrors.CodeToolboxVersionNotFound)
+	assert.Empty(t, client.createVersionCalls, "no version created when --from-version is invalid")
+}
+
+// `skill remove` also branches from the latest version.
+func TestRunSkillRemoveWith_BranchesFromLatestNotDefault(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	tbWithDefaultOneLatestTwo(client)
+
+	err := runSkillRemoveWith(
+		t.Context(), client, "tb", []string{"greeting"},
+		skillRemoveFlags{force: true}, toolboxFlags{output: "json", noPrompt: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+	assert.Empty(t, skillNames(client.createVersionCalls[0].req.Skills),
+		"removing greeting from latest (v2) leaves no skills")
+}
+
+// resolveBranchVersion falls back to the default version when the toolbox
+// reports no versions (edge case), preserving today's behavior.
+func TestResolveBranchVersion_EmptyListFallsBackToDefault(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	tb := &azure.ToolboxObject{Name: "tb", DefaultVersion: "1"}
+
+	got, err := resolveBranchVersion(t.Context(), client, "tb", tb, "")
+	require.NoError(t, err)
+	assert.Equal(t, "1", got.Branch)
+	assert.Equal(t, "1", got.Latest)
+	assert.Equal(t, "1", got.Default)
+	assert.False(t, got.branchedFromNonDefault())
+}
+
+// `connection add` also branches from the latest version, carrying forward the
+// tools attached to v2 rather than v1 (default).
+func TestRunConnectionAddWith_BranchesFromLatestNotDefault(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	client.getResults["tb"] = toolboxGetResult{obj: &azure.ToolboxObject{
+		Name: "tb", DefaultVersion: "1",
+	}}
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"}, {Name: "tb", Version: "2"},
+	}
+	client.versionResults["tb/1"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "1",
+		Tools: []map[string]any{{"type": "mcp", "name": "a", "project_connection_id": "/c/a"}},
+	}}
+	client.versionResults["tb/2"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "2",
+		Tools: []map[string]any{
+			{"type": "mcp", "name": "a", "project_connection_id": "/c/a"},
+			{"type": "mcp", "name": "b", "project_connection_id": "/c/b"},
+		},
+	}}
+	resolver := newStubConnectionResolver()
+	resolver.byName["c"] = &projectConnection{
+		ID: "/c/c", Category: connections.ConnectionTypeRemoteTool, Name: "c", Target: "https://mcp-c",
+	}
+
+	err := runConnectionAddWith(
+		t.Context(), client, resolver, "https://e/",
+		"tb", "c", connectionAddFlags{}, toolboxFlags{output: "json"},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+
+	ids := []string{}
+	forEachToolConnectionID(client.createVersionCalls[0].req.Tools, func(id string) bool {
+		ids = append(ids, id)
+		return false
+	})
+	assert.ElementsMatch(t, []string{"/c/a", "/c/b", "/c/c"}, ids,
+		"tools from latest version (v2: a,b) must be carried forward plus the new one (c)")
+}
+
+// skillNames extracts the "name" of each skill entry for assertions.
+func skillNames(skills []map[string]any) []string {
+	out := make([]string, 0, len(skills))
+	for _, s := range skills {
+		if n, ok := s["name"].(string); ok {
+			out = append(out, n)
+		}
+	}
+	return out
+}

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_branch_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_branch_test.go
@@ -116,6 +116,14 @@ func TestResolveBranchVersion_EmptyListFallsBackToDefault(t *testing.T) {
 	assert.False(t, got.branchedFromNonDefault())
 }
 
+func TestResolveBranchVersion_EmptyListRejectsUnknownFromVersion(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	tb := &azure.ToolboxObject{Name: "tb", DefaultVersion: "1"}
+
+	_, err := resolveBranchVersion(t.Context(), client, "tb", tb, "99")
+	requireLocalError(t, err, exterrors.CodeToolboxVersionNotFound)
+}
+
 // `connection add` also branches from the latest version, carrying forward the
 // tools attached to v2 rather than v1 (default).
 func TestRunConnectionAddWith_BranchesFromLatestNotDefault(t *testing.T) {
@@ -156,6 +164,45 @@ func TestRunConnectionAddWith_BranchesFromLatestNotDefault(t *testing.T) {
 	})
 	assert.ElementsMatch(t, []string{"/c/a", "/c/b", "/c/c"}, ids,
 		"tools from latest version (v2: a,b) must be carried forward plus the new one (c)")
+}
+
+func TestRunConnectionRemoveWith_BranchesFromLatestNotDefault(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	client.getResults["tb"] = toolboxGetResult{obj: &azure.ToolboxObject{
+		Name: "tb", DefaultVersion: "1",
+	}}
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"}, {Name: "tb", Version: "2"},
+	}
+	client.versionResults["tb/1"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "1",
+		Tools: []map[string]any{{"type": "mcp", "name": "a", "project_connection_id": "/c/a"}},
+	}}
+	client.versionResults["tb/2"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "2",
+		Tools: []map[string]any{
+			{"type": "mcp", "name": "a", "project_connection_id": "/c/a"},
+			{"type": "mcp", "name": "b", "project_connection_id": "/c/b"},
+		},
+		Skills: []map[string]any{{"type": "skill_reference", "name": "greeting"}},
+	}}
+	resolver := newStubConnectionResolver()
+	resolver.byName["b"] = &projectConnection{
+		ID: "/c/b", Category: connections.ConnectionTypeRemoteTool, Name: "b",
+	}
+
+	err := runConnectionRemoveWith(
+		t.Context(), client, resolver, "https://e/",
+		"tb", []string{"b"}, connectionRemoveFlags{force: true}, toolboxFlags{output: "json"},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+
+	req := client.createVersionCalls[0].req
+	require.Len(t, req.Tools, 1)
+	assert.Equal(t, "/c/a", req.Tools[0]["project_connection_id"])
+	assert.Equal(t, []string{"greeting"}, skillNames(req.Skills),
+		"skills from latest version must be carried forward")
 }
 
 // Regression for review feedback (#8674 PR): skill add/remove must carry

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_branch_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_branch_test.go
@@ -158,6 +158,79 @@ func TestRunConnectionAddWith_BranchesFromLatestNotDefault(t *testing.T) {
 		"tools from latest version (v2: a,b) must be carried forward plus the new one (c)")
 }
 
+// Regression for review feedback (#8674 PR): skill add/remove must carry
+// forward the branched-from version's policies (e.g. rai_config), matching
+// connection add/remove — otherwise a skill mutation silently drops governance.
+func TestRunSkillAddWith_CarriesForwardPolicies(t *testing.T) {
+	policies := &azure.ToolboxPolicies{RaiConfig: &azure.RaiConfig{RaiPolicyName: "strict"}}
+	client := newMockToolboxClient("https://e/")
+	client.getResults["tb"] = toolboxGetResult{obj: &azure.ToolboxObject{Name: "tb", DefaultVersion: "1"}}
+	client.versionResults["tb/1"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "1",
+		Tools:    []map[string]any{{"type": "mcp", "name": "a", "project_connection_id": "/c/a"}},
+		Policies: policies,
+	}}
+
+	err := runSkillAddWith(t.Context(), client, "tb", "new-skill", skillAddFlags{}, toolboxFlags{output: "json"})
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+	assert.Equal(t, policies, client.createVersionCalls[0].req.Policies,
+		"policies must be carried forward into the new version")
+}
+
+func TestRunSkillRemoveWith_CarriesForwardPolicies(t *testing.T) {
+	policies := &azure.ToolboxPolicies{RaiConfig: &azure.RaiConfig{RaiPolicyName: "strict"}}
+	client := newMockToolboxClient("https://e/")
+	client.getResults["tb"] = toolboxGetResult{obj: &azure.ToolboxObject{Name: "tb", DefaultVersion: "1"}}
+	client.versionResults["tb/1"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "1",
+		Tools:    []map[string]any{{"type": "mcp", "name": "a", "project_connection_id": "/c/a"}},
+		Skills:   []map[string]any{{"type": "skill_reference", "name": "greeting"}},
+		Policies: policies,
+	}}
+
+	err := runSkillRemoveWith(
+		t.Context(), client, "tb", []string{"greeting"},
+		skillRemoveFlags{force: true}, toolboxFlags{output: "json", noPrompt: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+	assert.Equal(t, policies, client.createVersionCalls[0].req.Policies,
+		"policies must be carried forward into the new version")
+}
+
+// resolveBranchVersion derives "latest" by recency (CreatedAt) first, so the
+// most recently created version wins even when it is not the highest number
+// (addresses the review question about max-numeric != true tip).
+func TestResolveBranchVersion_LatestByCreatedAt(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	tb := &azure.ToolboxObject{Name: "tb", DefaultVersion: "1"}
+	// Version "2" is numerically highest but "10" was created most recently.
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "2", CreatedAt: 100},
+		{Name: "tb", Version: "10", CreatedAt: 200},
+	}
+
+	got, err := resolveBranchVersion(t.Context(), client, "tb", tb, "")
+	require.NoError(t, err)
+	assert.Equal(t, "10", got.Latest, "most recently created version wins")
+	assert.Equal(t, "10", got.Branch)
+}
+
+// With CreatedAt unset (tied at 0), the numeric-aware comparator breaks the tie.
+func TestResolveBranchVersion_LatestNumericFallback(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	tb := &azure.ToolboxObject{Name: "tb", DefaultVersion: "1"}
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"},
+		{Name: "tb", Version: "2"},
+	}
+
+	got, err := resolveBranchVersion(t.Context(), client, "tb", tb, "")
+	require.NoError(t, err)
+	assert.Equal(t, "2", got.Latest, "highest version wins when CreatedAt is unset")
+}
+
 // skillNames extracts the "name" of each skill entry for assertions.
 func skillNames(skills []map[string]any) []string {
 	out := make([]string, 0, len(skills))

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_commands_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_commands_test.go
@@ -362,8 +362,11 @@ func TestRunConnectionRemoveWith_FilteredAndPromoted(t *testing.T) {
 func TestRunConnectionRemoveWith_ConnectionNotInToolbox(t *testing.T) {
 	client := newMockToolboxClient("https://e/")
 	client.getResults["tb"] = toolboxGetResult{obj: &azure.ToolboxObject{Name: "tb", DefaultVersion: "1"}}
-	client.versionResults["tb/1"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
-		Name: "tb", Version: "1", Tools: []map[string]any{
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"}, {Name: "tb", Version: "2"},
+	}
+	client.versionResults["tb/2"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "2", Tools: []map[string]any{
 			{"type": "mcp", "name": "other", "project_connection_id": "/c/other"},
 		},
 	}}
@@ -378,7 +381,8 @@ func TestRunConnectionRemoveWith_ConnectionNotInToolbox(t *testing.T) {
 		connectionRemoveFlags{force: true},
 		toolboxFlags{output: "table"},
 	)
-	requireLocalError(t, err, exterrors.CodeConnectionNotInToolbox)
+	localErr := requireLocalError(t, err, exterrors.CodeConnectionNotInToolbox)
+	assert.Contains(t, localErr.Suggestion, `azd ai toolbox show "tb" --version "2"`)
 }
 
 func TestRunConnectionListWith_EmitsAllShapes(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection.go
@@ -24,9 +24,11 @@ func newToolboxConnectionCommand(extCtx *azdext.ExtensionContext) *cobra.Command
 
 Tools are project connections. Supported categories: RemoteTool (MCP),
 CognitiveSearch (Azure AI Search), RemoteA2A, and GroundingWithCustomSearch.
-Each mutation creates a new immutable version; the toolbox's default version
-is unchanged. Use 'azd ai toolbox publish <toolbox> <version>'
-to promote a version.`,
+Each mutation creates a new immutable version branched from the toolbox's
+latest version, so sequential operations accumulate. Use --from-version to
+branch from a specific version instead. The toolbox's default version is
+unchanged; use 'azd ai toolbox publish <toolbox> <version>' to promote a
+version.`,
 	}
 	cmd.AddCommand(newToolboxConnectionAddCommand(extCtx))
 	cmd.AddCommand(newToolboxConnectionRemoveCommand(extCtx))

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_add.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_add.go
@@ -21,6 +21,7 @@ type connectionAddFlags struct {
 	index        string
 	instanceName string
 	fromFile     string
+	fromVersion  string
 }
 
 // newToolboxConnectionAddCommand returns the `connection add` command.
@@ -111,6 +112,7 @@ Examples:
 		&flags.fromFile, "from-file", "",
 		"Path to a JSON/YAML file describing the connections to add (see --help for the file shape).",
 	)
+	registerFromVersionFlag(cmd, &flags.fromVersion)
 	registerToolboxOutputFlag(cmd)
 	return cmd
 }
@@ -164,7 +166,11 @@ func runConnectionAddWith(
 		return exterrors.ServiceFromAzure(err, exterrors.OpGetToolbox)
 	}
 
-	current, err := client.GetToolboxVersion(ctx, toolboxName, tb.DefaultVersion)
+	branch, err := resolveBranchVersion(ctx, client, toolboxName, tb, verb.fromVersion)
+	if err != nil {
+		return err
+	}
+	current, err := client.GetToolboxVersion(ctx, toolboxName, branch.Branch)
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpGetToolboxVersion)
 	}
@@ -247,7 +253,13 @@ func runConnectionAddWith(
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateToolboxVersion)
 	}
 
-	return emitConnectionAddResult(toolboxName, created.Version, addedConnectionNames, parent.output, endpoint)
+	if err := emitConnectionAddResult(
+		toolboxName, created.Version, addedConnectionNames, parent.output, endpoint,
+	); err != nil {
+		return err
+	}
+	printBranchNote(parent.output, branch)
+	return nil
 }
 
 // rejectDuplicatesAgainstCurrentAndBatch flags a duplicate if any new entry

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_remove.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_remove.go
@@ -18,7 +18,8 @@ import (
 
 // connectionRemoveFlags carries the verb-specific flags for `connection remove`.
 type connectionRemoveFlags struct {
-	force bool
+	force       bool
+	fromVersion string
 }
 
 // newToolboxConnectionRemoveCommand returns the `connection remove` command.
@@ -55,6 +56,7 @@ Examples:
 		&flags.force, "force", false,
 		"Skip confirmation prompts and apply the removal immediately.",
 	)
+	registerFromVersionFlag(cmd, &flags.fromVersion)
 	registerToolboxOutputFlag(cmd)
 	return cmd
 }
@@ -121,7 +123,11 @@ func runConnectionRemoveWith(
 	if err != nil {
 		return toolboxNotFoundOrService(err, toolboxName, exterrors.OpGetToolbox)
 	}
-	current, err := client.GetToolboxVersion(ctx, toolboxName, tb.DefaultVersion)
+	branch, err := resolveBranchVersion(ctx, client, toolboxName, tb, verb.fromVersion)
+	if err != nil {
+		return err
+	}
+	current, err := client.GetToolboxVersion(ctx, toolboxName, branch.Branch)
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpGetToolboxVersion)
 	}
@@ -140,8 +146,8 @@ func runConnectionRemoveWith(
 			return exterrors.Validation(
 				exterrors.CodeConnectionNotInToolbox,
 				fmt.Sprintf(
-					"connection %q is not attached to toolbox %q's current default version",
-					name, toolboxName,
+					"connection %q is not attached to version %s of toolbox %q",
+					name, branch.Branch, toolboxName,
 				),
 				fmt.Sprintf("run 'azd ai toolbox connection list %q'", toolboxName),
 			)
@@ -203,7 +209,11 @@ func runConnectionRemoveWith(
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateToolboxVersion)
 	}
 
-	return emitConnectionRemoveResult(toolboxName, created.Version, removedConns, parent.output)
+	if err := emitConnectionRemoveResult(toolboxName, created.Version, removedConns, parent.output); err != nil {
+		return err
+	}
+	printBranchNote(parent.output, branch)
+	return nil
 }
 
 // summarizeConnectionNames renders "connection \"a\"" or "connections [\"a\", \"b\"]".

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_remove.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_remove.go
@@ -149,7 +149,7 @@ func runConnectionRemoveWith(
 					"connection %q is not attached to version %s of toolbox %q",
 					name, branch.Branch, toolboxName,
 				),
-				fmt.Sprintf("run 'azd ai toolbox connection list %q'", toolboxName),
+				fmt.Sprintf("run 'azd ai toolbox show %q --version %q'", toolboxName, branch.Branch),
 			)
 		}
 		removedConns = append(removedConns, conn)

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_add.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_add.go
@@ -18,7 +18,8 @@ import (
 
 // skillAddFlags carries the verb-specific flags for `skill add`.
 type skillAddFlags struct {
-	fromFile string
+	fromFile    string
+	fromVersion string
 }
 
 // newToolboxSkillAddCommand returns the `skill add` command.
@@ -70,6 +71,7 @@ Examples:
 		&flags.fromFile, "from-file", "",
 		"Path to a JSON/YAML file listing skills to attach (skills[] block).",
 	)
+	registerFromVersionFlag(cmd, &flags.fromVersion)
 	registerToolboxOutputFlag(cmd)
 	return cmd
 }
@@ -125,12 +127,16 @@ func runSkillAddWith(
 	if err != nil {
 		return toolboxNotFoundOrService(err, toolboxName, exterrors.OpGetToolbox)
 	}
-	current, err := client.GetToolboxVersion(ctx, toolboxName, tb.DefaultVersion)
+	branch, err := resolveBranchVersion(ctx, client, toolboxName, tb, verb.fromVersion)
+	if err != nil {
+		return err
+	}
+	current, err := client.GetToolboxVersion(ctx, toolboxName, branch.Branch)
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpGetToolboxVersion)
 	}
 
-	// Reject duplicates within the input and against the current default.
+	// Reject duplicates within the input and against the version being extended.
 	seen := map[string]struct{}{}
 	for _, sk := range current.Skills {
 		if n, ok := sk["name"].(string); ok && n != "" {
@@ -142,9 +148,9 @@ func runSkillAddWith(
 			return exterrors.Validation(
 				exterrors.CodeSkillAlreadyAttached,
 				fmt.Sprintf(
-					"skill %q is already attached to toolbox %q's current default version "+
+					"skill %q is already attached to version %s of toolbox %q "+
 						"(or appears more than once in the input)",
-					sp.Name, toolboxName,
+					sp.Name, branch.Branch, toolboxName,
 				),
 				fmt.Sprintf(
 					"remove the existing reference with `azd ai toolbox skill remove %q %q` first",
@@ -171,7 +177,11 @@ func runSkillAddWith(
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateToolboxVersion)
 	}
 
-	return emitSkillAddResult(toolboxName, created.Version, specs, parent.output)
+	if err := emitSkillAddResult(toolboxName, created.Version, specs, parent.output); err != nil {
+		return err
+	}
+	printBranchNote(parent.output, branch)
+	return nil
 }
 
 // collectSkillSpecs picks the active input mode and returns the parsed list.

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_add.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_add.go
@@ -171,6 +171,7 @@ func runSkillAddWith(
 		Metadata:    current.Metadata,
 		Tools:       current.Tools,
 		Skills:      newSkills,
+		Policies:    current.Policies,
 	}
 	created, err := client.CreateToolboxVersion(ctx, toolboxName, req)
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_group.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_group.go
@@ -16,9 +16,11 @@ func newToolboxSkillCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 		Short: "Manage skill references attached to a toolbox.",
 		Long: `Manage skill references attached to a toolbox.
 
-Each add/remove creates a new immutable version; the toolbox's default
-version is unchanged. Use 'azd ai toolbox publish <toolbox> <version>'
-to promote a version.`,
+Each add/remove creates a new immutable version branched from the toolbox's
+latest version, so sequential operations accumulate. Use --from-version to
+branch from a specific version instead. The toolbox's default version is
+unchanged; use 'azd ai toolbox publish <toolbox> <version>' to promote a
+version.`,
 	}
 	cmd.AddCommand(newToolboxSkillAddCommand(extCtx))
 	cmd.AddCommand(newToolboxSkillRemoveCommand(extCtx))

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_remove.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_remove.go
@@ -172,6 +172,7 @@ func runSkillRemoveWith(
 		Metadata:    current.Metadata,
 		Tools:       current.Tools,
 		Skills:      filtered,
+		Policies:    current.Policies,
 	}
 	created, err := client.CreateToolboxVersion(ctx, toolboxName, req)
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_remove.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_remove.go
@@ -18,7 +18,8 @@ import (
 
 // skillRemoveFlags carries the verb-specific flags for `skill remove`.
 type skillRemoveFlags struct {
-	force bool
+	force       bool
+	fromVersion string
 }
 
 // newToolboxSkillRemoveCommand returns the `skill remove` command.
@@ -52,6 +53,7 @@ Examples:
 		&flags.force, "force", false,
 		"Skip confirmation prompts and apply the removal immediately.",
 	)
+	registerFromVersionFlag(cmd, &flags.fromVersion)
 	registerToolboxOutputFlag(cmd)
 	return cmd
 }
@@ -111,7 +113,11 @@ func runSkillRemoveWith(
 	if err != nil {
 		return toolboxNotFoundOrService(err, toolboxName, exterrors.OpGetToolbox)
 	}
-	current, err := client.GetToolboxVersion(ctx, toolboxName, tb.DefaultVersion)
+	branch, err := resolveBranchVersion(ctx, client, toolboxName, tb, verb.fromVersion)
+	if err != nil {
+		return err
+	}
+	current, err := client.GetToolboxVersion(ctx, toolboxName, branch.Branch)
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpGetToolboxVersion)
 	}
@@ -124,8 +130,8 @@ func runSkillRemoveWith(
 			return exterrors.Validation(
 				exterrors.CodeSkillNotInToolbox,
 				fmt.Sprintf(
-					"skill %q is not attached to toolbox %q's current default version",
-					name, toolboxName,
+					"skill %q is not attached to version %s of toolbox %q",
+					name, branch.Branch, toolboxName,
 				),
 				fmt.Sprintf("run 'azd ai toolbox skill list %q'", toolboxName),
 			)
@@ -172,7 +178,11 @@ func runSkillRemoveWith(
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateToolboxVersion)
 	}
 
-	return emitSkillRemoveResult(toolboxName, created.Version, names, parent.output)
+	if err := emitSkillRemoveResult(toolboxName, created.Version, names, parent.output); err != nil {
+		return err
+	}
+	printBranchNote(parent.output, branch)
+	return nil
 }
 
 // summarizeSkillNames renders "skill \"a\"" or "skills [\"a\", \"b\"]".

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_remove.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_remove.go
@@ -133,7 +133,7 @@ func runSkillRemoveWith(
 					"skill %q is not attached to version %s of toolbox %q",
 					name, branch.Branch, toolboxName,
 				),
-				fmt.Sprintf("run 'azd ai toolbox skill list %q'", toolboxName),
+				fmt.Sprintf("run 'azd ai toolbox show %q --version %q'", toolboxName, branch.Branch),
 			)
 		}
 	}

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_verbs_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_verbs_test.go
@@ -214,8 +214,11 @@ func TestRunSkillRemoveWith_NotAttached(t *testing.T) {
 	client.getResults["tb"] = toolboxGetResult{obj: &azure.ToolboxObject{
 		Name: "tb", DefaultVersion: "1",
 	}}
-	client.versionResults["tb/1"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
-		Name: "tb", Version: "1",
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"}, {Name: "tb", Version: "2"},
+	}
+	client.versionResults["tb/2"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "2",
 		Tools: []map[string]any{{"type": "mcp", "name": "a"}},
 		Skills: []map[string]any{
 			{"type": "skill_reference", "name": "other"},
@@ -225,7 +228,8 @@ func TestRunSkillRemoveWith_NotAttached(t *testing.T) {
 	err := runSkillRemoveWith(t.Context(), client, "tb", []string{"missing"},
 		skillRemoveFlags{force: true}, toolboxFlags{output: "json"},
 	)
-	requireLocalError(t, err, exterrors.CodeSkillNotInToolbox)
+	localErr := requireLocalError(t, err, exterrors.CodeSkillNotInToolbox)
+	assert.Contains(t, localErr.Suggestion, `azd ai toolbox show "tb" --version "2"`)
 }
 
 func TestRunSkillRemove_NoPromptWithoutForce(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/exterrors/codes.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/exterrors/codes.go
@@ -30,6 +30,7 @@ const (
 // Error codes for toolbox operations.
 const (
 	CodeToolboxNotFound               = "toolbox_not_found"
+	CodeToolboxVersionNotFound        = "toolbox_version_not_found"
 	CodeInvalidToolboxName            = "invalid_toolbox_name"
 	CodeMissingUpdateField            = "missing_update_field"
 	CodeDefaultVersionDelete          = "default_version_delete"


### PR DESCRIPTION
Fixes #8674

## What

`azd ai toolbox skill add/remove` and `azd ai toolbox connection add/remove` created the new immutable toolbox version by branching from the toolbox's **default** version rather than its **latest**. Sequential mutations therefore produced *sibling* versions that each silently dropped earlier changes:

```pwsh
azd ai toolbox skill add web-search-toolbox greeting        # v2 = v1 + greeting
azd ai toolbox skill add web-search-toolbox code-review     # v3 = v1 + code-review  ❌ greeting dropped
```

No error, no warning — a silent, data-loss-shaped UX trap on a preview feature.

## Fix

Branch from the **latest** version by default so sequential mutations accumulate (`v3 = v2 + change`):

```pwsh
azd ai toolbox skill add web-search-toolbox greeting        # v2 = v1 + greeting
azd ai toolbox skill add web-search-toolbox code-review     # v3 = v2 + code-review  ✅ both present
```

- **`--from-version <n>`** (new, shared across all four verbs) overrides the branch source. The prior default-snapshot behavior is still reachable via `--from-version <default-version>`. An unknown version is rejected with a clear error.
- When the new version is branched from a **non-default** version, a note is printed clarifying the branch source and that the default is unchanged (text output only).
- The toolbox's default version is still unchanged — `publish` to promote, as before.

Implemented via a shared `resolveBranchVersion` helper (`toolbox_branch.go`) reused by all four verbs, reusing the existing numeric-aware `versionSortDescending`. When a toolbox reports no versions (edge case; a real toolbox always has its default), it falls back to the default version, preserving today's behavior. Duplicate/not-found messages now name the specific version being extended, and the skill/connection group `--help` documents the accumulate semantics and `--from-version`.

## Tests

- `skill add` / `skill remove` / `connection add` branch from **latest** (v2), not default (v1), carrying forward v2's contents.
- `--from-version` pins the branch source (v1) and does **not** carry v2's skills.
- unknown `--from-version` → `toolbox_version_not_found`, no version created.
- empty version list → falls back to default (preserves prior behavior).
- All existing toolbox tests still pass unchanged.

## Validation

`go build ./...`, full `go test ./...`, `go vet`, `gofmt`, `golangci-lint run` (0 issues), and `cspell` — all clean.

## Notes

- Scope: this fixes the **behavior** (item 1 of the issue's "Proposed fix", preferred) plus the CLI-output note and `--help` wording (stopgap UX items 1–2). Public-docs updates (item 3) live in a separate docs repo and are out of scope for this PR.