### PR TITLE
Preserve App Service container configuration during deploy

### DIFF
--- a/cli/azd/pkg/azapi/webapp.go
+++ b/cli/azd/pkg/azapi/webapp.go
@@ -422,8 +422,8 @@ func (cli *AzureClient) GetAppServiceSlots(
 }
 
 // UpdateAppServiceContainerImage updates the container image for a Linux Web App for Containers.
-// It only sets linuxFxVersion to "DOCKER|<imageName>"; infrastructure configuration (ACR auth,
-// managed identity) must be set via IaC (bicep/terraform), not at deploy time.
+// It patches linuxFxVersion through the dedicated configuration endpoint so unrelated site
+// configuration remains owned by infrastructure.
 func (cli *AzureClient) UpdateAppServiceContainerImage(
 	ctx context.Context,
 	subscriptionId string,
@@ -437,11 +437,9 @@ func (cli *AzureClient) UpdateAppServiceContainerImage(
 	}
 
 	linuxFxVersion := fmt.Sprintf("DOCKER|%s", imageName)
-	_, err = client.Update(ctx, resourceGroup, appName, armappservice.SitePatchResource{
-		Properties: &armappservice.SitePatchResourceProperties{
-			SiteConfig: &armappservice.SiteConfig{
-				LinuxFxVersion: &linuxFxVersion,
-			},
+	_, err = client.UpdateConfiguration(ctx, resourceGroup, appName, armappservice.SiteConfigResource{
+		Properties: &armappservice.SiteConfig{
+			LinuxFxVersion: &linuxFxVersion,
 		},
 	}, nil)
 	if err != nil {
@@ -452,7 +450,7 @@ func (cli *AzureClient) UpdateAppServiceContainerImage(
 }
 
 // UpdateAppServiceSlotContainerImage updates the container image for a deployment slot.
-// It only sets linuxFxVersion; infrastructure configuration must be set via IaC.
+// It patches linuxFxVersion through the dedicated slot configuration endpoint.
 func (cli *AzureClient) UpdateAppServiceSlotContainerImage(
 	ctx context.Context,
 	subscriptionId string,
@@ -467,11 +465,9 @@ func (cli *AzureClient) UpdateAppServiceSlotContainerImage(
 	}
 
 	linuxFxVersion := fmt.Sprintf("DOCKER|%s", imageName)
-	_, err = client.UpdateSlot(ctx, resourceGroup, appName, slotName, armappservice.SitePatchResource{
-		Properties: &armappservice.SitePatchResourceProperties{
-			SiteConfig: &armappservice.SiteConfig{
-				LinuxFxVersion: &linuxFxVersion,
-			},
+	_, err = client.UpdateConfigurationSlot(ctx, resourceGroup, appName, slotName, armappservice.SiteConfigResource{
+		Properties: &armappservice.SiteConfig{
+			LinuxFxVersion: &linuxFxVersion,
 		},
 	}, nil)
 	if err != nil {

--- a/cli/azd/pkg/azapi/webapp_test.go
+++ b/cli/azd/pkg/azapi/webapp_test.go
@@ -199,22 +199,15 @@ func Test_AzureClient_UpdateAppServiceContainerImage(t *testing.T) {
 	var capturedBody string
 	mockCtx.HttpClient.When(func(req *http.Request) bool {
 		return req.Method == http.MethodPatch &&
-			strings.Contains(req.URL.Path, "/Microsoft.Web/sites/my-app") &&
+			strings.HasSuffix(req.URL.Path, "/Microsoft.Web/sites/my-app/config/web") &&
 			!strings.Contains(req.URL.Path, "/slots/")
 	}).RespondFn(func(req *http.Request) (*http.Response, error) {
 		bodyBytes, _ := io.ReadAll(req.Body)
 		capturedBody = string(bodyBytes)
 		return mocks.CreateHttpResponseWithBody(req, http.StatusOK,
-			armappservice.Site{
-				ID:       new("/subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Web/sites/my-app"),
-				Name:     new("my-app"),
-				Location: new("eastus"),
-				Kind:     new("app,linux,container"),
-				Properties: &armappservice.SiteProperties{
-					DefaultHostName: new("my-app.azurewebsites.net"),
-					SiteConfig: &armappservice.SiteConfig{
-						LinuxFxVersion: new("DOCKER|myregistry.azurecr.io/myapp:v1"),
-					},
+			armappservice.SiteConfigResource{
+				Properties: &armappservice.SiteConfig{
+					LinuxFxVersion: new("DOCKER|myregistry.azurecr.io/myapp:v1"),
 				},
 			})
 	})
@@ -223,10 +216,11 @@ func Test_AzureClient_UpdateAppServiceContainerImage(t *testing.T) {
 		*mockCtx.Context, "SUB", "RG", "my-app", "myregistry.azurecr.io/myapp:v1")
 	require.NoError(t, err)
 	assert.NotEmpty(t, capturedBody, "Update should have been called with a body")
-	assert.Contains(t, capturedBody, "DOCKER|myregistry.azurecr.io/myapp:v1",
-		"body should contain the correct linuxFxVersion")
-	assert.NotContains(t, capturedBody, "acrUseManagedIdentityCreds",
-		"should NOT set acrUseManagedIdentityCreds (IaC responsibility)")
+	assert.JSONEq(t, `{
+		"properties": {
+			"linuxFxVersion": "DOCKER|myregistry.azurecr.io/myapp:v1"
+		}
+	}`, capturedBody, "body should patch only linuxFxVersion on the configuration resource")
 }
 
 func Test_AzureClient_UpdateAppServiceContainerImage_Error(t *testing.T) {
@@ -235,7 +229,7 @@ func Test_AzureClient_UpdateAppServiceContainerImage_Error(t *testing.T) {
 
 	mockCtx.HttpClient.When(func(req *http.Request) bool {
 		return req.Method == http.MethodPatch &&
-			strings.Contains(req.URL.Path, "/Microsoft.Web/sites/my-app")
+			strings.HasSuffix(req.URL.Path, "/Microsoft.Web/sites/my-app/config/web")
 	}).RespondFn(func(req *http.Request) (*http.Response, error) {
 		return mocks.CreateEmptyHttpResponse(req, http.StatusInternalServerError)
 	})
@@ -253,19 +247,14 @@ func Test_AzureClient_UpdateAppServiceSlotContainerImage(t *testing.T) {
 	var capturedBody string
 	mockCtx.HttpClient.When(func(req *http.Request) bool {
 		return req.Method == http.MethodPatch &&
-			strings.Contains(req.URL.Path, "/slots/staging")
+			strings.HasSuffix(req.URL.Path, "/slots/staging/config/web")
 	}).RespondFn(func(req *http.Request) (*http.Response, error) {
 		bodyBytes, _ := io.ReadAll(req.Body)
 		capturedBody = string(bodyBytes)
 		return mocks.CreateHttpResponseWithBody(req, http.StatusOK,
-			armappservice.Site{
-				ID:   new("/subscriptions/SUB/resourceGroups/RG/providers/Microsoft.Web/sites/my-app/slots/staging"),
-				Name: new("my-app/staging"),
-				Properties: &armappservice.SiteProperties{
-					DefaultHostName: new("my-app-staging.azurewebsites.net"),
-					SiteConfig: &armappservice.SiteConfig{
-						LinuxFxVersion: new("DOCKER|myregistry.azurecr.io/myapp:v1"),
-					},
+			armappservice.SiteConfigResource{
+				Properties: &armappservice.SiteConfig{
+					LinuxFxVersion: new("DOCKER|myregistry.azurecr.io/myapp:v1"),
 				},
 			})
 	})
@@ -274,10 +263,11 @@ func Test_AzureClient_UpdateAppServiceSlotContainerImage(t *testing.T) {
 		*mockCtx.Context, "SUB", "RG", "my-app", "staging", "myregistry.azurecr.io/myapp:v1")
 	require.NoError(t, err)
 	assert.NotEmpty(t, capturedBody, "UpdateSlot should have been called with a body")
-	assert.Contains(t, capturedBody, "DOCKER|myregistry.azurecr.io/myapp:v1",
-		"body should contain the correct linuxFxVersion")
-	assert.NotContains(t, capturedBody, "acrUseManagedIdentityCreds",
-		"should NOT set acrUseManagedIdentityCreds (IaC responsibility)")
+	assert.JSONEq(t, `{
+		"properties": {
+			"linuxFxVersion": "DOCKER|myregistry.azurecr.io/myapp:v1"
+		}
+	}`, capturedBody, "body should patch only linuxFxVersion on the slot configuration resource")
 }
 
 func Test_AzureClient_ValidateAppServiceForContainerDeploy(t *testing.T) {

--- a/cli/azd/pkg/project/framework_service_python_test.go
+++ b/cli/azd/pkg/project/framework_service_python_test.go
@@ -27,6 +27,7 @@ func Test_PythonProject_Restore(t *testing.T) {
 	var pipArgs exec.RunArgs
 
 	mockContext := mocks.NewMockContext(t.Context())
+	mockContext.CommandRunner.MockToolInPath(pythonExe(), nil)
 	mockContext.CommandRunner.
 		When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "-m venv")
@@ -84,6 +85,7 @@ func Test_PythonProject_Restore_PyprojectToml(t *testing.T) {
 	var pipArgs exec.RunArgs
 
 	mockContext := mocks.NewMockContext(t.Context())
+	mockContext.CommandRunner.MockToolInPath(pythonExe(), nil)
 	mockContext.CommandRunner.
 		When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "-m venv")
@@ -142,6 +144,7 @@ func Test_PythonProject_Restore_PyprojectTomlPriority(t *testing.T) {
 	var pipArgs exec.RunArgs
 
 	mockContext := mocks.NewMockContext(t.Context())
+	mockContext.CommandRunner.MockToolInPath(pythonExe(), nil)
 	mockContext.CommandRunner.
 		When(func(args exec.RunArgs, command string) bool {
 			return strings.Contains(command, "-m venv")


### PR DESCRIPTION
Fixes #9249

### Summary

This PR prevents container-based App Service deployments from clearing configuration owned by infrastructure or other tooling. It also makes the related Python restore tests deterministic on Windows.

### Issue

Container deployment support added in #8847 was intended to update only `linuxFxVersion`, but it sent that field as a nested `siteConfig` through the site-level PATCH operation. App Service can treat that nested object as a replacement, clearing omitted settings such as `acrUseManagedIdentityCreds` and `acrUserManagedIdentityID`.

### Configuration update

The image update now uses the dedicated App Service configuration endpoint for both production apps and deployment slots.

- PATCHes `/config/web` with only `properties.linuxFxVersion`.
- Leaves ACR authentication, managed identity, and other site configuration under Bicep, Terraform, user, or platform ownership.
- Avoids a GET-and-write-back merge, which would introduce a race and could lose fields unknown to the pinned SDK.

### Behaviour at a glance

| Scenario | Before | After |
|---|---|---|
| Container deploy to production | Site PATCH with a nested partial `siteConfig` | Configuration PATCH containing only `linuxFxVersion` |
| Container deploy to a slot | Slot site PATCH with a nested partial `siteConfig` | Slot configuration PATCH containing only `linuxFxVersion` |
| IaC-managed ACR identity | Could be cleared during deploy | Preserved |
| Zip deployment | Unchanged | Unchanged |

### Windows test isolation

The Python restore tests asserted the preferred platform launcher but allowed the mock command runner to inspect the host PATH. They now explicitly mock that launcher, preserving production fallback behavior while removing machine-dependent failures.

### Testing

Covered production and slot request paths and exact field-only payloads, repeated the Python restore cases, and ran the affected API and project package tests.