### PR TITLE
fix: stamp endpoint on ai-project service in adopt flow for existing projects

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -819,20 +819,8 @@ func runInitFromAzureYaml(
 	// azure.ai.project service so the provisioning provider recognizes the
 	// brownfield signal and reuses the project instead of creating a new one.
 	if result.FoundryProject != nil {
-		if endpoint := result.FoundryProject.Endpoint(); endpoint != "" {
-			if projectSvcKey := existingProjectServiceKey(ctx, azdClient); projectSvcKey != "" {
-				endpointVal, err := structpb.NewValue(endpoint)
-				if err != nil {
-					return fmt.Errorf("encoding project endpoint: %w", err)
-				}
-				if _, err := azdClient.Project().SetServiceConfigValue(ctx, &azdext.SetServiceConfigValueRequest{
-					ServiceName: projectSvcKey,
-					Path:        "endpoint",
-					Value:       endpointVal,
-				}); err != nil {
-					return fmt.Errorf("writing project endpoint to azure.yaml: %w", err)
-				}
-			}
+		if err := stampProjectEndpoint(ctx, azdClient, result.FoundryProject); err != nil {
+			return err
 		}
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -815,6 +815,27 @@ func runInitFromAzureYaml(
 		return err
 	}
 
+	// When an existing project was selected, stamp its endpoint onto the
+	// azure.ai.project service so the provisioning provider recognizes the
+	// brownfield signal and reuses the project instead of creating a new one.
+	if result.FoundryProject != nil {
+		if endpoint := result.FoundryProject.Endpoint(); endpoint != "" {
+			if projectSvcKey := existingProjectServiceKey(ctx, azdClient); projectSvcKey != "" {
+				endpointVal, err := structpb.NewValue(endpoint)
+				if err != nil {
+					return fmt.Errorf("encoding project endpoint: %w", err)
+				}
+				if _, err := azdClient.Project().SetServiceConfigValue(ctx, &azdext.SetServiceConfigValueRequest{
+					ServiceName: projectSvcKey,
+					Path:        "endpoint",
+					Value:       endpointVal,
+				}); err != nil {
+					return fmt.Errorf("writing project endpoint to azure.yaml: %w", err)
+				}
+			}
+		}
+	}
+
 	// --- Model deployment verification ---
 	// Parse deployments from the azure.yaml and verify them against the
 	// selected Foundry project. If the user opts to use existing deployments

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
@@ -4,14 +4,18 @@
 package cmd
 
 import (
+	"context"
+	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"azureaiagent/internal/project"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -552,4 +556,110 @@ services:
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestAdoptFlow_WritesEndpointForExistingProject verifies that when the adopt
+// flow selects an existing Foundry project, the endpoint is stamped onto the
+// azure.ai.project service in azure.yaml via SetServiceConfigValue.
+func TestAdoptFlow_WritesEndpointForExistingProject(t *testing.T) {
+	t.Parallel()
+
+	// Simulate an azure.yaml that already has an ai-project service (from the
+	// adopted template) but without an endpoint.
+	server := &endpointRecordingProjectServer{
+		existing: map[string]*azdext.ServiceConfig{
+			"ai-project": {Name: "ai-project", Host: AiProjectHost},
+		},
+	}
+	client := newEndpointRecorderClient(t, server)
+
+	// Simulate what the adopt flow does: look up the existing project service
+	// key and stamp the endpoint.
+	projectSvcKey := existingProjectServiceKey(t.Context(), client)
+	require.Equal(t, "ai-project", projectSvcKey)
+
+	endpoint := "https://myaccount.services.ai.azure.com/api/projects/myproject"
+	endpointVal, err := structpb.NewValue(endpoint)
+	require.NoError(t, err)
+
+	_, err = client.Project().SetServiceConfigValue(t.Context(), &azdext.SetServiceConfigValueRequest{
+		ServiceName: projectSvcKey,
+		Path:        "endpoint",
+		Value:       endpointVal,
+	})
+	require.NoError(t, err)
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	require.Equal(t, "ai-project", server.endpointService)
+	require.Equal(t, endpoint, server.endpointValue)
+}
+
+// TestAdoptFlow_SkipsEndpointWhenNoExistingProject verifies the endpoint is NOT
+// written when configureFoundryProject returns nil (user chose "Create new").
+func TestAdoptFlow_SkipsEndpointWhenNoExistingProject(t *testing.T) {
+	t.Parallel()
+
+	// A nil FoundryProject means "create new" — endpoint should be "".
+	var project *FoundryProjectInfo
+	require.Equal(t, "", project.Endpoint())
+}
+
+// endpointRecordingProjectServer captures SetServiceConfigValue calls for the
+// "endpoint" path, in addition to the standard Get behavior.
+type endpointRecordingProjectServer struct {
+	azdext.UnimplementedProjectServiceServer
+
+	mu              sync.Mutex
+	existing        map[string]*azdext.ServiceConfig
+	endpointService string
+	endpointValue   string
+}
+
+func (s *endpointRecordingProjectServer) Get(
+	_ context.Context, _ *azdext.EmptyRequest,
+) (*azdext.GetProjectResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return &azdext.GetProjectResponse{
+		Project: &azdext.ProjectConfig{Services: s.existing},
+	}, nil
+}
+
+func (s *endpointRecordingProjectServer) SetServiceConfigValue(
+	_ context.Context, req *azdext.SetServiceConfigValueRequest,
+) (*azdext.EmptyResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if req.Path == "endpoint" && req.Value != nil {
+		s.endpointService = req.ServiceName
+		if str, ok := req.Value.AsInterface().(string); ok {
+			s.endpointValue = str
+		}
+	}
+	return &azdext.EmptyResponse{}, nil
+}
+
+// newEndpointRecorderClient spins up an in-process gRPC server for endpoint
+// recording and returns a client wired to it.
+func newEndpointRecorderClient(t *testing.T, server azdext.ProjectServiceServer) *azdext.AzdClient {
+	t.Helper()
+
+	grpcServer := grpc.NewServer()
+	azdext.RegisterProjectServiceServer(grpcServer, server)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() { _ = grpcServer.Serve(listener) }()
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		_ = listener.Close()
+	})
+
+	client, err := azdext.NewAzdClient(azdext.WithAddress(listener.Addr().String()))
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	return client
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
@@ -4,18 +4,14 @@
 package cmd
 
 import (
-	"context"
-	"net"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 
 	"azureaiagent/internal/project"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -558,108 +554,84 @@ services:
 	}
 }
 
-// TestAdoptFlow_WritesEndpointForExistingProject verifies that when the adopt
-// flow selects an existing Foundry project, the endpoint is stamped onto the
-// azure.ai.project service in azure.yaml via SetServiceConfigValue.
-func TestAdoptFlow_WritesEndpointForExistingProject(t *testing.T) {
+// TestStampProjectEndpoint_WritesEndpoint verifies that stampProjectEndpoint
+// writes the endpoint to the existing azure.ai.project service via
+// SetServiceConfigValue when a valid project is provided.
+func TestStampProjectEndpoint_WritesEndpoint(t *testing.T) {
 	t.Parallel()
 
-	// Simulate an azure.yaml that already has an ai-project service (from the
-	// adopted template) but without an endpoint.
-	server := &endpointRecordingProjectServer{
+	server := &recordingProjectServer{
 		existing: map[string]*azdext.ServiceConfig{
 			"ai-project": {Name: "ai-project", Host: AiProjectHost},
 		},
 	}
-	client := newEndpointRecorderClient(t, server)
+	client := newProjectRecorderClient(t, server)
 
-	// Simulate what the adopt flow does: look up the existing project service
-	// key and stamp the endpoint.
-	projectSvcKey := existingProjectServiceKey(t.Context(), client)
-	require.Equal(t, "ai-project", projectSvcKey)
+	selectedProject := &FoundryProjectInfo{
+		AccountName: "myaccount",
+		ProjectName: "myproject",
+	}
 
-	endpoint := "https://myaccount.services.ai.azure.com/api/projects/myproject"
-	endpointVal, err := structpb.NewValue(endpoint)
-	require.NoError(t, err)
-
-	_, err = client.Project().SetServiceConfigValue(t.Context(), &azdext.SetServiceConfigValueRequest{
-		ServiceName: projectSvcKey,
-		Path:        "endpoint",
-		Value:       endpointVal,
-	})
+	err := stampProjectEndpoint(t.Context(), client, selectedProject)
 	require.NoError(t, err)
 
 	server.mu.Lock()
 	defer server.mu.Unlock()
-	require.Equal(t, "ai-project", server.endpointService)
-	require.Equal(t, endpoint, server.endpointValue)
+
+	// The recording server captures SetServiceConfigValue calls in uses map
+	// for "uses" path, but for "endpoint" we check the raw call was made by
+	// verifying through the actual project state. Since recordingProjectServer
+	// returns success, we verify the function didn't error and the endpoint
+	// would have been written. For a deeper assertion, check the call was made
+	// with the correct service name and value by inspecting configValues.
+	require.Equal(t, "ai-project", server.configValues["endpoint"].serviceName)
+	require.Equal(t,
+		"https://myaccount.services.ai.azure.com/api/projects/myproject",
+		server.configValues["endpoint"].value,
+	)
 }
 
-// TestAdoptFlow_SkipsEndpointWhenNoExistingProject verifies the endpoint is NOT
-// written when configureFoundryProject returns nil (user chose "Create new").
-func TestAdoptFlow_SkipsEndpointWhenNoExistingProject(t *testing.T) {
+// TestStampProjectEndpoint_NilProject verifies stampProjectEndpoint is a no-op
+// when the selected project is nil (user chose "Create new").
+func TestStampProjectEndpoint_NilProject(t *testing.T) {
 	t.Parallel()
 
-	// A nil FoundryProject means "create new" — endpoint should be "".
-	var project *FoundryProjectInfo
-	require.Equal(t, "", project.Endpoint())
-}
-
-// endpointRecordingProjectServer captures SetServiceConfigValue calls for the
-// "endpoint" path, in addition to the standard Get behavior.
-type endpointRecordingProjectServer struct {
-	azdext.UnimplementedProjectServiceServer
-
-	mu              sync.Mutex
-	existing        map[string]*azdext.ServiceConfig
-	endpointService string
-	endpointValue   string
-}
-
-func (s *endpointRecordingProjectServer) Get(
-	_ context.Context, _ *azdext.EmptyRequest,
-) (*azdext.GetProjectResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return &azdext.GetProjectResponse{
-		Project: &azdext.ProjectConfig{Services: s.existing},
-	}, nil
-}
-
-func (s *endpointRecordingProjectServer) SetServiceConfigValue(
-	_ context.Context, req *azdext.SetServiceConfigValueRequest,
-) (*azdext.EmptyResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if req.Path == "endpoint" && req.Value != nil {
-		s.endpointService = req.ServiceName
-		if str, ok := req.Value.AsInterface().(string); ok {
-			s.endpointValue = str
-		}
+	server := &recordingProjectServer{
+		existing: map[string]*azdext.ServiceConfig{
+			"ai-project": {Name: "ai-project", Host: AiProjectHost},
+		},
 	}
-	return &azdext.EmptyResponse{}, nil
+	client := newProjectRecorderClient(t, server)
+
+	err := stampProjectEndpoint(t.Context(), client, nil)
+	require.NoError(t, err)
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	require.Empty(t, server.configValues, "no SetServiceConfigValue calls expected for nil project")
 }
 
-// newEndpointRecorderClient spins up an in-process gRPC server for endpoint
-// recording and returns a client wired to it.
-func newEndpointRecorderClient(t *testing.T, server azdext.ProjectServiceServer) *azdext.AzdClient {
-	t.Helper()
+// TestStampProjectEndpoint_NoExistingService verifies stampProjectEndpoint is a
+// no-op when no azure.ai.project service exists in the project yet.
+func TestStampProjectEndpoint_NoExistingService(t *testing.T) {
+	t.Parallel()
 
-	grpcServer := grpc.NewServer()
-	azdext.RegisterProjectServiceServer(grpcServer, server)
+	server := &recordingProjectServer{
+		existing: map[string]*azdext.ServiceConfig{
+			"my-agent": {Name: "my-agent", Host: AiAgentHost},
+		},
+	}
+	client := newProjectRecorderClient(t, server)
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	selectedProject := &FoundryProjectInfo{
+		AccountName: "myaccount",
+		ProjectName: "myproject",
+	}
+
+	err := stampProjectEndpoint(t.Context(), client, selectedProject)
 	require.NoError(t, err)
 
-	go func() { _ = grpcServer.Serve(listener) }()
-	t.Cleanup(func() {
-		grpcServer.Stop()
-		_ = listener.Close()
-	})
-
-	client, err := azdext.NewAzdClient(azdext.WithAddress(listener.Addr().String()))
-	require.NoError(t, err)
-	t.Cleanup(func() { client.Close() })
-
-	return client
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	require.Empty(t, server.configValues, "no SetServiceConfigValue calls expected when no project service exists")
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services.go
@@ -233,6 +233,35 @@ func projectNameHint(
 	return v
 }
 
+// stampProjectEndpoint writes the selected project's endpoint onto the existing
+// azure.ai.project service in azure.yaml. This is a no-op when the project is
+// nil, has no endpoint, or when no ai-project service exists yet.
+func stampProjectEndpoint(ctx context.Context, azdClient *azdext.AzdClient, selectedProject *FoundryProjectInfo) error {
+	if selectedProject == nil {
+		return nil
+	}
+	endpoint := selectedProject.Endpoint()
+	if endpoint == "" {
+		return nil
+	}
+	projectSvcKey := existingProjectServiceKey(ctx, azdClient)
+	if projectSvcKey == "" {
+		return nil
+	}
+	endpointVal, err := structpb.NewValue(endpoint)
+	if err != nil {
+		return fmt.Errorf("encoding project endpoint: %w", err)
+	}
+	if _, err := azdClient.Project().SetServiceConfigValue(ctx, &azdext.SetServiceConfigValueRequest{
+		ServiceName: projectSvcKey,
+		Path:        "endpoint",
+		Value:       endpointVal,
+	}); err != nil {
+		return fmt.Errorf("writing project endpoint to azure.yaml: %w", err)
+	}
+	return nil
+}
+
 // addResourceService adds a single Foundry resource service to azure.yaml with
 // its keys composed at the service level (inline, via AdditionalProperties, the
 // same shape the agent service uses) and optionally wires its uses: list. The

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services_test.go
@@ -251,9 +251,17 @@ type recordingProjectServer struct {
 	mu    sync.Mutex
 	added []*azdext.ServiceConfig
 	uses  map[string][]string
+	// configValues records non-"uses" SetServiceConfigValue calls keyed by path.
+	configValues map[string]configValueRecord
 	// existing is returned by Get to simulate services already present in the
 	// project (e.g. a prior init's azure.ai.project service).
 	existing map[string]*azdext.ServiceConfig
+}
+
+// configValueRecord captures a single SetServiceConfigValue call.
+type configValueRecord struct {
+	serviceName string
+	value       string
 }
 
 func (s *recordingProjectServer) Get(
@@ -283,6 +291,9 @@ func (s *recordingProjectServer) SetServiceConfigValue(
 	if s.uses == nil {
 		s.uses = map[string][]string{}
 	}
+	if s.configValues == nil {
+		s.configValues = map[string]configValueRecord{}
+	}
 	if req.Path == "uses" && req.Value != nil {
 		if list, ok := req.Value.AsInterface().([]any); ok {
 			vals := make([]string, 0, len(list))
@@ -292,6 +303,13 @@ func (s *recordingProjectServer) SetServiceConfigValue(
 				}
 			}
 			s.uses[req.ServiceName] = vals
+		}
+	} else if req.Value != nil {
+		if str, ok := req.Value.AsInterface().(string); ok {
+			s.configValues[req.Path] = configValueRecord{
+				serviceName: req.ServiceName,
+				value:       str,
+			}
 		}
 	}
 	return &azdext.EmptyResponse{}, nil


### PR DESCRIPTION
## Why

When a user runs `azd ai agent init`, selects "Start new from a template", and chooses "Use an existing Foundry project", the subsequent `azd up` ignores that selection and provisions a brand-new account/project. The user's chosen project is never reused.

## Root Cause

The "adopt" init flow (`init_adopt.go`) calls `configureFoundryProject()` which correctly sets environment variables (`FOUNDRY_PROJECT_ENDPOINT`, `USE_EXISTING_AI_PROJECT=true`, `AZURE_AI_PROJECT_ID`, etc.), but never writes the `endpoint:` field to the `azure.ai.project` service in azure.yaml.

The provisioning provider uses that `endpoint:` field as its **brownfield signal** -- if present, it connects to the existing project; if absent, it creates a new one. Since the adopt flow never stamped the endpoint, provisioning always took the "create new" path.

## Fix

After `configureFoundryProject` returns with a non-nil `FoundryProject`, call `SetServiceConfigValue` to write the endpoint onto the existing `ai-project` service in azure.yaml. This uses the same `existingProjectServiceKey` helper the codebase already provides.

The resulting azure.yaml now includes:
```yaml
ai-project:
    endpoint: https://<account>.services.ai.azure.com/api/projects/<project>
    host: azure.ai.project
    ...
```

Which the provisioning provider recognizes as brownfield, skipping new resource creation.

## Testing

- Added `TestAdoptFlow_WritesEndpointForExistingProject` -- verifies the endpoint is written via `SetServiceConfigValue` when an existing project is selected
- Added `TestAdoptFlow_SkipsEndpointWhenNoExistingProject` -- verifies no endpoint is written when the user chose "Create new"
- All existing tests pass

Fixes: #9050