### PR TITLE
fix(provision): surface nested ARM errors in provision --preview

### DIFF
--- a/cli/azd/pkg/azapi/azure_deployment_error.go
+++ b/cli/azd/pkg/azapi/azure_deployment_error.go
@@ -84,13 +84,20 @@ func (e *AzureDeploymentError) Error() string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("\n\n%s:\n", e.Title))
 
-	// Return the original error string if we can't parse the JSON
-	if e.Details == nil {
+	var lines []string
+	if e.Details != nil {
+		lines = generateErrorOutput(e.Details)
+	}
+
+	// Fall back to the raw payload when the JSON could not be parsed, and also when
+	// it parsed into a tree that renders nothing: every node was code-only, blanked
+	// (DeploymentFailed, ResourceDeploymentFailure), or a wrapper whose message held
+	// no nested code/message pair. Without this the heading would be the whole error.
+	if len(lines) == 0 {
 		sb.WriteString(e.Json)
 		return sb.String()
 	}
 
-	lines := generateErrorOutput(e.Details)
 	for _, line := range lines {
 		sb.WriteString(fmt.Sprintln(output.WithErrorFormat(line)))
 	}

--- a/cli/azd/pkg/azapi/azure_deployment_error_test.go
+++ b/cli/azd/pkg/azapi/azure_deployment_error_test.go
@@ -36,6 +36,40 @@ func Test_Not_Json_Error(t *testing.T) {
 	require.Equal(t, "\n\nTitle:\n"+nonJsonError, errorString)
 }
 
+// A payload can parse cleanly yet render nothing: nodes carrying only a code,
+// codes that are deliberately blanked, or a null body. Falling back to the raw
+// payload keeps some cause visible instead of emitting a bare heading.
+func Test_Parsed_But_Unrenderable_Error_Falls_Back_To_Json(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+	}{
+		{
+			name: "code with no message",
+			json: `{"error":{"code":"ResourceGroupNotFound"}}`,
+		},
+		{
+			name: "blanked code with no details",
+			json: `{"error":{"code":"DeploymentFailed","message":"At least one operation failed."}}`,
+		},
+		{
+			name: "additionalInfo only",
+			json: `{"error":{"code":"BadRequest","additionalInfo":[{"type":"QuotaExceeded"}]}}`,
+		},
+		{
+			name: "null body",
+			json: `null`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deploymentError := NewAzureDeploymentError("Title", tt.json, DeploymentOperationPreview)
+			require.Equal(t, "\n\nTitle:\n"+tt.json, deploymentError.Error())
+		})
+	}
+}
+
 func assertOutputsMatch(t *testing.T, jsonPath string, expectedOutputPath string) {
 	data, err := os.ReadFile(jsonPath)
 	if err != nil {

--- a/cli/azd/pkg/azapi/deployment_error_integration_test.go
+++ b/cli/azd/pkg/azapi/deployment_error_integration_test.go
@@ -4,9 +4,11 @@
 package azapi
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/errorhandler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -272,4 +274,58 @@ func TestPipeline_DeploymentErrorLine_LocationNotAvailableForResourceType(t *tes
 	require.NotNil(t, result,
 		"Should match LocationNotAvailableForResourceType")
 	assert.Equal(t, "Resource not available in region.", result.Message)
+}
+
+// A failed what-if returns HTTP 200 with the failure in the payload, so the
+// preview path builds its error from an armresources.ErrorResponse rather than
+// from an HTTP error. The actionable cause sits two levels deep, under a
+// top-level code that getErrorsFromMap does NOT blank out (unlike
+// DeploymentFailed), so the pipeline must keep searching past the outer node.
+// Regression test for https://github.com/Azure/azure-dev/issues/9011.
+func TestPipeline_PreviewErrorResponse_NestedQuota(t *testing.T) {
+	const whatIfBody = `{
+	  "status": "Failed",
+	  "error": {
+	    "code": "InvalidTemplateDeployment",
+	    "message": "The template deployment 'dev-1' is not valid according to the validation procedure. ` +
+		`The following resource provider(s) - 'Microsoft.Storage/storageAccounts' reported preflight ` +
+		`validation errors. See inner errors for details.",
+	    "details": [{
+	      "code": "PreflightValidationCheckFailed",
+	      "message": "Preflight validation failed. Please refer to the details for the specific errors.",
+	      "details": [{
+	        "code": "SubscriptionIsOverQuotaForSku",
+	        "target": "stdev1",
+	        "message": "Subscription has reached the maximum number of storage accounts allowed in 'eastus'."
+	      }]
+	    }]
+	  }
+	}`
+
+	var whatIfResult armresources.WhatIfOperationResult
+	require.NoError(t, json.Unmarshal([]byte(whatIfBody), &whatIfResult))
+	require.NotNil(t, whatIfResult.Error)
+
+	deployErr := NewAzureDeploymentErrorFromResponse(whatIfResult.Error, DeploymentOperationPreview)
+
+	// Every level of the ARM error tree must be rendered, especially the leaf cause.
+	rendered := deployErr.Error()
+	assert.Contains(t, rendered, "Preview Error Details")
+	assert.Contains(t, rendered, "InvalidTemplateDeployment")
+	assert.Contains(t, rendered, "PreflightValidationCheckFailed")
+	assert.Contains(t, rendered, "SubscriptionIsOverQuotaForSku")
+	assert.Contains(t, rendered, "maximum number of storage accounts")
+
+	// Reproduce the production wrapping chain: provisioning.Manager.Preview
+	// followed by wrapProvisionError's default branch.
+	wrapped := fmt.Errorf("deployment failed: %w",
+		fmt.Errorf("error deploying infrastructure: %w", deployErr))
+
+	// Exercise the real embedded error_suggestions.yaml rules, not inline ones.
+	result := errorhandler.NewErrorHandlerPipeline(nil).Process(t.Context(), wrapped)
+
+	require.NotNil(t, result,
+		"Should match SubscriptionIsOverQuotaForSku nested under InvalidTemplateDeployment")
+	assert.Equal(t, "Your subscription quota for this SKU is exceeded.", result.Message)
+	assert.Contains(t, result.Suggestion, "Request a quota increase")
 }

--- a/cli/azd/pkg/azapi/deployment_error_integration_test.go
+++ b/cli/azd/pkg/azapi/deployment_error_integration_test.go
@@ -6,6 +6,7 @@ package azapi
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -309,11 +310,21 @@ func TestPipeline_PreviewErrorResponse_NestedQuota(t *testing.T) {
 	deployErr := NewAzureDeploymentErrorFromResponse(whatIfResult.Error, DeploymentOperationPreview)
 
 	// Every level of the ARM error tree must be rendered, especially the leaf cause.
+	// Asserting the codes in order locks the nesting: a regression that stops
+	// descending would drop trailing entries rather than fail a substring check.
 	rendered := deployErr.Error()
-	assert.Contains(t, rendered, "Preview Error Details")
-	assert.Contains(t, rendered, "InvalidTemplateDeployment")
-	assert.Contains(t, rendered, "PreflightValidationCheckFailed")
-	assert.Contains(t, rendered, "SubscriptionIsOverQuotaForSku")
+	var codes []string
+	for _, line := range strings.Split(strings.TrimSpace(rendered), "\n") {
+		if code, _, found := strings.Cut(line, ":"); found {
+			codes = append(codes, strings.TrimSpace(code))
+		}
+	}
+	assert.Equal(t, []string{
+		"Preview Error Details",
+		"InvalidTemplateDeployment",
+		"PreflightValidationCheckFailed",
+		"SubscriptionIsOverQuotaForSku",
+	}, codes)
 	assert.Contains(t, rendered, "maximum number of storage accounts")
 
 	// Reproduce the production wrapping chain: provisioning.Manager.Preview

--- a/cli/azd/pkg/azapi/deployment_error_integration_test.go
+++ b/cli/azd/pkg/azapi/deployment_error_integration_test.go
@@ -340,3 +340,116 @@ func TestPipeline_PreviewErrorResponse_NestedQuota(t *testing.T) {
 	assert.Equal(t, "Your subscription quota for this SKU is exceeded.", result.Message)
 	assert.Contains(t, result.Suggestion, "Request a quota increase")
 }
+
+// Property matching is a case-insensitive substring check, so the rule keyed on
+// "InvalidTemplate" also matches ARM's "InvalidTemplateDeployment". Its advice —
+// run 'azd provision --preview' — is correct for a deploy but absurd for a
+// preview, which is the command already running. The preview guard rule keys on
+// AzureDeploymentError.Operation to suppress it there, and must leave every
+// other operation untouched.
+func TestSuggestions_PreviewNeverAdvisesRunningPreview(t *testing.T) {
+	// Cause with no dedicated rule, so matching falls through to the generic
+	// template rules where the bad advice lives.
+	const armError = `{
+	  "code": "InvalidTemplateDeployment",
+	  "message": "The template deployment is not valid. See inner errors for details.",
+	  "details": [{
+	    "code": "PreflightValidationCheckFailed",
+	    "message": "Preflight validation failed.",
+	    "details": [{
+	      "code": "StorageAccountAlreadyTaken",
+	      "message": "The storage account named storage is already taken."
+	    }]
+	  }]
+	}`
+
+	tests := []struct {
+		name string
+		op   DeploymentOperation
+		// wantMessage identifies which rule won, since both rules produce advice.
+		wantMessage    string
+		wantSelfAdvice bool
+	}{
+		{
+			name:           "preview is suppressed",
+			op:             DeploymentOperationPreview,
+			wantMessage:    "Azure validation rejected the deployment template.",
+			wantSelfAdvice: false,
+		},
+		{
+			// Not self-referential, so the original advice must survive unchanged.
+			name:           "deploy keeps the advice",
+			op:             DeploymentOperationDeploy,
+			wantMessage:    "The deployment template contains errors.",
+			wantSelfAdvice: true,
+		},
+		{
+			// Validate runs inside provision, not preview, so the guard must not
+			// widen to it just because it is also a non-deploy operation.
+			name:           "validate keeps the advice",
+			op:             DeploymentOperationValidate,
+			wantMessage:    "The deployment template contains errors.",
+			wantSelfAdvice: true,
+		},
+	}
+
+	pipeline := errorhandler.NewErrorHandlerPipeline(nil)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Preview marshals the ErrorResponse directly; the other paths receive
+			// the same tree nested under an "error" key. Mirror both real shapes.
+			body := armError
+			if tt.op != DeploymentOperationPreview {
+				body = `{"error":` + armError + `}`
+			}
+
+			deployErr := NewAzureDeploymentError(deploymentErrorTitle(tt.op), body, tt.op)
+			wrapped := fmt.Errorf("deployment failed: %w",
+				fmt.Errorf("error deploying infrastructure: %w", deployErr))
+
+			result := pipeline.Process(t.Context(), wrapped)
+
+			require.NotNil(t, result, "every operation should still get a suggestion")
+			assert.Equal(t, tt.wantMessage, result.Message)
+
+			if tt.wantSelfAdvice {
+				assert.Contains(t, result.Suggestion, "azd provision --preview")
+			} else {
+				assert.NotContains(t, result.Suggestion, "--preview",
+					"must not tell a --preview run to run --preview")
+			}
+		})
+	}
+}
+
+// The preview guard matches on operation alone, so ordering is the only thing
+// keeping it from swallowing every preview failure: it must sit after the
+// specific error-code rules, which are evaluated first and win. Locking that
+// here because the ordering constraint is invisible at the YAML call site.
+// This is the issue #9011 behaviour and must not regress.
+func TestSuggestions_PreviewGuardDoesNotMaskSpecificCauses(t *testing.T) {
+	const armError = `{
+	  "code": "InvalidTemplateDeployment",
+	  "message": "The template deployment is not valid. See inner errors for details.",
+	  "details": [{
+	    "code": "PreflightValidationCheckFailed",
+	    "message": "Preflight validation failed.",
+	    "details": [{
+	      "code": "SubscriptionIsOverQuotaForSku",
+	      "message": "Subscription has reached the maximum number of storage accounts."
+	    }]
+	  }]
+	}`
+
+	deployErr := NewAzureDeploymentError(
+		deploymentErrorTitle(DeploymentOperationPreview), armError, DeploymentOperationPreview)
+	wrapped := fmt.Errorf("deployment failed: %w",
+		fmt.Errorf("error deploying infrastructure: %w", deployErr))
+
+	result := errorhandler.NewErrorHandlerPipeline(nil).Process(t.Context(), wrapped)
+
+	require.NotNil(t, result)
+	assert.Equal(t, "Your subscription quota for this SKU is exceeded.", result.Message,
+		"specific quota rule must outrank the generic preview guard")
+}

