### PR TITLE
fix(pipelines): correct invalid path filters in extension release pipelines

### DIFF
--- a/cli/azd/extensions/microsoft.azd.extensions/internal/resources/internal/go/pipelines/release-ext.yml.tmpl
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/resources/internal/go/pipelines/release-ext.yml.tmpl
@@ -5,9 +5,8 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/{{.Metadata.Id}}
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/{{.Metadata.Id}}
       - eng/pipelines/release-ext-{{.SanitizedId}}.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -18,7 +18,7 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
+      - cli/azd/go.mod
       - cli/
       - eng/pipelines/release-cli.yml
       - /eng/pipelines/templates/jobs/build-cli.yml
@@ -31,7 +31,7 @@ trigger:
 pr:
   paths:
     include:
-      - go.mod
+      - cli/azd/go.mod
       - cli/
       - eng/pipelines/release-cli.yml
       - eng/pipelines/templates/steps/publish-cli.yml

--- a/eng/pipelines/release-ext-azure-ai-agents.yml
+++ b/eng/pipelines/release-ext-azure-ai-agents.yml
@@ -5,9 +5,8 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/azure.ai.agents
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/azure.ai.agents
       - eng/pipelines/release-ext-azure-ai-agents.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-connections.yml
+++ b/eng/pipelines/release-ext-azure-ai-connections.yml
@@ -5,9 +5,8 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/azure.ai.connections
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/azure.ai.connections
       - eng/pipelines/release-ext-azure-ai-connections.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-finetune.yml
+++ b/eng/pipelines/release-ext-azure-ai-finetune.yml
@@ -5,9 +5,8 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/azure.ai.finetune
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/azure.ai.finetune
       - eng/pipelines/release-ext-azure-ai-finetune.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-inspector.yml
+++ b/eng/pipelines/release-ext-azure-ai-inspector.yml
@@ -5,9 +5,8 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/azure.ai.inspector
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/azure.ai.inspector
       - eng/pipelines/release-ext-azure-ai-inspector.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-models.yml
+++ b/eng/pipelines/release-ext-azure-ai-models.yml
@@ -5,9 +5,8 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/azure.ai.models
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/azure.ai.models
       - eng/pipelines/release-ext-azure-ai-models.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-projects.yml
+++ b/eng/pipelines/release-ext-azure-ai-projects.yml
@@ -5,9 +5,8 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/azure.ai.projects
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/azure.ai.projects
       - eng/pipelines/release-ext-azure-ai-projects.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-rle.yml
+++ b/eng/pipelines/release-ext-azure-ai-rle.yml
@@ -5,9 +5,8 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/azure.ai.rle
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/azure.ai.rle
       - eng/pipelines/release-ext-azure-ai-rle.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-routines.yml
+++ b/eng/pipelines/release-ext-azure-ai-routines.yml
@@ -5,9 +5,8 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/azure.ai.routines
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/azure.ai.routines
       - eng/pipelines/release-ext-azure-ai-routines.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-skills.yml
+++ b/eng/pipelines/release-ext-azure-ai-skills.yml
@@ -5,9 +5,8 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/azure.ai.skills
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/azure.ai.skills
       - eng/pipelines/release-ext-azure-ai-skills.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-toolboxes.yml
+++ b/eng/pipelines/release-ext-azure-ai-toolboxes.yml
@@ -5,9 +5,8 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/azure.ai.toolboxes
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/azure.ai.toolboxes
       - eng/pipelines/release-ext-azure-ai-toolboxes.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-training.yml
+++ b/eng/pipelines/release-ext-azure-ai-training.yml
@@ -5,9 +5,8 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/azure.ai.training
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/azure.ai.training
       - eng/pipelines/release-ext-azure-ai-training.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-appservice.yml
+++ b/eng/pipelines/release-ext-azure-appservice.yml
@@ -5,9 +5,8 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/azure.appservice
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/azure.appservice
       - eng/pipelines/release-ext-azure-appservice.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-coding-agent.yml
+++ b/eng/pipelines/release-ext-azure-coding-agent.yml
@@ -6,7 +6,7 @@ trigger:
   paths:
     include:
       - cli/azd/extensions/azure.coding-agent
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -16,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/azure.coding-agent
       - eng/pipelines/release-ext-azure-coding-agent.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-microsoft-azd-ai-builder.yml
+++ b/eng/pipelines/release-ext-microsoft-azd-ai-builder.yml
@@ -5,9 +5,8 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/microsoft.azd.ai.builder
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -15,10 +14,9 @@ trigger:
 pr:
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/microsoft.azd.ai.builder
       - eng/pipelines/release-ext-microsoft-azd-ai-builder.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-microsoft-azd-concurx.yml
+++ b/eng/pipelines/release-ext-microsoft-azd-concurx.yml
@@ -6,7 +6,7 @@ trigger:
   paths:
     include:
       - cli/azd/extensions/microsoft.azd.concurx
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -16,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/microsoft.azd.concurx
       - eng/pipelines/release-ext-microsoft-azd-concurx.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-microsoft-azd-demo.yml
+++ b/eng/pipelines/release-ext-microsoft-azd-demo.yml
@@ -5,9 +5,8 @@ trigger:
       - main
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/microsoft.azd.demo
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -15,10 +14,9 @@ trigger:
 pr:
   paths:
     include:
-      - go.mod
       - cli/azd/extensions/microsoft.azd.demo
       - eng/pipelines/release-ext-microsoft-azd-demo.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-microsoft-azd-extensions.yml
+++ b/eng/pipelines/release-ext-microsoft-azd-extensions.yml
@@ -6,7 +6,7 @@ trigger:
   paths:
     include:
       - cli/azd/extensions/microsoft.azd.extensions
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -16,7 +16,7 @@ pr:
     include:
       - cli/azd/extensions/microsoft.azd.extensions
       - eng/pipelines/release-ext-microsoft-azd-extensions.yml
-      - eng/pipelines/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/release-azd-extension.yml
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**


### PR DESCRIPTION
## Summary

Fixes #9216. Extension release pipelines (and `release-cli.yml`) referenced **non-existent paths** in their `trigger`/`pr` `paths` filters. Because these paths never match anything, they silently contributed nothing to change detection.

## Invalid paths corrected

### 1. `eng/pipelines/release-azd-extension.yml` → `/eng/pipelines/templates/stages/release-azd-extension.yml`
The referenced file does not exist; the real template each pipeline already `extends` lives under `templates/stages/`. Fixed in **both** `trigger` and `pr` filters across all **17** `release-ext-*.yml` pipelines.

### 2. root `go.mod` (does not exist)
There is no `go.mod` at the repo root — modules live at `cli/azd/go.mod` and per-extension `cli/azd/extensions/<id>/go.mod`.
- **Extension pipelines:** removed the line — each pipeline already includes its extension directory (`cli/azd/extensions/<id>`), which covers that extension's own `go.mod`.
- **`release-cli.yml`:** repointed to `cli/azd/go.mod`.

## Validation

Re-ran a path-existence audit over all `eng/pipelines/**/*.yml` `trigger`/`pr` filters: **0 invalid paths remain**.

## Out of scope (noted in the issue audit)

- `.github/workflows/cspell-misc.yml` has a stale `templates/**` `paths-ignore` entry, but it is intentionally kept in sync with the `templates` ignore in `.vscode/cspell.misc.yaml`, so it's left untouched here.
- Path filters mix leading-slash (`/eng/...`) and relative (`eng/...`) forms; both are accepted by Azure DevOps. Not changed to keep this PR focused.
