### PR TITLE
Fix incorrect 'azd --version' references to 'azd version'

### DIFF
--- a/cli/azd/cmd/update.go
+++ b/cli/azd/cmd/update.go
@@ -306,7 +306,7 @@ func (a *updateAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 				"Updated azd to version %s! Changes take effect on next invocation.",
 				versionInfo.Version,
 			),
-			FollowUp: "Run `azd --version` to confirm.",
+			FollowUp: "Run `azd version` to confirm.",
 		},
 	}, nil
 }

--- a/ext/vscode/TESTING_GUIDE.md
+++ b/ext/vscode/TESTING_GUIDE.md
@@ -385,7 +385,7 @@ This guide provides a comprehensive list of all extension features and how to te
 **How to test**:
 - Command Palette → "Azure Developer CLI: Install CLI"
 - Follow installation prompts for your OS
-- Verify installation with `azd --version` in terminal
+- Verify installation with `azd version` in terminal
 - Should show version number
 
 ### 34. Login


### PR DESCRIPTION
azd exposes its version via the `azd version` subcommand, not a global `--version` flag.

This corrects two incorrect references:
- The `azd update` success follow-up message in `cli/azd/cmd/update.go`.
- The VS Code extension testing guide in `ext/vscode/TESTING_GUIDE.md`.

Fixes #9084