### PR TITLE
fix: honor --infra when adopting a sample azure.yaml via -m

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [[#9225]](https://github.com/Azure/azure-dev/pull/9225) Fix `azd ai agent init` accepting stale Azure Container Registry connections from an existing Foundry project; init now validates discovered registries against ARM and clears missing ones instead of deferring the failure until publish.
 - [[#9254]](https://github.com/Azure/azure-dev/pull/9254) Fix `azd ai agent doctor` failing valid projects whose agent definition is declared inline in `azure.yaml`; the definition check now uses the same resolver as run and deploy.
 - [[#9264]](https://github.com/Azure/azure-dev/pull/9264) Fix `azd ai agent doctor` reporting a false pass for an inline or `$ref` agent definition with an unsupported kind; resolved non-hosted definitions are now validated, while valid `workflow` definitions still pass.
+- [[#9275]](https://github.com/Azure/azure-dev/pull/9275) Fix `azd ai agent init -m <azure.yaml> --infra` silently skipping infrastructure ejection when the manifest pointer resolved to a unified Foundry `azure.yaml` adopted as the project manifest; the adopt path now generates the `./infra/` directory like the other init flows.
 
 ### Other Changes
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1311,7 +1311,10 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 						}
 						return err
 					}
-					return nil
+					// Honor --infra for the adopt path too: the sample's
+					// azure.yaml was scaffolded into the project dir (now the
+					// working dir), so eject IaC from it before returning.
+					return maybeEjectInfraAfterInit(infraProvider)
 				}
 
 				// Resolve the agent name BEFORE creating the project folder
@@ -1510,30 +1513,9 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 				}
 			}
 
-			// New-project eject: when --infra is set on a fresh init that just
-			// wrote azure.yaml, chain the eject step. Skip silently when init
-			// didn't produce a foundry-bearing azure.yaml (cancelled or
-			// non-foundry flow) to avoid a confusing "nothing to eject" error.
-			if infraProvider != "" {
-				cwd, err := os.Getwd()
-				if err != nil {
-					return fmt.Errorf("resolve current directory: %w", err)
-				}
-				//nolint:gosec // G304: azure.yaml in the current azd project directory
-				rawYAML, readErr := os.ReadFile(filepath.Join(cwd, "azure.yaml"))
-				switch {
-				case errors.Is(readErr, fs.ErrNotExist):
-					// Init didn't write azure.yaml; nothing to eject.
-				case readErr != nil:
-					return fmt.Errorf("read azure.yaml after init: %w", readErr)
-				default:
-					// Skip silently when no foundry service is present.
-					if _, svcErr := findFoundryServiceForEject(rawYAML); svcErr == nil {
-						if err := ejectInfra(cwd, infraProvider); err != nil {
-							return err
-						}
-					}
-				}
+			// New-project eject: honor --infra after a fresh init.
+			if err := maybeEjectInfraAfterInit(infraProvider); err != nil {
+				return err
 			}
 
 			return nil
@@ -1593,6 +1575,37 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 	cmd.Flags().Lookup("infra").NoOptDefVal = project.BicepProviderName
 
 	return cmd
+}
+
+// maybeEjectInfraAfterInit ejects IaC after a fresh init when
+// --infra was passed. It reads the azure.yaml init wrote into the
+// working dir (init chdir's into the project dir) and ejects only
+// when a foundry service is present. A missing or non-foundry
+// azure.yaml is a silent no-op so non-foundry and cancelled flows
+// don't surface a confusing error.
+func maybeEjectInfraAfterInit(infraProvider string) error {
+	if infraProvider == "" {
+		return nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve current directory: %w", err)
+	}
+	//nolint:gosec // G304: azure.yaml in the current azd project directory
+	rawYAML, readErr := os.ReadFile(filepath.Join(cwd, "azure.yaml"))
+	switch {
+	case errors.Is(readErr, fs.ErrNotExist):
+		// Init didn't write azure.yaml; nothing to eject.
+		return nil
+	case readErr != nil:
+		return fmt.Errorf("read azure.yaml after init: %w", readErr)
+	default:
+		// Skip silently when no foundry service is present.
+		if _, svcErr := findFoundryServiceForEject(rawYAML); svcErr != nil {
+			return nil
+		}
+		return ejectInfra(cwd, infraProvider)
+	}
 }
 
 func (a *InitAction) Run(ctx context.Context) error {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_after_init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_after_init_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMaybeEjectInfraAfterInit_EjectsFromWorkingDir covers the regression
+// where `azd ai agent init -m <azure.yaml> --infra` adopted a sample but
+// silently dropped the eject. The post-init eject must read azure.yaml from
+// the working directory that init/scaffold left us in and write ./infra/.
+func TestMaybeEjectInfraAfterInit_EjectsFromWorkingDir(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), validFoundryAzureYAML)
+	t.Chdir(dir)
+
+	withCapturedStdout(t, func() {
+		require.NoError(t, maybeEjectInfraAfterInit("bicep"))
+	})
+
+	info, err := os.Stat(filepath.Join(dir, "infra", "main.bicep"))
+	require.NoError(t, err, "infra/main.bicep should be written")
+	assert.Greater(t, info.Size(), int64(0))
+}
+
+// TestMaybeEjectInfraAfterInit_NoopWhenFlagAbsent verifies the eject is a
+// no-op (no ./infra/, no error) when --infra was not passed, even with a
+// foundry azure.yaml present.
+func TestMaybeEjectInfraAfterInit_NoopWhenFlagAbsent(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), validFoundryAzureYAML)
+	t.Chdir(dir)
+
+	require.NoError(t, maybeEjectInfraAfterInit(""))
+
+	_, err := os.Stat(filepath.Join(dir, "infra"))
+	assert.True(t, os.IsNotExist(err), "infra/ must not be created")
+}
+
+// TestMaybeEjectInfraAfterInit_NoopWhenNoAzureYaml verifies a missing
+// azure.yaml is a silent no-op so cancelled init flows don't error.
+func TestMaybeEjectInfraAfterInit_NoopWhenNoAzureYaml(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	require.NoError(t, maybeEjectInfraAfterInit("bicep"))
+
+	_, err := os.Stat(filepath.Join(dir, "infra"))
+	assert.True(t, os.IsNotExist(err), "infra/ must not be created")
+}
+
+// TestMaybeEjectInfraAfterInit_NoopWhenNonFoundry verifies a non-foundry
+// azure.yaml is a silent no-op (no error, no ./infra/).
+func TestMaybeEjectInfraAfterInit_NoopWhenNonFoundry(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"),
+		"name: plain\nservices:\n  web:\n    host: containerapp\n")
+	t.Chdir(dir)
+
+	require.NoError(t, maybeEjectInfraAfterInit("bicep"))
+
+	_, err := os.Stat(filepath.Join(dir, "infra"))
+	assert.True(t, os.IsNotExist(err), "infra/ must not be created")
+}


