### PR TITLE
fix(agents): resolve project root for infra eject

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1311,6 +1311,13 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 						}
 						return err
 					}
+					if infraProvider != "" {
+						cwd, err := os.Getwd()
+						if err != nil {
+							return fmt.Errorf("resolve current directory: %w", err)
+						}
+						return ejectInfra(cwd, infraProvider)
+					}
 					return nil
 				}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -1123,22 +1123,24 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 				infraProvider = p
 			}
 
-			// `--infra` on a directory that already has an azd agent project
-			// is a standalone eject: synthesize infra (Bicep or Terraform) from
+			// `--infra` within an existing azd agent project is a standalone
+			// eject: synthesize infra (Bicep or Terraform) from
 			// the existing azure.yaml, write ./infra/, and return without
 			// prompting.
-			if infraProvider != "" && fileExists("azure.yaml") {
-				// Reject inputs the eject path would silently ignore (a
-				// positional arg, -m, or --src) instead of pretending they
-				// were honored.
-				if err := validateStandaloneEjectArgs(args, flags); err != nil {
-					return err
+			if infraProvider != "" {
+				projectRoot, projectRootErr := azdext.GetProjectDir()
+				if projectRootErr != nil && !errors.Is(projectRootErr, azdext.ErrProjectNotFound) {
+					return fmt.Errorf("resolve azd project directory: %w", projectRootErr)
 				}
-				cwd, err := os.Getwd()
-				if err != nil {
-					return fmt.Errorf("resolve current directory: %w", err)
+				if projectRootErr == nil {
+					// Reject inputs the eject path would silently ignore (a
+					// positional arg, -m, or --src) instead of pretending they
+					// were honored.
+					if err := validateStandaloneEjectArgs(args, flags); err != nil {
+						return err
+					}
+					return ejectInfra(projectRoot, infraProvider)
 				}
-				return ejectInfra(cwd, infraProvider)
 			}
 
 			ctx := azdext.WithAccessToken(cmd.Context())
@@ -1285,7 +1287,10 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 						if flags.src == "" {
 							flags.src = checkDir
 						}
-						return runReuseDefinition(ctx, flags, azdClient, httpClient, checkDir, existing)
+						if err := runReuseDefinition(ctx, flags, azdClient, httpClient, checkDir, existing); err != nil {
+							return err
+						}
+						return ejectInfraAfterInit(infraProvider)
 					}
 				}
 			}
@@ -1311,14 +1316,7 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 						}
 						return err
 					}
-					if infraProvider != "" {
-						cwd, err := os.Getwd()
-						if err != nil {
-							return fmt.Errorf("resolve current directory: %w", err)
-						}
-						return ejectInfra(cwd, infraProvider)
-					}
-					return nil
+					return ejectInfraAfterInit(infraProvider)
 				}
 
 				// Resolve the agent name BEFORE creating the project folder
@@ -1521,29 +1519,7 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 			// wrote azure.yaml, chain the eject step. Skip silently when init
 			// didn't produce a foundry-bearing azure.yaml (cancelled or
 			// non-foundry flow) to avoid a confusing "nothing to eject" error.
-			if infraProvider != "" {
-				cwd, err := os.Getwd()
-				if err != nil {
-					return fmt.Errorf("resolve current directory: %w", err)
-				}
-				//nolint:gosec // G304: azure.yaml in the current azd project directory
-				rawYAML, readErr := os.ReadFile(filepath.Join(cwd, "azure.yaml"))
-				switch {
-				case errors.Is(readErr, fs.ErrNotExist):
-					// Init didn't write azure.yaml; nothing to eject.
-				case readErr != nil:
-					return fmt.Errorf("read azure.yaml after init: %w", readErr)
-				default:
-					// Skip silently when no foundry service is present.
-					if _, svcErr := findFoundryServiceForEject(rawYAML); svcErr == nil {
-						if err := ejectInfra(cwd, infraProvider); err != nil {
-							return err
-						}
-					}
-				}
-			}
-
-			return nil
+			return ejectInfraAfterInit(infraProvider)
 		},
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra.go
@@ -19,6 +19,7 @@ import (
 	"azureaiagent/internal/project"
 	"azureaiagent/internal/synthesis"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/fatih/color"
 	"go.yaml.in/yaml/v3"
 )
