### PR TITLE
fix: detect modern Python agents for code deploy

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers.go
@@ -26,6 +26,7 @@ import (
 	projectpkg "azureaiagent/internal/project"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/google/uuid"
 	"golang.org/x/term"
 )
@@ -503,29 +504,99 @@ type ProjectType struct {
 	StartCmd string // suggested start command
 }
 
+type projectLanguages struct {
+	python         bool
+	pythonMetadata bool
+	pythonMain     bool
+	dotnet         bool
+	node           bool
+}
+
+func detectProjectLanguages(projectDir string) projectLanguages {
+	if projectDir == "" {
+		projectDir = "."
+	}
+
+	entries, err := os.ReadDir(projectDir)
+	if err != nil {
+		warnProjectInspectionFailure(os.Stderr, projectDir, err)
+		return projectLanguages{}
+	}
+
+	var languages projectLanguages
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		switch {
+		case name == "pyproject.toml",
+			name == "requirements.txt":
+			languages.python = true
+			languages.pythonMetadata = true
+		case strings.HasSuffix(name, ".py"):
+			languages.python = true
+			if name == "main.py" {
+				languages.pythonMain = true
+			}
+		case strings.HasSuffix(name, ".csproj"):
+			languages.dotnet = true
+		case name == "package.json":
+			languages.node = true
+		}
+	}
+
+	return languages
+}
+
+func warnProjectInspectionFailure(writer io.Writer, projectDir string, err error) {
+	fmt.Fprintf(writer, "%s", output.WithWarningFormat(
+		"WARNING: cannot read project directory %q: %v. "+
+			"Treating the project as unknown, so code deploy will not be offered "+
+			"and no local start command can be detected. "+
+			"Check the service path in azure.yaml and directory permissions.\n",
+		projectDir,
+		err,
+	))
+}
+
+func isPythonProject(projectDir string) bool {
+	return detectProjectLanguages(projectDir).python
+}
+
+func isDotnetProject(projectDir string) bool {
+	return detectProjectLanguages(projectDir).dotnet
+}
+
+func supportsCodeDeploy(projectDir string) bool {
+	languages := detectProjectLanguages(projectDir)
+	// Python metadata is authoritative. A lone .py file is only a
+	// fallback when package.json does not identify a Node project.
+	supportsPython := languages.pythonMetadata ||
+		(languages.python && !languages.node)
+	return languages.dotnet || supportsPython
+}
+
 func detectProjectType(projectDir string) ProjectType {
-	// Python: pyproject.toml or requirements.txt
-	if fileExists(filepath.Join(projectDir, "pyproject.toml")) ||
-		fileExists(filepath.Join(projectDir, "requirements.txt")) {
+	languages := detectProjectLanguages(projectDir)
+
+	if languages.pythonMetadata {
 		if fileExists(filepath.Join(projectDir, "main.py")) {
 			return ProjectType{Language: "python", StartCmd: "python main.py"}
 		}
 		return ProjectType{Language: "python", StartCmd: ""}
 	}
 
-	// .NET: any .csproj file
-	matches, _ := filepath.Glob(filepath.Join(projectDir, "*.csproj"))
-	if len(matches) > 0 {
+	if languages.dotnet {
 		return ProjectType{Language: "dotnet", StartCmd: "dotnet run"}
 	}
 
-	// Node.js: package.json
-	if fileExists(filepath.Join(projectDir, "package.json")) {
+	if languages.node {
 		return ProjectType{Language: "node", StartCmd: "npm start"}
 	}
 
-	// Check for standalone main.py as fallback
-	if fileExists(filepath.Join(projectDir, "main.py")) {
+	if languages.pythonMain {
 		return ProjectType{Language: "python", StartCmd: "python main.py"}
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
@@ -4,7 +4,9 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -57,6 +59,16 @@ func TestDetectStartupCommand(t *testing.T) {
 			expected: "python main.py",
 		},
 		{
+			name:     "python with main.py and helper file",
+			files:    []string{"main.py", "tools.py"},
+			expected: "python main.py",
+		},
+		{
+			name:     "case-sensitive Python entry point",
+			files:    []string{"Main.py"},
+			expected: "",
+		},
+		{
 			name:     "dotnet with csproj",
 			files:    []string{"MyAgent.csproj"},
 			expected: "dotnet run",
@@ -64,6 +76,11 @@ func TestDetectStartupCommand(t *testing.T) {
 		{
 			name:     "node with package.json",
 			files:    []string{"package.json"},
+			expected: "npm start",
+		},
+		{
+			name:     "node with Python helper file",
+			files:    []string{"package.json", "tools.py"},
 			expected: "npm start",
 		},
 		{
@@ -136,6 +153,12 @@ func TestDetectProjectType(t *testing.T) {
 			wantStartCmd: "npm start",
 		},
 		{
+			name:         "node takes precedence over Python helper file",
+			files:        []string{"package.json", "tools.py"},
+			wantLanguage: "node",
+			wantStartCmd: "npm start",
+		},
+		{
 			name:         "unknown when no markers",
 			files:        []string{"Dockerfile"},
 			wantLanguage: "unknown",
@@ -160,6 +183,101 @@ func TestDetectProjectType(t *testing.T) {
 			}
 			if pt.StartCmd != tt.wantStartCmd {
 				t.Errorf("StartCmd = %q, want %q", pt.StartCmd, tt.wantStartCmd)
+			}
+		})
+	}
+}
+
+func TestWarnProjectInspectionFailure(t *testing.T) {
+	var stderr bytes.Buffer
+	warnProjectInspectionFailure(&stderr, "missing-service", errors.New("access denied"))
+
+	warning := stderr.String()
+	require.Contains(t, warning, `cannot read project directory "missing-service": access denied`)
+	require.Contains(t, warning, "code deploy will not be offered")
+	require.Contains(t, warning, "no local start command can be detected")
+	require.Contains(t, warning, "Check the service path in azure.yaml and directory permissions")
+}
+
+func TestCodeDeployProjectDetection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		files      []string
+		wantPython bool
+		wantDotnet bool
+		wantCode   bool
+	}{
+		{
+			name:       "modern Python project",
+			files:      []string{"pyproject.toml"},
+			wantPython: true,
+			wantCode:   true,
+		},
+		{
+			name:       "requirements Python project",
+			files:      []string{"requirements.txt"},
+			wantPython: true,
+			wantCode:   true,
+		},
+		{
+			name:       "standalone Python file",
+			files:      []string{"agent.py"},
+			wantPython: true,
+			wantCode:   true,
+		},
+		{
+			name:       "Node project with Python helper",
+			files:      []string{"package.json", "tools.py"},
+			wantPython: true,
+		},
+		{
+			name:  "case-sensitive Python marker",
+			files: []string{"PYPROJECT.TOML"},
+		},
+		{
+			name:       "dotnet project",
+			files:      []string{"Agent.csproj"},
+			wantDotnet: true,
+			wantCode:   true,
+		},
+		{
+			name:       "mixed supported project",
+			files:      []string{"pyproject.toml", "Agent.csproj"},
+			wantPython: true,
+			wantDotnet: true,
+			wantCode:   true,
+		},
+		{
+			name:  "unsupported Node project",
+			files: []string{"package.json"},
+		},
+		{
+			name:  "unknown project",
+			files: []string{"README.md"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			for _, file := range tt.files {
+				if err := os.WriteFile(filepath.Join(dir, file), nil, 0600); err != nil {
+					t.Fatalf("failed to create test file %s: %v", file, err)
+				}
+			}
+
+			if got := isPythonProject(dir); got != tt.wantPython {
+				t.Errorf("isPythonProject() = %t, want %t", got, tt.wantPython)
+			}
+			if got := isDotnetProject(dir); got != tt.wantDotnet {
+				t.Errorf("isDotnetProject() = %t, want %t", got, tt.wantDotnet)
+			}
+			if got := supportsCodeDeploy(dir); got != tt.wantCode {
+				t.Errorf("supportsCodeDeploy() = %t, want %t", got, tt.wantCode)
 			}
 		})
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1601,7 +1601,7 @@ func (a *InitAction) Run(ctx context.Context) error {
 		// Prompt for deploy mode (code vs container) for hosted agents.
 		// Code deploy is supported for Python and .NET projects.
 		if _, ok := agentManifest.Template.(agent_yaml.ContainerAgent); ok {
-			showCodeDeploy := isPythonProject(targetDir) || isDotnetProject(targetDir)
+			showCodeDeploy := supportsCodeDeploy(targetDir)
 			deployMode, err := promptDeployMode(ctx, a.azdClient, a.flags.noPrompt, showCodeDeploy, a.flags.deployMode, a.userProvidedManifest)
 			if err != nil {
 				return fmt.Errorf("prompting for deploy mode: %w", err)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -19,6 +19,7 @@ import (
 
 	"azureaiagent/internal/cmd/nextstep"
 	"azureaiagent/internal/exterrors"
+	"azureaiagent/internal/pkg/paths"
 	"azureaiagent/internal/project"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -1343,7 +1344,14 @@ func applyDeployModeToAdoptedProject(
 	// resolves to a container deploy so the caller can wire an ACR.
 	usesContainer := false
 	for _, agent := range agentServices {
-		container, err := applyDeployModeToService(ctx, flags, azdClient, agent.name, agent.svc)
+		container, err := applyDeployModeToService(
+			ctx,
+			flags,
+			azdClient,
+			resp.GetProject().GetPath(),
+			agent.name,
+			agent.svc,
+		)
 		if err != nil {
 			return false, err
 		}
@@ -1364,6 +1372,7 @@ func applyDeployModeToService(
 	ctx context.Context,
 	flags *initFlags,
 	azdClient *azdext.AzdClient,
+	projectPath string,
 	serviceName string,
 	svc *azdext.ServiceConfig,
 ) (bool, error) {
@@ -1405,15 +1414,27 @@ func applyDeployModeToService(
 	if targetDir == "" {
 		targetDir = "."
 	}
-	showCodeDeploy := isPythonProject(targetDir) || isDotnetProject(targetDir)
+	serviceDir, err := paths.JoinAllowRoot(projectPath, targetDir)
+	if err != nil {
+		return false, exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			fmt.Sprintf("invalid service path for %s: %s", serviceName, err),
+			"update azure.yaml so the agent service path stays within the project directory",
+		)
+	}
+	showCodeDeploy := supportsCodeDeploy(serviceDir)
 	// userProvidedManifest is true: -m was explicitly provided.
-	deployMode, err := promptDeployMode(ctx, azdClient, flags.noPrompt, showCodeDeploy, flags.deployMode, true)
+	deployMode, err := promptDeployMode(
+		ctx, azdClient, flags.noPrompt, showCodeDeploy, flags.deployMode, true,
+	)
 	if err != nil {
 		return false, fmt.Errorf("resolving deploy mode for adopted project: %w", err)
 	}
 
 	if deployMode == "code" {
-		return false, applyCodeDeployToService(ctx, flags, azdClient, serviceName, targetDir, svc)
+		return false, applyCodeDeployToService(
+			ctx, flags, azdClient, serviceName, serviceDir, svc,
+		)
 	}
 	if err := applyContainerDeployToService(ctx, azdClient, serviceName, svc); err != nil {
 		return false, err

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_deploymode_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_deploymode_test.go
@@ -5,6 +5,8 @@ package cmd
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -21,6 +23,7 @@ type deployModeProjectServer struct {
 	azdext.UnimplementedProjectServiceServer
 
 	mu       sync.Mutex
+	path     string
 	services map[string]*azdext.ServiceConfig
 	sets     map[string]map[string]any // serviceName -> path -> value
 	unsets   map[string][]string       // serviceName -> unset paths
@@ -31,7 +34,9 @@ func (s *deployModeProjectServer) Get(
 ) (*azdext.GetProjectResponse, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return &azdext.GetProjectResponse{Project: &azdext.ProjectConfig{Services: s.services}}, nil
+	return &azdext.GetProjectResponse{
+		Project: &azdext.ProjectConfig{Path: s.path, Services: s.services},
+	}, nil
 }
 
 func (s *deployModeProjectServer) SetServiceConfigValue(
@@ -143,6 +148,7 @@ func TestApplyDeployModeToAdoptedProject(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			server := &deployModeProjectServer{
+				path:     t.TempDir(),
 				services: map[string]*azdext.ServiceConfig{svcName: tc.service},
 			}
 			client := newProjectRecorderClient(t, server)
@@ -174,6 +180,7 @@ func TestApplyDeployModeToAdoptedProject(t *testing.T) {
 // deploy (so ACR is skipped) rather than erroring.
 func TestApplyDeployModeToAdoptedProject_NoAgentServices(t *testing.T) {
 	server := &deployModeProjectServer{
+		path: t.TempDir(),
 		services: map[string]*azdext.ServiceConfig{
 			"web": {Name: "web", Host: "containerapp"},
 		},
@@ -183,4 +190,33 @@ func TestApplyDeployModeToAdoptedProject_NoAgentServices(t *testing.T) {
 	usesContainer, err := applyDeployModeToAdoptedProject(t.Context(), &initFlags{}, client)
 	require.NoError(t, err)
 	assert.False(t, usesContainer)
+}
+
+func TestApplyDeployModeToAdoptedProject_ResolvesServicePath(t *testing.T) {
+	projectDir := t.TempDir()
+	serviceDir := filepath.Join(projectDir, "src", "agent")
+	require.NoError(t, os.MkdirAll(serviceDir, 0750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(serviceDir, "pyproject.toml"),
+		nil,
+		0600,
+	))
+
+	service := agentServiceConfig(t, "agent", nil)
+	service.RelativePath = filepath.Join("src", "agent")
+	server := &deployModeProjectServer{
+		path:     projectDir,
+		services: map[string]*azdext.ServiceConfig{"agent": service},
+	}
+	client := newProjectRecorderClient(t, server)
+
+	usesContainer, err := applyDeployModeToAdoptedProject(
+		t.Context(),
+		&initFlags{noPrompt: true},
+		client,
+	)
+	require.NoError(t, err)
+	assert.False(t, usesContainer)
+	assert.Equal(t, "python", server.sets["agent"]["language"])
+	assert.Contains(t, server.sets["agent"], "codeConfiguration")
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -289,7 +289,7 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 	if srcDir == "" {
 		srcDir, _ = os.Getwd()
 	}
-	showCodeDeploy := isPythonProject(srcDir) || isDotnetProject(srcDir)
+	showCodeDeploy := supportsCodeDeploy(srcDir)
 	deployMode, err := promptDeployMode(ctx, a.azdClient, a.flags.noPrompt, showCodeDeploy, a.flags.deployMode, false)
 	if err != nil {
 		return nil, err
@@ -1270,45 +1270,4 @@ func promptCodeConfig(ctx context.Context, azdClient *azdext.AzdClient, srcDir s
 		EntryPoint:           entryPoint,
 		DependencyResolution: &depResolution,
 	}, nil
-}
-
-// isPythonProject returns true if the directory appears to be a Python project,
-// determined by the presence of requirements.txt or any .py file.
-func isPythonProject(dir string) bool {
-	if dir == "" {
-		dir = "."
-	}
-	// Check for requirements.txt
-	if _, err := os.Stat(filepath.Join(dir, "requirements.txt")); err == nil {
-		return true
-	}
-	// Check for any .py file (shallow scan)
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false
-	}
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".py") {
-			return true
-		}
-	}
-	return false
-}
-
-// isDotnetProject returns true if the directory contains a .csproj file.
-// NOTE: .fsproj (F#) is not yet supported by the packaging path (packageDotnetBundled/detectDefaultEntryPoint).
-func isDotnetProject(dir string) bool {
-	if dir == "" {
-		dir = "."
-	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false
-	}
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".csproj") {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Fixes: #9123

## Why

The "Use the code in the current directory" flow used a separate, older language detector that did not recognize `pyproject.toml`. Modern Python projects could therefore be treated as unsupported, silently routed to container deployment, and prompted for an unnecessary Azure Container Registry.

## What changed

- Consolidate Python, .NET, and Node.js project signals into one detector shared by init, manifest adoption, and local run flows.
- Recognize `pyproject.toml` as a Python code-deploy signal while preserving existing `requirements.txt`, `*.py`, and `*.csproj` behavior.
- Keep Node.js and unknown projects on container deployment.
- Add regression coverage for modern Python, existing Python/.NET, mixed, unsupported, and unknown projects.
- Document the fix in the extension changelog.

## Why this approach

Sharing one set of project signals prevents init and local-run behavior from drifting again. The change stays shallow and uses the selected source directory as the deployment root, avoiding false positives from nested projects whose entry point and service path would not match the chosen root.

## Validation

- `go test ./internal/cmd`
- `go test ./...`

## PR extension validation

- Built the PR's `azure.ai.agents` extension and packaged it as a self-contained bundle.
- Installed the bundle with `azd extension install` into an isolated `AZD_CONFIG_DIR`; `azd ai agent version` reported PR commit `c68cc1106`.
- Verified the installed extension routes `azd ai agent`, `azd ai agent init --help`, and `azd ai agent code --help` through the azd host.
- Started the installed `azd ai agent init --no-prompt --deploy-mode code` path for Python code deployment. It correctly reached the extension.