### PR TITLE
[microsoft.foundry] register microsoft.foundry meta-package 1.0.0-beta.2

### DIFF
--- a/cli/azd/extensions/registry.json
+++ b/cli/azd/extensions/registry.json
@@ -7279,6 +7279,42 @@
               "version": "~1.0.0-beta.1"
             }
           ]
+        },
+        {
+          "version": "1.0.0-beta.2",
+          "requiredAzdVersion": ">=1.27.1",
+          "usage": "",
+          "examples": null,
+          "dependencies": [
+            {
+              "id": "azure.ai.agents",
+              "version": "~1.0.0-beta.7"
+            },
+            {
+              "id": "azure.ai.connections",
+              "version": "~1.0.0-beta.1"
+            },
+            {
+              "id": "azure.ai.inspector",
+              "version": "~1.0.0-beta.1"
+            },
+            {
+              "id": "azure.ai.projects",
+              "version": "~1.0.0-beta.3"
+            },
+            {
+              "id": "azure.ai.routines",
+              "version": "~1.0.0-beta.1"
+            },
+            {
+              "id": "azure.ai.skills",
+              "version": "~1.0.0-beta.1"
+            },
+            {
+              "id": "azure.ai.toolboxes",
+              "version": "~1.0.0-beta.1"
+            }
+          ]
         }
       ],
       "tags": [


### PR DESCRIPTION
Adds the `microsoft.foundry` `1.0.0-beta.2` entry to `cli/azd/extensions/registry.json`.

Why: The `microsoft.foundry` provisioning provider is being moved from `azure.ai.agents` to `azure.ai.projects` (source change in #9133). 

## Merge order (blocked until dependencies land)

`TestRegistryFileIsValid` will stay red until the two dependency versions exist in `registry.json`:

- Depends on **#9276** — `azure.ai.agents` `1.0.0-beta.7` registry entry
- Depends on **#9273** — `azure.ai.projects` `1.0.0-beta.3` registry entry

Local validation confirms the entry is otherwise well-formed: the only two failures are the not-yet-published `~1.0.0-beta.7` and `~1.0.0-beta.3` dependencies. Once #9276 and #9273 merge, this entry resolves and the test passes.
