### PR TITLE
Add explicit codeowners line for who can approve extension publishing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 /cli/installer/                             @danieljurek @vhvb1989 @tg-msft @RickWinter
 
 # ── CLI extensions registry - anyone added to this can approve extension publishing.
-/cli/azd/extensions/registry.json           @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft
+/cli/azd/extensions/registry.json           @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft @XiaofuHuang @achauhan-scc @anchenyi @glharper @huimiu @hund030 @kingernupur @saanikaguptamicrosoft @therealjohn @trangevi @trrwilson
 
 # ── CLI extensions (AI) ──────────────────────────────────────────────────────
 /cli/azd/extensions/azure.ai.agents/        @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 /cli/installer/                             @danieljurek @vhvb1989 @tg-msft @RickWinter
 
 # ── CLI extensions registry - anyone added to this can approve extension publishing, provided they pass the `ext-registry-check` workflow.
-/cli/azd/extensions/registry.json           @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft @XiaofuHuang @achauhan-scc @anchenyi @glharper @huimiu @hund030 @kingernupur @saanikaguptamicrosoft @therealjohn @trangevi @trrwilson
+/cli/azd/extensions/registry.json           @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft
 
 # ── CLI extensions (AI) ──────────────────────────────────────────────────────
 /cli/azd/extensions/azure.ai.agents/        @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # everything else not listed below -- no need for a separate /cli/ rule.
 
 # ── Default (core team) ──────────────────────────────────────────────────────
