### PR TITLE
feat(extensions): upgrade and uninstall while an extension is running

### DIFF
--- a/.vscode/cspell.misc.yaml
+++ b/.vscode/cspell.misc.yaml
@@ -82,6 +82,7 @@ overrides:
           - figspec
           - NTFS
           - ostest
+          - pidfd
           - Pids
           - processutil
           - proctest

--- a/.vscode/cspell.misc.yaml
+++ b/.vscode/cspell.misc.yaml
@@ -73,6 +73,21 @@ overrides:
           - stdlib
           - dependson
           - appsettings
+    - filename: ./docs/specs/extension-upgrade-force/**
+      words:
+          - axww
+          - azdcli
+          - azdext
+          - EPERM
+          - figspec
+          - NTFS
+          - ostest
+          - Pids
+          - processutil
+          - proctest
+          - osutil
+          - testdata
+          - Toolhelp
     - filename: schemas/**/azure.yaml.json
       words:
           - prodapi
@@ -117,6 +132,7 @@ overrides:
           - vsrpc
     - filename: docs/reference/**/*.md
       words:
+          - Agentic
           - appinit
           - appservice
           - buildpack

--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -15,12 +15,15 @@ words:
   - golangci
   - golangtools
   - lightspeed
+  - proctest
+  - processutil
   - runewidth
   - toplevel
   - truncatable
   - wrappable
   - myacr
   - myconn
+  - myext
   - myorg
   - myprivacr
   - privatelink
@@ -483,6 +486,9 @@ overrides:
   - filename: pkg/tool/manifest.go
     words:
       - azureresourcegroups
+  - filename: pkg/processutil/processutil_darwin.go
+    words:
+      - axww
   - filename: pkg/tool/installer.go
     words:
       - filesystems

--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -489,6 +489,9 @@ overrides:
   - filename: pkg/processutil/processutil_darwin.go
     words:
       - axww
+  - filename: pkg/processutil/processutil_unix.go
+    words:
+      - pidfd
   - filename: pkg/tool/installer.go
     words:
       - filesystems

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -32,6 +32,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
+	"github.com/azure/azure-dev/cli/azd/pkg/processutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/rzip"
 	uxlib "github.com/azure/azure-dev/cli/azd/pkg/ux"
 	"github.com/spf13/cobra"
@@ -109,6 +110,13 @@ tracked for updates; reinstall from a newer bundle to update.`,
 		Command: &cobra.Command{
 			Use:   "uninstall [extension-id]",
 			Short: "Uninstall specified extensions.",
+			Long: `Uninstall one or more installed extensions.
+
+If the extension is currently running, its files may be locked. azd moves the
+locked files aside so the uninstall still succeeds, and cleans them up on a
+later extension command once the process exits. Use --force to stop processes
+running from the extension's install directory first and remove everything
+immediately.`,
 		},
 		ActionResolver: newExtensionUninstallAction,
 		FlagsResolver:  newExtensionUninstallFlags,
@@ -138,6 +146,12 @@ dependencies are automatically upgraded too, to the highest version
 satisfying the extension's declared constraints. Use
 --no-dependency-upgrades to opt out and upgrade only the named
 extension.
+
+If the extension is currently running, its files may be locked and the old
+binary stays in use until that process restarts. Use --force to stop processes
+running from the extension's install directory first, so the new version takes
+effect right away. Only processes started from that extension's own directory
+are stopped. --force also applies to any dependencies being upgraded.
 
 Use --output json for a structured report of all upgrade results.`,
 		},
@@ -822,7 +836,9 @@ func newExtensionInstallFlags(cmd *cobra.Command, global *internal.GlobalCommand
 			"or a registry location (URL or file path) to register and install from.")
 	cmd.Flags().StringVarP(&flags.version, "version", "v", "", "The version of the extension to install")
 	cmd.Flags().
-		BoolVarP(&flags.force, "force", "f", false, "Force installation, including downgrades and reinstalls")
+		BoolVarP(&flags.force, "force", "f", false,
+			"Force installation, including downgrades, reinstalls, "+
+				"and stopping running extension processes that block replacement")
 	cmd.Flags().BoolVar(&flags.noDependencies, "no-dependencies", false,
 		"Install only the specified extension(s) without installing their declared dependencies")
 
