### PR TITLE
ci: rerun failed integration tests once to handle flaky nightly failures

### DIFF
--- a/cli/azd/ci-test.ps1
+++ b/cli/azd/ci-test.ps1
@@ -4,7 +4,8 @@ param(
     [string] $IntegrationTestTimeout = '120m',
     [string] $IntegrationTestCoverageDir = 'cover-int',
     [string] $UnitTestTimingFile = 'test-timing-unit.json',
-    [string] $IntegrationTestTimingFile = 'test-timing-int.json'
+    [string] $IntegrationTestTimingFile = 'test-timing-int.json',
+    [string] $IntegrationTestRerunReport = 'test-rerun-int.txt'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -62,7 +63,22 @@ $env:GOCOVERDIR = $intCoverDir.FullName
 $env:GOEXPERIMENT=""
 
 try {
-    & $gotestsum --jsonfile $IntegrationTestTimingFile -- ./... -v -timeout $IntegrationTestTimeout
+    # Integration tests provision live Azure resources and are prone to flaky, environmental
+    # failures (credential token expiry during long provisioning, transient Azure service
+    # capacity such as App Service "No available instances", teardown races). A single such
+    # blip currently reds the whole nightly run. Re-run failed tests once to distinguish flaky
+    # failures from real regressions. See https://github.com/Azure/azure-dev/issues/8386
+    #
+    # --rerun-fails requires the package list to be passed via --packages instead of positionally.
+    # --rerun-fails-max-failures caps reruns so a mass failure (a genuine regression) is not masked.
+    # --rerun-fails-report records which tests were rerun so flaky tests remain visible for triage.
+    & $gotestsum `
+        --jsonfile $IntegrationTestTimingFile `
+        --rerun-fails=1 `
+        --rerun-fails-max-failures=5 `
+        --rerun-fails-report $IntegrationTestRerunReport `
+        --packages "./..." `
+        -- -v -timeout $IntegrationTestTimeout
     if ($LASTEXITCODE) {
         exit $LASTEXITCODE
     }    


### PR DESCRIPTION
## Summary

Fixes #8386

The nightly scheduled `azure-dev - cli` pipeline (definition 4643) has been red on nearly every run. As documented in #8386, **no single test is the persistent blocker** — the failures rotate night to night, which is the signature of **flaky test infrastructure**, not a code regression.

This PR implements the retry proposed in #8386: re-run failed **integration** tests once, so an environmental blip no longer reds the entire nightly, while genuine regressions still fail.

> Note: #8387 fixed the *phantom* failures (#8385, stdout interleaving) which made real failures visible. It did **not** add retry — that is this PR.

## What's failing and why retry helps

Investigating the recent nightlies, the dominant real failures are live-Azure, environmental issues that a single rerun typically clears:

- **Azure App Service capacity** — `Test_CLI_Deploy_SlotDeployment` and `Test_CLI_Deploy_StoppedWebApp` fail creating the App Service plan with `Conflict: No available instances to satisfy this request. App Service is attempting to increase capacity.` This is Azure-side **scale-unit capacity** in the test region (East US 2), not a subscription quota — live App Service core quota is ~4–5 of 36 used, nowhere near the limit. It appears in episodic clusters (e.g. ~5 consecutive nights) that a rerun rides out.
- **Credential/deployment timeouts** — `Test_DeploymentStacks`, `context deadline exceeded` during long provisioning.
- **Other rotating flakes** — `Test_CLI_Aspire_DetectGen`, `Test_CLI_Up_Down_FuncApp`, `Test_CLI_*_ContainerApp_RemoteBuild`, `Test_StorageBlobClient/Crud`, etc.

## Change

In `cli/azd/ci-test.ps1`, the **integration** test invocation now uses gotestsum's rerun:

```diff
- & $gotestsum --jsonfile $IntegrationTestTimingFile -- ./... -v -timeout $IntegrationTestTimeout
+ & $gotestsum `
+     --jsonfile $IntegrationTestTimingFile `
+     --rerun-fails=1 `
+     --rerun-fails-max-failures=5 `
+     --rerun-fails-report $IntegrationTestRerunReport `
+     --packages "./..." `
+     -- -v -timeout $IntegrationTestTimeout
```

- **`--rerun-fails=1`** — re-run each failed test **once** (only the failed tests, not the full suite), so a flaky test that passes on retry is counted as passed.
- **`--rerun-fails-max-failures=5`** — if the initial run has more than 5 failures, don't rerun anything. A mass failure is a genuine regression and should not be masked.
- **`--rerun-fails-report`** — write the list of rerun tests to `test-rerun-int.txt` so flaky tests stay visible for triage / trend tracking.
- **`--packages "./..."`** — required by `--rerun-fails`; gotestsum errors if the package list is passed positionally after `--`.

**Unit tests are intentionally left without retry** — they are fast and deterministic; if they fail it is almost certainly real.

## Time impact

Rerunning only the failed tests adds a couple of minutes at most (e.g. a single ~120s functional test), not the ~90-minute suite. Acceptable for a nightly.

## Testing

- `pwsh` parses the script without errors.
- Verified against the pinned `gotestsum` that `--rerun-fails` requires `--packages` (positional package list after `--` errors out), so the flag placement in this change is correct.

## Not addressed here

The App Service capacity failures are environmental (Azure East US 2 scale-unit capacity). Retry mitigates their impact on the nightly signal, but spreading the webapp deploy tests across regions and/or an Azure support follow-up for East US 2 dedicated-Linux capacity are worth tracking separately.