### PR TITLE
fix(toolboxes): skip env-sync gracefully when no azd project exists

### DIFF
--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_env.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_env.go
@@ -57,11 +57,10 @@ func setToolboxEndpointEnv(ctx context.Context, toolboxName, value string) error
 }
 
 // isNoAzdEnvironment reports whether err from GetCurrent means there is no azd
-// environment to write to: either the daemon is unreachable (codes.Unavailable)
-// or no default environment is selected. The host returns the latter as a
-// status-less sentinel that grpc surfaces as codes.Unknown with the message
-// "default environment not found", so we match on the message text (as
-// azure.ai.agents does).
+// environment to write to: the daemon is unreachable (codes.Unavailable), no
+// default environment is selected, or no azd project exists. The host returns
+// the latter two as status-less sentinels that gRPC surfaces as codes.Unknown,
+// so we match on the message text (as azure.ai.agents does).
 func isNoAzdEnvironment(err error) bool {
 	st, ok := status.FromError(err)
 	if !ok {
@@ -70,5 +69,7 @@ func isNoAzdEnvironment(err error) bool {
 	if st.Code() == codes.Unavailable {
 		return true
 	}
-	return strings.Contains(strings.ToLower(st.Message()), "default environment not found")
+	msg := strings.ToLower(st.Message())
+	return strings.Contains(msg, "default environment not found") ||
+		strings.Contains(msg, "no project exists")
 }

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_env_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_env_test.go
@@ -103,6 +103,7 @@ func TestIsNoAzdEnvironment(t *testing.T) {
 		{"unavailable", status.Error(codes.Unavailable, "connection refused"), true},
 		// The host returns a status-less sentinel that grpc maps to Unknown.
 		{"no default env", status.Error(codes.Unknown, "default environment not found"), true},
+		{"no project", status.Error(codes.Unknown, "no project exists; to create a new project, run `azd init`"), true},
 		{"other unknown", status.Error(codes.Unknown, "something else broke"), false},
 		{"plain error", errors.New("not a grpc status"), false},
 		{"nil", nil, false},


### PR DESCRIPTION
## Why

`azd ai toolbox create --project-endpoint <url> --from-file <path>` fails when run outside an azd project (no `azure.yaml`). The endpoint resolves fine via the `--project-endpoint` flag and the toolbox is created on the server, but the post-create step that writes the MCP endpoint to the azd environment crashes because `isNoAzdEnvironment()` doesn't recognize the "no project exists" gRPC error.

The env-sync is already documented as best-effort -- it should skip silently when there is no azd environment to write to, not fail the entire operation.

## Approach

Widened `isNoAzdEnvironment()` in `toolbox_env.go` to also match the `"no project exists"` message that the azd gRPC server returns when `GetCurrent()` is called without an `azure.yaml`. This sits alongside the existing `"default environment not found"` check and the `codes.Unavailable` check.

Added a corresponding test case to the `TestIsNoAzdEnvironment` table.

Fixes: #9219