@@ -65,6 +66,33 @@ func parseInfraProvider(value string) (string, error) {
 			"pass --infra=bicep or --infra=terraform (a bare --infra ejects Bicep)",
 		)
 	}
+}
+
+// ejectInfraAfterInit ejects from the azd project containing the current
+// directory. Init may create or discover a project above cwd, so use the same
+// upward project resolution as the rest of azd.
+func ejectInfraAfterInit(provider string) error {
+	if provider == "" {
+		return nil
+	}
+
+	projectRoot, err := azdext.GetProjectDir()
+	if errors.Is(err, azdext.ErrProjectNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("resolve azd project directory after init: %w", err)
+	}
+
+	rawYAML, err := os.ReadFile(filepath.Join(projectRoot, "azure.yaml")) //nolint:gosec // resolved azd project file
+	if err != nil {
+		return fmt.Errorf("read azure.yaml after init: %w", err)
+	}
+	if _, err := findFoundryServiceForEject(rawYAML); err != nil {
+		return nil
+	}
+
+	return ejectInfra(projectRoot, provider)
 }
 
 // ejectInfra synthesizes the embedded Bicep templates from azure.yaml and

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra.go
@@ -89,7 +89,11 @@ func ejectInfraAfterInit(provider string) error {
 		return fmt.Errorf("read azure.yaml after init: %w", err)
 	}
 	if _, err := findFoundryServiceForEject(rawYAML); err != nil {
-		return nil
+		if localErr, ok := errors.AsType[*azdext.LocalError](err); ok &&
+			localErr.Code == exterrors.CodeInfraEjectNoFoundryService {
+			return nil
+		}
+		return err
 	}
 
 	return ejectInfra(projectRoot, provider)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
