### PR TITLE
fix(provision): support ${VAR} substitution in infra.deploymentStacks

### DIFF
--- a/cli/azd/internal/grpcserver/external_provisioning_provider.go
+++ b/cli/azd/internal/grpcserver/external_provisioning_provider.go
@@ -334,18 +334,14 @@ func (p *ExternalProvisioningProvider) PlannedOutputs(
 func convertToProtoOptions(
 	options provisioning.Options,
 ) (*azdext.ProvisioningOptions, error) {
-	deploymentStacks := make(
-		map[string]string, len(options.DeploymentStacks),
-	)
-	for k, v := range options.DeploymentStacks {
-		deploymentStacks[k] = fmt.Sprintf("%v", v)
-	}
-
+	// deploymentStacks is intentionally not forwarded to external providers: it configures the
+	// Azure Deployment Stacks control-plane request and is only valid for the built-in Bicep
+	// provider. The proto field (deployment_stacks) is retained for wire compatibility but left
+	// empty for extension providers.
 	protoOptions := &azdext.ProvisioningOptions{
 		Provider:              string(options.Provider),
 		Path:                  options.Path,
 		Module:                options.Module,
-		DeploymentStacks:      deploymentStacks,
 		IgnoreDeploymentState: options.IgnoreDeploymentState,
 		Name:                  options.Name,
 	}

--- a/cli/azd/internal/grpcserver/external_provisioning_provider_test.go
+++ b/cli/azd/internal/grpcserver/external_provisioning_provider_test.go
@@ -35,10 +35,8 @@ func Test_convertToProtoOptions(t *testing.T) {
 				Path:     "/infra",
 				Module:   "main",
 				Name:     "layer1",
-				DeploymentStacks: map[string]any{
-					"stackName": "my-stack",
-					"intVal":    42,
-					"boolVal":   true,
+				DeploymentStacks: &provisioning.DeploymentStacksConfig{
+					DenySettings: &provisioning.DenySettingsConfig{Mode: "denyDelete"},
 				},
 				IgnoreDeploymentState: true,
 				Config: map[string]any{
@@ -56,9 +54,8 @@ func Test_convertToProtoOptions(t *testing.T) {
 				assert.Equal(t, "main", result.Module)
 				assert.Equal(t, "layer1", result.Name)
 				assert.True(t, result.IgnoreDeploymentState)
-				assert.Equal(t, "my-stack", result.DeploymentStacks["stackName"])
-				assert.Equal(t, "42", result.DeploymentStacks["intVal"])
-				assert.Equal(t, "true", result.DeploymentStacks["boolVal"])
+				// deploymentStacks is bicep-only and intentionally not forwarded to extensions.
+				assert.Empty(t, result.DeploymentStacks)
 				require.NotNil(t, result.Config)
 				assert.Equal(t, "value1", result.Config.Fields["key1"].GetStringValue())
 				nested := result.Config.Fields["nested"].GetStructValue()

--- a/cli/azd/internal/grpcserver/external_provisioning_provider_test.go
+++ b/cli/azd/internal/grpcserver/external_provisioning_provider_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/prompt"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
 )
 
 func Test_convertToProtoOptions(t *testing.T) {
@@ -119,6 +120,35 @@ func Test_convertToProtoOptions(t *testing.T) {
 			tt.verify(t, result, err)
 		})
 	}
+}
+
+// Test_ExternalProvisioningProvider_NameAndProgress covers the broker-independent surface of the
+// provider: the DI factory, Name(), and the reportProgress/stopProgress spinner helpers (including
+// their nil-console fallbacks). The broker-backed forwarders (Deploy/Preview/Destroy/etc.) require
+// a live gRPC broker and are tracked separately in issue #7480.
+func Test_ExternalProvisioningProvider_NameAndProgress(t *testing.T) {
+	factory := NewExternalProvisioningProviderFactory("my-provider", nil, nil)
+
+	t.Run("Name returns provider name", func(t *testing.T) {
+		provider := factory(mockinput.NewMockConsole())
+		assert.Equal(t, "my-provider", provider.Name())
+	})
+
+	t.Run("progress with console", func(t *testing.T) {
+		provider := factory(mockinput.NewMockConsole()).(*ExternalProvisioningProvider)
+		// Should not panic and should route through the console spinner.
+		provider.reportProgress(context.Background(), "deploying")
+		provider.stopProgress(context.Background(), nil)
+		provider.stopProgress(context.Background(), assert.AnError)
+	})
+
+	t.Run("progress with nil console", func(t *testing.T) {
+		provider := &ExternalProvisioningProvider{providerName: "no-console"}
+		// Falls back to a debug log / no-op without a console.
+		provider.reportProgress(context.Background(), "deploying")
+		provider.stopProgress(context.Background(), nil)
+		assert.Equal(t, "no-console", provider.Name())
+	})
 }
 
 func Test_convertFromProtoStateResult(t *testing.T) {

--- a/cli/azd/internal/grpcserver/external_provisioning_provider_test.go
+++ b/cli/azd/internal/grpcserver/external_provisioning_provider_test.go
@@ -137,16 +137,16 @@ func Test_ExternalProvisioningProvider_NameAndProgress(t *testing.T) {
 	t.Run("progress with console", func(t *testing.T) {
 		provider := factory(mockinput.NewMockConsole()).(*ExternalProvisioningProvider)
 		// Should not panic and should route through the console spinner.
-		provider.reportProgress(context.Background(), "deploying")
-		provider.stopProgress(context.Background(), nil)
-		provider.stopProgress(context.Background(), assert.AnError)
+		provider.reportProgress(t.Context(), "deploying")
+		provider.stopProgress(t.Context(), nil)
+		provider.stopProgress(t.Context(), assert.AnError)
 	})
 
 	t.Run("progress with nil console", func(t *testing.T) {
 		provider := &ExternalProvisioningProvider{providerName: "no-console"}
 		// Falls back to a debug log / no-op without a console.
-		provider.reportProgress(context.Background(), "deploying")
-		provider.stopProgress(context.Background(), nil)
+		provider.reportProgress(t.Context(), "deploying")
+		provider.stopProgress(t.Context(), nil)
 		assert.Equal(t, "no-console", provider.Name())
 	})
 }

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -898,7 +898,7 @@ func (p *BicepProvider) Deploy(ctx context.Context) (*provisioning.DeployResult,
 		deploymentTags[azure.TagKeyAzdDeploymentStateParamHashName] = new(currentParamsHash)
 	}
 
-	optionsMap, err := convert.ToMap(p.options)
+	optionsMap, err := p.deploymentOptionsMap()
 	if err != nil {
 		return nil, err
 	}
@@ -1660,7 +1660,7 @@ func (p *BicepProvider) destroyDeployment(
 			p.console.StopSpinner(ctx, progressMessage.Message, input.StepFailed)
 		}
 	}, func(progress *async.Progress[azapi.DeleteDeploymentProgress]) error {
-		optionsMap, err := convert.ToMap(p.options)
+		optionsMap, err := p.deploymentOptionsMap()
 		if err != nil {
 			return err
 		}

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -898,7 +898,7 @@ func (p *BicepProvider) Deploy(ctx context.Context) (*provisioning.DeployResult,
 		deploymentTags[azure.TagKeyAzdDeploymentStateParamHashName] = new(currentParamsHash)
 	}
 
-	optionsMap, err := p.deploymentOptionsMap()
+	optionsMap, err := p.deploymentOptionsMap(true)
 	if err != nil {
 		return nil, err
 	}
@@ -1660,7 +1660,7 @@ func (p *BicepProvider) destroyDeployment(
 			p.console.StopSpinner(ctx, progressMessage.Message, input.StepFailed)
 		}
 	}, func(progress *async.Progress[azapi.DeleteDeploymentProgress]) error {
-		optionsMap, err := p.deploymentOptionsMap()
+		optionsMap, err := p.deploymentOptionsMap(false)
 		if err != nil {
 			return err
 		}

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -833,7 +833,13 @@ func (p *BicepProvider) Deploy(ctx context.Context) (*provisioning.DeployResult,
 		logDS("%s", parametersHashErr.Error())
 	}
 
-	if !p.ignoreDeploymentState && parametersHashErr == nil {
+	useDeploymentState := !p.ignoreDeploymentState && parametersHashErr == nil
+	if useDeploymentState && p.hasActiveDeploymentStacksConfig() {
+		logDS("deployment stacks configuration present; bypassing deployment-state shortcut")
+		useDeploymentState = false
+	}
+
+	if useDeploymentState {
 		deploymentState, stateErr := p.deploymentState(ctx, planned, deployment, currentParamsHash)
 		if stateErr == nil {
 			// As a heuristic, we also check the existence of all resource groups

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -833,10 +833,11 @@ func (p *BicepProvider) Deploy(ctx context.Context) (*provisioning.DeployResult,
 		logDS("%s", parametersHashErr.Error())
 	}
 
-	useDeploymentState := !p.ignoreDeploymentState && parametersHashErr == nil
-	if useDeploymentState && p.hasActiveDeploymentStacksConfig() {
+	useDeploymentState := p.useDeploymentStateShortcut(parametersHashErr)
+	if !useDeploymentState && !p.ignoreDeploymentState && parametersHashErr == nil {
+		// The only remaining reason the shortcut is disabled here is an active deployment-stacks
+		// configuration; surface it in the deployment-stacks debug log.
 		logDS("deployment stacks configuration present; bypassing deployment-state shortcut")
-		useDeploymentState = false
 	}
 
 	if useDeploymentState {

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks.go
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package bicep
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/convert"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+)
+
+// resolveDeploymentStacksMap resolves the typed deployment-stacks configuration into a
+// camelCase map[string]any consumable by the deployment-stacks API layer
+// (azapi.parseDeploymentStackOptions). It performs ${VAR} environment-variable substitution
+// on denySettings.excludedPrincipals and denySettings.excludedActions, resolving values from
+// plan-time layer outputs (VirtualEnv) first and then the azd environment.
+//
+// It returns nil when no deployment-stacks configuration is present, in which case the caller
+// should omit the DeploymentStacks key entirely so the API layer applies its defaults.
+func (p *BicepProvider) resolveDeploymentStacksMap() (map[string]any, error) {
+	cfg := p.options.DeploymentStacks
+	if cfg == nil {
+		return nil, nil
+	}
+
+	result := map[string]any{}
+
+	if cfg.ActionOnUnmanage != nil {
+		actionOnUnmanage := map[string]any{}
+		if cfg.ActionOnUnmanage.Resources != "" {
+			actionOnUnmanage["resources"] = cfg.ActionOnUnmanage.Resources
+		}
+		if cfg.ActionOnUnmanage.ResourceGroups != "" {
+			actionOnUnmanage["resourceGroups"] = cfg.ActionOnUnmanage.ResourceGroups
+		}
+		if cfg.ActionOnUnmanage.ManagementGroups != "" {
+			actionOnUnmanage["managementGroups"] = cfg.ActionOnUnmanage.ManagementGroups
+		}
+		result["actionOnUnmanage"] = actionOnUnmanage
+	}
+
+	if cfg.DenySettings != nil {
+		denySettings := map[string]any{}
+		if cfg.DenySettings.Mode != "" {
+			denySettings["mode"] = cfg.DenySettings.Mode
+		}
+		if cfg.DenySettings.ApplyToChildScopes != nil {
+			denySettings["applyToChildScopes"] = *cfg.DenySettings.ApplyToChildScopes
+		}
+
+		excludedActions, err := p.resolveDeploymentStacksValues(cfg.DenySettings.ExcludedActions)
+		if err != nil {
+			return nil, err
+		}
+		if excludedActions != nil {
+			denySettings["excludedActions"] = excludedActions
+		}
+
+		excludedPrincipals, err := p.resolveDeploymentStacksValues(cfg.DenySettings.ExcludedPrincipals)
+		if err != nil {
+			return nil, err
+		}
+		if excludedPrincipals != nil {
+			denySettings["excludedPrincipals"] = excludedPrincipals
+		}
+
+		result["denySettings"] = denySettings
+	}
+
+	return result, nil
+}
+
+// resolveDeploymentStacksValues evaluates ${VAR} references in each value, resolving from the
+// plan-time layer outputs (VirtualEnv) first and then the azd environment. It returns an error
+// if any referenced environment variable is unset, since a blank value in deny settings (for
+// example, an empty excluded principal) is almost always a misconfiguration.
+func (p *BicepProvider) resolveDeploymentStacksValues(values []osutil.ExpandableString) ([]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+
+	resolved := make([]string, 0, len(values))
+	for _, value := range values {
+		var unset []string
+		substituted, err := value.Envsubst(func(name string) string {
+			if p.options.VirtualEnv != nil {
+				if v, has := p.options.VirtualEnv[name]; has {
+					return v
+				}
+			}
+
+			v, ok := p.env.LookupEnv(name)
+			if !ok {
+				unset = append(unset, name)
+			}
+			return v
+		})
+		if err != nil {
+			return nil, fmt.Errorf("resolving deploymentStacks value: %w", err)
+		}
+
+		if len(unset) > 0 {
+			return nil, fmt.Errorf(
+				"deploymentStacks references unset environment variable(s): %s", strings.Join(unset, ", "))
+		}
+
+		resolved = append(resolved, substituted)
+	}
+
+	return resolved, nil
+}
+
+// deploymentOptionsMap builds the generic options map handed to the deployment API layer,
+// with the deployment-stacks configuration resolved (including ${VAR} substitution). Standard
+// (non-stack) deployments ignore this map; stack deployments read only the DeploymentStacks key.
+func (p *BicepProvider) deploymentOptionsMap() (map[string]any, error) {
+	optionsMap, err := convert.ToMap(p.options)
+	if err != nil {
+		return nil, err
+	}
+
+	stacks, err := p.resolveDeploymentStacksMap()
+	if err != nil {
+		return nil, err
+	}
+
+	if stacks == nil {
+		// The typed DeploymentStacksConfig is not JSON-serializable in a form the API layer can
+		// consume (ExpandableString has no exported fields), so drop whatever convertOptionsToMap
+		// produced for it and let the API layer apply its defaults.
+		delete(optionsMap, "DeploymentStacks")
+	} else {
+		optionsMap["DeploymentStacks"] = stacks
+	}
+
+	return optionsMap, nil
+}

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks.go
@@ -35,6 +35,21 @@ func (p *BicepProvider) hasActiveDeploymentStacksConfig() bool {
 	return p.options.DeploymentStacks != nil && p.deploymentStacksEnabled()
 }
 
+// useDeploymentStateShortcut reports whether the deployment-state shortcut (which skips a
+// redeploy when the template and parameters are unchanged) may be used. It returns false when
+// deployment-state tracking is disabled (--no-state), when the parameters hash could not be
+// computed, or when an active deployment-stacks configuration is present. In the stacks case the
+// deny/unmanage settings — including ${VAR}-resolved deny lists — can change independently of the
+// template+parameters the state hash covers, so the shortcut must be bypassed to avoid leaving
+// stale settings on the stack and to preserve ${VAR} resolution/validation.
+func (p *BicepProvider) useDeploymentStateShortcut(parametersHashErr error) bool {
+	if p.ignoreDeploymentState || parametersHashErr != nil {
+		return false
+	}
+
+	return !p.hasActiveDeploymentStacksConfig()
+}
+
 // resolveDeploymentStacksMap resolves the typed deployment-stacks configuration into a
 // camelCase map[string]any consumable by the deployment-stacks API layer
 // (azapi.parseDeploymentStackOptions). It performs ${VAR} environment-variable substitution

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks.go
@@ -102,9 +102,11 @@ func (p *BicepProvider) resolveDeploymentStacksMap(includeDenySettings bool) (ma
 }
 
 // resolveDeploymentStacksValues evaluates ${VAR} references in each value, resolving from the
-// plan-time layer outputs (VirtualEnv) first and then the azd environment. It returns an error
-// if any referenced environment variable is unset, since a blank value in deny settings (for
-// example, an empty excluded principal) is almost always a misconfiguration.
+// plan-time layer outputs (VirtualEnv) first and then the azd environment. A value that resolves
+// to an empty string is treated as a misconfiguration (a blank deny-list entry, for example an
+// empty excluded principal, is almost always a mistake) and returns an error. Shell-style default
+// expressions such as ${VAR:-fallback} are honored: Envsubst applies the default before this check,
+// so a reference with a usable default yields a non-blank value and is accepted.
 func (p *BicepProvider) resolveDeploymentStacksValues(values []osutil.ExpandableString) ([]string, error) {
 	if len(values) == 0 {
 		return nil, nil
@@ -112,7 +114,7 @@ func (p *BicepProvider) resolveDeploymentStacksValues(values []osutil.Expandable
 
 	resolved := make([]string, 0, len(values))
 	for _, value := range values {
-		var unset []string
+		var lookedUpEmpty []string
 		substituted, err := value.Envsubst(func(name string) string {
 			if p.options.VirtualEnv != nil {
 				if v, has := p.options.VirtualEnv[name]; has {
@@ -121,8 +123,8 @@ func (p *BicepProvider) resolveDeploymentStacksValues(values []osutil.Expandable
 			}
 
 			v, ok := p.env.LookupEnv(name)
-			if !ok {
-				unset = append(unset, name)
+			if !ok || v == "" {
+				lookedUpEmpty = append(lookedUpEmpty, name)
 			}
 			return v
 		})
@@ -130,9 +132,13 @@ func (p *BicepProvider) resolveDeploymentStacksValues(values []osutil.Expandable
 			return nil, fmt.Errorf("resolving deploymentStacks value: %w", err)
 		}
 
-		if len(unset) > 0 {
-			return nil, fmt.Errorf(
-				"deploymentStacks references unset environment variable(s): %s", strings.Join(unset, ", "))
+		if strings.TrimSpace(substituted) == "" {
+			if len(lookedUpEmpty) > 0 {
+				return nil, fmt.Errorf(
+					"deploymentStacks references unset environment variable(s): %s",
+					strings.Join(lookedUpEmpty, ", "))
+			}
+			return nil, fmt.Errorf("deploymentStacks value resolved to an empty string")
 		}
 
 		resolved = append(resolved, substituted)

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks.go
@@ -25,6 +25,16 @@ func (p *BicepProvider) deploymentStacksEnabled() bool {
 	return featureManager.IsEnabled(azapi.FeatureDeploymentStacks)
 }
 
+// hasActiveDeploymentStacksConfig reports whether an effective deployment-stacks configuration is
+// present (config supplied AND the alpha feature enabled). When true, the deployment-state shortcut
+// must be bypassed: the stacks deny/unmanage settings — including ${VAR}-resolved deny lists — can
+// change independently of the ARM template and parameters that the state hash covers. Skipping the
+// deployment would otherwise leave stale deny settings on the stack and would also bypass the
+// ${VAR} resolution/validation performed while building the options map.
+func (p *BicepProvider) hasActiveDeploymentStacksConfig() bool {
+	return p.options.DeploymentStacks != nil && p.deploymentStacksEnabled()
+}
+
 // resolveDeploymentStacksMap resolves the typed deployment-stacks configuration into a
 // camelCase map[string]any consumable by the deployment-stacks API layer
 // (azapi.parseDeploymentStackOptions). It performs ${VAR} environment-variable substitution

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks.go
@@ -7,9 +7,23 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
+	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/convert"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 )
+
+// deploymentStacksEnabled reports whether the Deployment Stacks alpha feature is active. This
+// mirrors the deployment-service selection in cmd/container.go: only when the feature is enabled
+// is the stacks deployment service used (and the deployment-stacks options actually consumed).
+func (p *BicepProvider) deploymentStacksEnabled() bool {
+	var featureManager *alpha.FeatureManager
+	if err := p.serviceLocator.Resolve(&featureManager); err != nil {
+		return false
+	}
+
+	return featureManager.IsEnabled(azapi.FeatureDeploymentStacks)
+}
 
 // resolveDeploymentStacksMap resolves the typed deployment-stacks configuration into a
 // camelCase map[string]any consumable by the deployment-stacks API layer
@@ -17,9 +31,14 @@ import (
 // on denySettings.excludedPrincipals and denySettings.excludedActions, resolving values from
 // plan-time layer outputs (VirtualEnv) first and then the azd environment.
 //
+// When includeDenySettings is false the denySettings block is omitted entirely (and therefore
+// not resolved). The stack delete APIs only consume actionOnUnmanage and the bypass flag, so the
+// destroy path passes false to avoid failing `azd down` when a ${VAR} referenced only by the deny
+// lists is no longer available.
+//
 // It returns nil when no deployment-stacks configuration is present, in which case the caller
 // should omit the DeploymentStacks key entirely so the API layer applies its defaults.
-func (p *BicepProvider) resolveDeploymentStacksMap() (map[string]any, error) {
+func (p *BicepProvider) resolveDeploymentStacksMap(includeDenySettings bool) (map[string]any, error) {
 	cfg := p.options.DeploymentStacks
 	if cfg == nil {
 		return nil, nil
@@ -41,7 +60,7 @@ func (p *BicepProvider) resolveDeploymentStacksMap() (map[string]any, error) {
 		result["actionOnUnmanage"] = actionOnUnmanage
 	}
 
-	if cfg.DenySettings != nil {
+	if includeDenySettings && cfg.DenySettings != nil {
 		denySettings := map[string]any{}
 		if cfg.DenySettings.Mode != "" {
 			denySettings["mode"] = cfg.DenySettings.Mode
@@ -115,23 +134,32 @@ func (p *BicepProvider) resolveDeploymentStacksValues(values []osutil.Expandable
 // deploymentOptionsMap builds the generic options map handed to the deployment API layer,
 // with the deployment-stacks configuration resolved (including ${VAR} substitution). Standard
 // (non-stack) deployments ignore this map; stack deployments read only the DeploymentStacks key.
-func (p *BicepProvider) deploymentOptionsMap() (map[string]any, error) {
+//
+// Resolution is skipped entirely when the Deployment Stacks alpha feature is inactive, so an
+// otherwise-valid standard provision can't be failed by an unavailable ${VAR} in an inactive
+// deploymentStacks block. includeDenySettings is false on the destroy path, where the deny lists
+// are not consumed by the stack delete APIs.
+func (p *BicepProvider) deploymentOptionsMap(includeDenySettings bool) (map[string]any, error) {
 	optionsMap, err := convert.ToMap(p.options)
 	if err != nil {
 		return nil, err
 	}
 
-	stacks, err := p.resolveDeploymentStacksMap()
+	// The typed DeploymentStacksConfig is not JSON-serializable in a form the API layer can
+	// consume (ExpandableString has no exported fields), so always drop whatever convert.ToMap
+	// produced for it and only re-add a resolved map when stacks are actually in play.
+	delete(optionsMap, "DeploymentStacks")
+
+	if !p.deploymentStacksEnabled() {
+		return optionsMap, nil
+	}
+
+	stacks, err := p.resolveDeploymentStacksMap(includeDenySettings)
 	if err != nil {
 		return nil, err
 	}
 
-	if stacks == nil {
-		// The typed DeploymentStacksConfig is not JSON-serializable in a form the API layer can
-		// consume (ExpandableString has no exported fields), so drop whatever convertOptionsToMap
-		// produced for it and let the API layer apply its defaults.
-		delete(optionsMap, "DeploymentStacks")
-	} else {
+	if stacks != nil {
 		optionsMap["DeploymentStacks"] = stacks
 	}
 

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package bicep
+
+import (
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azure"
+	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+func expandableStrings(values ...string) []osutil.ExpandableString {
+	result := make([]osutil.ExpandableString, 0, len(values))
+	for _, value := range values {
+		result = append(result, osutil.NewExpandableString(value))
+	}
+	return result
+}
+
+func minimalArmTemplate() azure.ArmTemplate {
+	return azure.ArmTemplate{
+		Schema:         "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+		ContentVersion: "1.0.0.0",
+		Parameters:     azure.ArmTemplateParameterDefinitions{},
+		Outputs:        azure.ArmTemplateOutputs{},
+	}
+}
+
+func TestResolveDeploymentStacksMap_Nil(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+	provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
+	provider.options.DeploymentStacks = nil
+
+	stacks, err := provider.resolveDeploymentStacksMap()
+	require.NoError(t, err)
+	require.Nil(t, stacks)
+
+	// deploymentOptionsMap must omit the DeploymentStacks key entirely so the API layer
+	// applies its own defaults.
+	optionsMap, err := provider.deploymentOptionsMap()
+	require.NoError(t, err)
+	require.NotContains(t, optionsMap, "DeploymentStacks")
+}
+
+func TestResolveDeploymentStacksMap_ResolvesEnvSubstitution(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+	provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), map[string]string{
+		"OPERATOR_OBJECT_ID": "11111111-1111-1111-1111-111111111111",
+	})
+
+	// Plan-time layer output takes precedence over the azd environment.
+	provider.options.VirtualEnv = map[string]string{
+		"PIPELINE_SP_OBJECT_ID": "22222222-2222-2222-2222-222222222222",
+	}
+
+	provider.options.DeploymentStacks = &provisioning.DeploymentStacksConfig{
+		ActionOnUnmanage: &provisioning.ActionOnUnmanageConfig{
+			Resources:      "delete",
+			ResourceGroups: "delete",
+		},
+		DenySettings: &provisioning.DenySettingsConfig{
+			Mode:               "denyDelete",
+			ApplyToChildScopes: new(true),
+			ExcludedActions:    expandableStrings("Microsoft.Authorization/*/write"),
+			ExcludedPrincipals: expandableStrings("${PIPELINE_SP_OBJECT_ID}", "${OPERATOR_OBJECT_ID}"),
+		},
+	}
+
+	stacks, err := provider.resolveDeploymentStacksMap()
+	require.NoError(t, err)
+
+	actionOnUnmanage, ok := stacks["actionOnUnmanage"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "delete", actionOnUnmanage["resources"])
+	require.Equal(t, "delete", actionOnUnmanage["resourceGroups"])
+
+	denySettings, ok := stacks["denySettings"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "denyDelete", denySettings["mode"])
+	require.Equal(t, true, denySettings["applyToChildScopes"])
+	require.Equal(t, []string{"Microsoft.Authorization/*/write"}, denySettings["excludedActions"])
+	require.Equal(t, []string{
+		"22222222-2222-2222-2222-222222222222",
+		"11111111-1111-1111-1111-111111111111",
+	}, denySettings["excludedPrincipals"])
+}
+
+func TestResolveDeploymentStacksMap_UnsetVarErrors(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+	provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
+
+	provider.options.DeploymentStacks = &provisioning.DeploymentStacksConfig{
+		DenySettings: &provisioning.DenySettingsConfig{
+			Mode:               "denyDelete",
+			ExcludedPrincipals: expandableStrings("${DOES_NOT_EXIST}"),
+		},
+	}
+
+	_, err := provider.resolveDeploymentStacksMap()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "DOES_NOT_EXIST")
+}
+
+func TestResolveDeploymentStacksMap_EnvFallback(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+	provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), map[string]string{
+		"OPERATOR_OBJECT_ID": "33333333-3333-3333-3333-333333333333",
+	})
+
+	provider.options.DeploymentStacks = &provisioning.DeploymentStacksConfig{
+		DenySettings: &provisioning.DenySettingsConfig{
+			Mode:               "denyWriteAndDelete",
+			ExcludedPrincipals: expandableStrings("${OPERATOR_OBJECT_ID}"),
+		},
+	}
+
+	stacks, err := provider.resolveDeploymentStacksMap()
+	require.NoError(t, err)
+
+	denySettings := stacks["denySettings"].(map[string]any)
+	require.Equal(t, []string{"33333333-3333-3333-3333-333333333333"}, denySettings["excludedPrincipals"])
+}
+
+func TestDeploymentOptionsMap_IncludesResolvedStacks(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+	provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), map[string]string{
+		"OPERATOR_OBJECT_ID": "44444444-4444-4444-4444-444444444444",
+	})
+
+	provider.options.DeploymentStacks = &provisioning.DeploymentStacksConfig{
+		DenySettings: &provisioning.DenySettingsConfig{
+			Mode:               "denyDelete",
+			ExcludedPrincipals: expandableStrings("${OPERATOR_OBJECT_ID}"),
+		},
+	}
+
+	optionsMap, err := provider.deploymentOptionsMap()
+	require.NoError(t, err)
+
+	stacks, ok := optionsMap["DeploymentStacks"].(map[string]any)
+	require.True(t, ok)
+	denySettings := stacks["denySettings"].(map[string]any)
+	require.Equal(t, []string{"44444444-4444-4444-4444-444444444444"}, denySettings["excludedPrincipals"])
+}

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks_test.go
@@ -153,7 +153,8 @@ func TestResolveDeploymentStacksMap_EnvFallback(t *testing.T) {
 	stacks, err := provider.resolveDeploymentStacksMap(true)
 	require.NoError(t, err)
 
-	denySettings := stacks["denySettings"].(map[string]any)
+	denySettings, ok := stacks["denySettings"].(map[string]any)
+	require.True(t, ok)
 	require.Equal(t, []string{"33333333-3333-3333-3333-333333333333"}, denySettings["excludedPrincipals"])
 }
 
@@ -177,7 +178,8 @@ func TestDeploymentOptionsMap_IncludesResolvedStacks(t *testing.T) {
 
 	stacks, ok := optionsMap["DeploymentStacks"].(map[string]any)
 	require.True(t, ok)
-	denySettings := stacks["denySettings"].(map[string]any)
+	denySettings, ok := stacks["denySettings"].(map[string]any)
+	require.True(t, ok)
 	require.Equal(t, []string{"44444444-4444-4444-4444-444444444444"}, denySettings["excludedPrincipals"])
 }
 
@@ -234,4 +236,26 @@ func TestHasActiveDeploymentStacksConfig(t *testing.T) {
 		}
 		require.True(t, provider.hasActiveDeploymentStacksConfig())
 	})
+}
+
+// TestResolveDeploymentStacksMap_DefaultExpression verifies that shell-style default expressions
+// (${VAR:-fallback}) are honored: an unset variable with a usable default resolves to the default
+// and is accepted, rather than being rejected as an unset reference.
+func TestResolveDeploymentStacksMap_DefaultExpression(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+	provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
+
+	provider.options.DeploymentStacks = &provisioning.DeploymentStacksConfig{
+		DenySettings: &provisioning.DenySettingsConfig{
+			Mode:               "denyDelete",
+			ExcludedPrincipals: expandableStrings("${UNSET_PRINCIPAL:-55555555-5555-5555-5555-555555555555}"),
+		},
+	}
+
+	stacks, err := provider.resolveDeploymentStacksMap(true)
+	require.NoError(t, err)
+
+	denySettings, ok := stacks["denySettings"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, []string{"55555555-5555-5555-5555-555555555555"}, denySettings["excludedPrincipals"])
 }

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks_test.go
@@ -4,6 +4,7 @@
 package bicep
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
@@ -258,4 +259,87 @@ func TestResolveDeploymentStacksMap_DefaultExpression(t *testing.T) {
 	denySettings, ok := stacks["denySettings"].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, []string{"55555555-5555-5555-5555-555555555555"}, denySettings["excludedPrincipals"])
+}
+
+// TestUseDeploymentStateShortcut exercises every branch of the shortcut decision: it is disabled
+// when deployment-state tracking is off, when the parameters hash failed, and when an active
+// deployment-stacks configuration is present; otherwise it is enabled.
+func TestUseDeploymentStateShortcut(t *testing.T) {
+	t.Run("enabled by default", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(t.Context())
+		provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
+		require.True(t, provider.useDeploymentStateShortcut(nil))
+	})
+
+	t.Run("disabled when deployment state ignored", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(t.Context())
+		provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
+		provider.ignoreDeploymentState = true
+		require.False(t, provider.useDeploymentStateShortcut(nil))
+	})
+
+	t.Run("disabled when parameters hash failed", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(t.Context())
+		provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
+		require.False(t, provider.useDeploymentStateShortcut(errors.New("hash failed")))
+	})
+
+	t.Run("disabled when active deployment stacks config present", func(t *testing.T) {
+		enableDeploymentStacks(t)
+		mockContext := mocks.NewMockContext(t.Context())
+		provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
+		provider.options.DeploymentStacks = &provisioning.DeploymentStacksConfig{
+			DenySettings: &provisioning.DenySettingsConfig{Mode: "denyDelete"},
+		}
+		require.False(t, provider.useDeploymentStateShortcut(nil))
+	})
+
+	t.Run("enabled when stacks config present but feature disabled", func(t *testing.T) {
+		// deployment.stacks alpha feature is NOT enabled, so the config is inert.
+		mockContext := mocks.NewMockContext(t.Context())
+		provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
+		provider.options.DeploymentStacks = &provisioning.DeploymentStacksConfig{
+			DenySettings: &provisioning.DenySettingsConfig{Mode: "denyDelete"},
+		}
+		require.True(t, provider.useDeploymentStateShortcut(nil))
+	})
+}
+
+// TestResolveDeploymentStacksMap_ActionOnUnmanageManagementGroups covers the management-groups
+// branch of actionOnUnmanage and confirms an empty ActionOnUnmanage still produces the (empty) map.
+func TestResolveDeploymentStacksMap_ActionOnUnmanageManagementGroups(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+	provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
+
+	provider.options.DeploymentStacks = &provisioning.DeploymentStacksConfig{
+		ActionOnUnmanage: &provisioning.ActionOnUnmanageConfig{
+			ManagementGroups: "detach",
+		},
+	}
+
+	stacks, err := provider.resolveDeploymentStacksMap(true)
+	require.NoError(t, err)
+
+	actionOnUnmanage, ok := stacks["actionOnUnmanage"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "detach", actionOnUnmanage["managementGroups"])
+	require.NotContains(t, stacks, "denySettings")
+}
+
+// TestResolveDeploymentStacksValues_BlankLiteralErrors verifies that a literal blank deny-list
+// entry (no ${VAR} reference at all) is rejected as a misconfiguration.
+func TestResolveDeploymentStacksValues_BlankLiteralErrors(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+	provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
+
+	provider.options.DeploymentStacks = &provisioning.DeploymentStacksConfig{
+		DenySettings: &provisioning.DenySettingsConfig{
+			Mode:            "denyDelete",
+			ExcludedActions: expandableStrings("   "),
+		},
+	}
+
+	_, err := provider.resolveDeploymentStacksMap(true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty string")
 }

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks_test.go
@@ -30,18 +30,25 @@ func minimalArmTemplate() azure.ArmTemplate {
 	}
 }
 
+// enableDeploymentStacks turns on the deployment.stacks alpha feature for the duration of the test
+// so deploymentOptionsMap resolves the stacks configuration.
+func enableDeploymentStacks(t *testing.T) {
+	t.Setenv("AZD_ALPHA_ENABLE_DEPLOYMENT_STACKS", "true")
+}
+
 func TestResolveDeploymentStacksMap_Nil(t *testing.T) {
 	mockContext := mocks.NewMockContext(t.Context())
 	provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
 	provider.options.DeploymentStacks = nil
 
-	stacks, err := provider.resolveDeploymentStacksMap()
+	stacks, err := provider.resolveDeploymentStacksMap(true)
 	require.NoError(t, err)
 	require.Nil(t, stacks)
 
 	// deploymentOptionsMap must omit the DeploymentStacks key entirely so the API layer
 	// applies its own defaults.
-	optionsMap, err := provider.deploymentOptionsMap()
+	enableDeploymentStacks(t)
+	optionsMap, err := provider.deploymentOptionsMap(true)
 	require.NoError(t, err)
 	require.NotContains(t, optionsMap, "DeploymentStacks")
 }
@@ -70,7 +77,7 @@ func TestResolveDeploymentStacksMap_ResolvesEnvSubstitution(t *testing.T) {
 		},
 	}
 
-	stacks, err := provider.resolveDeploymentStacksMap()
+	stacks, err := provider.resolveDeploymentStacksMap(true)
 	require.NoError(t, err)
 
 	actionOnUnmanage, ok := stacks["actionOnUnmanage"].(map[string]any)
@@ -100,9 +107,34 @@ func TestResolveDeploymentStacksMap_UnsetVarErrors(t *testing.T) {
 		},
 	}
 
-	_, err := provider.resolveDeploymentStacksMap()
+	_, err := provider.resolveDeploymentStacksMap(true)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "DOES_NOT_EXIST")
+}
+
+// TestResolveDeploymentStacksMap_OmitsDenySettingsOnDestroy verifies that the destroy path
+// (includeDenySettings=false) never resolves the deny lists, so an unavailable ${VAR} referenced
+// only by denySettings can't fail `azd down`. The stack delete APIs consume only actionOnUnmanage.
+func TestResolveDeploymentStacksMap_OmitsDenySettingsOnDestroy(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+	provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
+
+	provider.options.DeploymentStacks = &provisioning.DeploymentStacksConfig{
+		ActionOnUnmanage: &provisioning.ActionOnUnmanageConfig{
+			Resources:      "delete",
+			ResourceGroups: "delete",
+		},
+		DenySettings: &provisioning.DenySettingsConfig{
+			Mode: "denyDelete",
+			// This variable is intentionally unset; it must not be resolved on the destroy path.
+			ExcludedPrincipals: expandableStrings("${DOES_NOT_EXIST}"),
+		},
+	}
+
+	stacks, err := provider.resolveDeploymentStacksMap(false)
+	require.NoError(t, err)
+	require.Contains(t, stacks, "actionOnUnmanage")
+	require.NotContains(t, stacks, "denySettings")
 }
 
 func TestResolveDeploymentStacksMap_EnvFallback(t *testing.T) {
@@ -118,7 +150,7 @@ func TestResolveDeploymentStacksMap_EnvFallback(t *testing.T) {
 		},
 	}
 
-	stacks, err := provider.resolveDeploymentStacksMap()
+	stacks, err := provider.resolveDeploymentStacksMap(true)
 	require.NoError(t, err)
 
 	denySettings := stacks["denySettings"].(map[string]any)
@@ -126,6 +158,8 @@ func TestResolveDeploymentStacksMap_EnvFallback(t *testing.T) {
 }
 
 func TestDeploymentOptionsMap_IncludesResolvedStacks(t *testing.T) {
+	enableDeploymentStacks(t)
+
 	mockContext := mocks.NewMockContext(t.Context())
 	provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), map[string]string{
 		"OPERATOR_OBJECT_ID": "44444444-4444-4444-4444-444444444444",
@@ -138,11 +172,32 @@ func TestDeploymentOptionsMap_IncludesResolvedStacks(t *testing.T) {
 		},
 	}
 
-	optionsMap, err := provider.deploymentOptionsMap()
+	optionsMap, err := provider.deploymentOptionsMap(true)
 	require.NoError(t, err)
 
 	stacks, ok := optionsMap["DeploymentStacks"].(map[string]any)
 	require.True(t, ok)
 	denySettings := stacks["denySettings"].(map[string]any)
 	require.Equal(t, []string{"44444444-4444-4444-4444-444444444444"}, denySettings["excludedPrincipals"])
+}
+
+// TestDeploymentOptionsMap_SkipsResolutionWhenStacksDisabled verifies that when the deployment
+// stacks alpha feature is inactive, the DeploymentStacks key is omitted and no ${VAR} resolution
+// happens, so an unavailable variable in an inactive deploymentStacks block can't fail an
+// otherwise-valid standard provision.
+func TestDeploymentOptionsMap_SkipsResolutionWhenStacksDisabled(t *testing.T) {
+	// Deployment stacks alpha feature is NOT enabled here.
+	mockContext := mocks.NewMockContext(t.Context())
+	provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
+
+	provider.options.DeploymentStacks = &provisioning.DeploymentStacksConfig{
+		DenySettings: &provisioning.DenySettingsConfig{
+			Mode:               "denyDelete",
+			ExcludedPrincipals: expandableStrings("${DOES_NOT_EXIST}"),
+		},
+	}
+
+	optionsMap, err := provider.deploymentOptionsMap(true)
+	require.NoError(t, err)
+	require.NotContains(t, optionsMap, "DeploymentStacks")
 }

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks_test.go
@@ -201,3 +201,37 @@ func TestDeploymentOptionsMap_SkipsResolutionWhenStacksDisabled(t *testing.T) {
 	require.NoError(t, err)
 	require.NotContains(t, optionsMap, "DeploymentStacks")
 }
+
+// TestHasActiveDeploymentStacksConfig guards the deployment-state bypass: when an effective
+// deployment-stacks configuration is present, Deploy must skip the state shortcut so a changed
+// ${VAR}-resolved deny principal/action is re-applied (rather than silently ignored because the
+// ARM template and parameters are unchanged) and the ${VAR} validation always runs.
+func TestHasActiveDeploymentStacksConfig(t *testing.T) {
+	t.Run("no config", func(t *testing.T) {
+		enableDeploymentStacks(t)
+		mockContext := mocks.NewMockContext(t.Context())
+		provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
+		provider.options.DeploymentStacks = nil
+		require.False(t, provider.hasActiveDeploymentStacksConfig())
+	})
+
+	t.Run("config present but feature disabled", func(t *testing.T) {
+		// deployment.stacks alpha feature is NOT enabled.
+		mockContext := mocks.NewMockContext(t.Context())
+		provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
+		provider.options.DeploymentStacks = &provisioning.DeploymentStacksConfig{
+			DenySettings: &provisioning.DenySettingsConfig{Mode: "denyDelete"},
+		}
+		require.False(t, provider.hasActiveDeploymentStacksConfig())
+	})
+
+	t.Run("config present and feature enabled", func(t *testing.T) {
+		enableDeploymentStacks(t)
+		mockContext := mocks.NewMockContext(t.Context())
+		provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
+		provider.options.DeploymentStacks = &provisioning.DeploymentStacksConfig{
+			DenySettings: &provisioning.DenySettingsConfig{Mode: "denyDelete"},
+		}
+		require.True(t, provider.hasActiveDeploymentStacksConfig())
+	})
+}

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_stacks_test.go
@@ -4,9 +4,11 @@
 package bicep
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeploymentstacks"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/azure/azure-dev/cli/azd/pkg/infra/provisioning"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
@@ -306,13 +308,15 @@ func TestUseDeploymentStateShortcut(t *testing.T) {
 }
 
 // TestResolveDeploymentStacksMap_ActionOnUnmanageManagementGroups covers the management-groups
-// branch of actionOnUnmanage and confirms an empty ActionOnUnmanage still produces the (empty) map.
+// branch of actionOnUnmanage. resources is set alongside it to mirror a schema-valid config
+// (the deployment stacks API requires actionOnUnmanage.resources).
 func TestResolveDeploymentStacksMap_ActionOnUnmanageManagementGroups(t *testing.T) {
 	mockContext := mocks.NewMockContext(t.Context())
 	provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), nil)
 
 	provider.options.DeploymentStacks = &provisioning.DeploymentStacksConfig{
 		ActionOnUnmanage: &provisioning.ActionOnUnmanageConfig{
+			Resources:        "delete",
 			ManagementGroups: "detach",
 		},
 	}
@@ -323,6 +327,7 @@ func TestResolveDeploymentStacksMap_ActionOnUnmanageManagementGroups(t *testing.
 	actionOnUnmanage, ok := stacks["actionOnUnmanage"].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, "detach", actionOnUnmanage["managementGroups"])
+	require.Equal(t, "delete", actionOnUnmanage["resources"])
 	require.NotContains(t, stacks, "denySettings")
 }
 
@@ -342,4 +347,62 @@ func TestResolveDeploymentStacksValues_BlankLiteralErrors(t *testing.T) {
 	_, err := provider.resolveDeploymentStacksMap(true)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "empty string")
+}
+
+// TestResolveDeploymentStacksMap_RoundTripsIntoSDKTypes guards against drift between the string
+// keys produced by resolveDeploymentStacksMap and the JSON field names the Deployment Stacks SDK
+// types consume. The runtime consumer (azapi.StackDeployments via config.GetSection) JSON-marshals
+// this map and unmarshals it into a struct whose fields are armdeploymentstacks.ActionOnUnmanage /
+// DenySettings, so this test mirrors that path exactly. If a key here is misspelled or the SDK
+// renames a field, the round-trip drops the value and the assertions fail.
+func TestResolveDeploymentStacksMap_RoundTripsIntoSDKTypes(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+	provider := createBicepProviderWithEnv(t, mockContext, minimalArmTemplate(), map[string]string{
+		"OPERATOR_OBJECT_ID": "11111111-1111-1111-1111-111111111111",
+	})
+
+	provider.options.DeploymentStacks = &provisioning.DeploymentStacksConfig{
+		ActionOnUnmanage: &provisioning.ActionOnUnmanageConfig{
+			Resources:        "delete",
+			ResourceGroups:   "detach",
+			ManagementGroups: "detach",
+		},
+		DenySettings: &provisioning.DenySettingsConfig{
+			Mode:               "denyDelete",
+			ApplyToChildScopes: new(true),
+			ExcludedActions:    expandableStrings("Microsoft.Authorization/*/write"),
+			ExcludedPrincipals: expandableStrings("${OPERATOR_OBJECT_ID}"),
+		},
+	}
+
+	stacks, err := provider.resolveDeploymentStacksMap(true)
+	require.NoError(t, err)
+
+	// Mirror azapi.deploymentStackOptions: the runtime consumer unmarshals the resolved map into
+	// the SDK types via config.GetSection (json.Marshal followed by json.Unmarshal).
+	var roundTrip struct {
+		ActionOnUnmanage *armdeploymentstacks.ActionOnUnmanage `json:"actionOnUnmanage"`
+		DenySettings     *armdeploymentstacks.DenySettings     `json:"denySettings"`
+	}
+
+	jsonBytes, err := json.Marshal(stacks)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(jsonBytes, &roundTrip))
+
+	require.NotNil(t, roundTrip.ActionOnUnmanage)
+	require.NotNil(t, roundTrip.ActionOnUnmanage.Resources)
+	require.Equal(t, armdeploymentstacks.DeploymentStacksDeleteDetachEnumDelete, *roundTrip.ActionOnUnmanage.Resources)
+	require.NotNil(t, roundTrip.ActionOnUnmanage.ResourceGroups)
+	require.Equal(t, armdeploymentstacks.DeploymentStacksDeleteDetachEnumDetach, *roundTrip.ActionOnUnmanage.ResourceGroups)
+	require.NotNil(t, roundTrip.ActionOnUnmanage.ManagementGroups)
+	require.Equal(
+		t, armdeploymentstacks.DeploymentStacksDeleteDetachEnumDetach, *roundTrip.ActionOnUnmanage.ManagementGroups)
+
+	require.NotNil(t, roundTrip.DenySettings)
+	require.NotNil(t, roundTrip.DenySettings.Mode)
+	require.Equal(t, armdeploymentstacks.DenySettingsModeDenyDelete, *roundTrip.DenySettings.Mode)
+	require.NotNil(t, roundTrip.DenySettings.ApplyToChildScopes)
+	require.True(t, *roundTrip.DenySettings.ApplyToChildScopes)
+	require.Equal(t, []*string{new("Microsoft.Authorization/*/write")}, roundTrip.DenySettings.ExcludedActions)
+	require.Equal(t, []*string{new("11111111-1111-1111-1111-111111111111")}, roundTrip.DenySettings.ExcludedPrincipals)
 }

--- a/cli/azd/pkg/infra/provisioning/deployment_stacks_config.go
+++ b/cli/azd/pkg/infra/provisioning/deployment_stacks_config.go
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package provisioning
+
+import "github.com/azure/azure-dev/cli/azd/pkg/osutil"
+
+// DeploymentStacksConfig is the typed representation of the `infra.deploymentStacks`
+// block in azure.yaml. It configures the Azure Deployment Stacks control-plane request
+// (not the IaC template inputs) and is only valid when the provider is Bicep.
+//
+// The JSON tags intentionally match the camelCase keys expected by the
+// armdeploymentstacks SDK (via its custom JSON marshaling) so the resolved
+// configuration can be handed to the deployment-stacks API layer unchanged.
+type DeploymentStacksConfig struct {
+	// ActionOnUnmanage defines the behavior of resources that are no longer managed
+	// after the deployment stack is updated or deleted.
+	ActionOnUnmanage *ActionOnUnmanageConfig `yaml:"actionOnUnmanage,omitempty" json:"actionOnUnmanage,omitempty"`
+	// DenySettings defines how resources deployed by the stack are locked.
+	DenySettings *DenySettingsConfig `yaml:"denySettings,omitempty" json:"denySettings,omitempty"`
+}
+
+// ActionOnUnmanageConfig defines the unmanage behavior for each resource scope.
+// Valid values are "delete" and "detach".
+type ActionOnUnmanageConfig struct {
+	Resources        string `yaml:"resources,omitempty" json:"resources,omitempty"`
+	ResourceGroups   string `yaml:"resourceGroups,omitempty" json:"resourceGroups,omitempty"`
+	ManagementGroups string `yaml:"managementGroups,omitempty" json:"managementGroups,omitempty"`
+}
+
+// DenySettingsConfig defines the deny-assignment (lock) configuration for a deployment stack.
+//
+// ExcludedActions and ExcludedPrincipals support ${VAR} environment-variable substitution,
+// resolved from the azd environment at provision time. This makes per-environment values
+// (for example, pipeline service principal or operator object IDs) expressible in a portable
+// template instead of being committed as literals.
+type DenySettingsConfig struct {
+	// Mode defines the denied actions. One of "none", "denyDelete", "denyWriteAndDelete".
+	Mode string `yaml:"mode,omitempty" json:"mode,omitempty"`
+	// ApplyToChildScopes applies the deny settings to child resource scopes of every managed
+	// resource with a deny assignment.
+	ApplyToChildScopes *bool `yaml:"applyToChildScopes,omitempty" json:"applyToChildScopes,omitempty"`
+	// ExcludedActions is the list of role-based management operations excluded from the deny settings.
+	ExcludedActions []osutil.ExpandableString `yaml:"excludedActions,omitempty" json:"excludedActions,omitempty"`
+	// ExcludedPrincipals is the list of Entra ID principal IDs excluded from the lock.
+	ExcludedPrincipals []osutil.ExpandableString `yaml:"excludedPrincipals,omitempty" json:"excludedPrincipals,omitempty"`
+}

--- a/cli/azd/pkg/infra/provisioning/deployment_stacks_config_test.go
+++ b/cli/azd/pkg/infra/provisioning/deployment_stacks_config_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package provisioning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestDeploymentStacksConfigUnmarshalYAML(t *testing.T) {
+	const source = `
+provider: bicep
+deploymentStacks:
+  actionOnUnmanage:
+    resources: delete
+    resourceGroups: detach
+  denySettings:
+    mode: denyDelete
+    applyToChildScopes: true
+    excludedActions:
+      - Microsoft.Authorization/*/write
+    excludedPrincipals:
+      - ${PIPELINE_SP_OBJECT_ID}
+      - literal-principal-id
+`
+
+	var options Options
+	require.NoError(t, yaml.Unmarshal([]byte(source), &options))
+
+	require.NotNil(t, options.DeploymentStacks)
+	require.NotNil(t, options.DeploymentStacks.ActionOnUnmanage)
+	require.Equal(t, "delete", options.DeploymentStacks.ActionOnUnmanage.Resources)
+	require.Equal(t, "detach", options.DeploymentStacks.ActionOnUnmanage.ResourceGroups)
+
+	denySettings := options.DeploymentStacks.DenySettings
+	require.NotNil(t, denySettings)
+	require.Equal(t, "denyDelete", denySettings.Mode)
+	require.NotNil(t, denySettings.ApplyToChildScopes)
+	require.True(t, *denySettings.ApplyToChildScopes)
+
+	require.Len(t, denySettings.ExcludedActions, 1)
+	action, err := denySettings.ExcludedActions[0].Envsubst(func(string) string { return "" })
+	require.NoError(t, err)
+	require.Equal(t, "Microsoft.Authorization/*/write", action)
+
+	require.Len(t, denySettings.ExcludedPrincipals, 2)
+	resolved, err := denySettings.ExcludedPrincipals[0].Envsubst(func(name string) string {
+		if name == "PIPELINE_SP_OBJECT_ID" {
+			return "resolved-sp-id"
+		}
+		return ""
+	})
+	require.NoError(t, err)
+	require.Equal(t, "resolved-sp-id", resolved)
+
+	literal, err := denySettings.ExcludedPrincipals[1].Envsubst(func(string) string { return "" })
+	require.NoError(t, err)
+	require.Equal(t, "literal-principal-id", literal)
+}

--- a/cli/azd/pkg/infra/provisioning/deployment_stacks_config_test.go
+++ b/cli/azd/pkg/infra/provisioning/deployment_stacks_config_test.go
@@ -6,8 +6,8 @@ package provisioning
 import (
 	"testing"
 
+	"github.com/braydonk/yaml"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 )
 
 func TestDeploymentStacksConfigUnmarshalYAML(t *testing.T) {

--- a/cli/azd/pkg/infra/provisioning/options_test.go
+++ b/cli/azd/pkg/infra/provisioning/options_test.go
@@ -218,7 +218,9 @@ func TestOptionsValidate(t *testing.T) {
 		"layers with DeploymentStacks set at top level is invalid",
 		func(t *testing.T) {
 			opts := &Options{
-				DeploymentStacks: map[string]any{"k": "v"},
+				DeploymentStacks: &DeploymentStacksConfig{
+					DenySettings: &DenySettingsConfig{Mode: "none"},
+				},
 				Layers: []Options{
 					{Name: "l1", Path: "infra/l1"},
 				},

--- a/cli/azd/pkg/infra/provisioning/provider.go
+++ b/cli/azd/pkg/infra/provisioning/provider.go
@@ -37,12 +37,12 @@ const (
 
 // Options for a provisioning provider.
 type Options struct {
-	Provider         ProviderKind   `yaml:"provider,omitempty"`
-	Path             string         `yaml:"path,omitempty"`
-	Module           string         `yaml:"module,omitempty"`
-	Name             string         `yaml:"name,omitempty"`
-	Hooks            HooksConfig    `yaml:"hooks,omitempty"`
-	DeploymentStacks map[string]any `yaml:"deploymentStacks,omitempty"`
+	Provider         ProviderKind            `yaml:"provider,omitempty"`
+	Path             string                  `yaml:"path,omitempty"`
+	Module           string                  `yaml:"module,omitempty"`
+	Name             string                  `yaml:"name,omitempty"`
+	Hooks            HooksConfig             `yaml:"hooks,omitempty"`
+	DeploymentStacks *DeploymentStacksConfig `yaml:"deploymentStacks,omitempty"`
 	// Config holds provider-specific configuration options
 	Config map[string]any `yaml:"config,omitempty"`
 	// DependsOn lists the names of other layers this layer must wait for

--- a/cli/azd/pkg/infra/provisioning/provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/provider_test.go
@@ -123,16 +123,24 @@ func TestOptions_GetWithDefaults(t *testing.T) {
 			baseOptions: Options{
 				Provider: Bicep,
 				DeploymentStacks: &DeploymentStacksConfig{
-					DenySettings: &DenySettingsConfig{Mode: "denyDelete"},
+					ActionOnUnmanage: &ActionOnUnmanageConfig{Resources: "delete"},
+					DenySettings:     &DenySettingsConfig{Mode: "denyDelete"},
 				},
 			},
-			otherOptions: nil,
+			otherOptions: []Options{
+				{
+					Module: "custom-module",
+					Name:   "custom-name",
+				},
+			},
 			expectedResult: Options{
 				Provider: Bicep,
-				Module:   "main",
+				Module:   "custom-module",
 				Path:     "infra",
+				Name:     "custom-name",
 				DeploymentStacks: &DeploymentStacksConfig{
-					DenySettings: &DenySettingsConfig{Mode: "denyDelete"},
+					ActionOnUnmanage: &ActionOnUnmanageConfig{Resources: "delete"},
+					DenySettings:     &DenySettingsConfig{Mode: "denyDelete"},
 				},
 			},
 			expectError: false,

--- a/cli/azd/pkg/infra/provisioning/provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/provider_test.go
@@ -122,24 +122,17 @@ func TestOptions_GetWithDefaults(t *testing.T) {
 			name: "merges deployment stacks",
 			baseOptions: Options{
 				Provider: Bicep,
-				DeploymentStacks: map[string]any{
-					"stack1": "value1",
+				DeploymentStacks: &DeploymentStacksConfig{
+					DenySettings: &DenySettingsConfig{Mode: "denyDelete"},
 				},
 			},
-			otherOptions: []Options{
-				{
-					DeploymentStacks: map[string]any{
-						"stack2": "value2",
-					},
-				},
-			},
+			otherOptions: nil,
 			expectedResult: Options{
 				Provider: Bicep,
 				Module:   "main",
 				Path:     "infra",
-				DeploymentStacks: map[string]any{
-					"stack1": "value1",
-					"stack2": "value2",
+				DeploymentStacks: &DeploymentStacksConfig{
+					DenySettings: &DenySettingsConfig{Mode: "denyDelete"},
 				},
 			},
 			expectError: false,
@@ -202,8 +195,8 @@ func TestOptions_GetWithDefaults(t *testing.T) {
 				Path:     "custom-path",
 				Module:   "custom-module",
 				Name:     "custom-name",
-				DeploymentStacks: map[string]any{
-					"key": "value",
+				DeploymentStacks: &DeploymentStacksConfig{
+					DenySettings: &DenySettingsConfig{Mode: "none"},
 				},
 				IgnoreDeploymentState: true,
 			},
@@ -213,8 +206,8 @@ func TestOptions_GetWithDefaults(t *testing.T) {
 				Path:     "custom-path",
 				Module:   "custom-module",
 				Name:     "custom-name",
-				DeploymentStacks: map[string]any{
-					"key": "value",
+				DeploymentStacks: &DeploymentStacksConfig{
+					DenySettings: &DenySettingsConfig{Mode: "none"},
 				},
 				IgnoreDeploymentState: true,
 			},

--- a/cli/azd/pkg/infra/provisioning/provider_test.go
+++ b/cli/azd/pkg/infra/provisioning/provider_test.go
@@ -124,13 +124,15 @@ func TestOptions_GetWithDefaults(t *testing.T) {
 				Provider: Bicep,
 				DeploymentStacks: &DeploymentStacksConfig{
 					ActionOnUnmanage: &ActionOnUnmanageConfig{Resources: "delete"},
-					DenySettings:     &DenySettingsConfig{Mode: "denyDelete"},
 				},
 			},
 			otherOptions: []Options{
 				{
 					Module: "custom-module",
 					Name:   "custom-name",
+					DeploymentStacks: &DeploymentStacksConfig{
+						DenySettings: &DenySettingsConfig{Mode: "denyDelete"},
+					},
 				},
 			},
 			expectedResult: Options{

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -1682,11 +1682,19 @@
                         },
                         "excludedActions": {
                             "type": "array",
-                            "title": "List of role-based management operations that are excluded from the denySettings."
+                            "title": "List of role-based management operations that are excluded from the denySettings.",
+                            "description": "Each entry supports ${VAR} environment variable substitution, resolved at deployment time.",
+                            "items": {
+                                "type": "string"
+                            }
                         },
                         "excludedPrincipals": {
                             "type": "array",
-                            "title": "List of Entra ID principal IDs excluded from the lock. Up to 5 principals are permitted."
+                            "title": "List of Entra ID principal IDs excluded from the lock. Up to 5 principals are permitted.",
+                            "description": "Each entry supports ${VAR} environment variable substitution, resolved at deployment time.",
+                            "items": {
+                                "type": "string"
+                            }
                         }
                     }
                 }

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -1631,13 +1631,22 @@
                     "title": "The action to take when when resources become unmanaged",
                     "description": "Defines the behavior of resources that are no longer managed after the Deployment stack is updated or deleted. Defaults to 'delete' for all resource scopes.",
                     "required": [
-                        "resourceGroups",
                         "resources"
                     ],
                     "properties": {
                         "resourceGroups": {
                             "type": "string",
-                            "title": "Required. The action on unmanage setting for resource groups",
+                            "title": "The action on unmanage setting for resource groups",
+                            "description": "Specifies an action for a newly unmanaged resource. Delete will attempt to delete the resource from Azure. Detach will leave the resource in it's current state.",
+                            "default": "delete",
+                            "enum": [
+                                "delete",
+                                "detach"
+                            ]
+                        },
+                        "managementGroups": {
+                            "type": "string",
+                            "title": "The action on unmanage setting for management groups",
                             "description": "Specifies an action for a newly unmanaged resource. Delete will attempt to delete the resource from Azure. Detach will leave the resource in it's current state.",
                             "default": "delete",
                             "enum": [


### PR DESCRIPTION
Fixes #9232

## Problem

Environment-variable substitution (`${VAR}`) was applied across most of `azure.yaml`, but **not** inside `infra.deploymentStacks`. Values like `denySettings.excludedPrincipals: [${PIPELINE_SP_OBJECT_ID}]` were passed verbatim (as the literal string `${PIPELINE_SP_OBJECT_ID}`) to the Azure Deployment Stacks API, so per-environment principal/action values couldn't be expressed portably.

## Change

- **Type-safe config**: Replaced the untyped `map[string]any` `DeploymentStacks` option with a typed `DeploymentStacksConfig` struct (`actionOnUnmanage`, `denySettings`). The `excludedActions` and `excludedPrincipals` leaves are `osutil.ExpandableString`, so `${VAR}` now works there like the rest of `azure.yaml`.
- **Lazy resolution**: `${VAR}` is resolved at deploy time, checking plan-time layer outputs (`VirtualEnv`) first, then the azd environment. An unset variable errors out (a blank excluded principal is almost always a misconfiguration). Resolved values are emitted as a camelCase `map[string]any` consumed by the unchanged deployment-stacks API layer.
- **gRPC contract preserved**: `deploymentStacks` is intentionally not forwarded to external (extension) providers — it configures the Deployment Stacks control-plane request and is bicep-only. The proto field (`deployment_stacks`) is retained for wire compatibility but left empty.
- **Schema**: The alpha schema tightens `excludedActions`/`excludedPrincipals` to string arrays and documents `${VAR}` support. The existing bicep-or-undefined gate is unchanged. v1.0 is untouched (deploymentStacks remains alpha-only).

## Notes

- SDK `armdeploymentstacks v1.0.1` is the latest; no bump needed. Its types have no struct tags and use custom JSON marshaling, so they can't be reused for YAML directly — hence the azd-owned yaml-tagged struct.
- Configuration is genuinely per-layer (mono-layer uses top-level config; multi-layer forbids top-level and each layer carries its own).
- No CHANGELOG entry (added at release time per repo convention).

## Testing

- New unit tests: typed YAML unmarshal, `${VAR}` resolution, `VirtualEnv` precedence, env fallback, unset-var error, options-map integration.
- `go build ./...`, `go test` (provisioning / bicep / grpcserver / azapi), gofmt, copyright, golangci-lint (0 issues), cspell — all pass.