### PR TITLE
fix: azure.ai.connections tenant scoping and connection-less ARM discovery

### DIFF
--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/connection_context.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/connection_context.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"azure.ai.connections/internal/exterrors"
 	"azure.ai.connections/internal/foundry/projectctx"
@@ -14,6 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices/v2"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 )
 
 // dataClient is a type alias for the data-plane client (used in endpoint.go).
@@ -51,7 +53,19 @@ func resolveConnectionContext(
 		return nil, err
 	}
 
-	cred, err := newCredential()
+	// Read the azd environment once for the values needed to build the clients:
+	// the subscription's user-access tenant (for credential scoping) and the
+	// Foundry project's ARM resource ID (for ARM context on connection-less
+	// projects). Every field is best-effort and may be empty.
+	envCtx := resolveEnvContext(ctx)
+
+	// Scope the credential to the subscription's user-access tenant so tokens are
+	// issued for the tenant that owns the Foundry resource. Multi-tenant / guest
+	// users have a home tenant that differs from the resource tenant; without this
+	// the data-plane and ARM calls below fail with "Tenant provided in token does
+	// not match resource token". An empty tenant falls back to the caller's
+	// default tenant (e.g. flag-only use outside an azd project).
+	cred, err := newCredential(envCtx.tenantID)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +73,11 @@ func resolveConnectionContext(
 	// Data-plane client (for list, get-with-credentials, and ARM discovery)
 	dpClient := connections.NewDataClient(endpoint, cred)
 
-	// Discover subscription + resource group from data-plane response
-	armCtx, err := discoverARMContext(ctx, dpClient)
+	// Resolve the ARM subscription + resource group. Preferring the azd
+	// environment's project resource ID lets the first connection be created on a
+	// project that has none yet (azd up / `azd ai connection create`); discovery
+	// from an existing connection is the fallback.
+	armCtx, err := resolveARMContext(ctx, envCtx.projectID, account, project, dpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -84,11 +101,19 @@ func resolveConnectionContext(
 	}, nil
 }
 
-// newCredential creates an Azure credential for API calls.
-func newCredential() (azcore.TokenCredential, error) {
-	cred, err := azidentity.NewAzureDeveloperCLICredential(
-		&azidentity.AzureDeveloperCLICredentialOptions{},
-	)
+// newCredential creates an Azure credential for API calls. When tenantID is
+// non-empty the credential is scoped to that tenant (with all other tenants
+// additionally allowed), so multi-tenant / guest users get a token for the
+// tenant that owns the Foundry resource. An empty tenantID uses the caller's
+// default (home) tenant.
+func newCredential(tenantID string) (azcore.TokenCredential, error) {
+	options := &azidentity.AzureDeveloperCLICredentialOptions{}
+	if tenantID != "" {
+		options.TenantID = tenantID
+		options.AdditionallyAllowedTenants = []string{"*"}
+	}
+
+	cred, err := azidentity.NewAzureDeveloperCLICredential(options)
 	if err != nil {
 		return nil, exterrors.Auth(
 			exterrors.CodeCredentialCreationFailed,
@@ -98,4 +123,78 @@ func newCredential() (azcore.TokenCredential, error) {
 	}
 
 	return cred, nil
+}
+
+// envContext holds the azd-environment-derived values used to build the
+// connection clients. Every field is optional; a zero value means the
+// corresponding source was unavailable and callers fall back to prior behavior.
+type envContext struct {
+	// tenantID is the user-access tenant for AZURE_SUBSCRIPTION_ID; "" when the
+	// subscription or tenant lookup is unavailable.
+	tenantID string
+	// projectID is AZURE_AI_PROJECT_ID (the Foundry project's ARM resource ID);
+	// "" when the azd environment does not have it.
+	projectID string
+}
+
+// resolveEnvContext best-effort reads the active azd environment for the values
+// needed to build the connection clients: the subscription's user-access tenant
+// (credential scoping) and the Foundry project's ARM resource ID (ARM context
+// for projects that have no connections yet).
+//
+// Every field is optional. On a missing azd daemon, environment, or
+// subscription the corresponding field is left empty and callers fall back to
+// prior behavior. Scoping the credential to the subscription's tenant mirrors
+// azure.ai.agents: LookupTenant returns the caller's access tenant for the
+// subscription, which is the tenant that owns the Foundry resource - so
+// multi-tenant / guest users get a token for that tenant instead of their home
+// tenant.
+func resolveEnvContext(ctx context.Context) envContext {
+	var out envContext
+
+	azdClient, err := azdext.NewAzdClient()
+	if err != nil {
+		log.Printf("connections: no azd client for environment resolution: %v", err)
+		return out
+	}
+	defer azdClient.Close()
+
+	envResp, err := azdClient.Environment().GetCurrent(ctx, &azdext.EmptyRequest{})
+	if err != nil || envResp.GetEnvironment() == nil {
+		log.Printf("connections: no active azd environment: %v", err)
+		return out
+	}
+	envName := envResp.GetEnvironment().GetName()
+
+	out.projectID = envValue(ctx, azdClient, envName, "AZURE_AI_PROJECT_ID")
+
+	subID := envValue(ctx, azdClient, envName, "AZURE_SUBSCRIPTION_ID")
+	if subID == "" {
+		log.Printf("connections: AZURE_SUBSCRIPTION_ID unavailable; using default tenant")
+		return out
+	}
+
+	tenantResp, err := azdClient.Account().LookupTenant(ctx, &azdext.LookupTenantRequest{
+		SubscriptionId: subID,
+	})
+	if err != nil {
+		log.Printf("connections: tenant lookup failed for subscription %s: %v", subID, err)
+		return out
+	}
+	out.tenantID = tenantResp.GetTenantId()
+
+	return out
+}
+
+// envValue reads a single value from the named azd environment, returning ""
+// when the key is unset or the read fails.
+func envValue(ctx context.Context, azdClient *azdext.AzdClient, envName, key string) string {
+	resp, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+		EnvName: envName,
+		Key:     key,
+	})
+	if err != nil {
+		return ""
+	}
+	return resp.GetValue()
 }

--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/connection_context_test.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/connection_context_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewCredential covers both credential shapes: the default (home) tenant
+// when no tenant is resolved, and a tenant-scoped credential for multi-tenant /
+// guest users. The tenant-scoped branch is what fixes "Tenant provided in token
+// does not match resource token".
+func TestNewCredential(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		tenantID string
+	}{
+		{name: "default tenant", tenantID: ""},
+		{name: "scoped tenant", tenantID: "11111111-1111-1111-1111-111111111111"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cred, err := newCredential(tc.tenantID)
+			require.NoError(t, err)
+			require.NotNil(t, cred)
+		})
+	}
+}

