### PR TITLE
DRAFT TEST ONLY - ADO live pipeline comment trigger

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/tests/e2e-live/COMMENT_TRIGGER_TEST.md
+++ b/cli/azd/extensions/azure.ai.agents/tests/e2e-live/COMMENT_TRIGGER_TEST.md
@@ -1,0 +1,37 @@
+# Live Pipeline Comment Trigger Test
+
+This temporary note exists to make this test PR match the live pipeline path
+filters. After PR #9039 is merged, use this PR to verify that the live pipeline
+can be queued from a GitHub PR comment.
+
+Full pipeline name:
+
+```text
+/azp run azure-dev - live - ext - azure.ai.agents
+```
+
+Short name to try if needed:
+
+```text
+/azp run ext-azure-ai-agents-live
+```
+
+Expected result: Azure Pipelines queues definition 8268 and does not reply with
+either of these errors:
+
+```text
+No pipelines are associated with this pull request.
+Azure Pipelines could not run because the pipeline triggers exclude this branch/path.
+```
+
+If allowed to run to completion, the live test should end with:
+
+```text
+--- PASS: TestTier2Live
+    --- PASS: TestTier2Live/code
+    --- PASS: TestTier2Live/container
+PASS
+```
+
+ADO pipeline summary:
+https://dev.azure.com/azure-sdk/internal/_build?definitionId=8268&_a=summary


### PR DESCRIPTION
## Purpose

This is a draft test PR for validating the `ext-azure-ai-agents-live` / `azure-dev - live - ext - azure.ai.agents` PR comment trigger after #9039 is merged.

This PR intentionally changes a file under `cli/azd/extensions/azure.ai.agents/**` so it matches the path filters added by #9039.

## When to test

After #9039 is merged, come back to this PR and comment:

```text
/azp run azure-dev - live - ext - azure.ai.agents
```

If we want to also test the short name, comment:

```text
/azp run ext-azure-ai-agents-live
```

## Expected trigger result

Azure Pipelines should queue definition 8268:
https://dev.azure.com/azure-sdk/internal/_build?definitionId=8268&_a=summary

It should not reply with either of these errors:

```text
No pipelines are associated with this pull request.
Azure Pipelines could not run because the pipeline triggers exclude this branch/path.
```

## Expected live test result

If the run is allowed to complete, the Tier 2 live golden path should pass for both modes:

```text
--- PASS: TestTier2Live
    --- PASS: TestTier2Live/code
    --- PASS: TestTier2Live/container
PASS
```

This PR is for validation/reference only and should not be approved or merged.