### PR TITLE
feat(skills): own azure.ai.skill service blocks in azure.yaml

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -41,6 +41,7 @@ var foundryServiceHosts = map[string]struct{}{
 	"azure.ai.project":    {},
 	"azure.ai.connection": {},
 	"azure.ai.toolbox":    {},
+	"azure.ai.skill":      {},
 	"microsoft.foundry":   {},
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
@@ -43,6 +43,16 @@ services:
 			want: true,
 		},
 		{
+			name: "skill-only composed manifest",
+			content: `name: foundry-skills
+services:
+  triage-rules:
+    host: azure.ai.skill
+    instructions: Triage incoming issues.
+`,
+			want: true,
+		},
+		{
 			name: "agent manifest with top-level template",
 			content: `name: my-agent
 template:

--- a/cli/azd/extensions/azure.ai.skills/README.md
+++ b/cli/azd/extensions/azure.ai.skills/README.md
@@ -11,10 +11,12 @@ azd ai skill create <name> [--description "..." --instructions "..."]
 azd ai skill create <name> --file ./SKILL.md
 azd ai skill create <name> --file ./skill.zip
 azd ai skill create <name> --file ./skill-src/
+azd ai skill create <name> --file ./SKILL.md --save-to-azure-yaml
 
 azd ai skill update <name> [--description "..."] [--instructions "..."] [--file ./SKILL.md]
 azd ai skill update <name> --file ./skill.zip
 azd ai skill update <name> --file ./skill-src/
+azd ai skill update <name> --file ./skill-src/ --save-to-azure-yaml
 azd ai skill update <name> --set-default-version <version>
 azd ai skill show <name>
 azd ai skill list [--top N] [--orderby <field>]
@@ -46,6 +48,46 @@ manual zip step.
 
 All commands accept the standard cross-cutting flags: `-p` / `--project-endpoint`,
 `--output table|json`, `--no-prompt`, and `--debug`.
+
+## Composing skills in `azure.yaml`
+
+Pass `--save-to-azure-yaml` to `skill create` or `skill update` to opt the
+skill into the current azd project. The extension adds or updates one service
+keyed by the skill name:
+
+```yaml
+services:
+  triage-rules:
+    host: azure.ai.skill
+    description: Rules for triaging incoming issues
+    instructions: Classify the issue, identify its owner, and recommend next steps.
+
+  support-agent:
+    host: azure.ai.agent
+    uses:
+      - triage-rules
+```
+
+Inline flags and `SKILL.md` inputs are stored as inline `description`,
+`instructions`, and `tools` properties. ZIP and directory inputs are stored as
+a portable `archive` path relative to the azd project:
+
+```yaml
+services:
+  triage-rules:
+    host: azure.ai.skill
+    archive: skills/triage-rules
+```
+
+`azd deploy` and `azd up` reconcile either shape by creating a new immutable
+default skill version. Re-running deploy creates another version. Removing the
+service stops azd managing the skill but does not delete it; use
+`azd ai skill delete` for deletion.
+
+The skill command does not infer which agents consume the skill. Add the skill
+service name to each consuming agent's `uses:` list to declare deployment
+ordering explicitly. Existing `uses:` and unrelated service fields are
+preserved when `--save-to-azure-yaml` updates a skill block.
 
 ## Project endpoint resolution
 

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target.go
@@ -4,12 +4,16 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
+	"azureaiskills/internal/exterrors"
 	"azureaiskills/internal/pkg/skill_api"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -29,12 +33,13 @@ type skillServiceConfig struct {
 	Description  string   `json:"description,omitempty"`
 	Instructions string   `json:"instructions,omitempty"`
 	Tools        []string `json:"tools,omitempty"`
+	Archive      string   `json:"archive,omitempty"`
 }
 
 // skillServiceTarget upserts a Foundry skill declared as an azure.ai.skill
-// service. Deploy creates a new default skill version from the entry's inline
-// instructions; the resource name is the service key. Package and Publish are
-// no-ops because a skill has no build artifact.
+// service. Deploy creates a new default skill version from either inline
+// instructions or an archive reference; the resource name is the service key.
+// Package and Publish are no-ops because a skill has no build artifact.
 type skillServiceTarget struct {
 	azdClient     *azdext.AzdClient
 	serviceConfig *azdext.ServiceConfig
@@ -100,9 +105,9 @@ func (p *skillServiceTarget) Publish(
 }
 
 // Deploy upserts the skill by creating a new default version from the entry's
-// instructions. Re-running deploy creates another immutable version rather than
-// failing. Removing the service from azure.yaml stops azd managing the skill but
-// does not delete it (use `azd ai skill delete`).
+// inline instructions or archive reference. Re-running deploy creates another
+// immutable version rather than failing. Removing the service from azure.yaml
+// stops azd managing the skill but does not delete it (use `azd ai skill delete`).
 func (p *skillServiceTarget) Deploy(
 	ctx context.Context,
 	serviceConfig *azdext.ServiceConfig,
@@ -114,12 +119,23 @@ func (p *skillServiceTarget) Deploy(
 	if err != nil {
 		return nil, err
 	}
-	instructions, err := resolveSkillInstructions(serviceConfig, cfg.Instructions)
-	if err != nil {
-		return nil, err
+	hasInline := cfg.Description != "" || cfg.Instructions != "" || len(cfg.Tools) > 0
+	if cfg.Archive != "" && hasInline {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidParameter,
+			fmt.Sprintf(
+				"skill service %q cannot combine archive with description, instructions, or tools",
+				serviceConfig.GetName(),
+			),
+			"configure either archive, or inline description/instructions/tools, but not both",
+		)
 	}
-	if instructions == "" {
-		return nil, fmt.Errorf("skill service %q requires instructions", serviceConfig.GetName())
+	if cfg.Archive == "" && cfg.Instructions == "" {
+		return nil, exterrors.Validation(
+			exterrors.CodeMissingRequiredField,
+			fmt.Sprintf("skill service %q requires instructions or archive", serviceConfig.GetName()),
+			"set instructions to inline text/a .md or .txt path, or set archive to a .zip/directory path",
+		)
 	}
 
 	if progress != nil {
@@ -131,19 +147,45 @@ func (p *skillServiceTarget) Deploy(
 		return nil, err
 	}
 
-	if _, err := skillCtx.client.CreateVersionInline(
-		ctx,
-		serviceConfig.GetName(),
-		skill_api.CreateVersionRequest{
-			InlineContent: &skill_api.SkillInlineContent{
-				Description:  cfg.Description,
-				Instructions: instructions,
-				AllowedTools: cfg.Tools,
+	if cfg.Archive != "" {
+		archivePath, err := resolveSkillArchivePath(serviceConfig, cfg.Archive)
+		if err != nil {
+			return nil, err
+		}
+		archive, err := prepareSkillArchive(archivePath)
+		if err != nil {
+			return nil, err
+		}
+		defer archive.Reader.Close()
+
+		if _, err := skillCtx.client.CreateVersionFromZip(
+			ctx,
+			serviceConfig.GetName(),
+			archive.Name,
+			archive.Reader,
+			true,
+		); err != nil {
+			return nil, exterrors.ServiceFromAzure(err, exterrors.OpReconcileSkill)
+		}
+	} else {
+		instructions, err := resolveSkillInstructions(serviceConfig, cfg.Instructions)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := skillCtx.client.CreateVersionInline(
+			ctx,
+			serviceConfig.GetName(),
+			skill_api.CreateVersionRequest{
+				InlineContent: &skill_api.SkillInlineContent{
+					Description:  cfg.Description,
+					Instructions: instructions,
+					AllowedTools: cfg.Tools,
+				},
+				Default: true,
 			},
-			Default: true,
-		},
-	); err != nil {
-		return nil, fmt.Errorf("upserting skill %q: %w", serviceConfig.GetName(), err)
+		); err != nil {
+			return nil, exterrors.ServiceFromAzure(err, exterrors.OpReconcileSkill)
+		}
 	}
 
 	return &azdext.ServiceDeployResult{}, nil
@@ -199,6 +241,87 @@ func resolveSkillInstructions(svc *azdext.ServiceConfig, instructions string) (s
 	return string(data), nil
 }
 
+type preparedSkillArchive struct {
+	Name   string
+	Reader io.ReadCloser
+}
+
+func resolveSkillArchivePath(svc *azdext.ServiceConfig, archive string) (string, error) {
+	path := strings.TrimSpace(archive)
+	if filepath.IsAbs(path) {
+		return path, nil
+	}
+	if hasParentTraversal(path) {
+		return "", exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf("skill archive path %q must not contain '..' or escape the service directory", archive),
+			"move the archive inside the service directory and use a relative path without '..'",
+		)
+	}
+	baseDir := svc.GetRelativePath()
+	if baseDir == "" {
+		baseDir = "."
+	}
+	return filepath.Join(baseDir, path), nil
+}
+
+func prepareSkillArchive(path string) (*preparedSkillArchive, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf("cannot inspect skill archive %s: %s", path, err),
+			"verify the archive or directory exists and is readable",
+		)
+	}
+
+	if info.IsDir() {
+		if _, found, err := skill_api.LocateSkillMdInDir(path); err != nil {
+			return nil, exterrors.Validation(
+				exterrors.CodeInvalidSkillFile,
+				fmt.Sprintf("cannot inspect SKILL.md in %s: %s", path, err),
+				"verify the directory is readable and SKILL.md is a regular file",
+			)
+		} else if !found {
+			return nil, exterrors.Validation(
+				exterrors.CodeInvalidSkillFile,
+				fmt.Sprintf("skill archive directory %s does not contain SKILL.md at its root", path),
+				"add SKILL.md to the directory root or reference a .zip archive",
+			)
+		}
+
+		data, err := skill_api.ArchiveDirectory(path, skill_api.ArchiveOptions{})
+		if err != nil {
+			return nil, classifyArchiveDirectoryError(err, path)
+		}
+		name := filepath.Base(filepath.Clean(path)) + ".zip"
+		return &preparedSkillArchive{
+			Name:   name,
+			Reader: io.NopCloser(bytes.NewReader(data)),
+		}, nil
+	}
+
+	if !strings.EqualFold(filepath.Ext(path), ".zip") {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf("skill archive %s must be a .zip file or a directory containing SKILL.md", path),
+			"set archive to a .zip file or a directory containing SKILL.md",
+		)
+	}
+	file, err := os.Open(path) //nolint:gosec // user-authored azure.yaml path opened on user's behalf
+	if err != nil {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf("cannot open skill archive %s: %s", path, err),
+			"verify the archive is readable",
+		)
+	}
+	return &preparedSkillArchive{
+		Name:   filepath.Base(path),
+		Reader: file,
+	}, nil
+}
+
 // hasParentTraversal reports whether a relative path contains a ".." segment
 // that could escape its base directory, treating both '/' and '\' as separators.
 func hasParentTraversal(p string) bool {
@@ -211,7 +334,11 @@ func hasParentTraversal(p string) bool {
 }
 
 func isInstructionFilePath(instructions string) bool {
-	switch strings.ToLower(filepath.Ext(strings.TrimSpace(instructions))) {
+	value := strings.TrimSpace(instructions)
+	if strings.ContainsAny(value, "\r\n") {
+		return false
+	}
+	switch strings.ToLower(filepath.Ext(value)) {
 	case ".md", ".txt":
 		return true
 	default:

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target.go
@@ -148,7 +148,11 @@ func (p *skillServiceTarget) Deploy(
 	}
 
 	if cfg.Archive != "" {
-		archivePath, err := resolveSkillArchivePath(serviceConfig, cfg.Archive)
+		projectResp, err := p.azdClient.Project().Get(ctx, &azdext.EmptyRequest{})
+		if err != nil {
+			return nil, fmt.Errorf("resolving azd project path for skill archive: %w", err)
+		}
+		archivePath, err := resolveSkillArchivePath(projectResp.GetProject().GetPath(), serviceConfig, cfg.Archive)
 		if err != nil {
 			return nil, err
 		}
@@ -246,7 +250,7 @@ type preparedSkillArchive struct {
 	Reader io.ReadCloser
 }
 
-func resolveSkillArchivePath(svc *azdext.ServiceConfig, archive string) (string, error) {
+func resolveSkillArchivePath(projectPath string, svc *azdext.ServiceConfig, archive string) (string, error) {
 	path := strings.TrimSpace(archive)
 	if filepath.IsAbs(path) {
 		return path, nil
@@ -262,7 +266,7 @@ func resolveSkillArchivePath(svc *azdext.ServiceConfig, archive string) (string,
 	if baseDir == "" {
 		baseDir = "."
 	}
-	return filepath.Join(baseDir, path), nil
+	return filepath.Join(projectPath, baseDir, path), nil
 }
 
 func prepareSkillArchive(path string) (*preparedSkillArchive, error) {

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target_test.go
@@ -132,12 +132,28 @@ func TestResolveSkillArchivePath_PathTraversal(t *testing.T) {
 
 	for _, archive := range []string{"../skill.zip", "../../secret", "sub/../../escape.zip"} {
 		_, err := resolveSkillArchivePath(
+			t.TempDir(),
 			&azdext.ServiceConfig{Name: "traversal", RelativePath: t.TempDir()},
 			archive,
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "must not contain '..'")
 	}
+}
+
+func TestResolveSkillArchivePath_FromNestedWorkingDirectory(t *testing.T) {
+	projectDir := t.TempDir()
+	nestedDir := filepath.Join(projectDir, "scripts", "nested")
+	require.NoError(t, os.MkdirAll(nestedDir, 0750))
+	t.Chdir(nestedDir)
+
+	path, err := resolveSkillArchivePath(
+		projectDir,
+		&azdext.ServiceConfig{Name: "code-review", RelativePath: "skills"},
+		"code-review",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(projectDir, "skills", "code-review"), path)
 }
 
 func TestPrepareSkillArchive_Directory(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -62,12 +63,38 @@ func TestParseSkillServiceConfig_Empty(t *testing.T) {
 	assert.Empty(t, cfg.Instructions)
 }
 
+func TestParseSkillServiceConfig_Archive(t *testing.T) {
+	t.Parallel()
+
+	props, err := structpb.NewStruct(map[string]any{
+		"archive": "skills/code-review",
+	})
+	require.NoError(t, err)
+
+	cfg, err := parseSkillServiceConfig(&azdext.ServiceConfig{
+		Name:                 "code-review",
+		Host:                 aiSkillHost,
+		AdditionalProperties: props,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "skills/code-review", cfg.Archive)
+}
+
 func TestResolveSkillInstructions_Inline(t *testing.T) {
 	t.Parallel()
 
 	got, err := resolveSkillInstructions(&azdext.ServiceConfig{Name: "inline"}, "Review code for correctness.")
 	require.NoError(t, err)
 	assert.Equal(t, "Review code for correctness.", got)
+}
+
+func TestResolveSkillInstructions_MultilineBodyEndingInFileExtensionIsInline(t *testing.T) {
+	t.Parallel()
+
+	instructions := "# Rules\nSee CONTRIBUTING.md"
+	got, err := resolveSkillInstructions(&azdext.ServiceConfig{Name: "inline"}, instructions)
+	require.NoError(t, err)
+	assert.Equal(t, instructions, got)
 }
 
 func TestResolveSkillInstructions_FilePath(t *testing.T) {
@@ -98,4 +125,57 @@ func TestResolveSkillInstructions_PathTraversal(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "must not contain '..'")
 	}
+}
+
+func TestResolveSkillArchivePath_PathTraversal(t *testing.T) {
+	t.Parallel()
+
+	for _, archive := range []string{"../skill.zip", "../../secret", "sub/../../escape.zip"} {
+		_, err := resolveSkillArchivePath(
+			&azdext.ServiceConfig{Name: "traversal", RelativePath: t.TempDir()},
+			archive,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must not contain '..'")
+	}
+}
+
+func TestPrepareSkillArchive_Directory(t *testing.T) {
+	t.Parallel()
+
+	dir := writeSkillDir(t, "code-review")
+	archive, err := prepareSkillArchive(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = archive.Reader.Close() })
+
+	assert.Equal(t, filepath.Base(dir)+".zip", archive.Name)
+	data, err := io.ReadAll(archive.Reader)
+	require.NoError(t, err)
+	assert.NotEmpty(t, data)
+}
+
+func TestPrepareSkillArchive_Zip(t *testing.T) {
+	t.Parallel()
+
+	path := writeZipWithSkillMd(t, "code-review")
+	archive, err := prepareSkillArchive(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = archive.Reader.Close() })
+
+	assert.Equal(t, filepath.Base(path), archive.Name)
+	data, err := io.ReadAll(archive.Reader)
+	require.NoError(t, err)
+	assert.NotEmpty(t, data)
+}
+
+func TestPrepareSkillArchive_RejectsUnsupportedFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "SKILL.md")
+	require.NoError(t, os.WriteFile(path, []byte("instructions"), 0600))
+
+	archive, err := prepareSkillArchive(path)
+	require.Error(t, err)
+	assert.Nil(t, archive)
+	assert.Contains(t, err.Error(), ".zip")
 }

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create.go
@@ -26,6 +26,7 @@ type createFlags struct {
 	instructions    string
 	file            string
 	force           bool
+	saveToAzureYaml bool
 	noPrompt        bool
 	output          string
 	projectEndpoint string
@@ -35,6 +36,21 @@ type createFlags struct {
 }
 
 type createAction struct{ flags *createFlags }
+
+func (a *createAction) saveService(
+	ctx context.Context,
+	cfg skillServiceConfig,
+	archiveSource string,
+) error {
+	if !a.flags.saveToAzureYaml {
+		return nil
+	}
+	return saveSkillServiceToProject(ctx, skillServiceDeclaration{
+		Name:          a.flags.name,
+		Config:        cfg,
+		ArchiveSource: archiveSource,
+	})
+}
 
 func (a *createAction) Run(ctx context.Context) error {
 	if err := validateSkillName(a.flags.name); err != nil {
@@ -124,6 +140,12 @@ func (a *createAction) runInline(ctx context.Context, client *skill_api.Client) 
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateSkill)
 	}
+	if err := a.saveService(ctx, skillServiceConfig{
+		Description:  a.flags.description,
+		Instructions: a.flags.instructions,
+	}, ""); err != nil {
+		return err
+	}
 	return a.printCreateResult(ctx, client, version)
 }
 
@@ -162,6 +184,13 @@ func (a *createAction) runFileMd(ctx context.Context, client *skill_api.Client) 
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateSkill)
 	}
+	if err := a.saveService(ctx, skillServiceConfig{
+		Description:  parsed.Description,
+		Instructions: parsed.Instructions,
+		Tools:        parsed.AllowedTools,
+	}, ""); err != nil {
+		return err
+	}
 	return a.printCreateResult(ctx, client, version)
 }
 
@@ -196,6 +225,9 @@ func (a *createAction) runFilePackage(ctx context.Context, client *skill_api.Cli
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateSkill)
 	}
+	if err := a.saveService(ctx, skillServiceConfig{}, a.flags.file); err != nil {
+		return err
+	}
 	return a.printCreateResult(ctx, client, version)
 }
 
@@ -228,6 +260,9 @@ func (a *createAction) runFileDirectory(ctx context.Context, client *skill_api.C
 	version, err := client.CreateVersionFromZip(ctx, a.flags.name, archiveName, bytes.NewReader(data), true)
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateSkill)
+	}
+	if err := a.saveService(ctx, skillServiceConfig{}, a.flags.file); err != nil {
+		return err
 	}
 	return a.printCreateResult(ctx, client, version)
 }
@@ -516,9 +551,15 @@ round-trip works without a manual zip step.
 
 Skills are versioned. ` + "`create`" + ` creates a new skill (if it does not exist)
 and uploads its first version as the default. Pass --force to delete an existing
-skill of the same name before creating.`,
+skill of the same name before creating.
+
+Pass --save-to-azure-yaml to add or update a host: azure.ai.skill service in
+the current azd project's azure.yaml. Inline and SKILL.md inputs are saved as
+inline service properties; ZIP and directory inputs are saved as portable
+archive references for azd deploy/up to reconcile.`,
 		Example: `  azd ai skill create greet-user --description "Welcomes a new user" --instructions "Greet ..."
   azd ai skill create greet-user --file ./SKILL.md
+  azd ai skill create greet-user --file ./SKILL.md --save-to-azure-yaml
   azd ai skill create greet-user --file ./skill.zip --force
   azd ai skill create greet-user --file ./skill-src/ --force`,
 		Args: cobra.ExactArgs(1),
@@ -538,6 +579,12 @@ skill of the same name before creating.`,
 	cmd.Flags().StringVar(&flags.file, "file", "",
 		"Path to SKILL.md (.md), a ZIP package (.zip), or a directory containing SKILL.md at its root")
 	cmd.Flags().BoolVar(&flags.force, "force", false, "Delete an existing skill of the same name before creating")
+	cmd.Flags().BoolVar(
+		&flags.saveToAzureYaml,
+		"save-to-azure-yaml",
+		false,
+		"Add or update this skill as a host: azure.ai.skill service in the current azure.yaml",
+	)
 	azdext.RegisterFlagOptions(cmd, azdext.FlagOptions{
 		Name: "output", AllowedValues: []string{outputJSON, outputTable}, Default: outputJSON,
 	})

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create.go
@@ -37,15 +37,15 @@ type createFlags struct {
 
 type createAction struct{ flags *createFlags }
 
-func (a *createAction) saveService(
+func (a *createAction) prepareService(
 	ctx context.Context,
 	cfg skillServiceConfig,
 	archiveSource string,
-) error {
+) (*preparedSkillService, error) {
 	if !a.flags.saveToAzureYaml {
-		return nil
+		return &preparedSkillService{}, nil
 	}
-	return saveSkillServiceToProject(ctx, skillServiceDeclaration{
+	return prepareSkillServiceToProject(ctx, skillServiceDeclaration{
 		Name:          a.flags.name,
 		Config:        cfg,
 		ArchiveSource: archiveSource,
@@ -91,12 +91,6 @@ func (a *createAction) Run(ctx context.Context) error {
 		}
 	}
 
-	if a.flags.force {
-		if _, delErr := skillCtx.client.DeleteSkill(ctx, a.flags.name); delErr != nil && !isNotFound(delErr) {
-			return exterrors.ServiceFromAzure(delErr, exterrors.OpDeleteSkill)
-		}
-	}
-
 	switch mode {
 	case modeInline:
 		return a.runInline(ctx, skillCtx.client)
@@ -130,6 +124,18 @@ func (a *createAction) runInline(ctx context.Context, client *skill_api.Client) 
 		)
 	}
 
+	service, err := a.prepareService(ctx, skillServiceConfig{
+		Description:  a.flags.description,
+		Instructions: a.flags.instructions,
+	}, "")
+	if err != nil {
+		return err
+	}
+	defer service.Close()
+
+	if err := a.deleteExistingSkill(ctx, client); err != nil {
+		return err
+	}
 	version, err := client.CreateVersionInline(ctx, a.flags.name, skill_api.CreateVersionRequest{
 		InlineContent: &skill_api.SkillInlineContent{
 			Description:  a.flags.description,
@@ -140,10 +146,7 @@ func (a *createAction) runInline(ctx context.Context, client *skill_api.Client) 
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateSkill)
 	}
-	if err := a.saveService(ctx, skillServiceConfig{
-		Description:  a.flags.description,
-		Instructions: a.flags.instructions,
-	}, ""); err != nil {
+	if err := service.Save(ctx); err != nil {
 		return err
 	}
 	return a.printCreateResult(ctx, client, version)
@@ -170,6 +173,19 @@ func (a *createAction) runFileMd(ctx context.Context, client *skill_api.Client) 
 		)
 	}
 
+	service, err := a.prepareService(ctx, skillServiceConfig{
+		Description:  parsed.Description,
+		Instructions: parsed.Instructions,
+		Tools:        parsed.AllowedTools,
+	}, "")
+	if err != nil {
+		return err
+	}
+	defer service.Close()
+
+	if err := a.deleteExistingSkill(ctx, client); err != nil {
+		return err
+	}
 	version, err := client.CreateVersionInline(ctx, a.flags.name, skill_api.CreateVersionRequest{
 		InlineContent: &skill_api.SkillInlineContent{
 			Description:   parsed.Description,
@@ -184,11 +200,7 @@ func (a *createAction) runFileMd(ctx context.Context, client *skill_api.Client) 
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateSkill)
 	}
-	if err := a.saveService(ctx, skillServiceConfig{
-		Description:  parsed.Description,
-		Instructions: parsed.Instructions,
-		Tools:        parsed.AllowedTools,
-	}, ""); err != nil {
+	if err := service.Save(ctx); err != nil {
 		return err
 	}
 	return a.printCreateResult(ctx, client, version)
@@ -221,11 +233,20 @@ func (a *createAction) runFilePackage(ctx context.Context, client *skill_api.Cli
 	}
 	defer f.Close()
 
+	service, err := a.prepareService(ctx, skillServiceConfig{}, a.flags.file)
+	if err != nil {
+		return err
+	}
+	defer service.Close()
+
+	if err := a.deleteExistingSkill(ctx, client); err != nil {
+		return err
+	}
 	version, err := client.CreateVersionFromZip(ctx, a.flags.name, filepath.Base(a.flags.file), f, true)
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateSkill)
 	}
-	if err := a.saveService(ctx, skillServiceConfig{}, a.flags.file); err != nil {
+	if err := service.Save(ctx); err != nil {
 		return err
 	}
 	return a.printCreateResult(ctx, client, version)
@@ -257,14 +278,33 @@ func (a *createAction) runFileDirectory(ctx context.Context, client *skill_api.C
 	}
 
 	archiveName := filepath.Base(filepath.Clean(a.flags.file)) + ".zip"
+	service, err := a.prepareService(ctx, skillServiceConfig{}, a.flags.file)
+	if err != nil {
+		return err
+	}
+	defer service.Close()
+
+	if err := a.deleteExistingSkill(ctx, client); err != nil {
+		return err
+	}
 	version, err := client.CreateVersionFromZip(ctx, a.flags.name, archiveName, bytes.NewReader(data), true)
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpCreateSkill)
 	}
-	if err := a.saveService(ctx, skillServiceConfig{}, a.flags.file); err != nil {
+	if err := service.Save(ctx); err != nil {
 		return err
 	}
 	return a.printCreateResult(ctx, client, version)
+}
+
+func (a *createAction) deleteExistingSkill(ctx context.Context, client *skill_api.Client) error {
+	if !a.flags.force {
+		return nil
+	}
+	if _, err := client.DeleteSkill(ctx, a.flags.name); err != nil && !isNotFound(err) {
+		return exterrors.ServiceFromAzure(err, exterrors.OpDeleteSkill)
+	}
+	return nil
 }
 
 // classifyArchiveDirectoryError wraps ArchiveDirectory's sentinel errors in

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_create_test.go
@@ -38,6 +38,11 @@ func TestCreateAction_NoPromptWithNoInput(t *testing.T) {
 	require.Equal(t, exterrors.CodeMissingRequiredField, le.Code)
 }
 
+func TestCreateCommand_HasSaveToAzureYamlFlag(t *testing.T) {
+	cmd := newCreateCommand(&azdext.ExtensionContext{})
+	require.NotNil(t, cmd.Flags().Lookup("save-to-azure-yaml"))
+}
+
 // TestCreateAction_ConflictingFlagsViRun exercises the full Run path (not just
 // selectCreateMode) so that the validation is also reached via the command
 // entry-point.

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_service_config.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_service_config.go
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"azureaiskills/internal/exterrors"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+var skillServiceOwnedFields = []string{
+	"archive",
+	"description",
+	"instructions",
+	"tools",
+}
+
+type skillServiceDeclaration struct {
+	Name          string
+	Config        skillServiceConfig
+	ArchiveSource string
+}
+
+type skillProjectClient interface {
+	Get(
+		ctx context.Context,
+		in *azdext.EmptyRequest,
+		opts ...grpc.CallOption,
+	) (*azdext.GetProjectResponse, error)
+	AddService(
+		ctx context.Context,
+		in *azdext.AddServiceRequest,
+		opts ...grpc.CallOption,
+	) (*azdext.EmptyResponse, error)
+	GetServiceConfigSection(
+		ctx context.Context,
+		in *azdext.GetServiceConfigSectionRequest,
+		opts ...grpc.CallOption,
+	) (*azdext.GetServiceConfigSectionResponse, error)
+	SetServiceConfigSection(
+		ctx context.Context,
+		in *azdext.SetServiceConfigSectionRequest,
+		opts ...grpc.CallOption,
+	) (*azdext.EmptyResponse, error)
+}
+
+func saveSkillServiceToProject(ctx context.Context, declaration skillServiceDeclaration) error {
+	azdClient, err := azdext.NewAzdClient()
+	if err != nil {
+		return fmt.Errorf("creating azd client to update azure.yaml: %w", err)
+	}
+	defer azdClient.Close()
+
+	return upsertSkillService(ctx, azdClient.Project(), declaration)
+}
+
+// upsertSkillService adds or updates the azure.ai.skill service owned by this
+// extension. Existing non-skill fields (including uses:) are preserved.
+func upsertSkillService(
+	ctx context.Context,
+	projectClient skillProjectClient,
+	declaration skillServiceDeclaration,
+) error {
+	projectResp, err := projectClient.Get(ctx, &azdext.EmptyRequest{})
+	if err != nil {
+		return exterrors.Dependency(
+			exterrors.CodeProjectManifestNotFound,
+			fmt.Sprintf("cannot save skill %q to azure.yaml: %s", declaration.Name, err),
+			"run this command from an azd project containing azure.yaml, or omit --save-to-azure-yaml",
+		)
+	}
+	project := projectResp.GetProject()
+	if project == nil {
+		return exterrors.Dependency(
+			exterrors.CodeProjectManifestNotFound,
+			fmt.Sprintf("cannot save skill %q to azure.yaml: no azd project is loaded", declaration.Name),
+			"run this command from an azd project containing azure.yaml, or omit --save-to-azure-yaml",
+		)
+	}
+
+	cfg := declaration.Config
+	if declaration.ArchiveSource != "" {
+		archive, err := portableSkillArchiveReference(project.GetPath(), declaration.ArchiveSource)
+		if err != nil {
+			return err
+		}
+		cfg.Archive = archive
+	}
+
+	cfgMap, err := skillServiceConfigMap(cfg)
+	if err != nil {
+		return fmt.Errorf("encoding skill service %q: %w", declaration.Name, err)
+	}
+	cfgStruct, err := structpb.NewStruct(cfgMap)
+	if err != nil {
+		return fmt.Errorf("encoding skill service %q: %w", declaration.Name, err)
+	}
+
+	existing, found := project.GetServices()[declaration.Name]
+	if !found {
+		_, err := projectClient.AddService(ctx, &azdext.AddServiceRequest{
+			Service: &azdext.ServiceConfig{
+				Name:                 declaration.Name,
+				Host:                 aiSkillHost,
+				AdditionalProperties: cfgStruct,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("adding azure.ai.skill service %q: %w", declaration.Name, err)
+		}
+		return nil
+	}
+
+	if existing.GetHost() != aiSkillHost {
+		return exterrors.Validation(
+			exterrors.CodeSkillServiceConflict,
+			fmt.Sprintf(
+				"cannot save skill %q to azure.yaml: service %q already uses host %q",
+				declaration.Name,
+				declaration.Name,
+				existing.GetHost(),
+			),
+			"choose a different skill name or rename the existing azure.yaml service",
+		)
+	}
+
+	sectionResp, err := projectClient.GetServiceConfigSection(ctx, &azdext.GetServiceConfigSectionRequest{
+		ServiceName: declaration.Name,
+	})
+	if err != nil {
+		return fmt.Errorf("reading azure.ai.skill service %q from azure.yaml: %w", declaration.Name, err)
+	}
+
+	merged := map[string]any{"host": aiSkillHost}
+	if sectionResp.GetFound() && sectionResp.GetSection() != nil {
+		merged = sectionResp.GetSection().AsMap()
+	}
+	for _, field := range skillServiceOwnedFields {
+		delete(merged, field)
+	}
+	maps.Copy(merged, cfgMap)
+	merged["host"] = aiSkillHost
+
+	section, err := structpb.NewStruct(merged)
+	if err != nil {
+		return fmt.Errorf("encoding updated skill service %q: %w", declaration.Name, err)
+	}
+	if _, err := projectClient.SetServiceConfigSection(ctx, &azdext.SetServiceConfigSectionRequest{
+		ServiceName: declaration.Name,
+		Section:     section,
+	}); err != nil {
+		return fmt.Errorf("updating azure.ai.skill service %q in azure.yaml: %w", declaration.Name, err)
+	}
+
+	return nil
+}
+
+func skillServiceConfigMap(cfg skillServiceConfig) (map[string]any, error) {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+	var values map[string]any
+	if err := json.Unmarshal(data, &values); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+func portableSkillArchiveReference(projectPath, source string) (string, error) {
+	projectRoot := projectPath
+	if projectRoot == "" {
+		var err error
+		projectRoot, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("resolving current project directory: %w", err)
+		}
+	}
+
+	rootAbs, err := filepath.Abs(projectRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolving project path %q: %w", projectRoot, err)
+	}
+	sourceAbs, err := filepath.Abs(source)
+	if err != nil {
+		return "", fmt.Errorf("resolving skill archive path %q: %w", source, err)
+	}
+	relative, err := filepath.Rel(rootAbs, sourceAbs)
+	if err != nil {
+		return "", fmt.Errorf("making skill archive path portable: %w", err)
+	}
+	if filepath.IsAbs(relative) ||
+		relative == ".." ||
+		strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf(
+				"cannot save archive reference %q to azure.yaml because it is outside the azd project at %q",
+				source,
+				projectRoot,
+			),
+			"move the skill archive or directory inside the azd project and retry",
+		)
+	}
+
+	return filepath.ToSlash(relative), nil
+}

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_service_config.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_service_config.go
@@ -55,14 +55,49 @@ type skillProjectClient interface {
 	) (*azdext.EmptyResponse, error)
 }
 
-func saveSkillServiceToProject(ctx context.Context, declaration skillServiceDeclaration) error {
+type preparedSkillService struct {
+	projectClient skillProjectClient
+	addRequest    *azdext.AddServiceRequest
+	setRequest    *azdext.SetServiceConfigSectionRequest
+	close         func()
+}
+
+func prepareSkillServiceToProject(
+	ctx context.Context,
+	declaration skillServiceDeclaration,
+) (*preparedSkillService, error) {
 	azdClient, err := azdext.NewAzdClient()
 	if err != nil {
-		return fmt.Errorf("creating azd client to update azure.yaml: %w", err)
+		return nil, fmt.Errorf("creating azd client to update azure.yaml: %w", err)
 	}
-	defer azdClient.Close()
 
-	return upsertSkillService(ctx, azdClient.Project(), declaration)
+	prepared, err := prepareSkillServiceUpsert(ctx, azdClient.Project(), declaration)
+	if err != nil {
+		azdClient.Close()
+		return nil, err
+	}
+	prepared.close = azdClient.Close
+	return prepared, nil
+}
+
+func (p *preparedSkillService) Save(ctx context.Context) error {
+	switch {
+	case p.addRequest != nil:
+		if _, err := p.projectClient.AddService(ctx, p.addRequest); err != nil {
+			return fmt.Errorf("adding azure.ai.skill service %q: %w", p.addRequest.GetService().GetName(), err)
+		}
+	case p.setRequest != nil:
+		if _, err := p.projectClient.SetServiceConfigSection(ctx, p.setRequest); err != nil {
+			return fmt.Errorf("updating azure.ai.skill service %q in azure.yaml: %w", p.setRequest.GetServiceName(), err)
+		}
+	}
+	return nil
+}
+
+func (p *preparedSkillService) Close() {
+	if p.close != nil {
+		p.close()
+	}
 }
 
 // upsertSkillService adds or updates the azure.ai.skill service owned by this
@@ -72,9 +107,21 @@ func upsertSkillService(
 	projectClient skillProjectClient,
 	declaration skillServiceDeclaration,
 ) error {
+	prepared, err := prepareSkillServiceUpsert(ctx, projectClient, declaration)
+	if err != nil {
+		return err
+	}
+	return prepared.Save(ctx)
+}
+
+func prepareSkillServiceUpsert(
+	ctx context.Context,
+	projectClient skillProjectClient,
+	declaration skillServiceDeclaration,
+) (*preparedSkillService, error) {
 	projectResp, err := projectClient.Get(ctx, &azdext.EmptyRequest{})
 	if err != nil {
-		return exterrors.Dependency(
+		return nil, exterrors.Dependency(
 			exterrors.CodeProjectManifestNotFound,
 			fmt.Sprintf("cannot save skill %q to azure.yaml: %s", declaration.Name, err),
 			"run this command from an azd project containing azure.yaml, or omit --save-to-azure-yaml",
@@ -82,48 +129,16 @@ func upsertSkillService(
 	}
 	project := projectResp.GetProject()
 	if project == nil {
-		return exterrors.Dependency(
+		return nil, exterrors.Dependency(
 			exterrors.CodeProjectManifestNotFound,
 			fmt.Sprintf("cannot save skill %q to azure.yaml: no azd project is loaded", declaration.Name),
 			"run this command from an azd project containing azure.yaml, or omit --save-to-azure-yaml",
 		)
 	}
 
-	cfg := declaration.Config
-	if declaration.ArchiveSource != "" {
-		archive, err := portableSkillArchiveReference(project.GetPath(), declaration.ArchiveSource)
-		if err != nil {
-			return err
-		}
-		cfg.Archive = archive
-	}
-
-	cfgMap, err := skillServiceConfigMap(cfg)
-	if err != nil {
-		return fmt.Errorf("encoding skill service %q: %w", declaration.Name, err)
-	}
-	cfgStruct, err := structpb.NewStruct(cfgMap)
-	if err != nil {
-		return fmt.Errorf("encoding skill service %q: %w", declaration.Name, err)
-	}
-
 	existing, found := project.GetServices()[declaration.Name]
-	if !found {
-		_, err := projectClient.AddService(ctx, &azdext.AddServiceRequest{
-			Service: &azdext.ServiceConfig{
-				Name:                 declaration.Name,
-				Host:                 aiSkillHost,
-				AdditionalProperties: cfgStruct,
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("adding azure.ai.skill service %q: %w", declaration.Name, err)
-		}
-		return nil
-	}
-
-	if existing.GetHost() != aiSkillHost {
-		return exterrors.Validation(
+	if found && existing.GetHost() != aiSkillHost {
+		return nil, exterrors.Validation(
 			exterrors.CodeSkillServiceConflict,
 			fmt.Sprintf(
 				"cannot save skill %q to azure.yaml: service %q already uses host %q",
@@ -135,11 +150,46 @@ func upsertSkillService(
 		)
 	}
 
+	cfg := declaration.Config
+	if declaration.ArchiveSource != "" {
+		serviceRoot := project.GetPath()
+		if found && existing.GetRelativePath() != "" {
+			serviceRoot = filepath.Join(serviceRoot, existing.GetRelativePath())
+		}
+		archive, err := portableSkillArchiveReference(serviceRoot, declaration.ArchiveSource)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Archive = archive
+	}
+
+	cfgMap, err := skillServiceConfigMap(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("encoding skill service %q: %w", declaration.Name, err)
+	}
+	cfgStruct, err := structpb.NewStruct(cfgMap)
+	if err != nil {
+		return nil, fmt.Errorf("encoding skill service %q: %w", declaration.Name, err)
+	}
+
+	if !found {
+		return &preparedSkillService{
+			projectClient: projectClient,
+			addRequest: &azdext.AddServiceRequest{
+				Service: &azdext.ServiceConfig{
+					Name:                 declaration.Name,
+					Host:                 aiSkillHost,
+					AdditionalProperties: cfgStruct,
+				},
+			},
+		}, nil
+	}
+
 	sectionResp, err := projectClient.GetServiceConfigSection(ctx, &azdext.GetServiceConfigSectionRequest{
 		ServiceName: declaration.Name,
 	})
 	if err != nil {
-		return fmt.Errorf("reading azure.ai.skill service %q from azure.yaml: %w", declaration.Name, err)
+		return nil, fmt.Errorf("reading azure.ai.skill service %q from azure.yaml: %w", declaration.Name, err)
 	}
 
 	merged := map[string]any{"host": aiSkillHost}
@@ -154,16 +204,16 @@ func upsertSkillService(
 
 	section, err := structpb.NewStruct(merged)
 	if err != nil {
-		return fmt.Errorf("encoding updated skill service %q: %w", declaration.Name, err)
-	}
-	if _, err := projectClient.SetServiceConfigSection(ctx, &azdext.SetServiceConfigSectionRequest{
-		ServiceName: declaration.Name,
-		Section:     section,
-	}); err != nil {
-		return fmt.Errorf("updating azure.ai.skill service %q in azure.yaml: %w", declaration.Name, err)
+		return nil, fmt.Errorf("encoding updated skill service %q: %w", declaration.Name, err)
 	}
 
-	return nil
+	return &preparedSkillService{
+		projectClient: projectClient,
+		setRequest: &azdext.SetServiceConfigSectionRequest{
+			ServiceName: declaration.Name,
+			Section:     section,
+		},
+	}, nil
 }
 
 func skillServiceConfigMap(cfg skillServiceConfig) (map[string]any, error) {

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_service_config_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_service_config_test.go
@@ -1,0 +1,232 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"azureaiskills/internal/exterrors"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type fakeSkillProjectClient struct {
+	project       *azdext.ProjectConfig
+	added         *azdext.ServiceConfig
+	current       map[string]any
+	updated       map[string]any
+	getErr        error
+	getSectionErr error
+	setSectionErr error
+}
+
+func (f *fakeSkillProjectClient) Get(
+	context.Context,
+	*azdext.EmptyRequest,
+	...grpc.CallOption,
+) (*azdext.GetProjectResponse, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return &azdext.GetProjectResponse{Project: f.project}, nil
+}
+
+func (f *fakeSkillProjectClient) AddService(
+	_ context.Context,
+	req *azdext.AddServiceRequest,
+	_ ...grpc.CallOption,
+) (*azdext.EmptyResponse, error) {
+	f.added = req.GetService()
+	return &azdext.EmptyResponse{}, nil
+}
+
+func (f *fakeSkillProjectClient) GetServiceConfigSection(
+	context.Context,
+	*azdext.GetServiceConfigSectionRequest,
+	...grpc.CallOption,
+) (*azdext.GetServiceConfigSectionResponse, error) {
+	if f.getSectionErr != nil {
+		return nil, f.getSectionErr
+	}
+	if f.current == nil {
+		return &azdext.GetServiceConfigSectionResponse{Found: false}, nil
+	}
+	section, err := structpb.NewStruct(f.current)
+	if err != nil {
+		return nil, err
+	}
+	return &azdext.GetServiceConfigSectionResponse{
+		Found:   true,
+		Section: section,
+	}, nil
+}
+
+func (f *fakeSkillProjectClient) SetServiceConfigSection(
+	_ context.Context,
+	req *azdext.SetServiceConfigSectionRequest,
+	_ ...grpc.CallOption,
+) (*azdext.EmptyResponse, error) {
+	if f.setSectionErr != nil {
+		return nil, f.setSectionErr
+	}
+	f.updated = req.GetSection().AsMap()
+	return &azdext.EmptyResponse{}, nil
+}
+
+func TestUpsertSkillService_AddsInlineService(t *testing.T) {
+	client := &fakeSkillProjectClient{
+		project: &azdext.ProjectConfig{
+			Path:     t.TempDir(),
+			Services: map[string]*azdext.ServiceConfig{},
+		},
+	}
+
+	err := upsertSkillService(t.Context(), client, skillServiceDeclaration{
+		Name: "triage-rules",
+		Config: skillServiceConfig{
+			Description:  "Issue triage rules",
+			Instructions: "Triage incoming issues.",
+			Tools:        []string{"web_search"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, client.added)
+	assert.Equal(t, "triage-rules", client.added.GetName())
+	assert.Equal(t, aiSkillHost, client.added.GetHost())
+	assert.Equal(t, "Issue triage rules", client.added.GetAdditionalProperties().AsMap()["description"])
+	assert.Equal(t, "Triage incoming issues.", client.added.GetAdditionalProperties().AsMap()["instructions"])
+	assert.Equal(t, []any{"web_search"}, client.added.GetAdditionalProperties().AsMap()["tools"])
+}
+
+func TestUpsertSkillService_UpdatesOwnedFieldsAndPreservesOthers(t *testing.T) {
+	client := &fakeSkillProjectClient{
+		project: &azdext.ProjectConfig{
+			Path: t.TempDir(),
+			Services: map[string]*azdext.ServiceConfig{
+				"triage-rules": {Name: "triage-rules", Host: aiSkillHost},
+			},
+		},
+		current: map[string]any{
+			"host":    aiSkillHost,
+			"archive": "./old.zip",
+			"uses":    []any{"ai-project"},
+			"custom":  "preserve-me",
+		},
+	}
+
+	err := upsertSkillService(t.Context(), client, skillServiceDeclaration{
+		Name: "triage-rules",
+		Config: skillServiceConfig{
+			Description:  "Updated",
+			Instructions: "Updated instructions.",
+		},
+	})
+	require.NoError(t, err)
+	require.Nil(t, client.added)
+	require.NotNil(t, client.updated)
+	assert.Equal(t, aiSkillHost, client.updated["host"])
+	assert.Equal(t, []any{"ai-project"}, client.updated["uses"])
+	assert.Equal(t, "preserve-me", client.updated["custom"])
+	assert.Equal(t, "Updated", client.updated["description"])
+	assert.Equal(t, "Updated instructions.", client.updated["instructions"])
+	assert.NotContains(t, client.updated, "archive")
+}
+
+func TestUpsertSkillService_SavesPortableArchiveReference(t *testing.T) {
+	projectDir := t.TempDir()
+	archiveDir := filepath.Join(projectDir, "skills", "triage-rules")
+	require.NoError(t, writeSkillMd(archiveDir, "triage-rules"))
+
+	client := &fakeSkillProjectClient{
+		project: &azdext.ProjectConfig{
+			Path:     projectDir,
+			Services: map[string]*azdext.ServiceConfig{},
+		},
+	}
+
+	err := upsertSkillService(t.Context(), client, skillServiceDeclaration{
+		Name:          "triage-rules",
+		ArchiveSource: archiveDir,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "skills/triage-rules", client.added.GetAdditionalProperties().AsMap()["archive"])
+}
+
+func TestUpsertSkillService_RejectsArchiveOutsideProject(t *testing.T) {
+	projectDir := t.TempDir()
+	outsideDir := t.TempDir()
+	require.NoError(t, writeSkillMd(outsideDir, "triage-rules"))
+
+	client := &fakeSkillProjectClient{
+		project: &azdext.ProjectConfig{
+			Path:     projectDir,
+			Services: map[string]*azdext.ServiceConfig{},
+		},
+	}
+
+	err := upsertSkillService(t.Context(), client, skillServiceDeclaration{
+		Name:          "triage-rules",
+		ArchiveSource: outsideDir,
+	})
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeInvalidSkillFile, localErr.Code)
+}
+
+func TestUpsertSkillService_RejectsHostConflict(t *testing.T) {
+	client := &fakeSkillProjectClient{
+		project: &azdext.ProjectConfig{
+			Path: t.TempDir(),
+			Services: map[string]*azdext.ServiceConfig{
+				"triage-rules": {Name: "triage-rules", Host: "containerapp"},
+			},
+		},
+	}
+
+	err := upsertSkillService(t.Context(), client, skillServiceDeclaration{
+		Name: "triage-rules",
+		Config: skillServiceConfig{
+			Instructions: "Triage issues.",
+		},
+	})
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeSkillServiceConflict, localErr.Code)
+}
+
+func TestUpsertSkillService_RequiresProject(t *testing.T) {
+	client := &fakeSkillProjectClient{getErr: errors.New("azure.yaml not found")}
+
+	err := upsertSkillService(t.Context(), client, skillServiceDeclaration{
+		Name: "triage-rules",
+		Config: skillServiceConfig{
+			Instructions: "Triage issues.",
+		},
+	})
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeProjectManifestNotFound, localErr.Code)
+}
+
+func writeSkillMd(dir, name string) error {
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return err
+	}
+	return os.WriteFile(
+		filepath.Join(dir, "SKILL.md"),
+		[]byte("---\nname: "+name+"\ndescription: test\n---\ninstructions\n"),
+		0600,
+	)
+}

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_service_config_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_service_config_test.go
@@ -161,6 +161,53 @@ func TestUpsertSkillService_SavesPortableArchiveReference(t *testing.T) {
 	assert.Equal(t, "skills/triage-rules", client.added.GetAdditionalProperties().AsMap()["archive"])
 }
 
+func TestUpsertSkillService_SavesArchiveRelativeToExistingServicePath(t *testing.T) {
+	projectDir := t.TempDir()
+	archiveDir := filepath.Join(projectDir, "skills", "triage-rules")
+	require.NoError(t, writeSkillMd(archiveDir, "triage-rules"))
+
+	client := &fakeSkillProjectClient{
+		project: &azdext.ProjectConfig{
+			Path: projectDir,
+			Services: map[string]*azdext.ServiceConfig{
+				"triage-rules": {
+					Name:         "triage-rules",
+					Host:         aiSkillHost,
+					RelativePath: "skills",
+				},
+			},
+		},
+		current: map[string]any{"host": aiSkillHost},
+	}
+
+	err := upsertSkillService(t.Context(), client, skillServiceDeclaration{
+		Name:          "triage-rules",
+		ArchiveSource: archiveDir,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "triage-rules", client.updated["archive"])
+}
+
+func TestPrepareSkillServiceUpsert_DoesNotWriteProject(t *testing.T) {
+	client := &fakeSkillProjectClient{
+		project: &azdext.ProjectConfig{
+			Path:     t.TempDir(),
+			Services: map[string]*azdext.ServiceConfig{},
+		},
+	}
+
+	prepared, err := prepareSkillServiceUpsert(t.Context(), client, skillServiceDeclaration{
+		Name:   "triage-rules",
+		Config: skillServiceConfig{Instructions: "Triage issues."},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, client.added)
+	assert.Nil(t, client.updated)
+
+	require.NoError(t, prepared.Save(t.Context()))
+	assert.NotNil(t, client.added)
+}
+
 func TestUpsertSkillService_RejectsArchiveOutsideProject(t *testing.T) {
 	projectDir := t.TempDir()
 	outsideDir := t.TempDir()

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_update.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_update.go
@@ -38,15 +38,15 @@ type updateFlags struct {
 
 type updateAction struct{ flags *updateFlags }
 
-func (a *updateAction) saveService(
+func (a *updateAction) prepareService(
 	ctx context.Context,
 	cfg skillServiceConfig,
 	archiveSource string,
-) error {
+) (*preparedSkillService, error) {
 	if !a.flags.saveToAzureYaml {
-		return nil
+		return &preparedSkillService{}, nil
 	}
-	return saveSkillServiceToProject(ctx, skillServiceDeclaration{
+	return prepareSkillServiceToProject(ctx, skillServiceDeclaration{
 		Name:          a.flags.name,
 		Config:        cfg,
 		ArchiveSource: archiveSource,
@@ -122,6 +122,16 @@ func (a *updateAction) runInline(ctx context.Context, client *skill_api.Client) 
 		return err
 	}
 
+	service, err := a.prepareService(ctx, skillServiceConfig{
+		Description:  content.Description,
+		Instructions: content.Instructions,
+		Tools:        content.AllowedTools,
+	}, "")
+	if err != nil {
+		return err
+	}
+	defer service.Close()
+
 	version, err := client.CreateVersionInline(ctx, a.flags.name, skill_api.CreateVersionRequest{
 		InlineContent: content,
 		Default:       true,
@@ -129,11 +139,7 @@ func (a *updateAction) runInline(ctx context.Context, client *skill_api.Client) 
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpUpdateSkill)
 	}
-	if err := a.saveService(ctx, skillServiceConfig{
-		Description:  content.Description,
-		Instructions: content.Instructions,
-		Tools:        content.AllowedTools,
-	}, ""); err != nil {
+	if err := service.Save(ctx); err != nil {
 		return err
 	}
 	return a.printUpdateResult(ctx, client, version)
@@ -169,11 +175,17 @@ func (a *updateAction) runFilePackage(ctx context.Context, client *skill_api.Cli
 	}
 	defer f.Close()
 
+	service, err := a.prepareService(ctx, skillServiceConfig{}, a.flags.file)
+	if err != nil {
+		return err
+	}
+	defer service.Close()
+
 	version, err := client.CreateVersionFromZip(ctx, a.flags.name, filepath.Base(a.flags.file), f, true)
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpUpdateSkill)
 	}
-	if err := a.saveService(ctx, skillServiceConfig{}, a.flags.file); err != nil {
+	if err := service.Save(ctx); err != nil {
 		return err
 	}
 	return a.printUpdateResult(ctx, client, version)
@@ -206,11 +218,17 @@ func (a *updateAction) runFileDirectory(ctx context.Context, client *skill_api.C
 	}
 
 	archiveName := filepath.Base(filepath.Clean(a.flags.file)) + ".zip"
+	service, err := a.prepareService(ctx, skillServiceConfig{}, a.flags.file)
+	if err != nil {
+		return err
+	}
+	defer service.Close()
+
 	version, err := client.CreateVersionFromZip(ctx, a.flags.name, archiveName, bytes.NewReader(data), true)
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpUpdateSkill)
 	}
-	if err := a.saveService(ctx, skillServiceConfig{}, a.flags.file); err != nil {
+	if err := service.Save(ctx); err != nil {
 		return err
 	}
 	return a.printUpdateResult(ctx, client, version)

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_update.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_update.go
@@ -28,6 +28,7 @@ type updateFlags struct {
 	instructions    string
 	file            string
 	setDefault      string
+	saveToAzureYaml bool
 	output          string
 	projectEndpoint string
 
@@ -36,6 +37,21 @@ type updateFlags struct {
 }
 
 type updateAction struct{ flags *updateFlags }
+
+func (a *updateAction) saveService(
+	ctx context.Context,
+	cfg skillServiceConfig,
+	archiveSource string,
+) error {
+	if !a.flags.saveToAzureYaml {
+		return nil
+	}
+	return saveSkillServiceToProject(ctx, skillServiceDeclaration{
+		Name:          a.flags.name,
+		Config:        cfg,
+		ArchiveSource: archiveSource,
+	})
+}
 
 // updateMode is the dispatch tag selectUpdateMode returns. It mirrors
 // createMode so the two commands route the same shapes through the same
@@ -113,6 +129,13 @@ func (a *updateAction) runInline(ctx context.Context, client *skill_api.Client) 
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpUpdateSkill)
 	}
+	if err := a.saveService(ctx, skillServiceConfig{
+		Description:  content.Description,
+		Instructions: content.Instructions,
+		Tools:        content.AllowedTools,
+	}, ""); err != nil {
+		return err
+	}
 	return a.printUpdateResult(ctx, client, version)
 }
 
@@ -150,6 +173,9 @@ func (a *updateAction) runFilePackage(ctx context.Context, client *skill_api.Cli
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpUpdateSkill)
 	}
+	if err := a.saveService(ctx, skillServiceConfig{}, a.flags.file); err != nil {
+		return err
+	}
 	return a.printUpdateResult(ctx, client, version)
 }
 
@@ -183,6 +209,9 @@ func (a *updateAction) runFileDirectory(ctx context.Context, client *skill_api.C
 	version, err := client.CreateVersionFromZip(ctx, a.flags.name, archiveName, bytes.NewReader(data), true)
 	if err != nil {
 		return exterrors.ServiceFromAzure(err, exterrors.OpUpdateSkill)
+	}
+	if err := a.saveService(ctx, skillServiceConfig{}, a.flags.file); err != nil {
+		return err
 	}
 	return a.printUpdateResult(ctx, client, version)
 }
@@ -271,6 +300,14 @@ func selectUpdateMode(f *updateFlags) (updateMode, error) {
 	inlineProvided := f.descriptionSet || f.instructionsSet
 	fileProvided := f.file != ""
 	setDefaultProvided := f.setDefault != ""
+
+	if setDefaultProvided && f.saveToAzureYaml {
+		return updateModeNone, exterrors.Validation(
+			exterrors.CodeConflictingArguments,
+			"--save-to-azure-yaml cannot be combined with --set-default-version",
+			"omit --save-to-azure-yaml, or provide new inline/file content that azure.yaml can reconcile",
+		)
+	}
 
 	// --set-default-version is a metadata-only update; it cannot be combined
 	// with content flags. Hand it back as its own mode so Run can dispatch
@@ -361,9 +398,15 @@ Directory mode requires SKILL.md at the root of the directory — the same
 layout that ` + "`azd ai skill download`" + ` writes by default.
 
 To repoint default_version at an existing version without uploading new
-content, pass --set-default-version <version>.`,
+content, pass --set-default-version <version>.
+
+Pass --save-to-azure-yaml to add or update a host: azure.ai.skill service in
+the current azd project's azure.yaml. Inline and SKILL.md inputs are saved as
+inline service properties; ZIP and directory inputs are saved as portable
+archive references for azd deploy/up to reconcile.`,
 		Example: `  azd ai skill update my-skill --description "Updated summary" --instructions "..."
   azd ai skill update my-skill --file ./SKILL.md
+  azd ai skill update my-skill --file ./SKILL.md --save-to-azure-yaml
   azd ai skill update my-skill --file ./skill.zip
   azd ai skill update my-skill --file ./skill-src/
   azd ai skill update my-skill --set-default-version 1`,
@@ -384,6 +427,12 @@ content, pass --set-default-version <version>.`,
 		"Path to a SKILL.md file, a .zip archive, or a directory whose contents become the next version. "+
 			"Archives and directories must contain a SKILL.md at the root.")
 	cmd.Flags().StringVar(&flags.setDefault, "set-default-version", "", "Set the skill's default_version to an existing version without uploading new content")
+	cmd.Flags().BoolVar(
+		&flags.saveToAzureYaml,
+		"save-to-azure-yaml",
+		false,
+		"Add or update this skill as a host: azure.ai.skill service in the current azure.yaml",
+	)
 	azdext.RegisterFlagOptions(cmd, azdext.FlagOptions{
 		Name: "output", AllowedValues: []string{outputJSON, outputTable}, Default: outputJSON,
 	})

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_update_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/skill_update_test.go
@@ -32,6 +32,9 @@ func TestUpdateAction_RejectsInvalidName(t *testing.T) {
 }
 
 func TestUpdateAction_ValidInputFailsAtEndpoint(t *testing.T) {
+	isolateFromAzdDaemon(t)
+	t.Setenv(foundryEnvKey, "")
+
 	// A fully valid inline update with no endpoint configured must fail at
 	// endpoint resolution (not at flag validation or name validation).
 	a := &updateAction{flags: &updateFlags{
@@ -41,7 +44,7 @@ func TestUpdateAction_ValidInputFailsAtEndpoint(t *testing.T) {
 		instructionsSet: true,
 		instructions:    "new instructions",
 	}}
-	err := a.Run(context.Background())
+	err := a.Run(t.Context())
 	require.Error(t, err)
 	var le *azdext.LocalError
 	require.True(t, errors.As(err, &le))
@@ -102,6 +105,23 @@ func TestSelectUpdateMode_SetDefaultConflictsWithContent(t *testing.T) {
 		require.True(t, errors.As(err, &le))
 		require.Equal(t, exterrors.CodeConflictingArguments, le.Code)
 	}
+}
+
+func TestSelectUpdateMode_SetDefaultConflictsWithSaveToAzureYaml(t *testing.T) {
+	mode, err := selectUpdateMode(&updateFlags{
+		setDefault:      "2",
+		saveToAzureYaml: true,
+	})
+	require.Error(t, err)
+	require.Equal(t, updateModeNone, mode)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	require.Equal(t, exterrors.CodeConflictingArguments, localErr.Code)
+}
+
+func TestUpdateCommand_HasSaveToAzureYamlFlag(t *testing.T) {
+	cmd := newUpdateCommand(&azdext.ExtensionContext{})
+	require.NotNil(t, cmd.Flags().Lookup("save-to-azure-yaml"))
 }
 
 func TestSelectUpdateMode_InlineAndFileConflict(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.skills/internal/exterrors/codes.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/exterrors/codes.go
@@ -13,11 +13,13 @@ const (
 
 // Codes shared across the extension surface.
 const (
-	CodeConflictingArguments   = "conflicting_arguments"
-	CodeInvalidParameter       = "invalid_parameter"
-	CodeMissingProjectEndpoint = "missing_project_endpoint"
-	CodeMissingRequiredField   = "missing_required_field"
-	CodeMissingForceFlag       = "missing_force_flag"
+	CodeConflictingArguments    = "conflicting_arguments"
+	CodeInvalidParameter        = "invalid_parameter"
+	CodeMissingProjectEndpoint  = "missing_project_endpoint"
+	CodeMissingRequiredField    = "missing_required_field"
+	CodeMissingForceFlag        = "missing_force_flag"
+	CodeProjectManifestNotFound = "project_manifest_not_found"
+	CodeSkillServiceConflict    = "skill_service_conflict"
 )
 
 const (
@@ -28,10 +30,11 @@ const (
 // Operation names for ServiceFromAzure errors. Prefixed to the Azure code,
 // e.g. "create_skill.NotFound".
 const (
-	OpCreateSkill   = "create_skill"
-	OpUpdateSkill   = "update_skill"
-	OpDeleteSkill   = "delete_skill"
-	OpGetSkill      = "get_skill"
-	OpListSkills    = "list_skills"
-	OpDownloadSkill = "download_skill"
+	OpCreateSkill    = "create_skill"
+	OpUpdateSkill    = "update_skill"
+	OpDeleteSkill    = "delete_skill"
+	OpGetSkill       = "get_skill"
+	OpListSkills     = "list_skills"
+	OpDownloadSkill  = "download_skill"
+	OpReconcileSkill = "reconcile_skill"
 )

--- a/cli/azd/extensions/azure.ai.skills/schemas/azure.ai.skill.json
+++ b/cli/azd/extensions/azure.ai.skills/schemas/azure.ai.skill.json
@@ -18,6 +18,10 @@
       "type": "array",
       "description": "Tool type names the skill uses (must be declared on a toolbox the agent references, or attached directly to the agent's tools list).",
       "items": { "type": "string" }
+    },
+    "archive": {
+      "type": "string",
+      "description": "Path to a .zip skill package or a directory containing SKILL.md. Mutually exclusive with description, instructions, and tools. Relative paths resolve from the service path when set, otherwise from the current project directory."
     }
   }
 }


### PR DESCRIPTION
## Summary

Gives the `azure.ai.skills` extension ownership of its `host: azure.ai.skill` service blocks in `azure.yaml`: command-driven authoring, idempotent updates, reading, and deploy-time reconciliation.

Developers can now opt a skill into the current azd project directly from the owning extension:

```console
azd ai skill create triage-rules --file ./skills/triage-rules --save-to-azure-yaml
azd ai skill update triage-rules --file ./SKILL.md --save-to-azure-yaml
```

This has no dependency on the agents extension. An agent that consumes the skill declares the dependency using the existing `uses:` field.

Fixes #9088

## What changed

### `azure.ai.skills` owns authoring and updates

- Adds `--save-to-azure-yaml` to `skill create` and `skill update` (opt-in; existing remote-only behavior remains the default).
- New manifest helper uses the azd extension framework APIs:
  - `Project.Get` to locate/read the current project and existing service.
  - `AddService` to create a new `host: azure.ai.skill` block.
  - `GetServiceConfigSection` + read/merge/`SetServiceConfigSection` to update an existing block while preserving `uses:`, `project`, and unrelated/unknown fields.
- Detects a same-name service with a different host and returns a structured, actionable conflict instead of overwriting it.
- Requires ZIP/directory references to live inside the azd project and writes a portable forward-slash relative path.
- `--set-default-version` is rejected with `--save-to-azure-yaml` because a default-version pointer is not a declarative content source that `azd deploy` can reconcile.

### Inline and archive declarations

Inline flags and parsed `SKILL.md` inputs are saved as service-level content:

```yaml
services:
  triage-rules:
    host: azure.ai.skill
    description: Rules for triaging incoming issues
    instructions: Classify the issue and recommend next steps.
    tools:
      - web_search
```

ZIP and directory inputs are saved as an archive reference:

```yaml
services:
  triage-rules:
    host: azure.ai.skill
    archive: skills/triage-rules
```

The existing skill service target now reads and reconciles both shapes. Archive reconciliation:

- Accepts a `.zip` file or a directory containing root-level `SKILL.md`.
- Reuses `ArchiveDirectory` safety limits for directories (no symlinks/non-regular entries; entry/size limits).
- Rejects parent traversal and unsupported archive files.
- Creates a new immutable default skill version, matching existing inline reconcile behavior.

The runtime validation keeps the pre-split legacy `config:` fallback compatible while enforcing that archive and inline fields are not combined.

### Composition/adoption

- Adds `azure.ai.skill` to the agents extension's generic Foundry host recognition, so a skill-only or composed unified `azure.yaml` round-trips through the adoption flow.
- Documents adding the skill service name to a consuming agent's `uses:` list.

## Tests

- Add vs idempotent update, including preservation of `uses:` and unknown fields.
- Host-name collision and missing-project structured errors.
- Project-relative archive path conversion and outside-project rejection.
- Inline/archive config parsing, traversal rejection, ZIP/directory preparation, unsupported file rejection.
- `--save-to-azure-yaml` flag registration and `--set-default-version` conflict.
- Regression coverage for multi-line inline instructions ending in `.md`/`.txt` (must not be misclassified as a file path).
- Agents adoption recognition for a skill-only manifest.

Validation run:

- `go build ./...` and `go test ./...` in `azure.ai.skills`
- `golangci-lint run ./...` and extension cspell in `azure.ai.skills`
- agents `internal/cmd` test/lint and cspell for the adoption change
- schema JSON parse and `git diff --check`