### PR TITLE
ci: remove --no-optional from vscode dependency install (fix #9140)

### DIFF
--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --no-optional
+          npm ci
         working-directory: ./ext/vscode
 
       - name: Test

--- a/eng/pipelines/templates/jobs/vscode-build.yml
+++ b/eng/pipelines/templates/jobs/vscode-build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - pwsh: |
           npm i -g npm @vscode/vsce
-          npm ci --no-optional
+          npm ci
         workingDirectory: ext/vscode
         displayName: Install dependencies
 


### PR DESCRIPTION
### Summary

Fixes #9140.

The `azure-dev - vscode` ADO pipeline Test task fails on all three OSes for any PR touching `ext/vscode` with:

```
Error: The package "@esbuild/<platform>" could not be found, and is needed by esbuild.
```

### Root cause

The dependency install step used `npm ci --no-optional`. esbuild ships its platform-specific binary (`@esbuild/<platform>`) as an **optional dependency**, so `--no-optional` drops it, breaking both `build:esbuild` and the extension-host test runner. Recent global npm (`npm i -g npm`) strictly honors `--no-optional`, which is why this regressed silently on ADO while GitHub Actions (using setup-node's bundled npm) stayed green.

### Change

Remove `--no-optional` from the dependency install step in:

- `eng/pipelines/templates/jobs/vscode-build.yml` (ADO job)
- `.github/workflows/vscode-ci.yml` (GitHub Actions, for parity)