### PR DESCRIPTION
## What

`azd ai agent init -m <pointer-to-azure.yaml> --infra` now ejects the
`./infra/` directory when the pointer resolves to a unified Foundry
`azure.yaml` that is adopted as the project manifest.

## Why this is needed

A user ran:

```
azd ai agent init -m https://github.com/.../hello-world/azure.yaml --infra
```

The sample was downloaded and adopted, but no `infra/` directory was
generated — `--infra` was silently ignored.

Root cause: `init` has two post-init eject entry points. The interactive
template-selection path falls through to the shared eject block at the end
of `RunE`, but the **direct `-m` fast path** — which adopts a unified
`azure.yaml` via `runInitFromAzureYaml` — did `return nil` immediately
afterward, short-circuiting before the eject block ever ran. So the one
flow a user is most likely to script (`-m <url> --infra`) was exactly the
flow that dropped the flag.

## Approach and why it was chosen

The post-init eject logic was duplicated inline in one place and missing
in the other. I extracted it into a single `maybeEjectInfraAfterInit`
helper and call it from **both** the direct `-m` adopt path and the
existing end-of-`RunE` block, so every init sub-flow (manifest, adopt,
code) honors `--infra` identically. This removes the asymmetry at the
source rather than papering over the one reported path.

The adopt flow's `scaffoldProject` already `chdir`s into the newly created
project folder and never returns, so the helper reads `azure.yaml` from
the working directory (the project folder) and ejects there. A missing or
non-foundry `azure.yaml` stays a silent no-op, preserving the existing
behavior for cancelled and non-foundry init flows.

## Testing

- `go build ./...` and `go vet ./internal/cmd/` pass.
- Existing `TestEjectInfra*` and `TestInitInfraFlagParsing` still pass.
- New `TestMaybeEjectInfraAfterInit_*` regression tests cover: ejects from
  the working dir for a foundry `azure.yaml`; no-op when `--infra` is
  absent; no-op when `azure.yaml` is missing; no-op for a non-foundry
  `azure.yaml`.