### PR TITLE
fix(foundry): prompt for confirmation on azd down instead of requiring --force

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs Fixed
 
+- [[#8839]](https://github.com/Azure/azure-dev/issues/8839) Fix `azd down` on a Foundry (`microsoft.foundry`) project failing outright without `--force`. It now prompts for confirmation (naming the resource group to be deleted, defaulting to "no") like the built-in Bicep provider, and only falls back to requiring `--force` when there is no interactive terminal (for example under `--no-prompt` or in CI).
 - [[#8987]](https://github.com/Azure/azure-dev/pull/8987) Fix `azd ai agent init -m <manifest>` not prompting for the agent name. The prompt default and project folder are now derived from the manifest's `template.name` (falling back to the top-level `name`), matching the interactive and template flows.
 - [[#8981]](https://github.com/Azure/azure-dev/pull/8981) Fix `azd ai agent init -m <azure.yaml> --deploy-mode container` not resolving a container registry when adopting a unified Foundry `azure.yaml` on an existing Foundry project, which made `azd deploy` fail with `could not determine container registry endpoint`. The deploy mode is now resolved before Foundry project setup, so a container agent wires `AZURE_CONTAINER_REGISTRY_ENDPOINT` (or is signaled to create one on provision) while code deploy and `--image` still skip ACR.
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider.go
@@ -1239,19 +1239,11 @@ func (p *FoundryProvisioningProvider) Destroy(
 		return &azdext.ProvisioningDestroyResult{}, nil
 	}
 
-	if !options.GetForce() {
-		confirmed, err := p.confirmDestroy(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if !confirmed {
-			return nil, exterrors.Cancelled("destroy cancelled")
-		}
-	}
-
 	// Fail closed when AZURE_RESOURCE_GROUP was never set: rgName is the rg-<env>
 	// default the provider made up, not a group it provisioned. Deleting it could
 	// wipe an unrelated group that happens to match a common env name like "dev".
+	// Check this before prompting so we never ask the user to confirm a deletion
+	// we are going to refuse anyway.
 	if !p.rgExplicit {
 		return nil, exterrors.Validation(
 			exterrors.CodeMissingResourceGroup,
@@ -1260,6 +1252,16 @@ func (p *FoundryProvisioningProvider) Destroy(
 			fmt.Sprintf("set the group to delete with `azd env set %s <name>` if it was provisioned here",
 				envKeyResourceGroup),
 		)
+	}
+
+	if !options.GetForce() {
+		confirmed, err := p.confirmDestroy(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if !confirmed {
+			return nil, exterrors.Cancelled("destroy cancelled")
+		}
 	}
 
 	if err := p.ensureCredential(ctx); err != nil {
@@ -1355,13 +1357,12 @@ func (p *FoundryProvisioningProvider) confirmDestroy(ctx context.Context) (bool,
 		return false, forceRequired
 	}
 
-	defaultValue := false
 	resp, err := p.azdClient.Prompt().Confirm(ctx, &azdext.ConfirmRequest{
 		Options: &azdext.ConfirmOptions{
 			Message: fmt.Sprintf(
 				"microsoft.foundry will delete resource group %q and all resources "+
 					"inside it. Are you sure you want to continue?", p.rgName),
-			DefaultValue: &defaultValue,
+			DefaultValue: new(false),
 		},
 	})
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider.go
@@ -1206,8 +1206,10 @@ func (p *FoundryProvisioningProvider) Preview(
 
 // Destroy tears down the Foundry deployment.
 //
-//   - Force == false (default): refuse with a structured error. This provider
-//     does not prompt, so deletion must be an explicit --force choice.
+//   - Force == false (default): prompt the user for confirmation before
+//     deleting, mirroring the built-in bicep provider. Under --no-prompt (or
+//     with no azd host attached) there is nothing to prompt, so deletion falls
+//     back to requiring an explicit --force choice via a structured error.
 //   - Force == true: delete every model deployment under the resource group's
 //     Cognitive Services accounts, then delete the resource group (Foundry
 //     account, project, and any ACR). Deployments must go first: Azure refuses
@@ -1238,14 +1240,13 @@ func (p *FoundryProvisioningProvider) Destroy(
 	}
 
 	if !options.GetForce() {
-		return nil, exterrors.Validation(
-			exterrors.CodeDestroyRequiresForce,
-			fmt.Sprintf("microsoft.foundry destroy will delete resource group %q "+
-				"and all resources inside it; this provider does not prompt for "+
-				"confirmation, so --force is required", p.rgName),
-			"re-run with `azd down --force` (add `--purge` to also purge "+
-				"soft-deleted Cognitive Services accounts)",
-		)
+		confirmed, err := p.confirmDestroy(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if !confirmed {
+			return nil, exterrors.Cancelled("destroy cancelled")
+		}
 	}
 
 	// Fail closed when AZURE_RESOURCE_GROUP was never set: rgName is the rg-<env>
@@ -1327,7 +1328,55 @@ func (p *FoundryProvisioningProvider) Destroy(
 	return invalidatedEnvKeysResult(), nil
 }
 
-// purgeableAccount captures the minimum state required to purge a
+// confirmDestroy asks the user to confirm resource-group deletion when the
+// caller didn't pass --force. It mirrors the built-in bicep provider, which
+// prompts instead of hard-failing.
+//
+// Fails closed in the non-interactive cases so we never silently delete:
+//   - No azd host attached (azdClient == nil): return the actionable
+//     CodeDestroyRequiresForce error.
+//   - Under `--no-prompt` the host returns a "prompt required" error; that is
+//     surfaced as the same CodeDestroyRequiresForce error so CI/scripts stay
+//     deterministic and are told to pass --force.
+//
+// A user cancellation (Ctrl-C) or an explicit "no" both return (false, nil) so
+// the caller reports a clean cancellation rather than an error.
+func (p *FoundryProvisioningProvider) confirmDestroy(ctx context.Context) (bool, error) {
+	forceRequired := exterrors.Validation(
+		exterrors.CodeDestroyRequiresForce,
+		fmt.Sprintf("microsoft.foundry destroy will delete resource group %q "+
+			"and all resources inside it; no interactive prompt is available, "+
+			"so --force is required", p.rgName),
+		"re-run with `azd down --force` (add `--purge` to also purge "+
+			"soft-deleted Cognitive Services accounts)",
+	)
+
+	if p.azdClient == nil {
+		return false, forceRequired
+	}
+
+	defaultValue := false
+	resp, err := p.azdClient.Prompt().Confirm(ctx, &azdext.ConfirmRequest{
+		Options: &azdext.ConfirmOptions{
+			Message: fmt.Sprintf(
+				"microsoft.foundry will delete resource group %q and all resources "+
+					"inside it. Are you sure you want to continue?", p.rgName),
+			DefaultValue: &defaultValue,
+		},
+	})
+	if err != nil {
+		if exterrors.IsCancellation(err) {
+			return false, nil
+		}
+		if exterrors.IsPromptRequired(err) {
+			return false, forceRequired
+		}
+		return false, fmt.Errorf("prompting for destroy confirmation: %w", err)
+	}
+
+	return resp.GetValue(), nil
+}
+
 // soft-deleted Cognitive Services account: its name and the location it
 // was created in (the soft-delete record is keyed by location, not by
 // resource group alone).

--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_destroy_confirm_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_destroy_confirm_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"azureaiagent/internal/exterrors"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// destroyConfirmStubPromptServer is a PromptService stub that answers Confirm
+// with a configured value (or error). It records how many times Confirm was
+// called so tests can assert the provider actually prompted.
+type destroyConfirmStubPromptServer struct {
+	azdext.UnimplementedPromptServiceServer
+	confirmValue bool
+	confirmErr   error
+	confirmN     int
+	lastMessage  string
+}
+
+func (s *destroyConfirmStubPromptServer) Confirm(
+	_ context.Context, req *azdext.ConfirmRequest,
+) (*azdext.ConfirmResponse, error) {
+	s.confirmN++
+	if req.GetOptions() != nil {
+		s.lastMessage = req.GetOptions().GetMessage()
+	}
+	if s.confirmErr != nil {
+		return nil, s.confirmErr
+	}
+	v := s.confirmValue
+	return &azdext.ConfirmResponse{Value: &v}, nil
+}
+
+// newDestroyConfirmTestClient spins up a real gRPC server exposing the given
+// prompt stub and returns an AzdClient connected to it, exercising the actual
+// Confirm wire protocol between the extension and the azd host.
+func newDestroyConfirmTestClient(
+	t *testing.T,
+	promptSrv azdext.PromptServiceServer,
+) *azdext.AzdClient {
+	t.Helper()
+
+	srv := grpc.NewServer()
+	azdext.RegisterPromptServiceServer(srv, promptSrv)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+	})
+
+	client, err := azdext.NewAzdClient(azdext.WithAddress(lis.Addr().String()))
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	return client
+}
+
+// TestDestroy_PromptDeclineReturnsCancelled drives the full Destroy path over a
+// real gRPC connection: without --force the provider prompts, the user declines,
+// and Destroy returns a clean cancellation without touching Azure.
+func TestDestroy_PromptDeclineReturnsCancelled(t *testing.T) {
+	prompt := &destroyConfirmStubPromptServer{confirmValue: false}
+	client := newDestroyConfirmTestClient(t, prompt)
+
+	p := &FoundryProvisioningProvider{azdClient: client, rgName: "rg-foundry-test"}
+	_, err := p.Destroy(t.Context(), &azdext.ProvisioningDestroyOptions{Force: false}, func(string) {})
+
+	require.Error(t, err)
+	assert.Equal(t, 1, prompt.confirmN, "expected exactly one confirmation prompt")
+	assert.Contains(t, prompt.lastMessage, "rg-foundry-test",
+		"prompt must name the resource group being deleted")
+
+	var local *azdext.LocalError
+	require.ErrorAs(t, err, &local)
+	assert.Equal(t, exterrors.CodeCancelled, local.Code)
+}
+
+// TestDestroy_PromptRequiredFallsBackToForce verifies that under `--no-prompt`
+// (the host returns a "prompt required" error) Destroy surfaces the actionable
+// --force guidance instead of proceeding, keeping CI/scripts deterministic.
+func TestDestroy_PromptRequiredFallsBackToForce(t *testing.T) {
+	prompt := &destroyConfirmStubPromptServer{
+		confirmErr: status.Error(codes.FailedPrecondition, "prompt required: no terminal"),
+	}
+	client := newDestroyConfirmTestClient(t, prompt)
+
+	p := &FoundryProvisioningProvider{azdClient: client, rgName: "rg-foundry-test"}
+	_, err := p.Destroy(t.Context(), &azdext.ProvisioningDestroyOptions{Force: false}, func(string) {})
+
+	require.Error(t, err)
+	var local *azdext.LocalError
+	require.ErrorAs(t, err, &local)
+	assert.Equal(t, exterrors.CodeDestroyRequiresForce, local.Code)
+	assert.Equal(t, azdext.LocalErrorCategoryValidation, local.Category)
+	assert.Contains(t, local.Message, "rg-foundry-test")
+	assert.Contains(t, local.Suggestion, "--force")
+}
+
+// TestDestroy_PromptCancelledReturnsCancelled verifies that a user cancellation
+// (Ctrl-C, surfaced as a gRPC Canceled status) is reported as a clean
+// cancellation rather than a hard error.
+func TestDestroy_PromptCancelledReturnsCancelled(t *testing.T) {
+	prompt := &destroyConfirmStubPromptServer{
+		confirmErr: status.Error(codes.Canceled, "user cancelled"),
+	}
+	client := newDestroyConfirmTestClient(t, prompt)
+
+	p := &FoundryProvisioningProvider{azdClient: client, rgName: "rg-foundry-test"}
+	_, err := p.Destroy(t.Context(), &azdext.ProvisioningDestroyOptions{Force: false}, func(string) {})
+
+	require.Error(t, err)
+	var local *azdext.LocalError
+	require.ErrorAs(t, err, &local)
+	assert.Equal(t, exterrors.CodeCancelled, local.Code)
+}
+
+// TestConfirmDestroy_AcceptReturnsTrue verifies the accept path over real gRPC:
+// when the user confirms, confirmDestroy reports true so Destroy proceeds.
+func TestConfirmDestroy_AcceptReturnsTrue(t *testing.T) {
+	prompt := &destroyConfirmStubPromptServer{confirmValue: true}
+	client := newDestroyConfirmTestClient(t, prompt)
+
+	p := &FoundryProvisioningProvider{azdClient: client, rgName: "rg-foundry-test"}
+	confirmed, err := p.confirmDestroy(t.Context())
+
+	require.NoError(t, err)
+	assert.True(t, confirmed)
+	assert.Equal(t, 1, prompt.confirmN)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_destroy_confirm_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_destroy_confirm_test.go
@@ -78,7 +78,7 @@ func TestDestroy_PromptDeclineReturnsCancelled(t *testing.T) {
 	prompt := &destroyConfirmStubPromptServer{confirmValue: false}
 	client := newDestroyConfirmTestClient(t, prompt)
 
-	p := &FoundryProvisioningProvider{azdClient: client, rgName: "rg-foundry-test"}
+	p := &FoundryProvisioningProvider{azdClient: client, rgName: "rg-foundry-test", rgExplicit: true}
 	_, err := p.Destroy(t.Context(), &azdext.ProvisioningDestroyOptions{Force: false}, func(string) {})
 
 	require.Error(t, err)
@@ -100,7 +100,7 @@ func TestDestroy_PromptRequiredFallsBackToForce(t *testing.T) {
 	}
 	client := newDestroyConfirmTestClient(t, prompt)
 
-	p := &FoundryProvisioningProvider{azdClient: client, rgName: "rg-foundry-test"}
+	p := &FoundryProvisioningProvider{azdClient: client, rgName: "rg-foundry-test", rgExplicit: true}
 	_, err := p.Destroy(t.Context(), &azdext.ProvisioningDestroyOptions{Force: false}, func(string) {})
 
 	require.Error(t, err)
@@ -121,7 +121,7 @@ func TestDestroy_PromptCancelledReturnsCancelled(t *testing.T) {
 	}
 	client := newDestroyConfirmTestClient(t, prompt)
 
-	p := &FoundryProvisioningProvider{azdClient: client, rgName: "rg-foundry-test"}
+	p := &FoundryProvisioningProvider{azdClient: client, rgName: "rg-foundry-test", rgExplicit: true}
 	_, err := p.Destroy(t.Context(), &azdext.ProvisioningDestroyOptions{Force: false}, func(string) {})
 
 	require.Error(t, err)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_test.go
@@ -592,13 +592,15 @@ func TestArmParameters_NilSafeOnMissingSynthResult(t *testing.T) {
 		"synthesizer-derived parameters should be absent when synthResult is nil")
 }
 
-func TestDestroy_RefusesWithoutForce(t *testing.T) {
+func TestDestroy_RefusesWithoutForceWhenNonInteractive(t *testing.T) {
 	// Destroy must NEVER silently delete (or, worse, silently leak)
-	// resources. Without --force the user gets a structured error
-	// telling them exactly what would have been deleted and how to
-	// confirm it. This is the bug we fixed: prior behavior was to
-	// delete only the deployment record and return success, leaving
-	// the Foundry account + ACR + role assignments live with no warning.
+	// resources. Without --force the provider prompts for confirmation, but
+	// when there is no interactive host attached (azdClient == nil, as in
+	// --no-prompt / CI) it falls back to a structured error telling the user
+	// exactly what would have been deleted and how to confirm it. The bug this
+	// guards against: prior behavior was to delete only the deployment record
+	// and return success, leaving the Foundry account + ACR + role assignments
+	// live with no warning.
 	p := &FoundryProvisioningProvider{
 		rgName: "rg-foundry-test",
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/foundry_provisioning_provider_test.go
@@ -602,7 +602,8 @@ func TestDestroy_RefusesWithoutForceWhenNonInteractive(t *testing.T) {
 	// and return success, leaving the Foundry account + ACR + role assignments
 	// live with no warning.
 	p := &FoundryProvisioningProvider{
-		rgName: "rg-foundry-test",
+		rgName:     "rg-foundry-test",
+		rgExplicit: true,
 	}
 	_, err := p.Destroy(t.Context(), &azdext.ProvisioningDestroyOptions{Force: false}, func(string) {})
 	require.Error(t, err)

--- a/cli/azd/extensions/azure.ai.agents/tests/e2e-live/README.md
+++ b/cli/azd/extensions/azure.ai.agents/tests/e2e-live/README.md
@@ -15,9 +15,15 @@ go-expect reads until the survey UI stops emitting — i.e. a prompt is fully
 drawn and waiting for input — instead of sleeping a fixed interval, then
 dispatches on the rendered prompt text. The deploy mode is chosen up front via
 `azd ai agent init --deploy-mode code|container` (it is not an interactive
-prompt once a manifest is supplied). The non-interactive phases (`provision`,
-`deploy`, `invoke`, `down`) shell out to `azd ... --no-prompt`. Both deploy
-modes are covered:
+prompt once a manifest is supplied). The `provision`, `deploy`, and `invoke`
+phases shell out to `azd ... --no-prompt`. The `down` phase deliberately runs
+**interactively without `--force`** (over the same PTS harness) to exercise the
+Foundry provider's destroy confirmation prompt (issue #8839): the driver waits
+for the "Are you sure you want to continue?" prompt, verifies it names the
+resource group, answers "yes", and then asserts (via `az group exists`) that the
+group was actually deleted. A `t.Cleanup` still runs `azd down --force --purge
+--no-prompt` as an idempotent safety net so a crash mid-run never leaks
+resources. Both deploy modes are covered:
 
 | Mode        | What it does                                            |
 | ----------- | ------------------------------------------------------- |
@@ -120,6 +126,7 @@ safe to include in a normal `go test ./...`.
 | -------------------------- | ------------------------------ | ----------------------------------------------------------- |
 | `AZURE_AI_AGENTS_E2E_LIVE` | —                              | **Required** `=1` gate; unset → the test is skipped         |
 | `E2E_DEPLOY_MODES`         | `both`                         | `both` / `code` / `container`                               |
+| `E2E_SKIP_DEPLOY`          | —                              | `true` → run only init → provision → down (fast down/#8839 check) |
 | `E2E_CREATE_PROJECT`       | `false`                        | `true` → always create a fresh Foundry project              |
 | `E2E_PROJECT`              | —                              | Name of an existing Foundry project to select instead       |
 | `E2E_LOCATION`             | `eastus2`                      | Region for new projects (needs model quota)                 |
@@ -131,8 +138,10 @@ safe to include in a normal `go test ./...`.
 | `GH_TOKEN`                 | —                              | GitHub token for template clone (optional)                  |
 
 In CI the driver auto-detects GitHub Actions (`GITHUB_ACTIONS`) and Azure DevOps
-(`TF_BUILD`) and switches to `az` CLI auth automatically. Azure resources are
-always torn down (`azd down --force --purge`) via `t.Cleanup`, even on failure.
+(`TF_BUILD`) and switches to `az` CLI auth automatically. The `down` phase tears
+resources down interactively (answering the confirmation prompt), and a
+`t.Cleanup` force teardown (`azd down --force --purge`) always runs on top, even
+on failure.
 
 ## Files
 
@@ -143,5 +152,7 @@ always torn down (`azd down --force --purge`) via `t.Cleanup`, even on failure.
 | `assert.go`          | Pure-logic answer matcher (`responseHasExpectedAnswer`) — builds on any platform |
 | `assert_test.go`     | Unit tests for the matcher — run anywhere via `go test ./tests/e2e-live/`        |
 
-Each phase has bounded timeouts and best-effort `azd down --force --purge`
-teardown so a crash mid-run does not leak billable resources.
+Each phase has bounded timeouts. The `down` phase runs an interactive `azd down`
+(exercising the destroy confirmation prompt), and a best-effort `azd down --force
+--purge` `t.Cleanup` teardown runs on top so a crash mid-run does not leak
+billable resources.

--- a/cli/azd/extensions/azure.ai.agents/tests/e2e-live/tier2_live_test.go
+++ b/cli/azd/extensions/azure.ai.agents/tests/e2e-live/tier2_live_test.go
@@ -189,6 +189,11 @@ func setupConfigDir(t *testing.T, configDir string) {
 
 // run executes the phases in order, stopping at the first failure. Teardown is
 // registered separately as a cleanup, so it always runs.
+//
+// E2E_SKIP_DEPLOY=true runs only init → provision → down, skipping deploy and
+// invoke. Those phases don't affect the interactive `azd down` teardown, so
+// this is the fast way to iterate on the provision/down path (issue #8839)
+// without paying for a full agent deploy.
 func (r *runner) run(ctx context.Context) {
 	if err := r.phaseInit(ctx); err != nil {
 		r.t.Errorf("init: %v", err)
@@ -198,12 +203,20 @@ func (r *runner) run(ctx context.Context) {
 		r.t.Errorf("provision: %v", err)
 		return
 	}
-	if err := r.phaseDeploy(ctx); err != nil {
-		r.t.Errorf("deploy: %v", err)
-		return
+	if envTrue("E2E_SKIP_DEPLOY") {
+		r.t.Log("E2E_SKIP_DEPLOY=true: skipping deploy and invoke phases")
+	} else {
+		if err := r.phaseDeploy(ctx); err != nil {
+			r.t.Errorf("deploy: %v", err)
+			return
+		}
+		if err := r.phaseInvoke(ctx); err != nil {
+			r.t.Errorf("invoke: %v", err)
+			return
+		}
 	}
-	if err := r.phaseInvoke(ctx); err != nil {
-		r.t.Errorf("invoke: %v", err)
+	if err := r.phaseDown(ctx); err != nil {
+		r.t.Errorf("down: %v", err)
 		return
 	}
 }
@@ -316,7 +329,15 @@ func (r *runner) driveInit(ctx context.Context, exited <-chan struct{}) error {
 			repeat, lastKey = 1, key
 		}
 		if repeat >= 3 {
-			if strings.Contains(prompt, "model") || strings.Contains(prompt, "is specified") {
+			// The model select/deployment prompts can legitimately need a
+			// different option than the default (e.g. the manifest model isn't
+			// available in the chosen region), so nudge to the next choice. Scope
+			// this strictly to the model prompts: the Foundry-project prompt text
+			// ("...host your agent and any models or tools it uses.") also contains
+			// "model", and must NOT be treated as a model prompt here.
+			isModelPrompt := strings.Contains(prompt, "select a model") ||
+				strings.Contains(prompt, "is specified in the agent manifest")
+			if isModelPrompt {
 				r.t.Log("loop detected on model prompt; trying next option")
 				r.c.send(keyDown)
 				r.c.waitForQuiet(listSettle)
@@ -591,6 +612,161 @@ func (r *runner) phaseInvoke(ctx context.Context) error {
 		return nil
 	}
 	return errors.New("invoke failed after all retries")
+}
+
+// phaseDown exercises the interactive `azd down` teardown. With no --force flag
+// the Foundry provider must prompt for confirmation (issue #8839) instead of
+// failing outright. This drives the confirmation prompt over a pseudo-terminal,
+// verifies it names the resource group, answers "yes", waits for the delete to
+// finish, and asserts the resource group is actually gone. The registered
+// force+purge teardown remains as an idempotent safety net.
+func (r *runner) phaseDown(ctx context.Context) error {
+	// Capture the resource group + subscription BEFORE deleting, so we can
+	// verify the group is gone afterward: `azd down` invalidates the env values.
+	vals := r.azdEnvValues(ctx)
+	rg := vals["AZURE_RESOURCE_GROUP"]
+	sub := vals["AZURE_SUBSCRIPTION_ID"]
+	if rg == "" {
+		return errors.New("AZURE_RESOURCE_GROUP not found in azd env; cannot exercise interactive down")
+	}
+
+	if err := r.runAzdDownInteractive(ctx, rg); err != nil {
+		return err
+	}
+
+	// Verify the resource group was actually deleted. `az group exists` prints
+	// "true"/"false". A verification hiccup (az error) is logged but not fatal —
+	// the force teardown safety net still guarantees cleanup — but a group that
+	// still exists means the interactive down did not actually tear down.
+	args := []string{"group", "exists", "--name", rg}
+	if sub != "" {
+		args = append(args, "--subscription", sub)
+	}
+	out, code := r.runQuiet(ctx, r.projectDir, tagTimeout, "az", args...)
+	if code != 0 {
+		r.t.Logf("warning: could not verify resource group deletion (exit %d): %s",
+			code, truncate(strings.TrimSpace(out), 200))
+		return nil
+	}
+	if strings.Contains(strings.ToLower(out), "true") {
+		return fmt.Errorf("resource group %q still exists after interactive `azd down`", rg)
+	}
+	r.t.Logf("interactive `azd down` deleted resource group %q", rg)
+	return nil
+}
+
+// runAzdDownInteractive runs `azd down --purge` (no --force) attached to a
+// pseudo-terminal and drives the destroy confirmation prompt to completion.
+// --purge is included so soft-deleted Cognitive Services accounts don't block a
+// later re-provision; the confirmation prompt fires regardless of --purge.
+func (r *runner) runAzdDownInteractive(ctx context.Context, rg string) error {
+	c, err := newConsole(initCols, initRows)
+	if err != nil {
+		return err
+	}
+	defer c.close()
+
+	dctx, cancel := context.WithTimeout(ctx, teardownTimeout)
+	defer cancel()
+
+	//nolint:gosec // azd is a trusted fixed binary; args are test-controlled.
+	cmd := exec.CommandContext(dctx, "azd", "down", "--purge")
+	cmd.Dir = r.projectDir
+	cmd.Env = r.env
+	cmd.Stdin = c.tty()
+	cmd.Stdout = c.tty()
+	cmd.Stderr = c.tty()
+	// Give the child the pts as its controlling terminal so the prompt library
+	// treats it as a real interactive terminal (mirrors phaseInit).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true, Setctty: true}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start azd down: %w", err)
+	}
+
+	exited := make(chan struct{})
+	var waitErr error
+	go func() {
+		waitErr = cmd.Wait()
+		close(exited)
+	}()
+
+	confirmed, driveErr := r.driveDown(dctx, c, exited, rg)
+
+	// Ensure the child is gone before returning (it normally exits itself).
+	select {
+	case <-exited:
+	case <-time.After(15 * time.Second):
+		_ = cmd.Process.Kill()
+		<-exited
+	}
+
+	if driveErr != nil {
+		return driveErr
+	}
+	if !confirmed {
+		return fmt.Errorf("azd down exited without prompting for confirmation\n--- tail ---\n%s",
+			tail(c.tailString(), 2000))
+	}
+	if code := exitCode(waitErr); code != 0 {
+		return fmt.Errorf("azd down (interactive) failed (exit %d)\n--- tail ---\n%s",
+			code, tail(c.tailString(), 2000))
+	}
+	return nil
+}
+
+// driveDown waits for the Foundry destroy confirmation prompt, verifies it names
+// the resource group, and answers "yes". It returns confirmed=true once it has
+// answered, then keeps draining output (rendering the delete progress) until the
+// child exits or ctx is cancelled.
+func (r *runner) driveDown(
+	ctx context.Context, c *console, exited <-chan struct{}, rg string,
+) (confirmed bool, err error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return confirmed, fmt.Errorf("azd down timed out: %w\n--- tail ---\n%s",
+				ctx.Err(), tail(c.tailString(), 2000))
+		case <-exited:
+			return confirmed, nil
+		default:
+		}
+
+		// Block until the UI stops emitting (prompt drawn, awaiting input) or
+		// the child exits.
+		if c.waitForQuiet(promptQuiet) {
+			return confirmed, nil // child exited
+		}
+		if confirmed {
+			continue // already answered; just drain until exit
+		}
+
+		screen := c.screen()
+		// Only answer once survey is actively blocking on a "?" prompt.
+		if activePrompt(screen) == "" {
+			continue
+		}
+		if !isDestroyConfirmScreen(screen) {
+			continue
+		}
+
+		r.t.Log("down: destroy confirmation prompt detected")
+		if !screenContains(screen, rg) {
+			return confirmed, fmt.Errorf(
+				"destroy confirmation did not name resource group %q\n--- screen ---\n%s", rg, screen)
+		}
+		c.send("y" + keyEnter)
+		confirmed = true
+	}
+}
+
+// isDestroyConfirmScreen reports whether the rendered screen shows the Foundry
+// provider's destroy confirmation prompt. Source: confirmDestroy in
+// foundry_provisioning_provider.go prints "... Are you sure you want to
+// continue?" as a survey Confirm.
+func isDestroyConfirmScreen(screen string) bool {
+	return screenContains(screen, "are you sure you want to continue") &&
+		screenContains(screen, "delete resource group")
 }
 
 // teardown runs `azd down` so a run never leaves billable resources behind. It


### PR DESCRIPTION
Fixes #8839

## Problem

Running `azd down` on a `microsoft.foundry` project failed outright unless `--force` was passed:

```
ERROR: microsoft.foundry destroy will delete resource group "..." and all resources inside it.
This provider does not prompt for confirmation, so --force is required.
```

The Foundry provisioning provider's `Destroy()` hard-failed when `--force` was absent, unlike the built-in Bicep provider, which prompts the user to confirm.

## Fix

`Destroy()` now prompts for confirmation via the azd `PromptService` `Confirm` RPC (the same callback path the core uses), matching Bicep provider behavior:

- **Interactive + confirmed** → resources are destroyed.
- **Interactive + declined** → clean cancellation (`destroy cancelled`), nothing deleted.
- **Non-interactive** (`--no-prompt`, or no azd client) → fails **closed**, still requiring `--force` so CI/scripts stay deterministic.

No core azd change is required — the `Confirm` RPC already exists in the SDK; only the extension is updated.

## Protocol note

azd core talks to the out-of-process provider over gRPC (`ProvisioningService`, `ProvisioningDestroyOptions{force, purge}`). The provider calls back into azd's `PromptService.Confirm` to drive console UI. The fix wires the destroy path into that existing callback.

## Tests

- **Unit / real-gRPC (bufconn):** new `foundry_provisioning_provider_destroy_confirm_test.go` covering decline→cancel, prompt-required→force error, cancel→cancel, accept→true.
- **Live tier2 e2e:** added an interactive teardown phase (`phaseDown`) that runs `azd down --purge` (no `--force`), answers the prompt, and verifies the resource group is gone; added an `E2E_SKIP_DEPLOY` gate for faster focused runs.

## Live validation

Validated end-to-end against a real subscription:

1. Provisioned a real Foundry account + project + model deployment.
2. `azd down --purge` (no `--force`) now shows: *"microsoft.foundry will delete resource group … Are you sure you want to continue?"*
3. **Decline** → `destroy cancelled`, RG preserved.
4. **Accept** → resources removed, `az group exists` returns `false`.