### PR TITLE
fix(agents): restrict deploy RBAC pre-flight to roles with CogSvc data plane access

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check.go
@@ -102,6 +102,7 @@ var sufficientRoleAssignWriteRoles = []string{
 	roleRBACAdministrator,
 	roleAzureAIProjectManager,
 	roleAzureAIAccountOwner,
+	roleFoundryOwner, // c883944f-...: includes Microsoft.Authorization/roleAssignments/write
 }
 
 // CheckDeveloperRBAC verifies that the currently authenticated developer has the required

--- a/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check.go
@@ -50,6 +50,11 @@ const (
 	// Assigned by older Bicep provisions (AZURE_PRINCIPAL_ID flow); has the same
 	// Microsoft.CognitiveServices/* dataActions as Foundry User and is accepted as equivalent.
 	roleCognitiveServicesUser = "a97b65f3-24c7-4388-baec-2e87135dc908"
+
+	// Foundry Owner: full Foundry project management + Microsoft.CognitiveServices/* dataActions.
+	// The code comment on sufficientAIUserRoles already recommends this role; include it so users
+	// with Foundry Owner are not falsely flagged as missing the data-plane role.
+	roleFoundryOwner = "c883944f-8b7b-4483-af10-35834be79c4a"
 )
 
 // sufficientACRRoles lists every role that grants enough ACR access to build
