### PR TITLE
feat: add new user agent: microsoft_foundry_canvas

### DIFF
--- a/cli/azd/internal/tracing/fields/fields.go
+++ b/cli/azd/internal/tracing/fields/fields.go
@@ -322,6 +322,7 @@ const (
 	// that signal specific types of usages.
 
 	EnvModifierAzureSpace            = "Azure App Spaces Portal"
+	EnvModifierFoundryAgentCanvas    = "Foundry Agent Canvas"
 	EnvModifierMicrosoftFoundrySkill = "Microsoft Foundry Skill"
 )
 

--- a/cli/azd/internal/tracing/fields/fields.go
+++ b/cli/azd/internal/tracing/fields/fields.go
@@ -321,9 +321,9 @@ const (
 	// Environment modifiers. These are not environments themselves, but rather modifiers to the environment
 	// that signal specific types of usages.
 
-	EnvModifierAzureSpace            = "Azure App Spaces Portal"
-	EnvModifierFoundryAgentCanvas    = "Foundry Agent Canvas"
-	EnvModifierMicrosoftFoundrySkill = "Microsoft Foundry Skill"
+	EnvModifierAzureSpace             = "Azure App Spaces Portal"
+	EnvModifierMicrosoftFoundryCanvas = "Microsoft Foundry Canvas"
+	EnvModifierMicrosoftFoundrySkill  = "Microsoft Foundry Skill"
 )
 
 // All possible enumerations of AccountTypeKey