--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/endpoint.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/endpoint.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/url"
 	"strings"
 )
@@ -44,6 +45,39 @@ type armContext struct {
 	ResourceGroup  string
 	AccountName    string
 	ProjectName    string
+}
+
+// resolveARMContext resolves the ARM subscription + resource group for the
+// project.
+//
+// It prefers projectID - the Foundry project's ARM resource ID, read from the
+// azd environment's AZURE_AI_PROJECT_ID - when it is present and matches the
+// resolved endpoint's account/project. That path works even when the project
+// has no connections yet, which is required to create the first connection via
+// `azd up` or `azd ai connection create`. When projectID is missing, malformed,
+// or points at a different project, it falls back to discovering the context
+// from an existing connection's ARM resource ID.
+func resolveARMContext(
+	ctx context.Context,
+	projectID, account, project string,
+	dpClient *dataClient,
+) (*armContext, error) {
+	if projectID != "" {
+		armCtx, err := parseARMResourceID(projectID)
+		switch {
+		case err != nil:
+			log.Printf("connections: could not parse AZURE_AI_PROJECT_ID %q; "+
+				"falling back to connection discovery: %v", projectID, err)
+		case !strings.EqualFold(armCtx.AccountName, account) ||
+			!strings.EqualFold(armCtx.ProjectName, project):
+			log.Printf("connections: AZURE_AI_PROJECT_ID %q does not match resolved "+
+				"endpoint %s/%s; falling back to connection discovery", projectID, account, project)
+		default:
+			return armCtx, nil
+		}
+	}
+
+	return discoverARMContext(ctx, dpClient)
 }
 
 // discoverARMContext makes a data-plane list call to discover subscription and

