### PR TITLE
fix(toolboxes): branch skill/connection add/remove from latest version

### DIFF
--- a/cli/azd/extensions/azure.ai.toolboxes/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.toolboxes/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## Unreleased
+
+### Bugs Fixed
+
+- [[#9034]](https://github.com/Azure/azure-dev/issues/9034) `azd ai toolbox skill add/remove` and `azd ai toolbox connection add/remove` now branch the new version from the toolbox's **latest** version by default, instead of its **default** version. Previously, two sequential mutations without an intervening `publish` produced sibling versions that each carried only one of the changes, silently dropping the other. A new `--from-version` flag lets callers opt back into the old behavior (`--from-version default`) or fork from a specific version.
+
 ## 1.0.0-beta.1 (2026-06-30)
 
 ### Features Added

--- a/cli/azd/extensions/azure.ai.toolboxes/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.toolboxes/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## Unreleased
+## 1.0.0-beta.2 (Unreleased)
 
 ### Bugs Fixed
 

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/root.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/root.go
@@ -17,8 +17,9 @@ func NewRootCommand() *cobra.Command {
 
 A toolbox is a versioned, named collection of connection-backed tools that
 agents reference at run time. Each version is immutable: mutations (connection
-add/remove, skill add/remove) create a new version but never change which
-version is the default. Use 'azd ai toolbox publish <toolbox> <version>'
+add/remove, skill add/remove) create a new version, branched from the
+toolbox's latest version by default, but never change which version is the
+default. Use 'azd ai toolbox publish <toolbox> <version>'
 to promote a version.`,
 	})
 

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_commands_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_commands_test.go
@@ -233,6 +233,64 @@ func TestRunConnectionAddWith_AppendsAndPromotesDefault(t *testing.T) {
 	assert.Empty(t, client.setDefaultCalls, "mutation verbs no longer auto-promote default")
 }
 
+// Regression test for azure-dev#9034: sequential `connection add` calls
+// (with no --from-version) must chain onto each other by branching from the
+// latest version, not both forking from the stale default version.
+func TestRunConnectionAddWith_SequentialAddsChainFromLatest(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	client.getResults["tb"] = toolboxGetResult{obj: &azure.ToolboxObject{
+		Name: "tb", DefaultVersion: "1",
+	}}
+	client.versionResults["tb/1"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "1", Tools: []map[string]any{},
+	}}
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"},
+	}
+
+	resolver := newStubConnectionResolver()
+	resolver.byName["mcp-a"] = &projectConnection{
+		ID: "/c/a", Category: connections.ConnectionTypeRemoteTool, Name: "mcp-a", Target: "https://mcp-a",
+	}
+	resolver.byName["mcp-b"] = &projectConnection{
+		ID: "/c/b", Category: connections.ConnectionTypeRemoteTool, Name: "mcp-b", Target: "https://mcp-b",
+	}
+
+	// Step 1: attach "mcp-a".
+	err := runConnectionAddWith(
+		t.Context(), client, resolver, "https://e/",
+		"tb", "mcp-a", connectionAddFlags{}, toolboxFlags{output: "json"},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+	firstReq := client.createVersionCalls[0].req
+	require.Len(t, firstReq.Tools, 1)
+
+	// Simulate the real service state after step 1: version "2" now exists,
+	// default is still "1" (no auto-promotion).
+	client.versionResults["tb/2"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "2", Tools: firstReq.Tools,
+	}}
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"},
+		{Name: "tb", Version: "2"},
+	}
+
+	// Step 2: attach "mcp-b" with no --from-version. Pre-fix, this would
+	// branch from the still-default version "1" (empty tools) and silently
+	// drop "mcp-a". Post-fix, it must branch from latest ("2": mcp-a) and
+	// end up with both.
+	err = runConnectionAddWith(
+		t.Context(), client, resolver, "https://e/",
+		"tb", "mcp-b", connectionAddFlags{}, toolboxFlags{output: "json"},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 2)
+	secondReq := client.createVersionCalls[1].req
+	require.Len(t, secondReq.Tools, 2,
+		"second add must carry mcp-a forward (branch from latest, not default)")
+}
+
 func TestRunConnectionAddWith_ConnectionNotFound(t *testing.T) {
 	client := newMockToolboxClient("https://e/")
 	client.getResults["tb"] = toolboxGetResult{obj: &azure.ToolboxObject{Name: "tb", DefaultVersion: "1"}}
@@ -357,6 +415,103 @@ func TestRunConnectionRemoveWith_FilteredAndPromoted(t *testing.T) {
 	require.NotNil(t, req.Policies, "policies must be carried forward on remove")
 	assert.Equal(t, "Microsoft.Default", req.Policies.RaiConfig.RaiPolicyName)
 	assert.Empty(t, client.setDefaultCalls)
+}
+
+// Regression test for azure-dev#9034: sequential `connection remove` calls
+// (with no --from-version) must chain onto each other by branching from the
+// latest version, not both forking from the stale default version.
+func TestRunConnectionRemoveWith_SequentialRemovesChainFromLatest(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	client.getResults["tb"] = toolboxGetResult{obj: &azure.ToolboxObject{
+		Name: "tb", DefaultVersion: "1",
+	}}
+	client.versionResults["tb/1"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "1", Tools: []map[string]any{
+			{"type": "mcp", "name": "a", "project_connection_id": "/c/a"},
+			{"type": "mcp", "name": "b", "project_connection_id": "/c/b"},
+			{"type": "mcp", "name": "c", "project_connection_id": "/c/c"},
+		},
+	}}
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"},
+	}
+	resolver := newStubConnectionResolver()
+	resolver.byName["a"] = &projectConnection{ID: "/c/a", Category: connections.ConnectionTypeRemoteTool, Name: "a"}
+	resolver.byName["b"] = &projectConnection{ID: "/c/b", Category: connections.ConnectionTypeRemoteTool, Name: "b"}
+
+	// Step 1: remove "a".
+	err := runConnectionRemoveWith(
+		t.Context(), client, resolver, "https://e/",
+		"tb", []string{"a"}, connectionRemoveFlags{force: true}, toolboxFlags{output: "json"},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+	firstReq := client.createVersionCalls[0].req
+	require.Len(t, firstReq.Tools, 2, "b and c remain after removing a")
+
+	// Simulate the real service state after step 1.
+	client.versionResults["tb/2"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "2", Tools: firstReq.Tools,
+	}}
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"},
+		{Name: "tb", Version: "2"},
+	}
+
+	// Step 2: remove "b" with no --from-version. Pre-fix, this would branch
+	// from the still-default version "1" (a, b, c) and produce a sibling
+	// that never reflects step 1's removal. Post-fix, it must branch from
+	// latest ("2": b, c) and end up with only "c".
+	err = runConnectionRemoveWith(
+		t.Context(), client, resolver, "https://e/",
+		"tb", []string{"b"}, connectionRemoveFlags{force: true}, toolboxFlags{output: "json"},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 2)
+	secondReq := client.createVersionCalls[1].req
+	require.Len(t, secondReq.Tools, 1,
+		"second remove must branch from latest (post-step-1 state), not the stale default")
+	assert.Equal(t, "/c/c", secondReq.Tools[0]["project_connection_id"])
+}
+
+// --from-version accepts an explicit version, forking from a specific point
+// in history rather than "default" or "latest".
+func TestRunConnectionRemoveWith_FromVersionExplicitOverride(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	client.getResults["tb"] = toolboxGetResult{obj: &azure.ToolboxObject{
+		Name: "tb", DefaultVersion: "1",
+	}}
+	client.versionResults["tb/1"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "1", Tools: []map[string]any{
+			{"type": "mcp", "name": "a", "project_connection_id": "/c/a"},
+		},
+	}}
+	// Version "3" is neither default ("1") nor latest; --from-version "3"
+	// must still be honored verbatim.
+	client.versionResults["tb/3"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "3", Tools: []map[string]any{
+			{"type": "mcp", "name": "a", "project_connection_id": "/c/a"},
+			{"type": "mcp", "name": "z", "project_connection_id": "/c/z"},
+		},
+	}}
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"},
+		{Name: "tb", Version: "3"},
+	}
+	resolver := newStubConnectionResolver()
+	resolver.byName["z"] = &projectConnection{ID: "/c/z", Category: connections.ConnectionTypeRemoteTool, Name: "z"}
+
+	err := runConnectionRemoveWith(
+		t.Context(), client, resolver, "https://e/",
+		"tb", []string{"z"},
+		connectionRemoveFlags{force: true, fromVersion: "3"},
+		toolboxFlags{output: "json"},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+	req := client.createVersionCalls[0].req
+	require.Len(t, req.Tools, 1, "must branch from explicit version 3, not default/latest")
+	assert.Equal(t, "/c/a", req.Tools[0]["project_connection_id"])
 }
 
 func TestRunConnectionRemoveWith_ConnectionNotInToolbox(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection.go
@@ -24,9 +24,9 @@ func newToolboxConnectionCommand(extCtx *azdext.ExtensionContext) *cobra.Command
 
 Tools are project connections. Supported categories: RemoteTool (MCP),
 CognitiveSearch (Azure AI Search), RemoteA2A, and GroundingWithCustomSearch.
-Each mutation creates a new immutable version; the toolbox's default version
-is unchanged. Use 'azd ai toolbox publish <toolbox> <version>'
-to promote a version.`,
+Each mutation creates a new immutable version, branched from the toolbox's
+latest version by default; the toolbox's default version is unchanged. Use
+'azd ai toolbox publish <toolbox> <version>' to promote a version.`,
 	}
 	cmd.AddCommand(newToolboxConnectionAddCommand(extCtx))
 	cmd.AddCommand(newToolboxConnectionRemoveCommand(extCtx))

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_add.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_add.go
@@ -21,6 +21,7 @@ type connectionAddFlags struct {
 	index        string
 	instanceName string
 	fromFile     string
+	fromVersion  string
 }
 
 // newToolboxConnectionAddCommand returns the `connection add` command.
@@ -49,10 +50,11 @@ File mode:
 
 Provide a JSON or YAML file with multiple connections. All inputs from a
 single invocation create exactly one new toolbox version, so adding three
-connections this way produces v(N+1), not v(N+3).
+connections this way produces one new version, not three.
 
-The new version is created but the toolbox's default version is unchanged;
-run 'azd ai toolbox publish <toolbox> <version>' to promote it.
+The new version is branched from the toolbox's latest version by default
+(see --from-version), and the toolbox's default version is unchanged; run
+'azd ai toolbox publish <toolbox> <version>' to promote it.
 
 ` + fileShapeBlurb(false) + `
 
@@ -111,6 +113,7 @@ Examples:
 		&flags.fromFile, "from-file", "",
 		"Path to a JSON/YAML file describing the connections to add (see --help for the file shape).",
 	)
+	registerFromVersionFlag(cmd, &flags.fromVersion)
 	registerToolboxOutputFlag(cmd)
 	return cmd
 }
@@ -164,9 +167,13 @@ func runConnectionAddWith(
 		return exterrors.ServiceFromAzure(err, exterrors.OpGetToolbox)
 	}
 
-	current, err := client.GetToolboxVersion(ctx, toolboxName, tb.DefaultVersion)
+	baseVersion, err := resolveBaseVersion(ctx, client, toolboxName, tb, verb.fromVersion)
 	if err != nil {
-		return exterrors.ServiceFromAzure(err, exterrors.OpGetToolboxVersion)
+		return err
+	}
+	current, err := client.GetToolboxVersion(ctx, toolboxName, baseVersion)
+	if err != nil {
+		return toolboxVersionNotFoundOrService(err, toolboxName, baseVersion, exterrors.OpGetToolboxVersion)
 	}
 
 	newEntries := []map[string]any{}
@@ -247,7 +254,7 @@ func runConnectionAddWith(
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateToolboxVersion)
 	}
 
-	return emitConnectionAddResult(toolboxName, created.Version, addedConnectionNames, parent.output, endpoint)
+	return emitConnectionAddResult(toolboxName, created.Version, baseVersion, addedConnectionNames, parent.output, endpoint)
 }
 
 // rejectDuplicatesAgainstCurrentAndBatch flags a duplicate if any new entry
@@ -287,15 +294,16 @@ func rejectDuplicatesAgainstCurrentAndBatch(current, added []map[string]any) err
 
 // emitConnectionAddResult prints the standard output for a successful add.
 func emitConnectionAddResult(
-	toolboxName, newVersion string, connectionNames []string, output, endpoint string,
+	toolboxName, newVersion, baseVersion string, connectionNames []string, output, endpoint string,
 ) error {
 	mcpURL := buildToolboxMcpURL(endpoint, toolboxName, newVersion)
 	if output == "json" {
 		payload := map[string]any{
-			"toolbox":     toolboxName,
-			"version":     newVersion,
-			"connections": connectionNames,
-			"endpoint":    mcpURL,
+			"toolbox":      toolboxName,
+			"version":      newVersion,
+			"base_version": baseVersion,
+			"connections":  connectionNames,
+			"endpoint":     mcpURL,
 		}
 		return emitJSON(payload)
 	}
@@ -305,7 +313,10 @@ func emitConnectionAddResult(
 		fmt.Printf("Connections: %s\n", strings.Join(connectionNames, ", "))
 	}
 	fmt.Printf("Endpoint: %s\n", mcpURL)
-	fmt.Printf("The default version is unchanged; "+
-		"run `azd ai toolbox publish %q %q` to promote.\n", toolboxName, newVersion)
+	fmt.Printf(
+		"Branched from version %s; the default version is unchanged. "+
+			"Run `azd ai toolbox publish %q %q` to promote.\n",
+		baseVersion, toolboxName, newVersion,
+	)
 	return nil
 }

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_remove.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_remove.go
@@ -18,7 +18,8 @@ import (
 
 // connectionRemoveFlags carries the verb-specific flags for `connection remove`.
 type connectionRemoveFlags struct {
-	force bool
+	force       bool
+	fromVersion string
 }
 
 // newToolboxConnectionRemoveCommand returns the `connection remove` command.
@@ -32,7 +33,8 @@ func newToolboxConnectionRemoveCommand(extCtx *azdext.ExtensionContext) *cobra.C
 		Long: `Detach one or more connections from a toolbox and create a new version.
 
 Pass one or more connection short names as positionals. All removals are
-applied atomically: each invocation creates exactly one new toolbox version.
+applied atomically: each invocation creates exactly one new toolbox version,
+branched from the toolbox's latest version by default (see --from-version).
 
 Refuses to leave the toolbox with zero tools (use 'toolbox delete' instead).
 
@@ -55,6 +57,7 @@ Examples:
 		&flags.force, "force", false,
 		"Skip confirmation prompts and apply the removal immediately.",
 	)
+	registerFromVersionFlag(cmd, &flags.fromVersion)
 	registerToolboxOutputFlag(cmd)
 	return cmd
 }
