### PR TITLE
feat(agents): add max_stalls parameter to optimize config and API

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
@@ -98,6 +98,12 @@ func (c *OptimizeConfig) Validate() error {
 				"or run 'azd ai agent eval generate' to generate one")
 	}
 
+	if c.Options.MaxStalls != nil && *c.Options.MaxStalls < 1 {
+		return fmt.Errorf(
+			"options.max_stalls must be >= 1 (got %d): set 'max_stalls' under 'options:' in your config file",
+			*c.Options.MaxStalls)
+	}
+
 	return nil
 }
 
@@ -129,6 +135,7 @@ func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, []string, e
 			MaxCandidates:     c.Options.MaxCandidates,
 			OptimizationModel: c.Options.OptimizationModel,
 			EvaluationLevel:   c.Options.EvaluationLevel,
+			MaxStalls:         c.Options.MaxStalls,
 		},
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
@@ -344,6 +344,73 @@ func TestValidate_NeitherDatasetFileNorReference(t *testing.T) {
 	assert.Contains(t, err.Error(), "a dataset is required")
 }
 
+func TestValidate_MaxStallsZeroIsRejected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent"},
+			Evaluators:  opt_eval.EvaluatorList{{Name: "builtin.task_adherence"}},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
+		},
+		Options: &opt_eval.Options{
+			EvalModel:         "gpt-4o-mini",
+			OptimizationModel: "gpt-5",
+			MaxStalls:         new(0),
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max_stalls must be >= 1")
+}
+
+// TestValidate_MaxStallsNegativeIsRejected verifies Validate() rejects a negative
+// max_stalls value set via the YAML config.
+func TestValidate_MaxStallsNegativeIsRejected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent"},
+			Evaluators:  opt_eval.EvaluatorList{{Name: "builtin.task_adherence"}},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
+		},
+		Options: &opt_eval.Options{
+			EvalModel:         "gpt-4o-mini",
+			OptimizationModel: "gpt-5",
+			MaxStalls:         new(-1),
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max_stalls must be >= 1")
+}
+
+func TestValidate_MaxStallsPositiveIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent"},
+			Evaluators:  opt_eval.EvaluatorList{{Name: "builtin.task_adherence"}},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
+		},
+		Options: &opt_eval.Options{
+			EvalModel:         "gpt-4o-mini",
+			OptimizationModel: "gpt-5",
+			MaxStalls:         new(3),
+		},
+	}
+
+	err := cfg.Validate()
+	require.NoError(t, err)
+}
+
 func TestLoadOptimizeConfig_FileNotFound(t *testing.T) {
 	t.Parallel()
 
@@ -826,4 +893,25 @@ func TestLoadSkillsFromDir_AllEmpty(t *testing.T) {
 	skills, err := loadSkillsFromDir(dir)
 	require.NoError(t, err)
 	assert.Empty(t, skills)
+}
+
+func TestToRequest_MaxStalls(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent"},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
+		},
+		Options: &opt_eval.Options{
+			EvalModel: "gpt-4o-mini",
+			MaxStalls: new(3),
+		},
+	}
+
+	req, _, err := cfg.ToRequest()
+	require.NoError(t, err)
+	require.NotNil(t, req.Options.MaxStalls)
+	assert.Equal(t, 3, *req.Options.MaxStalls)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
@@ -480,6 +480,10 @@ type Options struct {
 	MaxCandidates      *int               `yaml:"max_candidates,omitempty"`
 	OptimizationModel  string             `yaml:"optimization_model,omitempty"`
 	EvaluationLevel    string             `yaml:"evaluation_level,omitempty"`
+	// MaxStalls is the maximum number of consecutive stalled iterations
+	// (iterations that do not improve over the current best score) before
+	// the optimizer stops early. When nil the service default is used.
+	MaxStalls *int `yaml:"max_stalls,omitempty"`
 }
 
 // Read reads a YAML config file (eval or optimize format).

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml_test.go
@@ -351,6 +351,21 @@ max_candidates: 7
 	assert.Equal(t, 7, *opts.MaxCandidates)
 }
 
