### PR TITLE
feat(toolboxes): support new preview tools

### DIFF
--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_commands_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_commands_test.go
@@ -633,6 +633,51 @@ tools:
 	assert.Equal(t, "file_search", tools[1]["type"])
 }
 
+// Preview toolbox tools are forwarded in the exact shape defined by the
+// Foundry toolbox API. Type-specific validation remains service-owned.
+func TestRunToolboxCreateWith_NewPreviewTools(t *testing.T) {
+	client := newMockToolboxClient("https://e/")
+
+	inputPath := t.TempDir() + "/create.yaml"
+	require.NoError(t, os.WriteFile(inputPath, []byte(`
+tools:
+  - type: work_iq_preview
+    name: work-iq
+    project_connection_id: /connections/work-iq
+  - type: fabric_iq_preview
+    name: fabric-iq
+    project_connection_id: /connections/fabric-iq
+    server_label: fabric
+    server_url: https://fabric.example.com/mcp
+    require_approval: never
+  - type: toolbox_search_preview
+    name: toolbox-search
+`), 0o600))
+
+	err := runToolboxCreateWith(
+		t.Context(), client, newStubConnectionResolver(), "https://e/", "tb",
+		toolboxCreateFlags{fromFile: inputPath}, toolboxFlags{output: "json"},
+	)
+	require.NoError(t, err)
+	require.Len(t, client.createVersionCalls, 1)
+	assert.Equal(t, []map[string]any{
+		{
+			"type":                  "work_iq_preview",
+			"name":                  "work-iq",
+			"project_connection_id": "/connections/work-iq",
+		},
+		{
+			"type":                  "fabric_iq_preview",
+			"name":                  "fabric-iq",
+			"project_connection_id": "/connections/fabric-iq",
+			"server_label":          "fabric",
+			"server_url":            "https://fabric.example.com/mcp",
+			"require_approval":      "never",
+		},
+		{"type": "toolbox_search_preview", "name": "toolbox-search"},
+	}, client.createVersionCalls[0].req.Tools)
+}
+
 // Connection-backed entries come first, raw tools[] entries after.
 func TestRunToolboxCreateWith_MixedConnectionsAndTools(t *testing.T) {
 	client := newMockToolboxClient("https://e/")

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_list.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_connection_list.go
@@ -88,16 +88,16 @@ func extractConnectionTools(tools []map[string]any) []map[string]string {
 	for _, t := range tools {
 		toolType, _ := t["type"].(string)
 		toolName, _ := t["name"].(string)
+		if id, ok := t["project_connection_id"].(string); ok && id != "" {
+			rows = append(rows, map[string]string{
+				"name":          toolName,
+				"connection":    shortConnectionName(id),
+				"connection_id": id,
+				"type":          toolType,
+			})
+			continue
+		}
 		switch toolType {
-		case "mcp", "a2a_preview":
-			if id, ok := t["project_connection_id"].(string); ok && id != "" {
-				rows = append(rows, map[string]string{
-					"name":          toolName,
-					"connection":    shortConnectionName(id),
-					"connection_id": id,
-					"type":          toolType,
-				})
-			}
 		case "azure_ai_search":
 			if search, ok := t["azure_ai_search"].(map[string]any); ok {
 				if indexes, ok := search["indexes"].([]any); ok {

--- a/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.toolboxes/internal/cmd/toolbox_helpers_test.go
@@ -329,6 +329,18 @@ func TestExtractConnectionTools(t *testing.T) {
 			"name":                  "a2a",
 			"project_connection_id": "/conn/a2a",
 		},
+		// New connection-backed preview tools use the same top-level ID shape.
+		{
+			"type":                  "work_iq_preview",
+			"name":                  "work",
+			"project_connection_id": "/conn/work-iq",
+		},
+		{
+			"type":                  "fabric_iq_preview",
+			"name":                  "fabric",
+			"project_connection_id": "/conn/fabric-iq",
+			"server_label":          "fabric",
+		},
 		// Connection-backed web_search (GroundingWithCustomSearch).
 		{
 			"type": "web_search",
@@ -349,7 +361,7 @@ func TestExtractConnectionTools(t *testing.T) {
 	}
 
 	rows := extractConnectionTools(tools)
-	require.Len(t, rows, 4, "expected one row per connection-backed entry; built-in web_search must be skipped")
+	require.Len(t, rows, 6, "expected one row per connection-backed entry; built-in web_search must be skipped")
 
 	byName := map[string]map[string]string{}
 	for _, r := range rows {
@@ -374,6 +386,16 @@ func TestExtractConnectionTools(t *testing.T) {
 	require.NotNil(t, a2a)
 	assert.Equal(t, "a2a_preview", a2a["type"])
 	assert.Equal(t, "/conn/a2a", a2a["connection_id"])
+
+	workIQ := byName["work"]
+	require.NotNil(t, workIQ)
+	assert.Equal(t, "work_iq_preview", workIQ["type"])
+	assert.Equal(t, "/conn/work-iq", workIQ["connection_id"])
+
+	fabricIQ := byName["fabric"]
+	require.NotNil(t, fabricIQ)
+	assert.Equal(t, "fabric_iq_preview", fabricIQ["type"])
+	assert.Equal(t, "/conn/fabric-iq", fabricIQ["connection_id"])
 
 	bing := byName["bing"]
 	require.NotNil(t, bing)


### PR DESCRIPTION
## Summary

Fixes #8191. Toolbox creation already forwards new Foundry tool shapes, but connection listing omitted WorkIQ and FabricIQ tools.

## Changes

- **`toolbox create`**: verify `work_iq_preview`, `fabric_iq_preview`, and `toolbox_search_preview` pass through unchanged.
- **`toolbox connection list`**: surface any tool with a top-level `project_connection_id` instead of restricting the recognized tool types.

## Manual Validation

- Created a live Foundry toolbox containing WorkIQ, FabricIQ, and toolbox-search preview tools and confirmed `toolbox show` preserved their fields.
- Confirmed `toolbox connection list` returned the WorkIQ and FabricIQ connections.
- Added a skill to create a new toolbox version and verified all preview tools were preserved.
- Declared the three preview tools in `azure.yaml`, ran `azd deploy`, and confirmed connection resolution, field round-tripping, endpoint output, and connection listing.
- Deleted all disposable toolboxes and connections and verified they no longer appeared in project listings.