@@ -121,9 +124,13 @@ func runConnectionRemoveWith(
 	if err != nil {
 		return toolboxNotFoundOrService(err, toolboxName, exterrors.OpGetToolbox)
 	}
-	current, err := client.GetToolboxVersion(ctx, toolboxName, tb.DefaultVersion)
+	baseVersion, err := resolveBaseVersion(ctx, client, toolboxName, tb, verb.fromVersion)
 	if err != nil {
-		return exterrors.ServiceFromAzure(err, exterrors.OpGetToolboxVersion)
+		return err
+	}
+	current, err := client.GetToolboxVersion(ctx, toolboxName, baseVersion)
+	if err != nil {
+		return toolboxVersionNotFoundOrService(err, toolboxName, baseVersion, exterrors.OpGetToolboxVersion)
 	}
 
 	// Resolve each name and strip from the tools[].
@@ -140,8 +147,8 @@ func runConnectionRemoveWith(
 			return exterrors.Validation(
 				exterrors.CodeConnectionNotInToolbox,
 				fmt.Sprintf(
-					"connection %q is not attached to toolbox %q's current default version",
-					name, toolboxName,
+					"connection %q is not attached to toolbox %q's base version %q",
+					name, toolboxName, baseVersion,
 				),
 				fmt.Sprintf("run 'azd ai toolbox connection list %q'", toolboxName),
 			)
@@ -203,7 +210,7 @@ func runConnectionRemoveWith(
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateToolboxVersion)
 	}
 
-	return emitConnectionRemoveResult(toolboxName, created.Version, removedConns, parent.output)
+	return emitConnectionRemoveResult(toolboxName, created.Version, baseVersion, removedConns, parent.output)
 }
 
 // summarizeConnectionNames renders "connection \"a\"" or "connections [\"a\", \"b\"]".