+// TestOptions_MaxStalls verifies the max_stalls key populates MaxStalls.
+func TestOptions_MaxStalls(t *testing.T) {
+	t.Parallel()
+
+	input := `
+eval_model: gpt-4.1
+max_stalls: 3
+`
+	var opts Options
+	require.NoError(t, yaml.Unmarshal([]byte(input), &opts))
+
+	require.NotNil(t, opts.MaxStalls)
+	assert.Equal(t, 3, *opts.MaxStalls)
+}
+
 func TestOptions_OptimizationConfig_NativeYAML(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
@@ -113,6 +113,9 @@ type OptimizeOptions struct {
 	OptimizationModel  string                     `json:"optimization_model"`
 	OptimizationConfig map[string]json.RawMessage `json:"optimization_config,omitempty"`
 	EvaluationLevel    string                     `json:"evaluation_level,omitempty"`
+	// MaxStalls is the maximum number of consecutive non-improving iterations
+	// before the optimizer stops early. Omitted when nil (service default applies).
+	MaxStalls *int `json:"max_stalls,omitempty"`
 }
 
 // --- Response models ---

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models_test.go
@@ -34,6 +34,7 @@ func TestOptimizeRequest_RoundTrip(t *testing.T) {
 			MaxCandidates:     new(5),
 			EvalModel:         "gpt-4o-mini",
 			OptimizationModel: "gpt-4o",
+			MaxStalls:         new(3),
 		},
 	}
 
@@ -46,7 +47,7 @@ func TestOptimizeRequest_RoundTrip(t *testing.T) {
 		`"agent"`, `"agent_name"`, `"agent_version"`,
 		`"train_dataset"`, `"type"`, `"items"`, `"evaluators"`,
 		`"options"`, `"eval_model"`, `"max_candidates"`,
-		`"optimization_model"`,
+		`"optimization_model"`, `"max_stalls"`,
 		`"ground_truth"`,
 	} {
 		assert.True(t, strings.Contains(s, field), "JSON should contain %s", field)
@@ -64,6 +65,8 @@ func TestOptimizeRequest_RoundTrip(t *testing.T) {
 	assert.Equal(t, "relevance", got.Evaluators[1].Name)
 	assert.Equal(t, "1", got.Evaluators[1].Version)
 	assert.Equal(t, "gpt-4o-mini", got.Options.EvalModel)
+	require.NotNil(t, got.Options.MaxStalls)
+	assert.Equal(t, 3, *got.Options.MaxStalls)
 }
 
 func TestOptimizeJobStatus_RoundTrip(t *testing.T) {


### PR DESCRIPTION
Closes #9316

> **⚠️ FAOS Team Decision (2026-07-28 sync):** `max_stalls` is intentionally **not exposed as a `--max-stalls` CLI flag**. It is an advanced tuning parameter for power users who already understand prompt optimization budgets. The correct surface is the YAML eval-config file, consistent with how other advanced options (e.g. `evaluation_level`, `optimization_config`) are handled. A CLI flag was implemented, reviewed, and deliberately removed as part of this PR.

## Summary

Exposes the `max_stalls` early-stopping option in the YAML eval-config and the optimize API. When N consecutive full validation-set evaluations produce no improvement, the optimizer stops early to save cost.

The `max_stalls` parameter was added to the FAOS service in [Vienna PR #2189426](https://msdata.visualstudio.com/Vienna/_git/vienna/pullrequest/2189426). This PR wires it through the azd CLI extension (YAML → API only).

## Changes

- `opt_eval.Options`: add `MaxStalls *int` with `yaml:"max_stalls,omitempty"`
- `optimize_api.OptimizeOptions`: add `MaxStalls *int` with `json:"max_stalls,omitempty"`
- `OptimizeConfig.ToRequest()`: wire `MaxStalls` from YAML config to API request
- `Validate()`: reject `max_stalls < 1` with a clear error message

## Usage (YAML config file only)

```yaml
options:
  eval_model: gpt-4.1
  optimization_model: gpt-5
  max_stalls: 10  # stop early after 10 consecutive non-improving iterations
```

Omitting `max_stalls` uses the service default (5).

## Testing

- `TestOptions_MaxStalls` — verifies YAML key `max_stalls` populates `MaxStalls`
- `TestToRequest_MaxStalls` — verifies `MaxStalls` is passed through `ToRequest()` to the API
- `TestOptimizeRequest_RoundTrip` — verifies JSON tag `max_stalls` round-trips correctly
- `TestValidate_MaxStallsZeroIsRejected` — verifies YAML `max_stalls: 0` errors
- `TestValidate_MaxStallsNegativeIsRejected` — verifies YAML `max_stalls: -1` errors
- `TestValidate_MaxStallsPositiveIsAccepted` — verifies valid values pass
