### PR TITLE
feat: add a new user agent: microsoft_foundry_skill

### DIFF
--- a/cli/azd/internal/tracing/fields/fields.go
+++ b/cli/azd/internal/tracing/fields/fields.go
@@ -321,7 +321,8 @@ const (
 	// Environment modifiers. These are not environments themselves, but rather modifiers to the environment
 	// that signal specific types of usages.
 
-	EnvModifierAzureSpace = "Azure App Spaces Portal"
+	EnvModifierAzureSpace            = "Azure App Spaces Portal"
+	EnvModifierMicrosoftFoundrySkill = "Microsoft Foundry Skill"
 )
 
 // All possible enumerations of AccountTypeKey

--- a/cli/azd/internal/tracing/resource/exec_environment.go
+++ b/cli/azd/internal/tracing/resource/exec_environment.go
@@ -107,6 +107,9 @@ func execEnvModifiers() []string {
 	if strings.Contains(userAgent, "azure_app_space_portal") {
 		modifiers = append(modifiers, fields.EnvModifierAzureSpace)
 	}
+	if strings.Contains(userAgent, "microsoft-foundry-skill") {
+		modifiers = append(modifiers, fields.EnvModifierMicrosoftFoundrySkill)
+	}
 
 	return modifiers
 }

--- a/cli/azd/internal/tracing/resource/exec_environment.go
+++ b/cli/azd/internal/tracing/resource/exec_environment.go
@@ -107,7 +107,7 @@ func execEnvModifiers() []string {
 	if strings.Contains(userAgent, "azure_app_space_portal") {
 		modifiers = append(modifiers, fields.EnvModifierAzureSpace)
 	}
-	if strings.Contains(userAgent, "microsoft-foundry-skill") {
+	if strings.Contains(userAgent, "microsoft_foundry_skill") {
 		modifiers = append(modifiers, fields.EnvModifierMicrosoftFoundrySkill)
 	}
 

--- a/cli/azd/internal/tracing/resource/resource_test.go
+++ b/cli/azd/internal/tracing/resource/resource_test.go
@@ -5,6 +5,7 @@ package resource
 
 import (
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/internal/tracing/fields"
@@ -253,6 +254,48 @@ func TestExecEnvForHosts_no_host(t *testing.T) {
 	result := execEnvForHosts()
 	if result != "" {
 		t.Fatalf("execEnvForHosts() = %q, want empty string", result)
+	}
+}
+
+func TestExecEnvModifiers(t *testing.T) {
+	tests := []struct {
+		name      string
+		userAgent string
+		want      []string
+	}{
+		{
+			name:      "no modifiers",
+			userAgent: "custom-user-agent",
+			want:      []string{},
+		},
+		{
+			name:      "Azure App Spaces portal",
+			userAgent: "azure_app_space_portal:v1.0.0",
+			want:      []string{fields.EnvModifierAzureSpace},
+		},
+		{
+			name:      "Microsoft Foundry skill",
+			userAgent: "microsoft-foundry-skill",
+			want:      []string{fields.EnvModifierMicrosoftFoundrySkill},
+		},
+		{
+			name:      "multiple modifiers",
+			userAgent: "azure_app_space_portal microsoft-foundry-skill",
+			want: []string{
+				fields.EnvModifierAzureSpace,
+				fields.EnvModifierMicrosoftFoundrySkill,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AZURE_DEV_USER_AGENT", tt.userAgent)
+
+			if got := execEnvModifiers(); !slices.Equal(got, tt.want) {
+				t.Fatalf("execEnvModifiers() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cli/azd/internal/tracing/resource/resource_test.go
+++ b/cli/azd/internal/tracing/resource/resource_test.go
@@ -275,12 +275,12 @@ func TestExecEnvModifiers(t *testing.T) {
 		},
 		{
 			name:      "Microsoft Foundry skill",
-			userAgent: "microsoft-foundry-skill",
+			userAgent: "microsoft_foundry_skill",
 			want:      []string{fields.EnvModifierMicrosoftFoundrySkill},
 		},
 		{
 			name:      "multiple modifiers",
-			userAgent: "azure_app_space_portal microsoft-foundry-skill",
+			userAgent: "azure_app_space_portal microsoft_foundry_skill",
 			want: []string{
 				fields.EnvModifierAzureSpace,
 				fields.EnvModifierMicrosoftFoundrySkill,

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -237,8 +237,11 @@ func Test_CLI_Telemetry_NestedCommands(t *testing.T) {
 	// Always set telemetry opt-inn setting to avoid influence from user settings
 	cli.Env = append(os.Environ(), "AZURE_DEV_COLLECT_TELEMETRY=yes")
 
-	// set environment modifier
-	cli.Env = append(cli.Env, "AZURE_DEV_USER_AGENT=azure_app_space_portal:v1.0.0")
+	// set environment modifiers
+	cli.Env = append(
+		cli.Env,
+		"AZURE_DEV_USER_AGENT=azure_app_space_portal:v1.0.0 microsoft-foundry-skill",
+	)
 
 	// set a fixed traceparent to verify trace ID propagation for commands and nested commands
 	traceId := "246cfb7e1b1c5978f4b0fc2e41e98db6"
@@ -418,8 +421,15 @@ func verifyResource(
 	}
 
 	for _, env := range cmdEnv {
-		if strings.HasPrefix(env, "AZURE_DEV_USER_AGENT=") && strings.Contains(env, "azure_app_space_portal") {
+		if !strings.HasPrefix(env, "AZURE_DEV_USER_AGENT=") {
+			continue
+		}
+
+		if strings.Contains(env, "azure_app_space_portal") {
 			require.Contains(t, m[fields.ExecutionEnvironmentKey.Key], ";"+fields.EnvModifierAzureSpace)
+		}
+		if strings.Contains(env, "microsoft-foundry-skill") {
+			require.Contains(t, m[fields.ExecutionEnvironmentKey.Key], ";"+fields.EnvModifierMicrosoftFoundrySkill)
 		}
 	}
 

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -240,7 +240,7 @@ func Test_CLI_Telemetry_NestedCommands(t *testing.T) {
 	// set environment modifiers
 	cli.Env = append(
 		cli.Env,
-		"AZURE_DEV_USER_AGENT=azure_app_space_portal:v1.0.0 microsoft-foundry-skill",
+		"AZURE_DEV_USER_AGENT=azure_app_space_portal:v1.0.0 microsoft_foundry_skill",
 	)
 
 	// set a fixed traceparent to verify trace ID propagation for commands and nested commands
@@ -428,7 +428,7 @@ func verifyResource(
 		if strings.Contains(env, "azure_app_space_portal") {
 			require.Contains(t, m[fields.ExecutionEnvironmentKey.Key], ";"+fields.EnvModifierAzureSpace)
 		}
-		if strings.Contains(env, "microsoft-foundry-skill") {
+		if strings.Contains(env, "microsoft_foundry_skill") {
 			require.Contains(t, m[fields.ExecutionEnvironmentKey.Key], ";"+fields.EnvModifierMicrosoftFoundrySkill)
 		}
 	}

--- a/docs/reference/telemetry-data.md
+++ b/docs/reference/telemetry-data.md
@@ -587,7 +587,7 @@ The `execution.environment` field identifies where azd is running. Format: `<env
 | `GitHub Codespaces` | GitHub Codespaces |
 | Other CI systems | `AppVeyor`, `Bamboo`, `BitBucket Pipelines`, `Travis CI`, `Circle CI`, `GitLab CI`, `Jenkins`, `AWS CodeBuild`, `Google Cloud Build`, `TeamCity`, `JetBrains Space` |
 
-**Modifier:** `Azure App Spaces Portal` may be appended as a modifier (`;` separated).
+**Modifiers:** `Azure App Spaces Portal` and `Microsoft Foundry Skill` may be appended as modifiers (`;` separated).
 
 ## Data Nuances & Gotchas
 


### PR DESCRIPTION
## Summary

Recognize azd invocations from Microsoft Foundry Skill by appending `Microsoft Foundry Skill` to the existing `execution.environment` telemetry field when `AZURE_DEV_USER_AGENT` contains `microsoft_foundry_skill`.

## Changes

- Add the `Microsoft Foundry Skill` execution-environment modifier.
- Add unit tests covering individual and combined modifiers.
- Add functional coverage verifying the modifier appears in the emitted trace resource.
- Document the new modifier in the telemetry reference.


Fixes https://github.com/Azure/azure-dev/issues/9168