### PR TITLE
feat: enable Central US hosted agents

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/hosted-agent-regions.json
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/hosted-agent-regions.json
@@ -4,6 +4,7 @@
         "brazilsouth",
         "canadacentral",
         "canadaeast",
+        "centralus",
         "eastus2",
         "francecentral",
         "germanywestcentral",


### PR DESCRIPTION
## Summary

Add centralus to the hosted agent region allowlist, following the pattern from #8964.

## Validation

- go test ./internal/cmd -run TestParseEmbeddedHostedAgentRegions_NotEmpty -count=1
- cspell lint internal/cmd/hosted-agent-regions.json --relative --config cspell.yaml --no-progress

Fixes: #9106 