-/**                                         @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter
+/**                                         @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft
 
 # ── CLI installer ─────────────────────────────────────────────────────────────
 /cli/installer/                             @danieljurek @vhvb1989 @tg-msft @RickWinter

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,9 @@
 # ── CLI installer ─────────────────────────────────────────────────────────────
 /cli/installer/                             @danieljurek @vhvb1989 @tg-msft @RickWinter
 
+# ── CLI extensions registry - anyone added to this can approve extension publishing.
+/cli/azd/extensions/registry.json           @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft
+
 # ── CLI extensions (AI) ──────────────────────────────────────────────────────
 /cli/azd/extensions/azure.ai.agents/        @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030
 /cli/azd/test/functional/ai_agents/         @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 # ── CLI installer ─────────────────────────────────────────────────────────────
 /cli/installer/                             @danieljurek @vhvb1989 @tg-msft @RickWinter
 
-# ── CLI extensions registry - anyone added to this can approve extension publishing.
+# ── CLI extensions registry - anyone added to this can approve extension publishing, provided they pass the `ext-registry-check` workflow.
 /cli/azd/extensions/registry.json           @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft @XiaofuHuang @achauhan-scc @anchenyi @glharper @huimiu @hund030 @kingernupur @saanikaguptamicrosoft @therealjohn @trangevi @trrwilson
 
 # ── CLI extensions (AI) ──────────────────────────────────────────────────────

--- a/.github/scripts/src/ext-registry-check.js
+++ b/.github/scripts/src/ext-registry-check.js
@@ -145,7 +145,8 @@ function getCoreReviewers({ core }) {
     'hemarina',
     'JeffreyCA',
     'RickWinter',
-    'richardpark-msft',
+    // TODO: bring me back after we get this all working in production
+    //'richardpark-msft',
     'tg-msft',
     'vhvb1989',
   ];

--- a/.github/scripts/src/ext-registry-check.js
+++ b/.github/scripts/src/ext-registry-check.js
@@ -145,8 +145,7 @@ function getCoreReviewers({ core }) {
     'hemarina',
     'JeffreyCA',
     'RickWinter',
-    // TODO: bring me back from the dead!
-    // 'richardpark-msft',
+    'richardpark-msft',
     'tg-msft',
     'vhvb1989',
   ];

--- a/.github/workflows/event.yml
+++ b/.github/workflows/event.yml
@@ -12,7 +12,7 @@ on:
   # entirely of github actions won't trigger this action.
   workflow_run:
     types: [completed]
-    workflows: ["cli-ci", "templates-ci", "vscode-ci", "ext-registry-check"]
+    workflows: ["cli-ci", "templates-ci", "vscode-ci"]
 
 permissions: {}
 

--- a/.github/workflows/event.yml
+++ b/.github/workflows/event.yml
@@ -12,7 +12,7 @@ on:
   # entirely of github actions won't trigger this action.
   workflow_run:
     types: [completed]
-    workflows: ["cli-ci", "templates-ci", "vscode-ci"]
+    workflows: ["cli-ci", "templates-ci", "vscode-ci", "ext-registry-check"]
 
 permissions: {}
 

--- a/.github/workflows/ext-registry-check.yml
+++ b/.github/workflows/ext-registry-check.yml
@@ -1,9 +1,18 @@
 name: ext-registry-check
 
+# NOTE: We're using pull_request_target here, because the PR is untrusted and the entire point of this workflow is to judge 
+# if "untrusted registry.json update is safe", so we need to make sure the workflow is coming from our 'protected' 
+# main branch, not from the user's PR branch.
+#   
+# Currently, check-enforcer doesn't have the same support for `pull_request_target` as `pull_request` so we need to have a 
+# discussion about what's going on there. I filed an issue, so potentially we can revisit this:
+# - https://github.com/Azure/azure-sdk-tools/issues/16366
+#
+# This means we, instead, need to be set in GitHub as a "required to pass" workflow check. That means our workflow 
+# needs to run on _every_ PR because required workflows still need to report a status on each PR. We no-op quickly, 
+# but we still need to run and report a status, regardless.
 on:
   pull_request_target:
-    paths:
-      - "cli/azd/extensions/registry.json"
     branches: [main]
     types: [opened, edited, synchronize, labeled, unlabeled, reopened, ready_for_review]
 
@@ -26,12 +35,28 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Check if registry.json changed
+        id: changed
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const changed = files.some((f) => f.filename === 'cli/azd/extensions/registry.json');
+            core.info(`registry.json changed: ${changed}`);
+            core.setOutput('registry_json_changed', changed);
+
       - name: Checkout
+        if: steps.changed.outputs.registry_json_changed == 'true'
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Check extension registry update
+        if: steps.changed.outputs.registry_json_changed == 'true'
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
Prep for adding in Foundry developers so they can also approve their own registry update PRs, subject to the checks in the `ext-registry-check` workflow. (There's some github changes I need to do before I can add Foundry into CODEOWNERS, but this is very close!)

(small changes)
* Bring myself back as an azd reviewer.
* Adding myself to the global codeowners slot since everyone else is on that.

(these are those workflows, and it's js file):
- https://github.com/Azure/azure-dev/blob/main/.github/scripts/src/ext-registry-check.js
- https://github.com/Azure/azure-dev/blob/main/.github/workflows/ext-registry-check.yml

The way this works, with regards to registry PRs:
- Simple registry updates (new version for an existing extension, no provider or capability updates) can be approved by anyone in CODEOWNERS (azd team, foundry devs, currently).
- Complex updates (ie, any of those things mentioned above, change), you get a PR workflow fail for the "ext-registry-check" workflow run:

  <img width="1324" height="113" alt="image" src="https://github.com/user-attachments/assets/f444dcb1-a1b3-452f-b72f-577e76902980" />

  If you click it ([link](https://github.com/Azure/azure-dev/actions/runs/29439680201/job/87435127264?pr=9100)) it'll tell you the specific item that's requires approval. So then:

  1. The user needs to find an azd core team member, and provided it's "okay" (@tg-msft is working on docs) then they'll approve it and the release can happen (the 'super approvers' list is just hardcoded in the JS at this moment: (https://github.com/Azure/azure-dev/blob/cc1f941a9a27098facdd95db0f4f47fc5241a3b6/.github/scripts/src/ext-registry-check.js#L143))
  2. Re-run that failed workflow step - now it will pass.

Fixes #8997