@@ -219,13 +226,14 @@ func summarizeConnectionNames(conns []*projectConnection) string {
 }
 
 func emitConnectionRemoveResult(
-	toolboxName, newVersion string, conns []*projectConnection, output string,
+	toolboxName, newVersion, baseVersion string, conns []*projectConnection, output string,
 ) error {
 	if output == "json" {
 		if len(conns) == 1 {
 			return emitJSON(map[string]any{
 				"toolbox":       toolboxName,
 				"version":       newVersion,
+				"base_version":  baseVersion,
 				"connection":    conns[0].Name,
 				"connection_id": conns[0].ID,
 			})
@@ -238,9 +246,10 @@ func emitConnectionRemoveResult(
 			})
 		}
 		return emitJSON(map[string]any{
-			"toolbox":     toolboxName,
-			"version":     newVersion,
-			"connections": rows,
+			"toolbox":      toolboxName,
+			"version":      newVersion,
+			"base_version": baseVersion,
+			"connections":  rows,
 		})
 	}
 	if len(conns) == 1 {
@@ -258,7 +267,10 @@ func emitConnectionRemoveResult(
 			toolboxName, newVersion, strings.Join(names, ", "),
 		)
 	}
-	fmt.Printf("The default version is unchanged; "+
-		"run `azd ai toolbox publish %q %q` to promote.\n", toolboxName, newVersion)
+	fmt.Printf(
+		"Branched from version %s; the default version is unchanged. "+
+			"Run `azd ai toolbox publish %q %q` to promote.\n",
+		baseVersion, toolboxName, newVersion,
+	)
 	return nil
 }

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_shared.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_shared.go
@@ -26,6 +26,22 @@ func toolboxNotFoundOrService(err error, name, op string) error {
 	return exterrors.ServiceFromAzure(err, op)
 }
 
