### PR TITLE
fix: update default agent init model to gpt-5.4-mini

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1547,7 +1547,7 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 		"Name of an existing model deployment to use from the Foundry project. Only used when paired with an existing Foundry project, either via --project-id or interactive prompts")
 
 	cmd.Flags().StringVar(&flags.model, "model", "",
-		"Name of the AI model to use (e.g., 'gpt-4o'). If not specified, defaults to 'gpt-4.1-mini'. Mutually exclusive with --model-deployment, with --model-deployment being used if both are provided")
+		"Name of the AI model to use (e.g., 'gpt-4o'). If not specified, defaults to 'gpt-5.4-mini'. Mutually exclusive with --model-deployment, with --model-deployment being used if both are provided")
 
 	cmd.Flags().StringVarP(&flags.manifestPointer, "manifest", "m", "",
 		"Path or URI to an agent manifest, or to a sample's unified azure.yaml to adopt as the project manifest")

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1547,7 +1547,12 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 		"Name of an existing model deployment to use from the Foundry project. Only used when paired with an existing Foundry project, either via --project-id or interactive prompts")
 
 	cmd.Flags().StringVar(&flags.model, "model", "",
-		"Name of the AI model to use (e.g., 'gpt-4o'). If not specified, defaults to 'gpt-5.4-mini'. Mutually exclusive with --model-deployment, with --model-deployment being used if both are provided")
+		fmt.Sprintf(
+			"Name of the AI model to deploy. Defaults to '%s' during interactive model selection; "+
+				"required to deploy a new model with --no-prompt. Mutually exclusive with --model-deployment, "+
+				"with --model-deployment being used if both are provided",
+			defaultAgentModel,
+		))
 
 	cmd.Flags().StringVarP(&flags.manifestPointer, "manifest", "m", "",
 		"Path or URI to an agent manifest, or to a sample's unified azure.yaml to adopt as the project manifest")

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1549,8 +1549,8 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 	cmd.Flags().StringVar(&flags.model, "model", "",
 		fmt.Sprintf(
 			"Name of the AI model to deploy. Defaults to '%s' during interactive model selection; "+
-				"required to deploy a new model with --no-prompt. Mutually exclusive with --model-deployment, "+
-				"with --model-deployment being used if both are provided",
+				"required to deploy a new model with --no-prompt. If --model-deployment is also provided, "+
+				"--model-deployment takes precedence",
 			defaultAgentModel,
 		))
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -493,7 +493,7 @@ func promptAlternativeDeployment(
 	if useCatalog {
 		// Use the full model + deployment prompt which handles version,
 		// SKU, and capacity selection (same as manifest path).
-		defaultModel := "gpt-5.4-mini"
+		defaultModel := defaultAgentModel
 		if modelFlag != "" {
 			defaultModel = modelFlag
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -493,7 +493,7 @@ func promptAlternativeDeployment(
 	if useCatalog {
 		// Use the full model + deployment prompt which handles version,
 		// SKU, and capacity selection (same as manifest path).
-		defaultModel := "gpt-4.1-mini"
+		defaultModel := "gpt-5.4-mini"
 		if modelFlag != "" {
 			defaultModel = modelFlag
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -1241,7 +1241,7 @@ func selectNewModel(
 	azureContext *azdext.AzureContext,
 	modelFlag string,
 ) (*azdext.AiModel, error) {
-	defaultModel := "gpt-4.1-mini"
+	defaultModel := "gpt-5.4-mini"
 	if modelFlag != "" {
 		defaultModel = modelFlag
 	}
@@ -1266,7 +1266,7 @@ func selectNewModel(
 		return nil, exterrors.Dependency(
 			exterrors.CodeModelResolutionFailed,
 			fmt.Sprintf("failed to select an AI model: %s", err),
-			"pass --model <name> (e.g. --model gpt-4.1-mini) or --project-id "+
+			"pass --model <name> (e.g. --model gpt-5.4-mini) or --project-id "+
 				"<id> with --model-deployment <name> to skip interactive model selection",
 		)
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -1241,7 +1241,7 @@ func selectNewModel(
 	azureContext *azdext.AzureContext,
 	modelFlag string,
 ) (*azdext.AiModel, error) {
-	defaultModel := "gpt-5.4-mini"
+	defaultModel := defaultAgentModel
 	if modelFlag != "" {
 		defaultModel = modelFlag
 	}
@@ -1266,8 +1266,11 @@ func selectNewModel(
 		return nil, exterrors.Dependency(
 			exterrors.CodeModelResolutionFailed,
 			fmt.Sprintf("failed to select an AI model: %s", err),
-			"pass --model <name> (e.g. --model gpt-5.4-mini) or --project-id "+
-				"<id> with --model-deployment <name> to skip interactive model selection",
+			fmt.Sprintf(
+				"pass --model <name> (e.g. --model %s) or --project-id "+
+					"<id> with --model-deployment <name> to skip interactive model selection",
+				defaultAgentModel,
+			),
 		)
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -1267,8 +1267,9 @@ func selectNewModel(
 			exterrors.CodeModelResolutionFailed,
 			fmt.Sprintf("failed to select an AI model: %s", err),
 			fmt.Sprintf(
-				"pass --model <name> (e.g. --model %s) or --project-id "+
-					"<id> with --model-deployment <name> to skip interactive model selection",
+				"to run non-interactively, pass --no-prompt with --model <name> "+
+					"(e.g. --model %s), or --no-prompt with --project-id <id> "+
+					"and --model-deployment <name>",
 				defaultAgentModel,
 			),
 		)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
@@ -421,6 +421,79 @@ func TestAgentModelFilter(t *testing.T) {
 	}
 }
 
+type recordingPromptAiModelServer struct {
+	azdext.UnimplementedPromptServiceServer
+	requests []*azdext.PromptAiModelRequest
+}
+
+func (s *recordingPromptAiModelServer) PromptAiModel(
+	_ context.Context,
+	req *azdext.PromptAiModelRequest,
+) (*azdext.PromptAiModelResponse, error) {
+	s.requests = append(s.requests, req)
+	return &azdext.PromptAiModelResponse{
+		Model: &azdext.AiModel{Name: "selected-model"},
+	}, nil
+}
+
+func TestSelectNewModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		modelFlag   string
+		wantDefault string
+	}{
+		{
+			name:        "uses default agent model",
+			wantDefault: defaultAgentModel,
+		},
+		{
+			name:        "explicit model wins",
+			modelFlag:   "gpt-5",
+			wantDefault: "gpt-5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			promptServer := &recordingPromptAiModelServer{}
+			azdClient := newTestAzdClient(
+				t,
+				&testEnvironmentServiceServer{},
+				&testWorkflowServiceServer{},
+				promptServer,
+			)
+			azureContext := &azdext.AzureContext{
+				Scope: &azdext.AzureScope{Location: "eastus"},
+			}
+
+			model, err := selectNewModel(
+				t.Context(),
+				azdClient,
+				azureContext,
+				tt.modelFlag,
+			)
+
+			require.NoError(t, err)
+			require.Equal(t, "selected-model", model.Name)
+			require.Len(t, promptServer.requests, 1)
+
+			req := promptServer.requests[0]
+			require.Equal(t, tt.wantDefault, req.DefaultValue)
+			require.NotNil(t, req.Filter)
+			require.Equal(t, []string{"eastus"}, req.Filter.Locations)
+			require.Equal(
+				t,
+				[]string{agentsV2ModelCapability},
+				req.Filter.Capabilities,
+			)
+		})
+	}
+}
+
 func TestLocationAllowed(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
@@ -27,6 +27,9 @@ import (
 
 var defaultSkuPriority = []string{"GlobalStandard", "DataZoneStandard", "Standard"}
 
+// defaultAgentModel is preselected in interactive catalog prompts.
+const defaultAgentModel = "gpt-5.4-mini"
+
 // defaultDeploymentCapacity is the preferred deployment capacity for agent model deployments.
 // This overrides the lower SKU default (typically 10) which is insufficient for agents.
 const defaultDeploymentCapacity int32 = 50


### PR DESCRIPTION
Closes #9119.

## What changed

- Replaced the deprecated `gpt-4.1-mini` default in interactive model catalog prompts with `gpt-5.4-mini`.
- Centralized the value in `defaultAgentModel` so the From Code flow, adopt flow, help text, and error guidance stay synchronized.
- Clarified `--model` help: the default applies during interactive selection, `--model` is required to deploy a new model with `--no-prompt`, and `--model-deployment` takes precedence when both are supplied.
- Corrected the model-selection failure guidance to include `--no-prompt` for both non-interactive alternatives.
- Added regression coverage for the default and for explicit `--model` precedence.

An explicit `--model <name>` continues to override the interactive default.

## Why this change is needed

`gpt-4.1-mini` is deprecated, so it should no longer be preselected when users choose a new model from the catalog. Leaving it as the default steers users toward an obsolete model and can eventually leave the prompt without its intended selection as catalog availability changes.

While updating the surrounding text, two statements turned out to be inaccurate:

- The old help text called `--model` and `--model-deployment` "mutually exclusive", but nothing rejects using both; the code simply prefers `--model-deployment`. Saying "mutually exclusive" and "`--model-deployment` is used if both are provided" in the same sentence contradicts itself, so it is now described purely as precedence.
- The old failure suggestion told users to pass `--model` or `--project-id` with `--model-deployment` "to skip interactive model selection". Neither flag skips prompting on its own — `--model` only sets the preselected value and the prompt still runs, so a user following that advice lands back in the same interactive path that just failed. The guidance now says to run non-interactively and pairs both alternatives with `--no-prompt`.

The non-interactive behavior is intentionally unchanged. In the From Code flow, `--no-prompt` skips new-model configuration unless `--model` is provided; an existing deployment can still be selected with `--project-id` and `--model-deployment`.

## Why this approach

`gpt-5.4-mini` is a current Azure AI Foundry model and preserves the small, cost-efficient intent of the previous default. A shared constant is used instead of repeating the model name so future default changes cannot leave prompts, help text, and guidance out of sync. The focused gRPC test verifies both the default request value and explicit flag precedence.
