### PR TITLE
fix: send x-ms-correlation-request-id as a canonical hyphenated GUID

### DIFF
--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Other Changes
 
-- [[#9141]](https://github.com/Azure/azure-dev/pull/9141) Send the `x-ms-correlation-request-id` header as a canonical hyphenated GUID (derived losslessly from the OpenTelemetry trace ID) instead of an undecorated 32-character string, aligning azd with the ARM spec and other Azure tooling (Terraform AzureRM, Azure SDK for Go). This also resolves the historical AKS Deployment Safeguards `GetDeploymentSafeguardsFailed` correlation ID mismatch (#5851).
+- [[#9141]](https://github.com/Azure/azure-dev/pull/9141) Send ARM request correlation IDs as a canonical hyphenated GUID (derived losslessly from the OpenTelemetry trace ID) instead of an undecorated 32-character string — covering both the `x-ms-correlation-request-id` header on azd's direct ARM calls and the `ARM_CORRELATION_REQUEST_ID` value passed to the Terraform AzureRM provider. This aligns azd with the ARM spec and other Azure tooling (Terraform AzureRM, Azure SDK for Go) and resolves the historical AKS Deployment Safeguards `GetDeploymentSafeguardsFailed` correlation ID mismatch (#5851).
 
 ## 1.27.1 (2026-07-09)
 

--- a/cli/azd/CHANGELOG.md
+++ b/cli/azd/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Other Changes
 
+- [[#9141]](https://github.com/Azure/azure-dev/pull/9141) Send the `x-ms-correlation-request-id` header as a canonical hyphenated GUID (derived losslessly from the OpenTelemetry trace ID) instead of an undecorated 32-character string, aligning azd with the ARM spec and other Azure tooling (Terraform AzureRM, Azure SDK for Go). This also resolves the historical AKS Deployment Safeguards `GetDeploymentSafeguardsFailed` correlation ID mismatch (#5851).
+
 ## 1.27.1 (2026-07-09)
 
 ### Features Added

--- a/cli/azd/pkg/azsdk/correlation_policy.go
+++ b/cli/azd/pkg/azsdk/correlation_policy.go
@@ -33,13 +33,21 @@ func (p *traceCorrelationPolicy) Do(req *policy.Request) (*http.Response, error)
 		return req.Next()
 	}
 
-	// A W3C trace ID and a UUID are both 128-bit values, so we reformat the trace ID into the canonical
-	// hyphenated GUID form (8-4-4-4-12) that the ARM spec expects. This keeps the exact trace ID value
-	// (the conversion is reversible by removing the hyphens) while matching the format other Azure tools send.
-	// Some services (e.g. AKS Deployment Safeguards) parse this header as a GUID and fail a string comparison
-	// against azd's previously undecorated 32-character value. See azure-dev#5851.
-	rawRequest.Header.Set(p.headerName, uuid.UUID(spanCtx.TraceID()).String())
+	rawRequest.Header.Set(p.headerName, CorrelationIDFromTraceID(spanCtx.TraceID()))
 	return req.Next()
+}
+
+// CorrelationIDFromTraceID formats an OpenTelemetry trace ID as the canonical hyphenated GUID (8-4-4-4-12) that
+// ARM expects for correlation values — both the `x-ms-correlation-request-id` header and the
+// `ARM_CORRELATION_REQUEST_ID` variable azd passes to the Terraform AzureRM provider. A W3C trace ID and a UUID
+// are both 128-bit values, so the conversion is lossless and reversible: removing the hyphens recovers the
+// original trace ID, preserving end-to-end OpenTelemetry correlation.
+//
+// azd historically emitted the undecorated 32-character trace ID here, which AKS Deployment Safeguards parsed as
+// a GUID and string-compared against the original, causing GetDeploymentSafeguardsFailed (azure-dev#5851).
+// Emitting the canonical GUID also matches the format other Azure tools send (Terraform AzureRM, Azure SDK for Go).
+func CorrelationIDFromTraceID(traceID trace.TraceID) string {
+	return uuid.UUID(traceID).String()
 }
 
 // perRequestUUIDPolicy sets a header to a freshly generated UUID on every outgoing HTTP request. It is used for

--- a/cli/azd/pkg/azsdk/correlation_policy.go
+++ b/cli/azd/pkg/azsdk/correlation_policy.go
@@ -33,7 +33,12 @@ func (p *traceCorrelationPolicy) Do(req *policy.Request) (*http.Response, error)
 		return req.Next()
 	}
 
-	rawRequest.Header.Set(p.headerName, spanCtx.TraceID().String())
+	// A W3C trace ID and a UUID are both 128-bit values, so we reformat the trace ID into the canonical
+	// hyphenated GUID form (8-4-4-4-12) that the ARM spec expects. This keeps the exact trace ID value
+	// (the conversion is reversible by removing the hyphens) while matching the format other Azure tools send.
+	// Some services (e.g. AKS Deployment Safeguards) parse this header as a GUID and fail a string comparison
+	// against azd's previously undecorated 32-character value. See azure-dev#5851.
+	rawRequest.Header.Set(p.headerName, uuid.UUID(spanCtx.TraceID()).String())
 	return req.Next()
 }
 
@@ -50,10 +55,10 @@ func (p *perRequestUUIDPolicy) Do(req *policy.Request) (*http.Response, error) {
 	return req.Next()
 }
 
-// NewMsCorrelationPolicy creates a policy that sets the `x-ms-correlation-request-id` header on HTTP requests using
-// the ambient OpenTelemetry trace ID. Per the Azure ARM common-types spec this header is session-level and is
-// intended to correlate RELATED requests, so a single value shared across every call in an azd command is the
-// correct behavior.
+// NewMsCorrelationPolicy creates a policy that sets the `x-ms-correlation-request-id` header on HTTP requests from
+// the ambient OpenTelemetry trace ID, formatted as a canonical hyphenated GUID. Per the Azure ARM common-types spec
+// this header is session-level and is intended to correlate RELATED requests, so a single value shared across every
+// call in an azd command is the correct behavior.
 //
 // NOTE: One ARM data plane — ACR `GetBuildSourceUploadURL` — derives a blob path from this header and therefore
 // requires uniqueness per call. That collision is fixed at the call site (see `containerregistry.RemoteBuildManager`)

--- a/cli/azd/pkg/azsdk/correlation_policy_test.go
+++ b/cli/azd/pkg/azsdk/correlation_policy_test.go
@@ -6,6 +6,7 @@ package azsdk
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -60,8 +61,9 @@ func doRequest(t *testing.T, p policy.Policy, ctx context.Context) *http.Request
 }
 
 // Test_NewMsCorrelationPolicy verifies that the session-level `x-ms-correlation-request-id` header is set from
-// the ambient OpenTelemetry trace ID when present, and omitted otherwise. Using the trace ID is semantically
-// correct here: the ARM spec defines this header as session-level and meant to correlate RELATED requests.
+// the ambient OpenTelemetry trace ID (formatted as a canonical hyphenated GUID) when present, and omitted
+// otherwise. Using the trace ID is semantically correct here: the ARM spec defines this header as session-level
+// and meant to correlate RELATED requests.
 func Test_NewMsCorrelationPolicy(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -74,7 +76,7 @@ func Test_NewMsCorrelationPolicy(t *testing.T) {
 				t.Context(),
 				trace.SpanContext{}.WithTraceID(traceId),
 			),
-			expect: new(traceId.String()),
+			expect: new(uuid.UUID(traceId).String()),
 		},
 		{
 			name: "WithInvalidTraceId",
@@ -100,6 +102,25 @@ func Test_NewMsCorrelationPolicy(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test_NewMsCorrelationPolicy_FormatsTraceIdAsGuid verifies the emitted `x-ms-correlation-request-id` is the
+// ambient trace ID rendered in canonical hyphenated GUID form (8-4-4-4-12). The Azure ARM spec expects a GUID and
+// some services (e.g. AKS Deployment Safeguards) reject the undecorated 32-character trace ID. The reformat MUST
+// be lossless: stripping the hyphens must recover the original trace ID exactly. See azure-dev#5851.
+func Test_NewMsCorrelationPolicy_FormatsTraceIdAsGuid(t *testing.T) {
+	ctx := trace.ContextWithSpanContext(
+		t.Context(),
+		trace.SpanContext{}.WithTraceID(traceId),
+	)
+
+	got := doRequest(t, NewMsCorrelationPolicy(), ctx).Header.Get(MsCorrelationIdHeader)
+
+	_, parseErr := uuid.Parse(got)
+	require.NoError(t, parseErr, "correlation id %q must be a valid GUID", got)
+	require.Len(t, got, 36, "correlation id must be in hyphenated 8-4-4-4-12 form")
+	require.Equal(t, traceId.String(), strings.ReplaceAll(got, "-", ""),
+		"reformat must be lossless: stripping hyphens must recover the original trace ID")
 }
 
 // Test_NewMsClientRequestIdPolicy_UniquePerRequest verifies `x-ms-client-request-id` is a valid UUID on every

--- a/cli/azd/pkg/azsdk/correlation_policy_test.go
+++ b/cli/azd/pkg/azsdk/correlation_policy_test.go
@@ -105,9 +105,10 @@ func Test_NewMsCorrelationPolicy(t *testing.T) {
 }
 
 // Test_NewMsCorrelationPolicy_FormatsTraceIdAsGuid verifies the emitted `x-ms-correlation-request-id` is the
-// ambient trace ID rendered in canonical hyphenated GUID form (8-4-4-4-12). The Azure ARM spec expects a GUID and
-// some services (e.g. AKS Deployment Safeguards) reject the undecorated 32-character trace ID. The reformat MUST
-// be lossless: stripping the hyphens must recover the original trace ID exactly. See azure-dev#5851.
+// ambient trace ID rendered in canonical hyphenated GUID form (8-4-4-4-12), which the Azure ARM spec expects.
+// azd historically emitted the undecorated 32-character trace ID, which AKS Deployment Safeguards rejected
+// (GetDeploymentSafeguardsFailed, azure-dev#5851). The reformat MUST be lossless: stripping the hyphens must
+// recover the original trace ID exactly.
 func Test_NewMsCorrelationPolicy_FormatsTraceIdAsGuid(t *testing.T) {
 	ctx := trace.ContextWithSpanContext(
 		t.Context(),
@@ -115,6 +116,19 @@ func Test_NewMsCorrelationPolicy_FormatsTraceIdAsGuid(t *testing.T) {
 	)
 
 	got := doRequest(t, NewMsCorrelationPolicy(), ctx).Header.Get(MsCorrelationIdHeader)
+
+	_, parseErr := uuid.Parse(got)
+	require.NoError(t, parseErr, "correlation id %q must be a valid GUID", got)
+	require.Len(t, got, 36, "correlation id must be in hyphenated 8-4-4-4-12 form")
+	require.Equal(t, traceId.String(), strings.ReplaceAll(got, "-", ""),
+		"reformat must be lossless: stripping hyphens must recover the original trace ID")
+}
+
+// Test_CorrelationIDFromTraceID verifies the shared helper renders a trace ID as a canonical hyphenated GUID and
+// that the conversion is lossless (stripping the hyphens recovers the original 32-character trace ID). Both the
+// ARM correlation policy and the Terraform `ARM_CORRELATION_REQUEST_ID` env var rely on this shared formatting.
+func Test_CorrelationIDFromTraceID(t *testing.T) {
+	got := CorrelationIDFromTraceID(traceId)
 
 	_, parseErr := uuid.Parse(got)
 	require.NoError(t, parseErr, "correlation id %q must be a valid GUID", got)

--- a/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
+++ b/cli/azd/pkg/infra/provisioning/terraform/terraform_provider.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
@@ -113,7 +114,12 @@ func (t *TerraformProvider) Initialize(ctx context.Context, projectPath string, 
 
 	spanCtx := trace.SpanContextFromContext(ctx)
 	if spanCtx.HasTraceID() {
-		envVars = append(envVars, fmt.Sprintf("ARM_CORRELATION_REQUEST_ID=%s", spanCtx.TraceID().String()))
+		// Match azd's ARM correlation header format so Terraform-driven ARM requests send the same canonical
+		// GUID (the AzureRM provider forwards ARM_CORRELATION_REQUEST_ID verbatim as x-ms-correlation-request-id).
+		envVars = append(
+			envVars,
+			fmt.Sprintf("ARM_CORRELATION_REQUEST_ID=%s", azsdk.CorrelationIDFromTraceID(spanCtx.TraceID())),
+		)
 	}
 
 	t.cli.SetEnv(envVars)


### PR DESCRIPTION
Fix #5851

## Summary

`azd` sets the `x-ms-correlation-request-id` header on every ARM request from the ambient OpenTelemetry trace ID via `spanCtx.TraceID().String()`, which produces an **undecorated 32-character hex string** (no hyphens), e.g. `a161af237f2cd19acc115e06190a47f0`. Every other Azure tool sends this correlation value as a hyphenated GUID.

> [!NOTE]
> **This is no longer a blocking issue — it is a deliberate design choice.**
>
> The problem originally surfaced as a hard failure (#5851): AKS Deployment Safeguards parsed the header as a GUID, reformatted it with hyphens, and string-compared it against azd's undecorated value, failing `azd up` / `azd provision` for AKS clusters with Deployment Safeguards enabled (including AKS Automatic):
> ```
> GetDeploymentSafeguardsFailed: The on behalf of token's correlation ID 'a161af237f2cd19acc115e06190a47f0' does not match with current correlation ID 'a161af23-7f2c-d19a-cc11-5e06190a47f0'.
> ```
> The AKS service side has since relaxed this check and now **accepts the non-hyphenated ID**, so the original deployment failure no longer reproduces. This PR is therefore not an urgent bug fix — we are making it because azd's correlation ID format diverges from the industry standard and from the rest of the Azure tooling, and we want to bring it into line for **consistency, spec-correctness, and future-proofing** (nothing guarantees other resource providers won't apply the same strict GUID parsing AKS originally did).

## Change

Format the trace ID as a canonical hyphenated GUID. A W3C trace ID and a UUID are both 128-bit values, so `uuid.UUID(spanCtx.TraceID()).String()` (reusing the already-imported `github.com/google/uuid`) reshapes it into the RFC 9562 canonical lowercase `8-4-4-4-12` form. The conversion is **lossless and reversible** (stripping the hyphens recovers the original trace ID), so end-to-end OpenTelemetry correlation is preserved.

This aligns azd with the ARM RPC spec (which asks for "a GUID with no decoration such as curly braces") and with the industry standard (RFC 9562: lowercase, hyphenated `8-4-4-4-12`, no braces) followed by every other Azure tool:

| Tool | Header | Format |
|---|---|---|
| Terraform AzureRM | `x-ms-correlation-request-id` | lowercase hyphenated GUID (`hashicorp/go-uuid`) |
| Azure SDK for Go (azcore) | `x-ms-client-request-id` | lowercase hyphenated GUID (`sdk/internal/uuid`) |
| **azd (before)** | `x-ms-correlation-request-id` | 32 chars, no hyphens |
| **azd (after)** | `x-ms-correlation-request-id` | lowercase hyphenated GUID |

The change is in the shared correlation policy (`NewMsCorrelationPolicy`), so it applies to **all** ARM requests, not just AKS. AKS was simply the service strict enough to reject the old format; other services silently tolerated it.

## Testing

- Updated `Test_NewMsCorrelationPolicy` to expect the hyphenated GUID.
- Added `Test_NewMsCorrelationPolicy_FormatsTraceIdAsGuid` asserting the emitted value is a valid 36-char GUID and that stripping the hyphens losslessly recovers the original trace ID.
- `go build`, `go test ./pkg/azsdk/...`, `golangci-lint run ./pkg/azsdk/...`, `gofmt`, and `cspell` all pass.
