### PR TITLE
`azd env refresh` with extension-provided hosts and provisioning providers

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -957,6 +957,7 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 	container.MustRegisterSingleton(extensions.NewManager)
 	container.MustRegisterSingleton(extensions.NewSourceManager)
 	container.MustRegisterSingleton(extensions.NewRunner)
+	container.MustRegisterScoped(middleware.NewExtensionActivator)
 	container.MustRegisterSingleton(func(serviceLocator ioc.ServiceLocator) *lazy.Lazy[*extensions.Runner] {
 		return lazy.NewLazy(func() (*extensions.Runner, error) {
 			var runner *extensions.Runner

--- a/cli/azd/cmd/container_test.go
+++ b/cli/azd/cmd/container_test.go
@@ -638,3 +638,18 @@ func Test_ResolveAction_WithNilMiddleware(t *testing.T) {
 	_, err := resolveAction[*coverageTestAction](container, "test-action")
 	require.Error(t, err) // not registered
 }
+
+// Verifies the ExtensionActivator used by env refresh resolves from the IoC container.
+func Test_Resolve_ExtensionActivator(t *testing.T) {
+	t.Parallel()
+	container := ioc.NewNestedContainer(nil)
+	ioc.RegisterInstance(container, context.Background())
+	ioc.RegisterInstance(container, &internal.GlobalCommandOptions{})
+	ioc.RegisterInstance(container, &cobra.Command{})
+	registerCommonDependencies(container)
+
+	var activator *middleware.ExtensionActivator
+	err := container.Resolve(&activator)
+	require.NoError(t, err)
+	require.NotNil(t, activator)
+}

--- a/cli/azd/cmd/container_test.go
+++ b/cli/azd/cmd/container_test.go
@@ -643,7 +643,7 @@ func Test_ResolveAction_WithNilMiddleware(t *testing.T) {
 func Test_Resolve_ExtensionActivator(t *testing.T) {
 	t.Parallel()
 	container := ioc.NewNestedContainer(nil)
-	ioc.RegisterInstance(container, context.Background())
+	ioc.RegisterInstance(container, t.Context())
 	ioc.RegisterInstance(container, &internal.GlobalCommandOptions{})
 	ioc.RegisterInstance(container, &cobra.Command{})
 	registerCommonDependencies(container)

--- a/cli/azd/cmd/env.go
+++ b/cli/azd/cmd/env.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/azure/azure-dev/cli/azd/cmd/actions"
+	"github.com/azure/azure-dev/cli/azd/cmd/middleware"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing"
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
@@ -26,9 +27,11 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/entraid"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/bicep"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/pkg/keyvault"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
@@ -1100,10 +1103,18 @@ func newEnvRefreshCmd() *cobra.Command {
 	return cmd
 }
 
+// provisioningProviderActivator is the narrow slice of *middleware.ExtensionActivator that env
+// refresh consumes; it exists so tests can stub extension activation.
+type provisioningProviderActivator interface {
+	EnsureProvisioningProviders(ctx context.Context, providerNames []string, environmentName string) (func(), error)
+	SuggestExtensionForProvider(ctx context.Context, providerName string) string
+}
+
 type envRefreshAction struct {
 	provisionManager    *provisioning.Manager
 	projectConfig       *project.ProjectConfig
 	projectManager      project.ProjectManager
+	extensionActivator  provisioningProviderActivator
 	env                 *environment.Environment
 	envManager          environment.Manager
 	prompters           prompt.Prompter
@@ -1119,6 +1130,7 @@ func newEnvRefreshAction(
 	provisionManager *provisioning.Manager,
 	projectConfig *project.ProjectConfig,
 	projectManager project.ProjectManager,
+	extensionActivator *middleware.ExtensionActivator,
 	env *environment.Environment,
 	envManager environment.Manager,
 	prompters prompt.Prompter,
@@ -1132,6 +1144,7 @@ func newEnvRefreshAction(
 	return &envRefreshAction{
 		provisionManager:    provisionManager,
 		projectManager:      projectManager,
+		extensionActivator:  extensionActivator,
 		env:                 env,
 		envManager:          envManager,
 		prompters:           prompters,
@@ -1145,34 +1158,60 @@ func newEnvRefreshAction(
 	}
 }
 
+// suggestionForUnresolvedProvider returns the id of a registry extension to suggest installing
+// when err is a provider-resolution failure; any other initialization error skips the registry
+// lookup and returns an empty string.
+func suggestionForUnresolvedProvider(
+	ctx context.Context,
+	err error,
+	activator provisioningProviderActivator,
+	providerName string,
+) string {
+	if !errors.Is(err, ioc.ErrResolveInstance) {
+		return ""
+	}
+
+	return activator.SuggestExtensionForProvider(ctx, providerName)
+}
+
 func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	// Command title
 	ef.console.MessageUxItem(ctx, &ux.MessageTitle{
 		Title: fmt.Sprintf("Refreshing environment %s (azd env refresh)", ef.env.Name()),
 	})
 
-	if err := ef.projectManager.Initialize(ctx, ef.projectConfig); err != nil {
-		return nil, err
-	}
-
-	if err := ef.projectManager.EnsureAllTools(ctx, ef.projectConfig, nil); err != nil {
-		return nil, err
-	}
-
-	infra, err := ef.importManager.ProjectInfrastructure(ctx, ef.projectConfig)
+	// `env refresh` is read-only: it deliberately skips service-target initialization and tool
+	// checks, which would fail for extension-provided hosts (for example `azure.ai.agent`).
+	// Framework lifecycle hooks are wired best-effort after the outputs are pulled - see below.
+	projectInfra, err := ef.importManager.ProjectInfrastructure(ctx, ef.projectConfig)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = infra.Cleanup() }()
+	defer func() { _ = projectInfra.Cleanup() }()
 
-	layers := infra.Options.GetLayers()
+	layers := projectInfra.Options.GetLayers()
 	if ef.flags.layer != "" {
-		layerOpt, err := infra.Options.GetLayer(ef.flags.layer)
+		layerOpt, err := projectInfra.Options.GetLayer(ef.flags.layer)
 		if err != nil {
 			return nil, err
 		}
 		layers = []provisioning.Options{layerOpt}
 	}
+
+	// Extension-provided provisioning providers (for example `microsoft.foundry`) are only
+	// resolvable while the owning extension runs, and `env refresh` does not run the extensions
+	// middleware. Start just the installed extension(s) declaring the configured provider(s);
+	// all other names resolve natively as in every other command.
+	providerNames := make([]string, 0, len(layers))
+	for _, layer := range layers {
+		providerNames = append(providerNames, string(layer.Provider))
+	}
+
+	cleanupProviders, err := ef.extensionActivator.EnsureProvisioningProviders(ctx, providerNames, ef.env.Name())
+	if err != nil {
+		return nil, fmt.Errorf("activating provisioning provider extensions: %w", err)
+	}
+	defer cleanupProviders()
 
 	// If resource group is defined within the project but not in the environment then
 	// add it to the environment to support BYOI lookup scenarios like ADE
@@ -1183,6 +1222,7 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 	}
 
 	var state provisioning.State
+	stateRefreshed := false
 	for _, layer := range layers {
 		if ef.flags.layer != "" || len(layers) > 1 {
 			ef.console.EnsureBlankLine(ctx)
@@ -1200,13 +1240,54 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 				return nil, err
 			}
 		} else if err != nil {
-			return nil, fmt.Errorf("initializing provisioning manager: %w", err)
+			err = fmt.Errorf("initializing provisioning manager: %w", err)
+
+			// A resolution failure for a provider that a registry (non-installed) extension
+			// declares is almost certainly the missing extension: suggest installing it.
+			if extensionId := suggestionForUnresolvedProvider(
+				ctx, err, ef.extensionActivator, string(layer.Provider)); extensionId != "" {
+				return nil, &internal.ErrorWithSuggestion{
+					Err: err,
+					Suggestion: fmt.Sprintf(
+						"Provisioning provider '%s' is supplied by the '%s' extension. To install it, run %s",
+						layer.Provider,
+						extensionId,
+						output.WithHighLightFormat("azd extension install %s", extensionId),
+					),
+				}
+			}
+
+			return nil, err
 		}
 
 		stateOptions := provisioning.NewStateOptions(ef.flags.hint)
 		result, err := ef.provisionManager.State(ctx, stateOptions)
 		if err != nil {
+			// No deployment exists yet (for example, refresh before `azd provision`): this is
+			// informational, not an error - continue so any other layers still refresh. An
+			// explicit --hint stays a hard error because CompletedDeployments wraps the same
+			// sentinel when deployments exist but none matches the hint.
+			if errors.Is(err, infra.ErrDeploymentsNotFound) && ef.flags.hint == "" {
+				ef.console.Message(ctx, fmt.Sprintf(
+					"No deployment was found for environment '%s'; there are no outputs to refresh yet. "+
+						"Run %s to create one.",
+					ef.env.Name(),
+					output.WithHighLightFormat("azd provision"),
+				))
+				continue
+			}
+
 			return nil, fmt.Errorf("getting deployment: %w", err)
+		}
+
+		// Extension providers may reply with an empty state result (nothing deployed yet); treat
+		// it like the no-deployment case rather than dereferencing a nil state.
+		if result == nil || result.State == nil {
+			ef.console.Message(ctx, fmt.Sprintf(
+				"No deployment state was found for environment '%s'; there are no outputs to refresh yet.",
+				ef.env.Name(),
+			))
+			continue
 		}
 
 		if err := provisioning.UpdateEnvironment(ctx, result.State.Outputs, ef.env, ef.envManager); err != nil {
@@ -1214,6 +1295,7 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 		}
 
 		state.MergeInto(*result.State)
+		stateRefreshed = true
 	}
 
 	if ef.formatter.Kind() == output.JsonFormat {
@@ -1223,23 +1305,36 @@ func (ef *envRefreshAction) Run(ctx context.Context) (*actions.ActionResult, err
 		}
 	}
 
-	servicesStable, err := ef.importManager.ServiceStable(ctx, ef.projectConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, svc := range servicesStable {
-		eventArgs := project.ServiceLifecycleEventArgs{
-			Project:        ef.projectConfig,
-			Service:        svc,
-			ServiceContext: project.NewServiceContext(),
-			Args: map[string]any{
-				"bicepOutput": state.Outputs,
-			},
+	// Wire framework lifecycle hooks (such as the .NET ServiceEventEnvUpdated handler that syncs
+	// outputs into user-secrets) best-effort per service, and raise the event only when a layer
+	// actually produced state. Services whose framework fails to initialize are reported and
+	// skipped rather than failing the refresh.
+	if stateRefreshed {
+		initializedServices, skipped, err := ef.projectManager.InitializeFrameworks(ctx, ef.projectConfig)
+		if err != nil {
+			return nil, err
 		}
 
-		if err := svc.RaiseEvent(ctx, project.ServiceEventEnvUpdated, eventArgs); err != nil {
-			return nil, err
+		for _, skip := range skipped {
+			ef.console.MessageUxItem(ctx, &ux.WarningMessage{
+				Description: fmt.Sprintf(
+					"Skipping environment update events for service '%s': %v", skip.Service.Name, skip.Err),
+			})
+		}
+
+		for _, svc := range initializedServices {
+			eventArgs := project.ServiceLifecycleEventArgs{
+				Project:        ef.projectConfig,
+				Service:        svc,
+				ServiceContext: project.NewServiceContext(),
+				Args: map[string]any{
+					"bicepOutput": state.Outputs,
+				},
+			}
+
+			if err := svc.RaiseEvent(ctx, project.ServiceEventEnvUpdated, eventArgs); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/cli/azd/cmd/env_test.go
+++ b/cli/azd/cmd/env_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -31,7 +32,10 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
 	"github.com/azure/azure-dev/cli/azd/pkg/keyvault"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
@@ -1221,6 +1225,7 @@ func Test_NewEnvRefreshAction(t *testing.T) {
 		nil, // provisionManager
 		&project.ProjectConfig{},
 		nil, // projectManager
+		nil, // extensionActivator
 		environment.NewWithValues("test", nil),
 		nil, // envManager
 		nil, // prompters
@@ -1232,6 +1237,218 @@ func Test_NewEnvRefreshAction(t *testing.T) {
 		nil, // alphaFeatureManager
 	)
 	require.NotNil(t, action)
+}
+
+// stubProviderActivator is a no-op provisioningProviderActivator for tests.
+type stubProviderActivator struct {
+	suggestion string
+}
+
+func (s *stubProviderActivator) EnsureProvisioningProviders(
+	_ context.Context, _ []string, _ string,
+) (func(), error) {
+	return func() {}, nil
+}
+
+func (s *stubProviderActivator) SuggestExtensionForProvider(_ context.Context, _ string) string {
+	return s.suggestion
+}
+
+// The install suggestion must fire only for provider-resolution failures; any other provisioning
+// initialization error skips the registry lookup entirely.
+func Test_suggestionForUnresolvedProvider(t *testing.T) {
+	t.Parallel()
+	activator := &stubProviderActivator{suggestion: "azure.ai.agents"}
+
+	resolveErr := fmt.Errorf("initializing provisioning manager: %w",
+		fmt.Errorf("failed resolving IaC provider 'microsoft.foundry': %w", ioc.ErrResolveInstance))
+	require.Equal(t, "azure.ai.agents",
+		suggestionForUnresolvedProvider(t.Context(), resolveErr, activator, "microsoft.foundry"))
+
+	require.Empty(t,
+		suggestionForUnresolvedProvider(t.Context(), errors.New("deployment failed"), activator, "microsoft.foundry"))
+}
+
+// mockRefreshProvider is a provisioning.Provider whose State behavior is configurable.
+type mockRefreshProvider struct {
+	stateResult *provisioning.StateResult
+	stateErr    error
+}
+
+func (p *mockRefreshProvider) Name() string { return "mock" }
+
+func (p *mockRefreshProvider) Initialize(_ context.Context, _ string, _ provisioning.Options) error {
+	return nil
+}
+
+func (p *mockRefreshProvider) State(
+	_ context.Context, _ *provisioning.StateOptions,
+) (*provisioning.StateResult, error) {
+	return p.stateResult, p.stateErr
+}
+
+func (p *mockRefreshProvider) Deploy(_ context.Context) (*provisioning.DeployResult, error) {
+	return nil, nil
+}
+
+func (p *mockRefreshProvider) Preview(_ context.Context) (*provisioning.DeployPreviewResult, error) {
+	return nil, nil
+}
+
+func (p *mockRefreshProvider) Destroy(
+	_ context.Context, _ provisioning.DestroyOptions,
+) (*provisioning.DestroyResult, error) {
+	return nil, nil
+}
+
+func (p *mockRefreshProvider) EnsureEnv(_ context.Context) error { return nil }
+
+func (p *mockRefreshProvider) Parameters(_ context.Context) ([]provisioning.Parameter, error) {
+	return nil, nil
+}
+
+func (p *mockRefreshProvider) PlannedOutputs(_ context.Context) ([]provisioning.PlannedOutput, error) {
+	return nil, nil
+}
+
+// newTestEnvRefreshAction wires an envRefreshAction against a real provisioning.Manager backed by
+// the given mock provider, mirroring the setup in internal/cmd/provision_test.go.
+func newTestEnvRefreshAction(
+	t *testing.T,
+	provider provisioning.Provider,
+	flags *envRefreshFlags,
+) (*envRefreshAction, *mockinput.MockConsole, *mockenv.MockEnvManager, *mockProjectManager) {
+	projectDir := t.TempDir()
+	infraDir := filepath.Join(projectDir, "infra")
+	require.NoError(t, os.MkdirAll(infraDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(infraDir, "main.bicep"), []byte("targetScope = 'subscription'\n"), 0o600))
+
+	container := ioc.NewNestedContainer(nil)
+	ioc.RegisterNamedInstance(container, string(provisioning.Test), provider)
+
+	env := environment.New("test-env")
+	env.SetSubscriptionId("00000000-0000-0000-0000-000000000000")
+	env.SetLocation("eastus2")
+
+	console := mockinput.NewMockConsole()
+
+	provisionManager := provisioning.NewManager(
+		container,
+		func() (provisioning.ProviderKind, error) { return provisioning.Test, nil },
+		nil, // envManager - the mock provider does not prompt
+		env,
+		console,
+		alpha.NewFeaturesManagerWithConfig(config.NewEmptyConfig()),
+		nil, // fileShareService
+		cloud.AzurePublic(),
+	)
+
+	envManager := &mockenv.MockEnvManager{}
+	envManager.On("EnvPath", mock.Anything).Return(filepath.Join(projectDir, ".azure", "test-env", ".env"))
+
+	pm := &mockProjectManager{}
+
+	projectConfig := &project.ProjectConfig{
+		Name: "test-project",
+		Path: projectDir,
+		Infra: provisioning.Options{
+			Provider: provisioning.Test,
+			Path:     "infra",
+			Module:   "main",
+		},
+	}
+
+	action := &envRefreshAction{
+		provisionManager:    provisionManager,
+		projectConfig:       projectConfig,
+		projectManager:      pm,
+		extensionActivator:  &stubProviderActivator{},
+		env:                 env,
+		envManager:          envManager,
+		flags:               flags,
+		console:             console,
+		formatter:           &output.NoneFormatter{},
+		writer:              io.Discard,
+		importManager:       project.NewImportManager(nil),
+		alphaFeatureManager: alpha.NewFeaturesManagerWithConfig(config.NewEmptyConfig()),
+	}
+
+	return action, console, envManager, pm
+}
+
+func Test_EnvRefreshAction_Run_NoDeployments(t *testing.T) {
+	t.Parallel()
+
+	// The no-deployment case is informational, not an error: refresh completes, nothing is saved,
+	// and no service events are raised (issue #7195).
+	t.Run("InformationalWithoutHint", func(t *testing.T) {
+		provider := &mockRefreshProvider{stateErr: fmt.Errorf("looking up: %w", infra.ErrDeploymentsNotFound)}
+		action, console, envManager, pm := newTestEnvRefreshAction(t, provider, &envRefreshFlags{})
+
+		result, err := action.Run(t.Context())
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Contains(t,
+			strings.Join(console.Output(), "\n"), "No deployment was found for environment 'test-env'")
+		envManager.AssertNotCalled(t, "Save", mock.Anything, mock.Anything)
+		pm.AssertNotCalled(t, "InitializeFrameworks", mock.Anything, mock.Anything)
+	})
+
+	// An explicit --hint that matches nothing must stay a hard error: deployments may exist, and
+	// reporting "nothing to refresh yet" would misdiagnose a mistyped hint.
+	t.Run("HardErrorWithExplicitHint", func(t *testing.T) {
+		provider := &mockRefreshProvider{stateErr: fmt.Errorf("matching hint: %w", infra.ErrDeploymentsNotFound)}
+		action, _, _, _ := newTestEnvRefreshAction(t, provider, &envRefreshFlags{hint: "not-a-match"})
+
+		result, err := action.Run(t.Context())
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, infra.ErrDeploymentsNotFound)
+		require.Nil(t, result)
+	})
+}
+
+// A provider may return a StateResult with a nil State: the gRPC proxy for extension-provided
+// providers does this when the extension replies with an unset state result. Refresh must treat it
+// like the no-deployment case instead of panicking.
+func Test_EnvRefreshAction_Run_NilStateResult(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockRefreshProvider{stateResult: &provisioning.StateResult{}}
+	action, console, envManager, pm := newTestEnvRefreshAction(t, provider, &envRefreshFlags{})
+
+	result, err := action.Run(t.Context())
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Contains(t, strings.Join(console.Output(), "\n"), "No deployment state was found")
+	envManager.AssertNotCalled(t, "Save", mock.Anything, mock.Anything)
+	pm.AssertNotCalled(t, "InitializeFrameworks", mock.Anything, mock.Anything)
+}
+
+func Test_EnvRefreshAction_Run_RefreshesOutputs(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockRefreshProvider{stateResult: &provisioning.StateResult{
+		State: &provisioning.State{
+			Outputs: map[string]provisioning.OutputParameter{
+				"MY_OUTPUT": {Type: provisioning.ParameterTypeString, Value: "value"},
+			},
+		},
+	}}
+	action, _, envManager, pm := newTestEnvRefreshAction(t, provider, &envRefreshFlags{})
+	envManager.On("Save", mock.Anything, mock.Anything).Return(nil)
+	pm.On("InitializeFrameworks", mock.Anything, mock.Anything).Return(nil, nil, nil)
+
+	result, err := action.Run(t.Context())
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "value", action.env.Dotenv()["MY_OUTPUT"])
+	envManager.AssertCalled(t, "Save", mock.Anything, mock.Anything)
+	pm.AssertExpectations(t)
 }
 
 func Test_NewEnvSetSecretAction(t *testing.T) {

--- a/cli/azd/cmd/middleware/extension_activator.go
+++ b/cli/azd/cmd/middleware/extension_activator.go
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/internal/grpcserver"
+	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/fatih/color"
+)
+
+// ExtensionActivator starts installed extensions on demand so the capabilities they provide
+// (currently provisioning providers) become resolvable in commands that do not run the full
+// ExtensionsMiddleware, such as `azd env refresh`. Unlike the middleware, it starts only the
+// extensions declaring a requested capability, and only when that capability is not already
+// resolvable (for example when a parent command's middleware already started every extension).
+type ExtensionActivator struct {
+	serviceLocator   ioc.ServiceLocator
+	extensionManager *extensions.Manager
+	extensionRunner  *extensions.Runner
+	globalOptions    *internal.GlobalCommandOptions
+}
+
+// NewExtensionActivator creates a new ExtensionActivator.
+func NewExtensionActivator(
+	serviceLocator ioc.ServiceLocator,
+	extensionManager *extensions.Manager,
+	extensionRunner *extensions.Runner,
+	globalOptions *internal.GlobalCommandOptions,
+) *ExtensionActivator {
+	return &ExtensionActivator{
+		serviceLocator:   serviceLocator,
+		extensionManager: extensionManager,
+		extensionRunner:  extensionRunner,
+		globalOptions:    globalOptions,
+	}
+}
+
+// EnsureProvisioningProviders starts the installed extension(s) that declare any of the given
+// provisioning provider names, so those providers can be resolved from the IoC container. Names no
+// installed extension declares are left to native resolution, and already-resolvable providers are
+// left alone, making activation idempotent. The returned cleanup (always non-nil, safe to defer)
+// stops the extension host when one was started. A required extension failing to start is an
+// error, since the caller cannot make progress without the provider it declares.
+func (a *ExtensionActivator) EnsureProvisioningProviders(
+	ctx context.Context,
+	providerNames []string,
+	environmentName string,
+) (cleanup func(), err error) {
+	noop := func() {}
+
+	names := distinctProviderNames(providerNames)
+	if len(names) == 0 {
+		return noop, nil
+	}
+
+	installed, err := a.extensionManager.ListInstalled()
+	if err != nil {
+		return noop, err
+	}
+
+	toStart := extensionsForProviders(installed, names)
+
+	// Drop extensions whose requested providers are all already resolvable (host already running).
+	toStart = slices.DeleteFunc(toStart, func(ext *extensions.Extension) bool {
+		return !slices.ContainsFunc(names, func(name string) bool {
+			return providerFromExtension(ext, name) && !a.providerResolvable(name)
+		})
+	})
+
+	if len(toStart) == 0 {
+		return noop, nil
+	}
+
+	var grpcServer *grpcserver.Server
+	if err := a.serviceLocator.Resolve(&grpcServer); err != nil {
+		return noop, err
+	}
+
+	serverInfo, err := grpcServer.Start()
+	if err != nil {
+		return noop, err
+	}
+
+	cleanup = func() {
+		if err := grpcServer.Stop(); err != nil {
+			log.Printf("failed to stop gRPC server after extension activation: %v", err)
+		}
+	}
+
+	startOpts := extensionStartOptions{
+		debug:       a.globalOptions.EnableDebugLogging,
+		cwd:         a.globalOptions.Cwd,
+		environment: environmentName,
+		noPrompt:    a.globalOptions.NoPrompt,
+		forceColor:  !color.NoColor,
+	}
+
+	// Start the required extensions concurrently, mirroring ExtensionsMiddleware.
+	startErrs := make([]error, len(toStart))
+	var wg sync.WaitGroup
+	for i, ext := range toStart {
+		wg.Go(func() {
+			startErrs[i] = startAndWaitExtension(ctx, ext, a.extensionRunner, serverInfo, startOpts)
+		})
+	}
+	wg.Wait()
+
+	for i, startErr := range startErrs {
+		if startErr == nil {
+			continue
+		}
+
+		// Fail fast with the actual startup error rather than an opaque resolution failure later.
+		ext := toStart[i]
+		if reported := ext.GetReportedError(); reported != nil {
+			startErr = fmt.Errorf("%w: %w", startErr, reported)
+		}
+
+		cleanup()
+		return noop, &internal.ErrorWithSuggestion{
+			Err: fmt.Errorf("extension '%s', which provides provisioning provider '%s', failed to start: %w",
+				ext.Id, strings.Join(declaredProviders(ext, names), "', '"), startErr),
+			Suggestion: fmt.Sprintf(
+				"Run with %s for details, or check for an update with %s",
+				output.WithHighLightFormat("--debug"),
+				output.WithHighLightFormat("azd extension upgrade %s", ext.Id),
+			),
+		}
+	}
+
+	return cleanup, nil
+}
+
+// SuggestExtensionForProvider returns the id of a registry extension that declares the named
+// provisioning provider when no installed extension does, or an empty string when the provider is
+// unknown to the registry, already declared by an installed extension, or the lookup fails.
+func (a *ExtensionActivator) SuggestExtensionForProvider(ctx context.Context, providerName string) string {
+	if strings.TrimSpace(providerName) == "" {
+		return ""
+	}
+
+	// An installed extension declares this provider, so an install suggestion would be misleading.
+	if installed, err := a.extensionManager.ListInstalled(); err == nil {
+		if len(extensionsForProviders(installed, []string{providerName})) > 0 {
+			return ""
+		}
+	}
+
+	matches, err := a.extensionManager.FindExtensions(ctx, &extensions.FilterOptions{
+		Capability: extensions.ProvisioningProviderCapability,
+		Provider:   providerName,
+	})
+	if err != nil || len(matches) == 0 {
+		return ""
+	}
+
+	return matches[0].Id
+}
+
+// providerResolvable reports whether the named provisioning provider already resolves from the
+// IoC container, meaning the extension registering it is already running.
+func (a *ExtensionActivator) providerResolvable(providerName string) bool {
+	var provider provisioning.Provider
+	return a.serviceLocator.ResolveNamed(providerName, &provider) == nil
+}
+
+// distinctProviderNames reduces the given provisioning provider names to a distinct
+// (case-insensitive), non-empty set, preserving first-seen order and spelling.
+func distinctProviderNames(providerNames []string) []string {
+	seen := make(map[string]struct{}, len(providerNames))
+	names := make([]string, 0, len(providerNames))
+	for _, name := range providerNames {
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, has := seen[key]; has {
+			continue
+		}
+		seen[key] = struct{}{}
+		names = append(names, name)
+	}
+
+	return names
+}
+
+// extensionsForProviders returns the installed extensions that advertise the provisioning-provider
+// capability and declare at least one of the given provider names. When several installed
+// extensions declare the same provider, the one with the lexically smallest id wins so the choice
+// is deterministic. The result is ordered by extension id.
+func extensionsForProviders(
+	installed map[string]*extensions.Extension,
+	providerNames []string,
+) []*extensions.Extension {
+	installedIds := slices.Sorted(maps.Keys(installed))
+
+	byId := map[string]*extensions.Extension{}
+	for _, name := range providerNames {
+		for _, id := range installedIds {
+			ext := installed[id]
+			if !ext.HasCapability(extensions.ProvisioningProviderCapability) {
+				continue
+			}
+			if providerFromExtension(ext, name) {
+				byId[ext.Id] = ext
+				break
+			}
+		}
+	}
+
+	result := make([]*extensions.Extension, 0, len(byId))
+	for _, id := range slices.Sorted(maps.Keys(byId)) {
+		result = append(result, byId[id])
+	}
+
+	return result
+}
+
+// declaredProviders returns the subset of the requested provider names that the extension declares.
+func declaredProviders(ext *extensions.Extension, providerNames []string) []string {
+	declared := make([]string, 0, len(providerNames))
+	for _, name := range providerNames {
+		if providerFromExtension(ext, name) {
+			declared = append(declared, name)
+		}
+	}
+
+	return declared
+}
+
+// providerFromExtension reports whether the extension declares a provider with the given name.
+func providerFromExtension(ext *extensions.Extension, providerName string) bool {
+	return slices.ContainsFunc(ext.Providers, func(p extensions.Provider) bool {
+		return strings.EqualFold(p.Name, providerName)
+	})
+}

--- a/cli/azd/cmd/middleware/extension_activator.go
+++ b/cli/azd/cmd/middleware/extension_activator.go
@@ -242,6 +242,8 @@ func declaredProviders(ext *extensions.Extension, providerNames []string) []stri
 }
 
 // providerFromExtension reports whether the extension declares a provider with the given name.
+// Extension discovery is case-insensitive, but IoC provider resolution remains case-sensitive;
+// azure.yaml must still use the provider spelling registered by the extension.
 func providerFromExtension(ext *extensions.Extension, providerName string) bool {
 	return slices.ContainsFunc(ext.Providers, func(p extensions.Provider) bool {
 		return strings.EqualFold(p.Name, providerName)

--- a/cli/azd/cmd/middleware/extension_activator_test.go
+++ b/cli/azd/cmd/middleware/extension_activator_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package middleware
+
+import (
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_providerFromExtension(t *testing.T) {
+	t.Parallel()
+
+	ext := &extensions.Extension{
+		Id: "azure.ai.agents",
+		Providers: []extensions.Provider{
+			{Name: "microsoft.foundry", Type: "provisioning-provider"},
+			{Name: "azure.ai.agent", Type: extensions.ServiceTargetProviderType},
+		},
+	}
+
+	require.True(t, providerFromExtension(ext, "microsoft.foundry"))
+	// Matching is case-insensitive.
+	require.True(t, providerFromExtension(ext, "Microsoft.Foundry"))
+	require.False(t, providerFromExtension(ext, "some.other.provider"))
+	require.False(t, providerFromExtension(&extensions.Extension{}, "microsoft.foundry"))
+}
+
+func Test_distinctProviderNames(t *testing.T) {
+	t.Parallel()
+
+	// Empty names (NotSpecified provider) are dropped; duplicates are removed case-insensitively,
+	// preserving the first-seen order and spelling.
+	got := distinctProviderNames([]string{"", "bicep", "Bicep", "microsoft.foundry", "bicep", ""})
+	require.Equal(t, []string{"bicep", "microsoft.foundry"}, got)
+
+	require.Empty(t, distinctProviderNames(nil))
+	require.Empty(t, distinctProviderNames([]string{"", ""}))
+}
+
+func Test_extensionsForProviders(t *testing.T) {
+	t.Parallel()
+
+	withCapability := &extensions.Extension{
+		Id:           "azure.ai.agents",
+		Capabilities: []extensions.CapabilityType{extensions.ProvisioningProviderCapability},
+		Providers:    []extensions.Provider{{Name: "microsoft.foundry"}},
+	}
+
+	// Declares the provider but does NOT advertise the provisioning-provider capability.
+	withoutCapability := &extensions.Extension{
+		Id:        "other.ext",
+		Providers: []extensions.Provider{{Name: "microsoft.foundry"}},
+	}
+
+	t.Run("MatchesCapabilityAndProvider", func(t *testing.T) {
+		installed := map[string]*extensions.Extension{"azure.ai.agents": withCapability}
+		got := extensionsForProviders(installed, []string{"microsoft.foundry"})
+		require.Len(t, got, 1)
+		require.Equal(t, "azure.ai.agents", got[0].Id)
+	})
+
+	t.Run("CaseInsensitiveMatch", func(t *testing.T) {
+		installed := map[string]*extensions.Extension{"azure.ai.agents": withCapability}
+		require.Len(t, extensionsForProviders(installed, []string{"Microsoft.Foundry"}), 1)
+	})
+
+	t.Run("IgnoresProviderWithoutCapability", func(t *testing.T) {
+		installed := map[string]*extensions.Extension{"other.ext": withoutCapability}
+		require.Empty(t, extensionsForProviders(installed, []string{"microsoft.foundry"}))
+	})
+
+	// Native or unknown provider names are not declared by any installed extension and must be
+	// left alone - they resolve (or fail) natively, exactly as in every other command.
+	t.Run("IgnoresUndeclaredProviders", func(t *testing.T) {
+		installed := map[string]*extensions.Extension{"azure.ai.agents": withCapability}
+		require.Empty(t, extensionsForProviders(installed, []string{"bicep", "terraform", "devcenter", "bicpe"}))
+	})
+
+	t.Run("SingleExtensionForMultipleProviders", func(t *testing.T) {
+		multi := &extensions.Extension{
+			Id:           "multi.ext",
+			Capabilities: []extensions.CapabilityType{extensions.ProvisioningProviderCapability},
+			Providers:    []extensions.Provider{{Name: "provider.one"}, {Name: "provider.two"}},
+		}
+		installed := map[string]*extensions.Extension{"multi.ext": multi}
+		got := extensionsForProviders(installed, []string{"provider.one", "provider.two"})
+		require.Len(t, got, 1)
+	})
+
+	// When several installed extensions declare the same provider, the lexically smallest id wins
+	// so the choice is deterministic regardless of map iteration order.
+	t.Run("DeterministicChoiceAcrossExtensions", func(t *testing.T) {
+		first := &extensions.Extension{
+			Id:           "a.ext",
+			Capabilities: []extensions.CapabilityType{extensions.ProvisioningProviderCapability},
+			Providers:    []extensions.Provider{{Name: "microsoft.foundry"}},
+		}
+		second := &extensions.Extension{
+			Id:           "b.ext",
+			Capabilities: []extensions.CapabilityType{extensions.ProvisioningProviderCapability},
+			Providers:    []extensions.Provider{{Name: "microsoft.foundry"}},
+		}
+		installed := map[string]*extensions.Extension{"b.ext": second, "a.ext": first}
+
+		for range 10 {
+			got := extensionsForProviders(installed, []string{"microsoft.foundry"})
+			require.Len(t, got, 1)
+			require.Equal(t, "a.ext", got[0].Id)
+		}
+	})
+}
+
+func Test_declaredProviders(t *testing.T) {
+	t.Parallel()
+
+	ext := &extensions.Extension{
+		Id:        "multi.ext",
+		Providers: []extensions.Provider{{Name: "provider.one"}, {Name: "provider.two"}},
+	}
+
+	require.Equal(t,
+		[]string{"provider.one", "provider.two"},
+		declaredProviders(ext, []string{"provider.one", "bicep", "provider.two"}))
+	require.Empty(t, declaredProviders(ext, []string{"bicep"}))
+}
+
+// Requests that reduce to no candidate provider names (empty/NotSpecified) must short-circuit
+// before touching the extension manager, so a zero-value activator is sufficient here.
+func Test_EnsureProvisioningProviders_NoProviderNamesIsNoop(t *testing.T) {
+	t.Parallel()
+
+	activator := &ExtensionActivator{}
+	cleanup, err := activator.EnsureProvisioningProviders(t.Context(), []string{"", ""}, "test-env")
+
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	// Cleanup must be safe to call even when nothing was started.
+	cleanup()
+}

--- a/cli/azd/cmd/middleware/extension_activator_test.go
+++ b/cli/azd/cmd/middleware/extension_activator_test.go
@@ -4,11 +4,167 @@
 package middleware
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+	provisioningTest "github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning/test"
+	"github.com/azure/azure-dev/cli/azd/pkg/ioc"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
 )
+
+const testExtensionRegistryURL = "https://aka.ms/azd/extensions/registry"
+
+// stubProviderRegistry makes the extension registry respond with a single extension that declares
+// the given provisioning provider, so registry lookups resolve deterministically without network.
+func stubProviderRegistry(mockCtx *mocks.MockContext, extensionID, providerName string) {
+	registry := extensions.Registry{
+		Extensions: []*extensions.ExtensionMetadata{
+			{
+				Id: extensionID,
+				Versions: []extensions.ExtensionVersion{
+					{
+						Version:      "1.0.0",
+						Capabilities: []extensions.CapabilityType{extensions.ProvisioningProviderCapability},
+						Providers:    []extensions.Provider{{Name: providerName}},
+					},
+				},
+			},
+		},
+	}
+
+	mockCtx.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == testExtensionRegistryURL
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+}
+
+// newTestExtensionActivator builds an ExtensionActivator backed by an in-memory extension manager
+// seeded with the given installed extensions, using the mock context's container as the service
+// locator so tests can register (or omit) resolvable provisioning providers.
+func newTestExtensionActivator(
+	t *testing.T,
+	mockCtx *mocks.MockContext,
+	installed map[string]*extensions.Extension,
+) *ExtensionActivator {
+	t.Helper()
+	manager := createExtensionsManager(t, mockCtx, installed)
+	runner := extensions.NewRunner(exec.NewCommandRunner(nil))
+	return NewExtensionActivator(mockCtx.Container, manager, runner, &internal.GlobalCommandOptions{})
+}
+
+func Test_NewExtensionActivator(t *testing.T) {
+	t.Parallel()
+	mockCtx := mocks.NewMockContext(t.Context())
+	activator := newTestExtensionActivator(t, mockCtx, nil)
+	require.NotNil(t, activator)
+}
+
+func Test_ExtensionActivator_providerResolvable(t *testing.T) {
+	t.Parallel()
+	mockCtx := mocks.NewMockContext(t.Context())
+
+	// Register a named provisioning provider so it resolves from the container, as if the owning
+	// extension host were already running.
+	ioc.RegisterNamedInstance[provisioning.Provider](
+		mockCtx.Container, "microsoft.foundry", provisioningTest.NewTestProvider(nil, nil, nil, nil))
+
+	activator := newTestExtensionActivator(t, mockCtx, nil)
+
+	require.True(t, activator.providerResolvable("microsoft.foundry"))
+	require.False(t, activator.providerResolvable("bicep"))
+}
+
+func Test_EnsureProvisioningProviders_NoMatchingExtension(t *testing.T) {
+	t.Parallel()
+	mockCtx := mocks.NewMockContext(t.Context())
+
+	// The installed extension declares a different provider, so nothing is started for the
+	// requested name; it is left to native resolution.
+	installed := map[string]*extensions.Extension{
+		"other.ext": {
+			Id:           "other.ext",
+			Capabilities: []extensions.CapabilityType{extensions.ProvisioningProviderCapability},
+			Providers:    []extensions.Provider{{Name: "other.provider"}},
+		},
+	}
+	activator := newTestExtensionActivator(t, mockCtx, installed)
+
+	cleanup, err := activator.EnsureProvisioningProviders(t.Context(), []string{"microsoft.foundry"}, "env1")
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	cleanup()
+}
+
+func Test_EnsureProvisioningProviders_AlreadyResolvable(t *testing.T) {
+	t.Parallel()
+	mockCtx := mocks.NewMockContext(t.Context())
+
+	// The provider is already registered (extension host already running), so activation is a no-op
+	// and no extension process is started.
+	ioc.RegisterNamedInstance[provisioning.Provider](
+		mockCtx.Container, "microsoft.foundry", provisioningTest.NewTestProvider(nil, nil, nil, nil))
+
+	installed := map[string]*extensions.Extension{
+		"azure.ai.agents": {
+			Id:           "azure.ai.agents",
+			Capabilities: []extensions.CapabilityType{extensions.ProvisioningProviderCapability},
+			Providers:    []extensions.Provider{{Name: "microsoft.foundry"}},
+		},
+	}
+	activator := newTestExtensionActivator(t, mockCtx, installed)
+
+	cleanup, err := activator.EnsureProvisioningProviders(t.Context(), []string{"microsoft.foundry"}, "env1")
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	cleanup()
+}
+
+func Test_SuggestExtensionForProvider(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EmptyName", func(t *testing.T) {
+		mockCtx := mocks.NewMockContext(t.Context())
+		activator := newTestExtensionActivator(t, mockCtx, nil)
+		require.Empty(t, activator.SuggestExtensionForProvider(t.Context(), "  "))
+	})
+
+	// An installed extension already declares the provider, so an install suggestion would be
+	// misleading and none is returned.
+	t.Run("InstalledDeclaresProvider", func(t *testing.T) {
+		mockCtx := mocks.NewMockContext(t.Context())
+		installed := map[string]*extensions.Extension{
+			"azure.ai.agents": {
+				Id:           "azure.ai.agents",
+				Capabilities: []extensions.CapabilityType{extensions.ProvisioningProviderCapability},
+				Providers:    []extensions.Provider{{Name: "microsoft.foundry"}},
+			},
+		}
+		activator := newTestExtensionActivator(t, mockCtx, installed)
+		require.Empty(t, activator.SuggestExtensionForProvider(t.Context(), "microsoft.foundry"))
+	})
+
+	// No installed extension declares the provider, but the registry does: suggest that extension.
+	t.Run("RegistryMatch", func(t *testing.T) {
+		mockCtx := mocks.NewMockContext(t.Context())
+		stubProviderRegistry(mockCtx, "azure.ai.agents", "microsoft.foundry")
+		activator := newTestExtensionActivator(t, mockCtx, nil)
+		require.Equal(t, "azure.ai.agents", activator.SuggestExtensionForProvider(t.Context(), "microsoft.foundry"))
+	})
+
+	// No installed extension and no registry match yields no suggestion.
+	t.Run("NoRegistryMatch", func(t *testing.T) {
+		mockCtx := mocks.NewMockContext(t.Context())
+		stubProviderRegistry(mockCtx, "azure.ai.agents", "microsoft.foundry")
+		activator := newTestExtensionActivator(t, mockCtx, nil)
+		require.Empty(t, activator.SuggestExtensionForProvider(t.Context(), "unknown.provider"))
+	})
+}
 
 func Test_providerFromExtension(t *testing.T) {
 	t.Parallel()

--- a/cli/azd/cmd/middleware/extensions.go
+++ b/cli/azd/cmd/middleware/extensions.go
@@ -119,6 +119,19 @@ func (m *ExtensionsMiddleware) Run(ctx context.Context, next NextFn) (*actions.A
 	var mu sync.Mutex
 	var failedExtensions []extensionFailure
 
+	// Read global flags once for propagation to every extension's `listen` process.
+	debugEnabled, _ := m.options.Flags.GetBool("debug")
+	cwd, _ := m.options.Flags.GetString("cwd")
+	envName, _ := m.options.Flags.GetString("environment")
+	startOpts := extensionStartOptions{
+		debug:       debugEnabled,
+		cwd:         cwd,
+		environment: envName,
+		// Use globalOptions.NoPrompt which includes agent detection, not just the --no-prompt CLI flag
+		noPrompt:   m.globalOptions.NoPrompt,
+		forceColor: forceColor,
+	}
+
 	// Track total time for all extensions to become ready
 	allExtensionsStartTime := time.Now()
 	log.Printf("Starting %d extensions...\n", len(extensionList))
@@ -127,70 +140,8 @@ func (m *ExtensionsMiddleware) Run(ctx context.Context, next NextFn) (*actions.A
 	for _, extension := range extensionList {
 		ext := extension
 		wg.Go(func() {
-
-			jwtToken, err := grpcserver.GenerateExtensionToken(ext, serverInfo)
-			if err != nil {
-				log.Printf("failed to generate JWT token for '%s' extension: %v", ext.Id, err)
-				ext.Fail(err)
-				return
-			}
-
-			// Start the extension process in a separate goroutine
-			go func() {
-				allEnv := []string{
-					fmt.Sprintf("AZD_SERVER=%s", serverInfo.Address),
-					fmt.Sprintf("AZD_ACCESS_TOKEN=%s", jwtToken),
-				}
-
-				if forceColor {
-					allEnv = append(allEnv, "FORCE_COLOR=1")
-				}
-
-				// Read global flags for propagation via InvokeOptions
-				debugEnabled, _ := m.options.Flags.GetBool("debug")
-				cwd, _ := m.options.Flags.GetString("cwd")
-				env, _ := m.options.Flags.GetString("environment")
-
-				// Use globalOptions.NoPrompt which includes agent detection,
-				// not just the --no-prompt CLI flag
-				noPrompt := m.globalOptions.NoPrompt
-
-				// Propagate trace context to the extension process
-				if traceEnv := tracing.Environ(ctx); len(traceEnv) > 0 {
-					allEnv = append(allEnv, traceEnv...)
-				}
-
-				args := []string{"listen"}
-				if debugEnabled {
-					args = append(args, "--debug")
-				}
-
-				options := &extensions.InvokeOptions{
-					Args:        args,
-					Env:         allEnv,
-					StdIn:       ext.StdIn(),
-					StdOut:      ext.StdOut(),
-					StdErr:      ext.StdErr(),
-					Debug:       debugEnabled,
-					NoPrompt:    noPrompt,
-					Cwd:         cwd,
-					Environment: env,
-				}
-
-				if _, err := m.extensionRunner.Invoke(ctx, ext, options); err != nil {
-					log.Printf("%v", err)
-					ext.Fail(err)
-				}
-			}()
-
-			// Wait for the extension to signal readiness or failure.
-			// If AZD_EXT_DEBUG is set to a truthy value, wait indefinitely for debugger attachment
-			// If AZD_EXT_TIMEOUT is set to a number (seconds), use that as the timeout (default: 15 seconds)
-			readyCtx, cancel := getReadyContext(ctx)
-			defer cancel()
-
 			startTime := time.Now()
-			if err := ext.WaitUntilReady(readyCtx); err != nil {
+			if err := startAndWaitExtension(ctx, ext, m.extensionRunner, serverInfo, startOpts); err != nil {
 				elapsed := time.Since(startTime)
 				log.Printf("'%s' extension failed to become ready after %v: %v\n", ext.Id, elapsed, err)
 				if reportedErr := ext.GetReportedError(); reportedErr != nil {
@@ -360,4 +311,80 @@ func getReadyContext(ctx context.Context) (context.Context, context.CancelFunc) 
 	}
 
 	return context.WithTimeout(ctx, timeout)
+}
+
+// extensionStartOptions carries the flag/context values propagated to an extension's `listen`
+// process. They mirror the values ExtensionsMiddleware reads from the command flags.
+type extensionStartOptions struct {
+	debug       bool
+	cwd         string
+	environment string
+	noPrompt    bool
+	forceColor  bool
+}
+
+// startAndWaitExtension launches an extension's `listen` process against the gRPC server described
+// by serverInfo and blocks until the extension signals readiness or fails. It is the per-extension
+// startup shared by ExtensionsMiddleware (every listen-capable extension) and ExtensionActivator
+// (a targeted subset).
+func startAndWaitExtension(
+	ctx context.Context,
+	ext *extensions.Extension,
+	runner *extensions.Runner,
+	serverInfo *grpcserver.ServerInfo,
+	opts extensionStartOptions,
+) error {
+	jwtToken, err := grpcserver.GenerateExtensionToken(ext, serverInfo)
+	if err != nil {
+		err = fmt.Errorf("generating extension token for '%s': %w", ext.Id, err)
+		ext.Fail(err)
+		return err
+	}
+
+	// Start the extension process in a separate goroutine
+	go func() {
+		allEnv := []string{
+			fmt.Sprintf("AZD_SERVER=%s", serverInfo.Address),
+			fmt.Sprintf("AZD_ACCESS_TOKEN=%s", jwtToken),
+		}
+
+		if opts.forceColor {
+			allEnv = append(allEnv, "FORCE_COLOR=1")
+		}
+
+		// Propagate trace context to the extension process
+		if traceEnv := tracing.Environ(ctx); len(traceEnv) > 0 {
+			allEnv = append(allEnv, traceEnv...)
+		}
+
+		args := []string{"listen"}
+		if opts.debug {
+			args = append(args, "--debug")
+		}
+
+		invokeOptions := &extensions.InvokeOptions{
+			Args:        args,
+			Env:         allEnv,
+			StdIn:       ext.StdIn(),
+			StdOut:      ext.StdOut(),
+			StdErr:      ext.StdErr(),
+			Debug:       opts.debug,
+			NoPrompt:    opts.noPrompt,
+			Cwd:         opts.cwd,
+			Environment: opts.environment,
+		}
+
+		if _, err := runner.Invoke(ctx, ext, invokeOptions); err != nil {
+			log.Printf("%v", err)
+			ext.Fail(err)
+		}
+	}()
+
+	// Wait for the extension to signal readiness or failure.
+	// If AZD_EXT_DEBUG is set to a truthy value, wait indefinitely for debugger attachment.
+	// If AZD_EXT_TIMEOUT is set to a number (seconds), use that as the timeout (default: 15 seconds).
+	readyCtx, cancel := getReadyContext(ctx)
+	defer cancel()
+
+	return ext.WaitUntilReady(readyCtx)
 }

--- a/cli/azd/cmd/util_test.go
+++ b/cli/azd/cmd/util_test.go
@@ -315,6 +315,15 @@ func (m *mockProjectManager) Initialize(ctx context.Context, projectConfig *proj
 	return m.Called(ctx, projectConfig).Error(0)
 }
 
+func (m *mockProjectManager) InitializeFrameworks(
+	ctx context.Context, projectConfig *project.ProjectConfig,
+) ([]*project.ServiceConfig, []project.ServiceFrameworkInitFailure, error) {
+	args := m.Called(ctx, projectConfig)
+	services, _ := args.Get(0).([]*project.ServiceConfig)
+	skipped, _ := args.Get(1).([]project.ServiceFrameworkInitFailure)
+	return services, skipped, args.Error(2)
+}
+
 func (m *mockProjectManager) EnsureAllTools(
 	ctx context.Context, projectConfig *project.ProjectConfig, filter project.ServiceFilterPredicate,
 ) error {

--- a/cli/azd/docs/extensions/extension-framework.md
+++ b/cli/azd/docs/extensions/extension-framework.md
@@ -938,9 +938,9 @@ Extensions can provide a custom infrastructure provisioning experience as an alt
 - Custom deployment engines or resource orchestration
 - Provider-managed state and outputs
 
-A provisioning provider implements the full lifecycle (`Initialize`, `State`, `Deploy`, `Preview`, `Destroy`, `EnsureEnv`, `Parameters`, `PlannedOutputs`), but two of these matter beyond `azd provision`/`up`:
+A provisioning provider implements the full lifecycle (`Initialize`, `State`, `Deploy`, `Preview`, `Destroy`, `EnsureEnv`, `Parameters`, `PlannedOutputs`). Two aspects of its `State` method matter beyond `azd provision`/`up`:
 
-- **`State`** is what `azd env refresh` calls to pull the latest deployment outputs into the local `.env`. Because `env refresh` is read-only and does not run infrastructure, `State` must read persisted deployment state on its own (for example, by querying the deployment in Azure) rather than depending on an on-disk template being compiled first.
+- `azd env refresh` calls `State` to pull the latest deployment outputs into the local `.env`. Because `env refresh` is read-only and does not run infrastructure, `State` must read persisted deployment state on its own (for example, by querying the deployment in Azure) rather than depending on an on-disk template being compiled first.
 - When no deployment exists yet, `State` should return an **empty** state result rather than an error, so `env refresh` can report that there is nothing to refresh yet and exit successfully instead of failing.
 
 > [!NOTE]

--- a/cli/azd/docs/extensions/extension-framework.md
+++ b/cli/azd/docs/extensions/extension-framework.md
@@ -928,6 +928,24 @@ Extensions can provide custom language and framework support for build, restore,
 - Custom package managers
 - Specialized build toolchains
 
+##### Provisioning Providers (`provisioning-provider`)
+
+> Extensions must declare the `provisioning-provider` capability in their `extension.yaml` file.
+
+Extensions can provide a custom infrastructure provisioning experience as an alternative to the built-in Bicep and Terraform providers. Each provider is registered under a name (via `WithProvisioningProvider`) that must match the `infra.provider` value in `azure.yaml`. Examples include:
+
+- Provisioning without an on-disk `infra/` directory (templates synthesized from `azure.yaml`)
+- Custom deployment engines or resource orchestration
+- Provider-managed state and outputs
+
+A provisioning provider implements the full lifecycle (`Initialize`, `State`, `Deploy`, `Preview`, `Destroy`, `EnsureEnv`, `Parameters`, `PlannedOutputs`), but two of these matter beyond `azd provision`/`up`:
+
+- **`State`** is what `azd env refresh` calls to pull the latest deployment outputs into the local `.env`. Because `env refresh` is read-only and does not run infrastructure, `State` must read persisted deployment state on its own (for example, by querying the deployment in Azure) rather than depending on an on-disk template being compiled first.
+- When no deployment exists yet, `State` should return an **empty** state result rather than an error, so `env refresh` can report that there is nothing to refresh yet and exit successfully instead of failing.
+
+> [!NOTE]
+> Commands such as `azd env refresh` do not run the full extension lifecycle. When a project's `infra.provider` names an extension-provided provider, `azd` starts only that extension on demand to resolve the provider, then stops it once the operation completes.
+
 ##### Model Context Protocol Server (`mcp-server`)
 
 > Extensions must declare the `mcp-server` capability in their `extension.yaml` file.

--- a/cli/azd/internal/cmd/deploy_test.go
+++ b/cli/azd/internal/cmd/deploy_test.go
@@ -249,6 +249,15 @@ func (m *mockDeployProjectManager) Initialize(ctx context.Context, projectConfig
 	return args.Error(0)
 }
 
+func (m *mockDeployProjectManager) InitializeFrameworks(
+	ctx context.Context, projectConfig *project.ProjectConfig,
+) ([]*project.ServiceConfig, []project.ServiceFrameworkInitFailure, error) {
+	args := m.Called(projectConfig)
+	services, _ := args.Get(0).([]*project.ServiceConfig)
+	skipped, _ := args.Get(1).([]project.ServiceFrameworkInitFailure)
+	return services, skipped, args.Error(2)
+}
+
 func (m *mockDeployProjectManager) DefaultServiceFromWd(
 	ctx context.Context,
 	projectConfig *project.ProjectConfig,
@@ -309,6 +318,12 @@ func (m *mockDeployServiceManager) GetRequiredTools(
 }
 
 func (m *mockDeployServiceManager) Initialize(ctx context.Context, serviceConfig *project.ServiceConfig) error {
+	return nil
+}
+
+func (m *mockDeployServiceManager) InitializeFrameworkService(
+	ctx context.Context, serviceConfig *project.ServiceConfig,
+) error {
 	return nil
 }
 

--- a/cli/azd/internal/cmd/provision_test.go
+++ b/cli/azd/internal/cmd/provision_test.go
@@ -35,6 +35,15 @@ func (m *mockProjectManager) Initialize(ctx context.Context, projectConfig *proj
 	return m.Called(ctx, projectConfig).Error(0)
 }
 
+func (m *mockProjectManager) InitializeFrameworks(
+	ctx context.Context, projectConfig *project.ProjectConfig,
+) ([]*project.ServiceConfig, []project.ServiceFrameworkInitFailure, error) {
+	args := m.Called(ctx, projectConfig)
+	services, _ := args.Get(0).([]*project.ServiceConfig)
+	skipped, _ := args.Get(1).([]project.ServiceFrameworkInitFailure)
+	return services, skipped, args.Error(2)
+}
+
 func (m *mockProjectManager) EnsureAllTools(
 	ctx context.Context, projectConfig *project.ProjectConfig, _ project.ServiceFilterPredicate,
 ) error {

--- a/cli/azd/internal/cmd/service_graph_test.go
+++ b/cli/azd/internal/cmd/service_graph_test.go
@@ -33,6 +33,10 @@ func (s *stubServiceManager) GetRequiredTools(
 func (s *stubServiceManager) Initialize(_ context.Context, _ *project.ServiceConfig) error {
 	return nil
 }
+
+func (s *stubServiceManager) InitializeFrameworkService(_ context.Context, _ *project.ServiceConfig) error {
+	return nil
+}
 func (s *stubServiceManager) Restore(
 	_ context.Context, _ *project.ServiceConfig, _ *project.ServiceContext,
 	_ *async.Progress[project.ServiceProgress],

--- a/cli/azd/internal/vsrpc/environment_service_refresh.go
+++ b/cli/azd/internal/vsrpc/environment_service_refresh.go
@@ -71,11 +71,9 @@ func (s *environmentService) refreshEnvironmentAsync(
 
 	bicepProvider := c.bicep.(*bicep.BicepProvider)
 
-	if err := c.projectManager.Initialize(ctx, c.projectConfig); err != nil {
-		return nil, err
-	}
-
-	if err := c.projectManager.EnsureAllTools(ctx, c.projectConfig, nil); err != nil {
+	// Refresh is read-only: wire framework hooks best-effort without requiring service targets,
+	// which may be extension-provided. See envRefreshAction.Run for the CLI equivalent.
+	if _, _, err := c.projectManager.InitializeFrameworks(ctx, c.projectConfig); err != nil {
 		return nil, err
 	}
 

--- a/cli/azd/pkg/project/project_manager.go
+++ b/cli/azd/pkg/project/project_manager.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"slices"
 	"strings"
@@ -46,6 +47,17 @@ type ProjectManager interface {
 	// handlers to participate in the lifecycle of an azd project
 	Initialize(ctx context.Context, projectConfig *ProjectConfig) error
 
+	// InitializeFrameworks initializes only the framework service for each service in the project,
+	// best-effort: unlike Initialize, it never resolves service targets, and a per-service failure
+	// is skipped rather than fatal. It exists for read-only flows such as `env refresh`, which
+	// need framework lifecycle hooks (for example the .NET ServiceEventEnvUpdated handler) but
+	// must tolerate hosts provided by extensions that are not loaded. It returns the initialized
+	// services and the skipped services with their causes.
+	InitializeFrameworks(
+		ctx context.Context,
+		projectConfig *ProjectConfig,
+	) ([]*ServiceConfig, []ServiceFrameworkInitFailure, error)
+
 	// Returns the default service name to target based on the current working directory.
 	//
 	//   - If the working directory is the project directory, then an empty string is returned to indicate all services.
@@ -72,6 +84,13 @@ type ProjectManager interface {
 
 // ServiceFilterPredicate is a function that can be used to filter services that match a given criteria
 type ServiceFilterPredicate func(svc *ServiceConfig) bool
+
+// ServiceFrameworkInitFailure describes a service whose framework service could not be initialized
+// during best-effort initialization, along with the cause.
+type ServiceFrameworkInitFailure struct {
+	Service *ServiceConfig
+	Err     error
+}
 
 type projectManager struct {
 	azdContext     *azdcontext.AzdContext
@@ -113,6 +132,42 @@ func (pm *projectManager) Initialize(ctx context.Context, projectConfig *Project
 	}
 
 	return nil
+}
+
+// InitializeFrameworks initializes only the framework service for each service in the
+// project, on a best-effort, per-service basis. See the ProjectManager interface for details.
+func (pm *projectManager) InitializeFrameworks(
+	ctx context.Context,
+	projectConfig *ProjectConfig,
+) ([]*ServiceConfig, []ServiceFrameworkInitFailure, error) {
+	servicesStable, err := pm.importManager.ServiceStable(ctx, projectConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	serviceTargets := make([]string, 0, len(servicesStable))
+	for _, svc := range servicesStable {
+		serviceTargets = append(serviceTargets, string(svc.Host))
+	}
+
+	tracing.SetUsageAttributes(fields.ProjectServiceTargetsKey.StringSlice(serviceTargets))
+
+	initialized := make([]*ServiceConfig, 0, len(servicesStable))
+	var skipped []ServiceFrameworkInitFailure
+	for _, svc := range servicesStable {
+		if err := pm.serviceManager.InitializeFrameworkService(ctx, svc); err != nil {
+			log.Printf(
+				"skipping service events for service '%s'; its framework could not be initialized: %v",
+				svc.Name, err,
+			)
+			skipped = append(skipped, ServiceFrameworkInitFailure{Service: svc, Err: err})
+			continue
+		}
+
+		initialized = append(initialized, svc)
+	}
+
+	return initialized, skipped, nil
 }
 
 // Returns the default service name to target based on the current working directory.

--- a/cli/azd/pkg/project/project_manager_test.go
+++ b/cli/azd/pkg/project/project_manager_test.go
@@ -131,13 +131,15 @@ func Test_suggestRemoteBuild(t *testing.T) {
 
 // ---------- fake ServiceManager ----------
 type fakeServiceManager struct {
-	frameworkSvc        FrameworkService
-	serviceTarget       ServiceTarget
-	requiredTools       []tools.ExternalTool
-	getRequiredToolsErr error
-	getFrameworkErr     error
-	getTargetErr        error
-	initErr             error
+	frameworkSvc               FrameworkService
+	serviceTarget              ServiceTarget
+	requiredTools              []tools.ExternalTool
+	getRequiredToolsErr        error
+	getFrameworkErr            error
+	getTargetErr               error
+	initErr                    error
+	initFrameworkErr           error
+	initFrameworkErrForService map[string]error
 }
 
 func (f *fakeServiceManager) GetRequiredTools(
@@ -148,6 +150,16 @@ func (f *fakeServiceManager) GetRequiredTools(
 
 func (f *fakeServiceManager) Initialize(ctx context.Context, sc *ServiceConfig) error {
 	return f.initErr
+}
+
+func (f *fakeServiceManager) InitializeFrameworkService(ctx context.Context, sc *ServiceConfig) error {
+	if _, err := f.GetFrameworkService(ctx, sc); err != nil {
+		return err
+	}
+	if err, ok := f.initFrameworkErrForService[sc.Name]; ok {
+		return err
+	}
+	return f.initFrameworkErr
 }
 
 func (f *fakeServiceManager) Restore(
@@ -289,6 +301,54 @@ func Test_projectManager_Initialize(t *testing.T) {
 		err := pm.Initialize(t.Context(), sc.Project)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "initializing service 'api'")
+	})
+}
+
+func Test_projectManager_InitializeFrameworks(t *testing.T) {
+	newProject := func(dir string) *ProjectConfig {
+		prj := &ProjectConfig{Path: dir, Services: map[string]*ServiceConfig{}}
+		for _, name := range []string{"api", "agent"} {
+			prj.Services[name] = &ServiceConfig{
+				Name:         name,
+				RelativePath: name,
+				Host:         AppServiceTarget,
+				Language:     ServiceLanguagePython,
+				Project:      prj,
+			}
+		}
+		return prj
+	}
+
+	t.Run("AllServicesInitialized", func(t *testing.T) {
+		prj := newProject(t.TempDir())
+		pm := &projectManager{
+			importManager:  NewImportManager(nil),
+			serviceManager: &fakeServiceManager{frameworkSvc: &noOpProject{}},
+		}
+		initialized, skipped, err := pm.InitializeFrameworks(t.Context(), prj)
+		require.NoError(t, err)
+		require.Len(t, initialized, 2)
+		require.Empty(t, skipped)
+	})
+
+	// A per-service framework initialization failure (for example an extension-provided host that
+	// is not loaded) must be skipped, not abort the whole project. The other services still init.
+	t.Run("SkipsServiceThatFailsFrameworkInit", func(t *testing.T) {
+		prj := newProject(t.TempDir())
+		pm := &projectManager{
+			importManager: NewImportManager(nil),
+			serviceManager: &fakeServiceManager{
+				frameworkSvc:               &noOpProject{},
+				initFrameworkErrForService: map[string]error{"agent": assert.AnError},
+			},
+		}
+		initialized, skipped, err := pm.InitializeFrameworks(t.Context(), prj)
+		require.NoError(t, err)
+		require.Len(t, initialized, 1)
+		require.Equal(t, "api", initialized[0].Name)
+		require.Len(t, skipped, 1)
+		require.Equal(t, "agent", skipped[0].Service.Name)
+		require.ErrorIs(t, skipped[0].Err, assert.AnError)
 	})
 }
 

--- a/cli/azd/pkg/project/service_manager.go
+++ b/cli/azd/pkg/project/service_manager.go
@@ -134,6 +134,11 @@ type ServiceManager interface {
 		serviceTarget ServiceTarget,
 	) (*environment.TargetResource, error)
 
+	// Initializes only the framework service for the specified service config, without resolving
+	// the service target. This supports read-only flows such as `env refresh` that need framework
+	// lifecycle hooks but must not require a service target, which may be extension-provided.
+	InitializeFrameworkService(ctx context.Context, serviceConfig *ServiceConfig) error
+
 	// Gets the framework service for the specified service config
 	// The framework service performs the restoration and building of the service app code
 	GetFrameworkService(ctx context.Context, serviceConfig *ServiceConfig) (FrameworkService, error)
@@ -200,14 +205,36 @@ func (sm *serviceManager) GetRequiredTools(ctx context.Context, serviceConfig *S
 // Initializes the service configuration and dependent framework & service target
 // This allows frameworks & service targets to hook into a services lifecycle events
 func (sm *serviceManager) Initialize(ctx context.Context, serviceConfig *ServiceConfig) error {
-	frameworkService, err := sm.GetFrameworkService(ctx, serviceConfig)
-	if err != nil {
-		return fmt.Errorf("getting framework service: %w", err)
+	if err := sm.InitializeFrameworkService(ctx, serviceConfig); err != nil {
+		return err
 	}
 
 	serviceTarget, err := sm.GetServiceTarget(ctx, serviceConfig)
 	if err != nil {
 		return fmt.Errorf("getting service target: %w", err)
+	}
+
+	if ok := sm.isComponentInitialized(serviceConfig, serviceTarget); !ok {
+		if err := serviceTarget.Initialize(ctx, serviceConfig); err != nil {
+			return err
+		}
+
+		sm.mu.Lock()
+		sm.initialized[serviceConfig][serviceTarget] = true
+		sm.mu.Unlock()
+	}
+
+	return nil
+}
+
+// InitializeFrameworkService resolves and initializes only the framework service for the
+// specified service config, without resolving the service target. Frameworks resolve by service
+// language, so built-in languages work even when the host is extension-provided; extension-provided
+// languages may still fail to resolve, which ProjectManager.InitializeFrameworks tolerates.
+func (sm *serviceManager) InitializeFrameworkService(ctx context.Context, serviceConfig *ServiceConfig) error {
+	frameworkService, err := sm.GetFrameworkService(ctx, serviceConfig)
+	if err != nil {
+		return fmt.Errorf("getting framework service: %w", err)
 	}
 
 	if ok := sm.isComponentInitialized(serviceConfig, frameworkService); !ok {
@@ -220,16 +247,6 @@ func (sm *serviceManager) Initialize(ctx context.Context, serviceConfig *Service
 		sm.mu.Unlock()
 	} else {
 		log.Printf("frameworkService already initialized for service: %s", serviceConfig.Name)
-	}
-
-	if ok := sm.isComponentInitialized(serviceConfig, serviceTarget); !ok {
-		if err := serviceTarget.Initialize(ctx, serviceConfig); err != nil {
-			return err
-		}
-
-		sm.mu.Lock()
-		sm.initialized[serviceConfig][serviceTarget] = true
-		sm.mu.Unlock()
 	}
 
 	return nil

--- a/cli/azd/pkg/project/service_manager_test.go
+++ b/cli/azd/pkg/project/service_manager_test.go
@@ -88,6 +88,27 @@ func Test_ServiceManager_Initialize(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// InitializeFrameworkService must succeed for a service whose host cannot be resolved (for
+// example an extension-provided host during `env refresh`): it never touches the service target.
+func Test_ServiceManager_InitializeFrameworkService_UnsupportedHost(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+	setupMocksForServiceManager(mockContext)
+	env := environment.New("test")
+	sm := createServiceManager(mockContext, env, ServiceOperationCache{})
+
+	// "missing-target" is not registered as a service target, but the framework language is.
+	serviceConfig := createTestServiceConfig("./src/api", ServiceTargetKind("missing-target"), ServiceLanguageFake)
+
+	// Framework-only initialization succeeds despite the unsupported host...
+	err := sm.InitializeFrameworkService(*mockContext.Context, serviceConfig)
+	require.NoError(t, err)
+
+	// ...whereas full initialization (which resolves the service target) fails.
+	err = sm.Initialize(*mockContext.Context, serviceConfig)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "service host 'missing-target' for service 'api' is unsupported")
+}
+
 func Test_ServiceManager_Restore(t *testing.T) {
 	mockContext := mocks.NewMockContext(t.Context())
 	setupMocksForServiceManager(mockContext)


### PR DESCRIPTION
Fixes #7195

This PR makes `azd env refresh` work in projects whose service host or provisioning provider is supplied by an extension (for example the `azure.ai.agents` extension, which provides the `azure.ai.agent` host and the `microsoft.foundry` provisioning provider). Refresh previously failed outright; it now pulls the latest deployment outputs into the local `.env` like any other project, and reports informationally when there is nothing to refresh yet.

<img width="1195" height="305" alt="image" src="https://github.com/user-attachments/assets/e207c2cf-91cb-43ba-88ec-2611a6ea40df" />

### Issue

`env refresh` is a lightweight, read-only operation: it finds the last deployment, pulls its outputs, and writes them into `.azure/<env>/.env`. It does not build, package, or deploy, but it was coupled to machinery it does not need, and it never starts extensions, so two failures occurred.

- It called `projectManager.Initialize` and `EnsureAllTools` up front, which resolve a service target for every service. An extension-provided host like `azure.ai.agent` fails with `service host 'azure.ai.agent' for service 'agent' is unsupported`.
- Unlike `provision`/`deploy`/`up`, refresh does not attach the extensions middleware, so an extension-provided provisioning provider like `microsoft.foundry` is never registered and fails with `failed resolving IaC provider 'microsoft.foundry'`.

These pull in opposite directions: refresh does not need service targets, but it does need the provisioning provider, since reading deployment state is the provider's `State()` call.

### Decouple refresh from service targets

Refresh now initializes only framework services, never service targets, so an extension-provided host cannot block it.

- Framework-only initialization, best-effort per service: a service whose framework fails to initialize is skipped and reported as a warning instead of aborting the refresh.
- `ServiceEventEnvUpdated` still fires for the services that did initialize (keeping the .NET/Aspire user-secrets sync working), and only when a layer actually produced state.
- Removed the up-front `EnsureAllTools` call, since refresh never builds, packages, or deploys.

### Start extension-provided provisioning providers on demand

Rather than starting every installed extension (as the full middleware does), refresh activates only the extension that declares the configured provider, and only when needed.

- Starts the installed extension(s) declaring the configured provider name(s), waits for readiness, and stops the host afterward via deferred cleanup.
- Idempotent: already-resolvable providers are left alone, and names no installed extension declares fall through to native resolution, so `bicep`/`terraform` are a no-op.
- Deterministic selection when multiple extensions declare the same provider; required extensions start concurrently.
- If a required extension fails to start, refresh fails fast with the real startup error plus an `azd extension upgrade <id>` suggestion.
- The extension side is unchanged: its `State()` already reads outputs from the persisted subscription-scoped deployment (no on-disk template), which is exactly what refresh needs.

### Graceful handling and suggestions

- No deployment yet: refresh prints an informational message pointing at `azd provision` and exits successfully; an extension provider returning empty state is treated the same way. An explicit `--hint` that matches nothing stays a hard error.
- Provider not installed: on a resolution failure, refresh looks the provider up in the registry and returns an actionable `azd extension install <id>` suggestion when a match exists; other errors are returned as-is.

### Shared helper and VS parity

- Extracted the per-extension "start `listen` and wait for ready" logic into a shared helper used by both the middleware and the new activator.
- Applied the same framework-only best-effort init (and dropped `EnsureAllTools`) to the Visual Studio RPC refresh path.

### Behavior at a glance

| Scenario | Before | After |
| --- | --- | --- |
| Extension-provided host (e.g. `azure.ai.agent`) | `ERROR: service host '...' is unsupported` | Outputs refreshed into `.env` |
| Extension-provided provider (e.g. `microsoft.foundry`) | `ERROR: failed resolving IaC provider '...'` | Extension started on demand; outputs refreshed |
| Provider's extension not installed | Opaque resolution error | Error with `azd extension install <id>` suggestion |
| Required extension fails to start | Opaque resolution error later | Fails fast with `azd extension upgrade <id>` suggestion |
| No deployment yet (no `--hint`) | `ERROR: no deployments found` | Informational message, command succeeds |
| `--hint` matches no deployment | Error | Error (unchanged) |
| Plain `bicep`/`terraform` project | Works | Works, no extension started |

### Testing

- Unit tests for framework-only init under an unsupported host, best-effort per-service skipping, the activator helpers (distinct names, provider matching, deterministic selection, no-op path), and the `env refresh` action over the no-deployment, empty-state, and successful-refresh cases plus suggestion gating and IoC resolution.
- Verified with `go build ./...`, `go test` across the affected packages (including `-race`), and `golangci-lint run`.
- Tested manually on [notetaking agent sample](https://github.com/microsoft-foundry/foundry-samples/blob/12c97fbbf0518a7cac02acc1706cd5000e813ce0/samples/python/hosted-agents/bring-your-own/responses/notetaking-agent/agent.manifest.yaml) with azure.ai.agents v0.1.41-preview (native azd Bicep provisioner) and v1.0.0-beta.4 (custom in-memory Bicep provisioner)
