### PR TITLE
Extend registry checks to the development registry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 
 # ── CLI extensions registry - anyone added to this can approve extension publishing, provided they pass the `ext-registry-check` workflow.
 /cli/azd/extensions/registry.json           @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft @XiaofuHuang @achauhan-scc @anchenyi @glharper @huimiu @hund030 @kingernupur @saanikaguptamicrosoft @therealjohn @trangevi @trrwilson
+/cli/azd/extensions/registry.dev.json       @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft @XiaofuHuang @achauhan-scc @anchenyi @glharper @huimiu @hund030 @kingernupur @saanikaguptamicrosoft @therealjohn @trangevi @trrwilson
 
 # ── CLI extensions (AI) ──────────────────────────────────────────────────────
 /cli/azd/extensions/azure.ai.agents/        @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030

--- a/.github/scripts/src/ext-registry-check.js
+++ b/.github/scripts/src/ext-registry-check.js
@@ -20,7 +20,6 @@ const REGISTRY_JSON_PATHS = new Set([
   'cli/azd/extensions/registry.json',
   'cli/azd/extensions/registry.dev.json',
 ]);
-const DEFAULT_REGISTRY_JSON_PATH = 'cli/azd/extensions/registry.json';
 
 // We only allow URLs that point to our GitHub releases page.
 const ALLOWED_ARTIFACT_URL_ORIGIN = 'https://github.com';
