### PR TITLE
test: move webapp deploy tests off East US 2 to westus3 (#9235)

### DIFF
--- a/cli/azd/test/functional/deploy_test.go
+++ b/cli/azd/test/functional/deploy_test.go
@@ -122,7 +122,11 @@ func Test_CLI_Deploy_SlotDeployment(t *testing.T) {
 	cli := azdcli.NewCLI(t, azdcli.WithSession(session))
 	cli.WorkingDirectory = dir
 	cli.Env = append(cli.Env, os.Environ()...)
-	cli.Env = append(cli.Env, "AZURE_LOCATION=eastus2")
+	// Experiment (see issue #9235): use westus3 instead of eastus2 to avoid the recurring
+	// App Service "No available instances to satisfy this request" capacity failures that East US 2
+	// has been hitting on live nightly runs. Playback is unaffected (the recording proxy matches on
+	// method + URL only and no request URL contains the region).
+	cli.Env = append(cli.Env, "AZURE_LOCATION=westus3")
 
 	// Deploy to main app on initial `azd up` — explicit targeting required when slots exist
 	cli.Env = append(cli.Env, "AZD_DEPLOY_API_SLOT_NAME=production")
@@ -298,7 +302,10 @@ func Test_CLI_Deploy_StoppedWebApp(t *testing.T) {
 	cli := azdcli.NewCLI(t, azdcli.WithSession(session))
 	cli.WorkingDirectory = dir
 	cli.Env = append(cli.Env, os.Environ()...)
-	cli.Env = append(cli.Env, "AZURE_LOCATION=eastus2")
+	// Experiment (see issue #9235): use westus3 instead of eastus2 to avoid the recurring
+	// App Service "No available instances to satisfy this request" capacity failures that East US 2
+	// has been hitting on live nightly runs. This test is live-only, so there is no cassette to update.
+	cli.Env = append(cli.Env, "AZURE_LOCATION=westus3")
 
 	t.Cleanup(func() {
 		cleanupRg(context.Background(), t, cli, session, "rg-"+envName)


### PR DESCRIPTION
Fixes #9235

## What

Switch the two consistently-failing live webapp deploy tests from the hardcoded `eastus2` to `westus3`:

- `Test_CLI_Deploy_SlotDeployment`
- `Test_CLI_Deploy_StoppedWebApp`

## Why

Both fail on nearly every `azure-dev - cli` nightly (`live` record mode), on all platform legs and even on `(re-run 1)` from #9118, with:

```
Conflict: No available instances to satisfy this request.
App Service is attempting to increase capacity ...
```

This is an **App Service scale-unit capacity shortage in East US 2** (not subscription quota — live usage is ~4–5 of 36 cores). The ~40s retry gap can't clear it. East US 2 capacity shortages are documented and expected to persist into mid-2026.

Both tests **hardcode** `AZURE_LOCATION=eastus2` rather than reading the configurable `AZD_TEST_AZURE_LOCATION` / `cfg.Location`, so they're pinned to the congested region.

## Approach — Option A (targeted experiment)

Change **only these two tests** to `westus3` (better current App Service capacity) to observe whether it resolves the constant live failures. If it works, a follow-up can tackle the systemic fix (wire the ~52 hardcoded `eastus2` sites to `cfg.Location`).

## Playback safety (no re-recording needed)

The recording proxy matches on **method + URL only** (`cassette.DefaultMatcher`), and **no request URL** in the cassettes contains the region — every `eastus2` in the `SlotDeployment` cassette is in a response body (the ARM location catalog). So:

- `Test_CLI_Deploy_SlotDeployment` — plays back unchanged.
- `Test_CLI_Deploy_StoppedWebApp` — live-only (`t.Skip` in playback); no cassette dependency.

## Validation

- [x] `go test -c ./test/functional/` compiles
- [x] Changed lines within `lll` 125-char limit
- [ ] Watch next live nightlies to confirm the capacity failures stop