--- a/cli/azd/internal/tracing/resource/exec_environment.go
+++ b/cli/azd/internal/tracing/resource/exec_environment.go
@@ -107,6 +107,9 @@ func execEnvModifiers() []string {
 	if strings.Contains(userAgent, "azure_app_space_portal") {
 		modifiers = append(modifiers, fields.EnvModifierAzureSpace)
 	}
+	if strings.Contains(userAgent, "foundry_agent_canvas") {
+		modifiers = append(modifiers, fields.EnvModifierFoundryAgentCanvas)
+	}
 	if strings.Contains(userAgent, "microsoft_foundry_skill") {
 		modifiers = append(modifiers, fields.EnvModifierMicrosoftFoundrySkill)
 	}

--- a/cli/azd/internal/tracing/resource/exec_environment.go
+++ b/cli/azd/internal/tracing/resource/exec_environment.go
@@ -107,8 +107,8 @@ func execEnvModifiers() []string {
 	if strings.Contains(userAgent, "azure_app_space_portal") {
 		modifiers = append(modifiers, fields.EnvModifierAzureSpace)
 	}
-	if strings.Contains(userAgent, "foundry_agent_canvas") {
-		modifiers = append(modifiers, fields.EnvModifierFoundryAgentCanvas)
+	if strings.Contains(userAgent, "microsoft_foundry_canvas") {
+		modifiers = append(modifiers, fields.EnvModifierMicrosoftFoundryCanvas)
 	}
 	if strings.Contains(userAgent, "microsoft_foundry_skill") {
 		modifiers = append(modifiers, fields.EnvModifierMicrosoftFoundrySkill)

--- a/cli/azd/internal/tracing/resource/resource_test.go
+++ b/cli/azd/internal/tracing/resource/resource_test.go
@@ -279,10 +279,16 @@ func TestExecEnvModifiers(t *testing.T) {
 			want:      []string{fields.EnvModifierMicrosoftFoundrySkill},
 		},
 		{
+			name:      "Foundry Agent Canvas",
+			userAgent: "foundry_agent_canvas",
+			want:      []string{fields.EnvModifierFoundryAgentCanvas},
+		},
+		{
 			name:      "multiple modifiers",
-			userAgent: "azure_app_space_portal microsoft_foundry_skill",
+			userAgent: "azure_app_space_portal foundry_agent_canvas microsoft_foundry_skill",
 			want: []string{
 				fields.EnvModifierAzureSpace,
+				fields.EnvModifierFoundryAgentCanvas,
 				fields.EnvModifierMicrosoftFoundrySkill,
 			},
 		},

--- a/cli/azd/internal/tracing/resource/resource_test.go
+++ b/cli/azd/internal/tracing/resource/resource_test.go
@@ -279,16 +279,16 @@ func TestExecEnvModifiers(t *testing.T) {
 			want:      []string{fields.EnvModifierMicrosoftFoundrySkill},
 		},
 		{
-			name:      "Foundry Agent Canvas",
-			userAgent: "foundry_agent_canvas",
-			want:      []string{fields.EnvModifierFoundryAgentCanvas},
+			name:      "Microsoft Foundry Canvas",
+			userAgent: "microsoft_foundry_canvas",
+			want:      []string{fields.EnvModifierMicrosoftFoundryCanvas},
 		},
 		{
 			name:      "multiple modifiers",
-			userAgent: "azure_app_space_portal foundry_agent_canvas microsoft_foundry_skill",
+			userAgent: "azure_app_space_portal microsoft_foundry_canvas microsoft_foundry_skill",
 			want: []string{
 				fields.EnvModifierAzureSpace,
-				fields.EnvModifierFoundryAgentCanvas,
+				fields.EnvModifierMicrosoftFoundryCanvas,
 				fields.EnvModifierMicrosoftFoundrySkill,
 			},
 		},

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -240,7 +240,7 @@ func Test_CLI_Telemetry_NestedCommands(t *testing.T) {
 	// set environment modifiers
 	cli.Env = append(
 		cli.Env,
-		"AZURE_DEV_USER_AGENT=azure_app_space_portal:v1.0.0 foundry_agent_canvas microsoft_foundry_skill",
+		"AZURE_DEV_USER_AGENT=azure_app_space_portal:v1.0.0 microsoft_foundry_canvas microsoft_foundry_skill",
 	)
 
 	// set a fixed traceparent to verify trace ID propagation for commands and nested commands
@@ -442,8 +442,8 @@ func verifyResource(
 		if strings.Contains(env, "azure_app_space_portal") {
 			require.Contains(t, m[fields.ExecutionEnvironmentKey.Key], ";"+fields.EnvModifierAzureSpace)
 		}
-		if strings.Contains(env, "foundry_agent_canvas") {
-			require.Contains(t, m[fields.ExecutionEnvironmentKey.Key], ";"+fields.EnvModifierFoundryAgentCanvas)
+		if strings.Contains(env, "microsoft_foundry_canvas") {
+			require.Contains(t, m[fields.ExecutionEnvironmentKey.Key], ";"+fields.EnvModifierMicrosoftFoundryCanvas)
 		}
 		if strings.Contains(env, "microsoft_foundry_skill") {
 			require.Contains(t, m[fields.ExecutionEnvironmentKey.Key], ";"+fields.EnvModifierMicrosoftFoundrySkill)

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -240,7 +240,7 @@ func Test_CLI_Telemetry_NestedCommands(t *testing.T) {
 	// set environment modifiers
 	cli.Env = append(
 		cli.Env,
-		"AZURE_DEV_USER_AGENT=azure_app_space_portal:v1.0.0 microsoft_foundry_skill",
+		"AZURE_DEV_USER_AGENT=azure_app_space_portal:v1.0.0 foundry_agent_canvas microsoft_foundry_skill",
 	)
 
 	// set a fixed traceparent to verify trace ID propagation for commands and nested commands
@@ -441,6 +441,9 @@ func verifyResource(
 
 		if strings.Contains(env, "azure_app_space_portal") {
 			require.Contains(t, m[fields.ExecutionEnvironmentKey.Key], ";"+fields.EnvModifierAzureSpace)
+		}
+		if strings.Contains(env, "foundry_agent_canvas") {
+			require.Contains(t, m[fields.ExecutionEnvironmentKey.Key], ";"+fields.EnvModifierFoundryAgentCanvas)
 		}
 		if strings.Contains(env, "microsoft_foundry_skill") {
 			require.Contains(t, m[fields.ExecutionEnvironmentKey.Key], ";"+fields.EnvModifierMicrosoftFoundrySkill)

--- a/docs/reference/telemetry-data.md
+++ b/docs/reference/telemetry-data.md
@@ -587,7 +587,8 @@ The `execution.environment` field identifies where azd is running. Format: `<env
 | `GitHub Codespaces` | GitHub Codespaces |
 | Other CI systems | `AppVeyor`, `Bamboo`, `BitBucket Pipelines`, `Travis CI`, `Circle CI`, `GitLab CI`, `Jenkins`, `AWS CodeBuild`, `Google Cloud Build`, `TeamCity`, `JetBrains Space` |
 
-**Modifiers:** `Azure App Spaces Portal` and `Microsoft Foundry Skill` may be appended as modifiers (`;` separated).
+**Modifiers:** `Azure App Spaces Portal`, `Foundry Agent Canvas`, and `Microsoft Foundry Skill` may be appended as
+modifiers (`;` separated).
 
 ## Data Nuances & Gotchas
 

--- a/docs/reference/telemetry-data.md
+++ b/docs/reference/telemetry-data.md
@@ -587,7 +587,7 @@ The `execution.environment` field identifies where azd is running. Format: `<env
 | `GitHub Codespaces` | GitHub Codespaces |
 | Other CI systems | `AppVeyor`, `Bamboo`, `BitBucket Pipelines`, `Travis CI`, `Circle CI`, `GitLab CI`, `Jenkins`, `AWS CodeBuild`, `Google Cloud Build`, `TeamCity`, `JetBrains Space` |
 
-**Modifiers:** `Azure App Spaces Portal`, `Foundry Agent Canvas`, and `Microsoft Foundry Skill` may be appended as
+**Modifiers:** `Azure App Spaces Portal`, `Microsoft Foundry Canvas`, and `Microsoft Foundry Skill` may be appended as
 modifiers (`;` separated).
 
 ## Data Nuances & Gotchas

--- a/docs/specs/metrics-audit/telemetry-schema.md
+++ b/docs/specs/metrics-audit/telemetry-schema.md
@@ -58,7 +58,7 @@ These are set once at process startup via `resource.New()` and attached to every
 | Runtime version | `process.runtime.version` | SystemMetadata | PerformanceAndHealth | Go version |
 | Machine ID | `machine.id` | EndUserPseudonymizedInformation | BusinessInsight | MAC address hash |
 | Dev Device ID | `machine.devdeviceid` | EndUserPseudonymizedInformation | BusinessInsight | SQM User ID |
-| Execution environment | `execution.environment` | SystemMetadata | BusinessInsight | CI system detection |
+| Execution environment | `execution.environment` | SystemMetadata | BusinessInsight | Format: `<environment>[;<modifier>...]`. Base values: `Desktop`, `Visual Studio`, `Visual Studio Code`, `VS Code Azure GitHub Copilot`, `Azure CloudShell`, `Claude Code`, `GitHub Copilot CLI`, `Gemini`, `OpenCode`, `UnknownCI`, `Azure Pipelines`, `GitHub Actions`, `AppVeyor`, `Bamboo`, `BitBucket Pipelines`, `Travis CI`, `Circle CI`, `GitLab CI`, `Jenkins`, `AWS CodeBuild`, `Google Cloud Build`, `TeamCity`, `JetBrains Space`, `GitHub Codespaces`. Modifiers: `Azure App Spaces Portal`, `Microsoft Foundry Canvas`, `Microsoft Foundry Skill` |
 | Installer | `service.installer` | SystemMetadata | FeatureInsight | How azd was installed |
 
 ### Experimentation


### PR DESCRIPTION
## Summary

- recognize `microsoft_foundry_canvas` in `AZURE_DEV_USER_AGENT`
- append `Microsoft Foundry Canvas` to the existing `execution.environment` base value
- extend unit and functional telemetry verification
- document the modifier in the public telemetry reference and canonical metrics schema

## Related issue

Fixes #9207

## Testing

- `go test ./internal/tracing/resource -count=1`
- `go test ./test/functional -run '^$' -count=1`
- `gofmt` verification on changed Go files
- `git diff --check`
- `go test ./test/functional -run '^Test_CLI_Telemetry_NestedCommands$' -count=1 -timeout 10m` reached and verified `Desktop;Azure App Spaces Portal;Microsoft Foundry Canvas;Microsoft Foundry Skill`; the overall test later failed locally with `cmd.package not found` after the local multi-tenant prompt changed the expected command flow