@@ -633,7 +633,7 @@ services:
     host: azure.ai.project
 `), 0600))
 	nestedDir := filepath.Join(projectRoot, "src", "agent")
-	require.NoError(t, os.MkdirAll(nestedDir, 0755))
+	require.NoError(t, os.MkdirAll(nestedDir, 0750))
 	t.Chdir(nestedDir)
 
 	require.NoError(t, ejectInfraAfterInit("bicep"))

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
@@ -624,6 +624,31 @@ func TestParseInfraProvider(t *testing.T) {
 	}
 }
 
+func TestEjectInfraAfterInit_ResolvesParentProject(t *testing.T) {
+	t.Setenv("AZD_EXEC_PROJECT_DIR", "")
+	projectRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "azure.yaml"), []byte(`name: test
+services:
+  ai-project:
+    host: azure.ai.project
+`), 0600))
+	nestedDir := filepath.Join(projectRoot, "src", "agent")
+	require.NoError(t, os.MkdirAll(nestedDir, 0755))
+	t.Chdir(nestedDir)
+
+	require.NoError(t, ejectInfraAfterInit("bicep"))
+
+	assert.FileExists(t, filepath.Join(projectRoot, "infra", "main.bicep"))
+	assert.NoDirExists(t, filepath.Join(nestedDir, "infra"))
+}
+
+func TestEjectInfraAfterInit_NoProject(t *testing.T) {
+	t.Setenv("AZD_EXEC_PROJECT_DIR", "")
+	t.Chdir(t.TempDir())
+
+	assert.NoError(t, ejectInfraAfterInit("bicep"))
+}
+
 func TestEjectInfra_Terraform_HappyPath_WritesExpectedFiles(t *testing.T) {
 	// Not parallel: captures os.Stdout (see TestEjectInfra_HappyPath_WritesExpectedFiles).
 	dir := t.TempDir()

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
@@ -649,6 +649,26 @@ func TestEjectInfraAfterInit_NoProject(t *testing.T) {
 	assert.NoError(t, ejectInfraAfterInit("bicep"))
 }
 
+func TestEjectInfraAfterInit_PropagatesInvalidFoundryConfiguration(t *testing.T) {
+	t.Setenv("AZD_EXEC_PROJECT_DIR", "")
+	projectRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "azure.yaml"), []byte(`name: test
+services:
+  first-project:
+    host: azure.ai.project
+  second-project:
+    host: azure.ai.project
+`), 0600))
+	t.Chdir(projectRoot)
+
+	err := ejectInfraAfterInit("bicep")
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok, "expected *azdext.LocalError, got %T", err)
+	assert.Equal(t, exterrors.CodeInfraEjectMultipleFoundryServices, localErr.Code)
+	assert.NoDirExists(t, filepath.Join(projectRoot, "infra"))
+}
+
 func TestEjectInfra_Terraform_HappyPath_WritesExpectedFiles(t *testing.T) {
 	// Not parallel: captures os.Stdout (see TestEjectInfra_HappyPath_WritesExpectedFiles).
 	dir := t.TempDir()

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -640,6 +641,33 @@ services:
 		require.NoError(t, ejectInfraAfterInit("bicep"))
 	})
 
+	assert.FileExists(t, filepath.Join(projectRoot, "infra", "main.bicep"))
+	assert.NoDirExists(t, filepath.Join(nestedDir, "infra"))
+}
+
+func TestInitInfra_StandaloneEjectResolvesParentProject(t *testing.T) {
+	t.Setenv("AZD_EXEC_PROJECT_DIR", "")
+	projectRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "azure.yaml"), []byte(`name: test
+services:
+  ai-project:
+    host: azure.ai.project
+`), 0600))
+	nestedDir := filepath.Join(projectRoot, "src", "agent")
+	require.NoError(t, os.MkdirAll(nestedDir, 0750))
+	t.Chdir(nestedDir)
+
+	cmd := newInitCommand(&azdext.ExtensionContext{})
+	cmd.SetArgs([]string{"--infra"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	var execErr error
+	withCapturedStdout(t, func() {
+		execErr = cmd.Execute()
+	})
+
+	require.NoError(t, execErr)
 	assert.FileExists(t, filepath.Join(projectRoot, "infra", "main.bicep"))
 	assert.NoDirExists(t, filepath.Join(nestedDir, "infra"))
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
@@ -636,7 +636,7 @@ services:
 	require.NoError(t, os.MkdirAll(nestedDir, 0750))
 	t.Chdir(nestedDir)
 
-withCapturedStdout(t, func() {
+	withCapturedStdout(t, func() {
 		require.NoError(t, ejectInfraAfterInit("bicep"))
 	})
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
@@ -649,6 +649,20 @@ func TestEjectInfraAfterInit_NoProject(t *testing.T) {
 	assert.NoError(t, ejectInfraAfterInit("bicep"))
 }
 
+func TestEjectInfraAfterInit_SkipsProjectWithoutFoundryService(t *testing.T) {
+	t.Setenv("AZD_EXEC_PROJECT_DIR", "")
+	projectRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, "azure.yaml"), []byte(`name: test
+services:
+  web:
+    host: containerapp
+`), 0600))
+	t.Chdir(projectRoot)
+
+	assert.NoError(t, ejectInfraAfterInit("bicep"))
+	assert.NoDirExists(t, filepath.Join(projectRoot, "infra"))
+}
+
 func TestEjectInfraAfterInit_PropagatesInvalidFoundryConfiguration(t *testing.T) {
 	t.Setenv("AZD_EXEC_PROJECT_DIR", "")
 	projectRoot := t.TempDir()

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
@@ -636,7 +636,9 @@ services:
 	require.NoError(t, os.MkdirAll(nestedDir, 0750))
 	t.Chdir(nestedDir)
 
-	require.NoError(t, ejectInfraAfterInit("bicep"))
+withCapturedStdout(t, func() {
+		require.NoError(t, ejectInfraAfterInit("bicep"))
+	})
 
 	assert.FileExists(t, filepath.Join(projectRoot, "infra", "main.bicep"))
 	assert.NoDirExists(t, filepath.Join(nestedDir, "infra"))


### PR DESCRIPTION
## Summary

Fixes #9287. `azd ai agent init --infra` now generates infrastructure after unified-manifest adoption and bare-definition reuse, including when invoked below the azd project root.

## Changes

- **`agent init` flow**: chain infrastructure ejection after successful unified `azure.yaml` adoption and bare `agent.yaml` reuse.
- **Infrastructure ejection**: resolve the owning azd project with standard upward discovery and generate `infra/` beside its `azure.yaml`.
- **Tests**: cover parent-project resolution and the no-project post-init case.

## Manual Validation

- Initialized the hosted-agent hello-world unified manifest with `--infra --no-prompt`; Bicep files were generated in the adopted project.
- Ran standalone `--infra` from a nested agent source directory; files were generated at the parent project root, with no nested `infra/`.
- Reused a bare `agent.yaml` with `--infra --no-prompt`; init created `azure.yaml` and generated `infra/main.bicep`.