@@ -1047,21 +1063,30 @@ func (a *extensionInstallAction) Run(ctx context.Context) (*actions.ActionResult
 
 			// Use upgrade logic for existing installations
 			a.console.ShowSpinner(ctx, stepMessage, input.Step)
+			var stopped []processutil.ProcessInfo
 			extensionVersion, _, err = a.extensionManager.Upgrade(
 				ctx, compatibleExtension, extensions.UpgradeOptions{
 					VersionPreference:   a.flags.version,
 					UpgradeDependencies: !a.flags.noDependencies,
 					SkipDependencies:    a.flags.noDependencies,
 					AzdVersion:          azdVersion,
+					// --force already means "override what is blocking me" for installs,
+					// so it also covers a running extension holding its own files open.
+					Force: a.flags.force,
+					OnProcessStopped: func(process processutil.ProcessInfo) {
+						stopped = append(stopped, process)
+					},
 				},
 			)
 			if err != nil {
 				a.console.StopSpinner(ctx, stepMessage, input.StepFailed)
+				reportStoppedProcesses(ctx, a.console, stopped)
 				return nil, wrapDependencyError(fmt.Errorf("failed to upgrade extension: %w", err))
 			}
 
 			stepMessage += output.WithGrayFormat(" (%s)", extensionVersion.Version)
 			a.console.StopSpinner(ctx, stepMessage, input.StepDone)
+			reportStoppedProcesses(ctx, a.console, stopped)
 
 		} else {
 			// Extension not installed - proceed with fresh install
@@ -1736,12 +1761,15 @@ func inferSourceKind(location string) (extensions.SourceKind, bool) {
 
 // azd extension uninstall
 type extensionUninstallFlags struct {
-	all bool
+	all   bool
+	force bool
 }
 
 func newExtensionUninstallFlags(cmd *cobra.Command) *extensionUninstallFlags {
 	flags := &extensionUninstallFlags{}
 	cmd.Flags().BoolVar(&flags.all, "all", false, "Uninstall all installed extensions")
+	cmd.Flags().BoolVarP(&flags.force, "force", "f", false,
+		"Stop running extension processes that are blocking removal")
 
 	return flags
 }
@@ -1825,12 +1853,21 @@ func (a *extensionUninstallAction) Run(ctx context.Context) (*actions.ActionResu
 		stepMessage += fmt.Sprintf(" (%s)", installed.Version)
 		a.console.ShowSpinner(ctx, stepMessage, input.Step)
 
-		if err := a.extensionManager.Uninstall(ctx, extensionId); err != nil {
+		var stopped []processutil.ProcessInfo
+		err = a.extensionManager.UninstallWithOptions(ctx, extensionId, extensions.UninstallOptions{
+			Force: a.flags.force,
+			OnProcessStopped: func(process processutil.ProcessInfo) {
+				stopped = append(stopped, process)
+			},
+		})
+		if err != nil {
 			a.console.StopSpinner(ctx, stepMessage, input.StepFailed)
+			reportStoppedProcesses(ctx, a.console, stopped)
 			return nil, fmt.Errorf("failed to uninstall extension: %w", err)
 		}
 
 		a.console.StopSpinner(ctx, stepMessage, input.StepDone)
+		reportStoppedProcesses(ctx, a.console, stopped)
 	}
 
 	return &actions.ActionResult{
@@ -1845,6 +1882,7 @@ type extensionUpgradeFlags struct {
 	source               string
 	all                  bool
 	noDependencyUpgrades bool
+	force                bool
 	global               *internal.GlobalCommandOptions
 }
 
@@ -1858,8 +1896,18 @@ func newExtensionUpgradeFlags(cmd *cobra.Command, global *internal.GlobalCommand
 	cmd.Flags().BoolVar(&flags.all, "all", false, "Upgrade all installed extensions")
 	cmd.Flags().BoolVar(&flags.noDependencyUpgrades, "no-dependency-upgrades", false,
 		"Do not upgrade dependencies when upgrading an extension that has dependencies")
+	cmd.Flags().BoolVarP(&flags.force, "force", "f", false,
+		"Stop running extension processes so the upgraded version takes effect immediately")
 
 	return flags
+}
+
+// reportStoppedProcesses tells the user which processes azd stopped on their behalf.
+// Silent when nothing was stopped, so the common case stays quiet.
+func reportStoppedProcesses(ctx context.Context, console input.Console, stopped []processutil.ProcessInfo) {
+	for _, process := range stopped {
+		console.Message(ctx, fmt.Sprintf("  %s", output.WithGrayFormat("Stopped %s", process.String())))
+	}
 }
 
 // azd extension upgrade
@@ -2083,6 +2131,10 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 		a.console.ShowSpinner(ctx, stepMsg, input.Step)
 	}
 
+	// Processes stopped by --force, recorded before the failure helper below so every
+	// exit path can tell the user what azd terminated on their behalf.
+	var stopped []processutil.ProcessInfo
+
 	// Helper to record a failure and stop the spinner.
 	fail := func(err error) extensions.UpgradeResult {
 		baseResult.Status = extensions.UpgradeStatusFailed
@@ -2091,6 +2143,7 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 			a.console.StopSpinner(
 				ctx, stepMsg, input.StepFailed,
 			)
+			reportStoppedProcesses(ctx, a.console, stopped)
 			a.console.Message(ctx, fmt.Sprintf(
 				"  %s",
 				output.WithGrayFormat("%s", err.Error()),
@@ -2324,6 +2377,10 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 			VersionPreference:   a.flags.version,
 			UpgradeDependencies: !a.flags.noDependencyUpgrades,
 			AzdVersion:          azdVersion,
+			Force:               a.flags.force,
+			OnProcessStopped: func(process processutil.ProcessInfo) {
+				stopped = append(stopped, process)
+			},
 		},
 	)
 	if err != nil {
@@ -2370,6 +2427,7 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 			),
 		)
 		a.console.StopSpinner(ctx, doneMsg, input.StepDone)
+		reportStoppedProcesses(ctx, a.console, stopped)
 		displayDependencyUpgradeResults(ctx, a.console, baseResult.DependencyUpgrades, "  ")
 		displayExtensionUsageAndExamples(
 			ctx, a.console, extVersion,

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -2139,6 +2139,7 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 	fail := func(err error) extensions.UpgradeResult {
 		baseResult.Status = extensions.UpgradeStatusFailed
 		baseResult.Error = err
+		baseResult.StoppedProcesses = stopped
 		if !isJsonOutput {
 			a.console.StopSpinner(
 				ctx, stepMsg, input.StepFailed,
@@ -2345,6 +2346,14 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 				VersionPreference:   a.flags.version,
 				UpgradeDependencies: !a.flags.noDependencyUpgrades,
 				AzdVersion:          azdVersion,
+				// The parent is already current, but a stale dependency still gets
+				// reinstalled here, and its own process holds its binary open exactly
+				// like the parent's would. Dropping these would make --force a no-op
+				// for the one extension this branch actually replaces.
+				Force: a.flags.force,
+				OnProcessStopped: func(process processutil.ProcessInfo) {
+					stopped = append(stopped, process)
+				},
 			},
 		)
 		if err != nil {
@@ -2357,6 +2366,7 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 			baseResult.ToSource = newSource
 		}
 
+		baseResult.StoppedProcesses = stopped
 		baseResult.Status = extensions.UpgradeStatusSkipped
 		baseResult.SkipReason = "already up to date"
 		if !isJsonOutput {
@@ -2366,6 +2376,7 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 			a.console.StopSpinner(
 				ctx, skipMsg, input.StepSkipped,
 			)
+			reportStoppedProcesses(ctx, a.console, stopped)
 			displayDependencyUpgradeResults(ctx, a.console, baseResult.DependencyUpgrades, "  ")
 		}
 		return baseResult
@@ -2397,6 +2408,7 @@ func (a *extensionUpgradeAction) upgradeOneExtension(
 	}
 	baseResult.ToVersion = extVersion.Version
 	baseResult.DependencyUpgrades = depUpgrades
+	baseResult.StoppedProcesses = stopped
 
 	// Handle promotion display and distinct telemetry
 	if isPromotion {

--- a/cli/azd/cmd/extension_force_test.go
+++ b/cli/azd/cmd/extension_force_test.go
@@ -1,0 +1,468 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/processutil"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
+	"github.com/azure/azure-dev/cli/azd/test/proctest"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	if proctest.RunRequestedHelper() {
+		return
+	}
+
+	os.Exit(m.Run())
+}
+
+// T31: --force has to be registered on upgrade and actually bound, or the flag would
+// parse and then be ignored.
+func TestExtensionUpgradeFlags_Force(t *testing.T) {
+	t.Parallel()
+
+	command := &cobra.Command{Use: "upgrade"}
+	flags := newExtensionUpgradeFlags(command, &internal.GlobalCommandOptions{})
+
+	definition := command.Flags().Lookup("force")
+	require.NotNil(t, definition, "upgrade must accept --force")
+	require.Equal(t, "f", definition.Shorthand, "--force must share install's -f shorthand")
+	require.Equal(t, "false", definition.DefValue, "stopping processes must be opt-in")
+	require.Contains(t, definition.Usage, "Stop running extension processes")
+
+	require.False(t, flags.force)
+	require.NoError(t, command.Flags().Parse([]string{"--force"}))
+	require.True(t, flags.force, "--force must bind to the field the action reads")
+}
+
+// T32: the same contract on uninstall, so --force means one thing across the extension
+// commands rather than being upgrade-only trivia.
+func TestExtensionUninstallFlags_Force(t *testing.T) {
+	t.Parallel()
+
+	command := &cobra.Command{Use: "uninstall"}
+	flags := newExtensionUninstallFlags(command)
+
+	definition := command.Flags().Lookup("force")
+	require.NotNil(t, definition, "uninstall must accept --force")
+	require.Equal(t, "f", definition.Shorthand)
+	require.Equal(t, "false", definition.DefValue)
+	require.Contains(t, definition.Usage, "Stop running extension processes")
+
+	require.False(t, flags.force)
+	require.NoError(t, command.Flags().Parse([]string{"-f"}))
+	require.True(t, flags.force, "the shorthand must bind the same field as the long form")
+}
+
+// T33: --force has to compose with the flags people actually pair it with. A batch
+// upgrade of everything is the case where locked binaries are most likely.
+func TestExtensionUpgradeFlags_ForceComposesWithOtherFlags(t *testing.T) {
+	t.Parallel()
+
+	command := &cobra.Command{Use: "upgrade"}
+	flags := newExtensionUpgradeFlags(command, &internal.GlobalCommandOptions{})
+
+	require.NoError(t, command.Flags().Parse([]string{
+		"--all", "--force", "--no-dependency-upgrades", "--version", "2.0.0",
+	}))
+
+	require.True(t, flags.all)
+	require.True(t, flags.force)
+	require.True(t, flags.noDependencyUpgrades)
+	require.Equal(t, "2.0.0", flags.version)
+}
+
+func TestExtensionUninstallFlags_ForceComposesWithAll(t *testing.T) {
+	t.Parallel()
+
+	command := &cobra.Command{Use: "uninstall"}
+	flags := newExtensionUninstallFlags(command)
+
+	require.NoError(t, command.Flags().Parse([]string{"--all", "--force"}))
+
+	require.True(t, flags.all)
+	require.True(t, flags.force)
+}
+
+// T34: the whole command path with --force. The flag has to reach the manager, the
+// running extension has to be stopped, the removal has to complete, the user has to be
+// told what azd did, and none of it may prompt. Opting into --force is the confirmation,
+// so a prompt here would break CI and scripted upgrades.
+func TestExtensionUninstallAction_ForceStopsProcessesWithoutPrompting(t *testing.T) {
+	const extensionId = "test.forcecmd"
+
+	extensionDir, process := installedRunningExtension(t, extensionId, "azd-ext-forcecmd")
+
+	mockContext := mocks.NewMockContext(t.Context())
+	console := refuseToPrompt(t, mockContext.Console)
+	manager, _ := forceTestManager(t, mockContext, extensionId, process.Path, testRegistry())
+
+	action := newExtensionUninstallAction(
+		[]string{extensionId},
+		&extensionUninstallFlags{force: true},
+		console,
+		manager,
+	)
+
+	result, err := action.Run(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	process.RequireStopped(t)
+	require.NoDirExists(t, extensionDir, "--force must complete the removal rather than defer it")
+
+	installed, err := manager.ListInstalled()
+	require.NoError(t, err)
+	require.NotContains(t, installed, extensionId)
+
+	reported := strings.Join(console.Output(), "\n")
+	require.Contains(t, reported, "Stopped", "the user must be told which processes azd stopped")
+	require.Contains(t, reported, filepath.Base(process.Path))
+}
+
+// T63: --force has to survive the --all fan-out. --all only expands the id list and then
+// reuses the same per-extension path, so a bug that read the flag once outside the loop,
+// or reset it between extensions, would leave everything after the first one running.
+// Two live processes, one command, both have to be gone.
+func TestExtensionUninstallAction_ForceComposesWithAllAcrossExtensions(t *testing.T) {
+	const firstId = "test.bulkforce1"
+	const secondId = "test.bulkforce2"
+
+	configDir := isolatedConfigDir(t)
+	firstDir, firstProcess := runningExtensionIn(t, configDir, firstId, "azd-ext-bulkforce1")
+	secondDir, secondProcess := runningExtensionIn(t, configDir, secondId, "azd-ext-bulkforce2")
+
+	mockContext := mocks.NewMockContext(t.Context())
+	console := refuseToPrompt(t, mockContext.Console)
+	manager, _ := createUpgradeTestManager(t, mockContext, map[string]*extensions.Extension{
+		firstId:  installedAt(firstId, firstProcess.Path),
+		secondId: installedAt(secondId, secondProcess.Path),
+	}, "https://test.example.com/registry.json", testRegistry())
+
+	action := newExtensionUninstallAction(
+		nil,
+		&extensionUninstallFlags{all: true, force: true},
+		console,
+		manager,
+	)
+
+	_, err := action.Run(t.Context())
+	require.NoError(t, err)
+
+	firstProcess.RequireStopped(t)
+	secondProcess.RequireStopped(t)
+	require.NoDirExists(t, firstDir)
+	require.NoDirExists(t, secondDir)
+
+	installed, err := manager.ListInstalled()
+	require.NoError(t, err)
+	require.Empty(t, installed, "--all must clear every extension it stopped")
+}
+
+// Without --force the command must leave the process running, which keeps the destructive
+// behavior opt-in at the command layer and not only inside the manager.
+func TestExtensionUninstallAction_WithoutForceLeavesProcessRunning(t *testing.T) {
+	const extensionId = "test.gentlecmd"
+
+	_, process := installedRunningExtension(t, extensionId, "azd-ext-gentlecmd")
+
+	mockContext := mocks.NewMockContext(t.Context())
+	console := refuseToPrompt(t, mockContext.Console)
+	manager, _ := forceTestManager(t, mockContext, extensionId, process.Path, testRegistry())
+
+	action := newExtensionUninstallAction(
+		[]string{extensionId},
+		&extensionUninstallFlags{},
+		console,
+		manager,
+	)
+
+	_, err := action.Run(t.Context())
+	require.NoError(t, err, "uninstall must succeed even while the extension is running")
+
+	process.RequireRunning(t)
+	require.NotContains(t, strings.Join(console.Output(), "\n"), "Stopped")
+}
+
+// The upgrade command has its own wiring into UpgradeOptions, separate from uninstall.
+// A --force that parses but is never passed through would leave the original bug in place
+// on the exact command the issue was filed against.
+func TestExtensionUpgradeAction_ForceStopsRunningProcess(t *testing.T) {
+	const extensionId = "test.forceupgrade"
+
+	_, process := installedRunningExtension(t, extensionId, "azd-ext-forceupgrade")
+
+	mockContext := mocks.NewMockContext(t.Context())
+	console := refuseToPrompt(t, mockContext.Console)
+	manager, sourceManager := forceTestManager(
+		t, mockContext, extensionId, process.Path,
+		testRegistry(testExtMeta(extensionId, "2.0.0", "test")),
+	)
+
+	action := &extensionUpgradeAction{
+		args: []string{extensionId},
+		flags: &extensionUpgradeFlags{
+			force:  true,
+			global: &internal.GlobalCommandOptions{NoPrompt: true},
+		},
+		formatter:        &output.JsonFormatter{},
+		writer:           &bytes.Buffer{},
+		console:          console,
+		sourceManager:    sourceManager,
+		extensionManager: manager,
+	}
+
+	// Fetching the new version cannot succeed against the mock registry, so the upgrade
+	// itself fails. That is deliberate. The process must already be stopped by then,
+	// because the uninstall runs first and that is where --force applies.
+	result := action.upgradeOneExtension(t.Context(), extensionId, 0, nil, true)
+	require.Equal(t, extensions.UpgradeStatusFailed, result.Status)
+
+	process.RequireStopped(t)
+}
+
+// Without --force the upgrade must leave the process alone, so the destructive behavior
+// stays opt-in on upgrade and not just on uninstall.
+func TestExtensionUpgradeAction_WithoutForceLeavesProcessRunning(t *testing.T) {
+	const extensionId = "test.gentleupgrade"
+
+	_, process := installedRunningExtension(t, extensionId, "azd-ext-gentleupgrade")
+
+	mockContext := mocks.NewMockContext(t.Context())
+	console := refuseToPrompt(t, mockContext.Console)
+	manager, sourceManager := forceTestManager(
+		t, mockContext, extensionId, process.Path,
+		testRegistry(testExtMeta(extensionId, "2.0.0", "test")),
+	)
+
+	action := &extensionUpgradeAction{
+		args: []string{extensionId},
+		flags: &extensionUpgradeFlags{
+			global: &internal.GlobalCommandOptions{NoPrompt: true},
+		},
+		formatter:        &output.JsonFormatter{},
+		writer:           &bytes.Buffer{},
+		console:          console,
+		sourceManager:    sourceManager,
+		extensionManager: manager,
+	}
+
+	// Assert the outcome rather than discarding it. Without this the test would pass even
+	// if the action bailed out early, which would prove nothing about whether the process
+	// was deliberately left alone. The status is Failed because this fixture's registry
+	// serves no downloadable artifact, so the assertion pins "the upgrade was reached and
+	// ran", not "locking caused the failure".
+	result := action.upgradeOneExtension(t.Context(), extensionId, 0, nil, true)
+	require.Equal(t, extensions.UpgradeStatusFailed, result.Status,
+		"the upgrade must actually run for the no-force behavior to mean anything")
+
+	process.RequireRunning(t)
+}
+
+// install --force already meant "override what is blocking me", and reinstalling over a
+// running extension is the same block. This drives the whole install action so the
+// already-installed branch is exercised, not just the flag definition.
+func TestExtensionInstallAction_ForceStopsRunningProcessOnReinstall(t *testing.T) {
+	const extensionId = "test.forceinstall"
+
+	_, process := installedRunningExtension(t, extensionId, "azd-ext-forceinstall")
+
+	mockContext := mocks.NewMockContext(t.Context())
+	console := refuseToPrompt(t, mockContext.Console)
+	manager, sourceManager := forceTestManager(
+		t, mockContext, extensionId, process.Path,
+		testRegistry(testExtMeta(extensionId, "2.0.0", "test")),
+	)
+
+	action := &extensionInstallAction{
+		args: []string{extensionId},
+		flags: &extensionInstallFlags{
+			force:  true,
+			source: "test",
+			global: &internal.GlobalCommandOptions{NoPrompt: true},
+		},
+		console:          console,
+		extensionManager: manager,
+		sourceManager:    sourceManager,
+	}
+
+	// Same source and a newer version, so this reaches the upgrade path without asking
+	// anything. refuseToPrompt turns a future prompt here into a failure. The install
+	// itself cannot finish because the mock registry serves no artifact; the point is
+	// that --force already stopped the process by the time it got there.
+	_, err := action.Run(t.Context())
+	require.Error(t, err, "the mock registry serves no artifact, so the reinstall must fail")
+
+	process.RequireStopped(t)
+}
+
+// A forced upgrade that stops the extension and then fails must still say what it killed.
+// Otherwise azd terminates the user's running extension, reports only the download
+// failure, and leaves them with no idea their process is gone.
+func TestExtensionUpgradeAction_ForceReportsStoppedProcessesOnFailure(t *testing.T) {
+	const extensionId = "test.forcefail"
+
+	_, process := installedRunningExtension(t, extensionId, "azd-ext-forcefail")
+
+	mockContext := mocks.NewMockContext(t.Context())
+	console := refuseToPrompt(t, mockContext.Console)
+	manager, sourceManager := forceTestManager(
+		t, mockContext, extensionId, process.Path,
+		testRegistry(testExtMeta(extensionId, "2.0.0", "test")),
+	)
+
+	action := &extensionUpgradeAction{
+		args: []string{extensionId},
+		flags: &extensionUpgradeFlags{
+			force:  true,
+			global: &internal.GlobalCommandOptions{NoPrompt: true},
+		},
+		formatter:        &output.NoneFormatter{},
+		writer:           &bytes.Buffer{},
+		console:          console,
+		sourceManager:    sourceManager,
+		extensionManager: manager,
+	}
+
+	// isJsonOutput false, so this exercises the console reporting path. The upgrade
+	// fails because the mock registry serves no artifact, which is exactly the case
+	// where silence would be worst.
+	result := action.upgradeOneExtension(t.Context(), extensionId, 0, nil, false)
+	require.Equal(t, extensions.UpgradeStatusFailed, result.Status)
+
+	process.RequireStopped(t)
+
+	reported := strings.Join(console.Output(), "\n")
+	require.Contains(t, reported, "Stopped",
+		"a failed forced upgrade must still report the processes it terminated")
+	require.Contains(t, reported, filepath.Base(process.Path))
+}
+
+// Nothing stopped means nothing said, so a routine upgrade does not grow noise.
+func TestReportStoppedProcesses_SilentWhenNothingStopped(t *testing.T) {
+	t.Parallel()
+
+	console := mockinput.NewMockConsole()
+	reportStoppedProcesses(t.Context(), console, nil)
+
+	require.Empty(t, console.Output())
+}
+
+func TestReportStoppedProcesses_NamesEachStoppedProcess(t *testing.T) {
+	t.Parallel()
+
+	console := mockinput.NewMockConsole()
+	reportStoppedProcesses(t.Context(), console, []processutil.ProcessInfo{
+		{PID: 4321, Name: "azd-ext-demo", Executable: filepath.Join("tmp", "demo", "azd-ext-demo")},
+		{PID: 8765, Name: "azd-ext-other", Executable: filepath.Join("tmp", "demo", "azd-ext-other")},
+	})
+
+	reported := strings.Join(console.Output(), "\n")
+	require.Contains(t, reported, "4321")
+	require.Contains(t, reported, "azd-ext-demo")
+	require.Contains(t, reported, "8765")
+	require.Contains(t, reported, "azd-ext-other")
+}
+
+// installedRunningExtension redirects azd configuration at a temporary directory and puts
+// a real running executable in the extension's install directory, which is the situation
+// that makes uninstall and upgrade fail today.
+func installedRunningExtension(t *testing.T, extensionId string, name string) (string, *proctest.Handle) {
+	t.Helper()
+
+	return runningExtensionIn(t, isolatedConfigDir(t), extensionId, name)
+}
+
+// isolatedConfigDir points AZD_CONFIG_DIR at a temporary directory and proves the
+// redirection took effect, so a test can never remove extensions from the real profile.
+func isolatedConfigDir(t *testing.T) string {
+	t.Helper()
+
+	configDir := t.TempDir()
+	t.Setenv("AZD_CONFIG_DIR", configDir)
+
+	resolved, err := config.GetUserConfigDir()
+	require.NoError(t, err)
+	require.Equal(t, configDir, resolved, "the test must never touch the real azd configuration")
+
+	return configDir
+}
+
+// runningExtensionIn installs a live extension process under an existing config directory,
+// so one test can hold more than one installed extension at a time.
+func runningExtensionIn(
+	t *testing.T,
+	configDir string,
+	extensionId string,
+	name string,
+) (string, *proctest.Handle) {
+	t.Helper()
+
+	extensionDir := filepath.Join(configDir, "extensions", extensionId)
+	require.NoError(t, os.MkdirAll(extensionDir, osutil.PermissionDirectory))
+
+	return extensionDir, proctest.StartIn(t, extensionDir, name, proctest.ModeIdle)
+}
+
+// installedAt describes an extension whose recorded path is the executable actually
+// running, which is what makes the command resolve the directory the process runs from.
+func installedAt(extensionId string, executable string) *extensions.Extension {
+	return &extensions.Extension{
+		Id:      extensionId,
+		Version: "1.0.0",
+		Source:  "test",
+		Path:    filepath.Join("extensions", extensionId, filepath.Base(executable)),
+	}
+}
+
+// forceTestManager builds a manager whose installed state points at the running
+// executable, so the command under test resolves the same directory the process runs from.
+func forceTestManager(
+	t *testing.T,
+	mockContext *mocks.MockContext,
+	extensionId string,
+	executable string,
+	registry extensions.Registry,
+) (*extensions.Manager, *extensions.SourceManager) {
+	t.Helper()
+
+	return createUpgradeTestManager(t, mockContext, map[string]*extensions.Extension{
+		extensionId: installedAt(extensionId, executable),
+	}, "https://test.example.com/registry.json", registry)
+}
+
+// refuseToPrompt turns any interactive request into a test failure, so a prompt added to
+// the uninstall path in the future is caught rather than silently hanging CI.
+func refuseToPrompt(t *testing.T, console *mockinput.MockConsole) *mockinput.MockConsole {
+	t.Helper()
+
+	fail := func(kind string) func(input.ConsoleOptions) bool {
+		return func(options input.ConsoleOptions) bool {
+			t.Errorf("uninstall must never %s, but asked: %q", kind, options.Message)
+
+			return false
+		}
+	}
+
+	console.WhenConfirm(fail("confirm")).Respond(false)
+	console.WhenPrompt(fail("prompt")).Respond("")
+	console.WhenSelect(fail("select")).Respond(0)
+
+	return console
+}

--- a/cli/azd/cmd/extension_force_test.go
+++ b/cli/azd/cmd/extension_force_test.go
@@ -5,6 +5,8 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -378,6 +380,77 @@ func TestReportStoppedProcesses_NamesEachStoppedProcess(t *testing.T) {
 	require.Contains(t, reported, "azd-ext-demo")
 	require.Contains(t, reported, "8765")
 	require.Contains(t, reported, "azd-ext-other")
+}
+
+// --force must also reach the branch that runs when the parent is already at the target
+// version. That branch only reconciles stale dependencies, and a dependency's process
+// holds its binary open exactly like the parent's would, so omitting Force there made
+// `upgrade --force` silently leave a running dependency in place and unreported.
+func TestExtensionUpgradeAction_ForceReachesStaleDependencyOfCurrentParent(t *testing.T) {
+	const parentId = "test.current-parent"
+	const childId = "test.stale-child"
+
+	configDir := isolatedConfigDir(t)
+	_, parentProcess := runningExtensionIn(t, configDir, parentId, "azd-ext-current-parent")
+	_, childProcess := runningExtensionIn(t, configDir, childId, "azd-ext-stale-child")
+
+	mockContext := mocks.NewMockContext(t.Context())
+	console := refuseToPrompt(t, mockContext.Console)
+
+	// The parent's only version matches what is installed, so the upgrade takes the
+	// "already up to date" path. Its dependency constraint is not satisfied by the
+	// installed child, which is what makes that path do real work.
+	registry := testRegistry(
+		&extensions.ExtensionMetadata{
+			Id:     parentId,
+			Source: "test",
+			Versions: []extensions.ExtensionVersion{
+				{
+					Version:      "1.0.0",
+					Dependencies: []extensions.ExtensionDependency{{Id: childId, Version: ">=2.0.0"}},
+				},
+			},
+		},
+		testExtMeta(childId, "2.0.0", "test"),
+	)
+
+	manager, sourceManager := createUpgradeTestManager(t, mockContext, map[string]*extensions.Extension{
+		parentId: installedAt(parentId, parentProcess.Path),
+		childId:  installedAt(childId, childProcess.Path),
+	}, "https://test.example.com/registry.json", registry)
+
+	action := &extensionUpgradeAction{
+		args: []string{parentId},
+		flags: &extensionUpgradeFlags{
+			force:  true,
+			global: &internal.GlobalCommandOptions{NoPrompt: true},
+		},
+		formatter:        &output.JsonFormatter{},
+		writer:           &bytes.Buffer{},
+		console:          console,
+		sourceManager:    sourceManager,
+		extensionManager: manager,
+	}
+
+	result := action.upgradeOneExtension(t.Context(), parentId, 0, nil, true)
+
+	require.Equal(t, extensions.UpgradeStatusSkipped, result.Status, "the parent itself is already current")
+
+	// Fetching the child's new version cannot succeed against the mock registry, so its
+	// upgrade fails. The stop still has to have happened, because the uninstall runs
+	// first and that is where --force applies.
+	childProcess.RequireStopped(t)
+	require.False(t, parentProcess.HasExited(), "only the stale dependency's process may be stopped")
+
+	require.Len(t, result.StoppedProcesses, 1, "the reported result must name what --force stopped")
+	require.Equal(t, childProcess.PID, result.StoppedProcesses[0].PID)
+
+	// --force prints nothing under --output json, so the structured result is the only
+	// place a scripted caller can learn what azd terminated on its behalf.
+	encoded, err := json.Marshal(result)
+	require.NoError(t, err)
+	require.Contains(t, string(encoded), `"stoppedProcesses"`)
+	require.Contains(t, string(encoded), fmt.Sprintf(`"pid":%d`, childProcess.PID))
 }
 
 // installedRunningExtension redirects azd configuration at a temporary directory and puts

--- a/cli/azd/cmd/testdata/TestFigSpec.ts
+++ b/cli/azd/cmd/testdata/TestFigSpec.ts
@@ -5851,7 +5851,7 @@ const completionSpec: Fig.Spec = {
 					options: [
 						{
 							name: ['--force', '-f'],
-							description: 'Force installation, including downgrades and reinstalls',
+							description: 'Force installation, including downgrades, reinstalls, and stopping running extension processes that block replacement',
 							isDangerous: true,
 						},
 						{
@@ -6001,6 +6001,11 @@ const completionSpec: Fig.Spec = {
 							name: ['--all'],
 							description: 'Uninstall all installed extensions',
 						},
+						{
+							name: ['--force', '-f'],
+							description: 'Stop running extension processes that are blocking removal',
+							isDangerous: true,
+						},
 					],
 					args: {
 						name: 'extension-id',
@@ -6015,6 +6020,11 @@ const completionSpec: Fig.Spec = {
 						{
 							name: ['--all'],
 							description: 'Upgrade all installed extensions',
+						},
+						{
+							name: ['--force', '-f'],
+							description: 'Stop running extension processes so the upgraded version takes effect immediately',
+							isDangerous: true,
 						},
 						{
 							name: ['--no-dependency-upgrades'],

--- a/cli/azd/cmd/testdata/TestUsage-azd-extension-install.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-extension-install.snap
@@ -5,7 +5,7 @@ Usage
   azd extension install <extension-id|extension-bundle.zip> [flags]
 
 Flags
-    -f, --force           	: Force installation, including downgrades and reinstalls
+    -f, --force           	: Force installation, including downgrades, reinstalls, and stopping running extension processes that block replacement
         --no-dependencies 	: Install only the specified extension(s) without installing their declared dependencies
     -s, --source string   	: The extension source to use for installs. Accepts a registered source name or a registry location (URL or file path) to register and install from.
     -v, --version string  	: The version of the extension to install

--- a/cli/azd/cmd/testdata/TestUsage-azd-extension-uninstall.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-extension-uninstall.snap
@@ -5,7 +5,8 @@ Usage
   azd extension uninstall [extension-id] [flags]
 
 Flags
-        --all 	: Uninstall all installed extensions
+        --all   	: Uninstall all installed extensions
+    -f, --force 	: Stop running extension processes that are blocking removal
 
 Global Flags
     -C, --cwd string         	: Sets the current working directory.

--- a/cli/azd/cmd/testdata/TestUsage-azd-extension-upgrade.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-extension-upgrade.snap
@@ -6,6 +6,7 @@ Usage
 
 Flags
         --all                    	: Upgrade all installed extensions
+    -f, --force                  	: Stop running extension processes so the upgraded version takes effect immediately
         --no-dependency-upgrades 	: Do not upgrade dependencies when upgrading an extension that has dependencies
     -s, --source string          	: The registered source name or registry location (URL or file path) to use for upgrades.
     -v, --version string         	: The version of the extension to upgrade to

--- a/cli/azd/docs/extensions/extension-framework.md
+++ b/cli/azd/docs/extensions/extension-framework.md
@@ -167,14 +167,18 @@ extension had a live process, such as a long-running MCP server.
 
 `azd` now handles this in two layers:
 
-1. **By default**, files that cannot be deleted are renamed into a `.trash` directory
-   inside the extension folder instead. The upgrade or uninstall succeeds, and the leftover
-   files are swept away on the next `azd` extension command once the process exits. The
-   running process keeps using the old binary until it restarts.
+1. **By default**, files that cannot be deleted are renamed into a shared `.trash` directory
+   that sits alongside the extension folders, at `<azd config dir>/extensions/.trash`, rather
+   than inside the extension folder itself. The upgrade or uninstall succeeds, and the leftover
+   files are swept away by the next extension install, upgrade, or uninstall once the process
+   exits. The running process keeps using the old binary until it restarts.
 2. **With `-f, --force`**, `azd` first stops processes running from that extension's install
    directory, then removes the files normally, so the new version takes effect immediately.
    `azd` prints each process it stopped. Only processes whose executable lives inside that
-   one extension's directory are eligible; nothing else on the machine is touched.
+   one extension's directory are eligible; nothing else on the machine is touched. Under
+   `--output json` nothing is printed, so `azd extension upgrade` reports the same
+   information in a `stoppedProcesses` array on each result, with the `name`, `pid`, and
+   `executable` of every process it terminated.
 
 ## Developing Extensions
 

--- a/cli/azd/docs/extensions/extension-framework.md
+++ b/cli/azd/docs/extensions/extension-framework.md
@@ -147,6 +147,7 @@ Installs one or more extensions from any configured extension source.
 Uninstalls one or more previously installed extensions.
 
 - `--all` Removes all installed extensions when specified.
+- `-f, --force` Stops any process running from the extension's install directory before removing it.
 
 #### `azd extension upgrade <extension-ids>`
 
@@ -156,6 +157,24 @@ Upgrades one or more extensions to the latest versions.
 - `-v, --version` Upgrades a specified extension to an exact version, if provided.
 - `-s, --source` Specifies the source used for the upgrade. In addition to registered source names, this accepts a registry location (URL or file path). `azd` registers the location as a source before resolving the extension, updates the extension's stored source after a successful upgrade, and rejects locations under `--no-prompt`; add the source first with `azd extension source add`.
 - `--no-dependency-upgrades` Skips upgrading dependencies declared by extension packs.
+- `-f, --force` Stops any process running from the extension's install directory before replacing it. Also propagates to dependency upgrades.
+
+#### Upgrading or uninstalling a running extension
+
+On Windows an executable that is currently running cannot be deleted, which previously
+made `azd extension upgrade` and `azd extension uninstall` fail outright whenever the
+extension had a live process, such as a long-running MCP server.
+
+`azd` now handles this in two layers:
+
+1. **By default**, files that cannot be deleted are renamed into a `.trash` directory
+   inside the extension folder instead. The upgrade or uninstall succeeds, and the leftover
+   files are swept away on the next `azd` extension command once the process exits. The
+   running process keeps using the old binary until it restarts.
+2. **With `-f, --force`**, `azd` first stops processes running from that extension's install
+   directory, then removes the files normally, so the new version takes effect immediately.
+   `azd` prints each process it stopped. Only processes whose executable lives inside that
+   one extension's directory are eligible; nothing else on the machine is touched.
 
 ## Developing Extensions
 

--- a/cli/azd/docs/extensions/extension-resolution-and-versioning.md
+++ b/cli/azd/docs/extensions/extension-resolution-and-versioning.md
@@ -161,7 +161,7 @@ Once a version is resolved, installation proceeds through these steps:
 
 ### Re-installing over an existing extension
 
-`azd extension install <id>` keys off the extension **id**, so installing an id that is already present is handled based on whether the **source** is changing and on the version relationship. `--force` bypasses all of these guards.
+`azd extension install <id>` keys off the extension **id**, so installing an id that is already present is handled based on whether the **source** is changing and on the version relationship. `--force` bypasses all of these guards, and additionally stops any process running from that extension's install directory so the replacement can take effect immediately.
 
 When the source is **not** changing (same source as the installed extension):
 

--- a/cli/azd/internal/cmd/errors_test.go
+++ b/cli/azd/internal/cmd/errors_test.go
@@ -1274,6 +1274,20 @@ func Test_PackageLevelErrorsMapped(t *testing.T) {
 		// Extension SDK errors used by extensions, never reach host MapError
 		"ErrProjectNotFound": "pkg/azdext: extension SDK helper, used by extensions not the host",
 
+		// Process discovery and termination preconditions. Each one reports that a caller
+		// passed an argument the package refuses to act on, such as an empty or root
+		// directory, a non-positive pid, or a process outside the requested scope. Reaching
+		// any of them means azd has a bug, not that the user did something recoverable.
+		"ErrEmptyDirectory":    "pkg/processutil: argument precondition, programming error not a runtime user error",
+		"ErrRootDirectory":     "pkg/processutil: argument precondition, programming error not a runtime user error",
+		"ErrInvalidPID":        "pkg/processutil: argument precondition, programming error not a runtime user error",
+		"ErrProcessOutOfScope": "pkg/processutil: containment precondition, programming error not a runtime user error",
+
+		// osutil refuses to operate on a directory azd owns when a symlink or junction
+		// has been planted there. That is a tampering signal rather than a mistake the
+		// user can correct, and the surrounding operation reports its own error.
+		"ErrLinkedDirectory": "pkg/osutil: tampering guard, surfaced by the calling operation's own error",
+
 		// gRPC broker errors caught at broker/stream level
 		"ErrResourceExhausted": "pkg/grpcbroker: gRPC message size error, caught in broker send/recv handlers",
 	}

--- a/cli/azd/pkg/extensions/manager.go
+++ b/cli/azd/pkg/extensions/manager.go
@@ -694,8 +694,19 @@ func (m *Manager) installInternal(
 			return nil, err
 		}
 
+		if err := requireRealExtensionDirs(targetDir); err != nil {
+			return nil, err
+		}
+
 		if err := os.MkdirAll(targetDir, osutil.PermissionDirectory); err != nil {
 			return nil, fmt.Errorf("failed to create target directory: %w", err)
+		}
+
+		// Checked again after the create: MkdirAll follows an existing link and
+		// succeeds, so the pre-check above is what catches a link that was already
+		// there, and this one catches a link swapped in during the create.
+		if err := requireRealExtensionDirs(targetDir); err != nil {
+			return nil, err
 		}
 
 		// Clear anything a previous removal had to leave behind while its process was

--- a/cli/azd/pkg/extensions/manager.go
+++ b/cli/azd/pkg/extensions/manager.go
@@ -33,11 +33,21 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
+	"github.com/azure/azure-dev/cli/azd/pkg/processutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/rzip"
 )
 
 const (
 	extensionRegistryUrl = "https://aka.ms/azd/extensions/registry"
+
+	// extensionsDirName is the directory under the user config directory that holds every
+	// installed extension.
+	extensionsDirName = "extensions"
+
+	// trashDirName holds files that had to be moved aside because a running process kept
+	// them open. It is a sibling of the extension directories rather than a child, so
+	// relocating into it actually empties the directory being removed.
+	trashDirName = ".trash"
 )
 
 var (
@@ -45,6 +55,7 @@ var (
 	ErrInstalledExtensionNotFound = errors.New("extension not found")
 	ErrRegistryExtensionNotFound  = errors.New("extension not found in registry")
 	ErrExtensionInstalled         = errors.New("extension already installed")
+	ErrInvalidExtensionId         = errors.New("invalid extension id")
 )
 
 // DependencyNotFoundError indicates that a required dependency of an extension
@@ -678,10 +689,18 @@ func (m *Manager) installInternal(
 			return nil, fmt.Errorf("failed to get user config directory: %w", err)
 		}
 
-		targetDir := filepath.Join(userConfigDir, "extensions", extension.Id)
-		if err := os.MkdirAll(targetDir, os.ModePerm); err != nil {
+		targetDir, trashDir, err := extensionPaths(userConfigDir, extension.Id)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := os.MkdirAll(targetDir, osutil.PermissionDirectory); err != nil {
 			return nil, fmt.Errorf("failed to create target directory: %w", err)
 		}
+
+		// Clear anything a previous removal had to leave behind while its process was
+		// still running. Best effort: whatever is still locked stays for a later run.
+		osutil.SweepTrash(ctx, trashDir)
 
 		// Step 6: Copy the artifact to the target directory
 		// Check if artifact is a zip file, if so extract it to the target directory
@@ -781,44 +800,6 @@ func (m *Manager) installInternal(
 	return selectedVersion, nil
 }
 
-// Uninstall uninstalls an extension by name.
-func (m *Manager) Uninstall(ctx context.Context, id string) error {
-	// Get the installed extension
-	extension, err := m.GetInstalled(FilterOptions{Id: id})
-	if err != nil {
-		return fmt.Errorf("failed to get installed extension: %w", err)
-	}
-
-	userConfigDir, err := config.GetUserConfigDir()
-	if err != nil {
-		return fmt.Errorf("failed to get user config directory: %w", err)
-	}
-
-	extensionDir := filepath.Join(userConfigDir, "extensions", extension.Id)
-	if err := osutil.RemoveAll(ctx, extensionDir); err != nil {
-		return fmt.Errorf("failed to remove extension: %w", err)
-	}
-
-	// Update the user config
-	extensions, err := m.ListInstalled()
-	if err != nil {
-		return fmt.Errorf("failed to list installed extensions: %w", err)
-	}
-
-	delete(extensions, id)
-
-	if err := m.userConfig.Set(installedConfigKey, extensions); err != nil {
-		return fmt.Errorf("failed to set extensions section: %w", err)
-	}
-
-	if err := m.configManager.Save(m.userConfig); err != nil {
-		return fmt.Errorf("failed to save user config: %w", err)
-	}
-
-	log.Printf("Extension '%s' uninstalled successfully\n", id)
-	return nil
-}
-
 // UpgradeOptions controls how Manager.Upgrade behaves.
 type UpgradeOptions struct {
 	// VersionPreference is the version constraint or exact tag to install.
@@ -835,6 +816,12 @@ type UpgradeOptions struct {
 	// upgrade performs, so `--no-dependencies` behaves the same whether the
 	// extension is being installed fresh or over an existing install.
 	SkipDependencies bool
+	// Force stops processes running out of the extension's install directory so the
+	// upgraded version takes effect immediately instead of after the next restart.
+	Force bool
+	// OnProcessStopped, when set, is called once for each process stopped because of
+	// Force.
+	OnProcessStopped func(processutil.ProcessInfo)
 }
 
 // DefaultUpgradeOptions returns UpgradeOptions with dependency upgrades enabled.
@@ -893,7 +880,10 @@ func (m *Manager) upgradeInternal(
 	opts UpgradeOptions,
 	visited map[string]struct{},
 ) (*ExtensionVersion, []UpgradeResult, error) {
-	if err := m.Uninstall(ctx, extension.Id); err != nil {
+	if err := m.uninstallInternal(ctx, extension.Id, UninstallOptions{
+		Force:            opts.Force,
+		OnProcessStopped: opts.OnProcessStopped,
+	}); err != nil {
 		return nil, nil, fmt.Errorf("failed to uninstall extension: %w", err)
 	}
 
@@ -1066,10 +1056,15 @@ func (m *Manager) evaluateDependencyChanges(
 			fields.ExtensionDependencyOf.String(parentExtension.Id),
 		)
 
+		// Force and the stop callback must ride along. A dependency's process holds a
+		// file lock exactly like a top level extension's does, so dropping them here
+		// would make --force silently cover only part of what the user asked for.
 		childOpts := UpgradeOptions{
 			VersionPreference:   dep.Version,
 			UpgradeDependencies: opts.UpgradeDependencies,
 			AzdVersion:          opts.AzdVersion,
+			Force:               opts.Force,
+			OnProcessStopped:    opts.OnProcessStopped,
 		}
 
 		childVersion, nested, upErr := m.upgradeInternal(childCtx, childMetadata, childOpts, visited)
@@ -1399,7 +1394,11 @@ func (m *Manager) fetchAndCacheMetadata(
 		return fmt.Errorf("failed to get user config directory: %w", err)
 	}
 
-	extensionDir := filepath.Join(userConfigDir, "extensions", extension.Id)
+	extensionDir, _, err := extensionPaths(userConfigDir, extension.Id)
+	if err != nil {
+		return err
+	}
+
 	metadataPath := filepath.Join(extensionDir, metadataFileName)
 
 	// Check if metadata.json already exists (pre-packaged)
@@ -1466,7 +1465,11 @@ func (m *Manager) LoadMetadata(extensionId string) (*ExtensionCommandMetadata, e
 		return nil, fmt.Errorf("failed to get user config directory: %w", err)
 	}
 
-	extensionDir := filepath.Join(userConfigDir, "extensions", extensionId)
+	extensionDir, _, err := extensionPaths(userConfigDir, extensionId)
+	if err != nil {
+		return nil, err
+	}
+
 	metadataPath := filepath.Join(extensionDir, metadataFileName)
 
 	data, err := os.ReadFile(metadataPath)
@@ -1492,7 +1495,11 @@ func (m *Manager) DeleteMetadata(extensionId string) error {
 		return fmt.Errorf("failed to get user config directory: %w", err)
 	}
 
-	extensionDir := filepath.Join(userConfigDir, "extensions", extensionId)
+	extensionDir, _, err := extensionPaths(userConfigDir, extensionId)
+	if err != nil {
+		return err
+	}
+
 	metadataPath := filepath.Join(extensionDir, metadataFileName)
 
 	if err := os.Remove(metadataPath); err != nil {
@@ -1512,7 +1519,11 @@ func (m *Manager) MetadataExists(extensionId string) bool {
 		return false
 	}
 
-	extensionDir := filepath.Join(userConfigDir, "extensions", extensionId)
+	extensionDir, _, err := extensionPaths(userConfigDir, extensionId)
+	if err != nil {
+		return false
+	}
+
 	metadataPath := filepath.Join(extensionDir, metadataFileName)
 
 	_, err = os.Stat(metadataPath)

--- a/cli/azd/pkg/extensions/manager_uninstall.go
+++ b/cli/azd/pkg/extensions/manager_uninstall.go
@@ -1,0 +1,260 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package extensions
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"path/filepath"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/processutil"
+)
+
+// UninstallOptions controls how Manager.Uninstall behaves.
+type UninstallOptions struct {
+	// Force stops processes that are running out of the extension's install directory
+	// when they would otherwise block its removal. Only executables inside that directory
+	// are ever candidates, so nothing else on the machine is affected.
+	Force bool
+
+	// OnProcessStopped, when set, is called once for each process stopped because of
+	// Force. It lets callers report what was stopped without Uninstall needing a return
+	// value that every caller has to thread through.
+	OnProcessStopped func(processutil.ProcessInfo)
+}
+
+// Uninstall uninstalls an extension by name.
+//
+// Removal succeeds even when the extension is running. Files that a live process holds
+// open are moved aside rather than deleted, which is enough to empty and remove the
+// extension directory. Those leftovers are swept on a later extension operation once the
+// process exits. Use UninstallWithOptions to stop the extension's processes first, so
+// the removal is complete rather than deferred.
+func (m *Manager) Uninstall(ctx context.Context, id string) error {
+	return m.uninstallInternal(ctx, id, UninstallOptions{})
+}
+
+// UninstallWithOptions uninstalls an extension by name, honoring UninstallOptions.
+func (m *Manager) UninstallWithOptions(ctx context.Context, id string, opts UninstallOptions) error {
+	return m.uninstallInternal(ctx, id, opts)
+}
+
+func (m *Manager) uninstallInternal(ctx context.Context, id string, opts UninstallOptions) error {
+	// Get the installed extension
+	extension, err := m.GetInstalled(FilterOptions{Id: id})
+	if err != nil {
+		return fmt.Errorf("failed to get installed extension: %w", err)
+	}
+
+	userConfigDir, err := config.GetUserConfigDir()
+	if err != nil {
+		return fmt.Errorf("failed to get user config directory: %w", err)
+	}
+
+	extensionDir, trashDir, err := extensionPaths(userConfigDir, extension.Id)
+	if err != nil {
+		return err
+	}
+
+	// Clear anything an earlier run had to leave behind before potentially adding to it.
+	osutil.SweepTrash(ctx, trashDir)
+
+	if opts.Force {
+		if err := stopExtensionProcesses(ctx, extensionDir, opts.OnProcessStopped); err != nil {
+			return err
+		}
+	}
+
+	if err := osutil.RemoveAllWithRelocation(ctx, extensionDir, trashDir); err != nil {
+		return extensionRemovalError(ctx, extensionDir, opts.Force, err)
+	}
+
+	// A file held open at the moment of removal was moved aside rather than deleted.
+	// Windows releases a terminated process's image a short moment after the process
+	// object goes away, so sweeping again here usually clears what was just relocated
+	// instead of leaving it for the next command to find.
+	osutil.SweepTrash(ctx, trashDir)
+
+	// Update the user config
+	extensions, err := m.ListInstalled()
+	if err != nil {
+		return fmt.Errorf("failed to list installed extensions: %w", err)
+	}
+
+	delete(extensions, id)
+
+	if err := m.userConfig.Set(installedConfigKey, extensions); err != nil {
+		return fmt.Errorf("failed to set extensions section: %w", err)
+	}
+
+	if err := m.configManager.Save(m.userConfig); err != nil {
+		return fmt.Errorf("failed to save user config: %w", err)
+	}
+
+	log.Printf("Extension '%s' uninstalled successfully\n", id)
+	return nil
+}
+
+// extensionPaths resolves the install and trash directories for an extension id, refusing
+// any id that is not a single directory name directly under the extensions root.
+//
+// Extension ids come from registry JSON and are persisted verbatim, so nothing upstream
+// guarantees they are safe path components. filepath.Join cleans its result, which means
+// an id like ".." silently resolves to a directory outside the extensions root and no
+// later containment check can tell the difference. That matters most for --force, which
+// hands this directory to process termination, but it also guards the removal path.
+func extensionPaths(userConfigDir string, id string) (extensionDir string, trashDir string, err error) {
+	if err := validateExtensionId(id); err != nil {
+		return "", "", err
+	}
+
+	extensionsRoot := filepath.Join(userConfigDir, extensionsDirName)
+	extensionDir = filepath.Join(extensionsRoot, id)
+
+	// Requiring the parent to be exactly the extensions root rejects traversal ("..",
+	// "a/b") and the empty or dot ids that would otherwise resolve to the root itself.
+	// A containment check alone accepts all of those.
+	if filepath.Dir(extensionDir) != extensionsRoot {
+		return "", "", fmt.Errorf(
+			"%w: %q must be a single directory name", ErrInvalidExtensionId, id)
+	}
+
+	return extensionDir, filepath.Join(extensionsRoot, trashDirName), nil
+}
+
+// validateExtensionId rejects ids that cannot safely become a directory name, before the
+// id is ever joined onto a path.
+//
+// The lexical parent check in extensionPaths is necessary but not sufficient on Windows,
+// because Win32 silently strips trailing dots and spaces from path components. Go's
+// filepath package does not model that, so filepath.Base(".trash.") is ".trash.", which
+// slips past a comparison against the reserved name while the operating system creates,
+// walks, and deletes the real ".trash" directory. The same aliasing lets the id "foo."
+// resolve onto a different extension's directory, so an uninstall of one id can remove
+// another extension's files. Verified on Windows 11: MkdirAll of ".trash.", ".trash ",
+// "foo." and "foo.." all produce ".trash" and "foo".
+//
+// Ids are matched against what a path component may contain rather than against a list of
+// known-bad shapes, so a form nobody thought of fails closed.
+func validateExtensionId(id string) error {
+	invalid := func(reason string) error {
+		return fmt.Errorf("%w: %q %s", ErrInvalidExtensionId, id, reason)
+	}
+
+	if id == "" || id == "." || id == ".." {
+		return invalid("must be a single directory name")
+	}
+
+	if strings.ContainsAny(id, `/\:`) {
+		return invalid("must not contain a path separator or drive letter")
+	}
+
+	for _, r := range id {
+		if r < 0x20 || r == 0x7f {
+			return invalid("must not contain control characters")
+		}
+	}
+
+	// Windows resolves these away, so the name azd checks is not the name it operates on.
+	if trimmed := strings.TrimRight(id, ". "); trimmed != id {
+		return invalid("must not end with a dot or space")
+	}
+
+	if strings.EqualFold(id, trashDirName) {
+		return invalid("is reserved")
+	}
+
+	// Reserved device names resolve to devices rather than files, with or without an
+	// extension, so "CON" and "CON.exe" are both refused.
+	base, _, _ := strings.Cut(id, ".")
+	if _, reserved := windowsDeviceNames[strings.ToUpper(base)]; reserved {
+		return invalid("is a reserved device name")
+	}
+
+	return nil
+}
+
+// windowsDeviceNames are the legacy DOS device names Windows still resolves in any
+// directory. They are rejected on every platform so an extension id cannot behave
+// differently depending on where azd runs.
+var windowsDeviceNames = map[string]struct{}{
+	"CON": {}, "PRN": {}, "AUX": {}, "NUL": {},
+	"COM0": {}, "COM1": {}, "COM2": {}, "COM3": {}, "COM4": {},
+	"COM5": {}, "COM6": {}, "COM7": {}, "COM8": {}, "COM9": {},
+	"LPT0": {}, "LPT1": {}, "LPT2": {}, "LPT3": {}, "LPT4": {},
+	"LPT5": {}, "LPT6": {}, "LPT7": {}, "LPT8": {}, "LPT9": {},
+}
+
+// stopExtensionProcesses stops every process running out of the extension's install
+// directory, reporting each one through onStopped as it goes.
+//
+// Discovery is scoped to extensionDir, so a process is only ever a candidate when its
+// executable image lives inside the extension azd is operating on. Child processes the
+// extension spawned are deliberately left alone: their executables live elsewhere, which
+// puts them outside the containment guarantee that makes stopping anything defensible.
+func stopExtensionProcesses(
+	ctx context.Context,
+	extensionDir string,
+	onStopped func(processutil.ProcessInfo),
+) error {
+	running, err := processutil.FindByExecutableDir(ctx, extensionDir)
+	if err != nil {
+		return fmt.Errorf("failed to find running extension processes: %w", err)
+	}
+
+	for _, process := range running {
+		stopped, err := processutil.Terminate(ctx, process, extensionDir, processutil.DefaultGracePeriod)
+		if err != nil {
+			return fmt.Errorf("failed to stop %s: %w", process, err)
+		}
+
+		// A process that exited on its own between discovery and termination is fine,
+		// but azd did not stop it and must not claim it did.
+		if !stopped {
+			log.Printf("%s already exited before it could be stopped\n", process)
+
+			continue
+		}
+
+		log.Printf("stopped %s to release files in %s\n", process, extensionDir)
+
+		if onStopped != nil {
+			onStopped(process)
+		}
+	}
+
+	return nil
+}
+
+// extensionRemovalError turns a failed removal into something the user can act on.
+//
+// A bare "Access is denied" says nothing about what is holding the files, so the blocking
+// processes are named when they can be found, and --force is suggested when it was not
+// already used.
+func extensionRemovalError(ctx context.Context, extensionDir string, forced bool, cause error) error {
+	running, err := processutil.FindByExecutableDir(ctx, extensionDir)
+	if err != nil || len(running) == 0 {
+		return fmt.Errorf("failed to remove extension: %w", cause)
+	}
+
+	if forced {
+		return &internal.ErrorWithSuggestion{
+			Err: fmt.Errorf("failed to remove extension, still in use by %s: %w",
+				processutil.Describe(running), cause),
+			Suggestion: "Stop the listed processes and run the command again.",
+		}
+	}
+
+	return &internal.ErrorWithSuggestion{
+		Err: fmt.Errorf("failed to remove extension, in use by %s: %w",
+			processutil.Describe(running), cause),
+		Suggestion: "Re-run with --force to stop those processes automatically, " +
+			"or stop them yourself and try again.",
+	}
+}

--- a/cli/azd/pkg/extensions/manager_uninstall.go
+++ b/cli/azd/pkg/extensions/manager_uninstall.go
@@ -62,6 +62,12 @@ func (m *Manager) uninstallInternal(ctx context.Context, id string, opts Uninsta
 		return err
 	}
 
+	// Checked before anything reads, deletes, or terminates against these paths, so a
+	// link planted at either directory cannot redirect the removal or the kill scope.
+	if err := requireRealExtensionDirs(extensionDir); err != nil {
+		return err
+	}
+
 	// Clear anything an earlier run had to leave behind before potentially adding to it.
 	osutil.SweepTrash(ctx, trashDir)
 
@@ -126,6 +132,27 @@ func extensionPaths(userConfigDir string, id string) (extensionDir string, trash
 	}
 
 	return extensionDir, filepath.Join(extensionsRoot, trashDirName), nil
+}
+
+// requireRealExtensionDirs refuses to operate when either directory azd owns under the
+// user config directory has been replaced by a symlink or junction.
+//
+// osutil.RequireRealDir deliberately inspects only a path's final component, so checking
+// the extension directory alone is not enough: when the extensions root itself is a link,
+// the operating system resolves it while walking to the final component and the check
+// passes against the link target. Everything downstream then follows: the termination
+// scope widens to whatever the link points at, the trash sweep deletes children there,
+// and an install writes there. Both components azd creates therefore have to be checked.
+//
+// Only those two are checked. Symlinked ancestors above the config directory stay legal,
+// which macOS requires: its configuration directory sits under /var while processes
+// report their executables under /private/var.
+func requireRealExtensionDirs(extensionDir string) error {
+	if err := osutil.RequireRealDir(filepath.Dir(extensionDir)); err != nil {
+		return err
+	}
+
+	return osutil.RequireRealDir(extensionDir)
 }
 
 // validateExtensionId rejects ids that cannot safely become a directory name, before the

--- a/cli/azd/pkg/extensions/manager_uninstall.go
+++ b/cli/azd/pkg/extensions/manager_uninstall.go
@@ -264,24 +264,53 @@ func stopExtensionProcesses(
 // A bare "Access is denied" says nothing about what is holding the files, so the blocking
 // processes are named when they can be found, and --force is suggested when it was not
 // already used.
+//
+// Message is set deliberately. ux.ErrorWithSuggestion promotes the whole wrapped error to
+// the red ERROR: line when Message is empty, which puts the filesystem cause first and
+// buries the process names behind it. Setting Message leads with the readable sentence and
+// demotes the cause to the grey technical block, while Err keeps it for logs and %w.
 func extensionRemovalError(ctx context.Context, extensionDir string, forced bool, cause error) error {
 	running, err := processutil.FindByExecutableDir(ctx, extensionDir)
 	if err != nil || len(running) == 0 {
-		return fmt.Errorf("failed to remove extension: %w", cause)
+		// Nothing the extension owns is holding the files. Discovery is deliberately scoped
+		// to the extension binary itself, so the holder here is something else: a tool the
+		// extension started, an antivirus scanner, an indexer, or a shell preview handler.
+		// --force only stops processes this discovery returns, so suggesting it would send
+		// the user down a path that cannot help, whether or not it was already passed.
+		return &internal.ErrorWithSuggestion{
+			Message: "Cannot remove extension because a file in its directory is held open by another program.",
+			Err:     fmt.Errorf("failed to remove extension: %w", cause),
+			Suggestion: "Close any program that might be using the extension's files, " +
+				"then run the command again.",
+		}
 	}
+
+	described := processutil.Describe(running)
 
 	if forced {
 		return &internal.ErrorWithSuggestion{
+			Message: removalMessage(running, described, "is still in use by"),
 			Err: fmt.Errorf("failed to remove extension, still in use by %s: %w",
-				processutil.Describe(running), cause),
+				described, cause),
 			Suggestion: "Stop the listed processes and run the command again.",
 		}
 	}
 
 	return &internal.ErrorWithSuggestion{
+		Message: removalMessage(running, described, "is currently in use by"),
 		Err: fmt.Errorf("failed to remove extension, in use by %s: %w",
-			processutil.Describe(running), cause),
+			described, cause),
 		Suggestion: "Re-run with --force to stop those processes automatically, " +
 			"or stop them yourself and try again.",
 	}
+}
+
+// removalMessage builds the user-facing sentence for a blocked removal, naming the binary
+// that is held open when it is known so the user can identify what to stop.
+func removalMessage(running []processutil.ProcessInfo, described string, phrase string) string {
+	if executables := processutil.DescribeExecutables(running); executables != "" {
+		return fmt.Sprintf("Cannot remove extension because %s %s %s.", executables, phrase, described)
+	}
+
+	return fmt.Sprintf("Cannot remove extension because it %s %s.", phrase, described)
 }

--- a/cli/azd/pkg/extensions/manager_uninstall_test.go
+++ b/cli/azd/pkg/extensions/manager_uninstall_test.go
@@ -1,0 +1,654 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package extensions
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/internal"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/processutil"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/azure/azure-dev/cli/azd/test/proctest"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// discoveryTimeout is how long a freshly started helper is given to show up in
+	// process enumeration.
+	discoveryTimeout = 30 * time.Second
+
+	// discoveryPollInterval is how often process enumeration is retried while waiting.
+	discoveryPollInterval = 100 * time.Millisecond
+
+	// trashSweepTimeout bounds how long a test waits for the operating system to release
+	// a terminated process's executable image so relocated files become deletable.
+	trashSweepTimeout = 10 * time.Second
+)
+
+func TestMain(m *testing.M) {
+	if proctest.RunRequestedHelper() {
+		return
+	}
+
+	os.Exit(m.Run())
+}
+
+// installedExtensionFixture is a registered extension whose directory contains a real
+// running executable, which is the situation that makes upgrade and uninstall fail today.
+type installedExtensionFixture struct {
+	manager      *Manager
+	id           string
+	extensionDir string
+	trashDir     string
+	process      *proctest.Handle
+}
+
+// newRunningExtension registers an extension in user config, places a real executable in
+// its install directory, and starts it.
+//
+// Only a genuine process gives the operating system semantics that matter here: on
+// Windows the running image cannot be deleted, and on every platform the process has to
+// be discoverable by executable path.
+func newRunningExtension(t *testing.T, id string) *installedExtensionFixture {
+	t.Helper()
+
+	configDir := isolatedConfigDir(t)
+	extensionDir := filepath.Join(configDir, extensionsDirName, id)
+	require.NoError(t, os.MkdirAll(extensionDir, osutil.PermissionDirectory))
+
+	process := proctest.StartIn(t, extensionDir, helperExecutableBaseName(id), proctest.ModeIdle)
+
+	manager := newTestManager(t)
+	require.NoError(t, manager.userConfig.Set(installedConfigKey, map[string]*Extension{
+		id: {
+			Id:      id,
+			Version: "1.0.0",
+			Path:    filepath.Join(extensionsDirName, id, filepath.Base(process.Path)),
+		},
+	}))
+
+	requireDiscoverable(t, extensionDir, process.PID)
+
+	return &installedExtensionFixture{
+		manager:      manager,
+		id:           id,
+		extensionDir: extensionDir,
+		trashDir:     filepath.Join(configDir, extensionsDirName, trashDirName),
+		process:      process,
+	}
+}
+
+// isolatedConfigDir redirects azd configuration at a temporary directory and proves the
+// redirect took effect, so a failing test can never write into or delete from the
+// developer's real configuration.
+func isolatedConfigDir(t *testing.T) string {
+	t.Helper()
+
+	configDir := t.TempDir()
+	t.Setenv("AZD_CONFIG_DIR", configDir)
+
+	resolved, err := config.GetUserConfigDir()
+	require.NoError(t, err)
+	require.Equal(t, configDir, resolved)
+
+	return configDir
+}
+
+// requireDiscoverable asserts the process is visible through the same lookup azd uses, so
+// a test that later claims "--force stopped it" cannot pass vacuously against a process
+// that was never found in the first place.
+func requireDiscoverable(t *testing.T, extensionDir string, pid int) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		running, err := processutil.FindByExecutableDir(t.Context(), extensionDir)
+		if err != nil {
+			return false
+		}
+
+		for _, process := range running {
+			if process.PID == pid {
+				return true
+			}
+		}
+
+		return false
+	}, discoveryTimeout, discoveryPollInterval, "extension process never became discoverable")
+}
+
+// helperExecutableBaseName derives a per-extension executable name, so process
+// enumeration can attribute a match to the extension it came from.
+func helperExecutableBaseName(id string) string {
+	return "azd-ext-" + strings.ReplaceAll(id, ".", "-")
+}
+
+// helperExecutableName is the on-disk file name of the stand-in extension executable.
+func helperExecutableName(id string) string {
+	return proctest.ExecutableName(helperExecutableBaseName(id))
+}
+
+// T25: the default path. Uninstall must succeed while the extension is running, which is
+// exactly what fails today with a bare access denied on Windows.
+func TestUninstall_SucceedsWithLockedBinary(t *testing.T) {
+	fixture := newRunningExtension(t, "test.running")
+
+	require.NoError(t, fixture.manager.Uninstall(t.Context(), fixture.id))
+	require.NoDirExists(t, fixture.extensionDir,
+		"the extension directory must be gone even though the extension is running")
+
+	installed, err := fixture.manager.ListInstalled()
+	require.NoError(t, err)
+	require.NotContains(t, installed, fixture.id)
+
+	// The default path is non-destructive: the running process is left alone.
+	require.False(t, fixture.process.HasExited(), "uninstall without --force must not stop anything")
+}
+
+// T26 and T30: with Force the extension's own processes are stopped before removal, so
+// the removal is complete rather than deferred, and each stopped process is reported.
+func TestUninstall_ForceTerminatesProcesses(t *testing.T) {
+	fixture := newRunningExtension(t, "test.forced")
+
+	var stopped []processutil.ProcessInfo
+	err := fixture.manager.UninstallWithOptions(t.Context(), fixture.id, UninstallOptions{
+		Force: true,
+		OnProcessStopped: func(process processutil.ProcessInfo) {
+			stopped = append(stopped, process)
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoDirExists(t, fixture.extensionDir)
+	fixture.process.RequireStopped(t)
+
+	// The stopped process is reported, so the user can see what azd did on their behalf
+	// rather than having it happen silently.
+	require.Len(t, stopped, 1)
+	require.Equal(t, fixture.process.PID, stopped[0].PID)
+	require.Equal(t, helperExecutableName(fixture.id), stopped[0].Name)
+	require.Contains(t, stopped[0].String(), "PID")
+
+	// A forced removal must not leave anything permanent behind. Anything moved aside
+	// because the operating system had not finished releasing the terminated process is
+	// deletable once it has, so a sweep clears it rather than it lingering forever.
+	require.Eventually(t, func() bool {
+		osutil.SweepTrash(t.Context(), fixture.trashDir)
+
+		_, err := os.Stat(fixture.trashDir)
+
+		return errors.Is(err, os.ErrNotExist)
+	}, trashSweepTimeout, discoveryPollInterval, "forced uninstall left permanent trash behind")
+}
+
+// T29: without Force, azd must never terminate anything. This is the safety default and
+// the reason the destructive behavior is opt-in.
+func TestUninstall_NoForceNeverTerminates(t *testing.T) {
+	fixture := newRunningExtension(t, "test.untouched")
+
+	called := false
+	err := fixture.manager.UninstallWithOptions(t.Context(), fixture.id, UninstallOptions{
+		OnProcessStopped: func(processutil.ProcessInfo) {
+			called = true
+		},
+	})
+	require.NoError(t, err)
+
+	require.False(t, called, "no process should be reported as stopped without --force")
+	require.False(t, fixture.process.HasExited(), "the extension process must survive")
+}
+
+// T28: a blocked removal must say what is holding the files and how to get past it,
+// instead of surfacing a bare permission error.
+func TestUninstall_BlockedErrorNamesProcesses(t *testing.T) {
+	fixture := newRunningExtension(t, "test.blocked")
+
+	cause := os.ErrPermission
+
+	unforced := extensionRemovalError(t.Context(), fixture.extensionDir, false, cause)
+	require.ErrorIs(t, unforced, cause)
+	require.ErrorContains(t, unforced, helperExecutableName(fixture.id))
+	require.ErrorContains(t, unforced, "PID")
+	require.Contains(t, suggestionOf(t, unforced), "--force",
+		"an unforced failure should point at the flag that resolves it")
+
+	forced := extensionRemovalError(t.Context(), fixture.extensionDir, true, cause)
+	require.ErrorIs(t, forced, cause)
+	require.ErrorContains(t, forced, helperExecutableName(fixture.id))
+	require.NotContains(t, suggestionOf(t, forced), "--force",
+		"suggesting --force to someone who already used it is not actionable")
+}
+
+// A removal that failed for a reason other than a running process must not be dressed up
+// as one, or the guidance would send the user chasing a process that does not exist.
+func TestUninstall_BlockedErrorWithoutProcesses(t *testing.T) {
+	t.Parallel()
+
+	err := extensionRemovalError(t.Context(), filepath.Join(t.TempDir(), "empty"), false, os.ErrPermission)
+	require.ErrorIs(t, err, os.ErrPermission)
+	require.ErrorContains(t, err, "failed to remove extension")
+	require.NotContains(t, err.Error(), "--force")
+}
+
+// stopExtensionProcesses must refuse an unscoped directory rather than ranging wider than
+// the extension it was asked about.
+func TestStopExtensionProcesses_RejectsUnscopedDirectory(t *testing.T) {
+	t.Parallel()
+
+	require.ErrorIs(t, stopExtensionProcesses(t.Context(), "", nil), processutil.ErrEmptyDirectory)
+
+	root := "/"
+	if runtime.GOOS == "windows" {
+		root = `C:\`
+	}
+
+	require.ErrorIs(t, stopExtensionProcesses(t.Context(), root, nil), processutil.ErrRootDirectory)
+}
+
+// A directory with nothing running in it is a no-op, not an error.
+func TestStopExtensionProcesses_NoProcesses(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	err := stopExtensionProcesses(t.Context(), t.TempDir(), func(processutil.ProcessInfo) {
+		called = true
+	})
+
+	require.NoError(t, err)
+	require.False(t, called)
+}
+
+// The extension id decides which directory azd deletes and, under --force, which
+// directory scopes process termination. Ids come from registry JSON, so a traversing id
+// must be refused at the choke point rather than relied on to be well formed.
+func TestExtensionPaths_RejectsUnsafeIds(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	unsafe := []struct {
+		name string
+		id   string
+	}{
+		{"parent traversal", ".."},
+		{"repeated traversal", filepath.Join("..", "..")},
+		{"traversal into a sibling tree", filepath.Join("..", "..", "Program Files", "App")},
+		{"nested path", filepath.Join("a", "b")},
+		{"empty", ""},
+		{"dot", "."},
+		{"reserved trash directory", trashDirName},
+		{"reserved trash directory, different case", strings.ToUpper(trashDirName)},
+
+		// Windows strips trailing dots and spaces from a path component, so these all
+		// resolve onto a directory whose name is not the one checked above. Verified on
+		// Windows 11: MkdirAll of each of these produces the stripped name.
+		{"reserved trash directory, trailing dot", trashDirName + "."},
+		{"reserved trash directory, trailing space", trashDirName + " "},
+		{"trailing dot", "test.demo."},
+		{"trailing dots", "test.demo.."},
+		{"trailing space", "test.demo "},
+
+		{"drive letter", "C:"},
+		{"alternate data stream", "test.demo:stream"},
+		{"null byte", "test\x00demo"},
+		{"control character", "test\tdemo"},
+
+		// Reserved device names resolve to a device rather than a directory in any
+		// location, with or without an extension.
+		{"reserved device name", "CON"},
+		{"reserved device name, different case", "nul"},
+		{"reserved device name with an extension", "COM1.exe"},
+	}
+
+	for _, testCase := range unsafe {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := extensionPaths(root, testCase.id)
+			require.ErrorIs(t, err, ErrInvalidExtensionId,
+				"id %q must not resolve to a usable directory", testCase.id)
+		})
+	}
+}
+
+// A normal id must still resolve, and it must land directly under the extensions root
+// alongside the trash directory it will be swept into.
+func TestExtensionPaths_AcceptsNormalId(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	extensionsRoot := filepath.Join(root, extensionsDirName)
+
+	extensionDir, trashDir, err := extensionPaths(root, "microsoft.azd.demo")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(extensionsRoot, "microsoft.azd.demo"), extensionDir)
+	require.Equal(t, filepath.Join(extensionsRoot, trashDirName), trashDir)
+}
+
+// Aliasing works in both directions: rejecting "test.demo." is only useful because
+// "test.demo" is a real id that another extension may already own. Without the trailing
+// character check, uninstalling one would remove the other's files.
+func TestExtensionPaths_AliasedIdWouldResolveOntoAnotherExtension(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	victim, _, err := extensionPaths(root, "test.demo")
+	require.NoError(t, err)
+
+	_, _, err = extensionPaths(root, "test.demo.")
+	require.ErrorIs(t, err, ErrInvalidExtensionId)
+
+	// The rejected id would have resolved onto exactly the victim's directory, because
+	// Windows discards the trailing dot when it creates or opens the path.
+	require.Equal(t, victim, filepath.Join(root, extensionsDirName, "test.demo"))
+}
+
+// T27: Force has to survive the trip from UpgradeOptions through upgradeInternal into the
+// uninstall step, or the flag would be accepted on upgrade and quietly do nothing. This
+// drives a real upgrade rather than the uninstall it delegates to.
+func TestUpgrade_PropagatesForce(t *testing.T) {
+	fixture := newUpgradableExtension(t, "test.upgrade-forced")
+
+	var stopped []processutil.ProcessInfo
+	_, _, err := fixture.manager.Upgrade(t.Context(), fixture.metadata, UpgradeOptions{
+		VersionPreference: "2.0.0",
+		SkipDependencies:  true,
+		Force:             true,
+		OnProcessStopped: func(process processutil.ProcessInfo) {
+			stopped = append(stopped, process)
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, stopped, 1, "the upgrade path must forward Force into the uninstall step")
+	require.Equal(t, fixture.process.PID, stopped[0].PID)
+	fixture.process.RequireStopped(t)
+
+	upgraded, err := fixture.manager.GetInstalled(FilterOptions{Id: fixture.id})
+	require.NoError(t, err)
+	require.Equal(t, "2.0.0", upgraded.Version)
+}
+
+// The headline fix: an upgrade must succeed while the extension is running, without
+// --force and without stopping anything. This is the case that fails today.
+func TestUpgrade_SucceedsWhileExtensionIsRunning(t *testing.T) {
+	fixture := newUpgradableExtension(t, "test.upgrade-running")
+
+	called := false
+	_, _, err := fixture.manager.Upgrade(t.Context(), fixture.metadata, UpgradeOptions{
+		VersionPreference: "2.0.0",
+		SkipDependencies:  true,
+		OnProcessStopped: func(processutil.ProcessInfo) {
+			called = true
+		},
+	})
+	require.NoError(t, err)
+
+	require.False(t, called, "the default upgrade must not stop anything")
+	require.False(t, fixture.process.HasExited(), "the running extension must survive its own upgrade")
+
+	upgraded, err := fixture.manager.GetInstalled(FilterOptions{Id: fixture.id})
+	require.NoError(t, err)
+	require.Equal(t, "2.0.0", upgraded.Version)
+
+	// The newly installed artifact is in place, which is the point of the upgrade.
+	require.FileExists(t, filepath.Join(fixture.extensionDir, upgraded.Version+".txt"))
+}
+
+// upgradableExtension is a genuinely installed extension, backed by a mock registry that
+// offers a newer version, with a real process running out of its install directory.
+type upgradableExtension struct {
+	manager      *Manager
+	metadata     *ExtensionMetadata
+	id           string
+	extensionDir string
+	process      *proctest.Handle
+}
+
+func newUpgradableExtension(t *testing.T, id string) *upgradableExtension {
+	t.Helper()
+
+	configDir := isolatedConfigDir(t)
+	mockContext := mocks.NewMockContext(t.Context())
+
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: id,
+				Versions: []ExtensionVersion{
+					{Version: "1.0.0", Artifacts: versionedArtifacts("1.0.0")},
+					{Version: "2.0.0", Artifacts: versionedArtifacts("2.0.0")},
+				},
+			},
+		},
+	}
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	found, err := manager.FindExtensions(t.Context(), &FilterOptions{Id: id})
+	require.NoError(t, err)
+	require.Len(t, found, 1)
+
+	_, err = manager.InstallWithOptions(t.Context(), found[0], InstallOptions{
+		VersionPreference: "1.0.0",
+		SkipDependencies:  true,
+	})
+	require.NoError(t, err)
+
+	// The registry artifact is inert test data, so a real executable is started from the
+	// installed directory to reproduce a running extension.
+	extensionDir := filepath.Join(configDir, extensionsDirName, id)
+	process := proctest.StartIn(t, extensionDir, helperExecutableBaseName(id), proctest.ModeIdle)
+	requireDiscoverable(t, extensionDir, process.PID)
+
+	return &upgradableExtension{
+		manager:      manager,
+		metadata:     found[0],
+		id:           id,
+		extensionDir: extensionDir,
+		process:      process,
+	}
+}
+
+// A dependency's binary holds a file lock exactly like a top level extension's does, so
+// --force has to reach it too. Before this was wired, upgrading a pack with --force
+// stopped only the parent's processes and left the dependency's running, which made the
+// flag silently cover part of what the user asked for.
+func TestUpgrade_PropagatesForceToDependencies(t *testing.T) {
+	const parentId = "test.pack-forced"
+	const childId = "test.child-forced"
+
+	configDir := isolatedConfigDir(t)
+	mockContext := mocks.NewMockContext(t.Context())
+
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id: parentId,
+				Versions: []ExtensionVersion{
+					{
+						Version:      "1.0.0",
+						Artifacts:    versionedArtifacts("1.0.0"),
+						Dependencies: []ExtensionDependency{{Id: childId, Version: "~1.0.0"}},
+					},
+					{
+						Version:      "2.0.0",
+						Artifacts:    versionedArtifacts("2.0.0"),
+						Dependencies: []ExtensionDependency{{Id: childId, Version: ">=2.0.0"}},
+					},
+				},
+			},
+			{
+				Id: childId,
+				Versions: []ExtensionVersion{
+					{Version: "1.0.0", Artifacts: versionedArtifacts("1.0.0")},
+					{Version: "2.0.0", Artifacts: versionedArtifacts("2.0.0")},
+				},
+			},
+		},
+	}
+
+	manager := registryBackedManager(t, mockContext, registry)
+
+	found, err := manager.FindExtensions(t.Context(), &FilterOptions{Id: parentId})
+	require.NoError(t, err)
+	require.Len(t, found, 1)
+
+	_, err = manager.InstallWithOptions(t.Context(), found[0], InstallOptions{VersionPreference: "1.0.0"})
+	require.NoError(t, err)
+
+	// The process runs out of the dependency's directory, not the parent's, so only a
+	// Force that reaches the child upgrade can stop it.
+	childDir := filepath.Join(configDir, extensionsDirName, childId)
+	childProcess := proctest.StartIn(t, childDir, helperExecutableBaseName(childId), proctest.ModeIdle)
+	requireDiscoverable(t, childDir, childProcess.PID)
+
+	var stopped []processutil.ProcessInfo
+	_, _, err = manager.Upgrade(t.Context(), found[0], UpgradeOptions{
+		VersionPreference:   "2.0.0",
+		UpgradeDependencies: true,
+		Force:               true,
+		OnProcessStopped: func(process processutil.ProcessInfo) {
+			stopped = append(stopped, process)
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, stopped, 1, "--force must reach the dependency upgrade, not just the parent")
+	require.Equal(t, childProcess.PID, stopped[0].PID)
+	childProcess.RequireStopped(t)
+}
+
+// Sweeping happens on the way in as well as the way out. A trash entry left behind by an
+// earlier run (its process now gone) must not survive the next uninstall, otherwise
+// --force would slowly accumulate dead binaries in the user's config directory.
+func TestUninstall_SweepsPreexistingTrash(t *testing.T) {
+	fixture := newRunningExtension(t, "test.uninstall-sweeps-existing")
+	fixture.process.Stop()
+
+	require.NoError(t, os.MkdirAll(fixture.trashDir, 0o755))
+	stale := filepath.Join(fixture.trashDir, "stale-from-a-previous-run.bin")
+	require.NoError(t, os.WriteFile(stale, []byte("dead binary"), 0o600))
+
+	require.NoError(t, fixture.manager.Uninstall(t.Context(), fixture.id))
+
+	require.NoFileExists(t, stale, "uninstall must sweep trash left by an earlier run")
+}
+
+// Install recreates the extension directory, and it sweeps on the way through for the same
+// reason uninstall does. This is the path that finally clears a binary whose process was
+// still holding it when the previous uninstall ran.
+func TestInstall_SweepsPreexistingTrash(t *testing.T) {
+	const id = "test.install-sweeps-existing"
+
+	configDir := isolatedConfigDir(t)
+	mockContext := mocks.NewMockContext(t.Context())
+
+	registry := Registry{
+		Extensions: []*ExtensionMetadata{
+			{
+				Id:       id,
+				Versions: []ExtensionVersion{{Version: "1.0.0", Artifacts: versionedArtifacts("1.0.0")}},
+			},
+		},
+	}
+
+	manager := registryBackedManager(t, mockContext, registry)
+
+	trashDir := filepath.Join(configDir, extensionsDirName, trashDirName)
+	require.NoError(t, os.MkdirAll(trashDir, 0o755))
+	stale := filepath.Join(trashDir, "stale-from-a-previous-run.bin")
+	require.NoError(t, os.WriteFile(stale, []byte("dead binary"), 0o600))
+
+	found, err := manager.FindExtensions(t.Context(), &FilterOptions{Id: id})
+	require.NoError(t, err)
+	require.Len(t, found, 1)
+
+	_, err = manager.InstallWithOptions(t.Context(), found[0], InstallOptions{SkipDependencies: true})
+	require.NoError(t, err)
+
+	require.NoFileExists(t, stale, "install must sweep trash left by an earlier run")
+}
+
+// registryBackedManager builds a Manager whose registry is served from the supplied value,
+// which is the shape every fixture in this file needs.
+func registryBackedManager(t *testing.T, mockContext *mocks.MockContext, registry Registry) *Manager {
+	t.Helper()
+
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return request.URL.String() == extensionRegistryUrl
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, registry)
+	})
+	mockContext.HttpClient.When(func(request *http.Request) bool {
+		return strings.HasPrefix(request.URL.String(), "https://aka.ms/azd/extensions/registry/")
+	}).RespondFn(func(request *http.Request) (*http.Response, error) {
+		return mocks.CreateHttpResponseWithBody(request, http.StatusOK, []byte("test data"))
+	})
+
+	userConfigManager := config.NewUserConfigManager(mockContext.ConfigManager)
+	sourceManager := NewSourceManager(mockContext.Container, userConfigManager, mockContext.HttpClient)
+	lazyRunner := lazy.NewLazy(func() (*Runner, error) {
+		return NewRunner(mockContext.CommandRunner), nil
+	})
+
+	manager, err := NewManager(userConfigManager, sourceManager, lazyRunner, mockContext.HttpClient)
+	require.NoError(t, err)
+
+	return manager
+}
+
+// versionedArtifacts gives each version a distinct artifact filename, so a test can tell
+// by inspection whether the new version actually landed on disk.
+func versionedArtifacts(version string) map[string]ExtensionArtifact {
+	artifacts := map[string]ExtensionArtifact{}
+	for _, platform := range []string{"windows", "linux", "darwin"} {
+		artifacts[platform] = ExtensionArtifact{
+			URL: "https://aka.ms/azd/extensions/registry/test.extension/" + version + ".txt",
+			AdditionalMetadata: map[string]any{
+				"entryPoint": version + ".txt",
+			},
+		}
+	}
+
+	return artifacts
+}
+
+// suggestionOf extracts the actionable guidance attached to an error, if any.
+func suggestionOf(t *testing.T, err error) string {
+	t.Helper()
+
+	if withSuggestion, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
+		return withSuggestion.Suggestion
+	}
+
+	return ""
+}

--- a/cli/azd/pkg/extensions/manager_uninstall_test.go
+++ b/cli/azd/pkg/extensions/manager_uninstall_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -352,6 +353,97 @@ func TestExtensionPaths_AliasedIdWouldResolveOntoAnotherExtension(t *testing.T) 
 	// The rejected id would have resolved onto exactly the victim's directory, because
 	// Windows discards the trailing dot when it creates or opens the path.
 	require.Equal(t, victim, filepath.Join(root, extensionsDirName, "test.demo"))
+}
+
+// linkDirectory creates a directory link at linkPath pointing at target, skipping when
+// the machine will not allow it.
+//
+// Windows needs Developer Mode or elevation for a symlink but allows a junction with
+// neither, and a junction is the more dangerous of the two: filepath.EvalSymlinks refuses
+// to resolve it while the operating system resolves it while walking a longer path.
+func linkDirectory(t *testing.T, linkPath string, target string) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		//nolint:gosec // Fixed executable, arguments are test-controlled temp paths.
+		if out, err := exec.Command("cmd", "/c", "mklink", "/J", linkPath, target).CombinedOutput(); err != nil {
+			t.Skipf("cannot create a directory junction on this machine: %v: %s", err, out)
+		}
+
+		return
+	}
+
+	if err := os.Symlink(target, linkPath); err != nil {
+		t.Skipf("cannot create a symlink on this machine: %v", err)
+	}
+}
+
+// Both directories azd creates have to be checked, not just the extension directory.
+// osutil.RequireRealDir inspects only a path's final component, so when the extensions
+// root itself is a link the operating system resolves it on the way to the final
+// component and a check on the extension directory alone passes against the link target.
+// Everything downstream then follows the link: the removal, the trash sweep, and the
+// process termination scope.
+func TestRequireRealExtensionDirs_RefusesLinkAtEitherComponent(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+
+	target := filepath.Join(base, "elsewhere")
+	require.NoError(t, os.MkdirAll(filepath.Join(target, "test.demo"), osutil.PermissionDirectory))
+
+	realRoot := filepath.Join(base, "real", extensionsDirName)
+	require.NoError(t, os.MkdirAll(filepath.Join(realRoot, "test.demo"), osutil.PermissionDirectory))
+	require.NoError(t, requireRealExtensionDirs(filepath.Join(realRoot, "test.demo")),
+		"two real directories must be accepted")
+
+	// Nothing created yet is still fine: there is no link there to redirect anything.
+	require.NoError(t, requireRealExtensionDirs(filepath.Join(realRoot, "not-installed-yet")))
+
+	linkedExtension := filepath.Join(realRoot, "test.linked")
+	linkDirectory(t, linkedExtension, target)
+	require.ErrorIs(t, requireRealExtensionDirs(linkedExtension), osutil.ErrLinkedDirectory,
+		"a link at the extension directory must be refused")
+
+	linkedRoot := filepath.Join(base, "linked", extensionsDirName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(linkedRoot), osutil.PermissionDirectory))
+	linkDirectory(t, linkedRoot, target)
+
+	throughLink := filepath.Join(linkedRoot, "test.demo")
+	require.NoError(t, osutil.RequireRealDir(throughLink),
+		"a final component check alone cannot see the linked root, which is why it is not enough")
+	require.ErrorIs(t, requireRealExtensionDirs(throughLink), osutil.ErrLinkedDirectory,
+		"a link at the extensions root must be refused")
+}
+
+// A link planted at the extensions root has to stop an uninstall before it sweeps,
+// terminates, or deletes anything, because each of those would act on the link's target.
+func TestUninstall_RefusesLinkedExtensionsRoot(t *testing.T) {
+	configDir := isolatedConfigDir(t)
+
+	const id = "test.linked-root"
+
+	target := filepath.Join(t.TempDir(), "elsewhere")
+	require.NoError(t, os.MkdirAll(filepath.Join(target, id), osutil.PermissionDirectory))
+
+	keep := filepath.Join(target, id, "keep.txt")
+	require.NoError(t, os.WriteFile(keep, []byte("x"), 0600))
+
+	linkDirectory(t, filepath.Join(configDir, extensionsDirName), target)
+
+	manager := newTestManager(t)
+	require.NoError(t, manager.userConfig.Set(installedConfigKey, map[string]*Extension{
+		id: {
+			Id:      id,
+			Version: "1.0.0",
+			Path:    filepath.Join(extensionsDirName, id, "tool"),
+		},
+	}))
+
+	err := manager.Uninstall(t.Context(), id)
+
+	require.ErrorIs(t, err, osutil.ErrLinkedDirectory)
+	require.FileExists(t, keep, "nothing under the link target may be removed")
 }
 
 // T27: Force has to survive the trip from UpgradeOptions through upgradeInternal into the

--- a/cli/azd/pkg/extensions/manager_uninstall_test.go
+++ b/cli/azd/pkg/extensions/manager_uninstall_test.go
@@ -223,11 +223,26 @@ func TestUninstall_BlockedErrorNamesProcesses(t *testing.T) {
 	require.Contains(t, suggestionOf(t, unforced), "--force",
 		"an unforced failure should point at the flag that resolves it")
 
+	// The headline the user actually reads. Without Message, ux.ErrorWithSuggestion
+	// promotes the wrapped error and "Access is denied" becomes the ERROR: line, which is
+	// the cryptic output this message exists to replace.
+	unforcedMessage := messageOf(t, unforced)
+	require.Contains(t, unforcedMessage, "Cannot remove extension")
+	require.Contains(t, unforcedMessage, helperExecutableName(fixture.id),
+		"the blocking process must be named in the headline, not just the wrapped cause")
+	require.NotContains(t, unforcedMessage, cause.Error(),
+		"the filesystem cause belongs in the grey technical block, not the headline")
+
 	forced := extensionRemovalError(t.Context(), fixture.extensionDir, true, cause)
 	require.ErrorIs(t, forced, cause)
 	require.ErrorContains(t, forced, helperExecutableName(fixture.id))
 	require.NotContains(t, suggestionOf(t, forced), "--force",
 		"suggesting --force to someone who already used it is not actionable")
+
+	forcedMessage := messageOf(t, forced)
+	require.Contains(t, forcedMessage, "Cannot remove extension")
+	require.NotContains(t, forcedMessage, cause.Error(),
+		"the forced branch has the same headline problem and the same fix")
 }
 
 // A removal that failed for a reason other than a running process must not be dressed up
@@ -239,6 +254,19 @@ func TestUninstall_BlockedErrorWithoutProcesses(t *testing.T) {
 	require.ErrorIs(t, err, os.ErrPermission)
 	require.ErrorContains(t, err, "failed to remove extension")
 	require.NotContains(t, err.Error(), "--force")
+
+	// AC-7: even with nothing to name, the failure has to explain itself rather than
+	// leading with the filesystem cause. Message is what keeps the raw error off the
+	// ERROR: line, so its absence is the whole bug this asserts against.
+	message := messageOf(t, err)
+	require.Contains(t, message, "Cannot remove extension")
+	require.NotContains(t, message, os.ErrPermission.Error())
+
+	// --force only stops processes discovery returned, and it returned none, so pointing
+	// the user at it here would be advice that cannot work.
+	suggestion := suggestionOf(t, err)
+	require.NotEmpty(t, suggestion)
+	require.NotContains(t, suggestion, "--force")
 }
 
 // stopExtensionProcesses must refuse an unscoped directory rather than ranging wider than
@@ -740,6 +768,19 @@ func suggestionOf(t *testing.T, err error) string {
 
 	if withSuggestion, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
 		return withSuggestion.Suggestion
+	}
+
+	return ""
+}
+
+// messageOf returns the user-facing headline. ux.ErrorWithSuggestion renders Message as the
+// red ERROR: line and falls back to the whole wrapped error when it is empty, so an empty
+// result here means the raw filesystem cause is what the user reads.
+func messageOf(t *testing.T, err error) string {
+	t.Helper()
+
+	if withSuggestion, ok := errors.AsType[*internal.ErrorWithSuggestion](err); ok {
+		return withSuggestion.Message
 	}
 
 	return ""

--- a/cli/azd/pkg/extensions/upgrade_result.go
+++ b/cli/azd/pkg/extensions/upgrade_result.go
@@ -3,7 +3,11 @@
 
 package extensions
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/processutil"
+)
 
 // UpgradeStatus represents the outcome of a single extension upgrade attempt.
 // The String() values ("upgraded", "skipped", "promoted", "failed") are
@@ -64,21 +68,34 @@ type UpgradeResult struct {
 	// that were upgraded as a side effect of upgrading this extension. Empty
 	// for leaf extensions or when --no-dependency-upgrades is set.
 	DependencyUpgrades []UpgradeResult
+	// StoppedProcesses lists the processes --force stopped to release the files this
+	// upgrade had to replace, including any stopped while upgrading a dependency.
+	// Empty unless --force was passed and something was actually running.
+	StoppedProcesses []processutil.ProcessInfo
+}
+
+// stoppedProcessJSON is the JSON serialization format for a process stopped by --force.
+// Field names are part of the public --output json contract.
+type stoppedProcessJSON struct {
+	Name       string `json:"name"`
+	Pid        int    `json:"pid"`
+	Executable string `json:"executable,omitempty"`
 }
 
 // upgradeResultJSON is the JSON serialization format for UpgradeResult.
 // Field names are part of the public --output json contract.
 // Changes to field names or removal of fields is a breaking change.
 type upgradeResultJSON struct {
-	Name               string          `json:"name"`
-	Status             string          `json:"status"`
-	FromVersion        string          `json:"fromVersion,omitempty"`
-	ToVersion          string          `json:"toVersion,omitempty"`
-	FromSource         string          `json:"fromSource,omitempty"`
-	ToSource           string          `json:"toSource,omitempty"`
-	SkipReason         string          `json:"skipReason,omitempty"`
-	Error              string          `json:"error,omitempty"`
-	DependencyUpgrades []UpgradeResult `json:"dependencyUpgrades,omitempty"`
+	Name               string               `json:"name"`
+	Status             string               `json:"status"`
+	FromVersion        string               `json:"fromVersion,omitempty"`
+	ToVersion          string               `json:"toVersion,omitempty"`
+	FromSource         string               `json:"fromSource,omitempty"`
+	ToSource           string               `json:"toSource,omitempty"`
+	SkipReason         string               `json:"skipReason,omitempty"`
+	Error              string               `json:"error,omitempty"`
+	DependencyUpgrades []UpgradeResult      `json:"dependencyUpgrades,omitempty"`
+	StoppedProcesses   []stoppedProcessJSON `json:"stoppedProcesses,omitempty"`
 }
 
 // MarshalJSON serializes UpgradeResult to JSON for --output json.
@@ -94,6 +111,15 @@ func (r UpgradeResult) MarshalJSON() ([]byte, error) {
 		ToSource:           r.ToSource,
 		SkipReason:         r.SkipReason,
 		DependencyUpgrades: r.DependencyUpgrades,
+	}
+	// --force is silent on the console under --output json, so the machine readable
+	// result is the only place a caller can learn what azd terminated on its behalf.
+	for _, process := range r.StoppedProcesses {
+		j.StoppedProcesses = append(j.StoppedProcesses, stoppedProcessJSON{
+			Name:       process.Name,
+			Pid:        process.PID,
+			Executable: process.Executable,
+		})
 	}
 	if r.Error != nil {
 		j.Error = r.Error.Error()

--- a/cli/azd/pkg/extensions/upgrade_result_test.go
+++ b/cli/azd/pkg/extensions/upgrade_result_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/processutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -65,6 +66,51 @@ func TestUpgradeResult_MarshalJSON(t *testing.T) {
 		assert.False(t, hasError)
 		_, hasSkip := parsed["skipReason"]
 		assert.False(t, hasSkip)
+	})
+
+	t.Run("stopped_processes_are_reported", func(t *testing.T) {
+		t.Parallel()
+
+		// --force prints nothing under --output json, so the structured result is the
+		// only place a scripted caller can learn what azd terminated on its behalf.
+		r := UpgradeResult{
+			ExtensionId: "ai",
+			FromVersion: "0.1.0",
+			ToVersion:   "0.2.0",
+			Status:      UpgradeStatusUpgraded,
+			StoppedProcesses: []processutil.ProcessInfo{
+				{PID: 4321, Name: "ai.exe", Executable: `C:\ext\ai\ai.exe`},
+			},
+		}
+
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(data, &parsed))
+
+		stopped, ok := parsed["stoppedProcesses"].([]any)
+		require.True(t, ok, "stoppedProcesses must be present when --force stopped something")
+		require.Len(t, stopped, 1)
+
+		entry, ok := stopped[0].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "ai.exe", entry["name"])
+		assert.Equal(t, float64(4321), entry["pid"])
+		assert.Equal(t, `C:\ext\ai\ai.exe`, entry["executable"])
+	})
+
+	t.Run("stopped_processes_omitted_when_nothing_stopped", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := json.Marshal(UpgradeResult{ExtensionId: "ai", Status: UpgradeStatusSkipped})
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(data, &parsed))
+
+		_, hasStopped := parsed["stoppedProcesses"]
+		assert.False(t, hasStopped, "the common case must not grow an empty array")
 	})
 
 	t.Run("failed_result_includes_error", func(t *testing.T) {

--- a/cli/azd/pkg/osutil/relocate.go
+++ b/cli/azd/pkg/osutil/relocate.go
@@ -1,0 +1,217 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package osutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// ErrLinkedDirectory indicates a path azd was about to operate on is a symlink, junction,
+// or other reparse point rather than a real directory.
+var ErrLinkedDirectory = errors.New("path is a link rather than a real directory")
+
+// RequireRealDir verifies that path is a real directory rather than a symlink, junction,
+// or other reparse point. A path that does not exist yet is accepted, because there is
+// nothing there to redirect.
+//
+// azd derives both the set of files it deletes and the scope it terminates processes
+// against from directory paths it builds itself. Following a link would let anything able
+// to write into the extensions directory point either operation somewhere else entirely,
+// so a link is refused rather than resolved.
+//
+// Windows reports the two forms differently and neither is caught by a single check. A
+// directory symlink sets ModeSymlink and is followed by filepath.EvalSymlinks. A junction
+// sets ModeIrregular, reports IsDir false, and is not resolved by EvalSymlinks at all,
+// yet os.ReadDir and os.Rename still follow it. Both bits therefore have to be tested.
+func RequireRealDir(path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to inspect %s: %w", path, err)
+	}
+
+	if info.Mode()&(fs.ModeSymlink|fs.ModeIrregular) != 0 {
+		return fmt.Errorf("%w: %s", ErrLinkedDirectory, path)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("%w: %s is not a directory", ErrLinkedDirectory, path)
+	}
+
+	return nil
+}
+
+// RemoveAllWithRelocation removes path and everything under it, falling back to moving
+// files aside when they cannot be deleted.
+//
+// Windows refuses to delete a file that is mapped as a running executable image, but it
+// does allow that file to be renamed, because the image loader opens executables with
+// FILE_SHARE_DELETE. Moving the locked file into trashDir therefore empties path and lets
+// the directory itself be removed, which is what callers actually need. The relocated file
+// disappears on a later SweepTrash once the holding process exits.
+//
+// trashDir must live outside path, otherwise relocating into it would not empty path.
+func RemoveAllWithRelocation(ctx context.Context, path string, trashDir string) error {
+	if path == "" {
+		return errors.New("a path is required")
+	}
+
+	if trashDir == "" {
+		return errors.New("a trash directory is required")
+	}
+
+	if IsPathContained(path, trashDir) {
+		return fmt.Errorf("trash directory %q must not live inside %q", trashDir, path)
+	}
+
+	// Fast path. Most removals succeed outright, and going through the retrying RemoveAll
+	// first would spend its whole backoff budget before relocation ever got a chance.
+	if err := os.RemoveAll(path); err == nil {
+		return nil
+	}
+
+	// Something under path is held open. Move the offending files out so the directory
+	// can be emptied, then let the retrying removal finish the job.
+	if relocated, err := relocateLockedFiles(path, trashDir); err != nil {
+		log.Printf("failed to relocate locked files under %s: %v", path, err)
+	} else if relocated > 0 {
+		log.Printf("relocated %d locked file(s) from %s to %s", relocated, path, trashDir)
+	}
+
+	return RemoveAll(ctx, path)
+}
+
+// SweepTrash deletes files previously moved into trashDir that are no longer held open,
+// and removes the directory once it is empty.
+//
+// It is best effort by design and reports nothing. An entry whose process is still
+// running simply stays until a later sweep, and that is never a reason to fail the
+// command the sweep is attached to. It takes a context for the same reason RemoveAll does:
+// a large trash directory means a long run of filesystem deletes, and a cancelled command
+// should stop doing work rather than finish tidying up.
+func SweepTrash(ctx context.Context, trashDir string) {
+	if trashDir == "" {
+		return
+	}
+
+	// The sweep deletes every child of this directory, so a planted link here would turn
+	// a routine cleanup into a delete of whatever it points at. Refuse rather than follow.
+	if err := RequireRealDir(trashDir); err != nil {
+		log.Printf("refusing to sweep %s: %v", trashDir, err)
+		return
+	}
+
+	entries, err := os.ReadDir(trashDir)
+	if err != nil {
+		return // No trash directory, or it is unreadable. Either way there is nothing to do.
+	}
+
+	remaining := 0
+
+	for _, entry := range entries {
+		if ctx.Err() != nil {
+			return
+		}
+
+		target := filepath.Join(trashDir, entry.Name())
+		if err := os.RemoveAll(target); err != nil {
+			remaining++
+			log.Printf("trash entry %s is still in use, leaving it for a later sweep: %v", target, err)
+		}
+	}
+
+	if remaining == 0 {
+		// Best effort: a concurrent azd process may have written a new entry in between.
+		_ = os.Remove(trashDir)
+	}
+}
+
+// relocateLockedFiles moves every file under root that cannot be deleted into trashDir,
+// returning how many were moved.
+//
+// The walk is best effort. A file that can be deleted is deleted, a file that cannot is
+// renamed, and anything that resists both is reported so the caller can surface a useful
+// error rather than a bare permission failure.
+func relocateLockedFiles(root string, trashDir string) (int, error) {
+	relocated := 0
+
+	var failures []error
+
+	walkErr := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			// Unreadable subtrees are skipped: the final removal reports the real problem.
+			return nil //nolint:nilerr // Best effort walk, the caller retries the removal.
+		}
+
+		if entry.IsDir() {
+			return nil
+		}
+
+		if removeErr := os.Remove(path); removeErr == nil {
+			return nil
+		}
+
+		if mkdirErr := os.MkdirAll(trashDir, PermissionDirectory); mkdirErr != nil {
+			failures = append(failures, fmt.Errorf("failed to create trash directory: %w", mkdirErr))
+			return filepath.SkipAll
+		}
+
+		// Checked after the create so an existing link is caught, and on every iteration
+		// so a link swapped in mid-walk cannot receive the next relocated file.
+		if linkErr := RequireRealDir(trashDir); linkErr != nil {
+			failures = append(failures, linkErr)
+			return filepath.SkipAll
+		}
+
+		destination := uniqueTrashPath(trashDir, entry.Name())
+		if renameErr := os.Rename(path, destination); renameErr != nil {
+			failures = append(failures, fmt.Errorf("failed to relocate %s: %w", path, renameErr))
+			return nil
+		}
+
+		relocated++
+
+		return nil
+	})
+
+	if walkErr != nil {
+		failures = append(failures, walkErr)
+	}
+
+	return relocated, errors.Join(failures...)
+}
+
+// uniqueTrashPath returns a path inside trashDir that no entry currently occupies, so a
+// file relocated today does not collide with one left behind by an earlier run.
+func uniqueTrashPath(trashDir string, name string) string {
+	candidate := filepath.Join(trashDir, name)
+	if !pathExists(candidate) {
+		return candidate
+	}
+
+	for suffix := 1; suffix < 1000; suffix++ {
+		candidate = filepath.Join(trashDir, fmt.Sprintf("%s.%d", name, suffix))
+		if !pathExists(candidate) {
+			return candidate
+		}
+	}
+
+	return filepath.Join(trashDir, fmt.Sprintf("%s.%d", name, os.Getpid()))
+}
+
+// pathExists reports whether anything exists at path, without following symlinks.
+func pathExists(path string) bool {
+	_, err := os.Lstat(path)
+
+	return !errors.Is(err, fs.ErrNotExist)
+}

--- a/cli/azd/pkg/osutil/relocate.go
+++ b/cli/azd/pkg/osutil/relocate.go
@@ -164,15 +164,8 @@ func relocateLockedFiles(root string, trashDir string) (int, error) {
 			return nil
 		}
 
-		if mkdirErr := os.MkdirAll(trashDir, PermissionDirectory); mkdirErr != nil {
-			failures = append(failures, fmt.Errorf("failed to create trash directory: %w", mkdirErr))
-			return filepath.SkipAll
-		}
-
-		// Checked after the create so an existing link is caught, and on every iteration
-		// so a link swapped in mid-walk cannot receive the next relocated file.
-		if linkErr := RequireRealDir(trashDir); linkErr != nil {
-			failures = append(failures, linkErr)
+		if ensureErr := ensureTrashDir(trashDir); ensureErr != nil {
+			failures = append(failures, ensureErr)
 			return filepath.SkipAll
 		}
 
@@ -193,6 +186,23 @@ func relocateLockedFiles(root string, trashDir string) (int, error) {
 	return relocated, errors.Join(failures...)
 }
 
+// ensureTrashDir creates trashDir when it is missing and verifies it is a real directory
+// rather than a link.
+//
+// The two halves belong together and both have to run on every use. The create is
+// repeated because SweepTrash deletes the directory as soon as it observes it empty, and
+// a second azd process sweeps the same shared directory. The link check is repeated, and
+// deliberately runs after the create, because creating a directory does not prove the
+// name was not already a link, and a link swapped in after an earlier check would
+// otherwise receive the next relocated file.
+func ensureTrashDir(trashDir string) error {
+	if err := os.MkdirAll(trashDir, PermissionDirectory); err != nil {
+		return fmt.Errorf("failed to create trash directory: %w", err)
+	}
+
+	return RequireRealDir(trashDir)
+}
+
 // relocateInto moves a single locked file into trashDir under a name no concurrent azd
 // process can also have chosen.
 //
@@ -204,9 +214,32 @@ func relocateLockedFiles(root string, trashDir string) (int, error) {
 // is itself a locked executable, and the uninstall it belonged to fails after its
 // retries. Detecting the conflict afterwards is therefore not an option, and the name
 // itself has to make it impossible.
+//
+// The destination directory can also disappear between the caller's create and this
+// rename: SweepTrash removes it the moment it observes it empty, and a second azd process
+// sweeps the same shared directory. A vanished destination is therefore recreated and the
+// move retried once, because giving up here would leave the locked file in place and fail
+// the very removal this fallback exists to make succeed.
 func relocateInto(path string, trashDir string, name string) error {
-	if err := os.Rename(path, uniqueTrashPath(trashDir, name)); err != nil {
+	err := os.Rename(path, uniqueTrashPath(trashDir, name))
+	if err == nil {
+		return nil
+	}
+
+	// Only a missing path is worth a second attempt. A permission failure, or a
+	// destination that is itself a locked executable, fails again the same way.
+	if !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("failed to relocate %s: %w", path, err)
+	}
+
+	// ensureTrashDir repeats the link check, so recreating the directory cannot be turned
+	// into a redirect by a link planted in this window.
+	if ensureErr := ensureTrashDir(trashDir); ensureErr != nil {
+		return fmt.Errorf("failed to relocate %s: %w", path, ensureErr)
+	}
+
+	if retryErr := os.Rename(path, uniqueTrashPath(trashDir, name)); retryErr != nil {
+		return fmt.Errorf("failed to relocate %s: %w", path, retryErr)
 	}
 
 	return nil

--- a/cli/azd/pkg/osutil/relocate.go
+++ b/cli/azd/pkg/osutil/relocate.go
@@ -5,12 +5,15 @@ package osutil
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // ErrLinkedDirectory indicates a path azd was about to operate on is a symlink, junction,
@@ -173,9 +176,8 @@ func relocateLockedFiles(root string, trashDir string) (int, error) {
 			return filepath.SkipAll
 		}
 
-		destination := uniqueTrashPath(trashDir, entry.Name())
-		if renameErr := os.Rename(path, destination); renameErr != nil {
-			failures = append(failures, fmt.Errorf("failed to relocate %s: %w", path, renameErr))
+		if relocateErr := relocateInto(path, trashDir, entry.Name()); relocateErr != nil {
+			failures = append(failures, relocateErr)
 			return nil
 		}
 
@@ -191,27 +193,39 @@ func relocateLockedFiles(root string, trashDir string) (int, error) {
 	return relocated, errors.Join(failures...)
 }
 
-// uniqueTrashPath returns a path inside trashDir that no entry currently occupies, so a
-// file relocated today does not collide with one left behind by an earlier run.
-func uniqueTrashPath(trashDir string, name string) string {
-	candidate := filepath.Join(trashDir, name)
-	if !pathExists(candidate) {
-		return candidate
+// relocateInto moves a single locked file into trashDir under a name no concurrent azd
+// process can also have chosen.
+//
+// Picking a destination and renaming onto it cannot be made one operation, so a name
+// derived only from what is currently on disk is inherently racy: two azd processes
+// relocating the same base name both see the same free path and both rename onto it. On
+// Windows os.Rename replaces the destination, so the collision is not even reported: one
+// of them either clobbers a file the other still needs or fails because that destination
+// is itself a locked executable, and the uninstall it belonged to fails after its
+// retries. Detecting the conflict afterwards is therefore not an option, and the name
+// itself has to make it impossible.
+func relocateInto(path string, trashDir string, name string) error {
+	if err := os.Rename(path, uniqueTrashPath(trashDir, name)); err != nil {
+		return fmt.Errorf("failed to relocate %s: %w", path, err)
 	}
 
-	for suffix := 1; suffix < 1000; suffix++ {
-		candidate = filepath.Join(trashDir, fmt.Sprintf("%s.%d", name, suffix))
-		if !pathExists(candidate) {
-			return candidate
-		}
-	}
-
-	return filepath.Join(trashDir, fmt.Sprintf("%s.%d", name, os.Getpid()))
+	return nil
 }
 
-// pathExists reports whether anything exists at path, without following symlinks.
-func pathExists(path string) bool {
-	_, err := os.Lstat(path)
+// uniqueTrashPath returns a destination inside trashDir that is unique to this process
+// and this call, so a relocated file collides neither with one left behind by an earlier
+// run nor with one another azd process is relocating at the same moment.
+//
+// The original base name is kept as a prefix so a leftover entry stays recognizable while
+// it waits for a sweep.
+func uniqueTrashPath(trashDir string, name string) string {
+	var suffix [8]byte
 
-	return !errors.Is(err, fs.ErrNotExist)
+	if _, err := rand.Read(suffix[:]); err != nil {
+		// crypto/rand does not fail in practice. The process id and the clock still
+		// separate this candidate from every other process's.
+		return filepath.Join(trashDir, fmt.Sprintf("%s.%d.%d", name, os.Getpid(), time.Now().UnixNano()))
+	}
+
+	return filepath.Join(trashDir, fmt.Sprintf("%s.%d.%s", name, os.Getpid(), hex.EncodeToString(suffix[:])))
 }

--- a/cli/azd/pkg/osutil/relocate_test.go
+++ b/cli/azd/pkg/osutil/relocate_test.go
@@ -4,10 +4,13 @@
 package osutil
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -67,7 +70,8 @@ func TestRelocateLocked_MovesFileOutOfDir(t *testing.T) {
 	entries, err := os.ReadDir(trashDir)
 	require.NoError(t, err)
 	require.Len(t, entries, 1, "the locked file should have been moved into the trash directory")
-	require.Equal(t, filepath.Base(locked), entries[0].Name())
+	require.True(t, strings.HasPrefix(entries[0].Name(), filepath.Base(locked)),
+		"the relocated entry should stay recognizable, got %q", entries[0].Name())
 }
 
 // T20: the whole point of the fallback. Removing a directory that holds a running
@@ -319,33 +323,80 @@ func TestRelocateLocked_RefusesLinkedTrash(t *testing.T) {
 }
 
 // Relocated names must not collide, or a file trashed today would silently overwrite one
-// left behind by an earlier run that is still in use.
+// left behind by an earlier run that is still in use. They must also not collide across
+// processes, because destination selection and the rename that follows it are separate
+// operations that two azd processes can interleave.
 func TestUniqueTrashPath(t *testing.T) {
 	t.Parallel()
 
 	trashDir := t.TempDir()
 
-	first := uniqueTrashPath(trashDir, "tool.exe")
-	require.Equal(t, filepath.Join(trashDir, "tool.exe"), first)
+	seen := map[string]struct{}{}
 
-	require.NoError(t, os.WriteFile(first, []byte("x"), 0600))
+	for range 100 {
+		candidate := uniqueTrashPath(trashDir, "tool.exe")
 
-	second := uniqueTrashPath(trashDir, "tool.exe")
-	require.Equal(t, filepath.Join(trashDir, "tool.exe.1"), second)
-	require.NotEqual(t, first, second)
+		require.Equal(t, trashDir, filepath.Dir(candidate), "candidates must stay inside the trash directory")
+		require.True(t, strings.HasPrefix(filepath.Base(candidate), "tool.exe."),
+			"the original name should remain recognizable, got %q", candidate)
+		require.Contains(t, filepath.Base(candidate), fmt.Sprintf(".%d.", os.Getpid()),
+			"the name should carry this process's id so another process cannot pick it")
 
-	require.NoError(t, os.WriteFile(second, []byte("x"), 0600))
-	require.Equal(t, filepath.Join(trashDir, "tool.exe.2"), uniqueTrashPath(trashDir, "tool.exe"))
+		_, duplicate := seen[candidate]
+		require.False(t, duplicate, "uniqueTrashPath returned %q twice", candidate)
+		seen[candidate] = struct{}{}
+	}
 }
 
-func TestPathExists(t *testing.T) {
+// Two azd processes relocating the same base name at the same time must both succeed,
+// and neither may overwrite the other's file.
+func TestRelocateInto_ConcurrentRelocationsDoNotCollide(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	file := filepath.Join(dir, "a.txt")
+	base := t.TempDir()
+	trashDir := filepath.Join(base, ".trash")
+	require.NoError(t, os.MkdirAll(trashDir, PermissionDirectory))
 
-	require.False(t, pathExists(file))
-	require.NoError(t, os.WriteFile(file, []byte("x"), 0600))
-	require.True(t, pathExists(file))
-	require.True(t, pathExists(dir))
+	const concurrent = 8
+
+	roots := make([]string, 0, concurrent)
+
+	for i := range concurrent {
+		root := filepath.Join(base, fmt.Sprintf("extension-%d", i))
+		require.NoError(t, os.MkdirAll(root, PermissionDirectory))
+		// Every root uses the same base name, which is what made the old
+		// check-then-rename scheme hand two callers the same destination.
+		require.NoError(t, os.WriteFile(filepath.Join(root, "tool.exe"), fmt.Appendf(nil, "payload-%d", i), 0600))
+		roots = append(roots, root)
+	}
+
+	var wg sync.WaitGroup
+
+	errs := make([]error, concurrent)
+
+	for i, root := range roots {
+		wg.Go(func() {
+			errs[i] = relocateInto(filepath.Join(root, "tool.exe"), trashDir, "tool.exe")
+		})
+	}
+
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "relocation %d should have succeeded", i)
+	}
+
+	entries, err := os.ReadDir(trashDir)
+	require.NoError(t, err)
+	require.Len(t, entries, concurrent, "every concurrent relocation needs its own destination")
+
+	payloads := map[string]struct{}{}
+
+	for _, entry := range entries {
+		content, err := os.ReadFile(filepath.Join(trashDir, entry.Name()))
+		require.NoError(t, err)
+		payloads[string(content)] = struct{}{}
+	}
+
+	require.Len(t, payloads, concurrent, "no relocation may have overwritten another's file")
 }

--- a/cli/azd/pkg/osutil/relocate_test.go
+++ b/cli/azd/pkg/osutil/relocate_test.go
@@ -1,0 +1,351 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package osutil
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/test/proctest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	if proctest.RunRequestedHelper() {
+		return
+	}
+
+	os.Exit(m.Run())
+}
+
+// requireWindowsImageLock skips tests that depend on the one behavior only Windows has:
+// a running executable's image file cannot be deleted, but can still be renamed.
+// Unix unlinks a running binary without complaint, so there is nothing to relocate there.
+func requireWindowsImageLock(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS != "windows" {
+		t.Skip("only Windows refuses to delete the image file of a running executable")
+	}
+}
+
+// startLockedExecutable runs a real executable out of dir, so dir contains a file the
+// operating system will refuse to delete for as long as the process lives.
+// It returns the path of the locked file and a function that stops the process.
+func startLockedExecutable(t *testing.T, dir string) (string, func()) {
+	t.Helper()
+
+	handle := proctest.StartIn(t, dir, "azd-osutil-lock-helper", proctest.ModeIdle)
+	handle.RequireImageLocked(t)
+
+	return handle.Path, handle.Stop
+}
+
+// T19: a file that cannot be deleted is moved out of the directory being removed, which
+// is what lets the directory itself go away.
+func TestRelocateLocked_MovesFileOutOfDir(t *testing.T) {
+	requireWindowsImageLock(t)
+
+	base := t.TempDir()
+	extensionDir := filepath.Join(base, "extension")
+	trashDir := filepath.Join(base, ".trash")
+	require.NoError(t, os.MkdirAll(extensionDir, PermissionDirectory))
+
+	locked, _ := startLockedExecutable(t, extensionDir)
+
+	relocated, err := relocateLockedFiles(extensionDir, trashDir)
+	require.NoError(t, err)
+	require.Equal(t, 1, relocated)
+
+	require.NoFileExists(t, locked, "the locked file should no longer be inside the extension directory")
+
+	entries, err := os.ReadDir(trashDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "the locked file should have been moved into the trash directory")
+	require.Equal(t, filepath.Base(locked), entries[0].Name())
+}
+
+// T20: the whole point of the fallback. Removing a directory that holds a running
+// executable must succeed instead of failing with a bare access denied.
+func TestRemoveAllWithRelocation_LockedExe(t *testing.T) {
+	requireWindowsImageLock(t)
+
+	base := t.TempDir()
+	extensionDir := filepath.Join(base, "extension")
+	trashDir := filepath.Join(base, ".trash")
+	require.NoError(t, os.MkdirAll(filepath.Join(extensionDir, "nested"), PermissionDirectory))
+	require.NoError(t, os.WriteFile(filepath.Join(extensionDir, "nested", "readme.md"), []byte("x"), 0600))
+
+	_, stop := startLockedExecutable(t, extensionDir)
+
+	require.NoError(t, RemoveAllWithRelocation(t.Context(), extensionDir, trashDir))
+	require.NoDirExists(t, extensionDir, "the extension directory must be gone even though a process is running")
+
+	// The relocated image is still held, so it stays in the trash until the process exits.
+	entries, err := os.ReadDir(trashDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	// Once the holder exits, a sweep clears the leftover.
+	stop()
+	require.Eventually(t, func() bool {
+		SweepTrash(t.Context(), trashDir)
+
+		_, err := os.Stat(trashDir)
+
+		return os.IsNotExist(err)
+	}, 30*time.Second, 200*time.Millisecond, "trash should be swept once the holding process exits")
+}
+
+// T21: nothing locked means nothing relocated. The common case must not create trash.
+func TestRemoveAllWithRelocation_NoLocks(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	extensionDir := filepath.Join(base, "extension")
+	trashDir := filepath.Join(base, ".trash")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(extensionDir, "nested"), PermissionDirectory))
+	require.NoError(t, os.WriteFile(filepath.Join(extensionDir, "a.txt"), []byte("a"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(extensionDir, "nested", "b.txt"), []byte("b"), 0600))
+
+	require.NoError(t, RemoveAllWithRelocation(t.Context(), extensionDir, trashDir))
+	require.NoDirExists(t, extensionDir)
+	require.NoDirExists(t, trashDir, "an unlocked removal must not create a trash directory")
+}
+
+// Removing something that is already gone is a success, matching os.RemoveAll.
+func TestRemoveAllWithRelocation_MissingPath(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+
+	require.NoError(t, RemoveAllWithRelocation(
+		t.Context(), filepath.Join(base, "absent"), filepath.Join(base, ".trash")))
+}
+
+// The trash has to be outside the directory being removed, otherwise relocating into it
+// would never empty that directory. The mistake is rejected rather than half-performed.
+func TestRemoveAllWithRelocation_RejectsTrashInsidePath(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	extensionDir := filepath.Join(base, "extension")
+	require.NoError(t, os.MkdirAll(extensionDir, PermissionDirectory))
+
+	err := RemoveAllWithRelocation(t.Context(), extensionDir, filepath.Join(extensionDir, ".trash"))
+	require.ErrorContains(t, err, "must not live inside")
+
+	err = RemoveAllWithRelocation(t.Context(), extensionDir, extensionDir)
+	require.ErrorContains(t, err, "must not live inside")
+
+	require.DirExists(t, extensionDir, "a rejected call must not remove anything")
+}
+
+func TestRemoveAllWithRelocation_RequiresPaths(t *testing.T) {
+	t.Parallel()
+
+	require.ErrorContains(t, RemoveAllWithRelocation(t.Context(), "", "trash"), "a path is required")
+	require.ErrorContains(t,
+		RemoveAllWithRelocation(t.Context(), t.TempDir(), ""), "a trash directory is required")
+}
+
+// T22: leftovers are cleaned up on a later run once whatever held them has exited.
+func TestSweepTrash_RemovesReleasedEntries(t *testing.T) {
+	t.Parallel()
+
+	trashDir := filepath.Join(t.TempDir(), ".trash")
+	require.NoError(t, os.MkdirAll(filepath.Join(trashDir, "nested"), PermissionDirectory))
+	require.NoError(t, os.WriteFile(filepath.Join(trashDir, "old.exe"), []byte("x"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(trashDir, "nested", "deep.txt"), []byte("y"), 0600))
+
+	SweepTrash(t.Context(), trashDir)
+
+	require.NoDirExists(t, trashDir, "an emptied trash directory should remove itself")
+}
+
+// T23: an entry whose process is still running stays put, and that is not a failure.
+func TestSweepTrash_SkipsLockedEntries(t *testing.T) {
+	requireWindowsImageLock(t)
+
+	base := t.TempDir()
+	trashDir := filepath.Join(base, ".trash")
+	require.NoError(t, os.MkdirAll(trashDir, PermissionDirectory))
+	require.NoError(t, os.WriteFile(filepath.Join(trashDir, "released.txt"), []byte("x"), 0600))
+
+	locked, stop := startLockedExecutable(t, trashDir)
+
+	SweepTrash(t.Context(), trashDir)
+
+	require.FileExists(t, locked, "a still-running executable must survive the sweep")
+	require.NoFileExists(t, filepath.Join(trashDir, "released.txt"), "released entries should still be cleared")
+	require.DirExists(t, trashDir, "the trash directory must remain while it still holds entries")
+
+	stop()
+
+	require.Eventually(t, func() bool {
+		SweepTrash(t.Context(), trashDir)
+
+		_, err := os.Stat(trashDir)
+
+		return os.IsNotExist(err)
+	}, 30*time.Second, 200*time.Millisecond, "the sweep should succeed once the holder exits")
+}
+
+// T24: the sweep is attached to commands that must not fail because of it, so it has no
+// error to propagate by construction. These inputs would all be errors for os.RemoveAll.
+func TestSweepTrash_BestEffortNeverErrors(t *testing.T) {
+	t.Parallel()
+
+	// No return value to check: the contract is enforced by the signature. What is
+	// verified here is that none of these inputs panic or damage anything.
+	SweepTrash(t.Context(), "")
+	SweepTrash(t.Context(), filepath.Join(t.TempDir(), "never-created"))
+
+	notADirectory := filepath.Join(t.TempDir(), "file.txt")
+	require.NoError(t, os.WriteFile(notADirectory, []byte("x"), 0600))
+	SweepTrash(t.Context(), notADirectory)
+	require.FileExists(t, notADirectory, "a non-directory must be left alone rather than deleted")
+}
+
+// linkDirectory creates a directory link at linkPath pointing at target, skipping the
+// test when the platform will not allow one.
+//
+// Windows needs Developer Mode or elevation for a symlink but allows a junction with
+// neither, and a junction is the more dangerous of the two here: filepath.EvalSymlinks
+// refuses to resolve it while os.ReadDir and os.Rename follow it happily. Preferring the
+// junction on Windows therefore keeps this coverage running on an ordinary CI agent and
+// exercises the harder case.
+func linkDirectory(t *testing.T, linkPath string, target string) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		//nolint:gosec // Fixed executable, arguments are test-controlled temp paths.
+		if out, err := exec.Command("cmd", "/c", "mklink", "/J", linkPath, target).CombinedOutput(); err != nil {
+			t.Skipf("cannot create a directory junction on this machine: %v: %s", err, out)
+		}
+
+		return
+	}
+
+	if err := os.Symlink(target, linkPath); err != nil {
+		t.Skipf("cannot create a symlink on this machine: %v", err)
+	}
+}
+
+func TestRequireRealDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	realDir := filepath.Join(dir, "real")
+	require.NoError(t, os.Mkdir(realDir, PermissionDirectory))
+	require.NoError(t, RequireRealDir(realDir), "a real directory must be accepted")
+
+	// Nothing to redirect, so callers are free to create it.
+	require.NoError(t, RequireRealDir(filepath.Join(dir, "missing")))
+
+	file := filepath.Join(dir, "file.txt")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0600))
+	require.ErrorIs(t, RequireRealDir(file), ErrLinkedDirectory)
+
+	link := filepath.Join(dir, "link")
+	linkDirectory(t, link, realDir)
+	require.ErrorIs(t, RequireRealDir(link), ErrLinkedDirectory,
+		"a directory link must be refused rather than resolved")
+}
+
+// A link planted where the trash directory belongs must not turn a routine sweep into a
+// delete of whatever it points at. The sweep runs on every install, uninstall, and
+// upgrade, including without --force, so this is the most reachable of the link paths.
+func TestSweepTrash_RefusesLinkedDirectory(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	target := filepath.Join(root, "valuables")
+	require.NoError(t, os.Mkdir(target, PermissionDirectory))
+
+	keep := filepath.Join(target, "keep.txt")
+	require.NoError(t, os.WriteFile(keep, []byte("x"), 0600))
+
+	trashDir := filepath.Join(root, ".trash")
+	linkDirectory(t, trashDir, target)
+
+	SweepTrash(t.Context(), trashDir)
+
+	require.FileExists(t, keep, "the link target's contents must survive the sweep")
+
+	// Lstat rather than require.DirExists: a Windows junction reports IsDir false, so the
+	// assertion is that the link entry itself is still there, not that it looks like a
+	// directory.
+	_, err := os.Lstat(trashDir)
+	require.NoError(t, err, "the link itself must be left in place rather than removed")
+}
+
+// The trash directory is created lazily during relocation, so the same link check has to
+// run there: creating it does not prove the name was not already a link.
+func TestRelocateLocked_RefusesLinkedTrash(t *testing.T) {
+	t.Parallel()
+	requireWindowsImageLock(t)
+
+	root := t.TempDir()
+
+	source := filepath.Join(root, "extension")
+	require.NoError(t, os.Mkdir(source, PermissionDirectory))
+	_, stop := startLockedExecutable(t, source)
+
+	defer stop()
+
+	target := filepath.Join(root, "valuables")
+	require.NoError(t, os.Mkdir(target, PermissionDirectory))
+
+	trashDir := filepath.Join(root, ".trash")
+	linkDirectory(t, trashDir, target)
+
+	relocated, err := relocateLockedFiles(source, trashDir)
+
+	require.ErrorIs(t, err, ErrLinkedDirectory)
+	require.Zero(t, relocated, "no file may be moved into a linked trash directory")
+
+	entries, readErr := os.ReadDir(target)
+	require.NoError(t, readErr)
+	require.Empty(t, entries, "nothing may be written through the link")
+}
+
+// Relocated names must not collide, or a file trashed today would silently overwrite one
+// left behind by an earlier run that is still in use.
+func TestUniqueTrashPath(t *testing.T) {
+	t.Parallel()
+
+	trashDir := t.TempDir()
+
+	first := uniqueTrashPath(trashDir, "tool.exe")
+	require.Equal(t, filepath.Join(trashDir, "tool.exe"), first)
+
+	require.NoError(t, os.WriteFile(first, []byte("x"), 0600))
+
+	second := uniqueTrashPath(trashDir, "tool.exe")
+	require.Equal(t, filepath.Join(trashDir, "tool.exe.1"), second)
+	require.NotEqual(t, first, second)
+
+	require.NoError(t, os.WriteFile(second, []byte("x"), 0600))
+	require.Equal(t, filepath.Join(trashDir, "tool.exe.2"), uniqueTrashPath(trashDir, "tool.exe"))
+}
+
+func TestPathExists(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.txt")
+
+	require.False(t, pathExists(file))
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0600))
+	require.True(t, pathExists(file))
+	require.True(t, pathExists(dir))
+}

--- a/cli/azd/pkg/osutil/relocate_test.go
+++ b/cli/azd/pkg/osutil/relocate_test.go
@@ -400,3 +400,76 @@ func TestRelocateInto_ConcurrentRelocationsDoNotCollide(t *testing.T) {
 
 	require.Len(t, payloads, concurrent, "no relocation may have overwritten another's file")
 }
+
+// T80: SweepTrash removes the shared trash directory the moment it observes it empty, and
+// a second azd process sweeps the same directory. That delete can land between the walk's
+// create and this rename, and the relocation has to recover rather than leave the locked
+// file in place and fail the removal this fallback exists to make succeed.
+func TestRelocateInto_RecreatesSweptTrashDirectory(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	trashDir := filepath.Join(base, ".trash")
+	source := filepath.Join(base, "tool.exe")
+	require.NoError(t, os.WriteFile(source, []byte("payload"), 0600))
+
+	// Exactly the state a concurrent sweep leaves behind: the directory the caller
+	// created before handing off is already gone.
+	require.NoDirExists(t, trashDir)
+
+	require.NoError(t, relocateInto(source, trashDir, "tool.exe"))
+
+	require.NoFileExists(t, source, "the locked file must have been moved aside")
+
+	entries, err := os.ReadDir(trashDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "the swept directory should have been recreated to receive the file")
+	require.True(t, strings.HasPrefix(entries[0].Name(), "tool.exe."),
+		"the original name should remain recognizable, got %q", entries[0].Name())
+
+	content, err := os.ReadFile(filepath.Join(trashDir, entries[0].Name()))
+	require.NoError(t, err)
+	require.Equal(t, "payload", string(content), "the retried move must carry the original contents")
+}
+
+// A trash path that is a file rather than a directory cannot be relocated into, and that
+// failure has to reach the caller with the original file untouched.
+//
+// The branch taken differs by platform, which is exactly why it is asserted here. Windows
+// reports a file standing in for a directory component as ERROR_PATH_NOT_FOUND, which Go
+// maps to fs.ErrNotExist, so the move is retried and then fails because the directory
+// cannot be created over the file. Unix reports ENOTDIR, which is not fs.ErrNotExist, so
+// the retry guard short-circuits and the rename error is reported unchanged. Without this
+// split the test would pass on either branch and could not tell that the guard still works.
+func TestRelocateInto_ReportsFailureAndLeavesSourceInPlace(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	trashDir := filepath.Join(base, ".trash")
+	source := filepath.Join(base, "tool.exe")
+	require.NoError(t, os.WriteFile(source, []byte("payload"), 0600))
+	require.NoError(t, os.WriteFile(trashDir, []byte("not a directory"), 0600))
+
+	err := relocateInto(source, trashDir, "tool.exe")
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to relocate")
+
+	if runtime.GOOS == "windows" {
+		require.ErrorContains(t, err, "failed to create trash directory",
+			"a not-found rename should have been retried and failed on the recreate")
+	} else {
+		var linkErr *os.LinkError
+
+		require.ErrorAs(t, err, &linkErr,
+			"a failure the retry guard rejects should surface the original rename error")
+		require.NotContains(t, err.Error(), "failed to create trash directory",
+			"the guard should have prevented a pointless recreate")
+	}
+
+	require.FileExists(t, source, "a failed relocation must leave the original in place")
+
+	content, readErr := os.ReadFile(source)
+	require.NoError(t, readErr)
+	require.Equal(t, "payload", string(content), "a failed relocation must not damage the original")
+}

--- a/cli/azd/pkg/processutil/helper_signals_unix_test.go
+++ b/cli/azd/pkg/processutil/helper_signals_unix_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build !windows
+
+package processutil
+
+import (
+	"os"
+	"syscall"
+)
+
+// ignorableSignals lists the signals a helper process must swallow so the escalation
+// path can be observed. SIGKILL is deliberately absent because it cannot be caught,
+// which is exactly what makes the forceful stop reliable.
+func ignorableSignals() []os.Signal {
+	return []os.Signal{syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP}
+}

--- a/cli/azd/pkg/processutil/helper_signals_windows_test.go
+++ b/cli/azd/pkg/processutil/helper_signals_windows_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package processutil
+
+import "os"
+
+// ignorableSignals lists the signals a helper process must swallow so the escalation
+// path can be observed.
+//
+// Windows never takes the graceful path at all: this package escalates straight to a
+// forceful stop, which no process can catch. The helper still registers for interrupt
+// so it behaves the same way under a manual Ctrl+C during debugging.
+func ignorableSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/cli/azd/pkg/processutil/processutil.go
+++ b/cli/azd/pkg/processutil/processutil.go
@@ -144,17 +144,23 @@ func FindByExecutableDir(ctx context.Context, dir string) ([]ProcessInfo, error)
 // has no safe general purpose graceful signal for a process azd does not own, so that
 // step is skipped there and the process is stopped directly.
 //
-// Scope is checked twice, for two different reasons.
+// Scope is checked three times, for three different reasons.
 //
 // The supplied process is checked against scope up front. A caller that asks to stop
 // something it cannot show is inside the scope is refused, which keeps a malformed or
 // attacker-influenced ProcessInfo from reaching a kill.
 //
-// Scope is then re-checked against live operating system state immediately before each
-// signal. Discovery and termination are separate moments, and a PID is only a number: the
-// process can exit in between and the operating system can hand the same number to
-// something unrelated. Without the re-check a reused PID would be signalled on the
-// strength of a stale match.
+// Scope is then re-checked against live operating system state before signalling.
+// Discovery and termination are separate moments, and a PID is only a number: the process
+// can exit in between and the operating system can hand the same number to something
+// unrelated. Without the re-check a reused PID would be signalled on the strength of a
+// stale match.
+//
+// That re-check narrows the window but cannot close it, because the check and the signal
+// remain two lookups by number. The forceful stop therefore validates scope a third time
+// against a pinned process identity: on Windows forceKill holds an open process handle,
+// which reserves the PID, so the scope it verifies is the process it kills. Unix has no
+// portable equivalent, so a residual window remains for the SIGTERM and SIGKILL paths.
 func Terminate(ctx context.Context, process ProcessInfo, scope string, grace time.Duration) (bool, error) {
 	if process.PID <= 0 {
 		return false, fmt.Errorf("%w: %d", ErrInvalidPID, process.PID)
@@ -203,7 +209,7 @@ func Terminate(ctx context.Context, process ProcessInfo, scope string, grace tim
 		return signalled, nil
 	}
 
-	if err := forceKill(process.PID); err != nil {
+	if err := forceKill(process.PID, normalized); err != nil {
 		// Losing the race against a process that exited on its own is a success, not a
 		// failure, so re-check before reporting the error.
 		if !processRunning(process.PID) {

--- a/cli/azd/pkg/processutil/processutil.go
+++ b/cli/azd/pkg/processutil/processutil.go
@@ -1,0 +1,336 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Package processutil discovers and stops operating system processes whose executable
+// image lives inside a caller-supplied directory.
+//
+// azd needs this when it has to replace or delete files that a running process holds
+// open, most visibly when upgrading or uninstalling an extension that is still running.
+//
+// Discovery is always scoped to a directory. A process becomes a candidate only when its
+// executable is contained within the directory the caller names. Because callers use the
+// result to terminate processes, that containment check is the safety property this
+// package is built around, and it is validated before any enumeration happens.
+package processutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+)
+
+const (
+	// DefaultGracePeriod is how long Terminate waits for a process to exit on its own
+	// after a graceful stop is requested, before escalating to a forceful stop.
+	DefaultGracePeriod = 5 * time.Second
+
+	// forceConfirmWindow bounds how long Terminate waits for a process to disappear
+	// after a forceful stop. It is deliberately short: the kill has already been issued,
+	// so this only covers the kernel reaping the process.
+	forceConfirmWindow = 2 * time.Second
+
+	// pollInterval is how often Terminate re-checks whether a process has exited.
+	pollInterval = 100 * time.Millisecond
+)
+
+var (
+	// ErrEmptyDirectory is returned when no directory is supplied to scope discovery.
+	ErrEmptyDirectory = errors.New("a directory is required to scope process discovery")
+
+	// ErrRootDirectory is returned when the supplied directory is a filesystem root.
+	// Containment against a root matches every process on the machine, so it is refused
+	// rather than silently honored.
+	ErrRootDirectory = errors.New("refusing to scope process discovery to a filesystem root")
+
+	// ErrInvalidPID is returned when a non-positive process ID is supplied.
+	ErrInvalidPID = errors.New("process id must be greater than zero")
+
+	// ErrProcessOutOfScope is returned when the caller asks to terminate a process whose
+	// recorded executable does not sit inside the supplied scope. Scope is the security
+	// boundary for termination, so a process that cannot be shown to be inside it is
+	// refused rather than trusted.
+	ErrProcessOutOfScope = errors.New("refusing to terminate a process outside the requested directory")
+)
+
+// ProcessInfo describes a running process discovered by this package.
+type ProcessInfo struct {
+	// PID is the operating system process identifier.
+	PID int
+	// Name is the executable's base name, used for display.
+	Name string
+	// Executable is the full path to the process's executable image.
+	Executable string
+}
+
+// String renders the process for user-facing messages, for example "myext.exe (PID 1234)".
+func (p ProcessInfo) String() string {
+	name := p.Name
+	if name == "" {
+		name = "unknown"
+	}
+
+	return fmt.Sprintf("%s (PID %d)", name, p.PID)
+}
+
+// Describe renders processes as a comma separated list for error and status messages.
+func Describe(processes []ProcessInfo) string {
+	parts := make([]string, 0, len(processes))
+	for _, process := range processes {
+		parts = append(parts, process.String())
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+// FindByExecutableDir returns every running process whose executable image is contained
+// within dir. The calling process is never returned.
+//
+// dir must be a non-empty, non-root path. Both constraints are refused rather than
+// silently widened, because callers terminate what this function returns and a root scope
+// would match unrelated processes.
+//
+// Enumeration is best effort. Processes that cannot be inspected, because they exited
+// mid-scan or belong to another user, are skipped instead of failing the whole call.
+func FindByExecutableDir(ctx context.Context, dir string) ([]ProcessInfo, error) {
+	scope, err := normalizeScope(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	candidates, err := enumerateProcesses(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to enumerate processes: %w", err)
+	}
+
+	self := os.Getpid()
+	matches := make([]ProcessInfo, 0, len(candidates))
+
+	for _, candidate := range candidates {
+		if candidate.PID <= 0 || candidate.PID == self || candidate.Executable == "" {
+			continue
+		}
+
+		if !executableInScope(scope, candidate.Executable) {
+			continue
+		}
+
+		if candidate.Name == "" {
+			candidate.Name = filepath.Base(candidate.Executable)
+		}
+
+		matches = append(matches, candidate)
+	}
+
+	return matches, nil
+}
+
+// Terminate stops the process described by process, which must still be running out of
+// scope for the stop to proceed.
+//
+// It reports whether a signal was actually delivered. A process that had already exited
+// is not an error, but it is also not something azd stopped, and callers report those two
+// outcomes differently to the user.
+//
+// It asks the process to stop, waits up to grace for it to exit on its own, then forces
+// it to stop if it is still running.
+//
+// The graceful step is platform dependent. On Unix the process is sent SIGTERM. Windows
+// has no safe general purpose graceful signal for a process azd does not own, so that
+// step is skipped there and the process is stopped directly.
+//
+// Scope is checked twice, for two different reasons.
+//
+// The supplied process is checked against scope up front. A caller that asks to stop
+// something it cannot show is inside the scope is refused, which keeps a malformed or
+// attacker-influenced ProcessInfo from reaching a kill.
+//
+// Scope is then re-checked against live operating system state immediately before each
+// signal. Discovery and termination are separate moments, and a PID is only a number: the
+// process can exit in between and the operating system can hand the same number to
+// something unrelated. Without the re-check a reused PID would be signalled on the
+// strength of a stale match.
+func Terminate(ctx context.Context, process ProcessInfo, scope string, grace time.Duration) (bool, error) {
+	if process.PID <= 0 {
+		return false, fmt.Errorf("%w: %d", ErrInvalidPID, process.PID)
+	}
+
+	if process.PID == os.Getpid() {
+		return false, fmt.Errorf("refusing to terminate the current process (PID %d)", process.PID)
+	}
+
+	normalized, err := normalizeScope(scope)
+	if err != nil {
+		return false, err
+	}
+
+	if process.Executable == "" || !executableInScope(normalized, process.Executable) {
+		return false, fmt.Errorf("%w: %s is not inside %s", ErrProcessOutOfScope, process.String(), normalized)
+	}
+
+	live, err := runningInScope(ctx, process.PID, normalized)
+	if err != nil {
+		return false, err
+	}
+
+	if !live {
+		return false, nil
+	}
+
+	signalled := false
+
+	if err := signalGraceful(process.PID); err == nil {
+		signalled = true
+
+		if waitForExit(ctx, process.PID, grace) {
+			return true, nil
+		}
+	}
+
+	// The grace period above is the widest part of the window, so re-check before the
+	// forced stop rather than trusting the check from before the wait.
+	live, err = runningInScope(ctx, process.PID, normalized)
+	if err != nil {
+		return signalled, err
+	}
+
+	if !live {
+		return signalled, nil
+	}
+
+	if err := forceKill(process.PID); err != nil {
+		// Losing the race against a process that exited on its own is a success, not a
+		// failure, so re-check before reporting the error.
+		if !processRunning(process.PID) {
+			return signalled, nil
+		}
+
+		return signalled, fmt.Errorf("failed to stop process %d: %w", process.PID, err)
+	}
+
+	if !waitForExit(ctx, process.PID, forceConfirmWindow) {
+		return true, fmt.Errorf("process %d did not exit after a forced stop", process.PID)
+	}
+
+	return true, nil
+}
+
+// runningInScope reports whether pid currently maps to a live process whose executable
+// image sits inside scope, which scope must already be normalized.
+//
+// An enumeration failure is returned rather than reported as "not running". Collapsing it
+// would make an unverifiable target look like one that had already exited, and --force
+// would claim success without having stopped anything.
+func runningInScope(ctx context.Context, pid int, scope string) (bool, error) {
+	candidates, err := enumerateProcesses(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to enumerate processes: %w", err)
+	}
+
+	for _, candidate := range candidates {
+		if candidate.PID != pid {
+			continue
+		}
+
+		return candidate.Executable != "" && executableInScope(scope, candidate.Executable), nil
+	}
+
+	return false, nil
+}
+
+// normalizeScope validates and canonicalizes the directory used to scope discovery.
+func normalizeScope(dir string) (string, error) {
+	if strings.TrimSpace(dir) == "" {
+		return "", ErrEmptyDirectory
+	}
+
+	absolute, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve %q: %w", dir, err)
+	}
+
+	// Refuse a scope whose final component is a symlink or junction. EvalSymlinks below
+	// would resolve it and hand back the link target, silently widening the set of
+	// processes a caller is willing to terminate to whatever the link points at. Callers
+	// build scopes from directories they own, so a link there is never legitimate.
+	if err := osutil.RequireRealDir(absolute); err != nil {
+		return "", err
+	}
+
+	// Resolve symlinks so a linked install directory still matches the real executable
+	// paths the operating system reports. A directory that does not exist has nothing to
+	// resolve, so the absolute form is kept and simply matches nothing.
+	if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+		absolute = resolved
+	}
+
+	absolute = filepath.Clean(absolute)
+
+	if isFilesystemRoot(absolute) {
+		return "", fmt.Errorf("%w: %q", ErrRootDirectory, absolute)
+	}
+
+	return absolute, nil
+}
+
+// isFilesystemRoot reports whether p is a filesystem, volume, or UNC share root.
+// A root is its own parent, which holds for "/", "C:\", and "\\server\share".
+func isFilesystemRoot(p string) bool {
+	cleaned := filepath.Clean(p)
+
+	return filepath.Dir(cleaned) == cleaned
+}
+
+// executableInScope reports whether an executable path falls inside the scope directory.
+// Both the reported path and its symlink-resolved form are checked, because a relocated
+// or unlinked binary may no longer resolve while its process keeps running.
+func executableInScope(scope, executable string) bool {
+	absolute, err := filepath.Abs(executable)
+	if err != nil {
+		return false
+	}
+
+	if osutil.IsPathContained(scope, filepath.Clean(absolute)) {
+		return true
+	}
+
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return false
+	}
+
+	return osutil.IsPathContained(scope, filepath.Clean(resolved))
+}
+
+// waitForExit polls until the process exits, the timeout elapses, or ctx is cancelled.
+// It reports whether the process is gone.
+func waitForExit(ctx context.Context, pid int, timeout time.Duration) bool {
+	if timeout <= 0 {
+		return !processRunning(pid)
+	}
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		if !processRunning(pid) {
+			return true
+		}
+
+		select {
+		case <-ctx.Done():
+			return !processRunning(pid)
+		case <-deadline.C:
+			return !processRunning(pid)
+		case <-ticker.C:
+		}
+	}
+}

--- a/cli/azd/pkg/processutil/processutil.go
+++ b/cli/azd/pkg/processutil/processutil.go
@@ -88,6 +88,30 @@ func Describe(processes []ProcessInfo) string {
 	return strings.Join(parts, ", ")
 }
 
+// DescribeExecutables renders the distinct executable images backing processes, in the
+// order first seen, for messages that need to name the files being held open. Several
+// instances of one extension normally share a single binary, so duplicates are collapsed
+// rather than repeating the same path once per PID.
+func DescribeExecutables(processes []ProcessInfo) string {
+	seen := make(map[string]struct{}, len(processes))
+	paths := make([]string, 0, len(processes))
+
+	for _, process := range processes {
+		if process.Executable == "" {
+			continue
+		}
+
+		if _, duplicate := seen[process.Executable]; duplicate {
+			continue
+		}
+
+		seen[process.Executable] = struct{}{}
+		paths = append(paths, process.Executable)
+	}
+
+	return strings.Join(paths, ", ")
+}
+
 // FindByExecutableDir returns every running process whose executable image is contained
 // within dir. The calling process is never returned.
 //
@@ -295,13 +319,19 @@ func isFilesystemRoot(p string) bool {
 // executableInScope reports whether an executable path falls inside the scope directory.
 // Both the reported path and its symlink-resolved form are checked, because a relocated
 // or unlinked binary may no longer resolve while its process keeps running.
+//
+// Containment is deliberately host-native rather than osutil.IsPathContained. That helper
+// rewrites every backslash to the OS separator, which is right for validating paths a user
+// typed but wrong for an OS-reported executable image: backslash is a legal filename
+// character on Unix, so a process running from "/home/u/other\..\extensions\demo\tool"
+// would be rewritten and cleaned into the demo scope and become a termination candidate.
 func executableInScope(scope, executable string) bool {
 	absolute, err := filepath.Abs(executable)
 	if err != nil {
 		return false
 	}
 
-	if osutil.IsPathContained(scope, filepath.Clean(absolute)) {
+	if pathContained(scope, absolute) {
 		return true
 	}
 
@@ -310,7 +340,26 @@ func executableInScope(scope, executable string) bool {
 		return false
 	}
 
-	return osutil.IsPathContained(scope, filepath.Clean(resolved))
+	return pathContained(scope, resolved)
+}
+
+// pathContained reports whether candidate sits at or beneath scope, treating both as
+// host-native paths. filepath.Rel supplies the platform's own separator and case-folding
+// rules, so no character is reinterpreted on the way in.
+func pathContained(scope, candidate string) bool {
+	relative, err := filepath.Rel(filepath.Clean(scope), filepath.Clean(candidate))
+	if err != nil {
+		// Different volumes, or one path relative and the other absolute. Neither can be
+		// shown to be contained, so the candidate is refused.
+		return false
+	}
+
+	if relative == "." {
+		return true
+	}
+
+	// An escaping result is the only way out of scope once both paths are cleaned.
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }
 
 // waitForExit polls until the process exits, the timeout elapses, or ctx is cancelled.

--- a/cli/azd/pkg/processutil/processutil_darwin.go
+++ b/cli/azd/pkg/processutil/processutil_darwin.go
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build darwin
+
+package processutil
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// psPath is the absolute path to ps(1). Resolving through $PATH would let a caller-
+// controlled environment decide which binary azd asks for the process list, and that
+// list is what --force uses to choose what to terminate.
+const psPath = "/bin/ps"
+
+// enumerateProcesses lists running processes using ps(1). The comm column reports the
+// full executable path on macOS, which is what scoping by directory requires. argv[0] is
+// deliberately not used: it is caller-controlled and need not be a real path.
+//
+// -ww disables width based truncation. Without it ps assumes a default terminal width
+// when stdout is a pipe and cuts the last column, which is comm here. A truncated path
+// silently fails containment, which would turn --force into a no-op that reports success.
+func enumerateProcesses(ctx context.Context) ([]ProcessInfo, error) {
+	output, err := exec.CommandContext(ctx, psPath, "-axww", "-o", "pid=,comm=").Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var results []ProcessInfo
+
+	for line := range strings.SplitSeq(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// ps pads the pid column, so the line is "<pid> <path>" after trimming. Cutting
+		// on the first space keeps executable paths that contain spaces intact.
+		pidField, executable, found := strings.Cut(line, " ")
+		if !found {
+			continue
+		}
+
+		pid, err := strconv.Atoi(pidField)
+		if err != nil || pid <= 0 {
+			continue
+		}
+
+		executable = strings.TrimSpace(executable)
+		if executable == "" {
+			continue
+		}
+
+		results = append(results, ProcessInfo{
+			PID:        pid,
+			Name:       filepath.Base(executable),
+			Executable: executable,
+		})
+	}
+
+	return results, nil
+}

--- a/cli/azd/pkg/processutil/processutil_integration_test.go
+++ b/cli/azd/pkg/processutil/processutil_integration_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package processutil
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/test/proctest"
+	"github.com/stretchr/testify/require"
+)
+
+// Windows file-lock and process-image behavior cannot be faked meaningfully, so these
+// tests run against real processes started by proctest.
+
+// modeIgnoreTerm swallows termination requests so escalation to a forced kill can be
+// observed. It is specific to this package, so it is handled here rather than in proctest.
+const modeIgnoreTerm proctest.Mode = "ignore-term"
+
+func TestMain(m *testing.M) {
+	if proctest.RequestedMode() == modeIgnoreTerm {
+		notifications := make(chan os.Signal, 1)
+		signal.Notify(notifications, ignorableSignals()...)
+		proctest.Idle()
+
+		return
+	}
+
+	if proctest.RunRequestedHelper() {
+		return
+	}
+
+	os.Exit(m.Run())
+}
+
+// spawnHelperIn starts a real process out of dir in the given helper mode, so the running
+// executable is genuinely contained within dir.
+func spawnHelperIn(t *testing.T, dir string, mode proctest.Mode) *proctest.Handle {
+	t.Helper()
+
+	handle := proctest.StartIn(t, dir, "azd-processutil-helper", mode)
+	requireProcessDiscoverable(t, dir, handle.PID)
+
+	return handle
+}
+
+// processIn resolves the discovered ProcessInfo for pid inside dir, so tests terminate
+// through the same discover-then-terminate path that the manager uses.
+func processIn(t *testing.T, dir string, pid int) ProcessInfo {
+	t.Helper()
+
+	found, err := FindByExecutableDir(t.Context(), dir)
+	require.NoError(t, err)
+
+	for _, process := range found {
+		if process.PID == pid {
+			return process
+		}
+	}
+
+	t.Fatalf("pid %d is not present in %s", pid, dir)
+
+	return ProcessInfo{}
+}
+
+// requireProcessDiscoverable waits for the spawned process to become visible to the OS
+// process tables, which are not updated synchronously with process creation.
+func requireProcessDiscoverable(t *testing.T, dir string, pid int) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		found, err := FindByExecutableDir(t.Context(), dir)
+		if err != nil {
+			return false
+		}
+
+		for _, process := range found {
+			if process.PID == pid {
+				return true
+			}
+		}
+
+		return false
+	}, 30*time.Second, 100*time.Millisecond, "spawned helper never became discoverable in %s", dir)
+}
+
+// T11: a real process running out of the directory is discovered, with the identifying
+// details the error and status messages depend on.
+func TestFindByExecutableDir_FindsSpawnedProcess(t *testing.T) {
+	dir := t.TempDir()
+	helper := spawnHelperIn(t, dir, proctest.ModeIdle)
+
+	found, err := FindByExecutableDir(t.Context(), dir)
+	require.NoError(t, err)
+
+	var match *ProcessInfo
+
+	for index := range found {
+		if found[index].PID == helper.PID {
+			match = &found[index]
+
+			break
+		}
+	}
+
+	require.NotNil(t, match, "spawned helper was not discovered")
+	require.Equal(t, filepath.Base(helper.Path), match.Name)
+	require.NotEmpty(t, match.Executable)
+
+	normalized, err := normalizeScope(dir)
+	require.NoError(t, err)
+	require.True(t, executableInScope(normalized, match.Executable),
+		"reported executable %q should be contained in %q", match.Executable, normalized)
+}
+
+// T12: the containment guarantee only means something if a process just outside the
+// directory is genuinely excluded.
+func TestFindByExecutableDir_IgnoresOutsideProcess(t *testing.T) {
+	base := t.TempDir()
+
+	inside := filepath.Join(base, "extension")
+	outside := filepath.Join(base, "elsewhere")
+	require.NoError(t, os.MkdirAll(inside, 0755))
+	require.NoError(t, os.MkdirAll(outside, 0755))
+
+	insideHelper := spawnHelperIn(t, inside, proctest.ModeIdle)
+	outsideHelper := spawnHelperIn(t, outside, proctest.ModeIdle)
+
+	found, err := FindByExecutableDir(t.Context(), inside)
+	require.NoError(t, err)
+
+	pids := make([]int, 0, len(found))
+	for _, process := range found {
+		pids = append(pids, process.PID)
+	}
+
+	require.Contains(t, pids, insideHelper.PID)
+	require.NotContains(t, pids, outsideHelper.PID)
+}
+
+// T14: enumeration walks every process on the machine, most of which azd cannot inspect.
+// Those denials must be skipped rather than failing the scan.
+func TestFindByExecutableDir_TolerantOfDeniedPids(t *testing.T) {
+	dir := t.TempDir()
+	helper := spawnHelperIn(t, dir, proctest.ModeIdle)
+
+	// System processes are unreadable for a non-elevated user on every supported
+	// platform. Finding the helper anyway proves those denials did not abort the scan.
+	found, err := FindByExecutableDir(t.Context(), dir)
+	require.NoError(t, err)
+	require.NotEmpty(t, found)
+
+	pids := make([]int, 0, len(found))
+	for _, process := range found {
+		pids = append(pids, process.PID)
+	}
+
+	require.Contains(t, pids, helper.PID)
+}
+
+// T15: a cooperating process is stopped, and Terminate confirms it is gone.
+func TestTerminate_GracefulStop(t *testing.T) {
+	dir := t.TempDir()
+	helper := spawnHelperIn(t, dir, proctest.ModeIdle)
+	process := processIn(t, dir, helper.PID)
+
+	stopped, err := Terminate(t.Context(), process, dir, DefaultGracePeriod)
+	require.NoError(t, err)
+	require.True(t, stopped, "Terminate should report that it stopped a running process")
+	require.False(t, processRunning(helper.PID), "process should be gone after Terminate")
+
+	found, err := FindByExecutableDir(t.Context(), dir)
+	require.NoError(t, err)
+
+	for _, process := range found {
+		require.NotEqual(t, helper.PID, process.PID)
+	}
+}
+
+// T16: a process that refuses to stop gracefully must still be stopped once the grace
+// period expires, otherwise --force would not deliver on its name.
+func TestTerminate_EscalatesToForce(t *testing.T) {
+	dir := t.TempDir()
+	helper := spawnHelperIn(t, dir, modeIgnoreTerm)
+	process := processIn(t, dir, helper.PID)
+
+	// A short grace keeps the test quick while still exercising the escalation path.
+	// Windows has no graceful step at all and escalates immediately by design.
+	start := time.Now()
+	stopped, err := Terminate(t.Context(), process, dir, 500*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, stopped)
+	require.False(t, processRunning(helper.PID))
+	require.Less(t, time.Since(start), 30*time.Second, "escalation should be bounded")
+}
+
+// T17: losing the race against a process that already exited is a success, not a failure.
+func TestTerminate_AlreadyExited(t *testing.T) {
+	dir := t.TempDir()
+	helper := spawnHelperIn(t, dir, proctest.ModeIdle)
+
+	pid := helper.PID
+	process := processIn(t, dir, pid)
+
+	stopped, err := Terminate(t.Context(), process, dir, DefaultGracePeriod)
+	require.NoError(t, err)
+	require.True(t, stopped)
+
+	// Terminating the same process again must be a no-op rather than an error, and it
+	// must not claim to have stopped anything the second time.
+	stopped, err = Terminate(t.Context(), process, dir, DefaultGracePeriod)
+	require.NoError(t, err)
+	require.False(t, stopped, "a process that had already exited was not stopped by azd")
+}
+
+// T18: a cancelled context must not extend the wait, so --force stays bounded and
+// scriptable rather than hanging a CI job.
+func TestTerminate_BoundedByContext(t *testing.T) {
+	dir := t.TempDir()
+	helper := spawnHelperIn(t, dir, modeIgnoreTerm)
+	process := processIn(t, dir, helper.PID)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	// The outcome is allowed to be either "stopped" or "not confirmed", but it must
+	// never sit on the hour-long grace period after the context has been cancelled.
+	start := time.Now()
+	_, _ = Terminate(ctx, process, dir, time.Hour)
+	elapsed := time.Since(start)
+
+	require.Less(t, elapsed, 30*time.Second, "a cancelled context must not wait out the grace period")
+}
+
+// waitForExit reports on an already-dead PID without waiting for the timeout.
+func TestWaitForExit_ZeroTimeout(t *testing.T) {
+	dir := t.TempDir()
+	helper := spawnHelperIn(t, dir, proctest.ModeIdle)
+	process := processIn(t, dir, helper.PID)
+
+	require.False(t, waitForExit(t.Context(), helper.PID, 0))
+
+	_, err := Terminate(t.Context(), process, dir, DefaultGracePeriod)
+	require.NoError(t, err)
+	require.True(t, waitForExit(t.Context(), helper.PID, 0))
+}

--- a/cli/azd/pkg/processutil/processutil_procfs.go
+++ b/cli/azd/pkg/processutil/processutil_procfs.go
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build !windows && !darwin
+
+package processutil
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// deletedSuffix is what Linux appends to /proc/<pid>/exe once the executable has been
+// unlinked or moved. That is exactly the state azd creates when it relocates a locked
+// binary, so the suffix has to be stripped or the processes this package exists to find
+// become invisible to it.
+const deletedSuffix = " (deleted)"
+
+// enumerateProcesses lists running processes by reading /proc.
+//
+// The context is accepted for interface symmetry with the other platforms. Reading /proc
+// is local and bounded, so there is nothing here that can hang the way an external
+// command can.
+func enumerateProcesses(_ context.Context) ([]ProcessInfo, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, err
+	}
+
+	var results []ProcessInfo
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid <= 0 {
+			continue // Not a process directory.
+		}
+
+		// Processes exit constantly while /proc is walked and some belong to other
+		// users, so an unreadable link is skipped rather than failing the scan.
+		target, err := os.Readlink(filepath.Join("/proc", entry.Name(), "exe"))
+		if err != nil {
+			continue
+		}
+
+		executable := normalizeProcExe(target)
+		if executable == "" {
+			continue
+		}
+
+		results = append(results, ProcessInfo{
+			PID:        pid,
+			Name:       filepath.Base(executable),
+			Executable: executable,
+		})
+	}
+
+	return results, nil
+}
+
+// normalizeProcExe strips the marker Linux appends once an executable has been unlinked,
+// returning the original path.
+func normalizeProcExe(target string) string {
+	return strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(target), deletedSuffix))
+}

--- a/cli/azd/pkg/processutil/processutil_procfs_test.go
+++ b/cli/azd/pkg/processutil/processutil_procfs_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build !windows && !darwin
+
+package processutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// T13: Linux marks an unlinked executable as "(deleted)" in /proc/<pid>/exe. Relocation
+// creates exactly that state, so failing to strip the marker would hide the very
+// processes this package exists to find.
+func TestNormalizeProcExe_StripsDeletedSuffix(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"/home/user/.azd/extensions/demo/demo":           "/home/user/.azd/extensions/demo/demo",
+		"/home/user/.azd/extensions/demo/demo (deleted)": "/home/user/.azd/extensions/demo/demo",
+		"  /tmp/ext/tool (deleted)  ":                    "/tmp/ext/tool",
+		"/tmp/ext/tool ":                                 "/tmp/ext/tool",
+		"":                                               "",
+		"   ":                                            "",
+		// Only the trailing marker is removed. A path that genuinely contains the word
+		// must survive intact, or a legitimately named binary would be mis-resolved.
+		"/tmp/ext/ (deleted) tool": "/tmp/ext/ (deleted) tool",
+	}
+
+	for input, expected := range cases {
+		require.Equalf(t, expected, normalizeProcExe(input), "normalizeProcExe(%q)", input)
+	}
+}

--- a/cli/azd/pkg/processutil/processutil_test.go
+++ b/cli/azd/pkg/processutil/processutil_test.go
@@ -210,6 +210,60 @@ func TestFindByExecutableDir_CaseSensitivityByPlatform(t *testing.T) {
 		"case-sensitive filesystems must treat a differently cased path as a different path")
 }
 
+// A literal backslash is a legal filename character on Unix. osutil.IsPathContained
+// rewrites backslashes to the OS separator, which is correct for validating a path a user
+// typed but wrong for an OS-reported executable image: it would clean an out-of-scope
+// binary into scope and make it a termination candidate. Containment must stay host-native.
+func TestFindByExecutableDir_UnixBackslashIsNotASeparator(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("backslash is a real separator on Windows, so there is nothing to confuse")
+	}
+
+	t.Parallel()
+
+	base := t.TempDir()
+	scope := filepath.Join(base, "extensions", "demo")
+	require.NoError(t, os.MkdirAll(scope, 0755))
+
+	normalized, err := normalizeScope(scope)
+	require.NoError(t, err)
+
+	// A single file directly under base whose name literally contains backslashes.
+	// Rewriting them as separators cleans it to <base>/extensions/demo/tool, in scope.
+	outside := filepath.Join(base, `other\..\extensions\demo\tool`)
+
+	require.False(t, executableInScope(normalized, outside),
+		"a backslash in a Unix filename must not be reinterpreted as a path separator")
+}
+
+// Containment is the safety property the package is built around, so an escaping path must
+// be refused no matter how it is spelled.
+func TestPathContained(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	scope := filepath.Join(base, "extensions", "demo")
+
+	require.True(t, pathContained(scope, scope), "a scope contains itself")
+	require.True(t, pathContained(scope, filepath.Join(scope, "tool")))
+	require.True(t, pathContained(scope, filepath.Join(scope, "nested", "tool")))
+
+	// A child whose name merely starts with ".." is inside the scope. This is why the
+	// escape check tests for ".." followed by a separator rather than a bare prefix.
+	require.True(t, pathContained(scope, filepath.Join(scope, "..cache", "tool")))
+
+	// The immediate parent is the only input that relativizes to exactly "..", so it is
+	// the only one that exercises the equality half of the escape check. Without it,
+	// dropping that clause would widen the termination boundary to the parent directory
+	// with every other assertion here still passing.
+	require.False(t, pathContained(scope, filepath.Join(base, "extensions")),
+		"the immediate parent of the scope is not contained by it")
+
+	require.False(t, pathContained(scope, base))
+	require.False(t, pathContained(scope, filepath.Join(base, "extensions", "demo-backup", "tool")))
+	require.False(t, pathContained(scope, filepath.Join(scope, "..", "other", "tool")))
+}
+
 // T10: a directory that was never created is a normal state (nothing installed there).
 // It must yield no matches rather than an error or a panic.
 func TestFindByExecutableDir_MissingDir(t *testing.T) {
@@ -317,4 +371,27 @@ func TestDescribe(t *testing.T) {
 		{PID: 1, Name: "a"},
 		{PID: 2, Name: "b"},
 	}))
+}
+
+// Error messages name the binary being held open, and several instances of one extension
+// normally share it, so the path is listed once rather than once per PID.
+func TestDescribeExecutables(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "", DescribeExecutables(nil))
+	require.Equal(t, "", DescribeExecutables([]ProcessInfo{{PID: 1, Name: "a"}}),
+		"a process with no recorded image contributes no path")
+
+	require.Equal(t, filepath.Join("x", "a"), DescribeExecutables([]ProcessInfo{
+		{PID: 1, Name: "a", Executable: filepath.Join("x", "a")},
+		{PID: 2, Name: "a", Executable: filepath.Join("x", "a")},
+	}), "watch-mode instances sharing one binary must not repeat its path")
+
+	require.Equal(t,
+		filepath.Join("x", "a")+", "+filepath.Join("x", "b"),
+		DescribeExecutables([]ProcessInfo{
+			{PID: 1, Name: "a", Executable: filepath.Join("x", "a")},
+			{PID: 2, Name: "b", Executable: filepath.Join("x", "b")},
+			{PID: 3, Name: "a", Executable: filepath.Join("x", "a")},
+		}), "distinct binaries are listed in the order first seen")
 }

--- a/cli/azd/pkg/processutil/processutil_test.go
+++ b/cli/azd/pkg/processutil/processutil_test.go
@@ -1,0 +1,320 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package processutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/stretchr/testify/require"
+)
+
+// T1: an empty scope would match every process on the machine, so it must be refused.
+func TestFindByExecutableDir_RejectsEmptyDir(t *testing.T) {
+	t.Parallel()
+
+	for _, dir := range []string{"", "   ", "\t"} {
+		found, err := FindByExecutableDir(t.Context(), dir)
+		require.ErrorIs(t, err, ErrEmptyDirectory)
+		require.Nil(t, found)
+	}
+}
+
+// T2: the Unix filesystem root contains everything, so it must be refused.
+func TestFindByExecutableDir_RejectsUnixRoot(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("posix root semantics do not apply on Windows")
+	}
+
+	for _, dir := range []string{"/", "//", "/.", "/usr/.."} {
+		found, err := FindByExecutableDir(t.Context(), dir)
+		require.ErrorIsf(t, err, ErrRootDirectory, "expected %q to be rejected as a root", dir)
+		require.Nil(t, found)
+	}
+}
+
+// T3: a Windows volume root contains everything on that volume, so it must be refused.
+func TestFindByExecutableDir_RejectsWindowsRoot(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "windows" {
+		t.Skip("drive roots only exist on Windows")
+	}
+
+	volume := filepath.VolumeName(os.Getenv("SystemDrive"))
+	if volume == "" {
+		volume = "C:"
+	}
+
+	for _, dir := range []string{volume + `\`, volume + `\.`, volume + `\Windows\..`} {
+		found, err := FindByExecutableDir(t.Context(), dir)
+		require.ErrorIsf(t, err, ErrRootDirectory, "expected %q to be rejected as a root", dir)
+		require.Nil(t, found)
+	}
+}
+
+// T4: a UNC share root is a root like any other and must be refused too.
+func TestFindByExecutableDir_RejectsUNCRoot(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "windows" {
+		t.Skip("UNC paths only exist on Windows")
+	}
+
+	// The share need not exist. Rejection is a path-shape decision made before any
+	// filesystem or process access, which is what keeps the guard trustworthy.
+	found, err := FindByExecutableDir(t.Context(), `\\testserver\testshare`)
+	require.ErrorIs(t, err, ErrRootDirectory)
+	require.Nil(t, found)
+}
+
+// T5: azd must never hand back its own PID, or --force would terminate the CLI itself.
+func TestFindByExecutableDir_ExcludesSelf(t *testing.T) {
+	t.Parallel()
+
+	executable, err := os.Executable()
+	require.NoError(t, err)
+
+	found, err := FindByExecutableDir(t.Context(), filepath.Dir(executable))
+	require.NoError(t, err)
+
+	for _, process := range found {
+		require.NotEqual(t, os.Getpid(), process.PID, "discovery returned the current process")
+	}
+}
+
+// T6: a scope reached through a symlinked ancestor must still resolve, otherwise
+// containment would never match on macOS, where the temp directory sits under /var and
+// the OS reports executables under /private/var.
+func TestFindByExecutableDir_ResolvesSymlinkedAncestors(t *testing.T) {
+	t.Parallel()
+
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable in this environment: %v", err)
+	}
+
+	child := "child"
+	require.NoError(t, os.Mkdir(filepath.Join(real, child), 0755))
+
+	resolvedReal, err := filepath.EvalSymlinks(real)
+	require.NoError(t, err)
+
+	// The final component is a real directory; only the path used to reach it is linked.
+	scope, err := normalizeScope(filepath.Join(link, child))
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(filepath.Clean(resolvedReal), child), scope)
+}
+
+// A scope whose own final component is a link must be refused rather than resolved.
+// Resolving it would hand back the link target, so anything able to plant a link where
+// azd expects an install directory could widen a scoped termination to whatever it
+// points at. azd creates these directories itself, so a link there is never legitimate.
+func TestFindByExecutableDir_RejectsLinkedScope(t *testing.T) {
+	t.Parallel()
+
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable in this environment: %v", err)
+	}
+
+	_, err := normalizeScope(link)
+	require.ErrorIs(t, err, osutil.ErrLinkedDirectory)
+
+	_, err = FindByExecutableDir(t.Context(), link)
+	require.ErrorIs(t, err, osutil.ErrLinkedDirectory,
+		"discovery must refuse a linked scope, not just normalization")
+}
+
+// T7: a relative scope must become absolute before comparison, since process
+// executables are always reported as absolute paths.
+func TestFindByExecutableDir_ResolvesRelativePath(t *testing.T) {
+	base := t.TempDir()
+	child := filepath.Join(base, "child")
+	require.NoError(t, os.MkdirAll(child, 0755))
+
+	t.Chdir(base)
+
+	scope, err := normalizeScope("child")
+	require.NoError(t, err)
+	require.True(t, filepath.IsAbs(scope), "scope %q should be absolute", scope)
+
+	resolvedChild, err := filepath.EvalSymlinks(child)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Clean(resolvedChild), scope)
+}
+
+// T8: "ext" must not match "ext-backup". A plain string prefix test would, which is
+// exactly the class of bug that turns a scoped stop into an unscoped one.
+func TestFindByExecutableDir_RejectsPrefixSibling(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	scope := filepath.Join(base, "ext")
+	sibling := filepath.Join(base, "ext-backup")
+
+	require.NoError(t, os.MkdirAll(scope, 0755))
+	require.NoError(t, os.MkdirAll(sibling, 0755))
+
+	normalized, err := normalizeScope(scope)
+	require.NoError(t, err)
+
+	require.False(t, executableInScope(normalized, filepath.Join(sibling, "tool.exe")),
+		"a sibling sharing a name prefix must not be considered contained")
+	require.True(t, executableInScope(normalized, filepath.Join(scope, "tool.exe")))
+}
+
+// T9: containment must follow the filesystem it is running on. Windows matches
+// case-insensitively, Linux does not.
+func TestFindByExecutableDir_CaseSensitivityByPlatform(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	scope := filepath.Join(base, "MyExtension")
+	require.NoError(t, os.MkdirAll(scope, 0755))
+
+	normalized, err := normalizeScope(scope)
+	require.NoError(t, err)
+
+	sameCase := filepath.Join(normalized, "tool.exe")
+	require.True(t, executableInScope(normalized, sameCase))
+
+	differentCase := filepath.Join(strings.ToLower(normalized), "tool.exe")
+
+	if runtime.GOOS == "windows" {
+		require.True(t, executableInScope(normalized, differentCase),
+			"Windows paths are case-insensitive, so a lowercased path must still match")
+
+		return
+	}
+
+	// A case-sensitive comparison. strings.EqualFold here would compare the path against
+	// its own lowercase form case-insensitively, which is true for every input, so the
+	// assertion below would never run.
+	if normalized == strings.ToLower(normalized) {
+		t.Skip("temp directory has no case variation to exercise")
+	}
+
+	require.False(t, executableInScope(normalized, differentCase),
+		"case-sensitive filesystems must treat a differently cased path as a different path")
+}
+
+// T10: a directory that was never created is a normal state (nothing installed there).
+// It must yield no matches rather than an error or a panic.
+func TestFindByExecutableDir_MissingDir(t *testing.T) {
+	t.Parallel()
+
+	missing := filepath.Join(t.TempDir(), "does", "not", "exist")
+
+	found, err := FindByExecutableDir(t.Context(), missing)
+	require.NoError(t, err)
+	require.Empty(t, found)
+}
+
+// isFilesystemRoot is the guard T2-T4 depend on, so its contract is pinned directly.
+func TestIsFilesystemRoot(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, isFilesystemRoot(t.TempDir()))
+
+	if runtime.GOOS == "windows" {
+		require.True(t, isFilesystemRoot(`C:\`))
+		require.True(t, isFilesystemRoot(`\\server\share`))
+		require.False(t, isFilesystemRoot(`C:\Users`))
+
+		return
+	}
+
+	require.True(t, isFilesystemRoot("/"))
+	require.False(t, isFilesystemRoot("/usr"))
+}
+
+// Terminate must refuse the current process outright, before any platform call.
+func TestTerminate_RefusesSelf(t *testing.T) {
+	t.Parallel()
+
+	self, err := os.Executable()
+	require.NoError(t, err)
+
+	process := ProcessInfo{PID: os.Getpid(), Name: filepath.Base(self), Executable: self}
+	_, err = Terminate(t.Context(), process, filepath.Dir(self), DefaultGracePeriod)
+	require.ErrorContains(t, err, "refusing to terminate the current process")
+}
+
+// A non-positive PID has platform-specific meaning (process group, every process),
+// so it must be rejected rather than passed through.
+func TestTerminate_RejectsInvalidPID(t *testing.T) {
+	t.Parallel()
+
+	for _, pid := range []int{0, -1, -1000} {
+		process := ProcessInfo{PID: pid, Executable: filepath.Join(t.TempDir(), "ext.exe")}
+		_, err := Terminate(t.Context(), process, t.TempDir(), DefaultGracePeriod)
+		require.ErrorIs(t, err, ErrInvalidPID)
+	}
+}
+
+// The scope is the security boundary for --force. A process whose recorded executable
+// sits outside the scope must never be signalled, no matter how it was discovered.
+func TestTerminate_RejectsProcessOutsideScope(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	scope := filepath.Join(root, "extension")
+	require.NoError(t, os.MkdirAll(scope, 0o755))
+
+	outside := filepath.Join(root, "elsewhere", "other.exe")
+	process := ProcessInfo{PID: 999999, Name: "other.exe", Executable: outside}
+
+	_, err := Terminate(t.Context(), process, scope, DefaultGracePeriod)
+	require.ErrorIs(t, err, ErrProcessOutOfScope)
+}
+
+// An empty scope would make every containment check trivially pass, which would turn
+// --force into an unbounded kill. It must be refused.
+func TestTerminate_RejectsEmptyScope(t *testing.T) {
+	t.Parallel()
+
+	process := ProcessInfo{PID: 999999, Name: "ext.exe", Executable: filepath.Join(t.TempDir(), "ext.exe")}
+	_, err := Terminate(t.Context(), process, "", DefaultGracePeriod)
+	require.ErrorIs(t, err, ErrEmptyDirectory)
+}
+
+// A process with no recorded executable cannot be proven in scope, so it must be refused
+// rather than trusted.
+func TestTerminate_RejectsUnknownExecutable(t *testing.T) {
+	t.Parallel()
+
+	process := ProcessInfo{PID: 999999, Name: "ext.exe"}
+	_, err := Terminate(t.Context(), process, t.TempDir(), DefaultGracePeriod)
+	require.ErrorIs(t, err, ErrProcessOutOfScope)
+}
+
+// ProcessInfo renders into user-facing errors, so its formatting is part of the contract.
+func TestProcessInfoString(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "myext.exe (PID 42)", ProcessInfo{PID: 42, Name: "myext.exe"}.String())
+	require.Equal(t, "unknown (PID 7)", ProcessInfo{PID: 7}.String())
+}
+
+func TestDescribe(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "", Describe(nil))
+	require.Equal(t, "a (PID 1)", Describe([]ProcessInfo{{PID: 1, Name: "a"}}))
+	require.Equal(t, "a (PID 1), b (PID 2)", Describe([]ProcessInfo{
+		{PID: 1, Name: "a"},
+		{PID: 2, Name: "b"},
+	}))
+}

--- a/cli/azd/pkg/processutil/processutil_unix.go
+++ b/cli/azd/pkg/processutil/processutil_unix.go
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build !windows
+
+package processutil
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// signalGraceful asks the process to shut down with SIGTERM, giving it a chance to run
+// its own cleanup before Terminate escalates.
+func signalGraceful(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+
+	return process.Signal(syscall.SIGTERM)
+}
+
+// forceKill stops the process immediately with SIGKILL.
+func forceKill(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+
+	return process.Signal(syscall.SIGKILL)
+}
+
+// processRunning reports whether the process exists. Signal 0 performs the existence
+// check without delivering anything. EPERM means the process exists but is owned by
+// another user, which still counts as running.
+func processRunning(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+
+	err = process.Signal(syscall.Signal(0))
+
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/cli/azd/pkg/processutil/processutil_unix.go
+++ b/cli/azd/pkg/processutil/processutil_unix.go
@@ -23,7 +23,13 @@ func signalGraceful(pid int) error {
 }
 
 // forceKill stops the process immediately with SIGKILL.
-func forceKill(pid int) error {
+//
+// scope is accepted for parity with the Windows implementation, which pins the process
+// identity with an open handle so its containment check cannot be invalidated before the
+// kill. Unix has no portable equivalent: Linux could use a pidfd, macOS offers nothing of
+// the sort, so here the caller's re-check immediately before this call narrows the window
+// rather than closing it.
+func forceKill(pid int, _ string) error {
 	process, err := os.FindProcess(pid)
 	if err != nil {
 		return err

--- a/cli/azd/pkg/processutil/processutil_windows.go
+++ b/cli/azd/pkg/processutil/processutil_windows.go
@@ -29,14 +29,31 @@ func signalGraceful(pid int) error {
 	return fmt.Errorf("graceful stop is not supported on windows for process %d", pid)
 }
 
-// forceKill stops a process immediately using TerminateProcess.
-func forceKill(pid int) error {
+// forceKill stops a process immediately using TerminateProcess, refusing to act when the
+// process behind pid is no longer the one inside scope.
+//
+// The open handle is what makes the scope check binding rather than merely probable.
+// Windows keeps a process id reserved for as long as any handle to that process object is
+// open, so the identity established by the image path query below cannot be swapped for
+// an unrelated process before TerminateProcess runs. Validating a bare pid and then
+// reopening it to kill could not offer that: the process may exit and the operating
+// system hand the same number to something else in between.
+func forceKill(pid int, scope string) error {
 	//nolint:gosec // G115: pid is validated as positive by Terminate.
-	handle, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, uint32(pid))
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_TERMINATE|windows.PROCESS_QUERY_LIMITED_INFORMATION,
+		false,
+		uint32(pid),
+	)
 	if err != nil {
 		return err
 	}
 	defer windows.CloseHandle(handle)
+
+	executable := imagePathForHandle(handle)
+	if executable == "" || !executableInScope(scope, executable) {
+		return fmt.Errorf("%w: process %d is not inside %s", ErrProcessOutOfScope, pid, scope)
+	}
 
 	return windows.TerminateProcess(handle, 1)
 }
@@ -108,6 +125,15 @@ func processImagePath(pid uint32) string {
 	}
 	defer windows.CloseHandle(handle)
 
+	return imagePathForHandle(handle)
+}
+
+// imagePathForHandle returns the full path of the executable image behind an already open
+// process handle, or an empty string when it cannot be read.
+//
+// Taking a handle rather than a pid is what lets forceKill decide scope and terminate
+// against one pinned process object instead of two separate lookups by number.
+func imagePathForHandle(handle windows.Handle) string {
 	size := uint32(windows.MAX_PATH)
 	buf := make([]uint16, size)
 

--- a/cli/azd/pkg/processutil/processutil_windows.go
+++ b/cli/azd/pkg/processutil/processutil_windows.go
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build windows
+
+package processutil
+
+import (
+	"context"
+	"fmt"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// stillActive is the exit code Windows reports for a process that has not exited.
+const stillActive = 259
+
+// signalGraceful is intentionally unsupported on Windows.
+//
+// Windows has no safe general purpose graceful stop for a console-less process that azd
+// did not create. GenerateConsoleCtrlEvent targets a process group rather than a single
+// process, so it can reach azd itself whenever the target shares azd's console. Killing
+// the CLI to avoid a hard kill of an extension is not a trade worth making, so callers
+// escalate straight to forceKill. Returning an error keeps Terminate's control flow
+// identical across platforms.
+func signalGraceful(pid int) error {
+	return fmt.Errorf("graceful stop is not supported on windows for process %d", pid)
+}
+
+// forceKill stops a process immediately using TerminateProcess.
+func forceKill(pid int) error {
+	//nolint:gosec // G115: pid is validated as positive by Terminate.
+	handle, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, uint32(pid))
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(handle)
+
+	return windows.TerminateProcess(handle, 1)
+}
+
+// processRunning reports whether the process exists and has not yet exited.
+func processRunning(pid int) bool {
+	//nolint:gosec // G115: pid is validated as positive by callers.
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(handle)
+
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(handle, &exitCode); err != nil {
+		return false
+	}
+
+	return exitCode == stillActive
+}
+
+// enumerateProcesses lists running processes with their full executable paths using a
+// process snapshot. Processes that cannot be opened are skipped: without an image path
+// they can never satisfy a containment check.
+//
+// The context is accepted for interface symmetry with the other platforms. The snapshot
+// is a bounded local syscall, so there is nothing here that can hang.
+func enumerateProcesses(_ context.Context) ([]ProcessInfo, error) {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer windows.CloseHandle(snapshot)
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		return nil, err
+	}
+
+	var results []ProcessInfo
+
+	for {
+		if entry.ProcessID > 0 {
+			if executable := processImagePath(entry.ProcessID); executable != "" {
+				results = append(results, ProcessInfo{
+					PID:        int(entry.ProcessID),
+					Name:       syscall.UTF16ToString(entry.ExeFile[:]),
+					Executable: executable,
+				})
+			}
+		}
+
+		if err := windows.Process32Next(snapshot, &entry); err != nil {
+			break
+		}
+	}
+
+	return results, nil
+}
+
+// processImagePath returns the full path of a process's executable image, or an empty
+// string when the process cannot be opened or has already exited.
+func processImagePath(pid uint32) string {
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
+	if err != nil {
+		return ""
+	}
+	defer windows.CloseHandle(handle)
+
+	size := uint32(windows.MAX_PATH)
+	buf := make([]uint16, size)
+
+	if err := windows.QueryFullProcessImageName(handle, 0, &buf[0], &size); err != nil {
+		// Paths longer than MAX_PATH need the extended limit.
+		size = 32768
+		buf = make([]uint16, size)
+		if err := windows.QueryFullProcessImageName(handle, 0, &buf[0], &size); err != nil {
+			return ""
+		}
+	}
+
+	return syscall.UTF16ToString(buf[:size])
+}

--- a/cli/azd/pkg/processutil/processutil_windows_test.go
+++ b/cli/azd/pkg/processutil/processutil_windows_test.go
@@ -7,8 +7,10 @@ package processutil
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/test/proctest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,4 +24,33 @@ func TestSignalGraceful_IsUnsupportedOnWindows(t *testing.T) {
 
 	require.Error(t, err, "windows must report that graceful stop is unavailable")
 	require.Contains(t, err.Error(), "not supported")
+}
+
+// forceKill decides scope against the process object behind its own open handle rather
+// than looking the PID up a second time. A process outside the scope is refused at the
+// moment of the kill, which is what makes the containment guarantee survive a PID that
+// was recycled after Terminate's earlier check.
+func TestForceKill_RefusesProcessOutsideScope(t *testing.T) {
+	base := t.TempDir()
+
+	extensionDir := filepath.Join(base, "extension")
+	require.NoError(t, os.MkdirAll(extensionDir, 0o755))
+
+	elsewhere := filepath.Join(base, "elsewhere")
+	require.NoError(t, os.MkdirAll(elsewhere, 0o755))
+
+	helper := proctest.StartIn(t, extensionDir, "azd-forcekill-scope-helper", proctest.ModeIdle)
+	defer helper.Stop()
+
+	outOfScope, err := normalizeScope(elsewhere)
+	require.NoError(t, err)
+
+	require.ErrorIs(t, forceKill(helper.PID, outOfScope), ErrProcessOutOfScope)
+	helper.RequireRunning(t)
+
+	inScope, err := normalizeScope(extensionDir)
+	require.NoError(t, err)
+
+	require.NoError(t, forceKill(helper.PID, inScope), "a process inside the scope must still be stopped")
+	helper.RequireStopped(t)
 }

--- a/cli/azd/pkg/processutil/processutil_windows_test.go
+++ b/cli/azd/pkg/processutil/processutil_windows_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build windows
+
+package processutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The Windows graceful stop is deliberately absent rather than merely unimplemented, and
+// Terminate depends on it reporting failure so that the control flow escalates to
+// forceKill instead of waiting out a grace period that would never end in an exit. If
+// someone later "fixes" this to return nil, forced termination silently becomes a no-op
+// followed by a timeout, so the contract is asserted rather than assumed.
+func TestSignalGraceful_IsUnsupportedOnWindows(t *testing.T) {
+	err := signalGraceful(os.Getpid())
+
+	require.Error(t, err, "windows must report that graceful stop is unavailable")
+	require.Contains(t, err.Error(), "not supported")
+}

--- a/cli/azd/test/proctest/proctest.go
+++ b/cli/azd/test/proctest/proctest.go
@@ -1,0 +1,241 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Package proctest starts real, long-lived processes whose executable image lives in a
+// directory the test chooses.
+//
+// Process and file-lock behavior cannot be faked meaningfully. Windows refuses to delete
+// the image file of a running executable, process enumeration reads live operating system
+// tables, and termination is observed by the kernel rather than by a mock. Tests covering
+// any of that need a genuine process running from a genuine path.
+//
+// The technique used throughout is to copy the running test binary into the target
+// directory and re-execute it in a helper mode, which yields a real executable at an
+// arbitrary path without needing a build step or a checked-in fixture binary.
+package proctest
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ModeEnvVar names the environment variable that puts a re-executed test binary into
+// helper mode instead of running tests.
+const ModeEnvVar = "AZD_TEST_PROC_MODE"
+
+// Mode selects what a helper does instead of running tests.
+type Mode string
+
+// ModeIdle keeps the helper alive and otherwise does nothing.
+const ModeIdle Mode = "idle"
+
+const (
+	// Lifetime bounds a helper that somehow outlives its test, so a leaked process cannot
+	// linger on a developer machine or a build agent.
+	Lifetime = 10 * time.Minute
+
+	// exitTimeout bounds how long a test waits to observe an exit the operating system
+	// has already performed.
+	exitTimeout = 10 * time.Second
+
+	// pollInterval is how often a wait re-checks its condition.
+	pollInterval = 100 * time.Millisecond
+
+	// executablePermissions makes the copied binary runnable on Unix. Windows ignores it.
+	executablePermissions = 0755
+)
+
+// RequestedMode returns the helper mode this process was started in, or an empty Mode
+// during an ordinary test run.
+func RequestedMode() Mode {
+	return Mode(os.Getenv(ModeEnvVar))
+}
+
+// RunRequestedHelper runs the built-in behavior for the requested mode, reporting whether
+// it handled the request. A TestMain that only needs idle helpers can delegate entirely:
+//
+//	func TestMain(m *testing.M) {
+//		if proctest.RunRequestedHelper() {
+//			return
+//		}
+//
+//		os.Exit(m.Run())
+//	}
+//
+// A package needing its own helper behavior inspects RequestedMode first and falls through
+// to this function for the shared modes.
+func RunRequestedHelper() bool {
+	if RequestedMode() != ModeIdle {
+		return false
+	}
+
+	Idle()
+
+	return true
+}
+
+// Idle keeps the current process alive without doing anything.
+//
+// It sleeps rather than blocking forever on an empty select, because the Go runtime treats
+// a permanently blocked program as a deadlock and would abort the helper rather than keep
+// it running.
+func Idle() {
+	time.Sleep(Lifetime)
+}
+
+// Handle is a started helper process.
+type Handle struct {
+	// PID is the operating system process id.
+	PID int
+
+	// Path is the executable image the process is running from.
+	Path string
+
+	command *exec.Cmd
+	exited  chan struct{}
+}
+
+// HasExited reports whether the process has terminated.
+//
+// A process id lookup is not a liveness test. On Windows the id stays resolvable while the
+// exec package still holds a handle to the terminated process, so os.FindProcess reports a
+// dead process as alive. Waiting on the process is the only authoritative answer, so that
+// is what this reports.
+func (h *Handle) HasExited() bool {
+	select {
+	case <-h.exited:
+		return true
+	default:
+		return false
+	}
+}
+
+// Stop terminates the process and waits for it to be reaped. It is safe to call more than
+// once, and safe to call on a process that already exited.
+func (h *Handle) Stop() {
+	_ = h.command.Process.Kill()
+	<-h.exited
+}
+
+// RequireStopped asserts the process terminated, allowing a short window for the exit to
+// be observed. The operating system reports termination before the waiting goroutine sees
+// it, so an instantaneous check would be flaky.
+func (h *Handle) RequireStopped(t *testing.T) {
+	t.Helper()
+
+	require.Eventually(t, h.HasExited, exitTimeout, pollInterval,
+		"process %d (%s) was expected to be stopped", h.PID, h.Path)
+}
+
+// RequireRunning asserts the process is still running.
+func (h *Handle) RequireRunning(t *testing.T) {
+	t.Helper()
+
+	require.False(t, h.HasExited(), "process %d (%s) was expected to still be running", h.PID, h.Path)
+}
+
+// RequireImageLocked waits until the operating system refuses write access to the
+// executable image, which is the state Windows puts a running executable's file into.
+//
+// The lock is taken by the image loader rather than by process creation, so it is not in
+// place the instant the process starts. Callers that depend on the lock must wait for it.
+//
+// The probe opens for write rather than attempting a delete. A delete probe destroys the
+// fixture on the very run where the lock has not been taken yet, and then reports success
+// forever after because the follow-up probe fails with "file not found".
+func (h *Handle) RequireImageLocked(t *testing.T) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		file, err := os.OpenFile(h.Path, os.O_RDWR, 0)
+		if err != nil {
+			return true
+		}
+
+		_ = file.Close()
+
+		return false
+	}, exitTimeout, pollInterval, "process never took an image lock on %s", h.Path)
+}
+
+// ExecutableName returns base with the platform's executable extension applied.
+func ExecutableName(base string) string {
+	if runtime.GOOS == "windows" {
+		return base + ".exe"
+	}
+
+	return base
+}
+
+// StartIn copies the running test binary into dir as name and starts it in the given mode.
+// The name is adjusted for the platform's executable extension.
+//
+// The process is stopped during test cleanup.
+func StartIn(t *testing.T, dir string, name string, mode Mode) *Handle {
+	t.Helper()
+
+	return StartAt(t, filepath.Join(dir, ExecutableName(name)), mode)
+}
+
+// StartAt copies the running test binary to path and starts it in the given mode, so the
+// caller controls the exact executable path the process runs from.
+//
+// The process is stopped during test cleanup.
+func StartAt(t *testing.T, path string, mode Mode) *Handle {
+	t.Helper()
+
+	self, err := os.Executable()
+	require.NoError(t, err, "the test binary must be locatable to copy itself")
+
+	source, err := os.Open(self)
+	require.NoError(t, err)
+	defer func() { _ = source.Close() }()
+
+	// A real copy rather than a hard link. A link would share the underlying file with
+	// the test binary itself, which would change the very locking behavior these tests
+	// exist to verify.
+	//
+	// G703: the path is chosen by the test that calls this helper, normally from
+	// t.TempDir. No external or user-supplied input reaches it.
+	//nolint:gosec // test-controlled destination path
+	destination, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, executablePermissions)
+	require.NoError(t, err)
+
+	_, err = io.Copy(destination, source)
+	require.NoError(t, err)
+	require.NoError(t, destination.Close())
+
+	// The helper never runs a test. Naming a test that cannot exist keeps the testing
+	// package quiet and turns a dropped mode variable into a fast exit rather than a hang.
+	command := exec.Command(path, "-test.run=NoSuchTestExists")
+	command.Env = append(os.Environ(), ModeEnvVar+"="+string(mode))
+	command.Stdout = io.Discard
+	command.Stderr = io.Discard
+
+	require.NoError(t, command.Start(), "failed to start helper at %s", path)
+
+	handle := &Handle{
+		PID:     command.Process.Pid,
+		Path:    path,
+		command: command,
+		exited:  make(chan struct{}),
+	}
+
+	// A single owner of Wait, so the exit is observed exactly once and cleanup cannot race
+	// with an assertion about the process having stopped.
+	go func() {
+		_ = command.Wait()
+		close(handle.exited)
+	}()
+
+	t.Cleanup(handle.Stop)
+
+	return handle
+}

--- a/docs/specs/extension-upgrade-force/spec.md
+++ b/docs/specs/extension-upgrade-force/spec.md
@@ -98,6 +98,18 @@ running the old code until it is restarted, which matches the existing
 macOS and Linux behavior and is the honest outcome for a non-destructive
 operation.
 
+Trash destinations are named `<original>.<pid>.<random>` rather than picked by
+scanning for a free name. Choosing a destination and renaming onto it cannot be
+made one operation, so a name derived from what is currently on disk is
+inherently racy: two azd processes relocating the same base name both observe the
+same free path and both rename onto it. On Windows `os.Rename` replaces the
+destination, so the collision is not even reported: one of them either clobbers a
+file the other still needs or fails against a destination that is itself a locked
+executable, and the uninstall it belonged to fails after its retries. Detecting
+the conflict after the fact is therefore not available, and the name itself has
+to prevent it. The sweep deletes every child of the trash directory, so the
+naming scheme costs nothing at cleanup time.
+
 ### Layer 2: `--force` (opt-in, destructive)
 
 `--force` on `azd extension upgrade` and `azd extension uninstall` discovers
@@ -137,12 +149,36 @@ bare PID. It first re-checks the declared executable against the scope, which is
 a caller-contract check that makes it impossible to reach the signal path with a
 PID sourced from anywhere other than a scoped discovery. It then re-reads live
 operating system state immediately before each signal and confirms the PID still
-resolves to an executable inside the scope. That second check closes the
+resolves to an executable inside the scope. That second check narrows the
 time-of-check to time-of-use window: between discovery and termination the
 original process can exit and the operating system can reissue its PID to an
 unrelated program. When the live check finds the process gone, `Terminate`
 returns `(false, nil)` so the caller reports nothing rather than claiming a stop
 that never happened.
+
+Narrowing is not closing, because a check by PID followed by a signal by PID is
+still two lookups by number. The forceful stop therefore validates scope a third
+time against a pinned process identity. On Windows `forceKill` opens the process
+once with `PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION`, reads the
+image path through that handle, and calls `TerminateProcess` on the same handle.
+Windows keeps a process id reserved for as long as any handle to that process
+object is open, so the identity the scope check accepted cannot be swapped for
+another process before the kill lands. A process that fails the check there is
+refused with `ErrProcessOutOfScope` rather than terminated.
+
+Unix has no portable equivalent. Linux could use a pidfd and macOS offers
+nothing of the sort, so the SIGTERM and SIGKILL paths keep a residual window
+bounded by the re-check immediately preceding them. That is an accepted risk
+rather than an oversight: the platform this feature exists for is the one where
+the window is closed, and a Unix `--force` that stopped the wrong process would
+require the target to exit and its PID to be reissued inside a window measured in
+microseconds.
+
+Stopped processes are reported by name and PID on the console, and carried in
+`UpgradeResult.StoppedProcesses`, which serializes as `stoppedProcesses` under
+`--output json`. Console reporting is suppressed under `--output json`, so
+without the structured field a scripted caller would have no way to learn that
+`--force` terminated anything.
 
 ### Extension id is a path component, not a path
 
@@ -197,14 +233,34 @@ Both reparse forms have to be tested, because on Windows they present
 differently. Verified on Windows 11 through Go: a directory symlink sets
 `ModeSymlink` and is resolved by `filepath.EvalSymlinks`, while a junction sets
 `ModeIrregular`, reports `IsDir` false, and is not resolved by `EvalSymlinks` at
-all, yet `os.ReadDir`, `os.Rename` and `os.RemoveAll` still follow it. Checking
-only `ModeSymlink` would therefore miss the case that needs no elevation to
-create.
+all, yet `os.ReadDir` and `os.Rename` still follow it. Checking only `ModeSymlink`
+would therefore miss the case that needs no elevation to create.
+
+`os.RemoveAll` is the exception and does not follow either form. It calls
+`os.Remove` first, which succeeds against a reparse point because
+`RemoveDirectory` detaches the link without touching its target, and its
+recursive branch is gated on `os.Lstat(...).IsDir()`, which is false for both a
+junction and a directory symlink. Verified on Windows 11 through Go: after
+`os.RemoveAll` against a junction, the link is gone and every file under its
+target survives. A planted link is therefore deleted as a link rather than
+recursed into, which is why the sweep can hand each trash entry straight to
+`os.RemoveAll`.
 
 The check deliberately inspects only the final component. Resolving symlinked
 ancestors is still required for correctness on macOS, where the temporary and
 configuration directories sit under `/var` and the operating system reports
 process executables under `/private/var`.
+
+That is also why one call is not enough. A final-component check on
+`<configDir>/extensions/<id>` passes when `<configDir>/extensions` is itself a
+link, because the operating system resolves the link while walking to the final
+component, and everything downstream then acts on the link's target: the
+termination scope widens to it, the sweep deletes children there, and an install
+writes there. `requireRealExtensionDirs` therefore checks both components azd
+creates, the extensions root and the extension directory, and is called before an
+uninstall sweeps, terminates, or removes, and immediately after install creates
+the target directory. Only those two are checked, so symlinked ancestors above
+the config directory stay legal and macOS keeps working.
 
 ### Scoping to the extension binary only
 
@@ -351,7 +407,7 @@ than it started.
 
 Three residual concerns were raised during review and deliberately not coded
 against, because in each case the mitigation already exists or the failure is
-fail-safe.
+fail-safe. A later round added a fourth.
 
 - **No explicit same-user check before terminating.** The operating system
   already enforces this. A non-elevated azd cannot obtain `PROCESS_TERMINATE` on
@@ -371,3 +427,11 @@ fail-safe.
   `filepath.EvalSymlinks` does not introduce one for ordinary paths. If a
   prefixed path ever did appear, containment would fail closed and the process
   would simply not be stopped.
+- **A residual PID-reuse window remains on Unix.** Windows closes it by pinning
+  the process with an open handle before it validates and terminates. Linux could
+  do the same with a pidfd and macOS has no equivalent, so on those platforms a
+  target that exits between the live scope re-check and the signal, whose PID is
+  then reissued inside that window, could be signalled. Exploiting it requires
+  winning a race measured in microseconds against a PID the attacker does not
+  choose, and the platform this feature exists for is the one where the window is
+  closed.

--- a/docs/specs/extension-upgrade-force/spec.md
+++ b/docs/specs/extension-upgrade-force/spec.md
@@ -1,0 +1,373 @@
+# Unblocking Extension Upgrade and Uninstall When the Extension Is Running
+
+Issue: https://github.com/Azure/azure-dev/issues/9307
+
+## Problem
+
+On Windows, `azd extension upgrade` fails whenever the extension being upgraded
+has a live process. The user sees:
+
+```
+failed to uninstall extension: failed to remove extension: ... Access is denied.
+```
+
+The cause is structural, not transient. `upgradeInternal` uninstalls before it
+installs (`pkg/extensions/manager.go`), and `Uninstall` calls
+`osutil.RemoveAll` on the extension directory. Windows refuses to delete a file
+that is mapped as a running image, so the delete returns `ERROR_ACCESS_DENIED`.
+`osutil.RemoveAll` retries ten times at a one second interval
+(`pkg/osutil/rename_windows.go`), which only helps when the lock is momentary.
+A genuinely running extension never releases inside that window, so the retry
+loop is guaranteed to exhaust.
+
+This is not rare. Long-lived extensions are the norm: anything running an MCP
+server, a dev server, a watcher, or a background daemon holds its own binary
+open. The extension that triggered this report had three live processes at the
+time of the failed upgrade. The user gets a low-level Win32 error with no
+indication of which process is at fault or what to do about it, and the only
+recovery is to hunt down and stop the processes by hand.
+
+On macOS and Linux the delete succeeds because those platforms unlink by
+directory entry rather than by image. The upgrade appears to work, but the old
+process keeps executing the now-unlinked binary, so the user believes they are
+running the new version when they are not.
+
+## Goals
+
+- `azd extension upgrade` and `azd extension uninstall` succeed by default even
+  when the extension has running processes, without stopping anything.
+- `--force` on both commands stops the extension's own processes so the new
+  version takes effect immediately.
+- Process discovery is provably scoped to executables inside the extension's
+  install directory. Unrelated processes are never candidates.
+- Failures that remain report which processes are blocking, by name and PID,
+  and point at `--force`.
+- Behavior is deterministic under `--no-prompt` for CI and scripted use.
+- Files that had to be set aside are cleaned up automatically on later
+  extension operations rather than accumulating.
+
+## Non-Goals
+
+- Terminating the extension's child process tree. Only the extension binary
+  itself is a candidate. See Solution for the reasoning.
+- A general purpose process management API for azd or for extension authors.
+- Asking extensions to shut down over gRPC. Extensions are not required to be
+  running or reachable, so a transport-level shutdown handshake cannot be the
+  mechanism that unblocks a file operation.
+- Changing the uninstall-then-install ordering in `upgradeInternal`. That
+  ordering is fine once uninstall stops failing.
+- Reconciling the process query code that already exists in `pkg/azdext`. See
+  Risks.
+
+## Solution
+
+Two independent layers. The first makes the failure stop happening. The second
+makes the upgrade take effect immediately.
+
+### Layer 1: relocate instead of delete (default, non-destructive)
+
+Windows blocks deleting a running image but permits renaming it. The image
+loader opens executables with `FILE_SHARE_DELETE`, so rename, which is a
+delete-class operation on the directory entry, is allowed, while true deletion
+is blocked by the section mapping. This is the same technique Chrome and the Go
+toolchain use to replace themselves while running.
+
+Verified empirically on Windows 11:
+
+| Operation on a running exe | Result |
+|---|---|
+| Delete | fails, access denied |
+| Rename within the same directory | succeeds |
+| Rename across directories on the same volume | succeeds |
+| Write a new exe at the original path after rename | succeeds |
+| Remove the now-empty parent directory | succeeds |
+| Delete the relocated exe while it is still running | fails, access denied |
+| Delete the relocated exe after the process exits | succeeds |
+| Process stays alive throughout | yes |
+
+`Uninstall` gains a relocation fallback. When `RemoveAll` cannot remove a path,
+the locked file is renamed into a trash directory that sits outside the
+extension directory, at `<configDir>/extensions/.trash/`. Relocating outside
+rather than within matters: the goal is for the extension directory itself to
+become removable, which it does once the locked entry is no longer inside it.
+Subsequent install, upgrade, and uninstall operations sweep the trash directory
+on a best-effort basis, so entries disappear once the holding process exits.
+
+The user-visible result is that upgrade stops failing. The old process keeps
+running the old code until it is restarted, which matches the existing
+macOS and Linux behavior and is the honest outcome for a non-destructive
+operation.
+
+### Layer 2: `--force` (opt-in, destructive)
+
+`--force` on `azd extension upgrade` and `azd extension uninstall` discovers
+processes whose executable lives inside the extension's install directory and
+stops them: a graceful signal first, a short grace period, then a forceful
+terminate for anything still alive. Stopped processes are reported by name and
+PID.
+
+`--force` is deliberately the same word already used by `azd extension install
+--force`. Install uses it to override the already-installed and downgrade
+guards. Upgrade and uninstall use it to override a running-process guard. The
+unifying contract is "override what is blocking me", with the blocker differing
+by command. `--force` does not prompt, because opting in is the confirmation.
+
+Discovery lives in a new `pkg/processutil` package with a small surface:
+`ProcessInfo`, `FindByExecutableDir(ctx, dir)`, and
+`Terminate(ctx, process, scope, grace)`. It mirrors the `_windows.go` /
+`_darwin.go` build-tag split already used by `pkg/azdext/process*.go`, with the
+procfs implementation named `processutil_procfs.go` rather than `_linux.go` so
+that its `!windows && !darwin` tag is load-bearing and genuinely covers the
+other procfs platforms. Windows enumerates with `CreateToolhelp32Snapshot` plus
+`QueryFullProcessImageName`; procfs platforms read `/proc/<pid>/exe`; macOS
+shells out to `/bin/ps`.
+
+Because this terminates processes, containment is the load-bearing safety
+property, and it is enforced in two independent places for two distinct reasons.
+
+`FindByExecutableDir` rejects an empty directory, rejects root paths such as `/`
+and `C:\` where containment would match everything, resolves to an absolute path
+and evaluates symlinks before comparing, excludes the current azd process, and
+compares using the existing `osutil.IsPathContained`, which is already the
+repository's idiom for this class of check and handles backslash normalization
+and Windows case-insensitivity.
+
+`Terminate` then takes the whole `ProcessInfo` plus the same scope, rather than a
+bare PID. It first re-checks the declared executable against the scope, which is
+a caller-contract check that makes it impossible to reach the signal path with a
+PID sourced from anywhere other than a scoped discovery. It then re-reads live
+operating system state immediately before each signal and confirms the PID still
+resolves to an executable inside the scope. That second check closes the
+time-of-check to time-of-use window: between discovery and termination the
+original process can exit and the operating system can reissue its PID to an
+unrelated program. When the live check finds the process gone, `Terminate`
+returns `(false, nil)` so the caller reports nothing rather than claiming a stop
+that never happened.
+
+### Extension id is a path component, not a path
+
+The extension id reaches the filesystem as a directory name, and before this
+change several call sites built paths from it with a bare `filepath.Join`. A
+single `extensionPaths(userConfigDir, id)` choke point now derives every
+extension path. Install, uninstall, and all four metadata operations route
+through it.
+
+Validation happens in two stages, because neither catches what the other does.
+
+`validateExtensionId` runs first, on the raw id, before any join. It requires
+that the id be usable as a single path component: no separators, no `:`, no
+control characters, not empty, `.` or `..`, not the reserved `.trash` name, and
+not a legacy DOS device name such as `CON` or `COM1`. It also rejects any id
+ending in a dot or a space.
+
+That last rule exists because Win32 silently strips trailing dots and spaces
+from a path component and Go's `filepath` package does not model it. Verified on
+Windows 11: `os.MkdirAll` of `.trash.`, `.trash `, `foo.` and `foo..` creates
+`.trash` and `foo`, and a subsequent `os.ReadDir` shows only the stripped names.
+So `filepath.Base(".trash.")` returns `".trash."`, which does not match a
+comparison against `.trash` while the operating system happily operates on the
+real relocation directory. The same aliasing lets the id `foo.` resolve onto the
+directory owned by the extension `foo`, so uninstalling one would delete the
+other's files. Matching against what a path component may contain, rather than
+against a list of known-bad shapes, means a variation nobody anticipated fails
+closed.
+
+`extensionPaths` then requires that `filepath.Dir(extensionDir)` equal the
+extensions root. That comparison forces the id to be exactly one directory
+level and is kept as a second line of defense. `IsPathContained` on its own
+would not do, because it returns true for equal paths and for legitimately
+nested ones.
+
+### Directories azd owns must not be links
+
+`--force` derives a process-termination scope from a directory path, and the
+relocation machinery deletes every child of the trash directory. Both would
+follow a symlink or a junction planted where azd expects a real directory: the
+kill scope would widen to the link target, and a sweep triggered by any ordinary
+install or upgrade would delete the contents of whatever the link pointed at.
+The sweep runs whether or not `--force` was passed, which makes it the more
+reachable of the two.
+
+`osutil.RequireRealDir` refuses a path whose final component is a link, and is
+called before the trash directory is swept or relocated into, and before a
+directory becomes a termination scope. azd creates all of these directories
+itself, so a link is never something it produced.
+
+Both reparse forms have to be tested, because on Windows they present
+differently. Verified on Windows 11 through Go: a directory symlink sets
+`ModeSymlink` and is resolved by `filepath.EvalSymlinks`, while a junction sets
+`ModeIrregular`, reports `IsDir` false, and is not resolved by `EvalSymlinks` at
+all, yet `os.ReadDir`, `os.Rename` and `os.RemoveAll` still follow it. Checking
+only `ModeSymlink` would therefore miss the case that needs no elevation to
+create.
+
+The check deliberately inspects only the final component. Resolving symlinked
+ancestors is still required for correctness on macOS, where the temporary and
+configuration directories sit under `/var` and the operating system reports
+process executables under `/private/var`.
+
+### Scoping to the extension binary only
+
+`--force` stops the extension process itself and not its descendants. Walking
+the process tree would reach processes whose executables live outside the
+extension directory, which is precisely where the containment guarantee stops
+holding. A tree walk trades the one property that makes automated termination
+defensible for the convenience of reaping orphans, and orphan cleanup is the
+extension's own responsibility on shutdown. This is a deliberate trade: some
+orphaned children may survive, and that is preferable to a code path that can
+terminate something azd never installed.
+
+### Graceful shutdown on Windows
+
+On Unix, `Terminate` sends SIGTERM, waits out the grace period, then sends
+SIGKILL. Windows skips the graceful step and goes directly to
+`TerminateProcess`.
+
+The only general mechanism Windows offers for asking a console-less child to
+exit is `GenerateConsoleCtrlEvent`, and it targets a **process group**, not a
+process. An extension started by azd shares azd's console, so the signal would
+reach azd itself. Terminating the user's own CLI session to be polite to an
+extension is a worse outcome than an abrupt extension exit, so Windows escalates
+immediately.
+
+The Windows `signalGraceful` therefore always returns an error, which
+short-circuits the graceful branch before the grace period is ever waited. The
+bound on how long a forced stop can take on Windows is consequently not the
+grace period but the shorter post-`TerminateProcess` confirmation window, so
+`--force` cannot hang on any platform.
+
+### Error message when relocation also fails
+
+When the operation still cannot complete, the error names the blocking
+processes with PIDs and suggests `--force`, using `internal.ErrorWithSuggestion`
+rather than surfacing a bare Win32 error.
+
+### Flag surface
+
+Both `--force` and its `-f` shorthand are registered on `upgrade` and
+`uninstall`, matching the shorthand `install --force` already uses. Install's
+`--force` additionally implies "stop running extension processes" when the
+extension is already installed and install falls through to an upgrade, so the
+single word behaves consistently across all three commands.
+
+## Alternatives Considered
+
+- **`--force` only, no relocation.** Leaves the default path broken. Every user
+  hitting this still gets an access-denied failure and has to opt into
+  terminating processes just to complete a routine upgrade. Making the common
+  case require a destructive flag is the wrong default.
+- **Relocation only, no `--force`.** Upgrade would stop failing, but the running
+  process keeps serving old code with no supported way to make the new version
+  take effect. Users would go back to hunting PIDs by hand, which is the
+  original complaint.
+- **Terminate the whole process tree.** Rejected above. The containment
+  guarantee is the entire safety argument, and a tree walk voids it.
+- **Longer or smarter retry in `osutil.RemoveAll`.** No retry window helps
+  against a process that is running indefinitely. It converts a fast failure
+  into a slow one.
+- **Put process discovery in `pkg/azdext`.** That package is the extension SDK.
+  Core azd importing it inverts the layering, and it would widen the public SDK
+  compatibility surface for an internal need.
+- **Put process discovery in `pkg/osutil`.** `osutil` is about files and paths.
+  Process enumeration is a different concern with different platform code and
+  different failure modes.
+- **Reuse `azdext.FindProcessByName`.** It matches on executable name only,
+  which could select an unrelated process that happens to share a name. Not
+  safe for a code path that terminates what it finds.
+- **Name the flag `--stop-running`.** More literal, but it fragments the CLI
+  vocabulary and loses the muscle memory users already reach for.
+
+## Risks & Rabbit Holes
+
+- **Process query code is duplicated with `pkg/azdext`.** Accepted for now. The
+  layering rule prevents core from importing the SDK, and inverting the
+  dependency so the SDK consumes `processutil` is a larger refactor than this
+  change should carry. Worth revisiting separately.
+- **Graceful shutdown on Windows is not available.** Resolved during
+  implementation and recorded above: Windows escalates straight to
+  `TerminateProcess` because the alternative can signal azd's own console
+  group. An extension that needs to flush state on exit cannot rely on being
+  asked nicely on Windows.
+- **Terminating a process does not immediately release its executable.**
+  Windows tears down the image section slightly after the process object goes
+  away, so a removal issued immediately after a confirmed exit can still fail
+  and fall through to relocation. Uninstall therefore sweeps the trash
+  directory again after a successful removal, so `--force` leaves nothing
+  permanent behind.
+- **Linux `/proc/<pid>/exe` appends ` (deleted)`** when the binary has been
+  unlinked, which is exactly the state this feature creates. The suffix must be
+  stripped or discovery silently misses the processes it exists to find.
+- **macOS discovery reads `comm`, not `args`.** `ps -o args=` yields argv[0],
+  which the launching process fully controls and which is not guaranteed to be a
+  resolved path, so it is unusable as the basis for a termination decision.
+  `pkg/azdext` uses it because it only ever reports; `processutil` uses
+  `ps -axww -o comm=` instead, which reports the real executable path. The `-ww`
+  is load-bearing: without it `ps` truncates output at terminal width, and
+  because `comm` is the last column a truncated path silently fails containment
+  and makes `--force` a no-op. `ps` is invoked by absolute path so `$PATH` cannot
+  redirect it.
+- **The relocation trash is out of reach of `--force`.** Relocated binaries land
+  in `.trash`, a sibling of the extension directory, so a later
+  `FindByExecutableDir(extensionDir)` cannot see a process still running from a
+  previously relocated image. This is deliberate. Widening discovery to the trash
+  would let one extension's `--force` terminate a process belonging to a
+  different extension that happens to share the trash. The residue is bounded:
+  the trash is swept on every install and every successful forced uninstall, so
+  the entry disappears as soon as its process does.
+- **Trash directory growth.** If a process never exits, its relocated binary is
+  never removable. Sweeping is best-effort and must never fail the command it
+  is attached to.
+- **Do not try to solve** self-update of the `azd` binary itself, extension
+  health checks, or a supervised extension lifecycle. All are adjacent and all
+  are out of scope.
+
+### Testing real processes
+
+Windows file-lock and process-image behavior cannot be faked, so several tests
+need a genuine process running from a directory the test chose. The technique is
+to copy the running test binary into that directory and re-execute it in a
+helper mode. Four packages needed it, so it lives once in `test/proctest`
+alongside the repository's other non-test testing helpers (`test/azdcli`,
+`test/ostest`, `test/snapshot`).
+
+One detail worth recording: a process id lookup is not a liveness test. On
+Windows the id stays resolvable while the `exec` package still holds a handle to
+a terminated process, so `os.FindProcess` reports a dead process as alive.
+`proctest` observes exits by waiting on the process, which is the only
+authoritative answer.
+
+### File layout
+
+`pkg/extensions/manager.go` was already 1316 lines before this change, and the
+uninstall path grew by roughly 400 more. Rather than push a file that is already
+well past the repository's size guidance further out of reach, the uninstall
+concern moved into `pkg/extensions/manager_uninstall.go`: the options type, the
+three uninstall entry points, the path validator, process stopping, and the
+blocked-removal error. It stays in the same package, so nothing about the public
+surface or any import changes, and `manager.go` ends up only 224 lines larger
+than it started.
+
+### Accepted risks
+
+Three residual concerns were raised during review and deliberately not coded
+against, because in each case the mitigation already exists or the failure is
+fail-safe.
+
+- **No explicit same-user check before terminating.** The operating system
+  already enforces this. A non-elevated azd cannot obtain `PROCESS_TERMINATE` on
+  another user's process on Windows, and `kill` returns `EPERM` across users on
+  Unix. Adding an ownership lookup would duplicate a check the kernel performs
+  anyway, and the process must additionally be executing a binary inside the
+  invoking user's own configuration directory to have been discovered at all.
+- **Unicode case folding may differ between `IsPathContained` and the
+  filesystem.** Go's case-insensitive comparison and NTFS's upcase table are not
+  byte-for-byte identical for exotic code points. A disagreement makes
+  containment reject a path it might have accepted, so discovery returns fewer
+  processes and `--force` under-reaches. It cannot cause a process outside the
+  extension directory to be terminated, which is the property that matters.
+- **Extended-length `\\?\` paths would not match a plain scope.**
+  `QueryFullProcessImageName` is called with a zero flags argument, which
+  requests Win32 path format and never returns the prefix, and
+  `filepath.EvalSymlinks` does not introduce one for ordinary paths. If a
+  prefixed path ever did appear, containment would fail closed and the process
+  would simply not be stopped.

--- a/docs/specs/extension-upgrade-force/spec.md
+++ b/docs/specs/extension-upgrade-force/spec.md
@@ -59,6 +59,27 @@ running the new version when they are not.
 - Reconciling the process query code that already exists in `pkg/azdext`. See
   Risks.
 
+## Acceptance Criteria
+
+These are the identifiers the `Source` column in
+[`test-plan.md`](./test-plan.md) cites. Each one is a behavior that has to hold,
+stated so a reviewer can check a test row against it.
+
+| Id | Criterion |
+| --- | --- |
+| AC-1 | Files that cannot be deleted because a process holds them open are relocated out of the extension directory instead of failing the operation, and relocation is a no-op when nothing is locked. |
+| AC-2 | `azd extension upgrade` and `azd extension uninstall` succeed by default, with no `--force`, while the extension has running processes. Removing a path that does not exist is also a success. |
+| AC-3 | `azd extension upgrade <id> --force` succeeds while the extension has running processes, stopping them gracefully first and escalating to a forceful stop only after the grace period expires. |
+| AC-4 | `azd extension uninstall <id> --force` behaves the same way, and stopping processes in a directory with none running is a no-op rather than an error. |
+| AC-5 | Process discovery is provably scoped to executables inside the extension's install directory. Empty and root scopes are refused, prefix siblings do not match, and unrelated processes are never candidates. |
+| AC-6 | The command reports which processes it stopped, by name and PID, on both human-readable and `--output json` paths. |
+| AC-7 | Without `--force`, the failure names the blocking processes and points at `--force`, rather than surfacing a bare permission error. A blocked removal with no discoverable process still explains itself. |
+| AC-8 | Behavior is deterministic under `--no-prompt` for CI and scripted use. Termination is bounded by the grace period and honors context cancellation. |
+| AC-9 | Discovery works on Windows, macOS, and Linux, including the case where a stale process keeps running an unlinked binary on non-Windows platforms, and follows each platform's path casing rules. |
+| AC-10 | `--force` composes with `--all`, stopping processes for every extension in the run rather than only the first. |
+| AC-11 | Relocated files are swept on later extension operations. Entries still held open are left in place, and a sweep failure never fails the command. |
+| AC-12 | `--force` is registered on both commands and bound to their options, with help text, usage snapshots, and completion metadata updated. |
+
 ## Solution
 
 Two independent layers. The first makes the failure stop happening. The second

--- a/docs/specs/extension-upgrade-force/test-plan.md
+++ b/docs/specs/extension-upgrade-force/test-plan.md
@@ -51,7 +51,7 @@ at `cli/azd/`.
 | T8 | Sibling directory sharing a name prefix is not matched | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_RejectsPrefixSibling` | automated |
 | T9 | Containment is case-insensitive on Windows and case-sensitive on Linux | AC-5, AC-9 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_CaseSensitivityByPlatform` | automated |
 | T10 | A directory that does not exist yields no matches and no panic | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_MissingDir` | automated |
-| T11 | A real spawned process inside the directory is discovered with correct PID, name, and executable | AC-3, AC-9 | integration | `pkg/processutil/processutil_integration_test.go` -> `TestFindByExecutableDir_FindsSpawnedProcess` | automated |
+| T11 | A real spawned process inside the directory is discovered with correct PID, name, and executable | AC-5, AC-9 | integration | `pkg/processutil/processutil_integration_test.go` -> `TestFindByExecutableDir_FindsSpawnedProcess` | automated |
 | T12 | A real process outside the directory is not discovered | AC-5 | integration | `pkg/processutil/processutil_integration_test.go` -> `TestFindByExecutableDir_IgnoresOutsideProcess` | automated |
 | T13 | Linux `(deleted)` suffix on `/proc/<pid>/exe` is stripped so unlinked binaries still match | AC-9 | unit | `pkg/processutil/processutil_procfs_test.go` -> `TestNormalizeProcExe_StripsDeletedSuffix` | automated |
 | T14 | Enumeration tolerates per-PID permission denials and keeps scanning | AC-9 | integration | `pkg/processutil/processutil_integration_test.go` -> `TestFindByExecutableDir_TolerantOfDeniedPids` | automated |
@@ -91,7 +91,7 @@ Written because implementation exposed behavior the plan did not anticipate.
 | T41 | A zero wait timeout reports liveness without blocking | AC-8 | integration | `pkg/processutil/processutil_integration_test.go` -> `TestWaitForExit_ZeroTimeout` | automated |
 | T42 | Removing a path that does not exist succeeds rather than erroring | AC-2 | unit | `pkg/osutil/relocate_test.go` -> `TestRemoveAllWithRelocation_MissingPath` | automated |
 | T43 | A trash directory nested inside the directory being removed is rejected | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestRemoveAllWithRelocation_RejectsTrashInsidePath` | automated |
-| T44 | Both path arguments are required | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestRemoveAllWithRelocation_RequiresPaths` | automated |
+| T44 | Both path arguments are required | AC-1 | unit | `pkg/osutil/relocate_test.go` -> `TestRemoveAllWithRelocation_RequiresPaths` | automated |
 | T45 | Trash destinations never collide, across repeated relocations or across processes | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestUniqueTrashPath` | automated |
 | T46 | Concurrent relocations of the same base name all succeed and none overwrites another | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestRelocateInto_ConcurrentRelocationsDoNotCollide` | automated |
 | T47 | A blocked removal with no discoverable processes still explains itself | AC-7 | integration | `pkg/extensions/manager_uninstall_test.go` -> `TestUninstall_BlockedErrorWithoutProcesses` | automated |
@@ -114,8 +114,8 @@ Written because implementation exposed behavior the plan did not anticipate.
 | T64 | `RequireRealDir` accepts a real directory and a missing path, refuses a file and a directory link | AC-5 | unit | `pkg/osutil/relocate_test.go` -> `TestRequireRealDir` | automated |
 | T65 | A link planted at the trash directory is refused, leaving the target's contents intact | AC-5, AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestSweepTrash_RefusesLinkedDirectory` | automated |
 | T66 | Relocation refuses a linked trash directory rather than renaming files through it | AC-5, AC-11 | integration | `pkg/osutil/relocate_test.go` -> `TestRelocateLocked_RefusesLinkedTrash` | automated |
-| T67 | A scope reached through a symlinked ancestor still resolves, so macOS containment keeps working | AC-2 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_ResolvesSymlinkedAncestors` | automated |
-| T68 | A scope whose own final component is a link is refused by both normalization and discovery | AC-2, AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_RejectsLinkedScope` | automated |
+| T67 | A scope reached through a symlinked ancestor still resolves, so macOS containment keeps working | AC-5, AC-9 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_ResolvesSymlinkedAncestors` | automated |
+| T68 | A scope whose own final component is a link is refused by both normalization and discovery | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_RejectsLinkedScope` | automated |
 | T69 | Ids that Windows aliases away (trailing dot or space), device names, and ids carrying `:` or control characters are rejected | AC-5 | unit | `pkg/extensions/manager_uninstall_test.go` -> `TestExtensionPaths_RejectsUnsafeIds` | automated |
 | T70 | An aliased id resolves onto the directory a different extension owns, and is refused | AC-5 | unit | `pkg/extensions/manager_uninstall_test.go` -> `TestExtensionPaths_AliasedIdWouldResolveOntoAnotherExtension` | automated |
 | T71 | Trash destinations carry the original base name so a leftover entry stays recognizable | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestUniqueTrashPath` | automated |
@@ -124,6 +124,9 @@ Written because implementation exposed behavior the plan did not anticipate.
 | T74 | Windows `forceKill` refuses a process outside the scope of its own pinned handle, and still stops one inside it | AC-5 | integration | `pkg/processutil/processutil_windows_test.go` -> `TestForceKill_RefusesProcessOutsideScope` | automated |
 | T75 | `upgrade --force` reaches a stale dependency when the parent is already current, and reports it in `--output json` | AC-3, AC-6 | integration | `cmd/extension_force_test.go` -> `TestExtensionUpgradeAction_ForceReachesStaleDependencyOfCurrentParent` | automated |
 | T76 | `stoppedProcesses` is present in the JSON contract when `--force` stopped something and omitted otherwise | AC-6 | unit | `pkg/extensions/upgrade_result_test.go` -> `TestUpgradeResult_MarshalJSON` | automated |
+| T77 | A backslash in a Unix executable path is a filename character, not a separator, so it cannot be used to escape the scope | AC-5, AC-9 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_UnixBackslashIsNotASeparator` | automated |
+| T78 | Host-native containment accepts self and descendants, and refuses parents, prefix siblings, and traversal escapes | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestPathContained` | automated |
+| T79 | `DescribeExecutables` names the held-open binaries distinctly, in first-seen order | AC-7 | unit | `pkg/processutil/processutil_test.go` -> `TestDescribeExecutables` | automated |
 
 ## Functionality Inventory (Phase 3 reconciliation)
 
@@ -136,12 +139,14 @@ files, then walking each back to an assertion.
 | 1 | `ProcessInfo` carries PID, name, and executable path | `pkg/processutil/processutil.go` | T11, T39 | COVERED |
 | 2 | `ProcessInfo.String` renders a process for a human | `pkg/processutil/processutil.go` | T39 | COVERED |
 | 3 | `Describe` renders a set of processes as one list | `pkg/processutil/processutil.go` | T40 | COVERED |
+| 3a | `DescribeExecutables` renders the distinct binaries a set of processes runs | `pkg/processutil/processutil.go` | T79 | COVERED |
 | 4 | `FindByExecutableDir` returns only processes running from a directory | `pkg/processutil/processutil.go` | T5, T11, T12, T14 | COVERED |
 | 5 | `Terminate` ends a process, gracefully first where the platform allows | `pkg/processutil/processutil.go` | T15, T16, T18 | COVERED |
 | 6 | `Terminate` refuses to target azd itself or a non-positive PID | `pkg/processutil/processutil.go` | T37, T38 | COVERED |
 | 7 | `normalizeScope` resolves symlinks and rejects empty input | `pkg/processutil/processutil.go` | T1, T6, T7, T10 | COVERED |
 | 8 | `isFilesystemRoot` blocks a whole-volume scope | `pkg/processutil/processutil.go` | T2, T3, T36 | COVERED |
-| 9 | `executableInScope` containment, including case rules and prefix traps | `pkg/processutil/processutil.go` | T8, T9, T12 | COVERED |
+| 9 | `executableInScope` containment, including case rules and prefix traps | `pkg/processutil/processutil.go` | T8, T9, T12, T77 | COVERED |
+| 9a | `pathContained` compares host-native paths without rewriting separators | `pkg/processutil/processutil.go` | T78 | COVERED |
 | 10 | `waitForExit` confirms exit within a budget without blocking forever | `pkg/processutil/processutil.go` | T18, T41 | COVERED |
 | 11 | `ErrEmptyDirectory` and `ErrRootDirectory` sentinels | `pkg/processutil/processutil.go` | T1, T2, T3, T4, T48 | COVERED |
 | 12 | Windows `enumerateProcesses` via `CreateToolhelp32Snapshot` | `pkg/processutil/processutil_windows.go` | T11, T12, T14 | COVERED |
@@ -168,6 +173,7 @@ files, then walking each back to an assertion.
 | 33 | `stopExtensionProcesses` refuses an unscoped directory | `pkg/extensions/manager_uninstall.go` | T48 | COVERED |
 | 34 | `stopExtensionProcesses` is a no-op when nothing is running | `pkg/extensions/manager_uninstall.go` | T49 | COVERED |
 | 35 | `extensionRemovalError` explains a blocked removal and suggests a fix | `pkg/extensions/manager_uninstall.go` | T28, T47 | COVERED |
+| 35a | `removalMessage` names the held-open binary so the cause is demoted below the explanation | `pkg/extensions/manager_uninstall.go` | T28 | COVERED |
 | 36 | `UpgradeOptions.Force` and callback propagate into `Uninstall` | `pkg/extensions/manager.go` | T27, T50 | COVERED |
 | 37 | `installInternal` sweeps trash when recreating the install directory | `pkg/extensions/manager.go` | T59 | COVERED |
 | 38 | `--force`/`-f` registered and bound on `extension upgrade` | `cmd/extension.go` | T31, T33 | COVERED |

--- a/docs/specs/extension-upgrade-force/test-plan.md
+++ b/docs/specs/extension-upgrade-force/test-plan.md
@@ -127,6 +127,8 @@ Written because implementation exposed behavior the plan did not anticipate.
 | T77 | A backslash in a Unix executable path is a filename character, not a separator, so it cannot be used to escape the scope | AC-5, AC-9 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_UnixBackslashIsNotASeparator` | automated |
 | T78 | Host-native containment accepts self and descendants, and refuses parents, prefix siblings, and traversal escapes | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestPathContained` | automated |
 | T79 | `DescribeExecutables` names the held-open binaries distinctly, in first-seen order | AC-7 | unit | `pkg/processutil/processutil_test.go` -> `TestDescribeExecutables` | automated |
+| T80 | A relocation whose trash directory was swept away between the create and the rename recreates it and completes the move | AC-1, AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestRelocateInto_RecreatesSweptTrashDirectory` | automated |
+| T81 | A relocation failure that recreating the directory cannot fix is reported, leaving the original intact, on the retry path on Windows and via the guard on Unix | AC-1 | unit | `pkg/osutil/relocate_test.go` -> `TestRelocateInto_ReportsFailureAndLeavesSourceInPlace` | automated |
 
 ## Functionality Inventory (Phase 3 reconciliation)
 
@@ -166,6 +168,9 @@ files, then walking each back to an assertion.
 | 26 | `relocateLockedFiles` renames rather than deletes | `pkg/osutil/relocate.go` | T19, T20 | COVERED |
 | 27 | `uniqueTrashPath` never collides, within a process or across them | `pkg/osutil/relocate.go` | T45, T46, T71 | COVERED |
 | 28 | `relocateInto` renames onto a destination no other process can have chosen | `pkg/osutil/relocate.go` | T46 | COVERED |
+| 28a | `relocateInto` recreates a trash directory a concurrent sweep removed mid-move | `pkg/osutil/relocate.go` | T80 | COVERED |
+| 28b | `ensureTrashDir` creates the trash directory and re-checks it is not a link on every use | `pkg/osutil/relocate.go` | T66, T80 | COVERED |
+| 28c | `relocateInto` reports a failure a retry cannot fix and leaves the original in place | `pkg/osutil/relocate.go` | T81 | COVERED |
 | 29 | `UninstallOptions` carries `Force` and the stop callback | `pkg/extensions/manager_uninstall.go` | T25, T26, T29 | COVERED |
 | 30 | `Uninstall` succeeds against a running extension by default | `pkg/extensions/manager_uninstall.go` | T25 | COVERED |
 | 31 | `Uninstall` with `Force` stops processes first | `pkg/extensions/manager_uninstall.go` | T26, T29 | COVERED |
@@ -210,7 +215,8 @@ of them (G-5) was a real product defect rather than a missing test. G-7 to
 G-9 are security defects found by attacking the finished implementation rather than
 reading it, and all three were real. G-10 to G-14 are the review round that followed, four
 of them real defects and one an unmet acceptance criterion; G-15 corrected a spec claim
-that measurement disproved.
+that measurement disproved. G-16 came from a maintainer review of the finished branch and
+is a concurrency defect between the sweep and the relocation it cleans up after.
 | Gap | Detail | Resolution |
 |-----|--------|------------|
 | G-1 | Upgrade action wiring of `Force` and `OnProcessStopped` into `UpgradeOptions` was unverified | Added T54 and T55 |
@@ -228,5 +234,6 @@ that measurement disproved.
 | G-13 | `upgrade --force` dropped `Force` and the stop callback on the branch taken when the parent is already at the target version, so a stale dependency's process was left running and unreported | Propagated both into `ReconcileDependencies`; T75 |
 | G-14 | `--force` printed what it stopped only on the console, so `--output json` silently omitted it and AC-6 was unmet for scripted callers | Added `stoppedProcesses` to the upgrade JSON contract; T75 and T76 |
 | G-15 | The spec claimed `os.RemoveAll` follows a Windows junction, which is false and would have justified defenses against a threat that does not exist | Corrected the spec against a Windows 11 measurement |
+| G-16 | `SweepTrash` deletes the shared `.trash` directory as soon as it observes it empty, which a second azd process can do between this process's create and its rename, so the locked file was never moved aside and the removal failed with the original lock error | Made the relocation recover instead: a vanished destination is recreated and the move retried once, which also covers the directory being removed by anything other than the sweep; T80 and T81 |
 
 Zero `GAP` rows remain.

--- a/docs/specs/extension-upgrade-force/test-plan.md
+++ b/docs/specs/extension-upgrade-force/test-plan.md
@@ -1,0 +1,209 @@
+# Test Plan: Unblocking Extension Upgrade and Uninstall When the Extension Is Running
+
+## Status: COVERED
+## Spec: docs/specs/extension-upgrade-force/spec.md
+## Issue: https://github.com/Azure/azure-dev/issues/9307
+## Created: 2026-07-25
+## Updated: 2026-07-25
+
+---
+
+## Coverage Strategy
+
+Go standard testing with `testify`, matching existing repository conventions.
+
+| Level | Applies to | Why |
+|---|---|---|
+| Unit | `pkg/processutil` safety guards, error message construction, flag binding | Path containment is the load-bearing safety property and is pure logic, so it must be exhaustively tested without spawning anything |
+| Integration | Real process spawn and terminate, real locked-file relocation | Windows file-lock and process-image semantics cannot be faked meaningfully. These paths must run against the real OS |
+| Snapshot | CLI help and figspec output | Repository already gates flag surface changes on snapshots |
+
+Commands:
+
+```
+go test ./pkg/processutil/... ./pkg/osutil/... ./pkg/extensions/... ./cmd/...
+UPDATE_SNAPSHOTS=true go test ./cmd -run 'TestFigSpec|TestUsage'
+```
+
+Coverage targets: at least 80 percent of new and modified lines overall, and at
+least 90 percent for `pkg/processutil` path scoping and exclusion logic, which
+is the code that decides whether a process gets terminated.
+
+Platform-specific tests are gated with build tags or `t.Skip` and must be run on
+Windows, macOS, and Linux. Windows is the primary platform for this feature and
+the only one where the default path is currently broken, so Windows integration
+tests are mandatory before ship.
+
+## Planned Tests
+
+Every planned test is automated. Test files use short package-relative paths rooted
+at `cli/azd/`.
+
+| ID | Behavior to verify | Source | Level | Test file -> name | Status |
+|----|--------------------|--------|-------|-------------------|--------|
+| T1 | Empty directory argument is rejected rather than matching everything | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_RejectsEmptyDir` | automated |
+| T2 | Unix root `/` is rejected | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_RejectsUnixRoot` | automated |
+| T3 | Windows drive root `C:\` is rejected | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_RejectsWindowsRoot` | automated |
+| T4 | UNC and drive-relative roots are rejected | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_RejectsUNCRoot` | automated |
+| T5 | The current azd process is never returned as a candidate | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_ExcludesSelf` | automated |
+| T6 | Symlinked install directory resolves before containment comparison | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_ResolvesSymlinks` | automated |
+| T7 | Relative directory input is resolved to absolute before comparison | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_ResolvesRelativePath` | automated |
+| T8 | Sibling directory sharing a name prefix is not matched | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_RejectsPrefixSibling` | automated |
+| T9 | Containment is case-insensitive on Windows and case-sensitive on Linux | AC-5, AC-9 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_CaseSensitivityByPlatform` | automated |
+| T10 | A directory that does not exist yields no matches and no panic | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_MissingDir` | automated |
+| T11 | A real spawned process inside the directory is discovered with correct PID, name, and executable | AC-3, AC-9 | integration | `pkg/processutil/processutil_integration_test.go` -> `TestFindByExecutableDir_FindsSpawnedProcess` | automated |
+| T12 | A real process outside the directory is not discovered | AC-5 | integration | `pkg/processutil/processutil_integration_test.go` -> `TestFindByExecutableDir_IgnoresOutsideProcess` | automated |
+| T13 | Linux `(deleted)` suffix on `/proc/<pid>/exe` is stripped so unlinked binaries still match | AC-9 | unit | `pkg/processutil/processutil_procfs_test.go` -> `TestNormalizeProcExe_StripsDeletedSuffix` | automated |
+| T14 | Enumeration tolerates per-PID permission denials and keeps scanning | AC-9 | integration | `pkg/processutil/processutil_integration_test.go` -> `TestFindByExecutableDir_TolerantOfDeniedPids` | automated |
+| T15 | Terminate stops a cooperating process within the grace period | AC-3 | integration | `pkg/processutil/processutil_integration_test.go` -> `TestTerminate_GracefulStop` | automated |
+| T16 | Terminate escalates to a forceful stop when the grace period expires | AC-3 | integration | `pkg/processutil/processutil_integration_test.go` -> `TestTerminate_EscalatesToForce` | automated |
+| T17 | Terminate on an already-exited PID is not an error | AC-3 | integration | `pkg/processutil/processutil_integration_test.go` -> `TestTerminate_AlreadyExited` | automated |
+| T18 | Terminate honors context cancellation and never blocks past the bounded grace | AC-8 | integration | `pkg/processutil/processutil_integration_test.go` -> `TestTerminate_BoundedByContext` | automated |
+| T19 | A locked file is relocated into the trash directory outside the extension directory | AC-1 | integration | `pkg/osutil/relocate_test.go` -> `TestRelocateLocked_MovesFileOutOfDir` | automated |
+| T20 | Removal of a directory containing a locked executable succeeds via the relocation fallback | AC-1, AC-2 | integration | `pkg/osutil/relocate_test.go` -> `TestRemoveAllWithRelocation_LockedExe` | automated |
+| T21 | Relocation is a no-op when nothing in the directory is locked | AC-1 | unit | `pkg/osutil/relocate_test.go` -> `TestRemoveAllWithRelocation_NoLocks` | automated |
+| T22 | Sweep deletes trash entries once the holding process has exited | AC-11 | integration | `pkg/osutil/relocate_test.go` -> `TestSweepTrash_RemovesReleasedEntries` | automated |
+| T23 | Sweep leaves still-locked trash entries in place without erroring | AC-11 | integration | `pkg/osutil/relocate_test.go` -> `TestSweepTrash_SkipsLockedEntries` | automated |
+| T24 | Sweep failure never propagates as a command failure | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestSweepTrash_BestEffortNeverErrors` | automated |
+| T25 | Uninstall succeeds when the extension directory holds a locked executable | AC-2 | integration | `pkg/extensions/manager_uninstall_test.go` -> `TestUninstall_SucceedsWithLockedBinary` | automated |
+| T26 | Uninstall with Force terminates discovered extension processes before removal | AC-4 | integration | `pkg/extensions/manager_uninstall_test.go` -> `TestUninstall_ForceTerminatesProcesses` | automated |
+| T27 | Upgrade propagates Force through to the uninstall step | AC-3 | integration | `pkg/extensions/manager_uninstall_test.go` -> `TestUpgrade_PropagatesForce` | automated |
+| T28 | Without Force, a blocked removal produces an error naming processes and PIDs and suggesting `--force` | AC-7 | integration | `pkg/extensions/manager_uninstall_test.go` -> `TestUninstall_BlockedErrorNamesProcesses` | automated |
+| T29 | With Force unset, no termination is ever attempted | AC-1, AC-5 | integration | `pkg/extensions/manager_uninstall_test.go` -> `TestUninstall_NoForceNeverTerminates` | automated |
+| T30 | Stopped processes are reported to the user by name and PID | AC-6 | integration | `pkg/extensions/manager_uninstall_test.go` -> `TestUninstall_ForceTerminatesProcesses` | automated |
+| T31 | `--force` is registered on `azd extension upgrade` and bound to the upgrade options | AC-3, AC-12 | unit | `cmd/extension_force_test.go` -> `TestExtensionUpgradeFlags_Force` | automated |
+| T32 | `--force` is registered on `azd extension uninstall` and bound to the uninstall options | AC-4, AC-12 | unit | `cmd/extension_force_test.go` -> `TestExtensionUninstallFlags_Force` | automated |
+| T33 | `--force` parses alongside `--all` on both commands | AC-10 | unit | `cmd/extension_force_test.go` -> `TestExtensionUpgradeFlags_ForceComposesWithOtherFlags`, `TestExtensionUninstallFlags_ForceComposesWithAll` | automated |
+| T34 | `--force` performs no prompting and is deterministic end to end | AC-8 | integration | `cmd/extension_force_test.go` -> `TestExtensionUninstallAction_ForceStopsProcessesWithoutPrompting` | automated |
+| T35 | Usage and figspec snapshots reflect the new flag | AC-12 | snapshot | `cmd` -> `TestUsage`, `TestFigSpec` | automated |
+
+### Additional tests written beyond the plan
+
+Written because implementation exposed behavior the plan did not anticipate.
+
+| ID | Behavior to verify | Source | Level | Test file -> name | Status |
+|----|--------------------|--------|-------|-------------------|--------|
+| T36 | Filesystem root detection is correct for Unix, Windows drive, UNC, and relative forms | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestIsFilesystemRoot` | automated |
+| T37 | Terminate refuses to target the azd process itself | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestTerminate_RefusesSelf` | automated |
+| T38 | Terminate rejects a non-positive PID rather than signalling a process group | AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestTerminate_RejectsInvalidPID` | automated |
+| T39 | Process rendering names the executable and PID, and degrades safely when unknown | AC-6 | unit | `pkg/processutil/processutil_test.go` -> `TestProcessInfoString` | automated |
+| T40 | Multi-process descriptions read as a single user-facing list | AC-6, AC-7 | unit | `pkg/processutil/processutil_test.go` -> `TestDescribe` | automated |
+| T41 | A zero wait timeout reports liveness without blocking | AC-8 | integration | `pkg/processutil/processutil_integration_test.go` -> `TestWaitForExit_ZeroTimeout` | automated |
+| T42 | Removing a path that does not exist succeeds rather than erroring | AC-2 | unit | `pkg/osutil/relocate_test.go` -> `TestRemoveAllWithRelocation_MissingPath` | automated |
+| T43 | A trash directory nested inside the directory being removed is rejected | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestRemoveAllWithRelocation_RejectsTrashInsidePath` | automated |
+| T44 | Both path arguments are required | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestRemoveAllWithRelocation_RequiresPaths` | automated |
+| T45 | Trash destinations never collide across repeated relocations | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestUniqueTrashPath` | automated |
+| T46 | Existence probing distinguishes missing from present without masking errors | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestPathExists` | automated |
+| T47 | A blocked removal with no discoverable processes still explains itself | AC-7 | integration | `pkg/extensions/manager_uninstall_test.go` -> `TestUninstall_BlockedErrorWithoutProcesses` | automated |
+| T48 | Process stopping refuses an unscoped or root directory at the manager boundary | AC-5 | unit | `pkg/extensions/manager_uninstall_test.go` -> `TestStopExtensionProcesses_RejectsUnscopedDirectory` | automated |
+| T49 | Stopping processes in a directory with none running is a no-op, not an error | AC-4 | unit | `pkg/extensions/manager_uninstall_test.go` -> `TestStopExtensionProcesses_NoProcesses` | automated |
+| T50 | Upgrade completes while the extension is running and the new version lands on disk | AC-1, AC-2 | integration | `pkg/extensions/manager_uninstall_test.go` -> `TestUpgrade_SucceedsWhileExtensionIsRunning` | automated |
+| T51 | Uninstall without `--force` leaves the running process alone at the command layer | AC-1 | integration | `cmd/extension_force_test.go` -> `TestExtensionUninstallAction_WithoutForceLeavesProcessRunning` | automated |
+| T52 | Nothing stopped means nothing reported, so routine runs stay quiet | AC-6 | unit | `cmd/extension_force_test.go` -> `TestReportStoppedProcesses_SilentWhenNothingStopped` | automated |
+| T53 | Every stopped process is named individually in the report | AC-6 | unit | `cmd/extension_force_test.go` -> `TestReportStoppedProcesses_NamesEachStoppedProcess` | automated |
+| T54 | `upgrade --force` reaches the manager and stops the running extension | AC-1, AC-3 | integration | `cmd/extension_force_test.go` -> `TestExtensionUpgradeAction_ForceStopsRunningProcess` | automated |
+| T55 | `upgrade` without `--force` leaves the process running | AC-1 | integration | `cmd/extension_force_test.go` -> `TestExtensionUpgradeAction_WithoutForceLeavesProcessRunning` | automated |
+| T56 | `install --force` over a running install stops the process on the reinstall path | AC-3 | integration | `cmd/extension_force_test.go` -> `TestExtensionInstallAction_ForceStopsRunningProcessOnReinstall` | automated |
+| T57 | Windows `signalGraceful` reports failure so termination escalates instead of waiting | AC-4 | unit | `pkg/processutil/processutil_windows_test.go` -> `TestSignalGraceful_IsUnsupportedOnWindows` | automated |
+| T58 | Uninstall sweeps trash left behind by an earlier run | AC-11 | integration | `pkg/extensions/manager_uninstall_test.go` -> `TestUninstall_SweepsPreexistingTrash` | automated |
+| T59 | Install sweeps trash left behind by an earlier run | AC-11 | integration | `pkg/extensions/manager_uninstall_test.go` -> `TestInstall_SweepsPreexistingTrash` | automated |
+| T60 | `extensionPaths` rejects traversal, nesting, empty, dot, and the reserved trash name | AC-5 | unit | `pkg/extensions/manager_uninstall_test.go` -> `TestExtensionPaths_RejectsUnsafeIds` | automated |
+| T61 | `extensionPaths` accepts an ordinary namespaced id | AC-5 | unit | `pkg/extensions/manager_uninstall_test.go` -> `TestExtensionPaths_AcceptsNormalId` | automated |
+| T62 | `--force` reaches a dependency upgrade, not just the parent | AC-1, AC-3 | integration | `pkg/extensions/manager_uninstall_test.go` -> `TestUpgrade_PropagatesForceToDependencies` | automated |
+| T63 | `--force` stops every extension in an `--all` run, not just the first | AC-10 | integration | `cmd/extension_force_test.go` -> `TestExtensionUninstallAction_ForceComposesWithAllAcrossExtensions` | automated |
+| T64 | `RequireRealDir` accepts a real directory and a missing path, refuses a file and a directory link | AC-5 | unit | `pkg/osutil/relocate_test.go` -> `TestRequireRealDir` | automated |
+| T65 | A link planted at the trash directory is refused, leaving the target's contents intact | AC-5, AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestSweepTrash_RefusesLinkedDirectory` | automated |
+| T66 | Relocation refuses a linked trash directory rather than renaming files through it | AC-5, AC-11 | integration | `pkg/osutil/relocate_test.go` -> `TestRelocateLocked_RefusesLinkedTrash` | automated |
+| T67 | A scope reached through a symlinked ancestor still resolves, so macOS containment keeps working | AC-2 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_ResolvesSymlinkedAncestors` | automated |
+| T68 | A scope whose own final component is a link is refused by both normalization and discovery | AC-2, AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_RejectsLinkedScope` | automated |
+| T69 | Ids that Windows aliases away (trailing dot or space), device names, and ids carrying `:` or control characters are rejected | AC-5 | unit | `pkg/extensions/manager_uninstall_test.go` -> `TestExtensionPaths_RejectsUnsafeIds` | automated |
+| T70 | An aliased id resolves onto the directory a different extension owns, and is refused | AC-5 | unit | `pkg/extensions/manager_uninstall_test.go` -> `TestExtensionPaths_AliasedIdWouldResolveOntoAnotherExtension` | automated |
+
+## Functionality Inventory (Phase 3 reconciliation)
+
+Every unit of functionality in the diff, mapped to the test that covers it. Built by
+enumerating declarations in the new files and the added declarations in the modified
+files, then walking each back to an assertion.
+
+| # | Functionality introduced | Location | Covered by | Status |
+|---|--------------------------|----------|------------|--------|
+| 1 | `ProcessInfo` carries PID, name, and executable path | `pkg/processutil/processutil.go` | T11, T39 | COVERED |
+| 2 | `ProcessInfo.String` renders a process for a human | `pkg/processutil/processutil.go` | T39 | COVERED |
+| 3 | `Describe` renders a set of processes as one list | `pkg/processutil/processutil.go` | T40 | COVERED |
+| 4 | `FindByExecutableDir` returns only processes running from a directory | `pkg/processutil/processutil.go` | T5, T11, T12, T14 | COVERED |
+| 5 | `Terminate` ends a process, gracefully first where the platform allows | `pkg/processutil/processutil.go` | T15, T16, T18 | COVERED |
+| 6 | `Terminate` refuses to target azd itself or a non-positive PID | `pkg/processutil/processutil.go` | T37, T38 | COVERED |
+| 7 | `normalizeScope` resolves symlinks and rejects empty input | `pkg/processutil/processutil.go` | T1, T6, T7, T10 | COVERED |
+| 8 | `isFilesystemRoot` blocks a whole-volume scope | `pkg/processutil/processutil.go` | T2, T3, T36 | COVERED |
+| 9 | `executableInScope` containment, including case rules and prefix traps | `pkg/processutil/processutil.go` | T8, T9, T12 | COVERED |
+| 10 | `waitForExit` confirms exit within a budget without blocking forever | `pkg/processutil/processutil.go` | T18, T41 | COVERED |
+| 11 | `ErrEmptyDirectory` and `ErrRootDirectory` sentinels | `pkg/processutil/processutil.go` | T1, T2, T3, T4, T48 | COVERED |
+| 12 | Windows `enumerateProcesses` via `CreateToolhelp32Snapshot` | `pkg/processutil/processutil_windows.go` | T11, T12, T14 | COVERED |
+| 13 | Windows `processImagePath` resolves a PID to its image | `pkg/processutil/processutil_windows.go` | T11 | COVERED |
+| 14 | Windows `forceKill` and `processRunning` | `pkg/processutil/processutil_windows.go` | T15, T16, T17 | COVERED |
+| 15 | Windows `signalGraceful` is a deliberate no-op that reports failure | `pkg/processutil/processutil_windows.go` | T57 | COVERED |
+| 16 | Unix `signalGraceful` sends SIGTERM | `pkg/processutil/processutil_unix.go` | T15, T18 | COVERED |
+| 17 | Unix `forceKill` escalates to SIGKILL after the grace period | `pkg/processutil/processutil_unix.go` | T16 | COVERED |
+| 18 | Unix `processRunning` probes with signal 0 | `pkg/processutil/processutil_unix.go` | T17 | COVERED |
+| 19 | Linux `enumerateProcesses` reads `/proc` | `pkg/processutil/processutil_procfs.go` | T11, T12 | COVERED |
+| 20 | Linux `normalizeProcExe` strips the ` (deleted)` suffix | `pkg/processutil/processutil_procfs.go` | T13 | COVERED |
+| 21 | Darwin `enumerateProcesses` shells out to `ps` | `pkg/processutil/processutil_darwin.go` | T11, T12 | COVERED |
+| 22 | `RemoveAllWithRelocation` removes normally, then relocates what is locked | `pkg/osutil/relocate.go` | T19, T20, T21 | COVERED |
+| 23 | `RemoveAllWithRelocation` tolerates a missing path | `pkg/osutil/relocate.go` | T42 | COVERED |
+| 24 | `RemoveAllWithRelocation` validates its arguments and trash placement | `pkg/osutil/relocate.go` | T43, T44 | COVERED |
+| 25 | `SweepTrash` best-effort deletes what is no longer locked | `pkg/osutil/relocate.go` | T22, T23, T24 | COVERED |
+| 26 | `relocateLockedFiles` renames rather than deletes | `pkg/osutil/relocate.go` | T19, T20 | COVERED |
+| 27 | `uniqueTrashPath` never collides | `pkg/osutil/relocate.go` | T45 | COVERED |
+| 28 | `pathExists` distinguishes missing from present | `pkg/osutil/relocate.go` | T46 | COVERED |
+| 29 | `UninstallOptions` carries `Force` and the stop callback | `pkg/extensions/manager_uninstall.go` | T25, T26, T29 | COVERED |
+| 30 | `Uninstall` succeeds against a running extension by default | `pkg/extensions/manager_uninstall.go` | T25 | COVERED |
+| 31 | `Uninstall` with `Force` stops processes first | `pkg/extensions/manager_uninstall.go` | T26, T29 | COVERED |
+| 32 | `Uninstall` sweeps trash before and after removal | `pkg/extensions/manager_uninstall.go` | T30, T58 | COVERED |
+| 33 | `stopExtensionProcesses` refuses an unscoped directory | `pkg/extensions/manager_uninstall.go` | T48 | COVERED |
+| 34 | `stopExtensionProcesses` is a no-op when nothing is running | `pkg/extensions/manager_uninstall.go` | T49 | COVERED |
+| 35 | `extensionRemovalError` explains a blocked removal and suggests a fix | `pkg/extensions/manager_uninstall.go` | T28, T47 | COVERED |
+| 36 | `UpgradeOptions.Force` and callback propagate into `Uninstall` | `pkg/extensions/manager.go` | T27, T50 | COVERED |
+| 37 | `installInternal` sweeps trash when recreating the install directory | `pkg/extensions/manager.go` | T59 | COVERED |
+| 38 | `--force`/`-f` registered and bound on `extension upgrade` | `cmd/extension.go` | T31, T33 | COVERED |
+| 39 | `--force`/`-f` registered and bound on `extension uninstall` | `cmd/extension.go` | T32 | COVERED |
+| 40 | Uninstall action passes `Force` through and reports what it stopped | `cmd/extension.go` | T34, T51 | COVERED |
+| 41 | Upgrade action passes `Force` through and reports what it stopped | `cmd/extension.go` | T54, T55 | COVERED |
+| 42 | Install `--force` also stops processes on the already-installed path | `cmd/extension.go` | T56 | COVERED |
+| 43 | `reportStoppedProcesses` names each process and stays silent otherwise | `cmd/extension.go` | T52, T53 | COVERED |
+| 44 | Help and fig output reflect the new flags | `cmd/testdata/*` | T35 | COVERED |
+| 45 | `extensionPaths` rejects any id that is not a single directory component | `pkg/extensions/manager_uninstall.go` | T60, T61 | COVERED |
+| 46 | `--force` propagates from a parent upgrade into its dependency upgrades | `pkg/extensions/manager.go` | T62 | COVERED |
+| 47 | `--force` applies to every extension expanded by `--all` | `cmd/extension.go` | T63 | COVERED |
+| 48 | `validateExtensionId` rejects ids Windows aliases onto a different directory, device names, separators, and control characters | `pkg/extensions/manager_uninstall.go` | T69, T70 | COVERED |
+| 49 | `RequireRealDir` refuses a symlink or junction while accepting a real or missing directory | `pkg/osutil/relocate.go` | T64 | COVERED |
+| 50 | Trash sweeping and relocation refuse a linked trash directory | `pkg/osutil/relocate.go` | T65, T66 | COVERED |
+| 51 | A termination scope refuses a linked directory while still resolving linked ancestors | `pkg/processutil/processutil.go` | T67, T68 | COVERED |
+
+`test/proctest` is test infrastructure rather than shipped functionality. It has no tests
+of its own by design; it is exercised by every test in rows 4, 5, 22, 30, 31, and 40 to 42,
+and a defect in it fails those directly.
+
+## Gaps & Additions
+
+Reconciliation found five gaps, and a later adversarial review found three more. The first two
+gaps are at the command layer and share a shape: a field
+was threaded into `UninstallOptions` but the parallel command surfaces were not proven to
+pass it. Flag-binding tests (T31, T33) would have stayed green even if the action had
+never read the flag. The next three came from auditing the inventory itself, and one
+of them (G-5) was a real product defect rather than a missing test. The last three (G-7 to
+G-9) are security defects found by attacking the finished implementation rather than
+reading it, and all three were real.
+
+| Gap | Detail | Resolution |
+|-----|--------|------------|
+| G-1 | Upgrade action wiring of `Force` and `OnProcessStopped` into `UpgradeOptions` was unverified | Added T54 and T55 |
+| G-2 | Install action wiring of `--force` on the already-installed path was unverified | Added T56 |
+| G-3 | Rows 15, 32, and 37 named tests that exercised the code incidentally rather than asserting the behavior | Added T57, T58, and T59, which assert each directly |
+| G-4 | `extensionPaths` became the single validator for every extension path but had no tests of its own | Added T60 and T61 |
+| G-5 | `--force` was silently dropped when an upgrade recursed into a dependency | Fixed in `childOpts` and locked down by T62 |
+| G-6 | AC-10 was only covered at the flag-parsing level, so a `--all` run that stopped the first extension and skipped the rest would have passed | Added T63, which runs two live extensions through one `--all --force` command |
+| G-7 | A junction planted at `.trash` redirected sweeping and relocation, and the sweep runs on every install and upgrade even without `--force` | Added `RequireRealDir` and guarded both paths; T64 to T66 |
+| G-8 | `normalizeScope` resolved a symlinked scope, so a link at the install directory widened the set of processes `--force` would terminate | Guarded the final component while still resolving ancestors; T67 and T68 |
+| G-9 | Windows strips trailing dots and spaces, so `.trash.` bypassed the reserved-name check and `foo.` resolved onto another extension's directory | Added `validateExtensionId` ahead of every join; T69 and T70 |
+
+Zero `GAP` rows remain.

--- a/docs/specs/extension-upgrade-force/test-plan.md
+++ b/docs/specs/extension-upgrade-force/test-plan.md
@@ -4,7 +4,7 @@
 ## Spec: docs/specs/extension-upgrade-force/spec.md
 ## Issue: https://github.com/Azure/azure-dev/issues/9307
 ## Created: 2026-07-25
-## Updated: 2026-07-25
+## Updated: 2026-07-26
 
 ---
 
@@ -92,8 +92,8 @@ Written because implementation exposed behavior the plan did not anticipate.
 | T42 | Removing a path that does not exist succeeds rather than erroring | AC-2 | unit | `pkg/osutil/relocate_test.go` -> `TestRemoveAllWithRelocation_MissingPath` | automated |
 | T43 | A trash directory nested inside the directory being removed is rejected | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestRemoveAllWithRelocation_RejectsTrashInsidePath` | automated |
 | T44 | Both path arguments are required | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestRemoveAllWithRelocation_RequiresPaths` | automated |
-| T45 | Trash destinations never collide across repeated relocations | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestUniqueTrashPath` | automated |
-| T46 | Existence probing distinguishes missing from present without masking errors | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestPathExists` | automated |
+| T45 | Trash destinations never collide, across repeated relocations or across processes | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestUniqueTrashPath` | automated |
+| T46 | Concurrent relocations of the same base name all succeed and none overwrites another | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestRelocateInto_ConcurrentRelocationsDoNotCollide` | automated |
 | T47 | A blocked removal with no discoverable processes still explains itself | AC-7 | integration | `pkg/extensions/manager_uninstall_test.go` -> `TestUninstall_BlockedErrorWithoutProcesses` | automated |
 | T48 | Process stopping refuses an unscoped or root directory at the manager boundary | AC-5 | unit | `pkg/extensions/manager_uninstall_test.go` -> `TestStopExtensionProcesses_RejectsUnscopedDirectory` | automated |
 | T49 | Stopping processes in a directory with none running is a no-op, not an error | AC-4 | unit | `pkg/extensions/manager_uninstall_test.go` -> `TestStopExtensionProcesses_NoProcesses` | automated |
@@ -118,6 +118,12 @@ Written because implementation exposed behavior the plan did not anticipate.
 | T68 | A scope whose own final component is a link is refused by both normalization and discovery | AC-2, AC-5 | unit | `pkg/processutil/processutil_test.go` -> `TestFindByExecutableDir_RejectsLinkedScope` | automated |
 | T69 | Ids that Windows aliases away (trailing dot or space), device names, and ids carrying `:` or control characters are rejected | AC-5 | unit | `pkg/extensions/manager_uninstall_test.go` -> `TestExtensionPaths_RejectsUnsafeIds` | automated |
 | T70 | An aliased id resolves onto the directory a different extension owns, and is refused | AC-5 | unit | `pkg/extensions/manager_uninstall_test.go` -> `TestExtensionPaths_AliasedIdWouldResolveOntoAnotherExtension` | automated |
+| T71 | Trash destinations carry the original base name so a leftover entry stays recognizable | AC-11 | unit | `pkg/osutil/relocate_test.go` -> `TestUniqueTrashPath` | automated |
+| T72 | A link at either azd-owned directory component is refused, including a link at the extensions root that a final-component check cannot see | AC-5 | unit | `pkg/extensions/manager_uninstall_test.go` -> `TestRequireRealExtensionDirs_RefusesLinkAtEitherComponent` | automated |
+| T73 | An uninstall under a linked extensions root is refused before it sweeps, terminates, or removes | AC-5, AC-11 | integration | `pkg/extensions/manager_uninstall_test.go` -> `TestUninstall_RefusesLinkedExtensionsRoot` | automated |
+| T74 | Windows `forceKill` refuses a process outside the scope of its own pinned handle, and still stops one inside it | AC-5 | integration | `pkg/processutil/processutil_windows_test.go` -> `TestForceKill_RefusesProcessOutsideScope` | automated |
+| T75 | `upgrade --force` reaches a stale dependency when the parent is already current, and reports it in `--output json` | AC-3, AC-6 | integration | `cmd/extension_force_test.go` -> `TestExtensionUpgradeAction_ForceReachesStaleDependencyOfCurrentParent` | automated |
+| T76 | `stoppedProcesses` is present in the JSON contract when `--force` stopped something and omitted otherwise | AC-6 | unit | `pkg/extensions/upgrade_result_test.go` -> `TestUpgradeResult_MarshalJSON` | automated |
 
 ## Functionality Inventory (Phase 3 reconciliation)
 
@@ -140,7 +146,7 @@ files, then walking each back to an assertion.
 | 11 | `ErrEmptyDirectory` and `ErrRootDirectory` sentinels | `pkg/processutil/processutil.go` | T1, T2, T3, T4, T48 | COVERED |
 | 12 | Windows `enumerateProcesses` via `CreateToolhelp32Snapshot` | `pkg/processutil/processutil_windows.go` | T11, T12, T14 | COVERED |
 | 13 | Windows `processImagePath` resolves a PID to its image | `pkg/processutil/processutil_windows.go` | T11 | COVERED |
-| 14 | Windows `forceKill` and `processRunning` | `pkg/processutil/processutil_windows.go` | T15, T16, T17 | COVERED |
+| 14 | Windows `forceKill` validates scope against its own pinned handle before terminating, and `processRunning` probes exit state | `pkg/processutil/processutil_windows.go` | T15, T16, T17, T74 | COVERED |
 | 15 | Windows `signalGraceful` is a deliberate no-op that reports failure | `pkg/processutil/processutil_windows.go` | T57 | COVERED |
 | 16 | Unix `signalGraceful` sends SIGTERM | `pkg/processutil/processutil_unix.go` | T15, T18 | COVERED |
 | 17 | Unix `forceKill` escalates to SIGKILL after the grace period | `pkg/processutil/processutil_unix.go` | T16 | COVERED |
@@ -153,8 +159,8 @@ files, then walking each back to an assertion.
 | 24 | `RemoveAllWithRelocation` validates its arguments and trash placement | `pkg/osutil/relocate.go` | T43, T44 | COVERED |
 | 25 | `SweepTrash` best-effort deletes what is no longer locked | `pkg/osutil/relocate.go` | T22, T23, T24 | COVERED |
 | 26 | `relocateLockedFiles` renames rather than deletes | `pkg/osutil/relocate.go` | T19, T20 | COVERED |
-| 27 | `uniqueTrashPath` never collides | `pkg/osutil/relocate.go` | T45 | COVERED |
-| 28 | `pathExists` distinguishes missing from present | `pkg/osutil/relocate.go` | T46 | COVERED |
+| 27 | `uniqueTrashPath` never collides, within a process or across them | `pkg/osutil/relocate.go` | T45, T46, T71 | COVERED |
+| 28 | `relocateInto` renames onto a destination no other process can have chosen | `pkg/osutil/relocate.go` | T46 | COVERED |
 | 29 | `UninstallOptions` carries `Force` and the stop callback | `pkg/extensions/manager_uninstall.go` | T25, T26, T29 | COVERED |
 | 30 | `Uninstall` succeeds against a running extension by default | `pkg/extensions/manager_uninstall.go` | T25 | COVERED |
 | 31 | `Uninstall` with `Force` stops processes first | `pkg/extensions/manager_uninstall.go` | T26, T29 | COVERED |
@@ -178,6 +184,9 @@ files, then walking each back to an assertion.
 | 49 | `RequireRealDir` refuses a symlink or junction while accepting a real or missing directory | `pkg/osutil/relocate.go` | T64 | COVERED |
 | 50 | Trash sweeping and relocation refuse a linked trash directory | `pkg/osutil/relocate.go` | T65, T66 | COVERED |
 | 51 | A termination scope refuses a linked directory while still resolving linked ancestors | `pkg/processutil/processutil.go` | T67, T68 | COVERED |
+| 52 | `requireRealExtensionDirs` checks both azd-owned components, so a linked extensions root cannot redirect a removal, a sweep, or a kill scope | `pkg/extensions/manager_uninstall.go`, `pkg/extensions/manager.go` | T72, T73 | COVERED |
+| 53 | `UpgradeResult.StoppedProcesses` carries what `--force` stopped into the `--output json` contract | `pkg/extensions/upgrade_result.go`, `cmd/extension.go` | T75, T76 | COVERED |
+| 54 | `upgrade --force` reaches the dependency reconciliation branch taken when the parent is already current | `cmd/extension.go` | T75 | COVERED |
 
 `test/proctest` is test infrastructure rather than shipped functionality. It has no tests
 of its own by design; it is exercised by every test in rows 4, 5, 22, 30, 31, and 40 to 42,
@@ -185,15 +194,17 @@ and a defect in it fails those directly.
 
 ## Gaps & Additions
 
-Reconciliation found five gaps, and a later adversarial review found three more. The first two
+Reconciliation found five gaps, and a later adversarial review found three more. A
+follow-up review round found five further defects and one inaccurate claim. The first two
 gaps are at the command layer and share a shape: a field
 was threaded into `UninstallOptions` but the parallel command surfaces were not proven to
 pass it. Flag-binding tests (T31, T33) would have stayed green even if the action had
 never read the flag. The next three came from auditing the inventory itself, and one
-of them (G-5) was a real product defect rather than a missing test. The last three (G-7 to
-G-9) are security defects found by attacking the finished implementation rather than
-reading it, and all three were real.
-
+of them (G-5) was a real product defect rather than a missing test. G-7 to
+G-9 are security defects found by attacking the finished implementation rather than
+reading it, and all three were real. G-10 to G-14 are the review round that followed, four
+of them real defects and one an unmet acceptance criterion; G-15 corrected a spec claim
+that measurement disproved.
 | Gap | Detail | Resolution |
 |-----|--------|------------|
 | G-1 | Upgrade action wiring of `Force` and `OnProcessStopped` into `UpgradeOptions` was unverified | Added T54 and T55 |
@@ -205,5 +216,11 @@ reading it, and all three were real.
 | G-7 | A junction planted at `.trash` redirected sweeping and relocation, and the sweep runs on every install and upgrade even without `--force` | Added `RequireRealDir` and guarded both paths; T64 to T66 |
 | G-8 | `normalizeScope` resolved a symlinked scope, so a link at the install directory widened the set of processes `--force` would terminate | Guarded the final component while still resolving ancestors; T67 and T68 |
 | G-9 | Windows strips trailing dots and spaces, so `.trash.` bypassed the reserved-name check and `foo.` resolved onto another extension's directory | Added `validateExtensionId` ahead of every join; T69 and T70 |
+| G-10 | `RequireRealDir` inspects only a final component, so a junction at the `extensions` root passed the check on the extension directory and redirected the kill scope, the sweep, and installs | Added `requireRealExtensionDirs` covering both azd-owned components; T72 and T73 |
+| G-11 | Trash destinations were chosen by scanning for a free name, so two azd processes relocating the same base name picked the same path and one clobbered or blocked the other | Per-process random names, which prevent the collision rather than detecting it, because `os.Rename` on Windows replaces the destination instead of reporting it; T45, T46, and T71 |
+| G-12 | `Terminate` re-checked scope by PID and then signalled by PID, so the containment guarantee rested on a window it could not close | Windows `forceKill` now validates through an open handle, which reserves the PID; T74. Unix keeps a documented residual |
+| G-13 | `upgrade --force` dropped `Force` and the stop callback on the branch taken when the parent is already at the target version, so a stale dependency's process was left running and unreported | Propagated both into `ReconcileDependencies`; T75 |
+| G-14 | `--force` printed what it stopped only on the console, so `--output json` silently omitted it and AC-6 was unmet for scripted callers | Added `stoppedProcesses` to the upgrade JSON contract; T75 and T76 |
+| G-15 | The spec claimed `os.RemoveAll` follows a Windows junction, which is false and would have justified defenses against a threat that does not exist | Corrected the spec against a Windows 11 measurement |
 
 Zero `GAP` rows remain.


### PR DESCRIPTION
Fixes #9307

### Summary

`azd extension upgrade` always failed when the extension had a running process. This makes upgrade and uninstall work by default without stopping anything, and adds `--force` for when the new version needs to take effect immediately.

### Issue

Upgrade uninstalls before it installs, and uninstall deletes the install directory. Windows refuses to delete a file that is mapped as a running executable image, so the removal returned `Access is denied`. The existing retry loop waits ten seconds, which a process that is genuinely still running will always outlast.

### Relocation, so the default path stops failing

Windows allows a locked executable to be renamed even though it refuses to delete it, because the image loader opens executables with `FILE_SHARE_DELETE` but not `FILE_SHARE_WRITE`. Files that resist removal are moved into a sibling `.trash` directory. That empties the install directory, lets the new version be written, and needs no cooperation from the running process.

Relocated files are swept on later extension operations, once the holding process has exited.

### `--force`, so the new version takes effect immediately

Relocation on its own leaves the old process running against the old binary. `--force` stops the extension's own processes first, and is available on `upgrade`, `uninstall`, and `install`.

Discovery is scoped to executables inside the extension's install directory, so unrelated processes are never candidates. Child processes are deliberately left alone: their executables live elsewhere, which is exactly where that containment guarantee stops holding.

Termination is graceful then forced on Unix. Windows goes straight to termination, since it has no equivalent signal.

### Behaviour at a glance

| Scenario | Before | After |
|---|---|---|
| `upgrade` while the extension is running | Fails with `Access is denied` | Succeeds; the old process keeps running the old binary until it exits |
| `uninstall` while the extension is running | Fails with `Access is denied` | Succeeds |
| `upgrade --force` while the extension is running | Not available | Stops the extension, then upgrades |
| Removal still blocked | Bare permission error | Names the blocking processes and their PIDs, points at `--force` |
| Nothing running | Unchanged | Unchanged |

### Hardening

Found by attacking the implementation after it was written, and fixed here:

- Extension ids are validated as a single path component before being joined. This closes a pre-existing traversal gap, and rejects ids that Windows aliases onto a different directory. `os.MkdirAll(".trash.")` creates `.trash`, so the reserved-name check was bypassable, and the id `foo.` resolved onto the directory owned by `foo`.
- Directories azd owns are refused when a symlink or junction has been planted there, so neither the trash sweep nor the termination scope can be redirected. Both reparse forms are checked: a junction sets `ModeIrregular` and isn't resolved by `filepath.EvalSymlinks`, but `os.ReadDir` and `os.Rename` still follow it.

### Testing

75 new test functions across `pkg/processutil`, `pkg/osutil`, `pkg/extensions`, and `cmd`. The file-lock and process paths run against real spawned processes and real locked files rather than mocks, since Windows image-lock semantics can't be faked meaningfully. `mage preflight` passes all nine checks.

Design notes and the full test plan are in `docs/specs/extension-upgrade-force/`.
