### PR TITLE
ci: associate AI agents live pipeline with main PRs

### DIFF
--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -8,7 +8,11 @@
 # This pipeline is the live counterpart to the PR-gate checks in
 # `.github/workflows/lint-ext-azure-ai-agents.yml` (Tier 0 offline + Tier 1
 # recording/playback). Live Azure access is intentionally kept OUT of the
-# automatic PR pipeline (per Azure SDK EngSys / SFI guidance) and runs here only:
+# automatic PR pipeline (per Azure SDK EngSys / SFI guidance). The PR trigger
+# below only associates this pipeline with PRs targeting main so `/azp run
+# ext-azure-ai-agents-live` can queue it; the ADO pipeline definition must be
+# configured to require a team member comment before building PRs.
+# It runs only:
 #   - On demand via the PR comment:  /azp run ext-azure-ai-agents-live
 #     (requires write permission on the repo)
 #   - On the weekly schedule below.
@@ -23,7 +27,10 @@
 #     project) to avoid anonymous rate limits — no extra secret setup required.
 
 trigger: none
-pr: none
+pr:
+  branches:
+    include:
+      - main
 
 schedules:
   # 7am UTC Monday (offset from other weekly E2E pipelines to reduce contention).

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -13,7 +13,9 @@
 # `/azp run ext-azure-ai-agents-live` can queue it; the ADO pipeline definition
 # must be configured to require a team member comment before building PRs.
 # It runs only:
-#   - On demand via the PR comment:  /azp run ext-azure-ai-agents-live
+#   - On demand via the PR comment:
+#       /azp run azure-dev - live - ext - azure.ai.agents
+#     (or, if accepted by Azure Pipelines: /azp run ext-azure-ai-agents-live)
 #     (requires write permission on the repo)
 #   - On the weekly schedule below.
 #

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -9,9 +9,9 @@
 # `.github/workflows/lint-ext-azure-ai-agents.yml` (Tier 0 offline + Tier 1
 # recording/playback). Live Azure access is intentionally kept OUT of the
 # automatic PR pipeline (per Azure SDK EngSys / SFI guidance). The PR trigger
-# below only associates this pipeline with PRs targeting main so `/azp run
-# ext-azure-ai-agents-live` can queue it; the ADO pipeline definition must be
-# configured to require a team member comment before building PRs.
+# below only associates this pipeline with relevant PRs targeting main so
+# `/azp run ext-azure-ai-agents-live` can queue it; the ADO pipeline definition
+# must be configured to require a team member comment before building PRs.
 # It runs only:
 #   - On demand via the PR comment:  /azp run ext-azure-ai-agents-live
 #     (requires write permission on the repo)
@@ -31,6 +31,13 @@ pr:
   branches:
     include:
       - main
+  paths:
+    include:
+      - eng/pipelines/ext-azure-ai-agents-live.yml
+      - cli/azd/go.mod
+      - cli/azd/go.sum
+      - cli/azd/extensions/azure.ai.agents/**
+      - cli/azd/extensions/azure.ai.projects/**
 
 schedules:
   # 7am UTC Monday (offset from other weekly E2E pipelines to reduce contention).


### PR DESCRIPTION
Fixes #9077

## Summary

- Associates `ext-azure-ai-agents-live` with relevant PRs targeting `main` so `/azp run ...` can queue the live pipeline from a PR comment.
- Keeps normal push CI disabled with `trigger: none`.
- Adds PR path filters so only AI agents / projects extension and live-pipeline-related changes are associated with this live pipeline.

## PR trigger scope

This pipeline will only be associated with PRs that target `main` and change one of these paths:

```yaml
- eng/pipelines/ext-azure-ai-agents-live.yml
- cli/azd/go.mod
- cli/azd/go.sum
- cli/azd/extensions/azure.ai.agents/**
- cli/azd/extensions/azure.ai.projects/**
```

## ADO setup

ADO definition 8268 (`ext-azure-ai-agents-live`) must require a team member comment before building PRs, so the live pipeline does not run automatically.

ADO pipeline summary / all runs:
https://dev.azure.com/azure-sdk/internal/_build?definitionId=8268&_a=summary

## Validation plan

After this PR is merged, use draft test PR #9075 to validate the comment trigger:
https://github.com/Azure/azure-dev/pull/9075

Comment on #9075:

```text
/azp run azure-dev - live - ext - azure.ai.agents
```

Optionally also test the short name:

```text
/azp run ext-azure-ai-agents-live
```

Expected trigger result: ADO queues definition 8268 and does not reply with either:

```text
No pipelines are associated with this pull request.
Azure Pipelines could not run because the pipeline triggers exclude this branch/path.
```

## Related

- Initial live pipeline: https://github.com/Azure/azure-dev/pull/8758
- Pipeline setup / 1ES artifact fix and validation: https://github.com/Azure/azure-dev/pull/8998