### PR TITLE
[auto] instructions: add test coverage symmetry rule to Go review guidelines

### DIFF
--- a/.github/instructions/extensions.instructions.md
+++ b/.github/instructions/extensions.instructions.md
@@ -16,3 +16,21 @@ applyTo:
 - Follow extension guidelines in: cli/azd/docs/extensions/extensions-style-guide.md. If the work
   violates any of these principles, include a link to the guide so the user can read it and get
   ahead of some of the problems.
+
+- When generating text files (Dockerfiles, Python scripts, TOML files, etc.), never force Windows
+  line endings (`\r\n`) on all platforms. Use `\n` (Unix LF) exclusively. Unconditional CRLF breaks
+  shebang parsing inside Linux containers, causes `exec format error`, and introduces noisy git
+  diffs on Linux/macOS. If the Go `text/template` or `os.WriteFile` path writes through a
+  `strings.NewReplacer` or similar that converts `\n` → `\r\n`, remove that conversion.
+
+  _Source: [#8782](https://github.com/Azure/azure-dev/pull/8782)_
+
+- When adding URL validation as a security check, never rely on raw `startsWith()`, `strings.HasPrefix`,
+  or `strings.Contains` checks on an un-normalized URL string. Dot-segment sequences (`/../`, `%2e%2e/`)
+  can bypass prefix checks: `https://allowed-host/releases/../../../attacker/repo/x.zip` starts with
+  the allowed prefix but resolves to a different host after normalization. Always parse the URL into its
+  components (e.g. `new URL(str)` in JS, `url.Parse` in Go) and validate the normalized `Host` +
+  `Path` separately. Apply this to artifact download URLs, registry source fields, and any
+  allow-list checks on user-supplied URLs.
+
+  _Source: [#9042](https://github.com/Azure/azure-dev/pull/9042)_

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -31,3 +31,9 @@ all existing imports or declarations.
 
 - When reviewing command input resolution, explicit CLI args and flags should win over defaults. Do not prompt the user toward a different default when they provided a valid new value; reserve prompts for ambiguous choices and preserve deterministic `--no-prompt` behavior for CI/scripts.
 - When filtering AI models or quota data by location, keep location-specific usage data associated with only the models available in that location. Empty or unknown usage data from an unrelated location must not make a model eligible elsewhere; add regression coverage for cross-location quota cases.
+
+## Dead code
+
+- Remove unused functions, variables, and types before merging. Code that is defined but never called — even if planned for a follow-up — adds cognitive overhead and can mislead reviewers into thinking it is tested or reachable. If a function is genuinely coming soon, add a `// TODO:` comment or open a tracking issue instead of leaving an unreachable definition in the diff.
+
+_Source: [#8782](https://github.com/Azure/azure-dev/pull/8782)_


### PR DESCRIPTION
From mining 48 recently-merged PRs, three recurring reviewer themes reached the promotion threshold:

1. Dead code removal (go.instructions.md) — jongio flagged unused functions/types 3× in #8782.
2. CRLF in generated files (extensions.instructions.md) — jongio flagged unconditional \\r\\n in generated files 3× in #8782.
3. URL startsWith bypass (extensions.instructions.md) — richardpark-msft flagged dot-segment path-traversal bypasses 3× in #9042.