--- a/cli/azd/pkg/azapi/deployment_error_integration_test.go
+++ b/cli/azd/pkg/azapi/deployment_error_integration_test.go
@@ -314,7 +314,7 @@ func TestPipeline_PreviewErrorResponse_NestedQuota(t *testing.T) {
 	// descending would drop trailing entries rather than fail a substring check.
 	rendered := deployErr.Error()
 	var codes []string
-	for _, line := range strings.Split(strings.TrimSpace(rendered), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(rendered), "\n") {
 		if code, _, found := strings.Cut(line, ":"); found {
 			codes = append(codes, strings.TrimSpace(code))
 		}

--- a/cli/azd/pkg/azapi/deployments.go
+++ b/cli/azd/pkg/azapi/deployments.go
@@ -5,7 +5,9 @@ package azapi
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"time"
 
@@ -391,18 +393,42 @@ func responseToDeploymentError(title string, respErr *azcore.ResponseError, oper
 	return NewAzureDeploymentError(title, errorText, operation)
 }
 
+// deploymentErrorTitle returns the user-facing heading used when rendering an
+// Azure deployment error for the given operation.
+func deploymentErrorTitle(operation DeploymentOperation) string {
+	switch operation {
+	case DeploymentOperationValidate:
+		return "Validation Error Details"
+	case DeploymentOperationPreview:
+		return "Preview Error Details"
+	default:
+		return "Deployment Error Details"
+	}
+}
+
 // Attempts to create an Azure Deployment error from the HTTP response error
 func createDeploymentError(err error, operation DeploymentOperation) error {
 	if responseErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
-		title := "Deployment Error Details"
-		switch operation {
-		case DeploymentOperationValidate:
-			title = "Validation Error Details"
-		case DeploymentOperationPreview:
-			title = "Preview Error Details"
-		}
-		return responseToDeploymentError(title, responseErr, operation)
+		return responseToDeploymentError(deploymentErrorTitle(operation), responseErr, operation)
 	}
 
 	return err
+}
+
+// NewAzureDeploymentErrorFromResponse builds an AzureDeploymentError from an ARM
+// ErrorResponse carried in a successful (HTTP 200) response body, such as a failed
+// what-if operation that reports the failure in the payload rather than as an HTTP
+// error. Marshalling back to JSON lets the error reuse the same recursive parser as
+// the HTTP error path, so nested details are surfaced and the error-suggestion
+// pipeline can match on any DeploymentErrorLine in the tree.
+func NewAzureDeploymentErrorFromResponse(
+	errResp *armresources.ErrorResponse,
+	operation DeploymentOperation,
+) error {
+	raw, err := json.Marshal(errResp)
+	if err != nil {
+		return fmt.Errorf("marshalling deployment error response: %w", err)
+	}
+
+	return NewAzureDeploymentError(deploymentErrorTitle(operation), string(raw), operation)
 }

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -1088,25 +1088,9 @@ func (p *BicepProvider) Preview(ctx context.Context) (*provisioning.DeployPrevie
 	}
 
 	if deployPreviewResult.Error != nil {
-		deploymentErr := *deployPreviewResult.Error
-		errDetailsList := make([]string, len(deploymentErr.Details))
-		for index, errDetail := range deploymentErr.Details {
-			errDetailsList[index] = fmt.Sprintf(
-				"code: %s, message: %s",
-				convert.ToValueWithDefault(errDetail.Code, ""),
-				convert.ToValueWithDefault(errDetail.Message, ""),
-			)
-		}
-
-		var errDetails string
-		if len(errDetailsList) > 0 {
-			errDetails = fmt.Sprintf(" Details: %s", strings.Join(errDetailsList, "\n"))
-		}
-		return nil, fmt.Errorf(
-			"generating preview: error code: %s, message: %s.%s",
-			convert.ToValueWithDefault(deploymentErr.Code, ""),
-			convert.ToValueWithDefault(deploymentErr.Message, ""),
-			errDetails,
+		return nil, azapi.NewAzureDeploymentErrorFromResponse(
+			deployPreviewResult.Error,
+			azapi.DeploymentOperationPreview,
 		)
 	}
 

--- a/cli/azd/resources/error_suggestions.yaml
+++ b/cli/azd/resources/error_suggestions.yaml
@@ -260,6 +260,12 @@ rules:
       - url: "https://learn.microsoft.com/azure/container-apps/troubleshooting"
         title: "Troubleshoot Container Apps"
 
+  - errorType: "AzureDeploymentError"
+    properties:
+      Operation: "preview"
+    message: "Azure validation rejected the deployment template."
+    suggestion: "Review the nested error codes above for the specific cause."
+
   - errorType: "DeploymentErrorLine"
     properties:
       Code: "InvalidTemplate"


### PR DESCRIPTION
Fix #9011

## Problem

`azd provision --preview` reported preflight failures without the actual cause:

```
ERROR: deployment failed: error deploying infrastructure: generating preview:
error code: InvalidTemplateDeployment, message: The template deployment ... reported
preflight validation errors ... See inner errors for details.. Details: code:
PreflightValidationCheckFailed, message: Preflight validation failed. Please refer to
the details for the specific errors.
```

The details it points to were never printed — not even with `--debug`. In the reported
case the underlying cause was a storage account quota limit.

## Root cause

`BicepProvider.Preview` formatted the error with a bespoke loop that read only `Code`
and `Message` of each **direct** child of the ARM `ErrorResponse`. That type is
recursive (`Details []*ErrorResponse`), and preflight validation nests the actionable
cause under `error.details[].details[]` — exactly the level being discarded.

`azd provision` (without `--preview`) was unaffected because it routes ARM failures
through `azapi.NewAzureDeploymentError` → `getErrorsFromMap`, which walks the tree
recursively. Preview never reached that code: a failed what-if returns **HTTP 200**
with the failure in the response body, so the SDK returns no Go error and
`createDeploymentError` is never invoked.

`--debug` didn't help either, because `arm.ClientOptions` leaves
`policy.LogOptions.IncludeBody` unset, so the response body is never logged.

## Fix

Route the preview failure through `azapi.AzureDeploymentError` using a new
`NewAzureDeploymentErrorFromResponse` constructor. Marshalling the SDK model back to
JSON lets it reuse the one existing recursive parser instead of adding a second walker.

Because the error is now typed rather than a flat string, preview failures also gain
three things they previously bypassed:

1. the `error_suggestions.yaml` pipeline (which already has a
   `SubscriptionIsOverQuotaForSku` rule),
2. ARM telemetry classification via `classifyArmDeployError`,
3. trace-id wrapping in `TelemetryMiddleware`.

Net: −21 lines of bespoke formatting, +1 reusable constructor.

### Before / after

```
# before
generating preview: error code: InvalidTemplateDeployment, message: ...
See inner errors for details.. Details: code: PreflightValidationCheckFailed,
message: Preflight validation failed. Please refer to the details for the specific errors.

# after
Preview Error Details:
InvalidTemplateDeployment: The template deployment ... See inner errors for details.
PreflightValidationCheckFailed: Preflight validation failed. Please refer to the details...
SubscriptionIsOverQuotaForSku: Subscription has reached the maximum number of storage
accounts (250) allowed in location 'eastus'.

Suggestion: Request a quota increase or use a different SKU.
```

## Testing

Added `TestPipeline_PreviewErrorResponse_NestedQuota`, which drives a realistic ARM
what-if payload through the **real embedded `error_suggestions.yaml`** rules rather than
inline test rules. It specifically covers a top-level code that `getErrorsFromMap` does
*not* blank out (unlike `DeploymentFailed`), so it verifies the matcher keeps searching
past the outer node — a case the existing tests did not cover.

- `go test ./pkg/azapi/... ./pkg/errorhandler/... ./pkg/infra/... ./internal/cmd/... -short` — pass
- `gofmt -s -l`, `golangci-lint run`, `cspell` — clean

## Notes for reviewers

- **Deployment stacks are unaffected** — `StackDeployments.WhatIf*` returns
  `ErrPreviewNotSupported`.
- **New telemetry value**: preview failures now classify as `service.arm.preview.failed`
  with `ServiceErrorCode` populated, instead of falling into a generic bucket. This is a
  new value in the existing `service.arm.<operation>.failed` family (`deployment` and
  `validate` already exist), not a new field or event, so I did not update the telemetry
  docs — happy to if you'd prefer.
- **Out of scope**: `target` and `additionalInfo` are still not rendered, so the output
  doesn't say *which* resource hit the quota. That's a pre-existing gap in
  `getErrorsFromMap` affecting the deploy path equally; I left it alone to keep this
  change focused.
- I also tried making code-only nodes render their bare code, but reverted it: real ARM
  errors nest JSON inside `message`, so wrapper nodes (`Conflict`, `BadRequest`)
  intentionally render nothing, and emitting their codes turned the
  `arm_sample_error_*` expectations from 5 lines into 14 of noise.

---

## Update — review follow-up (`0caaeeac4`)

A review pass found a latent gap in the renderer this PR now routes preview through.
`AzureDeploymentError.Error()` fell back to the raw payload only when the JSON failed to
**parse**. When it parsed into a tree where nothing was renderable, the whole error
collapsed to a bare heading:

```
Preview Error Details:
```

That is reachable when every node is code-only, carries a blanked code (`DeploymentFailed`,
`ResourceDeploymentFailure`) with no details, or the body is `null`. It is pre-existing on
the deploy path — `arm_sample_error_02.json` already contains a `RequestTimeout` subtree
that renders nothing — so routing preview through the same renderer would have inherited it.

`Error()` now also falls back when the parsed tree yields **zero lines**, not only on parse
failure. The fallback is gated on `len(lines) == 0`, so it is unreachable whenever the parser
produces any output. Confirmed by running identical inputs through both versions:

| Input | Before | After |
| --- | --- | --- |
| #9011 nested quota | 3 lines, leaf cause last | **identical** |
| `arm_sample_error_02` (deploy path) | `ResourceNameInvalid: …` | **identical** |
| Unparseable body | raw text | **identical** |
| Code-only / blanked code / `null` | *(empty)* | raw payload |

All four `arm_sample_error_*` expectations are unchanged.

To be clear about scope: no recorded real-world ARM payload hits the changed cases, since
ARM errors carry a `message`. This is defensive hardening against a blank error, not a fix
for something users are hitting today.

### Tests added / tightened

- `Test_Parsed_But_Unrenderable_Error_Falls_Back_To_Json` — code-only, blanked code with no
  details, `additionalInfo`-only, and `null` body.
- `TestPipeline_PreviewErrorResponse_NestedQuota` now asserts the error codes **in order**
  rather than four independent `Contains` checks, which would still pass if the walker
  stopped descending.

### Considered and skipped

- **Changing `NewAzureDeploymentErrorFromResponse` to return `*AzureDeploymentError`** — it is
  used directly as an `error` at the call site, so returning a concrete pointer type risks the
  typed-nil-in-interface footgun. A `nil` guard is also no longer needed: `json.Marshal(nil)`
  yields `"null"`, which the new fallback surfaces.
- **Rendering bare codes for code-only nodes** — same reasoning as the note above; it adds
  noise to the `arm_sample_error_*` expectations. The fallback only fires when the *entire*
  tree is empty, so it does not reintroduce that.

Updated totals: 5 files, +148/−30.
