### PR TITLE
Fix phantom test failures from tool first-run spinners writing to os.Stdout

### DIFF
--- a/cli/azd/cmd/middleware/tool_first_run.go
+++ b/cli/azd/cmd/middleware/tool_first_run.go
@@ -230,6 +230,7 @@ func (m *ToolFirstRunMiddleware) runFirstRunExperience(ctx context.Context) erro
 	detectSpinner := uxlib.NewSpinner(&uxlib.SpinnerOptions{
 		Text:        "Detecting tools...",
 		ClearOnStop: true,
+		Writer:      m.console.Handles().Stdout,
 	})
 	if err := detectSpinner.Run(ctx, func(ctx context.Context) error {
 		var detectErr error
@@ -416,6 +417,7 @@ func (m *ToolFirstRunMiddleware) offerInstall(
 	installSpinner := uxlib.NewSpinner(&uxlib.SpinnerOptions{
 		Text:        "Installing tools...",
 		ClearOnStop: true,
+		Writer:      m.console.Handles().Stdout,
 	})
 	installErr := installSpinner.Run(ctx, func(ctx context.Context) error {
 		var batchErr error


### PR DESCRIPTION
Fixes #9029

This PR fixes intermittent, misattributed unit-test failures in `cmd/middleware` (and adjacent packages) caused by the tool first-run middleware spinners writing terminal control codes to real stdout during tests.

## The problem

The tool first-run middleware creates its "Detecting tools..." and "Installing tools..." spinners via `uxlib.NewSpinner` without a `Writer`, which defaults to `os.Stdout`.

- On start/stop, the spinner emits cursor escape codes (`\033[?25l` / `\033[?25h`) straight to stdout.
- Under `go test -json`, those raw bytes land between JSON events and corrupt the event stream.
- The test runner then reports a passing test as `FAIL (unknown)`, often bleeding onto whatever unrelated test ran concurrently:

```
=== FAIL: cmd/middleware TestToolFirstRunMiddleware_OfferInstall_PromptError (unknown)
25h--- PASS: TestToolFirstRunMiddleware_OfferInstall_PromptError (0.00s)
```

The `forbidigo` linter only guards against `os.Stdout` in `*_test.go`, so it does not catch this because the offending write originates in production middleware code.

## The fix

Route both spinners through `m.console.Handles().Stdout`, matching how prompts in the same file already resolve their writer.

- Under `MockConsole`, `Handles().Stdout` is `io.Discard`, so nothing leaks into the test stream.
- In production, it is the real stdout, so runtime behavior is unchanged.

## Behavior at a glance

| Scenario | Before | After |
| --- | --- | --- |
| Spinner writer in tests (`MockConsole`) | `os.Stdout` (leaks escape codes) | `io.Discard` (silent) |
| `go test -json` event stream | Corrupted by cursor codes | Clean |
| Production spinner output | Real stdout | Real stdout (unchanged) |

## Testing

- Verified the corrupting cursor code (`25h`/`25l`) appears in the `-json` stream before the change and is gone after.
- Confirmed the full `cmd/middleware` suite passes with a clean `-json` stream (no raw escape bytes, no malformed lines).