### PR TITLE
fix(agents): validate discovered ACR connections

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -7,6 +7,7 @@ import (
 	"azureaiagent/internal/exterrors"
 	"azureaiagent/internal/pkg/azure"
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -61,6 +62,8 @@ type FoundryDeploymentInfo struct {
 }
 
 const foundryProjectResourceType = "Microsoft.CognitiveServices/accounts/projects"
+
+var errAcrNotFound = errors.New("container registry not found")
 
 // setEnvValue sets a single environment variable in the azd environment.
 func setEnvValue(ctx context.Context, azdClient *azdext.AzdClient, envName, key, value string) error {
@@ -376,7 +379,7 @@ func lookupAcrResourceId(
 		}
 	}
 
-	return "", fmt.Errorf("container registry '%s' not found in subscription", registryName)
+	return "", fmt.Errorf("%w: '%s' in subscription", errAcrNotFound, registryName)
 }
 
 // configureFoundryProjectEnv sets all Foundry project environment variables and discovers
@@ -524,7 +527,49 @@ func configureAcrConnection(
 	subscriptionId string,
 	acrConnections []azure.Connection,
 ) error {
-	if len(acrConnections) == 0 {
+	return configureAcrConnectionWithLookup(
+		ctx, azdClient, credential, envName, subscriptionId, acrConnections, lookupAcrResourceId,
+	)
+}
+
+type acrResourceIdLookup func(context.Context, azcore.TokenCredential, string, string) (string, error)
+
+type validatedAcrConnection struct {
+	connection azure.Connection
+	resourceId string
+}
+
+func configureAcrConnectionWithLookup(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	credential azcore.TokenCredential,
+	envName string,
+	subscriptionId string,
+	acrConnections []azure.Connection,
+	lookup acrResourceIdLookup,
+) error {
+	validatedConnections := make([]validatedAcrConnection, 0, len(acrConnections))
+	for _, connection := range acrConnections {
+		loginServer := normalizeLoginServer(connection.Target)
+		resourceId, err := lookup(ctx, credential, subscriptionId, loginServer)
+		if err != nil {
+			if errors.Is(err, errAcrNotFound) || !strings.Contains(loginServer, ".") {
+				fmt.Printf(
+					"Skipping container registry connection %s because %s does not reference an existing registry "+
+						"in the selected subscription.\n",
+					connection.Name, connection.Target,
+				)
+				continue
+			}
+			return fmt.Errorf("validating container registry connection %q: %w", connection.Name, err)
+		}
+		validatedConnections = append(validatedConnections, validatedAcrConnection{
+			connection: connection,
+			resourceId: resourceId,
+		})
+	}
+
+	if len(validatedConnections) == 0 {
 		fmt.Println("\n" +
 			"An Azure Container Registry (ACR) is required\n\n" +
 			"Foundry Hosted Agents need an Azure Container Registry to store container images before deployment.\n\n" +
@@ -545,7 +590,7 @@ func configureAcrConnection(
 
 		if resp.Value != "" {
 			loginServer := normalizeLoginServer(resp.Value)
-			resourceId, err := lookupAcrResourceId(ctx, credential, subscriptionId, loginServer)
+			resourceId, err := lookup(ctx, credential, subscriptionId, loginServer)
 			if err != nil {
 				return fmt.Errorf("failed to lookup ACR resource ID: %w", err)
 			}
@@ -556,10 +601,22 @@ func configureAcrConnection(
 			if err := setEnvValue(ctx, azdClient, envName, "AZURE_CONTAINER_REGISTRY_RESOURCE_ID", resourceId); err != nil {
 				return err
 			}
+			if err := setEnvValue(ctx, azdClient, envName, "AZURE_AI_PROJECT_ACR_CONNECTION_NAME", ""); err != nil {
+				return err
+			}
 			if err := updatePendingACRSignal(ctx, azdClient, envName, true); err != nil {
 				log.Printf("warning: failed to update acr provision signal: %v", err)
 			}
 		} else {
+			for _, key := range []string{
+				"AZURE_CONTAINER_REGISTRY_ENDPOINT",
+				"AZURE_CONTAINER_REGISTRY_RESOURCE_ID",
+				"AZURE_AI_PROJECT_ACR_CONNECTION_NAME",
+			} {
+				if err := setEnvValue(ctx, azdClient, envName, key, ""); err != nil {
+					return err
+				}
+			}
 			if err := updatePendingACRSignal(ctx, azdClient, envName, false); err != nil {
 				log.Printf("warning: failed to update acr provision signal: %v", err)
 			}
@@ -567,18 +624,22 @@ func configureAcrConnection(
 		return nil
 	}
 
-	var selectedConnection *azure.Connection
+	var selectedConnection *validatedAcrConnection
 
-	if len(acrConnections) == 1 {
-		selectedConnection = &acrConnections[0]
-		fmt.Printf("Using container registry connection: %s (%s)\n", selectedConnection.Name, selectedConnection.Target)
+	if len(validatedConnections) == 1 {
+		selectedConnection = &validatedConnections[0]
+		fmt.Printf(
+			"Using container registry connection: %s (%s)\n",
+			selectedConnection.connection.Name,
+			selectedConnection.connection.Target,
+		)
 	} else {
-		fmt.Printf("Found %d container registry connections:\n", len(acrConnections))
+		fmt.Printf("Found %d container registry connections:\n", len(validatedConnections))
 
-		choices := make([]*azdext.SelectChoice, len(acrConnections))
-		for i, conn := range acrConnections {
+		choices := make([]*azdext.SelectChoice, len(validatedConnections))
+		for i, validated := range validatedConnections {
 			choices[i] = &azdext.SelectChoice{
-				Label: conn.Name,
+				Label: validated.connection.Name,
 				Value: fmt.Sprintf("%d", i),
 			}
 		}
@@ -594,13 +655,34 @@ func configureAcrConnection(
 		if err != nil {
 			return fmt.Errorf("failed to prompt for connection selection: %w", err)
 		}
-		selectedConnection = &acrConnections[int(*selectResp.Value)]
+		selectedConnection = &validatedConnections[int(*selectResp.Value)]
 	}
 
-	if err := setEnvValue(ctx, azdClient, envName, "AZURE_AI_PROJECT_ACR_CONNECTION_NAME", selectedConnection.Name); err != nil {
+	if err := setEnvValue(
+		ctx,
+		azdClient,
+		envName,
+		"AZURE_AI_PROJECT_ACR_CONNECTION_NAME",
+		selectedConnection.connection.Name,
+	); err != nil {
 		return err
 	}
-	if err := setEnvValue(ctx, azdClient, envName, "AZURE_CONTAINER_REGISTRY_ENDPOINT", normalizeLoginServer(selectedConnection.Target)); err != nil {
+	if err := setEnvValue(
+		ctx,
+		azdClient,
+		envName,
+		"AZURE_CONTAINER_REGISTRY_ENDPOINT",
+		normalizeLoginServer(selectedConnection.connection.Target),
+	); err != nil {
+		return err
+	}
+	if err := setEnvValue(
+		ctx,
+		azdClient,
+		envName,
+		"AZURE_CONTAINER_REGISTRY_RESOURCE_ID",
+		selectedConnection.resourceId,
+	); err != nil {
 		return err
 	}
 	if err := updatePendingACRSignal(ctx, azdClient, envName, true); err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -7,7 +7,6 @@ import (
 	"azureaiagent/internal/exterrors"
 	"azureaiagent/internal/pkg/azure"
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -62,8 +61,6 @@ type FoundryDeploymentInfo struct {
 }
 
 const foundryProjectResourceType = "Microsoft.CognitiveServices/accounts/projects"
-
-var errAcrNotFound = errors.New("container registry not found")
 
 // setEnvValue sets a single environment variable in the azd environment.
 func setEnvValue(ctx context.Context, azdClient *azdext.AzdClient, envName, key, value string) error {
@@ -345,41 +342,33 @@ func normalizeLoginServer(endpoint string) string {
 	return endpoint
 }
 
-// lookupAcrResourceId finds the ARM resource ID for an ACR given its login server endpoint.
-func lookupAcrResourceId(
+// listAcrResourceIds returns ARM resource IDs keyed by normalized ACR login server.
+func listAcrResourceIds(
 	ctx context.Context,
 	credential azcore.TokenCredential,
 	subscriptionId string,
-	loginServer string,
-) (string, error) {
-	loginServer = normalizeLoginServer(loginServer)
-	parts := strings.Split(loginServer, ".")
-	if len(parts) < 2 || parts[0] == "" {
-		return "", fmt.Errorf("invalid login server format: %q, expected e.g. %q", loginServer, "registry.azurecr.io")
-	}
-	registryName := parts[0]
-
+) (map[string]string, error) {
 	client, err := armcontainerregistry.NewRegistriesClient(subscriptionId, credential, azure.NewArmClientOptions())
 	if err != nil {
-		return "", fmt.Errorf("failed to create container registry client: %w", err)
+		return nil, fmt.Errorf("failed to create container registry client: %w", err)
 	}
 
+	resourceIds := map[string]string{}
 	pager := client.NewListPager(nil)
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			return "", fmt.Errorf("failed to list registries: %w", err)
+			return nil, fmt.Errorf("failed to list registries: %w", err)
 		}
 		for _, registry := range page.Value {
-			if registry.Name != nil && strings.EqualFold(*registry.Name, registryName) {
-				if registry.ID != nil {
-					return *registry.ID, nil
-				}
+			if registry.Properties != nil && registry.Properties.LoginServer != nil && registry.ID != nil {
+				loginServer := strings.ToLower(normalizeLoginServer(*registry.Properties.LoginServer))
+				resourceIds[loginServer] = *registry.ID
 			}
 		}
 	}
 
-	return "", fmt.Errorf("%w: '%s' in subscription", errAcrNotFound, registryName)
+	return resourceIds, nil
 }
 
 // configureFoundryProjectEnv sets all Foundry project environment variables and discovers
@@ -527,41 +516,43 @@ func configureAcrConnection(
 	subscriptionId string,
 	acrConnections []azure.Connection,
 ) error {
-	return configureAcrConnectionWithLookup(
-		ctx, azdClient, credential, envName, subscriptionId, acrConnections, lookupAcrResourceId,
+	return configureAcrConnectionWithRegistryLoader(
+		ctx, azdClient, credential, envName, subscriptionId, acrConnections, listAcrResourceIds,
 	)
 }
 
-type acrResourceIdLookup func(context.Context, azcore.TokenCredential, string, string) (string, error)
+type acrRegistryLoader func(context.Context, azcore.TokenCredential, string) (map[string]string, error)
 
 type validatedAcrConnection struct {
 	connection azure.Connection
 	resourceId string
 }
 
-func configureAcrConnectionWithLookup(
+func configureAcrConnectionWithRegistryLoader(
 	ctx context.Context,
 	azdClient *azdext.AzdClient,
 	credential azcore.TokenCredential,
 	envName string,
 	subscriptionId string,
 	acrConnections []azure.Connection,
-	lookup acrResourceIdLookup,
+	loadRegistries acrRegistryLoader,
 ) error {
+	resourceIds, err := loadRegistries(ctx, credential, subscriptionId)
+	if err != nil {
+		return fmt.Errorf("listing container registries for connection validation: %w", err)
+	}
+
 	validatedConnections := make([]validatedAcrConnection, 0, len(acrConnections))
 	for _, connection := range acrConnections {
 		loginServer := normalizeLoginServer(connection.Target)
-		resourceId, err := lookup(ctx, credential, subscriptionId, loginServer)
-		if err != nil {
-			if errors.Is(err, errAcrNotFound) || !strings.Contains(loginServer, ".") {
-				fmt.Printf(
-					"Skipping container registry connection %s because %s does not reference an existing registry "+
-						"in the selected subscription.\n",
-					connection.Name, connection.Target,
-				)
-				continue
-			}
-			return fmt.Errorf("validating container registry connection %q: %w", connection.Name, err)
+		resourceId, found := resourceIds[strings.ToLower(loginServer)]
+		if !found {
+			fmt.Printf(
+				"Skipping container registry connection %s because %s does not reference an existing registry "+
+					"in the selected subscription.\n",
+				connection.Name, connection.Target,
+			)
+			continue
 		}
 		validatedConnections = append(validatedConnections, validatedAcrConnection{
 			connection: connection,
@@ -590,9 +581,9 @@ func configureAcrConnectionWithLookup(
 
 		if resp.Value != "" {
 			loginServer := normalizeLoginServer(resp.Value)
-			resourceId, err := lookup(ctx, credential, subscriptionId, loginServer)
-			if err != nil {
-				return fmt.Errorf("failed to lookup ACR resource ID: %w", err)
+			resourceId, found := resourceIds[strings.ToLower(loginServer)]
+			if !found {
+				return fmt.Errorf("container registry with login server %q not found in subscription", loginServer)
 			}
 
 			if err := setEnvValue(ctx, azdClient, envName, "AZURE_CONTAINER_REGISTRY_ENDPOINT", loginServer); err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -332,14 +332,16 @@ func listProjectDeployments(
 	return results, nil
 }
 
-// normalizeLoginServer strips any scheme (https://, http://) and trailing slash
-// from a container registry endpoint so it becomes a plain login server
-// (e.g., "myregistry.azurecr.io").
+// normalizeLoginServer strips any scheme (https://, http://) and trailing slash,
+// then lowercases a container registry endpoint for consistent comparison.
 func normalizeLoginServer(endpoint string) string {
-	endpoint = strings.TrimPrefix(endpoint, "https://")
-	endpoint = strings.TrimPrefix(endpoint, "http://")
-	endpoint = strings.TrimRight(endpoint, "/")
-	return endpoint
+	for _, prefix := range []string{"https://", "http://"} {
+		if len(endpoint) >= len(prefix) && strings.EqualFold(endpoint[:len(prefix)], prefix) {
+			endpoint = endpoint[len(prefix):]
+			break
+		}
+	}
+	return strings.ToLower(strings.TrimRight(endpoint, "/"))
 }
 
 // listAcrResourceIds returns ARM resource IDs keyed by normalized ACR login server.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
 	"testing"
 
@@ -775,7 +774,8 @@ func TestConfigureAcrConnection_ValidatesDiscoveredConnections(t *testing.T) {
 	tests := []struct {
 		name        string
 		connections []azure.Connection
-		lookup      acrResourceIdLookup
+		registries  map[string]string
+		loadErr     error
 		prompts     []string
 		initial     map[string]string
 		wantErr     string
@@ -786,9 +786,7 @@ func TestConfigureAcrConnection_ValidatesDiscoveredConnections(t *testing.T) {
 			connections: []azure.Connection{{
 				Name: "valid-conn", Target: "https://valid.azurecr.io/",
 			}},
-			lookup: func(context.Context, azcore.TokenCredential, string, string) (string, error) {
-				return resourceId, nil
-			},
+			registries: map[string]string{"valid.azurecr.io": resourceId},
 			wantValues: map[string]string{
 				"AZURE_AI_PROJECT_ACR_CONNECTION_NAME": "valid-conn",
 				"AZURE_CONTAINER_REGISTRY_ENDPOINT":    "valid.azurecr.io",
@@ -800,9 +798,6 @@ func TestConfigureAcrConnection_ValidatesDiscoveredConnections(t *testing.T) {
 			connections: []azure.Connection{{
 				Name: "stale-conn", Target: "stale.azurecr.io",
 			}},
-			lookup: func(context.Context, azcore.TokenCredential, string, string) (string, error) {
-				return "", fmt.Errorf("%w: stale", errAcrNotFound)
-			},
 			prompts: []string{""},
 			initial: map[string]string{
 				"AZURE_AI_PROJECT_ACR_CONNECTION_NAME": "old-conn",
@@ -822,12 +817,7 @@ func TestConfigureAcrConnection_ValidatesDiscoveredConnections(t *testing.T) {
 				{Name: "stale-conn", Target: "stale.azurecr.io"},
 				{Name: "valid-conn", Target: "valid.azurecr.io"},
 			},
-			lookup: func(_ context.Context, _ azcore.TokenCredential, _, loginServer string) (string, error) {
-				if loginServer == "stale.azurecr.io" {
-					return "", fmt.Errorf("%w: stale", errAcrNotFound)
-				}
-				return resourceId, nil
-			},
+			registries: map[string]string{"valid.azurecr.io": resourceId},
 			wantValues: map[string]string{
 				"AZURE_AI_PROJECT_ACR_CONNECTION_NAME": "valid-conn",
 				"AZURE_CONTAINER_REGISTRY_ENDPOINT":    "valid.azurecr.io",
@@ -839,23 +829,29 @@ func TestConfigureAcrConnection_ValidatesDiscoveredConnections(t *testing.T) {
 			connections: []azure.Connection{{
 				Name: "unknown-conn", Target: "unknown.azurecr.io",
 			}},
-			lookup: func(context.Context, azcore.TokenCredential, string, string) (string, error) {
-				return "", errors.New("authorization failed")
+			loadErr: errors.New("authorization failed"),
+			wantErr: "listing container registries for connection validation: authorization failed",
+		},
+		{
+			name: "mismatched host suffix is stale",
+			connections: []azure.Connection{{
+				Name: "invalid-host-conn", Target: "valid.azurecr.io.invalid.example",
+			}},
+			registries: map[string]string{"valid.azurecr.io": resourceId},
+			prompts:    []string{""},
+			wantValues: map[string]string{
+				"AZURE_CONTAINER_REGISTRY_ENDPOINT":    "",
+				"AZURE_CONTAINER_REGISTRY_RESOURCE_ID": "",
+				"AI_AGENT_PENDING_PROVISION":           "acr",
 			},
-			wantErr: "validating container registry connection \"unknown-conn\": authorization failed",
 		},
 		{
 			name: "manual fallback writes resource id and clears connection name",
 			connections: []azure.Connection{{
 				Name: "stale-conn", Target: "stale.azurecr.io",
 			}},
-			lookup: func(_ context.Context, _ azcore.TokenCredential, _, loginServer string) (string, error) {
-				if loginServer == "stale.azurecr.io" {
-					return "", fmt.Errorf("%w: stale", errAcrNotFound)
-				}
-				return resourceId, nil
-			},
-			prompts: []string{"valid.azurecr.io"},
+			registries: map[string]string{"valid.azurecr.io": resourceId},
+			prompts:    []string{"valid.azurecr.io"},
 			initial: map[string]string{
 				"AZURE_AI_PROJECT_ACR_CONNECTION_NAME": "stale-conn",
 			},
@@ -876,9 +872,15 @@ func TestConfigureAcrConnection_ValidatesDiscoveredConnections(t *testing.T) {
 			prompts := &testPromptServiceServer{promptResponses: tt.prompts}
 			azdClient := newTestAzdClient(t, envServer, &testWorkflowServiceServer{}, prompts)
 
-			err := configureAcrConnectionWithLookup(
-				t.Context(), azdClient, nil, envName, "sub", tt.connections, tt.lookup,
+			loadCalls := 0
+			loader := func(context.Context, azcore.TokenCredential, string) (map[string]string, error) {
+				loadCalls++
+				return tt.registries, tt.loadErr
+			}
+			err := configureAcrConnectionWithRegistryLoader(
+				t.Context(), azdClient, nil, envName, "sub", tt.connections, loader,
 			)
+			require.Equal(t, 1, loadCalls)
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)
 				return

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
@@ -549,6 +549,7 @@ func TestNormalizeLoginServer(t *testing.T) {
 		{"https://myregistry.azurecr.io", "myregistry.azurecr.io"},
 		{"http://myregistry.azurecr.io", "myregistry.azurecr.io"},
 		{"https://myregistry.azurecr.io/", "myregistry.azurecr.io"},
+		{"HTTPS://MYREGISTRY.AZURECR.IO/", "myregistry.azurecr.io"},
 		{"https://crdyt765he4tmsy.azurecr.io", "crdyt765he4tmsy.azurecr.io"},
 		{"", ""},
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
@@ -5,9 +5,14 @@ package cmd
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"testing"
 
+	"azureaiagent/internal/pkg/azure"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armcognitiveservices "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -758,5 +763,130 @@ func TestConfigureFoundryProjectEnv_BicepLessShortCircuits(t *testing.T) {
 		"APPLICATIONINSIGHTS_CONNECTION_NAME",
 	} {
 		require.Empty(t, written[key], "must not write %q when bicepless+skipACR", key)
+	}
+}
+
+func TestConfigureAcrConnection_ValidatesDiscoveredConnections(t *testing.T) {
+	const (
+		envName    = "test-env"
+		resourceId = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerRegistry/registries/valid"
+	)
+
+	tests := []struct {
+		name        string
+		connections []azure.Connection
+		lookup      acrResourceIdLookup
+		prompts     []string
+		initial     map[string]string
+		wantErr     string
+		wantValues  map[string]string
+	}{
+		{
+			name: "valid sole connection is selected with resource id",
+			connections: []azure.Connection{{
+				Name: "valid-conn", Target: "https://valid.azurecr.io/",
+			}},
+			lookup: func(context.Context, azcore.TokenCredential, string, string) (string, error) {
+				return resourceId, nil
+			},
+			wantValues: map[string]string{
+				"AZURE_AI_PROJECT_ACR_CONNECTION_NAME": "valid-conn",
+				"AZURE_CONTAINER_REGISTRY_ENDPOINT":    "valid.azurecr.io",
+				"AZURE_CONTAINER_REGISTRY_RESOURCE_ID": resourceId,
+			},
+		},
+		{
+			name: "stale sole connection falls back to create on provision and clears stale values",
+			connections: []azure.Connection{{
+				Name: "stale-conn", Target: "stale.azurecr.io",
+			}},
+			lookup: func(context.Context, azcore.TokenCredential, string, string) (string, error) {
+				return "", fmt.Errorf("%w: stale", errAcrNotFound)
+			},
+			prompts: []string{""},
+			initial: map[string]string{
+				"AZURE_AI_PROJECT_ACR_CONNECTION_NAME": "old-conn",
+				"AZURE_CONTAINER_REGISTRY_ENDPOINT":    "old.azurecr.io",
+				"AZURE_CONTAINER_REGISTRY_RESOURCE_ID": "old-id",
+			},
+			wantValues: map[string]string{
+				"AZURE_AI_PROJECT_ACR_CONNECTION_NAME": "",
+				"AZURE_CONTAINER_REGISTRY_ENDPOINT":    "",
+				"AZURE_CONTAINER_REGISTRY_RESOURCE_ID": "",
+				"AI_AGENT_PENDING_PROVISION":           "acr",
+			},
+		},
+		{
+			name: "mixed connections skip stale and select valid",
+			connections: []azure.Connection{
+				{Name: "stale-conn", Target: "stale.azurecr.io"},
+				{Name: "valid-conn", Target: "valid.azurecr.io"},
+			},
+			lookup: func(_ context.Context, _ azcore.TokenCredential, _, loginServer string) (string, error) {
+				if loginServer == "stale.azurecr.io" {
+					return "", fmt.Errorf("%w: stale", errAcrNotFound)
+				}
+				return resourceId, nil
+			},
+			wantValues: map[string]string{
+				"AZURE_AI_PROJECT_ACR_CONNECTION_NAME": "valid-conn",
+				"AZURE_CONTAINER_REGISTRY_ENDPOINT":    "valid.azurecr.io",
+				"AZURE_CONTAINER_REGISTRY_RESOURCE_ID": resourceId,
+			},
+		},
+		{
+			name: "lookup service error stops init",
+			connections: []azure.Connection{{
+				Name: "unknown-conn", Target: "unknown.azurecr.io",
+			}},
+			lookup: func(context.Context, azcore.TokenCredential, string, string) (string, error) {
+				return "", errors.New("authorization failed")
+			},
+			wantErr: "validating container registry connection \"unknown-conn\": authorization failed",
+		},
+		{
+			name: "manual fallback writes resource id and clears connection name",
+			connections: []azure.Connection{{
+				Name: "stale-conn", Target: "stale.azurecr.io",
+			}},
+			lookup: func(_ context.Context, _ azcore.TokenCredential, _, loginServer string) (string, error) {
+				if loginServer == "stale.azurecr.io" {
+					return "", fmt.Errorf("%w: stale", errAcrNotFound)
+				}
+				return resourceId, nil
+			},
+			prompts: []string{"valid.azurecr.io"},
+			initial: map[string]string{
+				"AZURE_AI_PROJECT_ACR_CONNECTION_NAME": "stale-conn",
+			},
+			wantValues: map[string]string{
+				"AZURE_AI_PROJECT_ACR_CONNECTION_NAME": "",
+				"AZURE_CONTAINER_REGISTRY_ENDPOINT":    "valid.azurecr.io",
+				"AZURE_CONTAINER_REGISTRY_RESOURCE_ID": resourceId,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envServer := &testEnvironmentServiceServer{
+				environments: map[string]*azdext.Environment{envName: {Name: envName}},
+				values:       map[string]map[string]string{envName: tt.initial},
+			}
+			prompts := &testPromptServiceServer{promptResponses: tt.prompts}
+			azdClient := newTestAzdClient(t, envServer, &testWorkflowServiceServer{}, prompts)
+
+			err := configureAcrConnectionWithLookup(
+				t.Context(), azdClient, nil, envName, "sub", tt.connections, tt.lookup,
+			)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			for key, want := range tt.wantValues {
+				require.Equal(t, want, envServer.values[envName][key], "environment value %s", key)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #9224. Hosted container agent initialization no longer accepts stale ACR connections from an existing Foundry project and defers the failure until publish.

## Changes

- **`agent init`**: validate discovered container registry targets against ARM, skip missing registries, and preserve authorization or service errors.
- **ACR environment state**: persist resource IDs for valid selections and clear stale connection values before manual or create-on-provision fallback.
- **Tests**: cover valid, stale, mixed, manual fallback, and lookup-error scenarios.

## Manual Validation

- Built and installed the extension from this branch, then ran `azd ai agent init -m` against an existing Foundry project whose sole ACR connection referenced a deleted registry.
- Confirmed init skipped the stale connection and cleared `AZURE_CONTAINER_REGISTRY_ENDPOINT`, `AZURE_CONTAINER_REGISTRY_RESOURCE_ID`, and `AZURE_AI_PROJECT_ACR_CONNECTION_NAME`, while setting `AI_AGENT_PENDING_PROVISION=acr`.
- Set a valid replacement ACR and confirmed `azd deploy` resolved it and started an ACR build. The build later failed because that existing registry requires push credentials, after stale-connection handling had completed.