+// toolboxVersionNotFoundOrService maps a GetToolboxVersion error for a
+// resolved base/shown version to the right structured error:
+// Dependency(CodeToolboxNotFound) on 404, ServiceError otherwise. Used
+// whenever the version came from user input (--version, --from-version)
+// rather than being read back verbatim from the toolbox object.
+func toolboxVersionNotFoundOrService(err error, toolboxName, version, op string) error {
+	if isAzureNotFound(err) {
+		return exterrors.Dependency(
+			exterrors.CodeToolboxNotFound,
+			fmt.Sprintf("version %q of toolbox %q not found", version, toolboxName),
+			fmt.Sprintf("run 'azd ai toolbox versions list %q' to see available versions", toolboxName),
+		)
+	}
+	return exterrors.ServiceFromAzure(err, op)
+}
+
 // forEachToolConnectionID invokes fn for every project_connection_id reference
 // in tools[] (top-level on mcp entries, nested under azure_ai_search.indexes
 // on search entries). fn returns true to stop early.

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_add.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_add.go
@@ -18,7 +18,8 @@ import (
 
 // skillAddFlags carries the verb-specific flags for `skill add`.
 type skillAddFlags struct {
-	fromFile string
+	fromFile    string
+	fromVersion string
 }
 
 // newToolboxSkillAddCommand returns the `skill add` command.
@@ -32,7 +33,8 @@ func newToolboxSkillAddCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 		Long: `Attach one or more skill references to a toolbox.
 
 Pass a single skill as the positional, or many via --from-file. Either way
-the invocation creates exactly one new toolbox version. The toolbox's
+the invocation creates exactly one new toolbox version, branched from the
+toolbox's latest version by default (see --from-version). The toolbox's
 default version is unchanged; run
 'azd ai toolbox publish <toolbox> <version>' to promote it.
 
@@ -70,6 +72,7 @@ Examples:
 		&flags.fromFile, "from-file", "",
 		"Path to a JSON/YAML file listing skills to attach (skills[] block).",
 	)
+	registerFromVersionFlag(cmd, &flags.fromVersion)
 	registerToolboxOutputFlag(cmd)
 	return cmd
 }
@@ -125,12 +128,16 @@ func runSkillAddWith(
 	if err != nil {
 		return toolboxNotFoundOrService(err, toolboxName, exterrors.OpGetToolbox)
 	}
-	current, err := client.GetToolboxVersion(ctx, toolboxName, tb.DefaultVersion)
+	baseVersion, err := resolveBaseVersion(ctx, client, toolboxName, tb, verb.fromVersion)
 	if err != nil {
-		return exterrors.ServiceFromAzure(err, exterrors.OpGetToolboxVersion)
+		return err
+	}
+	current, err := client.GetToolboxVersion(ctx, toolboxName, baseVersion)
+	if err != nil {
+		return toolboxVersionNotFoundOrService(err, toolboxName, baseVersion, exterrors.OpGetToolboxVersion)
 	}
 
-	// Reject duplicates within the input and against the current default.
+	// Reject duplicates within the input and against the base version.
 	seen := map[string]struct{}{}
 	for _, sk := range current.Skills {
 		if n, ok := sk["name"].(string); ok && n != "" {
@@ -142,9 +149,9 @@ func runSkillAddWith(
 			return exterrors.Validation(
 				exterrors.CodeSkillAlreadyAttached,
 				fmt.Sprintf(
-					"skill %q is already attached to toolbox %q's current default version "+
+					"skill %q is already attached to toolbox %q's base version %q "+
 						"(or appears more than once in the input)",
-					sp.Name, toolboxName,
+					sp.Name, toolboxName, baseVersion,
 				),
 				fmt.Sprintf(
 					"remove the existing reference with `azd ai toolbox skill remove %q %q` first",
@@ -171,7 +178,7 @@ func runSkillAddWith(
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateToolboxVersion)
 	}
 
-	return emitSkillAddResult(toolboxName, created.Version, specs, parent.output)
+	return emitSkillAddResult(toolboxName, created.Version, baseVersion, specs, parent.output)
 }
 
 // collectSkillSpecs picks the active input mode and returns the parsed list.
@@ -207,13 +214,14 @@ func collectSkillSpecs(rawSkill string, verb skillAddFlags) ([]skillSpec, error)
 	return []skillSpec{sp}, nil
 }
 
-func emitSkillAddResult(toolboxName, newVersion string, specs []skillSpec, output string) error {
+func emitSkillAddResult(toolboxName, newVersion, baseVersion string, specs []skillSpec, output string) error {
 	if output == "json" {
 		if len(specs) == 1 {
 			payload := map[string]any{
-				"toolbox": toolboxName,
-				"version": newVersion,
-				"skill":   specs[0].Name,
+				"toolbox":      toolboxName,
+				"version":      newVersion,
+				"base_version": baseVersion,
+				"skill":        specs[0].Name,
 			}
 			if specs[0].Version != "" {
 				payload["skill_version"] = specs[0].Version
@@ -229,9 +237,10 @@ func emitSkillAddResult(toolboxName, newVersion string, specs []skillSpec, outpu
 			rows = append(rows, row)
 		}
 		return emitJSON(map[string]any{
-			"toolbox": toolboxName,
-			"version": newVersion,
-			"skills":  rows,
+			"toolbox":      toolboxName,
+			"version":      newVersion,
+			"base_version": baseVersion,
+			"skills":       rows,
 		})
 	}
 
@@ -258,7 +267,10 @@ func emitSkillAddResult(toolboxName, newVersion string, specs []skillSpec, outpu
 			toolboxName, newVersion, strings.Join(names, ", "),
 		)
 	}
-	fmt.Printf("The default version is unchanged; "+
-		"run `azd ai toolbox publish %q %q` to promote.\n", toolboxName, newVersion)
+	fmt.Printf(
+		"Branched from version %s; the default version is unchanged. "+
+			"Run `azd ai toolbox publish %q %q` to promote.\n",
+		baseVersion, toolboxName, newVersion,
+	)
 	return nil
 }

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_group.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_group.go
@@ -16,9 +16,9 @@ func newToolboxSkillCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 		Short: "Manage skill references attached to a toolbox.",
 		Long: `Manage skill references attached to a toolbox.
 
-Each add/remove creates a new immutable version; the toolbox's default
-version is unchanged. Use 'azd ai toolbox publish <toolbox> <version>'
-to promote a version.`,
+Each add/remove creates a new immutable version, branched from the toolbox's
+latest version by default; the toolbox's default version is unchanged. Use
+'azd ai toolbox publish <toolbox> <version>' to promote a version.`,
 	}
 	cmd.AddCommand(newToolboxSkillAddCommand(extCtx))
 	cmd.AddCommand(newToolboxSkillRemoveCommand(extCtx))

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_remove.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_remove.go
@@ -18,7 +18,8 @@ import (
 
 // skillRemoveFlags carries the verb-specific flags for `skill remove`.
 type skillRemoveFlags struct {
-	force bool
+	force       bool
+	fromVersion string
 }
 
 // newToolboxSkillRemoveCommand returns the `skill remove` command.
@@ -32,7 +33,8 @@ func newToolboxSkillRemoveCommand(extCtx *azdext.ExtensionContext) *cobra.Comman
 		Long: `Detach one or more skill references from a toolbox and create a new version.
 
 Pass one or more skill short names as positionals. All removals are applied
-atomically: each invocation creates exactly one new toolbox version.
+atomically: each invocation creates exactly one new toolbox version, branched
+from the toolbox's latest version by default (see --from-version).
 
 Removing the last skill is allowed.
 
@@ -52,6 +54,7 @@ Examples:
 		&flags.force, "force", false,
 		"Skip confirmation prompts and apply the removal immediately.",
 	)
+	registerFromVersionFlag(cmd, &flags.fromVersion)
 	registerToolboxOutputFlag(cmd)
 	return cmd
 }
@@ -111,9 +114,13 @@ func runSkillRemoveWith(
 	if err != nil {
 		return toolboxNotFoundOrService(err, toolboxName, exterrors.OpGetToolbox)
 	}
-	current, err := client.GetToolboxVersion(ctx, toolboxName, tb.DefaultVersion)
+	baseVersion, err := resolveBaseVersion(ctx, client, toolboxName, tb, verb.fromVersion)
 	if err != nil {
-		return exterrors.ServiceFromAzure(err, exterrors.OpGetToolboxVersion)
+		return err
+	}
+	current, err := client.GetToolboxVersion(ctx, toolboxName, baseVersion)
+	if err != nil {
+		return toolboxVersionNotFoundOrService(err, toolboxName, baseVersion, exterrors.OpGetToolboxVersion)
 	}
 
 	filtered := slices.Clone(current.Skills)
@@ -124,8 +131,8 @@ func runSkillRemoveWith(
 			return exterrors.Validation(
 				exterrors.CodeSkillNotInToolbox,
 				fmt.Sprintf(
-					"skill %q is not attached to toolbox %q's current default version",
-					name, toolboxName,
+					"skill %q is not attached to toolbox %q's base version %q",
+					name, toolboxName, baseVersion,
 				),
 				fmt.Sprintf("run 'azd ai toolbox skill list %q'", toolboxName),
 			)
@@ -172,7 +179,7 @@ func runSkillRemoveWith(
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateToolboxVersion)
 	}
 
-	return emitSkillRemoveResult(toolboxName, created.Version, names, parent.output)
+	return emitSkillRemoveResult(toolboxName, created.Version, baseVersion, names, parent.output)
 }
 
 // summarizeSkillNames renders "skill \"a\"" or "skills [\"a\", \"b\"]".
@@ -187,19 +194,21 @@ func summarizeSkillNames(names []string) string {
 	return "skills [" + strings.Join(quoted, ", ") + "]"
 }
 
-func emitSkillRemoveResult(toolboxName, newVersion string, names []string, output string) error {
+func emitSkillRemoveResult(toolboxName, newVersion, baseVersion string, names []string, output string) error {
 	if output == "json" {
 		if len(names) == 1 {
 			return emitJSON(map[string]any{
-				"toolbox": toolboxName,
-				"version": newVersion,
-				"skill":   names[0],
+				"toolbox":      toolboxName,
+				"version":      newVersion,
+				"base_version": baseVersion,
+				"skill":        names[0],
 			})
 		}
 		return emitJSON(map[string]any{
-			"toolbox": toolboxName,
-			"version": newVersion,
-			"skills":  names,
+			"toolbox":      toolboxName,
+			"version":      newVersion,
+			"base_version": baseVersion,
+			"skills":       names,
 		})
 	}
 	if len(names) == 1 {
@@ -213,7 +222,10 @@ func emitSkillRemoveResult(toolboxName, newVersion string, names []string, outpu
 			toolboxName, newVersion, strings.Join(names, ", "),
 		)
 	}
-	fmt.Printf("The default version is unchanged; "+
-		"run `azd ai toolbox publish %q %q` to promote.\n", toolboxName, newVersion)
+	fmt.Printf(
+		"Branched from version %s; the default version is unchanged. "+
+			"Run `azd ai toolbox publish %q %q` to promote.\n",
+		baseVersion, toolboxName, newVersion,
+	)
 	return nil
 }

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_verbs_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_skill_verbs_test.go
@@ -228,6 +228,61 @@ func TestRunSkillRemoveWith_NotAttached(t *testing.T) {
 	requireLocalError(t, err, exterrors.CodeSkillNotInToolbox)
 }
 
+// Regression test for azure-dev#9034: sequential `skill remove` calls (with
+// no --from-version) must chain onto each other by branching from the latest
+// version, not both forking from the stale default version.
+func TestRunSkillRemoveWith_SequentialRemovesChainFromLatest(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	client.getResults["tb"] = toolboxGetResult{obj: &azure.ToolboxObject{
+		Name: "tb", DefaultVersion: "1",
+	}}
+	client.versionResults["tb/1"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "1",
+		Tools: []map[string]any{{"type": "mcp", "name": "a", "project_connection_id": "/c/a"}},
+		Skills: []map[string]any{
+			{"type": "skill_reference", "name": "alpha"},
+			{"type": "skill_reference", "name": "beta"},
+			{"type": "skill_reference", "name": "gamma"},
+		},
+	}}
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"},
+	}
+
+	// Step 1: remove "alpha".
+	err := runSkillRemoveWith(t.Context(), client, "tb", []string{"alpha"},
+		skillRemoveFlags{force: true}, toolboxFlags{output: "json"},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+	firstReq := client.createVersionCalls[0].req
+	require.Len(t, firstReq.Skills, 2, "beta and gamma remain after removing alpha")
+
+	// Simulate the real service state after step 1.
+	client.versionResults["tb/2"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "2", Tools: firstReq.Tools, Skills: firstReq.Skills,
+	}}
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"},
+		{Name: "tb", Version: "2"},
+	}
+
+	// Step 2: remove "beta" with no --from-version. Pre-fix, this would
+	// branch from the still-default version "1" (which still has alpha,
+	// beta, gamma) and produce a sibling that never reflects step 1's
+	// removal. Post-fix, it must branch from latest ("2": beta, gamma) and
+	// end up with only "gamma".
+	err = runSkillRemoveWith(t.Context(), client, "tb", []string{"beta"},
+		skillRemoveFlags{force: true}, toolboxFlags{output: "json"},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 2)
+	secondReq := client.createVersionCalls[1].req
+	require.Len(t, secondReq.Skills, 1,
+		"second remove must branch from latest (post-step-1 state), not the stale default")
+	assert.Equal(t, "gamma", secondReq.Skills[0]["name"])
+}
+
 func TestRunSkillRemove_NoPromptWithoutForce(t *testing.T) {
 	err := runSkillRemove(
 		t.Context(), "tb", []string{"any-skill"},
@@ -300,6 +355,93 @@ func TestRunSkillRemoveWith_VariadicPositionals(t *testing.T) {
 	require.Len(t, client.createVersionCalls, 1, "one new version created for the whole batch")
 	require.Len(t, client.createVersionCalls[0].req.Skills, 1)
 	assert.Equal(t, "beta", client.createVersionCalls[0].req.Skills[0]["name"])
+}
+
+// Regression test for azure-dev#9034: sequential `skill add` calls (with no
+// --from-version) must chain onto each other by branching from the latest
+// version, not both forking from the stale default version.
+func TestRunSkillAddWith_SequentialAddsChainFromLatest(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	client.getResults["tb"] = toolboxGetResult{obj: &azure.ToolboxObject{
+		Name: "tb", DefaultVersion: "1",
+	}}
+	client.versionResults["tb/1"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "1", Description: "base",
+		Tools: []map[string]any{{"type": "mcp", "name": "a", "project_connection_id": "/c/a"}},
+	}}
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"},
+	}
+
+	// Step 1: attach "greeting". Only version "1" exists so this branches
+	// from it either way; the mock synthesizes the created version.
+	err := runSkillAddWith(t.Context(), client, "tb", "greeting", skillAddFlags{}, toolboxFlags{output: "json"})
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+	firstReq := client.createVersionCalls[0].req
+	require.Len(t, firstReq.Skills, 1)
+	assert.Equal(t, "greeting", firstReq.Skills[0]["name"])
+
+	// Simulate what the real service does after step 1: the new version "2"
+	// now exists with the content just sent, the default is still "1" (no
+	// auto-promotion — see toolbox_publish.go), and versions-list reports both.
+	client.versionResults["tb/2"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "2", Description: firstReq.Description,
+		Tools: firstReq.Tools, Skills: firstReq.Skills,
+	}}
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"},
+		{Name: "tb", Version: "2"},
+	}
+
+	// Step 2: attach "code-review" with no --from-version. Pre-fix, this
+	// would branch from the still-default version "1" and silently drop
+	// "greeting" (the exact #9034 repro). Post-fix, it must branch from the
+	// latest version "2" and carry "greeting" forward.
+	err = runSkillAddWith(t.Context(), client, "tb", "code-review", skillAddFlags{}, toolboxFlags{output: "json"})
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 2)
+	secondReq := client.createVersionCalls[1].req
+	names := make([]string, 0, len(secondReq.Skills))
+	for _, s := range secondReq.Skills {
+		names = append(names, s["name"].(string))
+	}
+	assert.ElementsMatch(t, []string{"greeting", "code-review"}, names,
+		"second add must carry the first add's skill forward (branch from latest, not default)")
+}
+
+// --from-version default opts back into the pre-#9034-fix behavior: branch
+// from the toolbox's current default rather than the latest version.
+func TestRunSkillAddWith_FromVersionDefaultOptsOutOfLatest(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+	client.getResults["tb"] = toolboxGetResult{obj: &azure.ToolboxObject{
+		Name: "tb", DefaultVersion: "1",
+	}}
+	client.versionResults["tb/1"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "1",
+		Skills: []map[string]any{{"type": "skill_reference", "name": "in-default"}},
+	}}
+	client.versionResults["tb/2"] = toolboxVersionResult{obj: &azure.ToolboxVersionObject{
+		Name: "tb", Version: "2",
+		Skills: []map[string]any{{"type": "skill_reference", "name": "in-latest"}},
+	}}
+	client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+		{Name: "tb", Version: "1"},
+		{Name: "tb", Version: "2"},
+	}
+
+	err := runSkillAddWith(
+		t.Context(), client, "tb", "new-skill",
+		skillAddFlags{fromVersion: "default"}, toolboxFlags{output: "json"},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+	names := make([]string, 0, 2)
+	for _, s := range client.createVersionCalls[0].req.Skills {
+		names = append(names, s["name"].(string))
+	}
+	assert.ElementsMatch(t, []string{"in-default", "new-skill"}, names,
+		"--from-version default must branch from the default version, not the latest")
 }
 
 // Batch attachment via --from-file.

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_version_resolve.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_version_resolve.go
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"azure.ai.toolboxes/internal/exterrors"
+	"azure.ai.toolboxes/internal/pkg/azure"
+
+	"github.com/spf13/cobra"
+)
+
+// fromVersionFlagHelp is the shared --from-version help text for the
+// skill/connection add and remove verbs.
+const fromVersionFlagHelp = `Version to branch the new version from. Defaults to the numerically ` +
+	`latest existing version (same as passing "latest") so sequential add/remove ` +
+	`calls chain onto each other instead of silently forking from a stale default. ` +
+	`Pass "default" to branch from the toolbox's current default version instead, ` +
+	`or an explicit version number to fork from a specific point in history.`
+
+// registerFromVersionFlag attaches the --from-version flag shared by the
+// skill/connection add and remove verbs.
+func registerFromVersionFlag(cmd *cobra.Command, dest *string) {
+	cmd.Flags().StringVar(dest, "from-version", "", fromVersionFlagHelp)
+}
+
+// resolveBaseVersion determines which existing toolbox version a skill or
+// connection mutation should branch its new version from.
+//
+// fromVersion is normally sourced from the verb's --from-version flag:
+//   - "" or "latest": the numerically highest existing version. This is the
+//     default so sequential add/remove calls chain onto each other instead of
+//     silently forking from a stale default version (see azure-dev#9034).
+//   - "default": the toolbox's current default version — the pre-fix
+//     behavior, kept reachable for callers that deliberately want to fork
+//     from what's currently published rather than the newest version.
+//   - anything else: used verbatim as the version to fetch. An invalid value
+//     surfaces as a "version not found" error from the caller's subsequent
+//     GetToolboxVersion call.
+func resolveBaseVersion(
+	ctx context.Context, client toolboxClient, toolboxName string,
+	tb *azure.ToolboxObject, fromVersion string,
+) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(fromVersion)) {
+	case "", "latest":
+		return latestToolboxVersion(ctx, client, toolboxName, tb.DefaultVersion)
+	case "default":
+		return tb.DefaultVersion, nil
+	default:
+		return strings.TrimSpace(fromVersion), nil
+	}
+}
+
+// latestToolboxVersion returns the numerically highest version among
+// toolboxName's published versions. Falls back to `fallback` (normally the
+// toolbox's default version) when the listing comes back empty, which should
+// not happen for a toolbox that exists but keeps this defensive.
+func latestToolboxVersion(
+	ctx context.Context, client toolboxClient, toolboxName, fallback string,
+) (string, error) {
+	versions, err := client.ListToolboxVersions(ctx, toolboxName)
+	if err != nil {
+		return "", exterrors.ServiceFromAzure(err, exterrors.OpListToolboxVersions)
+	}
+	if len(versions) == 0 {
+		return fallback, nil
+	}
+	// Same ordering as `toolbox versions list`: numeric descending, lexical
+	// descending fallback. versions[0] after sorting is the latest.
+	slices.SortFunc(versions, func(a, b azure.ToolboxVersionObject) int {
+		return versionSortDescending(a.Version, b.Version)
+	})
+	return versions[0].Version, nil
+}

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_version_resolve_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_version_resolve_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"azure.ai.toolboxes/internal/pkg/azure"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionSortDescending(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+		want int // sign only: <0, 0, >0
+	}{
+		{"numeric a greater", "3", "1", -1},
+		{"numeric b greater", "1", "3", 1},
+		{"numeric equal", "2", "2", 0},
+		{"double digit beats single digit", "10", "9", -1},
+		{"lexical fallback a greater", "v2", "v1", -1},
+		{"lexical fallback b greater", "v1", "v2", 1},
+		{"mixed numeric/non-numeric falls back to lexical", "1", "abc", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := versionSortDescending(tc.a, tc.b)
+			switch {
+			case tc.want < 0:
+				assert.Negative(t, got)
+			case tc.want > 0:
+				assert.Positive(t, got)
+			default:
+				assert.Zero(t, got)
+			}
+		})
+	}
+}
+
+func TestLatestToolboxVersion(t *testing.T) {
+	t.Run("empty_list_falls_back", func(t *testing.T) {
+		client := newMockToolboxClient("https://e/")
+		got, err := latestToolboxVersion(t.Context(), client, "tb", "7")
+		require.NoError(t, err)
+		assert.Equal(t, "7", got, "no versions returned: fall back to the caller-supplied default")
+	})
+
+	t.Run("returns_numeric_max_regardless_of_input_order", func(t *testing.T) {
+		client := newMockToolboxClient("https://e/")
+		client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+			{Name: "tb", Version: "1"},
+			{Name: "tb", Version: "10"},
+			{Name: "tb", Version: "2"},
+		}
+		got, err := latestToolboxVersion(t.Context(), client, "tb", "1")
+		require.NoError(t, err)
+		assert.Equal(t, "10", got)
+	})
+
+	t.Run("propagates_list_error", func(t *testing.T) {
+		client := newMockToolboxClient("https://e/")
+		client.listVersionsErr = errors.New("boom")
+		_, err := latestToolboxVersion(t.Context(), client, "tb", "1")
+		require.Error(t, err)
+	})
+}
+
+func TestResolveBaseVersion(t *testing.T) {
+	tb := &azure.ToolboxObject{Name: "tb", DefaultVersion: "1"}
+
+	newClientWithLatest := func(latest string) *mockToolboxClient {
+		client := newMockToolboxClient("https://e/")
+		client.listVersionsResults["tb"] = []azure.ToolboxVersionObject{
+			{Name: "tb", Version: "1"},
+			{Name: "tb", Version: latest},
+		}
+		return client
+	}
+
+	cases := []struct {
+		name        string
+		fromVersion string
+		want        string
+	}{
+		{"empty_defaults_to_latest", "", "3"},
+		{"latest_keyword", "latest", "3"},
+		{"latest_keyword_case_and_whitespace_insensitive", "  LATEST  ", "3"},
+		{"default_keyword_uses_toolbox_default", "default", "1"},
+		{"default_keyword_case_insensitive", "DEFAULT", "1"},
+		{"explicit_version_passed_verbatim", "2", "2"},
+		{"explicit_version_with_whitespace_trimmed", "  2  ", "2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newClientWithLatest("3")
+			got, err := resolveBaseVersion(t.Context(), client, "tb", tb, tc.fromVersion)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/pkg/azure/foundry_toolsets_client_regression_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/pkg/azure/foundry_toolsets_client_regression_test.go
@@ -1,0 +1,336 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package azure
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- roundtrip test harness ----
+//
+// Mirrors the pattern used by azure.ai.agents' copy of this client
+// (internal/pkg/azure/foundry_toolsets_client_test.go): a custom
+// http.RoundTripper intercepts requests before any real network I/O, so the
+// real production pipeline (URL construction, JSON marshaling/unmarshaling,
+// status-code handling, pagination) runs exactly as it would against the
+// live service, without touching the network.
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newTestPipeline(fn roundTripFunc) runtime.Pipeline {
+	return runtime.NewPipeline(
+		"test",
+		"v0.0.0",
+		runtime.PipelineOptions{},
+		&policy.ClientOptions{
+			Transport: &http.Client{Transport: fn},
+		},
+	)
+}
+
+// newTestToolboxClient creates a FoundryToolboxClient backed by a custom HTTP
+// round-tripper so we can exercise the real client end-to-end (real JSON
+// wire format, real URL building) without touching the network.
+func newTestToolboxClient(endpoint string, fn roundTripFunc) *FoundryToolboxClient {
+	return &FoundryToolboxClient{
+		endpoint: endpoint,
+		pipeline: newTestPipeline(fn),
+	}
+}
+
+func jsonResponse(status int, v any) *http.Response {
+	body, _ := json.Marshal(v)
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
+
+func notFoundResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"code":"NotFound"}}`)),
+		Header:     make(http.Header),
+	}
+}
+
+// ---- fake Foundry Toolboxes v1 service ----
+//
+// A small, stateful, in-memory stand-in for the real data-plane API. It is
+// faithful to the semantics that matter for azure-dev#9034: versions are
+// immutable and numbered sequentially, and creating a new version NEVER
+// advances default_version (only a PATCH to the toolbox does that — see
+// toolbox_publish.go / SetDefaultVersion). This lets a test prove, over the
+// real HTTP/JSON wire format, that "read latest -> merge -> create" behaves
+// the way the fixed command layer (resolveBaseVersion) expects.
+type fakeToolboxService struct {
+	mu             sync.Mutex
+	name           string
+	defaultVersion string
+	nextVersion    int
+	versions       map[string]ToolboxVersionObject
+}
+
+func newFakeToolboxService(name string, initial ToolboxVersionObject) *fakeToolboxService {
+	initial.Name = name
+	initial.Version = "1"
+	return &fakeToolboxService{
+		name:           name,
+		defaultVersion: "1",
+		nextVersion:    1,
+		versions:       map[string]ToolboxVersionObject{"1": initial},
+	}
+}
+
+func (f *fakeToolboxService) handle(req *http.Request) (*http.Response, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// The real endpoint has its own path prefix (e.g.
+	// "/api/projects/agent-with-toolbox-dev"), so find the "toolboxes"
+	// segment rather than assuming it's the first path element.
+	all := strings.Split(strings.Trim(req.URL.Path, "/"), "/")
+	idx := -1
+	for i, seg := range all {
+		if seg == "toolboxes" {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return notFoundResponse(), nil
+	}
+	parts := all[idx:]
+	// parts[0] == "toolboxes", parts[1] == name, optionally
+	// parts[2] == "versions", optionally parts[3] == version.
+
+	switch {
+	case req.Method == http.MethodGet && len(parts) == 2:
+		// GET /toolboxes/{name}
+		return jsonResponse(http.StatusOK, ToolboxObject{
+			ID: f.name, Name: f.name, DefaultVersion: f.defaultVersion,
+		}), nil
+
+	case req.Method == http.MethodGet && len(parts) == 3 && parts[2] == "versions":
+		// GET /toolboxes/{name}/versions (list, single page)
+		list := make([]ToolboxVersionObject, 0, len(f.versions))
+		for _, v := range f.versions {
+			list = append(list, v)
+		}
+		sort.Slice(list, func(i, j int) bool {
+			vi, _ := strconv.Atoi(list[i].Version)
+			vj, _ := strconv.Atoi(list[j].Version)
+			return vi < vj
+		})
+		return jsonResponse(http.StatusOK, struct {
+			Data    []ToolboxVersionObject `json:"data"`
+			HasMore bool                   `json:"has_more,omitempty"`
+		}{Data: list}), nil
+
+	case req.Method == http.MethodGet && len(parts) == 4 && parts[2] == "versions":
+		// GET /toolboxes/{name}/versions/{version}
+		v, ok := f.versions[parts[3]]
+		if !ok {
+			return notFoundResponse(), nil
+		}
+		return jsonResponse(http.StatusOK, v), nil
+
+	case req.Method == http.MethodPost && len(parts) == 3 && parts[2] == "versions":
+		// POST /toolboxes/{name}/versions (create a new immutable version)
+		raw, _ := io.ReadAll(req.Body)
+		var body CreateToolboxVersionRequest
+		_ = json.Unmarshal(raw, &body)
+
+		f.nextVersion++
+		newVersion := strconv.Itoa(f.nextVersion)
+		created := ToolboxVersionObject{
+			ID: f.name, Name: f.name, Version: newVersion,
+			Description: body.Description, Metadata: body.Metadata,
+			Tools: body.Tools, Skills: body.Skills, Policies: body.Policies,
+		}
+		f.versions[newVersion] = created
+		// default_version is deliberately NOT advanced here — matches the
+		// real service post-PR#8396 (mutation verbs no longer auto-promote).
+		return jsonResponse(http.StatusCreated, created), nil
+
+	case req.Method == http.MethodPatch && len(parts) == 2:
+		// PATCH /toolboxes/{name} (azd ai toolbox publish)
+		raw, _ := io.ReadAll(req.Body)
+		var body struct {
+			DefaultVersion string `json:"default_version"`
+		}
+		_ = json.Unmarshal(raw, &body)
+		f.defaultVersion = body.DefaultVersion
+		return jsonResponse(http.StatusOK, ToolboxObject{
+			ID: f.name, Name: f.name, DefaultVersion: f.defaultVersion,
+		}), nil
+	}
+
+	return notFoundResponse(), nil
+}
+
+// TestFoundryToolboxClient_Live_SkillAddChainsFromLatest_Regression9034 is an
+// HTTP-wire-level regression test for azure-dev#9034, using the exact repro
+// from the issue (toolbox/skill names included). It drives the REAL
+// production FoundryToolboxClient — real JSON marshaling/unmarshaling, real
+// URL construction, real status-code handling — against a stateful fake
+// service, replicating exactly what the fixed command layer
+// (resolveBaseVersion + runSkillAddWith) does: read the toolbox, list
+// versions, pick the numerically latest, fetch it, merge in the new skill,
+// and create a new version.
+//
+// This closes a real coverage gap: internal/cmd's own tests exercise this
+// logic exclusively through the toolboxClient mock interface, which never
+// touches JSON serialization or HTTP semantics at all. This test proves the
+// real client correctly round-trips that data end-to-end.
+func TestFoundryToolboxClient_Live_SkillAddChainsFromLatest_Regression9034(t *testing.T) {
+	const toolboxName = "web-search-toolbox"
+
+	svc := newFakeToolboxService(toolboxName, ToolboxVersionObject{
+		Description: "web search toolbox",
+		Tools:       []map[string]any{{"type": "web_search", "name": "web_search"}},
+		Skills:      []map[string]any{},
+	})
+	client := newTestToolboxClient(
+		"https://example.services.ai.azure.com/api/projects/agent-with-toolbox-dev",
+		roundTripFunc(svc.handle),
+	)
+	ctx := context.Background()
+
+	// pickLatest mirrors internal/cmd's latestToolboxVersion: numerically
+	// highest version wins.
+	pickLatest := func(versions []ToolboxVersionObject) string {
+		latest := versions[0].Version
+		latestNum, _ := strconv.Atoi(latest)
+		for _, v := range versions[1:] {
+			n, _ := strconv.Atoi(v.Version)
+			if n > latestNum {
+				latest, latestNum = v.Version, n
+			}
+		}
+		return latest
+	}
+
+	// addSkill replicates runSkillAddWith's post-fix logic: branch from the
+	// latest version (not the toolbox's default_version), merge in the new
+	// skill, and create a new immutable version.
+	addSkill := func(skillName string) (newVersion, baseVersion string) {
+		versions, err := client.ListToolboxVersions(ctx, toolboxName)
+		require.NoError(t, err)
+		base := pickLatest(versions)
+
+		current, err := client.GetToolboxVersion(ctx, toolboxName, base)
+		require.NoError(t, err)
+
+		newSkills := append(append([]map[string]any{}, current.Skills...), map[string]any{
+			"type": "skill_reference", "name": skillName,
+		})
+		created, err := client.CreateToolboxVersion(ctx, toolboxName, &CreateToolboxVersionRequest{
+			Description: current.Description,
+			Metadata:    current.Metadata,
+			Tools:       current.Tools,
+			Skills:      newSkills,
+		})
+		require.NoError(t, err)
+		return created.Version, base
+	}
+
+	// Step 1 (issue repro): skill add web-search-toolbox greeting-test-2606
+	v2, base1 := addSkill("greeting-test-2606")
+	require.Equal(t, "2", v2, "first add creates version 2")
+	require.Equal(t, "1", base1, "first add has only version 1 to branch from")
+
+	// Step 2 (issue repro): skill add web-search-toolbox code-review-test-2606
+	v3, base2 := addSkill("code-review-test-2606")
+	require.Equal(t, "3", v3, "second add creates version 3")
+	require.Equal(t, "2", base2,
+		"regression azure-dev#9034: second add must branch from latest (v2), not the stale default (v1)")
+
+	// Step 3 (issue repro): toolbox show web-search-toolbox --version 3
+	shown, err := client.GetToolboxVersion(ctx, toolboxName, "3")
+	require.NoError(t, err)
+	names := make([]string, 0, len(shown.Skills))
+	for _, s := range shown.Skills {
+		names = append(names, s["name"].(string))
+	}
+	require.ElementsMatch(t, []string{"greeting-test-2606", "code-review-test-2606"}, names,
+		"v3 must carry forward BOTH skills — this is the exact assertion the "+
+			"GitHub issue reports failing")
+
+	// The toolbox's default version must remain untouched (publish is a
+	// separate, deliberate user gesture — no auto-promotion).
+	tb, err := client.GetToolbox(ctx, toolboxName)
+	require.NoError(t, err)
+	require.Equal(t, "1", tb.DefaultVersion, "default version must remain unchanged")
+}
+
+// TestFoundryToolboxClient_Live_PreFixBehavior_WouldDropSkill_Regression9034
+// demonstrates, over the same real wire-level client, that branching from
+// the toolbox's *default* version (the pre-fix behavior) reproduces the
+// issue exactly: the second add's result is missing the first add's skill.
+// This is a characterization test of the OLD behavior, kept side-by-side
+// with the fixed-behavior test above as documentation of what the fix
+// actually changed.
+func TestFoundryToolboxClient_Live_PreFixBehavior_WouldDropSkill_Regression9034(t *testing.T) {
+	const toolboxName = "web-search-toolbox"
+
+	svc := newFakeToolboxService(toolboxName, ToolboxVersionObject{
+		Tools:  []map[string]any{{"type": "web_search", "name": "web_search"}},
+		Skills: []map[string]any{},
+	})
+	client := newTestToolboxClient(
+		"https://example.services.ai.azure.com/api/projects/agent-with-toolbox-dev",
+		roundTripFunc(svc.handle),
+	)
+	ctx := context.Background()
+
+	// addSkillFromDefault replicates the PRE-FIX behavior: always branch
+	// from tb.DefaultVersion, regardless of what the latest version is.
+	addSkillFromDefault := func(skillName string) string {
+		tb, err := client.GetToolbox(ctx, toolboxName)
+		require.NoError(t, err)
+
+		current, err := client.GetToolboxVersion(ctx, toolboxName, tb.DefaultVersion)
+		require.NoError(t, err)
+
+		newSkills := append(append([]map[string]any{}, current.Skills...), map[string]any{
+			"type": "skill_reference", "name": skillName,
+		})
+		created, err := client.CreateToolboxVersion(ctx, toolboxName, &CreateToolboxVersionRequest{
+			Tools: current.Tools, Skills: newSkills,
+		})
+		require.NoError(t, err)
+		return created.Version
+	}
+
+	v2 := addSkillFromDefault("greeting-test-2606")
+	require.Equal(t, "2", v2)
+	v3 := addSkillFromDefault("code-review-test-2606")
+	require.Equal(t, "3", v3)
+
+	shown, err := client.GetToolboxVersion(ctx, toolboxName, "3")
+	require.NoError(t, err)
+	require.Len(t, shown.Skills, 1,
+		"pre-fix behavior: v3 only has code-review-test-2606 — greeting-test-2606 "+
+			"was silently dropped because both adds branched from the stale default (v1)")
+	require.Equal(t, "code-review-test-2606", shown.Skills[0]["name"])
+}


### PR DESCRIPTION
## Summary

Fixes #9034. `azd ai toolbox skill add/remove` and `connection add/remove` branched the new version from the toolbox's default version instead of its latest version, so two sequential mutations without an intervening `publish` silently dropped one of the changes into a sibling version.

## Changes

- **`toolbox_version_resolve.go`**: new `resolveBaseVersion`/`latestToolboxVersion` helpers; `""`/`"latest"` resolves to the numerically highest version, `"default"` opts back into the old behavior.
- **`toolbox_skill_add.go`, `toolbox_skill_remove.go`, `toolbox_connection_add.go`, `toolbox_connection_remove.go`**: all four verbs resolve a base version via the new `--from-version` flag instead of reading `tb.DefaultVersion` directly; error/output messages and help text now name the base version explicitly.
- **`toolbox_shared.go`**: added `toolboxVersionNotFoundOrService` for a friendly error when `--from-version` points at a nonexistent version.
- **`CHANGELOG.md`**: bugfix entry under `## Unreleased`.

## Out of Scope

The issue's alternative fix (hard-error when `default != latest`) and the public docs callout aren't addressed here — only the preferred "branch from latest" behavior change.