--- a/cli/azd/extensions/azure.ai.connections/internal/cmd/endpoint_test.go
+++ b/cli/azd/extensions/azure.ai.connections/internal/cmd/endpoint_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveARMContext_PrefersEnvProjectID verifies that a matching
+// AZURE_AI_PROJECT_ID resolves the ARM context without any data-plane call, so
+// the first connection can be created on a project that has none yet. The nil
+// dpClient asserts that discovery is not reached on this path.
+func TestResolveARMContext_PrefersEnvProjectID(t *testing.T) {
+	t.Parallel()
+
+	projectID := "/subscriptions/sub-123/resourceGroups/rg-abc/providers/" +
+		"Microsoft.CognitiveServices/accounts/cog-xyz/projects/proj-1"
+
+	armCtx, err := resolveARMContext(t.Context(), projectID, "cog-xyz", "proj-1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "sub-123", armCtx.SubscriptionID)
+	assert.Equal(t, "rg-abc", armCtx.ResourceGroup)
+	assert.Equal(t, "cog-xyz", armCtx.AccountName)
+	assert.Equal(t, "proj-1", armCtx.ProjectName)
+}
+
+// TestResolveARMContext_MatchIsCaseInsensitive verifies the account/project
+// guard tolerates casing differences between the endpoint host and the ARM
+// resource ID, which are case-insensitive in Azure.
+func TestResolveARMContext_MatchIsCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	projectID := "/subscriptions/sub-123/resourceGroups/rg-abc/providers/" +
+		"Microsoft.CognitiveServices/accounts/Cog-XYZ/projects/Proj-1"
+
+	armCtx, err := resolveARMContext(t.Context(), projectID, "cog-xyz", "proj-1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "rg-abc", armCtx.ResourceGroup)
+}


### PR DESCRIPTION
## Summary

Fixes two bugs in the `azure.ai.connections` extension that block `azd up` / `azd deploy` for a `host: azure.ai.connection` service (and the `azd ai connection` commands) on real Foundry projects.

### 1. Credential not scoped to the resource tenant (the reported bug)

For multi-tenant / guest users - where the signed-in account's home tenant differs from the tenant that owns the Foundry resource - the extension built its Azure credential with no tenant, so tokens were issued for the caller's home tenant. The Foundry data-plane and ARM calls then failed with:

```
RESPONSE 400: Tenant provided in token does not match resource token
```

Fix: scope the credential to the subscription's user-access tenant, resolved via `Account().LookupTenant` on `AZURE_SUBSCRIPTION_ID` with `AdditionallyAllowedTenants: ["*"]`, mirroring `azure.ai.agents`. An empty tenant falls back to the caller's default tenant (flag-only use outside an azd project).

### 2. First connection cannot be created (surfaced while validating #1)

`resolveConnectionContext` bootstrapped the ARM subscription + resource group from an *existing* connection's resource ID (`discoverARMContext`). Creating the first connection on a fresh project therefore failed with:

```
no connections found in project; cannot discover ARM context...
```

Fix: prefer the Foundry project's ARM resource ID from the azd environment (`AZURE_AI_PROJECT_ID`) - which yields subscription + resource group without needing any connection - when it matches the resolved endpoint's account/project. Falls back to connection-based discovery otherwise.

Fixes #9052

## Testing

- `go build ./...`, `go test ./...`, `go vet ./...`, `gofmt`, `golangci-lint run`, and `cspell` all pass for the extension.
- Added unit tests for the tenant-scoped credential and the env-based ARM context resolution (including the case-insensitive account/project guard).
- End-to-end: rebuilt the extension with `azd x build` and ran `azd deploy` against a live Foundry project signed in as a guest user (home tenant differs from the resource tenant). Both errors above are gone - the connection `PUT` now reaches the correct resource ID and authenticates against the resource tenant.

## Notes

- Extension-only change: no azd core changes and no `go.mod` / `go.sum` changes.
- No `CHANGELOG.md` entry here; the extension changelog is updated in the version-bump release PR per the extension release process in `cli/azd/extensions/azure.ai.connections/AGENTS.md`.