@@ -82,6 +87,8 @@ var sufficientACRAbacRoles = []string{
 var sufficientAIUserRoles = []string{
 	roleAzureAIUser,           // 53ca6127-... Foundry User: dataActions Microsoft.CognitiveServices/*
 	roleCognitiveServicesUser, // a97b65f3-... backward compat: same dataActions, assigned by older Bicep
+	roleAzureAIProjectManager, // eadc314b-... Foundry Project Manager: dataActions Microsoft.CognitiveServices/*
+	roleFoundryOwner,          // c883944f-... Foundry Owner: dataActions Microsoft.CognitiveServices/*
 }
 
 // sufficientRoleAssignWriteRoles lists every role that grants

--- a/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check.go
@@ -45,6 +45,11 @@ const (
 
 	// AI-specific roles that grant agent management access.
 	roleAzureAIDeveloper = "64702f94-c441-49e6-a78b-ef80e0188fee"
+
+	// Cognitive Services User: backward-compat alias for Foundry User.
+	// Assigned by older Bicep provisions (AZURE_PRINCIPAL_ID flow); has the same
+	// Microsoft.CognitiveServices/* dataActions as Foundry User and is accepted as equivalent.
+	roleCognitiveServicesUser = "a97b65f3-24c7-4388-baec-2e87135dc908"
 )
 
 // sufficientACRRoles lists every role that grants enough ACR access to build
@@ -66,13 +71,17 @@ var sufficientACRAbacRoles = []string{
 	roleContainerRegistryRepositoryContributor, // superset of RepositoryWriter
 }
 
-// sufficientAIUserRoles lists every role that grants enough Foundry Project
-// access to create and run agents.
+// sufficientAIUserRoles lists roles whose dataActions cover Microsoft.CognitiveServices/*,
+// specifically the AIServices namespace required for Foundry agents (agents/write).
+//
+// Excluded intentionally:
+//   - roleOwner / roleContributor: management-plane only, zero dataActions
+//   - roleAzureAIDeveloper: dataActions cover only OpenAI/Speech/ContentSafety/MaaS,
+//     NOT the AIServices.* namespace used by Foundry agents; Azure docs state
+//     "For Foundry project access, use the Foundry User or Foundry Owner roles instead"
 var sufficientAIUserRoles = []string{
-	roleOwner,
-	roleContributor,
-	roleAzureAIUser,
-	roleAzureAIDeveloper,
+	roleAzureAIUser,           // 53ca6127-... Foundry User: dataActions Microsoft.CognitiveServices/*
+	roleCognitiveServicesUser, // a97b65f3-... backward compat: same dataActions, assigned by older Bicep
 }
 
 // sufficientRoleAssignWriteRoles lists every role that grants

--- a/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check_test.go
@@ -81,6 +81,7 @@ func TestSufficientRoleLists(t *testing.T) {
 	assert.Contains(t, sufficientRoleAssignWriteRoles, roleRBACAdministrator)
 	assert.Contains(t, sufficientRoleAssignWriteRoles, roleAzureAIProjectManager)
 	assert.Contains(t, sufficientRoleAssignWriteRoles, roleAzureAIAccountOwner)
+	assert.Contains(t, sufficientRoleAssignWriteRoles, roleFoundryOwner) // Foundry Owner has roleAssignments/write
 	assert.NotContains(t, sufficientRoleAssignWriteRoles, roleContributor)
 
 	// ABAC ACR roles: Owner, RepositoryWriter, RepositoryContributor; AcrPush must NOT be included.

--- a/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check_test.go
@@ -51,6 +51,7 @@ func TestDeveloperRBACRoleConstants(t *testing.T) {
 
 	// AI roles
 	assert.Equal(t, "64702f94-c441-49e6-a78b-ef80e0188fee", roleAzureAIDeveloper)
+	assert.Equal(t, "a97b65f3-24c7-4388-baec-2e87135dc908", roleCognitiveServicesUser)
 }
 
 func TestSufficientRoleLists(t *testing.T) {
@@ -61,10 +62,14 @@ func TestSufficientRoleLists(t *testing.T) {
 	assert.Contains(t, sufficientACRRoles, roleContainerRegistryTasksContributor)
 	assert.Contains(t, sufficientACRRoles, roleContainerRegistryRepositoryContributor)
 
-	assert.Contains(t, sufficientAIUserRoles, roleOwner)
-	assert.Contains(t, sufficientAIUserRoles, roleContributor)
-	assert.Contains(t, sufficientAIUserRoles, roleAzureAIUser)
-	assert.Contains(t, sufficientAIUserRoles, roleAzureAIDeveloper)
+	// sufficientAIUserRoles must contain only roles whose dataActions cover AIServices.*
+	assert.Contains(t, sufficientAIUserRoles, roleAzureAIUser)           // Foundry User: CogSvc.*
+	assert.Contains(t, sufficientAIUserRoles, roleCognitiveServicesUser) // backward compat: CogSvc.*
+	// Owner/Contributor have no dataActions and must NOT be treated as sufficient
+	assert.NotContains(t, sufficientAIUserRoles, roleOwner)
+	assert.NotContains(t, sufficientAIUserRoles, roleContributor)
+	// Azure AI Developer only covers OpenAI/Speech/ContentSafety/MaaS — NOT AIServices.*
+	assert.NotContains(t, sufficientAIUserRoles, roleAzureAIDeveloper)
 
 	// Role-assignment write: Owner, UAA, RBAC Admin, Foundry Project Manager, Foundry Account Owner;
 	// Contributor must NOT be included.

--- a/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_check_test.go
@@ -52,6 +52,7 @@ func TestDeveloperRBACRoleConstants(t *testing.T) {
 	// AI roles
 	assert.Equal(t, "64702f94-c441-49e6-a78b-ef80e0188fee", roleAzureAIDeveloper)
 	assert.Equal(t, "a97b65f3-24c7-4388-baec-2e87135dc908", roleCognitiveServicesUser)
+	assert.Equal(t, "c883944f-8b7b-4483-af10-35834be79c4a", roleFoundryOwner)
 }
 
 func TestSufficientRoleLists(t *testing.T) {
@@ -65,6 +66,8 @@ func TestSufficientRoleLists(t *testing.T) {
 	// sufficientAIUserRoles must contain only roles whose dataActions cover AIServices.*
 	assert.Contains(t, sufficientAIUserRoles, roleAzureAIUser)           // Foundry User: CogSvc.*
 	assert.Contains(t, sufficientAIUserRoles, roleCognitiveServicesUser) // backward compat: CogSvc.*
+	assert.Contains(t, sufficientAIUserRoles, roleAzureAIProjectManager) // Foundry Project Manager: CogSvc.*
+	assert.Contains(t, sufficientAIUserRoles, roleFoundryOwner)          // Foundry Owner: CogSvc.*
 	// Owner/Contributor have no dataActions and must NOT be treated as sufficient
 	assert.NotContains(t, sufficientAIUserRoles, roleOwner)
 	assert.NotContains(t, sufficientAIUserRoles, roleContributor)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_query.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/developer_rbac_query.go
@@ -64,8 +64,8 @@ type DeveloperRBACResult struct {
 	PrincipalDisplay string
 
 	// HasSufficientAIRole is true when the principal has at least
-	// one of `sufficientAIUserRoles` (Owner, Contributor, Foundry
-	// User, Azure AI Developer) on the project scope.
+	// one of `sufficientAIUserRoles` (Foundry User, Cognitive Services User,
+	// Foundry Project Manager, or Foundry Owner) on the project scope.
 	HasSufficientAIRole bool
 
 	// ProjectScope is the full ARM resource ID of the Foundry


### PR DESCRIPTION
Fixes: #9169 

## Description

### Problem

`developer_rbac_check.go` — `sufficientAIUserRoles` — contained three incorrect entries that caused a false-positive "sufficient" result, silently blocking the Foundry User auto-assignment and ultimately producing a deploy 403:

| Role | Why it was wrong |
|------|-----------------|
| **Owner** | Management-plane only (`actions: ["*"]`). Zero `dataActions`. A user with inherited subscription-level Owner satisfies the check but still cannot call `POST /agents/{name}/versions` (needs `Microsoft.CognitiveServices/accounts/AIServices/agents/write` dataAction). |
| **Contributor** | Same — no `dataActions`. Additionally, its `notActions` explicitly block `Microsoft.Authorization/*/Write`, so it cannot even perform the Foundry User auto-assignment. |
| **Azure AI Developer** | Its `dataActions` cover only `OpenAI/*`, `SpeechServices/*`, `ContentSafety/*`, `MaaS/*` — **not** the `AIServices.*` namespace used by Foundry agents. Azure docs explicitly state: *"For Foundry project access, use the Foundry User or Foundry Owner roles instead."* |

When any of these roles was present (e.g. Owner inherited from the subscription), the check returned `hasAIAccess = true`, skipping the Foundry User auto-assignment. The user ended up with no Cognitive Services dataActions on the project scope, causing deploy to fail with HTTP 403:

```
Identity does not have permissions for
Microsoft.CognitiveServices/accounts/AIServices/agents/write actions
```

### Fix

Restrict `sufficientAIUserRoles` to **only roles that include `Microsoft.CognitiveServices/*` dataActions** covering the `AIServices.*` namespace, and add the two previously missing roles:

```go
// Before
var sufficientAIUserRoles = []string{
    roleOwner,            // ❌ no dataActions
    roleContributor,      // ❌ no dataActions
    roleAzureAIUser,      // ✅ Foundry User — CogSvc.*
    roleAzureAIDeveloper, // ❌ only OpenAI/Speech/ContentSafety/MaaS
}

// After
var sufficientAIUserRoles = []string{
    roleAzureAIUser,           // ✅ Foundry User: Microsoft.CognitiveServices/*
    roleCognitiveServicesUser, // ✅ backward compat: same dataActions, assigned by older Bicep
    roleAzureAIProjectManager, // ✅ Foundry Project Manager: Microsoft.CognitiveServices/*
    roleFoundryOwner,          // ✅ Foundry Owner: Microsoft.CognitiveServices/*
}
```

A new constant `roleCognitiveServicesUser` (`a97b65f3-...`) is added for the Cognitive Services User role, which carries identical `dataActions` to Foundry User and is assigned by older `azd provision` Bicep templates (the `AZURE_PRINCIPAL_ID` flow). Recognising it avoids a redundant auto-assignment on re-deploy.

A new constant `roleFoundryOwner` (`c883944f-...`) is added. The code comment already recommended Foundry Owner (`"use the Foundry User or Foundry Owner roles instead"`), but the role was missing from the list.

`roleAzureAIProjectManager` (`eadc314b-...`) was already defined as a constant but was not included in the list.

The stale doc comment on `DeveloperRBACResult.HasSufficientAIRole` in `developer_rbac_query.go` is updated to name the actual role set.

### Behavior after fix

| Scenario | Before | After |
|----------|--------|-------|
| User has Owner only (subscription-inherited) | `hasAIAccess = true` → skip assignment → **deploy 403** | `hasAIAccess = false` → auto-assign Foundry User → deploy succeeds |
| User has Cognitive Services User (from Bicep provision) | `hasAIAccess = false` → redundant re-assignment every deploy | `hasAIAccess = true` → skip ✅ |
| User has Foundry User | `hasAIAccess = true` → skip ✅ | unchanged ✅ |
| User has Azure AI Developer only | `hasAIAccess = true` → skip → **deploy 403** | `hasAIAccess = false` → auto-assign Foundry User → deploy succeeds |
| User has Foundry Project Manager | `hasAIAccess = false` → redundant re-assignment | `hasAIAccess = true` → skip ✅ |
| User has Foundry Owner | `hasAIAccess = false` → redundant re-assignment | `hasAIAccess = true` → skip ✅ |

### Files changed

| File | Change |
|------|--------|
| `internal/project/developer_rbac_check.go` | Add `roleCognitiveServicesUser` and `roleFoundryOwner` constants; rewrite `sufficientAIUserRoles` to include all four valid roles |
| `internal/project/developer_rbac_check_test.go` | Update `TestSufficientRoleLists` (assert new members + NotContains for removed roles); add `roleCognitiveServicesUser` and `roleFoundryOwner` to `TestDeveloperRBACRoleConstants` |
| `internal/project/developer_rbac_query.go` | Fix stale doc comment on `HasSufficientAIRole` to reflect the actual role set |