@@ -244,14 +243,14 @@ function isCreatedByCoreTeam({ context, core, coreTeam }) {
 /**
  * Checks whether the registry update is simple enough to proceed without core-team review.
  *
- * @param {{ octokit: Octokit, context: Context, registryBaseRef?: string, registryPath?: string }} args
+ * @param {{ octokit: Octokit, context: Context, registryPath: string, registryBaseRef: string }} args
  * @returns {Promise<string[]>} the reasons core review is needed; empty means the change is approved
  */
 async function isAllowedRegistryJsonUpdate({
   octokit,
   context,
-  registryBaseRef = 'main',
-  registryPath = DEFAULT_REGISTRY_JSON_PATH,
+  registryPath,
+  registryBaseRef,
 }) {
   assertHasPullRequest(context);
   const pr = context.payload.pull_request;
@@ -310,17 +309,18 @@ function diffChangedFiles(changedFiles) {
   }
 
   return [
-    `PR changes files outside the extension registries; core review required for registry-only PRs: ${unexpectedFiles.join(', ')}`,
+    `PR changes files outside ${[...REGISTRY_JSON_PATHS].join(', ')}; ` +
+    `core review required for registry-only PRs: ${unexpectedFiles.join(', ')}`,
   ];
 }
 
 /**
  * Fetches and parses an extension registry at a given ref.
  *
- * @param {{ octokit: Octokit, owner: string, repo: string, ref: string, registryPath?: string }} args
+ * @param {{ octokit: Octokit, owner: string, repo: string, ref: string, registryPath: string }} args
  * @returns {Promise<RegistryJson>}
  */
-async function getRegistryJson({ octokit, owner, repo, ref, registryPath = DEFAULT_REGISTRY_JSON_PATH }) {
+async function getRegistryJson({ octokit, owner, repo, ref, registryPath }) {
   const { data } = await octokit.rest.repos.getContent({
     owner,
     repo,

--- a/.github/scripts/src/ext-registry-check.js
+++ b/.github/scripts/src/ext-registry-check.js
@@ -16,10 +16,13 @@ module.exports.forTests = {
   diffRegistry,
 }
 
-const REGISTRY_JSON_PATH = 'cli/azd/extensions/registry.json';
+const REGISTRY_JSON_PATHS = new Set([
+  'cli/azd/extensions/registry.json',
+  'cli/azd/extensions/registry.dev.json',
+]);
+const DEFAULT_REGISTRY_JSON_PATH = 'cli/azd/extensions/registry.json';
 
 // We only allow URLs that point to our GitHub releases page.
-// NOTE: this script is only for production registry.json - nightlies go to a non-releases spot, etc...
 const ALLOWED_ARTIFACT_URL_ORIGIN = 'https://github.com';
 const ALLOWED_ARTIFACT_URL_PATH_PREFIX = '/Azure/azure-dev/releases/download/';
 const ALLOWED_ARTIFACT_URL_PREFIX = `${ALLOWED_ARTIFACT_URL_ORIGIN}${ALLOWED_ARTIFACT_URL_PATH_PREFIX}`;
@@ -97,18 +100,24 @@ async function run({ github: octokit, context, core, coreTeam, registryBaseRef }
       return;
     }
 
+    const changedFiles = await getChangedFiles({ octokit, context });
+
     // Non-registry file changes require core review.
-    const changedFileReviewReasons = await getChangedFileReviewReasons({
-      octokit,
-      context,
-    });
+    const changedFileReviewReasons = diffChangedFiles(changedFiles);
 
     // Simple release-only registry changes can proceed without core review.
-    const registryReviewReasons = await isAllowedRegistryJsonUpdate({
-      octokit,
-      context,
-      registryBaseRef: baseRef,
-    });
+    const changedRegistryPaths = [...REGISTRY_JSON_PATHS]
+      .filter((registryPath) => changedFiles.some((file) => file.filename === registryPath));
+    const registryReviewReasons = [];
+    for (const registryPath of changedRegistryPaths) {
+      const reasons = await isAllowedRegistryJsonUpdate({
+        octokit,
+        context,
+        registryBaseRef: baseRef,
+        registryPath,
+      });
+      registryReviewReasons.push(...reasons.map((reason) => `${registryPath}: ${reason}`));
+    }
 
     const reviewReasons = changedFileReviewReasons.concat(registryReviewReasons);
 
@@ -235,10 +244,15 @@ function isCreatedByCoreTeam({ context, core, coreTeam }) {
 /**
  * Checks whether the registry update is simple enough to proceed without core-team review.
  *
- * @param {{ octokit: Octokit, context: Context, registryBaseRef?: string }} args
+ * @param {{ octokit: Octokit, context: Context, registryBaseRef?: string, registryPath?: string }} args
  * @returns {Promise<string[]>} the reasons core review is needed; empty means the change is approved
  */
-async function isAllowedRegistryJsonUpdate({ octokit, context, registryBaseRef = 'main' }) {
+async function isAllowedRegistryJsonUpdate({
+  octokit,
+  context,
+  registryBaseRef = 'main',
+  registryPath = DEFAULT_REGISTRY_JSON_PATH,
+}) {
   assertHasPullRequest(context);
   const pr = context.payload.pull_request;
 
@@ -247,6 +261,7 @@ async function isAllowedRegistryJsonUpdate({ octokit, context, registryBaseRef =
     owner: context.repo.owner,
     repo: context.repo.repo,
     ref: registryBaseRef,
+    registryPath,
   });
 
   const head = pr['head'];
@@ -260,20 +275,10 @@ async function isAllowedRegistryJsonUpdate({ octokit, context, registryBaseRef =
     owner: head?.repo?.owner?.login ?? context.repo.owner,
     repo: head?.repo?.name ?? context.repo.repo,
     ref,
+    registryPath,
   });
 
   return diffRegistry(mainRegistry, prRegistry);
-}
-
-/**
- * Checks whether the PR changed only registry.json.
- *
- * @param {{ octokit: Octokit, context: Context }} args
- * @returns {Promise<string[]>}
- */
-async function getChangedFileReviewReasons({ octokit, context }) {
-  const changedFiles = await getChangedFiles({ octokit, context });
-  return diffChangedFiles(changedFiles);
 }
 
 /**
@@ -297,7 +302,7 @@ async function getChangedFiles({ octokit, context }) {
  */
 function diffChangedFiles(changedFiles) {
   const unexpectedFiles = changedFiles
-    .filter((file) => file.filename !== REGISTRY_JSON_PATH || file.previous_filename != null)
+    .filter((file) => !REGISTRY_JSON_PATHS.has(file.filename) || file.previous_filename != null)
     .map((file) => file.filename);
 
   if (unexpectedFiles.length === 0) {
@@ -305,21 +310,21 @@ function diffChangedFiles(changedFiles) {
   }
 
   return [
-    `PR changes files outside ${REGISTRY_JSON_PATH}; core review required for non-registry-only PRs: ${unexpectedFiles.join(', ')}`,
+    `PR changes files outside the extension registries; core review required for registry-only PRs: ${unexpectedFiles.join(', ')}`,
   ];
 }
 
 /**
- * Fetches and parses cli/azd/extensions/registry.json at a given ref.
+ * Fetches and parses an extension registry at a given ref.
  *
- * @param {{ octokit: Octokit, owner: string, repo: string, ref: string }} args
+ * @param {{ octokit: Octokit, owner: string, repo: string, ref: string, registryPath?: string }} args
  * @returns {Promise<RegistryJson>}
  */
-async function getRegistryJson({ octokit, owner, repo, ref }) {
+async function getRegistryJson({ octokit, owner, repo, ref, registryPath = DEFAULT_REGISTRY_JSON_PATH }) {
   const { data } = await octokit.rest.repos.getContent({
     owner,
     repo,
-    path: REGISTRY_JSON_PATH,
+    path: registryPath,
     ref,
     mediaType: {
       format: 'raw',
@@ -327,7 +332,7 @@ async function getRegistryJson({ octokit, owner, repo, ref }) {
   });
 
   if (typeof data !== 'string') {
-    throw new Error(`Unable to load ${REGISTRY_JSON_PATH} from ${owner}/${repo}@${ref}`);
+    throw new Error(`Unable to load ${registryPath} from ${owner}/${repo}@${ref}`);
   }
 
   return JSON.parse(data);
@@ -803,5 +808,3 @@ function assertHasPullRequest(context) {
     throw new Error('No pull_request found in event payload. Workflow targeting should only target pull requests.');
   }
 }
-
-

--- a/.github/scripts/src/ext-registry-check.js
+++ b/.github/scripts/src/ext-registry-check.js
@@ -296,22 +296,41 @@ async function getChangedFiles({ octokit, context }) {
 }
 
 /**
+ * Flags file-level changes that disqualify a PR from the registry-only fast path.
+ * Only in-place edits to the known registry files may skip core review; touching any
+ * other file, or renaming a registry file, requires a core reviewer.
+ *
  * @param {PullRequestFile[]} changedFiles
- * @returns {string[]}
+ * @returns {string[]} the reasons core review is needed; empty means every change is registry-only
  */
 function diffChangedFiles(changedFiles) {
-  const unexpectedFiles = changedFiles
-    .filter((file) => !REGISTRY_JSON_PATHS.has(file.filename) || file.previous_filename != null)
+  const registryPaths = [...REGISTRY_JSON_PATHS].join(', ');
+
+  const nonRegistryFiles = changedFiles
+    .filter((file) => !REGISTRY_JSON_PATHS.has(file.filename))
     .map((file) => file.filename);
 
-  if (unexpectedFiles.length === 0) {
-    return [];
+  const renamedRegistryFiles = changedFiles
+    .filter((file) => REGISTRY_JSON_PATHS.has(file.filename) && file.previous_filename != null)
+    .map((file) => `${file.previous_filename} -> ${file.filename}`);
+
+  const reasons = [];
+
+  if (nonRegistryFiles.length > 0) {
+    reasons.push(
+      `PR changes files outside the extension registries (${registryPaths}), ` +
+      `which requires core review: ${nonRegistryFiles.join(', ')}`,
+    );
   }
 
-  return [
-    `PR changes files outside ${[...REGISTRY_JSON_PATHS].join(', ')}; ` +
-    `core review required for registry-only PRs: ${unexpectedFiles.join(', ')}`,
-  ];
+  if (renamedRegistryFiles.length > 0) {
+    reasons.push(
+      `PR renames extension registry files, which requires core review: ` +
+      `${renamedRegistryFiles.join(', ')}`,
+    );
+  }
+
+  return reasons;
 }
 
 /**

--- a/.github/scripts/src/ext-registry-check.js
+++ b/.github/scripts/src/ext-registry-check.js
@@ -104,9 +104,12 @@ async function run({ github: octokit, context, core, coreTeam, registryBaseRef }
     // Non-registry file changes require core review.
     const changedFileReviewReasons = diffChangedFiles(changedFiles);
 
-    // Simple release-only registry changes can proceed without core review.
+    // Simple release-only registry changes can proceed without core review. Deleted registries
+    // are reported by diffChangedFiles above and skipped here, since there's nothing to fetch
+    // at the PR head.
     const changedRegistryPaths = [...REGISTRY_JSON_PATHS]
-      .filter((registryPath) => changedFiles.some((file) => file.filename === registryPath));
+      .filter((registryPath) => changedFiles.some(
+        (file) => file.filename === registryPath && file.status !== 'removed'));
     const registryReviewReasons = [];
     for (const registryPath of changedRegistryPaths) {
       const reasons = await isAllowedRegistryJsonUpdate({
@@ -296,9 +299,22 @@ async function getChangedFiles({ octokit, context }) {
 }
 
 /**
+ * Whether a changed file refers to one of the known registries, on either side of a rename.
+ * Checking `previous_filename` catches a registry that was renamed away, where the new
+ * filename is no longer one of the registry paths.
+ *
+ * @param {PullRequestFile} file
+ * @returns {boolean}
+ */
+function isRegistryFile(file) {
+  return REGISTRY_JSON_PATHS.has(file.filename) ||
+    (file.previous_filename != null && REGISTRY_JSON_PATHS.has(file.previous_filename));
+}
+
+/**
  * Flags file-level changes that disqualify a PR from the registry-only fast path.
  * Only in-place edits to the known registry files may skip core review; touching any
- * other file, or renaming a registry file, requires a core reviewer.
+ * other file, or renaming/deleting a registry file, requires a core reviewer.
  *
  * @param {PullRequestFile[]} changedFiles
  * @returns {string[]} the reasons core review is needed; empty means every change is registry-only
@@ -307,12 +323,16 @@ function diffChangedFiles(changedFiles) {
   const registryPaths = [...REGISTRY_JSON_PATHS].join(', ');
 
   const nonRegistryFiles = changedFiles
-    .filter((file) => !REGISTRY_JSON_PATHS.has(file.filename))
+    .filter((file) => !isRegistryFile(file))
     .map((file) => file.filename);
 
   const renamedRegistryFiles = changedFiles
-    .filter((file) => REGISTRY_JSON_PATHS.has(file.filename) && file.previous_filename != null)
+    .filter((file) => isRegistryFile(file) && file.previous_filename != null)
     .map((file) => `${file.previous_filename} -> ${file.filename}`);
+
+  const deletedRegistryFiles = changedFiles
+    .filter((file) => isRegistryFile(file) && file.status === 'removed')
+    .map((file) => file.filename);
 
   const reasons = [];
 
@@ -327,6 +347,13 @@ function diffChangedFiles(changedFiles) {
     reasons.push(
       `PR renames extension registry files, which requires core review: ` +
       `${renamedRegistryFiles.join(', ')}`,
+    );
+  }
+
+  if (deletedRegistryFiles.length > 0) {
+    reasons.push(
+      `PR deletes extension registry files, which requires core review: ` +
+      `${deletedRegistryFiles.join(', ')}`,
     );
   }
 

--- a/.github/scripts/test/ext-registry-check.test.js
+++ b/.github/scripts/test/ext-registry-check.test.js
@@ -546,6 +546,21 @@ describe('isAllowedRegistryJsonUpdate', () => {
     }));
   });
 
+  it('loads and validates registry.dev.json when requested', async () => {
+    const base = registry([extension({ id: 'ext.one' })]);
+    const pr = registry([{ ...extension({ id: 'ext.one' }), namespace: 'other' }]);
+    const octokit = createRegistryOctokit({ base, pr });
+
+    await expect(isAllowedRegistryJsonUpdate({
+      octokit,
+      context: createRegistryContext(),
+      registryPath: 'cli/azd/extensions/registry.dev.json',
+    })).resolves.toContainEqual(expect.stringContaining('changes metadata that requires core review'));
+    expect(octokit.rest.repos.getContent).toHaveBeenCalledWith(expect.objectContaining({
+      path: 'cli/azd/extensions/registry.dev.json',
+    }));
+  });
+
   it('requires review when an existing release changes capabilities', async () => {
     const base = registry([extension({ id: 'ext.one', versions: [version({ capabilities: ['custom-commands'] })] })]);
     const pr = registry([extension({ id: 'ext.one', versions: [version({ capabilities: ['lifecycle-events'] })] })]);
@@ -613,6 +628,54 @@ describe('run', () => {
     expect(core.setFailed).not.toHaveBeenCalled();
     expect(octokit.paginate).toHaveBeenCalledWith(octokit.rest.pulls.listFiles, expect.objectContaining({
       pull_number: 1,
+    }));
+  });
+
+  it('allows a simple registry.dev.json-only PR without core review', async () => {
+    const core = createNoopCore();
+    const octokit = createRegistryOctokit({
+      base: registry([extension({ versions: [version({ version: '1.0.0' })] })]),
+      pr: registry([extension({ versions: [version({ version: '1.0.0' }), version({ version: '1.1.0' })] })]),
+      files: [{ filename: 'cli/azd/extensions/registry.dev.json' }],
+    });
+
+    await run({
+      github: octokit,
+      context: createRegistryContext(),
+      core,
+      coreTeam: new Set(['core-member']),
+    });
+
+    expect(core.setFailed).not.toHaveBeenCalled();
+    expect(octokit.rest.repos.getContent).toHaveBeenCalledWith(expect.objectContaining({
+      path: 'cli/azd/extensions/registry.dev.json',
+    }));
+  });
+
+  it('allows simple updates to both registries without core review', async () => {
+    const core = createNoopCore();
+    const octokit = createRegistryOctokit({
+      base: registry([extension({ versions: [version({ version: '1.0.0' })] })]),
+      pr: registry([extension({ versions: [version({ version: '1.0.0' }), version({ version: '1.1.0' })] })]),
+      files: [
+        { filename: 'cli/azd/extensions/registry.json' },
+        { filename: 'cli/azd/extensions/registry.dev.json' },
+      ],
+    });
+
+    await run({
+      github: octokit,
+      context: createRegistryContext(),
+      core,
+      coreTeam: new Set(['core-member']),
+    });
+
+    expect(core.setFailed).not.toHaveBeenCalled();
+    expect(octokit.rest.repos.getContent).toHaveBeenCalledWith(expect.objectContaining({
+      path: 'cli/azd/extensions/registry.json',
+    }));
+    expect(octokit.rest.repos.getContent).toHaveBeenCalledWith(expect.objectContaining({
+      path: 'cli/azd/extensions/registry.dev.json',
     }));
   });
 
@@ -687,7 +750,7 @@ describe('run', () => {
       coreTeam: new Set(['core-member']),
     });
 
-    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('files outside cli/azd/extensions/registry.json'));
+    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('files outside the extension registries'));
     expect(octokit.paginate).toHaveBeenCalledWith(octokit.rest.pulls.listFiles, expect.objectContaining({
       pull_number: 1,
     }));
@@ -745,7 +808,7 @@ describe('run', () => {
       coreTeam: new Set(['core-member']),
     });
 
-    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('files outside cli/azd/extensions/registry.json'));
+    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('files outside the extension registries'));
     expect(octokit.paginate).toHaveBeenCalledWith(octokit.rest.pulls.listFiles, expect.objectContaining({
       pull_number: 1,
     }));
@@ -817,7 +880,7 @@ describe('run', () => {
       coreTeam: new Set(['core-member']),
     });
 
-    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('files outside cli/azd/extensions/registry.json'));
+    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('files outside the extension registries'));
     expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('cli/azd/extensions/README.md'));
   });
 });

--- a/.github/scripts/test/ext-registry-check.test.js
+++ b/.github/scripts/test/ext-registry-check.test.js
@@ -763,7 +763,8 @@ describe('run', () => {
       coreTeam: new Set(['core-member']),
     });
 
-    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining(`files outside ${REGISTRY_PATH_LIST}`));
+    expect(core.setFailed).toHaveBeenCalledWith(
+      expect.stringContaining(`files outside the extension registries (${REGISTRY_PATH_LIST})`));
     expect(octokit.paginate).toHaveBeenCalledWith(octokit.rest.pulls.listFiles, expect.objectContaining({
       pull_number: 1,
     }));
@@ -821,7 +822,8 @@ describe('run', () => {
       coreTeam: new Set(['core-member']),
     });
 
-    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining(`files outside ${REGISTRY_PATH_LIST}`));
+    expect(core.setFailed).toHaveBeenCalledWith(
+      expect.stringContaining(`files outside the extension registries (${REGISTRY_PATH_LIST})`));
     expect(octokit.paginate).toHaveBeenCalledWith(octokit.rest.pulls.listFiles, expect.objectContaining({
       pull_number: 1,
     }));
@@ -893,8 +895,70 @@ describe('run', () => {
       coreTeam: new Set(['core-member']),
     });
 
-    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining(`files outside ${REGISTRY_PATH_LIST}`));
+    expect(core.setFailed).toHaveBeenCalledWith(
+      expect.stringContaining(`files outside the extension registries (${REGISTRY_PATH_LIST})`));
     expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('cli/azd/extensions/README.md'));
+  });
+
+  it('requires review when a registry file is renamed', async () => {
+    const core = createNoopCore();
+    const octokit = createRegistryOctokit({
+      base: registry([extension()]),
+      pr: registry([extension()]),
+      files: [
+        { filename: PROD_REGISTRY_PATH, previous_filename: 'cli/azd/extensions/registry.old.json' },
+      ],
+    });
+
+    await run({
+      github: octokit,
+      context: createRegistryContext(),
+      core,
+      coreTeam: new Set(['core-member']),
+    });
+
+    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('renames extension registry files'));
+    expect(core.setFailed).toHaveBeenCalledWith(
+      expect.stringContaining(`cli/azd/extensions/registry.old.json -> ${PROD_REGISTRY_PATH}`));
+  });
+
+  it('evaluates each registry independently and names only the one that requires review', async () => {
+    const core = createNoopCore();
+    const octokit = createRegistryOctokit({
+      registries: {
+        // Prod registry: a simple, policy-valid new release.
+        [PROD_REGISTRY_PATH]: {
+          base: registry([extension({ versions: [version({ version: '1.0.0' })] })]),
+          pr: registry([extension({ versions: [version({ version: '1.0.0' }), version({ version: '1.1.0' })] })]),
+        },
+        // Dev registry: a new release that changes capabilities, which requires core review.
+        [DEV_REGISTRY_PATH]: {
+          base: registry([extension({ versions: [version({ version: '1.0.0', capabilities: ['custom-commands'] })] })]),
+          pr: registry([
+            extension({
+              versions: [
+                version({ version: '1.0.0', capabilities: ['custom-commands'] }),
+                version({ version: '1.1.0', capabilities: ['custom-commands', 'lifecycle-events'] }),
+              ],
+            }),
+          ]),
+        },
+      },
+      files: [
+        { filename: PROD_REGISTRY_PATH },
+        { filename: DEV_REGISTRY_PATH },
+      ],
+    });
+
+    await run({
+      github: octokit,
+      context: createRegistryContext(),
+      core,
+      coreTeam: new Set(['core-member']),
+    });
+
+    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining(`${DEV_REGISTRY_PATH}: `));
+    expect(core.setFailed).not.toHaveBeenCalledWith(expect.stringContaining(`${PROD_REGISTRY_PATH}: `));
   });
 });
 
@@ -912,10 +976,24 @@ describe('getCoreReviewers', () => {
 });
 
 /**
- * @param {{ base: RegistryJson, pr: RegistryJson, files?: { filename: string, previous_filename?: string }[], reviews?: { user: { login: string }, state: string, commit_id: string }[] }} args
+ * @param {{
+ *   base?: RegistryJson,
+ *   pr?: RegistryJson,
+ *   registries?: Object<string, { base: RegistryJson, pr: RegistryJson }>,
+ *   files?: { filename: string, previous_filename?: string }[],
+ *   reviews?: { user: { login: string }, state: string, commit_id: string }[],
+ * }} args
  * @returns {Octokit}
  */
-function createRegistryOctokit({ base, pr, files = [{ filename: 'cli/azd/extensions/registry.json' }], reviews = [] }) {
+function createRegistryOctokit({ base, pr, registries, files = [{ filename: PROD_REGISTRY_PATH }], reviews = [] }) {
+  // Per-path fixtures let a test drive each registry independently. When they're not
+  // supplied, every registry path shares the same base/pr content.
+  /** @type {Record<string, { base?: RegistryJson | undefined, pr?: RegistryJson | undefined }>} */
+  const registriesByPath = registries ?? {
+    [PROD_REGISTRY_PATH]: { base, pr },
+    [DEV_REGISTRY_PATH]: { base, pr },
+  };
+
   const octokit = {
     rest: {
       pulls: {
@@ -923,9 +1001,16 @@ function createRegistryOctokit({ base, pr, files = [{ filename: 'cli/azd/extensi
         listFiles: vi.fn(),
       },
       repos: {
-        getContent: vi.fn(({ ref }) => Promise.resolve({
-          data: JSON.stringify(ref === 'abc123' ? pr : base),
-        })),
+        getContent: vi.fn(({ path, ref }) => {
+          const fixture = registriesByPath[path];
+          if (fixture == null) {
+            throw new Error(`No registry fixture configured for ${path}`);
+          }
+
+          return Promise.resolve({
+            data: JSON.stringify(ref === 'abc123' ? fixture.pr : fixture.base),
+          });
+        }),
       },
     },
     paginate: vi.fn((endpoint) => {

--- a/.github/scripts/test/ext-registry-check.test.js
+++ b/.github/scripts/test/ext-registry-check.test.js
@@ -37,6 +37,10 @@ const {
   isAllowedRegistryJsonUpdate,
 } = run.forTests;
 
+const PROD_REGISTRY_PATH = 'cli/azd/extensions/registry.json';
+const DEV_REGISTRY_PATH = 'cli/azd/extensions/registry.dev.json';
+const REGISTRY_PATH_LIST = `${PROD_REGISTRY_PATH}, ${DEV_REGISTRY_PATH}`;
+
 /**
  * @param {object} [opts]
  * @param {string[]} [opts.capabilities]
@@ -515,7 +519,12 @@ describe('isAllowedRegistryJsonUpdate', () => {
     const octokit = createRegistryOctokit({ base, pr });
     const context = createRegistryContext();
 
-    await expect(isAllowedRegistryJsonUpdate({ octokit, context })).resolves.toContainEqual(expect.stringContaining('changes metadata that requires core review'));
+    await expect(isAllowedRegistryJsonUpdate({
+      octokit,
+      context,
+      registryPath: PROD_REGISTRY_PATH,
+      registryBaseRef: 'main',
+    })).resolves.toContainEqual(expect.stringContaining('changes metadata that requires core review'));
     expect(octokit.rest.repos.getContent).toHaveBeenCalledWith(expect.objectContaining({
       owner: 'Azure',
       repo: 'azure-dev',
@@ -537,6 +546,7 @@ describe('isAllowedRegistryJsonUpdate', () => {
     await expect(isAllowedRegistryJsonUpdate({
       octokit,
       context,
+      registryPath: PROD_REGISTRY_PATH,
       registryBaseRef: 'base-before-pr',
     })).resolves.toContainEqual(expect.stringContaining('changes metadata that requires core review'));
     expect(octokit.rest.repos.getContent).toHaveBeenCalledWith(expect.objectContaining({
@@ -554,7 +564,8 @@ describe('isAllowedRegistryJsonUpdate', () => {
     await expect(isAllowedRegistryJsonUpdate({
       octokit,
       context: createRegistryContext(),
-      registryPath: 'cli/azd/extensions/registry.dev.json',
+      registryPath: DEV_REGISTRY_PATH,
+      registryBaseRef: 'main',
     })).resolves.toContainEqual(expect.stringContaining('changes metadata that requires core review'));
     expect(octokit.rest.repos.getContent).toHaveBeenCalledWith(expect.objectContaining({
       path: 'cli/azd/extensions/registry.dev.json',
@@ -569,6 +580,8 @@ describe('isAllowedRegistryJsonUpdate', () => {
     const reasons = await isAllowedRegistryJsonUpdate({
       octokit,
       context: createRegistryContext(),
+      registryPath: PROD_REGISTRY_PATH,
+      registryBaseRef: 'main',
     });
 
     expect(reasons).toContainEqual(expect.stringContaining('changes capabilities'));
@@ -750,7 +763,7 @@ describe('run', () => {
       coreTeam: new Set(['core-member']),
     });
 
-    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('files outside the extension registries'));
+    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining(`files outside ${REGISTRY_PATH_LIST}`));
     expect(octokit.paginate).toHaveBeenCalledWith(octokit.rest.pulls.listFiles, expect.objectContaining({
       pull_number: 1,
     }));
@@ -808,7 +821,7 @@ describe('run', () => {
       coreTeam: new Set(['core-member']),
     });
 
-    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('files outside the extension registries'));
+    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining(`files outside ${REGISTRY_PATH_LIST}`));
     expect(octokit.paginate).toHaveBeenCalledWith(octokit.rest.pulls.listFiles, expect.objectContaining({
       pull_number: 1,
     }));
@@ -862,7 +875,7 @@ describe('run', () => {
     }));
   });
 
-  it('requires review when the PR changes files outside registry.json', async () => {
+  it('requires review when the PR changes files outside the extension registries', async () => {
     const core = createNoopCore();
     const octokit = createRegistryOctokit({
       base: registry([extension()]),
@@ -880,7 +893,7 @@ describe('run', () => {
       coreTeam: new Set(['core-member']),
     });
 
-    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('files outside the extension registries'));
+    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining(`files outside ${REGISTRY_PATH_LIST}`));
     expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('cli/azd/extensions/README.md'));
   });
 });

--- a/.github/scripts/test/ext-registry-check.test.js
+++ b/.github/scripts/test/ext-registry-check.test.js
@@ -900,13 +900,13 @@ describe('run', () => {
     expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('cli/azd/extensions/README.md'));
   });
 
-  it('requires review when a registry file is renamed', async () => {
+  it('requires review when a file is renamed into a registry path', async () => {
     const core = createNoopCore();
     const octokit = createRegistryOctokit({
       base: registry([extension()]),
       pr: registry([extension()]),
       files: [
-        { filename: PROD_REGISTRY_PATH, previous_filename: 'cli/azd/extensions/registry.old.json' },
+        { filename: PROD_REGISTRY_PATH, previous_filename: 'cli/azd/extensions/registry.old.json', status: 'renamed' },
       ],
     });
 
@@ -920,6 +920,55 @@ describe('run', () => {
     expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('renames extension registry files'));
     expect(core.setFailed).toHaveBeenCalledWith(
       expect.stringContaining(`cli/azd/extensions/registry.old.json -> ${PROD_REGISTRY_PATH}`));
+  });
+
+  it('requires review when a registry file is renamed away', async () => {
+    const core = createNoopCore();
+    // A registry renamed away no longer exists at either registry path, so no fixture is
+    // configured - the mock throws if the policy tries to load one anyway.
+    const octokit = createRegistryOctokit({
+      registries: {},
+      files: [
+        { filename: 'cli/azd/extensions/registry.old.json', previous_filename: DEV_REGISTRY_PATH, status: 'renamed' },
+      ],
+    });
+
+    await run({
+      github: octokit,
+      context: createRegistryContext(),
+      core,
+      coreTeam: new Set(['core-member']),
+    });
+
+    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('renames extension registry files'));
+    expect(core.setFailed).toHaveBeenCalledWith(
+      expect.stringContaining(`${DEV_REGISTRY_PATH} -> cli/azd/extensions/registry.old.json`));
+    // The renamed registry must be reported as a rename, not as an unrelated outside file.
+    expect(core.setFailed).not.toHaveBeenCalledWith(
+      expect.stringContaining('files outside the extension registries'));
+  });
+
+  it('requires review with a policy message when a registry file is deleted', async () => {
+    const core = createNoopCore();
+    // A deleted registry has nothing to fetch at the PR head, so no fixture is configured -
+    // the mock throws if the policy tries to load it anyway.
+    const octokit = createRegistryOctokit({
+      registries: {},
+      files: [{ filename: DEV_REGISTRY_PATH, status: 'removed' }],
+    });
+
+    await run({
+      github: octokit,
+      context: createRegistryContext(),
+      core,
+      coreTeam: new Set(['core-member']),
+    });
+
+    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('deletes extension registry files'));
+    expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining(DEV_REGISTRY_PATH));
+    // A deletion must surface as policy guidance, not as an unhandled 404 from the registry fetch.
+    expect(core.setFailed).not.toHaveBeenCalledWith(expect.stringContaining('Internal failure in script'));
+    expect(octokit.rest.repos.getContent).not.toHaveBeenCalled();
   });
 
   it('evaluates each registry independently and names only the one that requires review', async () => {
@@ -980,7 +1029,7 @@ describe('getCoreReviewers', () => {
  *   base?: RegistryJson,
  *   pr?: RegistryJson,
  *   registries?: Object<string, { base: RegistryJson, pr: RegistryJson }>,
- *   files?: { filename: string, previous_filename?: string }[],
+ *   files?: { filename: string, previous_filename?: string, status?: string }[],
  *   reviews?: { user: { login: string }, state: string, commit_id: string }[],
  * }} args
  * @returns {Octokit}

--- a/.github/workflows/ext-registry-check.yml
+++ b/.github/workflows/ext-registry-check.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check if registry.json changed
+      - name: Check if an extension registry changed
         id: changed
         uses: actions/github-script@v9
         with:
@@ -45,18 +45,24 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
             });
-            const changed = files.some((f) => f.filename === 'cli/azd/extensions/registry.json');
-            core.info(`registry.json changed: ${changed}`);
-            core.setOutput('registry_json_changed', changed);
+            const registryPaths = new Set([
+              'cli/azd/extensions/registry.json',
+              'cli/azd/extensions/registry.dev.json',
+            ]);
+            const changed = files.some(
+              (f) => registryPaths.has(f.filename) || registryPaths.has(f.previous_filename),
+            );
+            core.info(`extension registry changed: ${changed}`);
+            core.setOutput('registry_changed', changed);
 
       - name: Checkout
-        if: steps.changed.outputs.registry_json_changed == 'true'
+        if: steps.changed.outputs.registry_changed == 'true'
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Check extension registry update
-        if: steps.changed.outputs.registry_json_changed == 'true'
+        if: steps.changed.outputs.registry_changed == 'true'
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/ext-registry-check.yml
+++ b/.github/workflows/ext-registry-check.yml
@@ -50,7 +50,8 @@ jobs:
               'cli/azd/extensions/registry.dev.json',
             ]);
             const changed = files.some(
-              (f) => registryPaths.has(f.filename) || registryPaths.has(f.previous_filename),
+              (f) => registryPaths.has(f.filename) ||
+                  registryPaths.has(f.previous_filename), // Also fire if someone tries to delete a registry
             );
             core.info(`extension registry changed: ${changed}`);
             core.setOutput('registry_changed', changed);

--- a/.github/workflows/ext-registry-check.yml
+++ b/.github/workflows/ext-registry-check.yml
@@ -51,7 +51,10 @@ jobs:
             ]);
             const changed = files.some(
               (f) => registryPaths.has(f.filename) ||
-                  registryPaths.has(f.previous_filename), // Also fire if someone tries to delete a registry
+                  // `previous_filename` is only set on renames, and catches a registry renamed
+                  // away, where the new filename is no longer one of the registry paths.
+                  // Deletions keep `filename` set, so they're covered by the check above.
+                  registryPaths.has(f.previous_filename),
             );
             core.info(`extension registry changed: ${changed}`);
             core.setOutput('registry_changed', changed);


### PR DESCRIPTION
Closes #9234

This PR extends the existing extension registry approval policy to `cli/azd/extensions/registry.dev.json`, applying the same validation and CODEOWNERS rules currently used for the production registry.

### Changes

- Trigger `ext-registry-check` when either production or development registry changes, including rename scenarios.
- Independently evaluate each changed registry through the existing metadata, release immutability, version progression, capability, provider, and artifact URL policies.
- Allow registry-only PRs to update either or both registry files while continuing to require core review for unrelated file changes.
- Assign `registry.dev.json` the same CODEOWNERS as `registry.json`.

### Testing

- `npm test`: 54 tests passed, with 5 opt-in live tests skipped.
- `RUN_LIVE_TESTS=1 npm test`: all 59 tests passed, including the existing real GitHub PR scenarios.
- End-to-end canary using a temporary workflow and draft PR [JeffreyCA/azure-dev#53](https://github.com/JeffreyCA/azure-dev/pull/53):
  - A cosmetic `registry.dev.json` display-name update [passed](https://github.com/JeffreyCA/azure-dev/actions/runs/29854288179).
  - A restricted namespace update [failed as expected](https://github.com/JeffreyCA/azure-dev/actions/runs/29854460319), reporting that core review was required for the `registry.dev.json` metadata change.
  - The canary PR was closed and all temporary branches were deleted after testing.
