### PR TITLE
fix: resolve toolbox $ref config before deploy

### DIFF
--- a/cli/azd/extensions/azure.ai.toolboxes/README.md
+++ b/cli/azd/extensions/azure.ai.toolboxes/README.md
@@ -22,3 +22,4 @@ Get the endpoint value from `azd ai toolbox show <name>` (the `Endpoint:` line).
 The value may contain `${VAR}` references, which resolve against the azd
 environment. Because a toolbox version is immutable, `endpoint` cannot be
 combined with `tools` or `description`.
+

--- a/cli/azd/extensions/azure.ai.toolboxes/README.md
+++ b/cli/azd/extensions/azure.ai.toolboxes/README.md
@@ -22,4 +22,3 @@ Get the endpoint value from `azd ai toolbox show <name>` (the `Endpoint:` line).
 The value may contain `${VAR}` references, which resolve against the azd
 environment. Because a toolbox version is immutable, `endpoint` cannot be
 combined with `tools` or `description`.
-

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/service_target.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/service_target.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"azure.ai.toolboxes/internal/exterrors"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/foundry"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // aiToolboxHost is the azure.yaml service host kind owned by this extension. A
@@ -126,7 +128,10 @@ func (p *toolboxServiceTarget) Deploy(
 	targetResource *azdext.TargetResource,
 	progress azdext.ProgressReporter,
 ) (*azdext.ServiceDeployResult, error) {
-	cfg, err := parseToolboxServiceConfig(serviceConfig)
+	cfg, err := p.parseToolboxServiceConfig(
+		ctx,
+		serviceConfig,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -305,15 +310,62 @@ func (p *toolboxServiceTarget) buildToolEntries(
 // back to the deprecated config: shape for azure.yaml files written before the
 // per-resource service split.
 func parseToolboxServiceConfig(svc *azdext.ServiceConfig) (*toolboxServiceConfig, error) {
-	props := svc.GetAdditionalProperties()
-	if props == nil || len(props.GetFields()) == 0 {
-		props = svc.GetConfig()
+	return parseToolboxServiceConfigAtRoot(svc, "")
+}
+
+func (p *toolboxServiceTarget) parseToolboxServiceConfig(
+	ctx context.Context,
+	svc *azdext.ServiceConfig,
+) (*toolboxServiceConfig, error) {
+	props := toolboxServiceProps(svc)
+	if props == nil || !containsToolboxFileRef(props.AsMap()) {
+		return parseToolboxServiceConfig(svc)
 	}
+	project, err := p.azdClient.Project().Get(
+		ctx,
+		&azdext.EmptyRequest{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"resolving project root for toolbox %q: %w",
+			svc.GetName(),
+			err,
+		)
+	}
+	if project.GetProject() == nil {
+		return nil, fmt.Errorf(
+			"resolving project root for toolbox %q: empty project",
+			svc.GetName(),
+		)
+	}
+	return parseToolboxServiceConfigAtRoot(
+		svc,
+		project.GetProject().GetPath(),
+	)
+}
+
+func parseToolboxServiceConfigAtRoot(
+	svc *azdext.ServiceConfig,
+	projectRoot string,
+) (*toolboxServiceConfig, error) {
+	props := toolboxServiceProps(svc)
 	cfg := &toolboxServiceConfig{}
 	if props == nil {
 		return cfg, nil
 	}
-	b, err := json.Marshal(props.AsMap())
+	values := props.AsMap()
+	if projectRoot != "" {
+		resolved, err := foundry.ResolveFileRefs(values, projectRoot)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"resolving toolbox service %q config: %w",
+				svc.GetName(),
+				err,
+			)
+		}
+		values = resolved
+	}
+	b, err := json.Marshal(values)
 	if err != nil {
 		return nil, fmt.Errorf("encoding toolbox service %q config: %w", svc.GetName(), err)
 	}
@@ -321,6 +373,35 @@ func parseToolboxServiceConfig(svc *azdext.ServiceConfig) (*toolboxServiceConfig
 		return nil, fmt.Errorf("parsing toolbox service %q config: %w", svc.GetName(), err)
 	}
 	return cfg, nil
+}
+
+func toolboxServiceProps(
+	svc *azdext.ServiceConfig,
+) *structpb.Struct {
+	props := svc.GetAdditionalProperties()
+	if props == nil || len(props.GetFields()) == 0 {
+		return svc.GetConfig()
+	}
+	return props
+}
+
+func containsToolboxFileRef(value any) bool {
+	switch typed := value.(type) {
+	case map[string]any:
+		if _, exists := typed["$ref"]; exists {
+			return true
+		}
+		for _, child := range typed {
+			if containsToolboxFileRef(child) {
+				return true
+			}
+		}
+	case []any:
+		if slices.ContainsFunc(typed, containsToolboxFileRef) {
+			return true
+		}
+	}
+	return false
 }
 
 // currentEnvValues loads all key-value pairs from the active azd environment, used to

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/service_target_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/service_target_test.go
@@ -5,6 +5,8 @@ package cmd
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -48,6 +50,39 @@ func TestParseToolboxServiceConfig_ServiceLevel(t *testing.T) {
 	require.Len(t, cfg.Tools, 2)
 	assert.Equal(t, "web_search", cfg.Tools[0]["type"])
 	assert.Equal(t, "github-mcp", cfg.Tools[1]["connection"])
+}
+
+func TestParseToolboxServiceConfig_FileRef(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "toolbox.yaml"),
+		[]byte(
+			"description: referenced tools\n"+
+				"tools:\n"+
+				"  - type: web_search\n",
+		),
+		0o600,
+	))
+	props, err := structpb.NewStruct(map[string]any{
+		"$ref": "./toolbox.yaml",
+	})
+	require.NoError(t, err)
+
+	cfg, err := parseToolboxServiceConfigAtRoot(
+		&azdext.ServiceConfig{
+			Name:                 "referenced",
+			Host:                 aiToolboxHost,
+			AdditionalProperties: props,
+		},
+		root,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "referenced tools", cfg.Description)
+	require.Len(t, cfg.Tools, 1)
+	assert.Equal(t, "web_search", cfg.Tools[0]["type"])
 }
 
 func TestParseToolboxServiceConfig_Endpoint(t *testing.T) {


### PR DESCRIPTION
## Why this PR is needed

Toolbox service configuration can be written inline in `azure.yaml` or loaded from a local file with `$ref`. The deploy path previously parsed the `$ref` object as the toolbox configuration instead of loading the referenced file. As a result, deployments using file-based toolbox configuration could omit the description and tools defined in that file, or fail to deploy with the expected configuration.

This fix resolves local `$ref` files relative to the project root before parsing the toolbox configuration. Inline configuration and the legacy `config:` shape continue to use the existing behavior. This keeps file-based and inline configuration consistent at deploy time.

## Changes

- Resolve toolbox `$ref` file includes with `foundry.ResolveFileRefs` when a reference is present anywhere in the service configuration.
- Preserve the existing inline and legacy `config:` parsing behavior when no `$ref` is present.
- Add a regression test covering a toolbox configuration loaded from a local file.

## Testing

- `go build ./...` in `cli/azd/extensions/azure.ai.toolboxes`
- `go test ./internal/cmd/...` in `cli/azd/extensions/azure.ai.toolboxes`