### PR TITLE
fix(routines): extend routines HTTP timeout configuration

### DIFF
--- a/cli/azd/docs/environment-variables.md
+++ b/cli/azd/docs/environment-variables.md
@@ -162,6 +162,12 @@ specific version of the tool installed on the machine.
 | `ENABLE_CONTAINER_AGENTS` | If set, indicates that container agents are enabled for the current azd environment. |
 | `AGENT_DEFINITION_PATH` | Path to an agent definition file for AI agent workflows. |
 
+### azure.ai.routines
+
+| Variable | Description |
+| --- | --- |
+| `AZURE_AI_ROUTINES_HTTP_TIMEOUT` | Overrides the `azure.ai.routines` HTTP request timeout when no `--timeout` flag is provided. Parsed with Go's `time.ParseDuration` format (for example, `90s`, `2m`, or `1m30s`) and must be a positive duration. |
+
 ## UI Prompt Integration
 
 | Variable | Description |

--- a/cli/azd/extensions/azure.ai.routines/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.routines/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 
-- [[#8419]](https://github.com/Azure/azure-dev/issues/8419) Increase the default routines HTTP timeout and add `--timeout` / `AZURE_AI_ROUTINES_HTTP_TIMEOUT` overrides so cold recurring routine creates are not cancelled before AgentIdentity binding completes.
+- [[#8419]](https://github.com/Azure/azure-dev/issues/8419) Increase the default routines write timeout and add `--timeout` / `AZURE_AI_ROUTINES_HTTP_TIMEOUT` overrides so cold recurring routine creates are not cancelled before AgentIdentity binding completes.
 - [[#8986]](https://github.com/Azure/azure-dev/pull/8986) Fix `azd ai routine` commands failing to decode routine responses when the service returns numeric (Unix epoch) timestamp values for fields such as schedule `created_at` and timer `triggers.<name>.at`.
 
 ## 1.0.0-beta.1 (2026-06-30)

--- a/cli/azd/extensions/azure.ai.routines/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.routines/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs Fixed
 
+- [[#8419]](https://github.com/Azure/azure-dev/issues/8419) Increase the default routines HTTP timeout and add `--timeout` / `AZURE_AI_ROUTINES_HTTP_TIMEOUT` overrides so cold recurring routine creates are not cancelled before AgentIdentity binding completes.
 - [[#8986]](https://github.com/Azure/azure-dev/pull/8986) Fix `azd ai routine` commands failing to decode routine responses when the service returns numeric (Unix epoch) timestamp values for fields such as schedule `created_at` and timer `triggers.<name>.at`.
 
 ## 1.0.0-beta.1 (2026-06-30)

--- a/cli/azd/extensions/azure.ai.routines/README.md
+++ b/cli/azd/extensions/azure.ai.routines/README.md
@@ -1,3 +1,16 @@
 # Foundry Routines
 
 Manage Microsoft Foundry Routines from your terminal. (Preview)
+
+## Timeout configuration
+
+Routine API calls default to a two-minute HTTP request timeout. Override
+it with the root `--timeout` flag, using Go duration syntax:
+
+```bash
+azd ai routine --timeout 3m create my-routine ...
+```
+
+Set `AZURE_AI_ROUTINES_HTTP_TIMEOUT` to apply the same override when the
+extension runs without command flags, such as during `azd deploy` service
+target upserts. The `--timeout` flag wins when both are provided.

--- a/cli/azd/extensions/azure.ai.routines/README.md
+++ b/cli/azd/extensions/azure.ai.routines/README.md
@@ -4,13 +4,16 @@ Manage Microsoft Foundry Routines from your terminal. (Preview)
 
 ## Timeout configuration
 
-Routine API calls default to a two-minute HTTP request timeout. Override
-it with the root `--timeout` flag, using Go duration syntax:
+Routine read API calls default to a 30-second HTTP request timeout.
+Routine write API calls default to a two-minute timeout to allow cold
+recurring routine creates to finish AgentIdentity binding. Override both
+defaults with the root `--timeout` flag, using Go duration syntax:
 
 ```bash
 azd ai routine --timeout 3m create my-routine ...
 ```
 
-Set `AZURE_AI_ROUTINES_HTTP_TIMEOUT` to apply the same override when the
-extension runs without command flags, such as during `azd deploy` service
-target upserts. The `--timeout` flag wins when both are provided.
+Set `AZURE_AI_ROUTINES_HTTP_TIMEOUT` to apply the same override when
+the extension runs without command flags, such as during `azd deploy`
+service target upserts. The `--timeout` flag wins when both are
+provided.

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/root.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/root.go
@@ -4,6 +4,10 @@
 package cmd
 
 import (
+	"fmt"
+
+	"azure.ai.routines/internal/pkg/routines"
+
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/spf13/cobra"
 )
@@ -23,9 +27,12 @@ func NewRootCommand() *cobra.Command {
 
 	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
 
-	// -p / --project-endpoint is a persistent flag so all subcommands inherit it.
+	// -p / --project-endpoint is inherited by all subcommands.
 	rootCmd.PersistentFlags().StringP("project-endpoint", "p", "",
 		"Foundry project endpoint URL (overrides env var and config)")
+	rootCmd.PersistentFlags().String(routineHTTPTimeoutFlag, "",
+		fmt.Sprintf("HTTP request timeout (for example, 2m or 90s). Defaults to %s.",
+			routines.DefaultRequestTimeout))
 
 	rootCmd.AddCommand(azdext.NewListenCommand(configureExtensionHost))
 	rootCmd.AddCommand(newContextCommand())

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/root.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/root.go
@@ -31,8 +31,9 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.PersistentFlags().StringP("project-endpoint", "p", "",
 		"Foundry project endpoint URL (overrides env var and config)")
 	rootCmd.PersistentFlags().String(routineHTTPTimeoutFlag, "",
-		fmt.Sprintf("HTTP request timeout (for example, 2m or 90s). Defaults to %s.",
-			routines.DefaultRequestTimeout))
+		fmt.Sprintf("HTTP request timeout override (for example, 2m or 90s). "+
+			"Defaults to %s for reads and %s for writes.",
+			routines.DefaultReadRequestTimeout, routines.DefaultWriteRequestTimeout))
 
 	rootCmd.AddCommand(azdext.NewListenCommand(configureExtensionHost))
 	rootCmd.AddCommand(newContextCommand())

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_helpers.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_helpers.go
@@ -27,7 +27,7 @@ const (
 
 // newRoutineClient resolves an authenticated routine client.
 func newRoutineClient(ctx context.Context, cmd *cobra.Command) (*routines.Client, string, error) {
-	requestTimeout, err := routineHTTPTimeoutFromCommand(cmd)
+	requestTimeout, err := routineHTTPTimeoutOverrideFromCommand(cmd)
 	if err != nil {
 		return nil, "", err
 	}
@@ -53,11 +53,18 @@ func newRoutineClient(ctx context.Context, cmd *cobra.Command) (*routines.Client
 	return routines.NewClient(
 		resolved.Endpoint,
 		cred,
-		&routines.ClientOptions{RequestTimeout: requestTimeout},
+		routineClientOptions(requestTimeout),
 	), resolved.Endpoint, nil
 }
 
-func routineHTTPTimeoutFromCommand(cmd *cobra.Command) (time.Duration, error) {
+func routineClientOptions(timeoutOverride time.Duration) *routines.ClientOptions {
+	if timeoutOverride <= 0 {
+		return nil
+	}
+	return &routines.ClientOptions{RequestTimeout: timeoutOverride}
+}
+
+func routineHTTPTimeoutOverrideFromCommand(cmd *cobra.Command) (time.Duration, error) {
 	if cmd != nil {
 		if flag := cmd.Flag(routineHTTPTimeoutFlag); flag != nil && flag.Changed {
 			return parseRoutineHTTPTimeout(
@@ -66,13 +73,13 @@ func routineHTTPTimeoutFromCommand(cmd *cobra.Command) (time.Duration, error) {
 			)
 		}
 	}
-	return routineHTTPTimeoutFromEnv()
+	return routineHTTPTimeoutOverrideFromEnv()
 }
 
-func routineHTTPTimeoutFromEnv() (time.Duration, error) {
+func routineHTTPTimeoutOverrideFromEnv() (time.Duration, error) {
 	raw, ok := os.LookupEnv(routineHTTPTimeoutEnvVar)
 	if !ok {
-		return routines.DefaultRequestTimeout, nil
+		return 0, nil
 	}
 	return parseRoutineHTTPTimeout(raw, routineHTTPTimeoutEnvVar)
 }

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_helpers.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_helpers.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 	"text/tabwriter"
+	"time"
 
 	"azure.ai.routines/internal/exterrors"
 	"azure.ai.routines/internal/pkg/routines"
@@ -18,8 +20,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// newRoutineClient resolves the project endpoint and creates an authenticated routine client.
+const (
+	routineHTTPTimeoutEnvVar = "AZURE_AI_ROUTINES_HTTP_TIMEOUT"
+	routineHTTPTimeoutFlag   = "timeout"
+)
+
+// newRoutineClient resolves an authenticated routine client.
 func newRoutineClient(ctx context.Context, cmd *cobra.Command) (*routines.Client, string, error) {
+	requestTimeout, err := routineHTTPTimeoutFromCommand(cmd)
+	if err != nil {
+		return nil, "", err
+	}
+
 	flagEndpoint, _ := cmd.Flags().GetString("project-endpoint")
 
 	resolved, err := resolveProjectEndpoint(ctx, flagEndpoint)
@@ -38,7 +50,44 @@ func newRoutineClient(ctx context.Context, cmd *cobra.Command) (*routines.Client
 		)
 	}
 
-	return routines.NewClient(resolved.Endpoint, cred), resolved.Endpoint, nil
+	return routines.NewClient(
+		resolved.Endpoint,
+		cred,
+		&routines.ClientOptions{RequestTimeout: requestTimeout},
+	), resolved.Endpoint, nil
+}
+
+func routineHTTPTimeoutFromCommand(cmd *cobra.Command) (time.Duration, error) {
+	if cmd != nil {
+		if flag := cmd.Flag(routineHTTPTimeoutFlag); flag != nil && flag.Changed {
+			return parseRoutineHTTPTimeout(
+				flag.Value.String(),
+				"--"+routineHTTPTimeoutFlag,
+			)
+		}
+	}
+	return routineHTTPTimeoutFromEnv()
+}
+
+func routineHTTPTimeoutFromEnv() (time.Duration, error) {
+	raw, ok := os.LookupEnv(routineHTTPTimeoutEnvVar)
+	if !ok {
+		return routines.DefaultRequestTimeout, nil
+	}
+	return parseRoutineHTTPTimeout(raw, routineHTTPTimeoutEnvVar)
+}
+
+func parseRoutineHTTPTimeout(raw, source string) (time.Duration, error) {
+	value := strings.TrimSpace(raw)
+	timeout, err := time.ParseDuration(value)
+	if value == "" || err != nil || timeout <= 0 {
+		return 0, exterrors.Validation(
+			exterrors.CodeInvalidParameter,
+			fmt.Sprintf("%s must be a positive duration: %q", source, raw),
+			"use a Go duration such as 2m, 90s, or 1m30s",
+		)
+	}
+	return timeout, nil
 }
 
 // printJSON marshals v to indented JSON and writes to stdout.

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_helpers_test.go
@@ -56,8 +56,8 @@ func TestRoutineHTTPTimeoutOverrideFromEnv_Invalid(t *testing.T) {
 	_, err := routineHTTPTimeoutOverrideFromEnv()
 	require.Error(t, err)
 
-	var localErr *azdext.LocalError
-	require.True(t, errors.As(err, &localErr))
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
 	assert.Equal(t, exterrors.CodeInvalidParameter, localErr.Code)
 	assert.Contains(t, localErr.Message, routineHTTPTimeoutEnvVar)
 }

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_helpers_test.go
@@ -4,10 +4,103 @@
 package cmd
 
 import (
+	"errors"
+	"os"
 	"testing"
+	"time"
 
+	"azure.ai.routines/internal/exterrors"
+	"azure.ai.routines/internal/pkg/routines"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+
+	old, found := os.LookupEnv(key)
+	require.NoError(t, os.Unsetenv(key))
+	t.Cleanup(func() {
+		if found {
+			require.NoError(t, os.Setenv(key, old))
+			return
+		}
+		require.NoError(t, os.Unsetenv(key))
+	})
+}
+
+// --- HTTP timeout config
+
+func TestRoutineHTTPTimeoutFromEnv_Default(t *testing.T) {
+	unsetEnv(t, routineHTTPTimeoutEnvVar)
+
+	got, err := routineHTTPTimeoutFromEnv()
+	require.NoError(t, err)
+	assert.Equal(t, routines.DefaultRequestTimeout, got)
+}
+
+func TestRoutineHTTPTimeoutFromEnv_Override(t *testing.T) {
+	t.Setenv(routineHTTPTimeoutEnvVar, "90s")
+
+	got, err := routineHTTPTimeoutFromEnv()
+	require.NoError(t, err)
+	assert.Equal(t, 90*time.Second, got)
+}
+
+func TestRoutineHTTPTimeoutFromEnv_Invalid(t *testing.T) {
+	t.Setenv(routineHTTPTimeoutEnvVar, "soon")
+
+	_, err := routineHTTPTimeoutFromEnv()
+	require.Error(t, err)
+
+	var localErr *azdext.LocalError
+	require.True(t, errors.As(err, &localErr))
+	assert.Equal(t, exterrors.CodeInvalidParameter, localErr.Code)
+	assert.Contains(t, localErr.Message, routineHTTPTimeoutEnvVar)
+}
+
+func TestRoutineHTTPTimeoutFromCommand_FlagWins(t *testing.T) {
+	t.Setenv(routineHTTPTimeoutEnvVar, "5m")
+	cmd := &cobra.Command{}
+	cmd.Flags().String(routineHTTPTimeoutFlag, "", "")
+	require.NoError(t, cmd.Flags().Set(routineHTTPTimeoutFlag, "90s"))
+
+	got, err := routineHTTPTimeoutFromCommand(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, 90*time.Second, got)
+}
+
+func TestRoutineHTTPTimeoutFromCommand_InheritedFlagWins(t *testing.T) {
+	t.Setenv(routineHTTPTimeoutEnvVar, "5m")
+	var got time.Duration
+
+	rootCmd := &cobra.Command{Use: "root"}
+	rootCmd.PersistentFlags().String(routineHTTPTimeoutFlag, "", "")
+	childCmd := &cobra.Command{
+		Use: "child",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			got, err = routineHTTPTimeoutFromCommand(cmd)
+			return err
+		},
+	}
+	rootCmd.AddCommand(childCmd)
+	rootCmd.SetArgs([]string{"--timeout", "90s", "child"})
+
+	require.NoError(t, rootCmd.Execute())
+	assert.Equal(t, 90*time.Second, got)
+}
+
+func TestRootCommandRegistersTimeoutFlag(t *testing.T) {
+	rootCmd := NewRootCommand()
+
+	flag := rootCmd.PersistentFlags().Lookup(routineHTTPTimeoutFlag)
+	require.NotNil(t, flag)
+	assert.Empty(t, flag.DefValue)
+}
 
 // ─── boolStr ─────────────────────────────────────────────────────────────────
 

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_helpers_test.go
@@ -34,26 +34,26 @@ func unsetEnv(t *testing.T, key string) {
 
 // --- HTTP timeout config
 
-func TestRoutineHTTPTimeoutFromEnv_Default(t *testing.T) {
+func TestRoutineHTTPTimeoutOverrideFromEnv_Default(t *testing.T) {
 	unsetEnv(t, routineHTTPTimeoutEnvVar)
 
-	got, err := routineHTTPTimeoutFromEnv()
+	got, err := routineHTTPTimeoutOverrideFromEnv()
 	require.NoError(t, err)
-	assert.Equal(t, routines.DefaultRequestTimeout, got)
+	assert.Zero(t, got)
 }
 
-func TestRoutineHTTPTimeoutFromEnv_Override(t *testing.T) {
+func TestRoutineHTTPTimeoutOverrideFromEnv_Override(t *testing.T) {
 	t.Setenv(routineHTTPTimeoutEnvVar, "90s")
 
-	got, err := routineHTTPTimeoutFromEnv()
+	got, err := routineHTTPTimeoutOverrideFromEnv()
 	require.NoError(t, err)
 	assert.Equal(t, 90*time.Second, got)
 }
 
-func TestRoutineHTTPTimeoutFromEnv_Invalid(t *testing.T) {
+func TestRoutineHTTPTimeoutOverrideFromEnv_Invalid(t *testing.T) {
 	t.Setenv(routineHTTPTimeoutEnvVar, "soon")
 
-	_, err := routineHTTPTimeoutFromEnv()
+	_, err := routineHTTPTimeoutOverrideFromEnv()
 	require.Error(t, err)
 
 	var localErr *azdext.LocalError
@@ -62,18 +62,18 @@ func TestRoutineHTTPTimeoutFromEnv_Invalid(t *testing.T) {
 	assert.Contains(t, localErr.Message, routineHTTPTimeoutEnvVar)
 }
 
-func TestRoutineHTTPTimeoutFromCommand_FlagWins(t *testing.T) {
+func TestRoutineHTTPTimeoutOverrideFromCommand_FlagWins(t *testing.T) {
 	t.Setenv(routineHTTPTimeoutEnvVar, "5m")
 	cmd := &cobra.Command{}
 	cmd.Flags().String(routineHTTPTimeoutFlag, "", "")
 	require.NoError(t, cmd.Flags().Set(routineHTTPTimeoutFlag, "90s"))
 
-	got, err := routineHTTPTimeoutFromCommand(cmd)
+	got, err := routineHTTPTimeoutOverrideFromCommand(cmd)
 	require.NoError(t, err)
 	assert.Equal(t, 90*time.Second, got)
 }
 
-func TestRoutineHTTPTimeoutFromCommand_InheritedFlagWins(t *testing.T) {
+func TestRoutineHTTPTimeoutOverrideFromCommand_InheritedFlagWins(t *testing.T) {
 	t.Setenv(routineHTTPTimeoutEnvVar, "5m")
 	var got time.Duration
 
@@ -83,7 +83,7 @@ func TestRoutineHTTPTimeoutFromCommand_InheritedFlagWins(t *testing.T) {
 		Use: "child",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			got, err = routineHTTPTimeoutFromCommand(cmd)
+			got, err = routineHTTPTimeoutOverrideFromCommand(cmd)
 			return err
 		},
 	}
@@ -92,6 +92,13 @@ func TestRoutineHTTPTimeoutFromCommand_InheritedFlagWins(t *testing.T) {
 
 	require.NoError(t, rootCmd.Execute())
 	assert.Equal(t, 90*time.Second, got)
+}
+
+func TestRoutineClientOptions_DefaultsToSeparateTimeouts(t *testing.T) {
+	assert.Nil(t, routineClientOptions(0))
+	assert.Equal(t, &routines.ClientOptions{
+		RequestTimeout: 90 * time.Second,
+	}, routineClientOptions(90*time.Second))
 }
 
 func TestRootCommandRegistersTimeoutFlag(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target.go
@@ -165,7 +165,7 @@ func parseRoutineServiceConfig(svc *azdext.ServiceConfig) (*routines.Routine, er
 // upserts. It mirrors newRoutineClient but takes no cobra command, since a
 // service target has no flags.
 func newRoutineServiceClient(ctx context.Context) (*routines.Client, error) {
-	requestTimeout, err := routineHTTPTimeoutFromEnv()
+	requestTimeout, err := routineHTTPTimeoutOverrideFromEnv()
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func newRoutineServiceClient(ctx context.Context) (*routines.Client, error) {
 	return routines.NewClient(
 		resolved.Endpoint,
 		cred,
-		&routines.ClientOptions{RequestTimeout: requestTimeout},
+		routineClientOptions(requestTimeout),
 	), nil
 }
 

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target.go
@@ -165,6 +165,11 @@ func parseRoutineServiceConfig(svc *azdext.ServiceConfig) (*routines.Routine, er
 // upserts. It mirrors newRoutineClient but takes no cobra command, since a
 // service target has no flags.
 func newRoutineServiceClient(ctx context.Context) (*routines.Client, error) {
+	requestTimeout, err := routineHTTPTimeoutFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
 	resolved, err := resolveProjectEndpoint(ctx, "")
 	if err != nil {
 		return nil, err
@@ -173,7 +178,11 @@ func newRoutineServiceClient(ctx context.Context) (*routines.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Azure credential: %w", err)
 	}
-	return routines.NewClient(resolved.Endpoint, cred), nil
+	return routines.NewClient(
+		resolved.Endpoint,
+		cred,
+		&routines.ClientOptions{RequestTimeout: requestTimeout},
+	), nil
 }
 
 // currentEnvValues loads all key-value pairs from the active azd environment, used to

--- a/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/client.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/client.go
@@ -28,19 +28,27 @@ const (
 	routinesPreviewValue  = "Routines=V1Preview"
 )
 
-// Client is the data-plane client for Foundry Routines API operations.
+// DefaultRequestTimeout is the default timeout for each HTTP try.
+const DefaultRequestTimeout = 2 * time.Minute
+
+// Client is a Foundry Routines data-plane client.
 type Client struct {
 	endpoint string
 	pipeline runtime.Pipeline
 }
 
-// newHTTPClient returns the *http.Client used by the data-plane pipeline.
+// ClientOptions configures a Routines data-plane client.
+type ClientOptions struct {
+	// RequestTimeout caps each HTTP request try.
+	RequestTimeout time.Duration
+}
+
+// newHTTPClient returns the data-plane pipeline's HTTP client.
 //
-// The default azcore transport relies on Go's HTTP/2 client, which can wait
-// minutes before surfacing a server-side stream reset (RST_STREAM). We set
-// explicit response-header and connection-level timeouts so failures surface
-// within tens of seconds.
-func newHTTPClient() *http.Client {
+// The default azcore transport relies on Go's HTTP/2 client, which
+// can wait minutes before surfacing a server-side stream reset
+// (RST_STREAM). Explicit timeouts keep failures bounded.
+func newHTTPClient(requestTimeout time.Duration) *http.Client {
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
@@ -52,21 +60,29 @@ func newHTTPClient() *http.Client {
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		ResponseHeaderTimeout: 60 * time.Second,
+		ResponseHeaderTimeout: requestTimeout,
 	}
 	return &http.Client{Transport: transport}
 }
 
+func resolveRequestTimeout(options *ClientOptions) time.Duration {
+	if options != nil && options.RequestTimeout > 0 {
+		return options.RequestTimeout
+	}
+	return DefaultRequestTimeout
+}
+
 // NewClient creates a new Routines data-plane client.
-func NewClient(endpoint string, cred azcore.TokenCredential) *Client {
+func NewClient(endpoint string, cred azcore.TokenCredential, options *ClientOptions) *Client {
+	requestTimeout := resolveRequestTimeout(options)
 	clientOptions := &policy.ClientOptions{
-		Transport: newHTTPClient(),
+		Transport: newHTTPClient(requestTimeout),
 		Logging: policy.LogOptions{
 			AllowedHeaders: []string{azsdk.MsCorrelationIdHeader},
 		},
 		Retry: policy.RetryOptions{
 			MaxRetries: 1,
-			TryTimeout: 30 * time.Second,
+			TryTimeout: requestTimeout,
 		},
 		PerCallPolicies: []policy.Policy{
 			runtime.NewBearerTokenPolicy(

--- a/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/client.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/client.go
@@ -28,13 +28,19 @@ const (
 	routinesPreviewValue  = "Routines=V1Preview"
 )
 
-// DefaultRequestTimeout is the default timeout for each HTTP try.
-const DefaultRequestTimeout = 2 * time.Minute
+const (
+	// DefaultReadRequestTimeout is the default timeout for read tries.
+	DefaultReadRequestTimeout = 30 * time.Second
+
+	// DefaultWriteRequestTimeout is the default timeout for write tries.
+	DefaultWriteRequestTimeout = 2 * time.Minute
+)
 
 // Client is a Foundry Routines data-plane client.
 type Client struct {
-	endpoint string
-	pipeline runtime.Pipeline
+	endpoint      string
+	readPipeline  runtime.Pipeline
+	writePipeline runtime.Pipeline
 }
 
 // ClientOptions configures a Routines data-plane client.
@@ -65,16 +71,24 @@ func newHTTPClient(requestTimeout time.Duration) *http.Client {
 	return &http.Client{Transport: transport}
 }
 
-func resolveRequestTimeout(options *ClientOptions) time.Duration {
+func resolveRequestTimeouts(options *ClientOptions) (time.Duration, time.Duration) {
 	if options != nil && options.RequestTimeout > 0 {
-		return options.RequestTimeout
+		return options.RequestTimeout, options.RequestTimeout
 	}
-	return DefaultRequestTimeout
+	return DefaultReadRequestTimeout, DefaultWriteRequestTimeout
 }
 
 // NewClient creates a new Routines data-plane client.
 func NewClient(endpoint string, cred azcore.TokenCredential, options *ClientOptions) *Client {
-	requestTimeout := resolveRequestTimeout(options)
+	readTimeout, writeTimeout := resolveRequestTimeouts(options)
+	return &Client{
+		endpoint:      strings.TrimRight(endpoint, "/"),
+		readPipeline:  newPipeline(cred, readTimeout),
+		writePipeline: newPipeline(cred, writeTimeout),
+	}
+}
+
+func newPipeline(cred azcore.TokenCredential, requestTimeout time.Duration) runtime.Pipeline {
 	clientOptions := &policy.ClientOptions{
 		Transport: newHTTPClient(requestTimeout),
 		Logging: policy.LogOptions{
@@ -95,14 +109,12 @@ func NewClient(endpoint string, cred azcore.TokenCredential, options *ClientOpti
 		},
 	}
 
-	pipeline := runtime.NewPipeline(
+	return runtime.NewPipeline(
 		"azure-ai-routines",
 		"v0.1.0",
 		runtime.PipelineOptions{},
 		clientOptions,
 	)
-
-	return &Client{endpoint: strings.TrimRight(endpoint, "/"), pipeline: pipeline}
 }
 
 // routineURL returns the URL for a named routine.
@@ -146,7 +158,7 @@ func (c *Client) GetRoutine(ctx context.Context, name string) (*Routine, error) 
 	}
 	addPreviewHeader(req)
 
-	resp, err := c.pipeline.Do(req)
+	resp, err := c.readPipeline.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}
@@ -192,7 +204,7 @@ func (c *Client) getPage(ctx context.Context, pageURL string, out any) error {
 	}
 	addPreviewHeader(req)
 
-	resp, err := c.pipeline.Do(req)
+	resp, err := c.readPipeline.Do(req)
 	if err != nil {
 		return fmt.Errorf("HTTP request failed: %w", err)
 	}
@@ -217,7 +229,7 @@ func (c *Client) PutRoutine(ctx context.Context, name string, body *Routine) (*R
 		return nil, err
 	}
 
-	resp, err := c.pipeline.Do(req)
+	resp, err := c.writePipeline.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}
@@ -242,7 +254,7 @@ func (c *Client) DeleteRoutine(ctx context.Context, name string) error {
 	}
 	addPreviewHeader(req)
 
-	resp, err := c.pipeline.Do(req)
+	resp, err := c.writePipeline.Do(req)
 	if err != nil {
 		return fmt.Errorf("HTTP request failed: %w", err)
 	}
@@ -274,7 +286,7 @@ func (c *Client) postRoutineAction(ctx context.Context, name, action string) (*R
 	}
 	addPreviewHeader(req)
 
-	resp, err := c.pipeline.Do(req)
+	resp, err := c.writePipeline.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}
@@ -309,7 +321,7 @@ func (c *Client) DispatchRoutineAsync(
 		}
 	}
 
-	resp, err := c.pipeline.Do(req)
+	resp, err := c.writePipeline.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}

--- a/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/client_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/client_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -17,6 +18,27 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// --- Client options
+
+func TestResolveRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, DefaultRequestTimeout, resolveRequestTimeout(nil))
+	assert.Equal(t, DefaultRequestTimeout, resolveRequestTimeout(&ClientOptions{}))
+	assert.Equal(t, 90*time.Second, resolveRequestTimeout(&ClientOptions{
+		RequestTimeout: 90 * time.Second,
+	}))
+}
+
+func TestNewHTTPClient_UsesRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	client := newHTTPClient(90 * time.Second)
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.Equal(t, 90*time.Second, transport.ResponseHeaderTimeout)
+}
 
 // newTestClient creates a Client with a pipeline that skips auth (no TLS
 // requirement) pointing at a local httptest server.

--- a/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/client_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/pkg/routines/client_test.go
@@ -21,14 +21,22 @@ import (
 
 // --- Client options
 
-func TestResolveRequestTimeout(t *testing.T) {
+func TestResolveRequestTimeouts(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, DefaultRequestTimeout, resolveRequestTimeout(nil))
-	assert.Equal(t, DefaultRequestTimeout, resolveRequestTimeout(&ClientOptions{}))
-	assert.Equal(t, 90*time.Second, resolveRequestTimeout(&ClientOptions{
+	readTimeout, writeTimeout := resolveRequestTimeouts(nil)
+	assert.Equal(t, DefaultReadRequestTimeout, readTimeout)
+	assert.Equal(t, DefaultWriteRequestTimeout, writeTimeout)
+
+	readTimeout, writeTimeout = resolveRequestTimeouts(&ClientOptions{})
+	assert.Equal(t, DefaultReadRequestTimeout, readTimeout)
+	assert.Equal(t, DefaultWriteRequestTimeout, writeTimeout)
+
+	readTimeout, writeTimeout = resolveRequestTimeouts(&ClientOptions{
 		RequestTimeout: 90 * time.Second,
-	}))
+	})
+	assert.Equal(t, 90*time.Second, readTimeout)
+	assert.Equal(t, 90*time.Second, writeTimeout)
 }
 
 func TestNewHTTPClient_UsesRequestTimeout(t *testing.T) {
@@ -40,6 +48,26 @@ func TestNewHTTPClient_UsesRequestTimeout(t *testing.T) {
 	assert.Equal(t, 90*time.Second, transport.ResponseHeaderTimeout)
 }
 
+type testPipelineHeaderPolicy string
+
+func (p testPipelineHeaderPolicy) Do(req *policy.Request) (*http.Response, error) {
+	req.Raw().Header.Set("X-Test-Pipeline", string(p))
+	return req.Next()
+}
+
+func newTestPipeline(name string) azruntime.Pipeline {
+	return azruntime.NewPipeline(
+		"test",
+		"v0",
+		azruntime.PipelineOptions{},
+		&policy.ClientOptions{
+			PerCallPolicies: []policy.Policy{
+				testPipelineHeaderPolicy(name),
+			},
+		},
+	)
+}
+
 // newTestClient creates a Client with a pipeline that skips auth (no TLS
 // requirement) pointing at a local httptest server.
 func newTestClient(t *testing.T, handler http.Handler) (*Client, *httptest.Server) {
@@ -48,10 +76,10 @@ func newTestClient(t *testing.T, handler http.Handler) (*Client, *httptest.Serve
 	t.Cleanup(srv.Close)
 
 	// Build a pipeline without bearer-token policy so plain HTTP works.
-	pipeline := azruntime.NewPipeline("test", "v0", azruntime.PipelineOptions{}, &policy.ClientOptions{})
 	client := &Client{
-		endpoint: srv.URL + "/api/projects/test-project",
-		pipeline: pipeline,
+		endpoint:      srv.URL + "/api/projects/test-project",
+		readPipeline:  newTestPipeline("read"),
+		writePipeline: newTestPipeline("write"),
 	}
 	return client, srv
 }
@@ -66,6 +94,7 @@ func TestGetRoutine_Success(t *testing.T) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Contains(t, r.URL.Path, "/routines/my-routine")
 		assert.Equal(t, routinesPreviewValue, r.Header.Get(routinesPreviewHeader))
+		assert.Equal(t, "read", r.Header.Get("X-Test-Pipeline"))
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(routine)
@@ -182,6 +211,7 @@ func TestPutRoutine_Created(t *testing.T) {
 	client, _ := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "write", r.Header.Get("X-Test-Pipeline"))
 
 		var body Routine
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -478,8 +508,7 @@ func TestListRoutineRuns_Pagination(t *testing.T) {
 
 func TestRoutineURL_EscapesName(t *testing.T) {
 	t.Parallel()
-	pipeline := azruntime.NewPipeline("test", "v0", azruntime.PipelineOptions{}, &policy.ClientOptions{})
-	c := &Client{endpoint: "https://example.com/api/projects/p", pipeline: pipeline}
+	c := &Client{endpoint: "https://example.com/api/projects/p"}
 
 	url := c.routineURL("has space")
 	assert.Contains(t, url, "/routines/has%20space")
@@ -488,8 +517,7 @@ func TestRoutineURL_EscapesName(t *testing.T) {
 
 func TestRoutineActionURL(t *testing.T) {
 	t.Parallel()
-	pipeline := azruntime.NewPipeline("test", "v0", azruntime.PipelineOptions{}, &policy.ClientOptions{})
-	c := &Client{endpoint: "https://example.com/api/projects/p", pipeline: pipeline}
+	c := &Client{endpoint: "https://example.com/api/projects/p"}
 
 	url := c.routineActionURL("my-routine", "enable")
 	assert.Contains(t, url, "/routines/my-routine:enable")
@@ -497,8 +525,7 @@ func TestRoutineActionURL(t *testing.T) {
 
 func TestRoutineRunsURL_WithQuery(t *testing.T) {
 	t.Parallel()
-	pipeline := azruntime.NewPipeline("test", "v0", azruntime.PipelineOptions{}, &policy.ClientOptions{})
-	c := &Client{endpoint: "https://example.com/api/projects/p", pipeline: pipeline}
+	c := &Client{endpoint: "https://example.com/api/projects/p"}
 
 	url := c.routineRunsURL("r1", "limit=5", "after=tok")
 	assert.Contains(t, url, "/routines/r1/runs")


### PR DESCRIPTION
## Summary
- Fixes #8419 by raising the routines client default request timeout to two minutes.
- Adds a root `--timeout` flag and `AZURE_AI_ROUTINES_HTTP_TIMEOUT` override with flag > env > default precedence.
- Applies the configured timeout to both Azure SDK `TryTimeout` and HTTP response-header timeout.