### PR TITLE
fix(agents): resolve remote invoke name from inline service config

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -27,6 +27,8 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/google/uuid"
 	"golang.org/x/term"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -744,8 +746,9 @@ func resolveAgentServiceFromProject(
 	}
 
 	info := &AgentServiceInfo{ServiceName: svc.Name}
+	brownfieldName := ""
 	if resolutionOptions.allowBrownfieldInlineName {
-		info.AgentName = brownfieldInlineAgentName(svc, projectConfig)
+		brownfieldName = brownfieldInlineAgentName(svc, projectConfig)
 	}
 
 	// Resolve deployed agent name and version from the azd environment. The
@@ -759,11 +762,22 @@ func resolveAgentServiceFromProject(
 	nameKey := fmt.Sprintf("AGENT_%s_NAME", serviceKey)
 	versionKey := fmt.Sprintf("AGENT_%s_VERSION", serviceKey)
 
-	if v, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+	nameResponse, nameErr := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
 		EnvName: envResponse.Environment.Name,
 		Key:     nameKey,
-	}); err == nil && v.Value != "" {
-		info.AgentName = v.Value
+	})
+	switch {
+	case nameErr == nil && nameResponse != nil && nameResponse.Value != "":
+		info.AgentName = nameResponse.Value
+	case nameErr == nil || status.Code(nameErr) == codes.NotFound:
+		// The active environment was read successfully and confirms the deploy
+		// output is absent, so the brownfield inline fallback is safe to use.
+		info.AgentName = brownfieldName
+	default:
+		// A transient/auth/daemon error is not evidence that the output is
+		// absent. Keep the name empty rather than silently targeting a possibly
+		// different existing agent.
+		log.Printf("resolve agent service %q: failed to read %s: %v", svc.Name, nameKey, nameErr)
 	}
 
 	if v, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -545,7 +545,7 @@ func fileExists(path string) bool {
 // AgentServiceInfo holds the resolved name and version for an agent service.
 type AgentServiceInfo struct {
 	ServiceName   string // azure.yaml service key
-	AgentName     string // deployed agent name from env, falling back to the inline definition
+	AgentName     string // deployed agent name from env, falling back for brownfield adoption
 	Version       string // deployed agent version from env
 	AgentEndpoint string // full AGENT_{SVC}_ENDPOINT URL (includes name + version)
 }
@@ -656,27 +656,69 @@ func resolveAgentService(
 	return svc, projectResponse.Project, nil
 }
 
+// brownfieldInlineAgentName returns the inline hosted-agent name only when the
+// agent explicitly depends on an azure.ai.project service whose endpoint points
+// at an existing Foundry project. This is the brownfield adoption signal: the
+// inline name may identify an agent that already exists in that project.
+//
+// A greenfield, undeployed service deliberately returns an empty name. Using
+// its inline name could silently invoke an older agent with matching name but
+// different code or protocols.
+func brownfieldInlineAgentName(
+	svc *azdext.ServiceConfig,
+	projectConfig *azdext.ProjectConfig,
+) string {
+	if svc == nil || projectConfig == nil {
+		return ""
+	}
+
+	var hasBrownfieldProject bool
+	for _, dependency := range svc.GetUses() {
+		projectService := projectConfig.GetServices()[dependency]
+		if projectService == nil || projectService.GetHost() != AiProjectHost {
+			continue
+		}
+		cfg, err := projectpkg.LoadServiceTargetAgentConfig(projectService)
+		if err != nil {
+			log.Printf(
+				"resolve agent service %q: failed to read project dependency %q: %v",
+				svc.Name, dependency, err,
+			)
+			continue
+		}
+		if cfg != nil && strings.TrimSpace(cfg.Endpoint) != "" {
+			hasBrownfieldProject = true
+			break
+		}
+	}
+	if !hasBrownfieldProject {
+		return ""
+	}
+
+	definition, isHosted, found, _, err := projectpkg.AgentDefinitionFromService(svc)
+	if err != nil {
+		log.Printf("resolve agent service %q: failed to read inline agent definition: %v", svc.Name, err)
+		return ""
+	}
+	if !found || !isHosted {
+		return ""
+	}
+	return strings.TrimSpace(definition.Name)
+}
+
 // resolveAgentServiceFromProject finds the azure.ai.agent service in azure.yaml
-// and resolves its agent name and deployed version. The inline service
-// definition supplies the name before the first deploy (for example, after
-// brownfield init against an existing Foundry project); AGENT_<SERVICE>_NAME
-// overrides it once deployment outputs are available.
+// and resolves its agent name and deployed version. A brownfield project
+// dependency allows the inline name to identify an existing agent; the
+// deployed AGENT_<SERVICE>_NAME output overrides it when available.
 func resolveAgentServiceFromProject(ctx context.Context, azdClient *azdext.AzdClient, name string, noPrompt bool) (*AgentServiceInfo, error) {
-	svc, _, err := resolveAgentService(ctx, azdClient, name, noPrompt)
+	svc, projectConfig, err := resolveAgentService(ctx, azdClient, name, noPrompt)
 	if err != nil {
 		return nil, err
 	}
 
-	info := &AgentServiceInfo{ServiceName: svc.Name}
-
-	// Seed the agent name from the inline/config-nested service definition so
-	// remote invoke works before a deploy has populated AGENT_<SERVICE>_NAME.
-	// This deliberately does not fall back to the service key: service and
-	// deployed agent names may differ.
-	if definition, isHosted, found, _, defErr := projectpkg.AgentDefinitionFromService(svc); defErr != nil {
-		log.Printf("resolve agent service %q: failed to read inline agent definition: %v", svc.Name, defErr)
-	} else if found && isHosted {
-		info.AgentName = strings.TrimSpace(definition.Name)
+	info := &AgentServiceInfo{
+		ServiceName: svc.Name,
+		AgentName:   brownfieldInlineAgentName(svc, projectConfig),
 	}
 
 	// Resolve deployed agent name and version from the azd environment. The

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -545,7 +545,7 @@ func fileExists(path string) bool {
 // AgentServiceInfo holds the resolved name and version for an agent service.
 type AgentServiceInfo struct {
 	ServiceName   string // azure.yaml service key
-	AgentName     string // deployed agent name from env
+	AgentName     string // deployed agent name from env, falling back to the inline definition
 	Version       string // deployed agent version from env
 	AgentEndpoint string // full AGENT_{SVC}_ENDPOINT URL (includes name + version)
 }
@@ -657,7 +657,10 @@ func resolveAgentService(
 }
 
 // resolveAgentServiceFromProject finds the azure.ai.agent service in azure.yaml
-// and resolves its deployed agent name and version from the azd environment.
+// and resolves its agent name and deployed version. The inline service
+// definition supplies the name before the first deploy (for example, after
+// brownfield init against an existing Foundry project); AGENT_<SERVICE>_NAME
+// overrides it once deployment outputs are available.
 func resolveAgentServiceFromProject(ctx context.Context, azdClient *azdext.AzdClient, name string, noPrompt bool) (*AgentServiceInfo, error) {
 	svc, _, err := resolveAgentService(ctx, azdClient, name, noPrompt)
 	if err != nil {
@@ -666,7 +669,18 @@ func resolveAgentServiceFromProject(ctx context.Context, azdClient *azdext.AzdCl
 
 	info := &AgentServiceInfo{ServiceName: svc.Name}
 
-	// Resolve agent name and version from azd environment
+	// Seed the agent name from the inline/config-nested service definition so
+	// remote invoke works before a deploy has populated AGENT_<SERVICE>_NAME.
+	// This deliberately does not fall back to the service key: service and
+	// deployed agent names may differ.
+	if definition, isHosted, found, _, defErr := projectpkg.AgentDefinitionFromService(svc); defErr != nil {
+		log.Printf("resolve agent service %q: failed to read inline agent definition: %v", svc.Name, defErr)
+	} else if found && isHosted {
+		info.AgentName = strings.TrimSpace(definition.Name)
+	}
+
+	// Resolve deployed agent name and version from the azd environment. The
+	// deployed name wins because it reflects the resource actually created.
 	envResponse, err := azdClient.Environment().GetCurrent(ctx, &azdext.EmptyRequest{})
 	if err != nil {
 		return info, nil

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -545,7 +545,7 @@ func fileExists(path string) bool {
 // AgentServiceInfo holds the resolved name and version for an agent service.
 type AgentServiceInfo struct {
 	ServiceName   string // azure.yaml service key
-	AgentName     string // deployed agent name from env, falling back for brownfield adoption
+	AgentName     string // deployed agent name from env; invoke may opt into brownfield fallback
 	Version       string // deployed agent version from env
 	AgentEndpoint string // full AGENT_{SVC}_ENDPOINT URL (includes name + version)
 }
@@ -706,19 +706,46 @@ func brownfieldInlineAgentName(
 	return strings.TrimSpace(definition.Name)
 }
 
+type agentServiceResolutionOptions struct {
+	allowBrownfieldInlineName bool
+}
+
+type agentServiceResolutionOption func(*agentServiceResolutionOptions)
+
+// withBrownfieldInlineAgentName allows remote invoke to use an inline agent
+// name when the service explicitly adopts an existing Foundry project. It is
+// opt-in because shared callers include destructive commands such as delete,
+// which must continue requiring deployment state or an explicit agent name.
+func withBrownfieldInlineAgentName() agentServiceResolutionOption {
+	return func(options *agentServiceResolutionOptions) {
+		options.allowBrownfieldInlineName = true
+	}
+}
+
 // resolveAgentServiceFromProject finds the azure.ai.agent service in azure.yaml
-// and resolves its agent name and deployed version. A brownfield project
-// dependency allows the inline name to identify an existing agent; the
-// deployed AGENT_<SERVICE>_NAME output overrides it when available.
-func resolveAgentServiceFromProject(ctx context.Context, azdClient *azdext.AzdClient, name string, noPrompt bool) (*AgentServiceInfo, error) {
+// and resolves its deployed agent name and version from the azd environment.
+// Callers may explicitly opt into the brownfield inline-name fallback; deployed
+// AGENT_<SERVICE>_NAME output always overrides it.
+func resolveAgentServiceFromProject(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	name string,
+	noPrompt bool,
+	options ...agentServiceResolutionOption,
+) (*AgentServiceInfo, error) {
 	svc, projectConfig, err := resolveAgentService(ctx, azdClient, name, noPrompt)
 	if err != nil {
 		return nil, err
 	}
 
-	info := &AgentServiceInfo{
-		ServiceName: svc.Name,
-		AgentName:   brownfieldInlineAgentName(svc, projectConfig),
+	resolutionOptions := agentServiceResolutionOptions{}
+	for _, option := range options {
+		option(&resolutionOptions)
+	}
+
+	info := &AgentServiceInfo{ServiceName: svc.Name}
+	if resolutionOptions.allowBrownfieldInlineName {
+		info.AgentName = brownfieldInlineAgentName(svc, projectConfig)
 	}
 
 	// Resolve deployed agent name and version from the azd environment. The

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"azureaiagent/internal/exterrors"
+	"azureaiagent/internal/pkg/agents"
 	"azureaiagent/internal/pkg/agents/agent_api"
 	"azureaiagent/internal/pkg/agents/agent_yaml"
 	"azureaiagent/internal/pkg/paths"
@@ -27,8 +28,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/google/uuid"
 	"golang.org/x/term"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const (
@@ -546,10 +545,11 @@ func fileExists(path string) bool {
 
 // AgentServiceInfo holds the resolved name and version for an agent service.
 type AgentServiceInfo struct {
-	ServiceName   string // azure.yaml service key
-	AgentName     string // deployed agent name from env; invoke may opt into brownfield fallback
-	Version       string // deployed agent version from env
-	AgentEndpoint string // full AGENT_{SVC}_ENDPOINT URL (includes name + version)
+	ServiceName     string // azure.yaml service key
+	AgentName       string // deployed agent name from env; invoke may opt into brownfield fallback
+	Version         string // deployed agent version from env
+	AgentEndpoint   string // full AGENT_{SVC}_ENDPOINT URL (includes name + version)
+	ProjectEndpoint string // adopted project endpoint used by a verified brownfield fallback
 }
 
 // promptForAgentService prompts the user to select one of multiple azure.ai.agent services.
@@ -658,23 +658,24 @@ func resolveAgentService(
 	return svc, projectResponse.Project, nil
 }
 
-// brownfieldInlineAgentName returns the inline hosted-agent name only when the
-// agent explicitly depends on an azure.ai.project service whose endpoint points
-// at an existing Foundry project. This is the brownfield adoption signal: the
-// inline name may identify an agent that already exists in that project.
-//
-// A greenfield, undeployed service deliberately returns an empty name. Using
-// its inline name could silently invoke an older agent with matching name but
-// different code or protocols.
-func brownfieldInlineAgentName(
+type brownfieldAgentReference struct {
+	name            string
+	projectEndpoint string
+}
+
+// brownfieldInlineAgentReference returns the inline hosted-agent name and the
+// endpoint of the adopted Foundry project it belongs to. The endpoint is only a
+// candidate signal; callers must verify that the named agent exists there
+// before using the reference.
+func brownfieldInlineAgentReference(
 	svc *azdext.ServiceConfig,
 	projectConfig *azdext.ProjectConfig,
-) string {
+) *brownfieldAgentReference {
 	if svc == nil || projectConfig == nil {
-		return ""
+		return nil
 	}
 
-	var hasBrownfieldProject bool
+	var projectEndpoint string
 	for _, dependency := range svc.GetUses() {
 		projectService := projectConfig.GetServices()[dependency]
 		if projectService == nil || projectService.GetHost() != AiProjectHost {
@@ -689,38 +690,73 @@ func brownfieldInlineAgentName(
 			continue
 		}
 		if cfg != nil && strings.TrimSpace(cfg.Endpoint) != "" {
-			hasBrownfieldProject = true
+			projectEndpoint = strings.TrimSpace(cfg.Endpoint)
 			break
 		}
 	}
-	if !hasBrownfieldProject {
-		return ""
+	if projectEndpoint == "" {
+		return nil
 	}
 
 	definition, isHosted, found, _, err := projectpkg.AgentDefinitionFromService(svc)
 	if err != nil {
 		log.Printf("resolve agent service %q: failed to read inline agent definition: %v", svc.Name, err)
-		return ""
+		return nil
 	}
 	if !found || !isHosted {
-		return ""
+		return nil
 	}
-	return strings.TrimSpace(definition.Name)
+
+	agentName := strings.TrimSpace(definition.Name)
+	if agentName == "" {
+		return nil
+	}
+	return &brownfieldAgentReference{
+		name:            agentName,
+		projectEndpoint: projectEndpoint,
+	}
 }
+
+type brownfieldAgentExistenceResolver func(context.Context, string, string) (bool, error)
 
 type agentServiceResolutionOptions struct {
 	allowBrownfieldInlineName bool
+	brownfieldAgentExists     brownfieldAgentExistenceResolver
 }
 
 type agentServiceResolutionOption func(*agentServiceResolutionOptions)
 
-// withBrownfieldInlineAgentName allows remote invoke to use an inline agent
-// name when the service explicitly adopts an existing Foundry project. It is
-// opt-in because shared callers include destructive commands such as delete,
-// which must continue requiring deployment state or an explicit agent name.
+func resolveBrownfieldAgentExists(
+	ctx context.Context,
+	projectEndpoint string,
+	agentName string,
+) (bool, error) {
+	credential, err := newAgentCredential()
+	if err != nil {
+		return false, err
+	}
+
+	client := agent_api.NewAgentClient(projectEndpoint, credential)
+	return agents.AgentExists(ctx, client, agentName, DefaultAgentAPIVersion)
+}
+
+// withBrownfieldInlineAgentName allows remote invoke to use an inline agent name
+// after verifying it exists in the adopted Foundry project. It is opt-in because
+// shared callers include destructive commands such as delete, which must
+// continue requiring deployment state or an explicit agent name.
 func withBrownfieldInlineAgentName() agentServiceResolutionOption {
 	return func(options *agentServiceResolutionOptions) {
 		options.allowBrownfieldInlineName = true
+		options.brownfieldAgentExists = resolveBrownfieldAgentExists
+	}
+}
+
+func withBrownfieldAgentExistenceResolver(
+	resolver brownfieldAgentExistenceResolver,
+) agentServiceResolutionOption {
+	return func(options *agentServiceResolutionOptions) {
+		options.allowBrownfieldInlineName = true
+		options.brownfieldAgentExists = resolver
 	}
 }
 
@@ -746,15 +782,20 @@ func resolveAgentServiceFromProject(
 	}
 
 	info := &AgentServiceInfo{ServiceName: svc.Name}
-	brownfieldName := ""
-	if resolutionOptions.allowBrownfieldInlineName {
-		brownfieldName = brownfieldInlineAgentName(svc, projectConfig)
-	}
 
 	// Resolve deployed agent name and version from the azd environment. The
 	// deployed name wins because it reflects the resource actually created.
 	envResponse, err := azdClient.Environment().GetCurrent(ctx, &azdext.EmptyRequest{})
 	if err != nil {
+		if resolutionOptions.allowBrownfieldInlineName {
+			return info, fmt.Errorf("getting current environment for agent service %q: %w", svc.Name, err)
+		}
+		return info, nil
+	}
+	if envResponse == nil || envResponse.Environment == nil || envResponse.Environment.Name == "" {
+		if resolutionOptions.allowBrownfieldInlineName {
+			return info, fmt.Errorf("current environment is not available for agent service %q", svc.Name)
+		}
 		return info, nil
 	}
 
@@ -767,17 +808,43 @@ func resolveAgentServiceFromProject(
 		Key:     nameKey,
 	})
 	switch {
-	case nameErr == nil && nameResponse != nil && nameResponse.Value != "":
-		info.AgentName = nameResponse.Value
-	case nameErr == nil || status.Code(nameErr) == codes.NotFound:
-		// The active environment was read successfully and confirms the deploy
-		// output is absent, so the brownfield inline fallback is safe to use.
-		info.AgentName = brownfieldName
-	default:
-		// A transient/auth/daemon error is not evidence that the output is
-		// absent. Keep the name empty rather than silently targeting a possibly
-		// different existing agent.
+	case nameErr != nil:
+		if resolutionOptions.allowBrownfieldInlineName {
+			return info, fmt.Errorf(
+				"reading %s from environment %q: %w",
+				nameKey,
+				envResponse.Environment.Name,
+				nameErr,
+			)
+		}
 		log.Printf("resolve agent service %q: failed to read %s: %v", svc.Name, nameKey, nameErr)
+	case nameResponse != nil && nameResponse.Value != "":
+		info.AgentName = nameResponse.Value
+	case resolutionOptions.allowBrownfieldInlineName:
+		reference := brownfieldInlineAgentReference(svc, projectConfig)
+		if reference == nil {
+			break
+		}
+		if resolutionOptions.brownfieldAgentExists == nil {
+			return info, fmt.Errorf("brownfield agent existence resolver is not configured")
+		}
+
+		exists, err := resolutionOptions.brownfieldAgentExists(
+			ctx,
+			reference.projectEndpoint,
+			reference.name,
+		)
+		if err != nil {
+			return info, fmt.Errorf(
+				"checking whether agent %q exists in the adopted Foundry project: %w",
+				reference.name,
+				err,
+			)
+		}
+		if exists {
+			info.AgentName = reference.name
+			info.ProjectEndpoint = reference.projectEndpoint
+		}
 	}
 
 	if v, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -844,6 +844,7 @@ func resolveAgentServiceFromProject(
 		if exists {
 			info.AgentName = reference.name
 			info.ProjectEndpoint = reference.projectEndpoint
+			return info, nil
 		}
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
@@ -462,7 +462,14 @@ func TestResolveAgentServiceFromProject_UsesInlineNameForBrownfieldProject(t *te
 		t, projectServer, &helpersPromptServer{}, envServer,
 	)
 
-	info, err := resolveAgentServiceFromProject(t.Context(), azdClient, "", true)
+	defaultInfo, err := resolveAgentServiceFromProject(t.Context(), azdClient, "", true)
+	require.NoError(t, err)
+	require.Empty(t, defaultInfo.AgentName,
+		"shared commands must not implicitly target a brownfield agent")
+
+	info, err := resolveAgentServiceFromProject(
+		t.Context(), azdClient, "", true, withBrownfieldInlineAgentName(),
+	)
 	require.NoError(t, err)
 	require.Equal(t, "service-key", info.ServiceName)
 	require.Equal(t, "inline-agent", info.AgentName,
@@ -510,7 +517,9 @@ func TestResolveAgentServiceFromProject_GreenfieldRequiresDeploy(t *testing.T) {
 		t, projectServer, &helpersPromptServer{}, envServer,
 	)
 
-	info, err := resolveAgentServiceFromProject(t.Context(), azdClient, "", true)
+	info, err := resolveAgentServiceFromProject(
+		t.Context(), azdClient, "", true, withBrownfieldInlineAgentName(),
+	)
 	require.NoError(t, err)
 	require.Empty(t, info.AgentName,
 		"greenfield service must require deploy output rather than using the inline name")
@@ -560,7 +569,9 @@ func TestResolveAgentServiceFromProject_EnvironmentNameWins(t *testing.T) {
 		t, projectServer, &helpersPromptServer{}, envServer,
 	)
 
-	info, err := resolveAgentServiceFromProject(t.Context(), azdClient, "", true)
+	info, err := resolveAgentServiceFromProject(
+		t.Context(), azdClient, "", true, withBrownfieldInlineAgentName(),
+	)
 	require.NoError(t, err)
 	require.Equal(t, "deployed-agent", info.AgentName,
 		"deployed environment output should override the inline definition")

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"azureaiagent/internal/pkg/agents/agent_yaml"
+	projectpkg "azureaiagent/internal/project"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/require"
@@ -379,18 +380,23 @@ func (s *helpersPromptServer) Select(
 	return &azdext.SelectResponse{Value: &idx}, nil
 }
 
-// newHelpersTestAzdClient spins up a gRPC server with the supplied Project and
-// Prompt stubs and returns a client wired to its address.
+// newHelpersTestAzdClient spins up a gRPC server with the supplied Project,
+// Prompt, and optional Environment stubs and returns a client wired to its
+// address.
 func newHelpersTestAzdClient(
 	t *testing.T,
 	projectServer *helpersProjectServer,
 	promptServer *helpersPromptServer,
+	environmentServers ...azdext.EnvironmentServiceServer,
 ) *azdext.AzdClient {
 	t.Helper()
 
 	grpcServer := grpc.NewServer()
 	azdext.RegisterProjectServiceServer(grpcServer, projectServer)
 	azdext.RegisterPromptServiceServer(grpcServer, promptServer)
+	if len(environmentServers) > 0 {
+		azdext.RegisterEnvironmentServiceServer(grpcServer, environmentServers[0])
+	}
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -406,6 +412,91 @@ func newHelpersTestAzdClient(
 	t.Cleanup(func() { azdClient.Close() })
 
 	return azdClient
+}
+
+// TestResolveAgentServiceFromProject_UsesInlineNameBeforeDeploy is a regression
+// test for #9109. Brownfield init writes the hosted agent definition inline in
+// azure.yaml, but AGENT_<SERVICE>_NAME is not populated until deploy. Remote
+// invoke must use the inline name rather than reporting that no agent service
+// can be resolved.
+func TestResolveAgentServiceFromProject_UsesInlineNameBeforeDeploy(t *testing.T) {
+	t.Parallel()
+
+	props, err := projectpkg.AgentDefinitionToServiceProperties(agent_yaml.ContainerAgent{
+		AgentDefinition: agent_yaml.AgentDefinition{
+			Kind: agent_yaml.AgentKindHosted,
+			Name: "inline-agent",
+		},
+		Protocols: []agent_yaml.ProtocolVersionRecord{{
+			Protocol: "invocations",
+			Version:  "2.0.0",
+		}},
+	}, nil)
+	require.NoError(t, err)
+
+	projectServer := &helpersProjectServer{project: &azdext.ProjectConfig{
+		Path: t.TempDir(),
+		Services: map[string]*azdext.ServiceConfig{
+			"service-key": {
+				Name:                 "service-key",
+				Host:                 AiAgentHost,
+				AdditionalProperties: props,
+			},
+		},
+	}}
+	envServer := &testEnvironmentServiceServer{
+		current: &azdext.Environment{Name: "test"},
+		values:  map[string]map[string]string{"test": {}},
+	}
+	azdClient := newHelpersTestAzdClient(
+		t, projectServer, &helpersPromptServer{}, envServer,
+	)
+
+	info, err := resolveAgentServiceFromProject(t.Context(), azdClient, "", true)
+	require.NoError(t, err)
+	require.Equal(t, "service-key", info.ServiceName)
+	require.Equal(t, "inline-agent", info.AgentName,
+		"inline agent name should be available before deployment outputs exist")
+}
+
+// TestResolveAgentServiceFromProject_EnvironmentNameWins verifies a deployed
+// agent name remains authoritative when it differs from the current inline
+// definition.
+func TestResolveAgentServiceFromProject_EnvironmentNameWins(t *testing.T) {
+	t.Parallel()
+
+	props, err := projectpkg.AgentDefinitionToServiceProperties(agent_yaml.ContainerAgent{
+		AgentDefinition: agent_yaml.AgentDefinition{
+			Kind: agent_yaml.AgentKindHosted,
+			Name: "inline-agent",
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	projectServer := &helpersProjectServer{project: &azdext.ProjectConfig{
+		Path: t.TempDir(),
+		Services: map[string]*azdext.ServiceConfig{
+			"service-key": {
+				Name:                 "service-key",
+				Host:                 AiAgentHost,
+				AdditionalProperties: props,
+			},
+		},
+	}}
+	envServer := &testEnvironmentServiceServer{
+		current: &azdext.Environment{Name: "test"},
+		values: map[string]map[string]string{"test": {
+			"AGENT_SERVICE_KEY_NAME": "deployed-agent",
+		}},
+	}
+	azdClient := newHelpersTestAzdClient(
+		t, projectServer, &helpersPromptServer{}, envServer,
+	)
+
+	info, err := resolveAgentServiceFromProject(t.Context(), azdClient, "", true)
+	require.NoError(t, err)
+	require.Equal(t, "deployed-agent", info.AgentName,
+		"deployed environment output should override the inline definition")
 }
 
 // TestResolveAgentProtocol_ReturnsServiceName verifies that resolveAgentProtocol

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 	goyaml "go.yaml.in/yaml/v3"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestDetectStartupCommand(t *testing.T) {
@@ -372,6 +374,17 @@ type helpersPromptServer struct {
 	selectCalls atomic.Int32
 }
 
+type helpersFailingEnvironmentServer struct {
+	testEnvironmentServiceServer
+	getValueErr error
+}
+
+func (s *helpersFailingEnvironmentServer) GetValue(
+	context.Context, *azdext.GetEnvRequest,
+) (*azdext.KeyValueResponse, error) {
+	return nil, s.getValueErr
+}
+
 func (s *helpersPromptServer) Select(
 	_ context.Context, req *azdext.SelectRequest,
 ) (*azdext.SelectResponse, error) {
@@ -575,6 +588,58 @@ func TestResolveAgentServiceFromProject_EnvironmentNameWins(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "deployed-agent", info.AgentName,
 		"deployed environment output should override the inline definition")
+}
+
+// TestResolveAgentServiceFromProject_EnvLookupFailureDoesNotFallback verifies a
+// transient env read failure is not treated as proof that the deploy output is
+// absent. Falling back in that case could target a different existing agent.
+func TestResolveAgentServiceFromProject_EnvLookupFailureDoesNotFallback(t *testing.T) {
+	t.Parallel()
+
+	agentProps, err := projectpkg.AgentDefinitionToServiceProperties(agent_yaml.ContainerAgent{
+		AgentDefinition: agent_yaml.AgentDefinition{
+			Kind: agent_yaml.AgentKindHosted,
+			Name: "inline-agent",
+		},
+	}, nil)
+	require.NoError(t, err)
+	projectProps, err := projectpkg.MarshalStruct(&projectpkg.ServiceTargetAgentConfig{
+		Endpoint: "https://account.services.ai.azure.com/api/projects/existing",
+	})
+	require.NoError(t, err)
+
+	projectServer := &helpersProjectServer{project: &azdext.ProjectConfig{
+		Path: t.TempDir(),
+		Services: map[string]*azdext.ServiceConfig{
+			"ai-project": {
+				Name:                 "ai-project",
+				Host:                 AiProjectHost,
+				AdditionalProperties: projectProps,
+			},
+			"service-key": {
+				Name:                 "service-key",
+				Host:                 AiAgentHost,
+				AdditionalProperties: agentProps,
+				Uses:                 []string{"ai-project"},
+			},
+		},
+	}}
+	envServer := &helpersFailingEnvironmentServer{
+		testEnvironmentServiceServer: testEnvironmentServiceServer{
+			current: &azdext.Environment{Name: "test"},
+		},
+		getValueErr: status.Error(codes.Unavailable, "environment service unavailable"),
+	}
+	azdClient := newHelpersTestAzdClient(
+		t, projectServer, &helpersPromptServer{}, envServer,
+	)
+
+	info, err := resolveAgentServiceFromProject(
+		t.Context(), azdClient, "", true, withBrownfieldInlineAgentName(),
+	)
+	require.NoError(t, err)
+	require.Empty(t, info.AgentName,
+		"transient env lookup failure must not enable the inline fallback")
 }
 
 // TestResolveAgentProtocol_ReturnsServiceName verifies that resolveAgentProtocol

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
@@ -414,15 +414,15 @@ func newHelpersTestAzdClient(
 	return azdClient
 }
 
-// TestResolveAgentServiceFromProject_UsesInlineNameBeforeDeploy is a regression
-// test for #9109. Brownfield init writes the hosted agent definition inline in
-// azure.yaml, but AGENT_<SERVICE>_NAME is not populated until deploy. Remote
-// invoke must use the inline name rather than reporting that no agent service
-// can be resolved.
-func TestResolveAgentServiceFromProject_UsesInlineNameBeforeDeploy(t *testing.T) {
+// TestResolveAgentServiceFromProject_UsesInlineNameForBrownfieldProject is a
+// regression test for #9109. Brownfield init writes the hosted agent definition
+// inline and points the used azure.ai.project service at an existing project,
+// but AGENT_<SERVICE>_NAME is not populated. Remote invoke may use the inline
+// name to target the existing agent in that explicitly adopted project.
+func TestResolveAgentServiceFromProject_UsesInlineNameForBrownfieldProject(t *testing.T) {
 	t.Parallel()
 
-	props, err := projectpkg.AgentDefinitionToServiceProperties(agent_yaml.ContainerAgent{
+	agentProps, err := projectpkg.AgentDefinitionToServiceProperties(agent_yaml.ContainerAgent{
 		AgentDefinition: agent_yaml.AgentDefinition{
 			Kind: agent_yaml.AgentKindHosted,
 			Name: "inline-agent",
@@ -433,14 +433,24 @@ func TestResolveAgentServiceFromProject_UsesInlineNameBeforeDeploy(t *testing.T)
 		}},
 	}, nil)
 	require.NoError(t, err)
+	projectProps, err := projectpkg.MarshalStruct(&projectpkg.ServiceTargetAgentConfig{
+		Endpoint: "https://account.services.ai.azure.com/api/projects/existing",
+	})
+	require.NoError(t, err)
 
 	projectServer := &helpersProjectServer{project: &azdext.ProjectConfig{
 		Path: t.TempDir(),
 		Services: map[string]*azdext.ServiceConfig{
+			"ai-project": {
+				Name:                 "ai-project",
+				Host:                 AiProjectHost,
+				AdditionalProperties: projectProps,
+			},
 			"service-key": {
 				Name:                 "service-key",
 				Host:                 AiAgentHost,
-				AdditionalProperties: props,
+				AdditionalProperties: agentProps,
+				Uses:                 []string{"ai-project"},
 			},
 		},
 	}}
@@ -456,7 +466,54 @@ func TestResolveAgentServiceFromProject_UsesInlineNameBeforeDeploy(t *testing.T)
 	require.NoError(t, err)
 	require.Equal(t, "service-key", info.ServiceName)
 	require.Equal(t, "inline-agent", info.AgentName,
-		"inline agent name should be available before deployment outputs exist")
+		"inline agent name should resolve for an explicitly adopted existing project")
+}
+
+// TestResolveAgentServiceFromProject_GreenfieldRequiresDeploy verifies that an
+// undeployed greenfield service does not auto-resolve its inline name. This
+// prevents invoke from silently targeting an older live agent whose name
+// happens to match the local definition.
+func TestResolveAgentServiceFromProject_GreenfieldRequiresDeploy(t *testing.T) {
+	t.Parallel()
+
+	agentProps, err := projectpkg.AgentDefinitionToServiceProperties(agent_yaml.ContainerAgent{
+		AgentDefinition: agent_yaml.AgentDefinition{
+			Kind: agent_yaml.AgentKindHosted,
+			Name: "inline-agent",
+		},
+	}, nil)
+	require.NoError(t, err)
+	projectProps, err := projectpkg.MarshalStruct(&projectpkg.ServiceTargetAgentConfig{})
+	require.NoError(t, err)
+
+	projectServer := &helpersProjectServer{project: &azdext.ProjectConfig{
+		Path: t.TempDir(),
+		Services: map[string]*azdext.ServiceConfig{
+			"ai-project": {
+				Name:                 "ai-project",
+				Host:                 AiProjectHost,
+				AdditionalProperties: projectProps,
+			},
+			"service-key": {
+				Name:                 "service-key",
+				Host:                 AiAgentHost,
+				AdditionalProperties: agentProps,
+				Uses:                 []string{"ai-project"},
+			},
+		},
+	}}
+	envServer := &testEnvironmentServiceServer{
+		current: &azdext.Environment{Name: "test"},
+		values:  map[string]map[string]string{"test": {}},
+	}
+	azdClient := newHelpersTestAzdClient(
+		t, projectServer, &helpersPromptServer{}, envServer,
+	)
+
+	info, err := resolveAgentServiceFromProject(t.Context(), azdClient, "", true)
+	require.NoError(t, err)
+	require.Empty(t, info.AgentName,
+		"greenfield service must require deploy output rather than using the inline name")
 }
 
 // TestResolveAgentServiceFromProject_EnvironmentNameWins verifies a deployed
@@ -465,21 +522,31 @@ func TestResolveAgentServiceFromProject_UsesInlineNameBeforeDeploy(t *testing.T)
 func TestResolveAgentServiceFromProject_EnvironmentNameWins(t *testing.T) {
 	t.Parallel()
 
-	props, err := projectpkg.AgentDefinitionToServiceProperties(agent_yaml.ContainerAgent{
+	agentProps, err := projectpkg.AgentDefinitionToServiceProperties(agent_yaml.ContainerAgent{
 		AgentDefinition: agent_yaml.AgentDefinition{
 			Kind: agent_yaml.AgentKindHosted,
 			Name: "inline-agent",
 		},
 	}, nil)
 	require.NoError(t, err)
+	projectProps, err := projectpkg.MarshalStruct(&projectpkg.ServiceTargetAgentConfig{
+		Endpoint: "https://account.services.ai.azure.com/api/projects/existing",
+	})
+	require.NoError(t, err)
 
 	projectServer := &helpersProjectServer{project: &azdext.ProjectConfig{
 		Path: t.TempDir(),
 		Services: map[string]*azdext.ServiceConfig{
+			"ai-project": {
+				Name:                 "ai-project",
+				Host:                 AiProjectHost,
+				AdditionalProperties: projectProps,
+			},
 			"service-key": {
 				Name:                 "service-key",
 				Host:                 AiAgentHost,
-				AdditionalProperties: props,
+				AdditionalProperties: agentProps,
+				Uses:                 []string{"ai-project"},
 			},
 		},
 	}}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
@@ -427,14 +427,15 @@ func newHelpersTestAzdClient(
 	return azdClient
 }
 
-// TestResolveAgentServiceFromProject_UsesInlineNameForBrownfieldProject is a
-// regression test for #9109. Brownfield init writes the hosted agent definition
-// inline and points the used azure.ai.project service at an existing project,
-// but AGENT_<SERVICE>_NAME is not populated. Remote invoke may use the inline
-// name to target the existing agent in that explicitly adopted project.
-func TestResolveAgentServiceFromProject_UsesInlineNameForBrownfieldProject(t *testing.T) {
+// TestResolveAgentServiceFromProject_UsesVerifiedInlineNameForBrownfieldProject
+// is a regression test for #9109. Brownfield init writes the hosted agent
+// definition inline and points the used azure.ai.project service at an existing
+// project, but AGENT_<SERVICE>_NAME is not populated. Remote invoke may use the
+// inline name only after confirming the agent exists in that adopted project.
+func TestResolveAgentServiceFromProject_UsesVerifiedInlineNameForBrownfieldProject(t *testing.T) {
 	t.Parallel()
 
+	projectEndpoint := "https://account.services.ai.azure.com/api/projects/existing"
 	agentProps, err := projectpkg.AgentDefinitionToServiceProperties(agent_yaml.ContainerAgent{
 		AgentDefinition: agent_yaml.AgentDefinition{
 			Kind: agent_yaml.AgentKindHosted,
@@ -447,7 +448,7 @@ func TestResolveAgentServiceFromProject_UsesInlineNameForBrownfieldProject(t *te
 	}, nil)
 	require.NoError(t, err)
 	projectProps, err := projectpkg.MarshalStruct(&projectpkg.ServiceTargetAgentConfig{
-		Endpoint: "https://account.services.ai.azure.com/api/projects/existing",
+		Endpoint: projectEndpoint,
 	})
 	require.NoError(t, err)
 
@@ -481,12 +482,58 @@ func TestResolveAgentServiceFromProject_UsesInlineNameForBrownfieldProject(t *te
 		"shared commands must not implicitly target a brownfield agent")
 
 	info, err := resolveAgentServiceFromProject(
-		t.Context(), azdClient, "", true, withBrownfieldInlineAgentName(),
+		t.Context(),
+		azdClient,
+		"",
+		true,
+		withBrownfieldAgentExistenceResolver(func(
+			_ context.Context,
+			endpoint string,
+			agentName string,
+		) (bool, error) {
+			require.Equal(t, projectEndpoint, endpoint)
+			require.Equal(t, "inline-agent", agentName)
+			return true, nil
+		}),
 	)
 	require.NoError(t, err)
 	require.Equal(t, "service-key", info.ServiceName)
 	require.Equal(t, "inline-agent", info.AgentName,
 		"inline agent name should resolve for an explicitly adopted existing project")
+	require.Equal(t, projectEndpoint, info.ProjectEndpoint,
+		"verified inline name must remain bound to its adopted project")
+
+	missingInfo, err := resolveAgentServiceFromProject(
+		t.Context(),
+		azdClient,
+		"",
+		true,
+		withBrownfieldAgentExistenceResolver(func(
+			context.Context,
+			string,
+			string,
+		) (bool, error) {
+			return false, nil
+		}),
+	)
+	require.NoError(t, err)
+	require.Empty(t, missingInfo.AgentName,
+		"inline name must not resolve when the agent does not exist in the adopted project")
+
+	_, err = resolveAgentServiceFromProject(
+		t.Context(),
+		azdClient,
+		"",
+		true,
+		withBrownfieldAgentExistenceResolver(func(
+			context.Context,
+			string,
+			string,
+		) (bool, error) {
+			return false, status.Error(codes.Unavailable, "agent lookup unavailable")
+		}),
+	)
+	require.ErrorContains(t, err, "checking whether agent")
 }
 
 // TestResolveAgentServiceFromProject_GreenfieldRequiresDeploy verifies that an
@@ -531,7 +578,18 @@ func TestResolveAgentServiceFromProject_GreenfieldRequiresDeploy(t *testing.T) {
 	)
 
 	info, err := resolveAgentServiceFromProject(
-		t.Context(), azdClient, "", true, withBrownfieldInlineAgentName(),
+		t.Context(),
+		azdClient,
+		"",
+		true,
+		withBrownfieldAgentExistenceResolver(func(
+			context.Context,
+			string,
+			string,
+		) (bool, error) {
+			t.Fatal("greenfield service must not check for an existing agent")
+			return false, nil
+		}),
 	)
 	require.NoError(t, err)
 	require.Empty(t, info.AgentName,
@@ -583,7 +641,18 @@ func TestResolveAgentServiceFromProject_EnvironmentNameWins(t *testing.T) {
 	)
 
 	info, err := resolveAgentServiceFromProject(
-		t.Context(), azdClient, "", true, withBrownfieldInlineAgentName(),
+		t.Context(),
+		azdClient,
+		"",
+		true,
+		withBrownfieldAgentExistenceResolver(func(
+			context.Context,
+			string,
+			string,
+		) (bool, error) {
+			t.Fatal("deployed environment name must bypass the inline agent check")
+			return false, nil
+		}),
 	)
 	require.NoError(t, err)
 	require.Equal(t, "deployed-agent", info.AgentName,
@@ -593,9 +662,7 @@ func TestResolveAgentServiceFromProject_EnvironmentNameWins(t *testing.T) {
 // TestResolveAgentServiceFromProject_EnvLookupFailureDoesNotFallback verifies a
 // transient env read failure is not treated as proof that the deploy output is
 // absent. Falling back in that case could target a different existing agent.
-func TestResolveAgentServiceFromProject_EnvLookupFailureDoesNotFallback(t *testing.T) {
-	t.Parallel()
-
+func TestResolveAgentServiceFromProject_EnvLookupFailureIsReturned(t *testing.T) {
 	agentProps, err := projectpkg.AgentDefinitionToServiceProperties(agent_yaml.ContainerAgent{
 		AgentDefinition: agent_yaml.AgentDefinition{
 			Kind: agent_yaml.AgentKindHosted,
@@ -624,22 +691,42 @@ func TestResolveAgentServiceFromProject_EnvLookupFailureDoesNotFallback(t *testi
 			},
 		},
 	}}
-	envServer := &helpersFailingEnvironmentServer{
-		testEnvironmentServiceServer: testEnvironmentServiceServer{
-			current: &azdext.Environment{Name: "test"},
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "environment unavailable",
+			err:  status.Error(codes.Unavailable, "environment service unavailable"),
 		},
-		getValueErr: status.Error(codes.Unavailable, "environment service unavailable"),
+		{
+			name: "environment not found",
+			err:  status.Error(codes.NotFound, "environment not found"),
+		},
 	}
-	azdClient := newHelpersTestAzdClient(
-		t, projectServer, &helpersPromptServer{}, envServer,
-	)
 
-	info, err := resolveAgentServiceFromProject(
-		t.Context(), azdClient, "", true, withBrownfieldInlineAgentName(),
-	)
-	require.NoError(t, err)
-	require.Empty(t, info.AgentName,
-		"transient env lookup failure must not enable the inline fallback")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			envServer := &helpersFailingEnvironmentServer{
+				testEnvironmentServiceServer: testEnvironmentServiceServer{
+					current: &azdext.Environment{Name: "test"},
+				},
+				getValueErr: tt.err,
+			}
+			azdClient := newHelpersTestAzdClient(
+				t, projectServer, &helpersPromptServer{}, envServer,
+			)
+
+			info, err := resolveAgentServiceFromProject(
+				t.Context(), azdClient, "", true, withBrownfieldInlineAgentName(),
+			)
+			require.Error(t, err)
+			require.Empty(t, info.AgentName)
+			require.ErrorContains(t, err, "reading AGENT_SERVICE_KEY_NAME")
+		})
+	}
 }
 
 // TestResolveAgentProtocol_ReturnsServiceName verifies that resolveAgentProtocol

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -755,6 +755,18 @@ func incrementDecimalString(value string) string {
 	return "1" + string(digits)
 }
 
+type existingAgentNameConflictOptions struct {
+	noPromptSuggestion string
+}
+
+type existingAgentNameConflictOption func(*existingAgentNameConflictOptions)
+
+func withNoPromptAgentNameConflictSuggestion(suggestion string) existingAgentNameConflictOption {
+	return func(options *existingAgentNameConflictOptions) {
+		options.noPromptSuggestion = suggestion
+	}
+}
+
 func resolveExistingAgentNameConflict(
 	ctx context.Context,
 	azdClient *azdext.AzdClient,
@@ -762,6 +774,7 @@ func resolveExistingAgentNameConflict(
 	credential azcore.TokenCredential,
 	noPrompt bool,
 	agentName string,
+	options ...existingAgentNameConflictOption,
 ) (string, error) {
 	if azdClient == nil || environment == nil || environment.Name == "" || credential == nil {
 		return agentName, nil
@@ -788,7 +801,14 @@ func resolveExistingAgentNameConflict(
 	}
 
 	agentClient := agent_api.NewAgentClient(endpointResp.Value, credential)
-	return resolveExistingAgentNameConflictWithChecker(ctx, azdClient, agentClient, noPrompt, agentName)
+	return resolveExistingAgentNameConflictWithChecker(
+		ctx,
+		azdClient,
+		agentClient,
+		noPrompt,
+		agentName,
+		options...,
+	)
 }
 
 func resolveExistingAgentNameConflictWithChecker(
@@ -797,7 +817,15 @@ func resolveExistingAgentNameConflictWithChecker(
 	agentChecker agents.AgentChecker,
 	noPrompt bool,
 	agentName string,
+	options ...existingAgentNameConflictOption,
 ) (string, error) {
+	resolutionOptions := existingAgentNameConflictOptions{
+		noPromptSuggestion: "To create a separate agent, re-run init with --agent-name <unique-name>.\n",
+	}
+	for _, option := range options {
+		option(&resolutionOptions)
+	}
+
 	for {
 		exists, err := agents.AgentExists(ctx, agentChecker, agentName, DefaultAgentAPIVersion)
 		if err != nil {
@@ -821,7 +849,8 @@ func resolveExistingAgentNameConflictWithChecker(
 		fmt.Fprintf(os.Stderr, "%s", agents.ExistingAgentWarning(agentName))
 		if noPrompt {
 			fmt.Fprintf(os.Stderr, "%s", output.WithGrayFormat(
-				"To create a separate agent, re-run init with --agent-name <unique-name>.\n",
+				"%s",
+				resolutionOptions.noPromptSuggestion,
 			))
 			return agentName, nil
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -652,6 +652,102 @@ func updateAzureYamlDeployments(
 	return nil
 }
 
+type adoptedAgentNameResolver func(context.Context, string) (string, error)
+
+// confirmAdoptedAgentNameConflicts checks every agent definition embedded in an
+// adopted azure.yaml against the selected existing Foundry project. The shared
+// resolver warns and asks for confirmation before reusing a name, or prompts
+// for a replacement name and returns it.
+func confirmAdoptedAgentNameConflicts(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	environment *azdext.Environment,
+	credential azcore.TokenCredential,
+	noPrompt bool,
+) error {
+	return updateAdoptedAgentNames(ctx, azdClient, func(ctx context.Context, agentName string) (string, error) {
+		return resolveExistingAgentNameConflict(
+			ctx,
+			azdClient,
+			environment,
+			credential,
+			noPrompt,
+			agentName,
+		)
+	})
+}
+
+// updateAdoptedAgentNames resolves name conflicts for adopted agent services
+// and persists any replacement names in azure.yaml.
+func updateAdoptedAgentNames(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	resolveName adoptedAgentNameResolver,
+) error {
+	resp, err := azdClient.Project().Get(ctx, &azdext.EmptyRequest{})
+	if err != nil {
+		return fmt.Errorf("reading adopted project for agent name conflicts: %w", err)
+	}
+
+	services := resp.GetProject().GetServices()
+	serviceNames := make([]string, 0, len(services))
+	for serviceName, svc := range services {
+		if svc.GetHost() == AiAgentHost {
+			serviceNames = append(serviceNames, serviceName)
+		}
+	}
+	slices.Sort(serviceNames)
+
+	for _, serviceName := range serviceNames {
+		agentName, configPath := adoptedAgentNameConfig(services[serviceName])
+		if agentName == "" {
+			continue
+		}
+
+		resolvedName, err := resolveName(ctx, agentName)
+		if err != nil {
+			return err
+		}
+		if resolvedName == agentName {
+			continue
+		}
+
+		value, err := structpb.NewValue(resolvedName)
+		if err != nil {
+			return fmt.Errorf("encoding replacement name for agent service %q: %w", serviceName, err)
+		}
+		if _, err := azdClient.Project().SetServiceConfigValue(ctx, &azdext.SetServiceConfigValueRequest{
+			ServiceName: serviceName,
+			Path:        configPath,
+			Value:       value,
+		}); err != nil {
+			return fmt.Errorf("updating agent name in azure.yaml for service %q: %w", serviceName, err)
+		}
+	}
+
+	return nil
+}
+
+// adoptedAgentNameConfig returns the Foundry agent name and its service-relative
+// config path for the unified inline shape or deprecated config-nested shape.
+func adoptedAgentNameConfig(svc *azdext.ServiceConfig) (string, string) {
+	if svc == nil {
+		return "", ""
+	}
+
+	inline := svc.GetAdditionalProperties()
+	if inline != nil && inline.GetFields()["kind"].GetStringValue() != "" {
+		return strings.TrimSpace(inline.GetFields()["name"].GetStringValue()), "name"
+	}
+
+	legacy := svc.GetConfig()
+	if legacy != nil && legacy.GetFields()["kind"].GetStringValue() != "" {
+		return strings.TrimSpace(legacy.GetFields()["name"].GetStringValue()), "config.name"
+	}
+
+	return "", ""
+}
+
 // readManifestContentForInitDetection returns the pointed-at YAML content for
 // init-mode routing. It first uses the cheap peek path; when that cannot read a
 // GitHub URL (for example, a private repository), it falls back to the
@@ -820,6 +916,15 @@ func runInitFromAzureYaml(
 	// brownfield signal and reuses the project instead of creating a new one.
 	if result.FoundryProject != nil {
 		if err := stampProjectEndpoint(ctx, azdClient, result.FoundryProject); err != nil {
+			return err
+		}
+		if err := confirmAdoptedAgentNameConflicts(
+			ctx,
+			azdClient,
+			env,
+			result.Credential,
+			flags.noPrompt,
+		); err != nil {
 			return err
 		}
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -654,6 +654,10 @@ func updateAzureYamlDeployments(
 
 type adoptedAgentNameResolver func(context.Context, string) (string, error)
 
+func adoptedAgentNameConflictSuggestion() string {
+	return "To create a separate agent, update the agent service's `name` in the adopted azure.yaml before deploying.\n"
+}
+
 // confirmAdoptedAgentNameConflicts checks every agent definition embedded in an
 // adopted azure.yaml against the selected existing Foundry project. The shared
 // resolver warns and asks for confirmation before reusing a name, or prompts
@@ -673,6 +677,7 @@ func confirmAdoptedAgentNameConflicts(
 			credential,
 			noPrompt,
 			agentName,
+			withNoPromptAgentNameConflictSuggestion(adoptedAgentNameConflictSuggestion()),
 		)
 	})
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
@@ -4,6 +4,8 @@
 package cmd
 
 import (
+	"context"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,6 +14,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -552,6 +555,243 @@ services:
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestAdoptedAgentNameConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		svc      *azdext.ServiceConfig
+		wantName string
+		wantPath string
+	}{
+		{
+			name: "unified inline hosted agent",
+			svc: &azdext.ServiceConfig{
+				AdditionalProperties: &structpb.Struct{Fields: map[string]*structpb.Value{
+					"kind": structpb.NewStringValue("hosted"),
+					"name": structpb.NewStringValue("inline-agent"),
+				}},
+			},
+			wantName: "inline-agent",
+			wantPath: "name",
+		},
+		{
+			name: "unified inline workflow agent",
+			svc: &azdext.ServiceConfig{
+				AdditionalProperties: &structpb.Struct{Fields: map[string]*structpb.Value{
+					"kind": structpb.NewStringValue("workflow"),
+					"name": structpb.NewStringValue("workflow-agent"),
+				}},
+			},
+			wantName: "workflow-agent",
+			wantPath: "name",
+		},
+		{
+			name: "deprecated config-nested agent",
+			svc: &azdext.ServiceConfig{
+				AdditionalProperties: &structpb.Struct{Fields: map[string]*structpb.Value{
+					"docker": structpb.NewStructValue(&structpb.Struct{}),
+				}},
+				Config: &structpb.Struct{Fields: map[string]*structpb.Value{
+					"kind": structpb.NewStringValue("hosted"),
+					"name": structpb.NewStringValue("legacy-agent"),
+				}},
+			},
+			wantName: "legacy-agent",
+			wantPath: "config.name",
+		},
+		{
+			name: "inline definition remains authoritative during partial migration",
+			svc: &azdext.ServiceConfig{
+				AdditionalProperties: &structpb.Struct{Fields: map[string]*structpb.Value{
+					"kind": structpb.NewStringValue("hosted"),
+				}},
+				Config: &structpb.Struct{Fields: map[string]*structpb.Value{
+					"kind": structpb.NewStringValue("hosted"),
+					"name": structpb.NewStringValue("legacy-agent"),
+				}},
+			},
+			wantPath: "name",
+		},
+		{
+			name: "service properties without agent definition",
+			svc: &azdext.ServiceConfig{
+				AdditionalProperties: &structpb.Struct{Fields: map[string]*structpb.Value{
+					"name": structpb.NewStringValue("not-an-agent-definition"),
+				}},
+			},
+		},
+		{name: "nil service"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotName, gotPath := adoptedAgentNameConfig(tt.svc)
+			require.Equal(t, tt.wantName, gotName)
+			require.Equal(t, tt.wantPath, gotPath)
+		})
+	}
+}
+
+func newAdoptedAgentNameTestClient(
+	t *testing.T,
+	projectServer azdext.ProjectServiceServer,
+	promptServer azdext.PromptServiceServer,
+) *azdext.AzdClient {
+	t.Helper()
+
+	grpcServer := grpc.NewServer()
+	azdext.RegisterProjectServiceServer(grpcServer, projectServer)
+	azdext.RegisterPromptServiceServer(grpcServer, promptServer)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() {
+		_ = grpcServer.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		_ = listener.Close()
+	})
+
+	client, err := azdext.NewAzdClient(azdext.WithAddress(listener.Addr().String()))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		client.Close()
+	})
+
+	return client
+}
+
+func TestUpdateAdoptedAgentNames_PersistsReplacement(t *testing.T) {
+	t.Parallel()
+
+	server := &recordingProjectServer{
+		existing: map[string]*azdext.ServiceConfig{
+			"agent-service": {
+				Name: "agent-service",
+				Host: AiAgentHost,
+				AdditionalProperties: &structpb.Struct{Fields: map[string]*structpb.Value{
+					"kind": structpb.NewStringValue("hosted"),
+					"name": structpb.NewStringValue("existing-agent"),
+				}},
+			},
+			"ai-project": {
+				Name: "ai-project",
+				Host: AiProjectHost,
+			},
+		},
+	}
+	prompts := &testPromptServiceServer{
+		confirmResponses: []bool{false},
+		promptResponses:  []string{"replacement-agent"},
+	}
+	client := newAdoptedAgentNameTestClient(t, server, prompts)
+	checker := &fakeConflictAgentChecker{
+		exists: map[string]bool{"existing-agent": true},
+	}
+
+	err := updateAdoptedAgentNames(
+		t.Context(),
+		client,
+		func(ctx context.Context, agentName string) (string, error) {
+			return resolveExistingAgentNameConflictWithChecker(
+				ctx,
+				client,
+				checker,
+				false,
+				agentName,
+			)
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"existing-agent", "replacement-agent"}, checker.calls)
+	require.Len(t, prompts.confirmRequests, 1)
+	require.Len(t, prompts.promptRequests, 1)
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	require.Equal(t, "agent-service", server.configValues["name"].serviceName)
+	require.Equal(t, "replacement-agent", server.configValues["name"].value)
+}
+
+func TestUpdateAdoptedAgentNames_UsesLegacyConfigPath(t *testing.T) {
+	t.Parallel()
+
+	server := &recordingProjectServer{
+		existing: map[string]*azdext.ServiceConfig{
+			"agent-service": {
+				Name: "agent-service",
+				Host: AiAgentHost,
+				Config: &structpb.Struct{Fields: map[string]*structpb.Value{
+					"kind": structpb.NewStringValue("hosted"),
+					"name": structpb.NewStringValue("existing-agent"),
+				}},
+			},
+		},
+	}
+	client := newProjectRecorderClient(t, server)
+
+	err := updateAdoptedAgentNames(
+		t.Context(),
+		client,
+		func(_ context.Context, _ string) (string, error) {
+			return "replacement-agent", nil
+		},
+	)
+	require.NoError(t, err)
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	require.Equal(t, "agent-service", server.configValues["config.name"].serviceName)
+	require.Equal(t, "replacement-agent", server.configValues["config.name"].value)
+}
+
+func TestUpdateAdoptedAgentNames_UnchangedNamesAreNotWritten(t *testing.T) {
+	t.Parallel()
+
+	server := &recordingProjectServer{
+		existing: map[string]*azdext.ServiceConfig{
+			"zeta-service": {
+				Name: "zeta-service",
+				Host: AiAgentHost,
+				AdditionalProperties: &structpb.Struct{Fields: map[string]*structpb.Value{
+					"kind": structpb.NewStringValue("hosted"),
+					"name": structpb.NewStringValue("zeta-agent"),
+				}},
+			},
+			"alpha-service": {
+				Name: "alpha-service",
+				Host: AiAgentHost,
+				AdditionalProperties: &structpb.Struct{Fields: map[string]*structpb.Value{
+					"kind": structpb.NewStringValue("hosted"),
+					"name": structpb.NewStringValue("alpha-agent"),
+				}},
+			},
+		},
+	}
+	client := newProjectRecorderClient(t, server)
+
+	var checkedNames []string
+	err := updateAdoptedAgentNames(
+		t.Context(),
+		client,
+		func(_ context.Context, agentName string) (string, error) {
+			checkedNames = append(checkedNames, agentName)
+			return agentName, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"alpha-agent", "zeta-agent"}, checkedNames)
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	require.Empty(t, server.configValues)
 }
 
 // TestStampProjectEndpoint_WritesEndpoint verifies that stampProjectEndpoint

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
@@ -637,6 +637,14 @@ func TestAdoptedAgentNameConfig(t *testing.T) {
 	}
 }
 
+func TestAdoptedAgentNameConflictSuggestion(t *testing.T) {
+	t.Parallel()
+
+	suggestion := adoptedAgentNameConflictSuggestion()
+	require.Contains(t, suggestion, "adopted azure.yaml")
+	require.NotContains(t, suggestion, "--agent-name")
+}
+
 func newAdoptedAgentNameTestClient(
 	t *testing.T,
 	projectServer azdext.ProjectServiceServer,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
@@ -231,7 +231,7 @@ func (s *testEnvironmentServiceServer) GetValue(
 			}
 		}
 	}
-	return nil, status.Error(codes.NotFound, "key not found")
+	return &azdext.KeyValueResponse{}, nil
 }
 
 func (s *testEnvironmentServiceServer) GetValues(

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -903,7 +903,9 @@ func (a *InvokeAction) resolveRemoteContext(ctx context.Context) (*remoteContext
 	// so post-success next-step suggestions emit the service name; show
 	// keys on s.Name in azure.yaml and would 404 on the deployed Foundry
 	// name in the divergent case.
-	if info, err := resolveAgentServiceFromProject(ctx, azdClient, rc.name, a.noPrompt); err == nil {
+	if info, err := resolveAgentServiceFromProject(
+		ctx, azdClient, rc.name, a.noPrompt, withBrownfieldInlineAgentName(),
+	); err == nil {
 		rc.serviceName = info.ServiceName
 		if info.AgentName != "" {
 			rc.name = info.AgentName

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -851,6 +851,26 @@ func (rc *remoteContext) nextStepName() string {
 	return rc.name
 }
 
+// remoteAgentNameFromService applies the project-service resolution result to
+// the invoke target name. An auto-detected protocol uses flags.name as a cached
+// service selector, not as an explicit Foundry agent name; clear it when no
+// deployed/brownfield name was resolved so invoke returns deploy-first guidance.
+// With an explicit protocol, a user-provided name remains an intentional direct
+// target even when it also happens to match an azure.yaml service key.
+func remoteAgentNameFromService(
+	currentName string,
+	info *AgentServiceInfo,
+	protocolExplicit bool,
+) string {
+	if info != nil && info.AgentName != "" {
+		return info.AgentName
+	}
+	if !protocolExplicit {
+		return ""
+	}
+	return currentName
+}
+
 func unresolvedRemoteAgentNameError(serviceName string) error {
 	if serviceName != "" {
 		return exterrors.Dependency(
@@ -907,9 +927,7 @@ func (a *InvokeAction) resolveRemoteContext(ctx context.Context) (*remoteContext
 		ctx, azdClient, rc.name, a.noPrompt, withBrownfieldInlineAgentName(),
 	); err == nil {
 		rc.serviceName = info.ServiceName
-		if info.AgentName != "" {
-			rc.name = info.AgentName
-		}
+		rc.name = remoteAgentNameFromService(rc.name, info, a.flags.protocol != "")
 		if info.AgentEndpoint != "" {
 			rc.agentKey = buildRemoteAgentKeyFromEndpoint(info.AgentEndpoint)
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -851,6 +851,21 @@ func (rc *remoteContext) nextStepName() string {
 	return rc.name
 }
 
+func unresolvedRemoteAgentNameError(serviceName string) error {
+	if serviceName != "" {
+		return exterrors.Validation(
+			exterrors.CodeInvalidParameter,
+			fmt.Sprintf("agent service %q does not appear to have been deployed", serviceName),
+			"run `azd deploy` before invoking, or pass an existing Foundry agent name "+
+				"or --agent-endpoint explicitly",
+		)
+	}
+	return fmt.Errorf(
+		"agent name is required; provide as the first argument or " +
+			"define an azure.ai.agent service in azure.yaml",
+	)
+}
+
 // resolveRemoteContext returns the inputs required to invoke a remote agent.
 // In project mode it opens an azd client and reads the environment; in ephemeral
 // mode (--agent-endpoint) it skips both. Auth token acquisition is intentionally
@@ -899,10 +914,7 @@ func (a *InvokeAction) resolveRemoteContext(ctx context.Context) (*remoteContext
 	}
 	if rc.name == "" {
 		azdClient.Close()
-		return nil, fmt.Errorf(
-			"agent name is required; provide as the first argument or " +
-				"define an azure.ai.agent service in azure.yaml",
-		)
+		return nil, unresolvedRemoteAgentNameError(rc.serviceName)
 	}
 
 	ep, err := resolveAgentEndpoint(ctx, "", "")

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -871,6 +871,18 @@ func remoteAgentNameFromService(
 	return currentName
 }
 
+// remoteAgentServiceResolutionError returns a resolver error in auto-protocol
+// mode because flags.name is only a cached azure.yaml service selector there;
+// continuing would treat that selector as a Foundry agent name. With an
+// explicit protocol, resolver failure is intentionally ignored so a
+// user-provided direct agent name can work without an azd project service.
+func remoteAgentServiceResolutionError(resolveErr error, protocolExplicit bool) error {
+	if resolveErr == nil || protocolExplicit {
+		return nil
+	}
+	return fmt.Errorf("failed to resolve agent service for remote invoke: %w", resolveErr)
+}
+
 func unresolvedRemoteAgentNameError(serviceName string) error {
 	if serviceName != "" {
 		return exterrors.Dependency(
@@ -923,14 +935,18 @@ func (a *InvokeAction) resolveRemoteContext(ctx context.Context) (*remoteContext
 	// so post-success next-step suggestions emit the service name; show
 	// keys on s.Name in azure.yaml and would 404 on the deployed Foundry
 	// name in the divergent case.
-	if info, err := resolveAgentServiceFromProject(
+	info, serviceErr := resolveAgentServiceFromProject(
 		ctx, azdClient, rc.name, a.noPrompt, withBrownfieldInlineAgentName(),
-	); err == nil {
+	)
+	if serviceErr == nil {
 		rc.serviceName = info.ServiceName
 		rc.name = remoteAgentNameFromService(rc.name, info, a.flags.protocol != "")
 		if info.AgentEndpoint != "" {
 			rc.agentKey = buildRemoteAgentKeyFromEndpoint(info.AgentEndpoint)
 		}
+	} else if err := remoteAgentServiceResolutionError(serviceErr, a.flags.protocol != ""); err != nil {
+		azdClient.Close()
+		return nil, err
 	}
 	if rc.name == "" {
 		azdClient.Close()

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -853,8 +853,8 @@ func (rc *remoteContext) nextStepName() string {
 
 func unresolvedRemoteAgentNameError(serviceName string) error {
 	if serviceName != "" {
-		return exterrors.Validation(
-			exterrors.CodeInvalidParameter,
+		return exterrors.Dependency(
+			exterrors.CodeMissingAgentEnvVars,
 			fmt.Sprintf("agent service %q does not appear to have been deployed", serviceName),
 			"run `azd deploy` before invoking, or pass an existing Foundry agent name "+
 				"or --agent-endpoint explicitly",

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke.go
@@ -66,10 +66,11 @@ const maxInvokeVersionLength = 128
 var createInvokeVersionSession = createInvokeVersionSessionImpl
 
 type InvokeAction struct {
-	flags         *invokeFlags
-	noPrompt      bool
-	endpoint      *parsedAgentEndpoint
-	clientHeaders http.Header
+	flags               *invokeFlags
+	noPrompt            bool
+	endpoint            *parsedAgentEndpoint
+	clientHeaders       http.Header
+	protocolServiceName string
 }
 
 func newInvokeCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
@@ -528,10 +529,9 @@ func (a *InvokeAction) emitInvokeFailureNextStep(mode nextstep.InvokeMode, agent
 // resolveProtocol returns the protocol to use for this invocation.
 // The explicit --protocol flag takes priority; otherwise the protocol
 // is auto-detected from agent.yaml (local or remote).
-// When the protocol is auto-detected and the agent name was not already
-// set, the resolved service name is cached in a.flags.name so that
-// downstream calls (resolveRemoteContext, resolveLocalAgentKey) do an
-// exact lookup instead of prompting the user a second time.
+// When the protocol is auto-detected without an explicit agent name, the
+// resolved service name is cached separately so downstream calls do an exact
+// lookup without confusing the service selector for a Foundry agent name.
 func (a *InvokeAction) resolveProtocol(
 	ctx context.Context,
 ) (agent_api.AgentProtocol, error) {
@@ -554,10 +554,17 @@ func (a *InvokeAction) resolveProtocol(
 
 	// Cache the resolved service name so downstream calls avoid re-prompting.
 	if a.flags.name == "" && serviceName != "" {
-		a.flags.name = serviceName
+		a.protocolServiceName = serviceName
 	}
 
 	return protocol, nil
+}
+
+func (a *InvokeAction) serviceNameSelector() string {
+	if a.protocolServiceName != "" {
+		return a.protocolServiceName
+	}
+	return a.flags.name
 }
 
 func (a *InvokeAction) httpTimeout() time.Duration {
@@ -700,7 +707,7 @@ func (a *InvokeAction) responsesLocal(ctx context.Context) error {
 		defer azdClient.Close()
 	}
 
-	agentKey := resolveLocalAgentKey(ctx, azdClient, a.flags.name, a.noPrompt)
+	agentKey := resolveLocalAgentKey(ctx, azdClient, a.serviceNameSelector(), a.noPrompt)
 
 	// Resolve local session and conversation IDs (always generated locally).
 	var sid, convID string
@@ -852,32 +859,29 @@ func (rc *remoteContext) nextStepName() string {
 }
 
 // remoteAgentNameFromService applies the project-service resolution result to
-// the invoke target name. An auto-detected protocol uses flags.name as a cached
-// service selector, not as an explicit Foundry agent name; clear it when no
-// deployed/brownfield name was resolved so invoke returns deploy-first guidance.
-// With an explicit protocol, a user-provided name remains an intentional direct
-// target even when it also happens to match an azure.yaml service key.
+// the invoke target name. A protocol-selected service is not a Foundry agent
+// name, so it must not survive when no deployed/brownfield name was resolved.
+// A positional name remains an intentional direct target whether the protocol
+// was explicit or auto-detected.
 func remoteAgentNameFromService(
 	currentName string,
 	info *AgentServiceInfo,
-	protocolExplicit bool,
+	protocolServiceSelected bool,
 ) string {
 	if info != nil && info.AgentName != "" {
 		return info.AgentName
 	}
-	if !protocolExplicit {
+	if protocolServiceSelected {
 		return ""
 	}
 	return currentName
 }
 
-// remoteAgentServiceResolutionError returns a resolver error in auto-protocol
-// mode because flags.name is only a cached azure.yaml service selector there;
-// continuing would treat that selector as a Foundry agent name. With an
-// explicit protocol, resolver failure is intentionally ignored so a
-// user-provided direct agent name can work without an azd project service.
-func remoteAgentServiceResolutionError(resolveErr error, protocolExplicit bool) error {
-	if resolveErr == nil || protocolExplicit {
+// remoteAgentServiceResolutionError returns resolver failures unless the user
+// supplied an intentional direct agent name. Protocol selection alone is not
+// enough to ignore a project lookup failure when no target name was provided.
+func remoteAgentServiceResolutionError(resolveErr error, directNameProvided bool) error {
+	if resolveErr == nil || directNameProvided {
 		return nil
 	}
 	return fmt.Errorf("failed to resolve agent service for remote invoke: %w", resolveErr)
@@ -900,10 +904,9 @@ func unresolvedRemoteAgentNameError(serviceName string) error {
 
 // resolveRemoteContext returns the inputs required to invoke a remote agent.
 // In project mode it opens an azd client and reads the environment; in ephemeral
-// mode (--agent-endpoint) it skips both. Auth token acquisition is intentionally
-// deferred to acquireBearerToken so callers can validate the request body first
-// and avoid unnecessary token round-trips on invalid input. Callers must close
-// rc.azdClient when non-nil.
+// mode (--agent-endpoint) it skips both. Brownfield resolution may authenticate
+// to verify that the inline agent exists, so remote callers validate the request
+// body before calling this method. Callers must close rc.azdClient when non-nil.
 func (a *InvokeAction) resolveRemoteContext(ctx context.Context) (*remoteContext, error) {
 	rc := &remoteContext{apiVersion: DefaultAgentAPIVersion, version: a.flags.version}
 
@@ -936,15 +939,22 @@ func (a *InvokeAction) resolveRemoteContext(ctx context.Context) (*remoteContext
 	// keys on s.Name in azure.yaml and would 404 on the deployed Foundry
 	// name in the divergent case.
 	info, serviceErr := resolveAgentServiceFromProject(
-		ctx, azdClient, rc.name, a.noPrompt, withBrownfieldInlineAgentName(),
+		ctx,
+		azdClient,
+		a.serviceNameSelector(),
+		a.noPrompt,
+		withBrownfieldInlineAgentName(),
 	)
 	if serviceErr == nil {
 		rc.serviceName = info.ServiceName
-		rc.name = remoteAgentNameFromService(rc.name, info, a.flags.protocol != "")
+		rc.name = remoteAgentNameFromService(rc.name, info, a.protocolServiceName != "")
 		if info.AgentEndpoint != "" {
 			rc.agentKey = buildRemoteAgentKeyFromEndpoint(info.AgentEndpoint)
 		}
-	} else if err := remoteAgentServiceResolutionError(serviceErr, a.flags.protocol != ""); err != nil {
+		if info.ProjectEndpoint != "" {
+			rc.projectEndpoint = info.ProjectEndpoint
+		}
+	} else if err := remoteAgentServiceResolutionError(serviceErr, a.flags.name != ""); err != nil {
 		azdClient.Close()
 		return nil, err
 	}
@@ -953,13 +963,15 @@ func (a *InvokeAction) resolveRemoteContext(ctx context.Context) (*remoteContext
 		return nil, unresolvedRemoteAgentNameError(rc.serviceName)
 	}
 
-	ep, err := resolveAgentEndpoint(ctx, "", "")
-	if err != nil {
-		azdClient.Close()
-		return nil, err
+	if rc.projectEndpoint == "" {
+		ep, err := resolveAgentEndpoint(ctx, "", "")
+		if err != nil {
+			azdClient.Close()
+			return nil, err
+		}
+		rc.projectEndpoint = ep
 	}
-	rc.projectEndpoint = ep
-	if rc.version != "" {
+	if rc.agentKey == "" {
 		rc.agentKey = buildAgentKey(rc.projectEndpoint, rc.name, rc.version, false)
 	}
 	return rc, nil
@@ -1096,17 +1108,17 @@ func ephemeralAuthError(ephemeral bool, err error) error {
 }
 
 func (a *InvokeAction) responsesRemote(ctx context.Context) error {
+	body, bodyLabel, err := a.resolveBody()
+	if err != nil {
+		return err
+	}
+
 	rc, err := a.resolveRemoteContext(ctx)
 	if err != nil {
 		return err
 	}
 	if rc.azdClient != nil {
 		defer rc.azdClient.Close()
-	}
-
-	body, bodyLabel, err := a.resolveBody()
-	if err != nil {
-		return err
 	}
 
 	agentKey := rc.agentKey
@@ -1284,7 +1296,7 @@ func (a *InvokeAction) invocationsLocal(ctx context.Context) error {
 	// Resolving twice would re-prompt the user on multi-agent projects
 	// AND risk picking different services for the two values (silent
 	// state corruption: session under A, cache under B).
-	agentName := resolveLocalAgentName(ctx, azdClient, a.flags.name, a.noPrompt)
+	agentName := resolveLocalAgentName(ctx, azdClient, a.serviceNameSelector(), a.noPrompt)
 	agentKey := buildLocalAgentKey(DefaultPort, agentName, "", resolveProjectPath(ctx, azdClient))
 
 	// Resolve local session ID (generated locally, not server-assigned).
@@ -1376,6 +1388,11 @@ func (a *InvokeAction) invocationsLocal(ctx context.Context) error {
 // invocationsRemote sends the user's message to Foundry using
 // the invocations protocol (POST /agents/{name}/endpoint/protocols/invocations).
 func (a *InvokeAction) invocationsRemote(ctx context.Context) error {
+	body, bodyLabel, err := a.resolveBody()
+	if err != nil {
+		return err
+	}
+
 	rc, err := a.resolveRemoteContext(ctx)
 	if err != nil {
 		return err
@@ -1393,11 +1410,6 @@ func (a *InvokeAction) invocationsRemote(ctx context.Context) error {
 		fmt.Fprintln(os.Stderr,
 			"note: --new-conversation has no effect for the invocations protocol "+
 				"(memory is bound to the session; use --new-session to reset).")
-	}
-
-	body, bodyLabel, err := a.resolveBody()
-	if err != nil {
-		return err
 	}
 
 	// Acquire the bearer token after body validation so a local input error

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_a2a.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_a2a.go
@@ -112,6 +112,11 @@ func applyA2ARequestHeaders(req *http.Request, bearerToken string, identity *use
 // message/send request. Memory is bound to the agent session, like the
 // invocations protocol.
 func (a *InvokeAction) a2aRemote(ctx context.Context) error {
+	body, bodyLabel, err := a.buildA2ARequestBody()
+	if err != nil {
+		return err
+	}
+
 	rc, err := a.resolveRemoteContext(ctx)
 	if err != nil {
 		return err
@@ -129,11 +134,6 @@ func (a *InvokeAction) a2aRemote(ctx context.Context) error {
 		fmt.Fprintln(os.Stderr,
 			"note: --new-conversation has no effect for the a2a protocol "+
 				"(memory is bound to the session; use --new-session to reset).")
-	}
-
-	body, bodyLabel, err := a.buildA2ARequestBody()
-	if err != nil {
-		return err
 	}
 
 	// Acquire the bearer token after body validation so a local input error

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
@@ -538,6 +538,32 @@ func TestRemoteAgentNameFromService(t *testing.T) {
 	}
 }
 
+func TestRemoteAgentServiceResolutionError(t *testing.T) {
+	t.Parallel()
+
+	resolveErr := errors.New("project service unavailable")
+
+	t.Run("auto protocol surfaces resolver failure", func(t *testing.T) {
+		t.Parallel()
+
+		err := remoteAgentServiceResolutionError(resolveErr, false)
+		if err == nil {
+			t.Fatal("expected resolver error, got nil")
+		}
+		if !errors.Is(err, resolveErr) {
+			t.Errorf("error %q does not wrap resolver error", err)
+		}
+	})
+
+	t.Run("explicit protocol preserves direct-name fallback", func(t *testing.T) {
+		t.Parallel()
+
+		if err := remoteAgentServiceResolutionError(resolveErr, true); err != nil {
+			t.Errorf("explicit protocol should ignore project resolver failure, got %v", err)
+		}
+	})
+}
+
 func TestUserIdentityFlags_SessionRequestOptions(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -453,6 +454,35 @@ func TestInvokeLocalWithNamedAgent(t *testing.T) {
 	if strings.Contains(err.Error(), "cannot use --local with a named agent") {
 		t.Fatalf("unexpected validation rejection: %v", err)
 	}
+}
+
+func TestUnresolvedRemoteAgentNameError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resolved service has not been deployed", func(t *testing.T) {
+		t.Parallel()
+
+		err := unresolvedRemoteAgentNameError("my-agent-service")
+		localErr, ok := errors.AsType[*azdext.LocalError](err)
+		if !ok {
+			t.Fatalf("error type = %T, want *azdext.LocalError", err)
+		}
+		if !strings.Contains(localErr.Message, "does not appear to have been deployed") {
+			t.Errorf("message = %q, want deploy-state guidance", localErr.Message)
+		}
+		if !strings.Contains(localErr.Suggestion, "azd deploy") {
+			t.Errorf("suggestion = %q, want azd deploy guidance", localErr.Suggestion)
+		}
+	})
+
+	t.Run("no service resolved", func(t *testing.T) {
+		t.Parallel()
+
+		err := unresolvedRemoteAgentNameError("")
+		if !strings.Contains(err.Error(), "agent name is required") {
+			t.Errorf("error = %q, want missing-name guidance", err)
+		}
+	})
 }
 
 func TestUserIdentityFlags_SessionRequestOptions(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"azureaiagent/internal/exterrors"
 	"azureaiagent/internal/pkg/agents/agent_api"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -472,6 +473,12 @@ func TestUnresolvedRemoteAgentNameError(t *testing.T) {
 		}
 		if !strings.Contains(localErr.Suggestion, "azd deploy") {
 			t.Errorf("suggestion = %q, want azd deploy guidance", localErr.Suggestion)
+		}
+		if localErr.Code != exterrors.CodeMissingAgentEnvVars {
+			t.Errorf("code = %q, want %q", localErr.Code, exterrors.CodeMissingAgentEnvVars)
+		}
+		if localErr.Category != azdext.LocalErrorCategoryDependency {
+			t.Errorf("category = %q, want %q", localErr.Category, azdext.LocalErrorCategoryDependency)
 		}
 	})
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
@@ -496,24 +496,24 @@ func TestRemoteAgentNameFromService(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name             string
-		currentName      string
-		info             *AgentServiceInfo
-		protocolExplicit bool
-		want             string
+		name                    string
+		currentName             string
+		info                    *AgentServiceInfo
+		protocolServiceSelected bool
+		want                    string
 	}{
 		{
-			name:        "auto protocol clears cached service key without deploy output",
-			currentName: "service-key",
-			info:        &AgentServiceInfo{ServiceName: "service-key"},
-			want:        "",
+			name:                    "auto protocol clears cached service key without deploy output",
+			currentName:             "service-key",
+			info:                    &AgentServiceInfo{ServiceName: "service-key"},
+			protocolServiceSelected: true,
+			want:                    "",
 		},
 		{
-			name:             "explicit protocol preserves intentional direct name",
-			currentName:      "existing-agent",
-			info:             &AgentServiceInfo{ServiceName: "service-key"},
-			protocolExplicit: true,
-			want:             "existing-agent",
+			name:        "positional name survives auto-detected protocol",
+			currentName: "existing-agent",
+			info:        &AgentServiceInfo{ServiceName: "service-key"},
+			want:        "existing-agent",
 		},
 		{
 			name:        "resolved deployed or brownfield name wins",
@@ -530,7 +530,7 @@ func TestRemoteAgentNameFromService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := remoteAgentNameFromService(tt.currentName, tt.info, tt.protocolExplicit)
+			got := remoteAgentNameFromService(tt.currentName, tt.info, tt.protocolServiceSelected)
 			if got != tt.want {
 				t.Errorf("remoteAgentNameFromService() = %q, want %q", got, tt.want)
 			}
@@ -543,7 +543,7 @@ func TestRemoteAgentServiceResolutionError(t *testing.T) {
 
 	resolveErr := errors.New("project service unavailable")
 
-	t.Run("auto protocol surfaces resolver failure", func(t *testing.T) {
+	t.Run("missing direct name surfaces resolver failure", func(t *testing.T) {
 		t.Parallel()
 
 		err := remoteAgentServiceResolutionError(resolveErr, false)
@@ -555,11 +555,40 @@ func TestRemoteAgentServiceResolutionError(t *testing.T) {
 		}
 	})
 
-	t.Run("explicit protocol preserves direct-name fallback", func(t *testing.T) {
+	t.Run("direct name preserves fallback", func(t *testing.T) {
 		t.Parallel()
 
 		if err := remoteAgentServiceResolutionError(resolveErr, true); err != nil {
-			t.Errorf("explicit protocol should ignore project resolver failure, got %v", err)
+			t.Errorf("direct name should ignore project resolver failure, got %v", err)
+		}
+	})
+}
+
+func TestInvokeActionServiceNameSelector(t *testing.T) {
+	t.Parallel()
+
+	t.Run("auto-selected protocol service is kept separate", func(t *testing.T) {
+		t.Parallel()
+
+		action := &InvokeAction{
+			flags:               &invokeFlags{},
+			protocolServiceName: "service-key",
+		}
+
+		if got := action.serviceNameSelector(); got != "service-key" {
+			t.Errorf("serviceNameSelector() = %q, want service-key", got)
+		}
+		if action.flags.name != "" {
+			t.Errorf("flags.name = %q, want empty", action.flags.name)
+		}
+	})
+
+	t.Run("positional name remains the selector without cached service", func(t *testing.T) {
+		t.Parallel()
+
+		action := &InvokeAction{flags: &invokeFlags{name: "existing-agent"}}
+		if got := action.serviceNameSelector(); got != "existing-agent" {
+			t.Errorf("serviceNameSelector() = %q, want existing-agent", got)
 		}
 	})
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/invoke_test.go
@@ -492,6 +492,52 @@ func TestUnresolvedRemoteAgentNameError(t *testing.T) {
 	})
 }
 
+func TestRemoteAgentNameFromService(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		currentName      string
+		info             *AgentServiceInfo
+		protocolExplicit bool
+		want             string
+	}{
+		{
+			name:        "auto protocol clears cached service key without deploy output",
+			currentName: "service-key",
+			info:        &AgentServiceInfo{ServiceName: "service-key"},
+			want:        "",
+		},
+		{
+			name:             "explicit protocol preserves intentional direct name",
+			currentName:      "existing-agent",
+			info:             &AgentServiceInfo{ServiceName: "service-key"},
+			protocolExplicit: true,
+			want:             "existing-agent",
+		},
+		{
+			name:        "resolved deployed or brownfield name wins",
+			currentName: "service-key",
+			info: &AgentServiceInfo{
+				ServiceName: "service-key",
+				AgentName:   "resolved-agent",
+			},
+			want: "resolved-agent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := remoteAgentNameFromService(tt.currentName, tt.info, tt.protocolExplicit)
+			if got != tt.want {
+				t.Errorf("remoteAgentNameFromService() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUserIdentityFlags_SessionRequestOptions(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_test.go
@@ -70,7 +70,7 @@ func TestPostdeployHandler_MissingTelemetryEnv_ReturnsNil(t *testing.T) {
 	}{
 		{
 			name:   "FOUNDRY_PROJECT_ENDPOINT not set",
-			values: nil, // GetValue returns NotFound for every key
+			values: nil, // GetValue returns an empty value for every missing key
 		},
 		{
 			name:   "FOUNDRY_PROJECT_ENDPOINT empty",


### PR DESCRIPTION
## What

Remote `azd ai agent invoke` failed after initializing a unified `azure.yaml` against an existing (brownfield) Foundry project, even though the agent service and inline name were declared.

## Root cause

Project-mode invoke normally gets the deployed agent identity from `AGENT_<SERVICE>_NAME`, which is created by deployment. Brownfield adoption can point `azure.yaml` at an **existing** Foundry project/agent without producing a new deploy output, leaving automatic name resolution empty.

## Fix

The final implementation distinguishes intentional brownfield adoption from an undeployed greenfield service and scopes the behavior to invoke only:

- **Remote invoke only** opts into inline-name resolution when the agent's `uses:` list references an `azure.ai.project` service with a non-empty `endpoint`. This is the explicit brownfield signal.
- Shared resolver callers — including destructive commands such as `delete` — remain env-only and cannot implicitly target an adopted agent.
- `AGENT_<SERVICE>_NAME` remains authoritative whenever deployment output exists.
- The brownfield fallback is used only after the active environment was read successfully and the name key was confirmed absent/empty. Transient/auth/daemon lookup failures do not trigger it.
- Auto protocol detection caches an azure.yaml service key; when no deployed/brownfield name resolves, that cached selector is cleared. If the second service resolution fails, the error is surfaced rather than treating the cached service key as a Foundry agent name.
- A greenfield service with no deployment output fails with a dependency error (`missing_agent_env_vars`) and guidance to run `azd deploy`.
- Explicit agent-name and `--agent-endpoint` invocation remain unchanged for users intentionally targeting an existing agent without deployment.
- The azure.yaml service key is never used as the implicit agent-name fallback because service and deployed agent names may differ.

This preserves the reported brownfield workflow while preventing greenfield or shared/destructive commands from silently targeting an older live agent with matching name but different code or protocols.

## Tests

- Brownfield `uses:` + project `endpoint` resolves the inline name only through invoke's opt-in resolver option.
- The default shared resolver does not return the brownfield inline name.
- Greenfield project with no endpoint does not resolve the inline name.
- Deployed environment output overrides the inline name.
- Transient env lookup failure does not enable the fallback.
- Auto protocol clears a cached service selector when no target name resolves; explicit protocol preserves an intentional direct name.
- Missing deploy output returns dependency-category `azd deploy` guidance with `CodeMissingAgentEnvVars`.

## Validation

- `go build ./...`
- `go test ./... -count=1` (all extension packages)
- `go vet ./...`
- `gofmt` clean
- `golangci-lint run ./internal/cmd/...` — 0 issues
- `cspell` — 0 issues

No `CHANGELOG.md` entry is included; extension changelog entries are added during the release process.

Fixes #9109
