### PR TITLE
fix(update): pin stable updates to the resolved version

### DIFF
--- a/cli/azd/cmd/update.go
+++ b/cli/azd/cmd/update.go
@@ -264,13 +264,17 @@ func (a *updateAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 		}
 	}
 
-	// Perform the update
-	a.console.MessageUxItem(ctx, &ux.MessageTitle{
-		Title: fmt.Sprintf("Updating azd to %s (%s)", versionInfo.Version, cfg.Channel),
-	})
+	// Perform the update.
+	// Package manager installs can't be pinned to a version, so don't promise one.
+	updateTitle := fmt.Sprintf("Updating azd to %s (%s)", versionInfo.Version, cfg.Channel)
+	if installedBy == installer.InstallTypeBrew || update.IsPackageManagerInstall() {
+		updateTitle = fmt.Sprintf("Updating azd via %s (%s)", installedBy, cfg.Channel)
+	}
+
+	a.console.MessageUxItem(ctx, &ux.MessageTitle{Title: updateTitle})
 
 	stdout := a.console.Handles().Stdout
-	if err := mgr.Update(ctx, cfg, stdout); err != nil {
+	if err := mgr.Update(ctx, versionInfo, stdout); err != nil {
 		// UpdateError already has the right code, just track it
 		if updateErr, ok := errors.AsType[*update.UpdateError](err); ok {
 			tracing.SetUsageAttributes(fields.UpdateResult.String(updateErr.Code))
@@ -300,12 +304,16 @@ func (a *updateAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	// Clean up any staged binary now that a manual update succeeded
 	update.CleanStagedUpdate()
 
+	// Report the resolved version only when the install method can be pinned to it.
+	// Package managers decide which version they make available, so don't claim one.
+	header := fmt.Sprintf("Updated azd to version %s! Changes take effect on next invocation.", versionInfo.Version)
+	if installedBy == installer.InstallTypeBrew || update.IsPackageManagerInstall() {
+		header = "Updated azd! Changes take effect on next invocation."
+	}
+
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: fmt.Sprintf(
-				"Updated azd to version %s! Changes take effect on next invocation.",
-				versionInfo.Version,
-			),
+			Header:   header,
 			FollowUp: "Run `azd version` to confirm.",
 		},
 	}, nil

--- a/cli/azd/cmd/update.go
+++ b/cli/azd/cmd/update.go
@@ -308,21 +308,25 @@ func (a *updateAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 
 // updateTitle returns the progress title shown before an update runs.
 //
-// A version is named only when azd controls which version gets installed. Package manager
-// installs resolve the version themselves, so naming one would promise a version azd cannot
-// guarantee — the mismatch this fix exists to remove (Azure/azure-dev#9145).
+// A version is named only when azd controls exactly which build gets installed. Package
+// managers resolve the version themselves, and daily installs come from a rolling folder
+// that can advance between the check and the download, so neither can be promised a
+// specific version — that mismatch is what this fix removes (Azure/azure-dev#9145).
 func updateTitle(installedBy installer.InstallType, target *update.VersionInfo) string {
-	if !update.CanPinVersion(installedBy) {
+	switch {
+	case update.CanPinVersion(installedBy, target.Channel):
+		return fmt.Sprintf("Updating azd to %s (%s)", target.Version, target.Channel)
+	case update.UsesPackageManager(installedBy):
 		return fmt.Sprintf("Updating azd via %s (%s)", installedBy, target.Channel)
+	default:
+		return fmt.Sprintf("Updating azd (%s)", target.Channel)
 	}
-
-	return fmt.Sprintf("Updating azd to %s (%s)", target.Version, target.Channel)
 }
 
 // updatedHeader returns the success message shown after an update completes.
 // It reports the resolved version only when the install was pinned to it; see [updateTitle].
 func updatedHeader(installedBy installer.InstallType, target *update.VersionInfo) string {
-	if !update.CanPinVersion(installedBy) {
+	if !update.CanPinVersion(installedBy, target.Channel) {
 		return "Updated azd! Changes take effect on next invocation."
 	}
 

--- a/cli/azd/cmd/update.go
+++ b/cli/azd/cmd/update.go
@@ -265,13 +265,7 @@ func (a *updateAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	}
 
 	// Perform the update.
-	// Package manager installs can't be pinned to a version, so don't promise one.
-	updateTitle := fmt.Sprintf("Updating azd to %s (%s)", versionInfo.Version, cfg.Channel)
-	if installedBy == installer.InstallTypeBrew || update.IsPackageManagerInstall() {
-		updateTitle = fmt.Sprintf("Updating azd via %s (%s)", installedBy, cfg.Channel)
-	}
-
-	a.console.MessageUxItem(ctx, &ux.MessageTitle{Title: updateTitle})
+	a.console.MessageUxItem(ctx, &ux.MessageTitle{Title: updateTitle(installedBy, versionInfo)})
 
 	stdout := a.console.Handles().Stdout
 	if err := mgr.Update(ctx, versionInfo, stdout); err != nil {
@@ -304,19 +298,35 @@ func (a *updateAction) Run(ctx context.Context) (*actions.ActionResult, error) {
 	// Clean up any staged binary now that a manual update succeeded
 	update.CleanStagedUpdate()
 
-	// Report the resolved version only when the install method can be pinned to it.
-	// Package managers decide which version they make available, so don't claim one.
-	header := fmt.Sprintf("Updated azd to version %s! Changes take effect on next invocation.", versionInfo.Version)
-	if installedBy == installer.InstallTypeBrew || update.IsPackageManagerInstall() {
-		header = "Updated azd! Changes take effect on next invocation."
-	}
-
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header:   header,
+			Header:   updatedHeader(installedBy, versionInfo),
 			FollowUp: "Run `azd version` to confirm.",
 		},
 	}, nil
+}
+
+// updateTitle returns the progress title shown before an update runs.
+//
+// A version is named only when azd controls which version gets installed. Package manager
+// installs resolve the version themselves, so naming one would promise a version azd cannot
+// guarantee — the mismatch this fix exists to remove (Azure/azure-dev#9145).
+func updateTitle(installedBy installer.InstallType, target *update.VersionInfo) string {
+	if !update.CanPinVersion(installedBy) {
+		return fmt.Sprintf("Updating azd via %s (%s)", installedBy, target.Channel)
+	}
+
+	return fmt.Sprintf("Updating azd to %s (%s)", target.Version, target.Channel)
+}
+
+// updatedHeader returns the success message shown after an update completes.
+// It reports the resolved version only when the install was pinned to it; see [updateTitle].
+func updatedHeader(installedBy installer.InstallType, target *update.VersionInfo) string {
+	if !update.CanPinVersion(installedBy) {
+		return "Updated azd! Changes take effect on next invocation."
+	}
+
+	return fmt.Sprintf("Updated azd to version %s! Changes take effect on next invocation.", target.Version)
 }
 
 // persistNonChannelFlags saves check-interval flags to config.

--- a/cli/azd/cmd/update_test.go
+++ b/cli/azd/cmd/update_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/pkg/installer"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/pkg/update"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
@@ -294,6 +295,93 @@ func Test_UpdateAction_Run_NoChannelNoConfigFlags(t *testing.T) {
 	_, err := action.Run(t.Context())
 	// Will fail at CI check or CheckForUpdate since noopCommandRunner returns error
 	require.Error(t, err)
+}
+
+// A misleading version promise for brew, winget, or choco users is exactly the mismatch
+// this messaging exists to avoid, so both branches are asserted.
+// See https://github.com/Azure/azure-dev/issues/9145.
+func Test_UpdateMessages_NameVersionOnlyWhenPinnable(t *testing.T) {
+	t.Parallel()
+
+	target := &update.VersionInfo{Channel: update.ChannelStable, Version: "1.28.1"}
+
+	tests := []struct {
+		name         string
+		installedBy  installer.InstallType
+		wantTitle    string
+		wantHeader   string
+		wantNoDigits bool
+	}{
+		{
+			name:        "install script pins the resolved version",
+			installedBy: installer.InstallTypeSh,
+			wantTitle:   "Updating azd to 1.28.1 (stable)",
+			wantHeader:  "Updated azd to version 1.28.1! Changes take effect on next invocation.",
+		},
+		{
+			name:        "ps1 install pins the resolved version",
+			installedBy: installer.InstallTypePs,
+			wantTitle:   "Updating azd to 1.28.1 (stable)",
+			wantHeader:  "Updated azd to version 1.28.1! Changes take effect on next invocation.",
+		},
+		{
+			name:        "deb install pins the resolved version",
+			installedBy: installer.InstallTypeDeb,
+			wantTitle:   "Updating azd to 1.28.1 (stable)",
+			wantHeader:  "Updated azd to version 1.28.1! Changes take effect on next invocation.",
+		},
+		{
+			name:         "brew names no version",
+			installedBy:  installer.InstallTypeBrew,
+			wantTitle:    "Updating azd via brew (stable)",
+			wantHeader:   "Updated azd! Changes take effect on next invocation.",
+			wantNoDigits: true,
+		},
+		{
+			name:         "winget names no version",
+			installedBy:  installer.InstallTypeWinget,
+			wantTitle:    "Updating azd via winget (stable)",
+			wantHeader:   "Updated azd! Changes take effect on next invocation.",
+			wantNoDigits: true,
+		},
+		{
+			name:         "choco names no version",
+			installedBy:  installer.InstallTypeChoco,
+			wantTitle:    "Updating azd via choco (stable)",
+			wantHeader:   "Updated azd! Changes take effect on next invocation.",
+			wantNoDigits: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			title := updateTitle(tt.installedBy, target)
+			header := updatedHeader(tt.installedBy, target)
+
+			require.Equal(t, tt.wantTitle, title)
+			require.Equal(t, tt.wantHeader, header)
+
+			if tt.wantNoDigits {
+				require.NotContains(t, title, target.Version)
+				require.NotContains(t, header, target.Version)
+			}
+		})
+	}
+}
+
+func Test_UpdateMessages_Daily(t *testing.T) {
+	t.Parallel()
+
+	target := &update.VersionInfo{Channel: update.ChannelDaily, Version: "1.29.0-beta.1-daily.6614998"}
+
+	require.Equal(t,
+		"Updating azd to 1.29.0-beta.1-daily.6614998 (daily)",
+		updateTitle(installer.InstallTypeSh, target))
+	require.Equal(t,
+		"Updating azd via brew (daily)",
+		updateTitle(installer.InstallTypeBrew, target))
 }
 
 func Test_UpdateAction_OnlyConfigFlagsSet(t *testing.T) {

--- a/cli/azd/cmd/update_test.go
+++ b/cli/azd/cmd/update_test.go
@@ -297,59 +297,85 @@ func Test_UpdateAction_Run_NoChannelNoConfigFlags(t *testing.T) {
 	require.Error(t, err)
 }
 
-// A misleading version promise for brew, winget, or choco users is exactly the mismatch
-// this messaging exists to avoid, so both branches are asserted.
+// A version is named only when azd controls exactly which build lands. Promising one for a
+// package manager, or for daily's rolling folder, is the mismatch this fix removes.
 // See https://github.com/Azure/azure-dev/issues/9145.
 func Test_UpdateMessages_NameVersionOnlyWhenPinnable(t *testing.T) {
 	t.Parallel()
 
-	target := &update.VersionInfo{Channel: update.ChannelStable, Version: "1.28.1"}
+	const stableVersion = "1.28.1"
+	const dailyVersion = "1.29.0-beta.1-daily.6614998"
+
+	stable := &update.VersionInfo{Channel: update.ChannelStable, Version: stableVersion}
+	daily := &update.VersionInfo{Channel: update.ChannelDaily, Version: dailyVersion}
+
+	pinnedHeader := "Updated azd to version " + stableVersion + "! Changes take effect on next invocation."
+	unpinnedHeader := "Updated azd! Changes take effect on next invocation."
 
 	tests := []struct {
-		name         string
-		installedBy  installer.InstallType
-		wantTitle    string
-		wantHeader   string
-		wantNoDigits bool
+		name        string
+		installedBy installer.InstallType
+		target      *update.VersionInfo
+		wantTitle   string
+		wantHeader  string
 	}{
 		{
-			name:        "install script pins the resolved version",
+			name:        "stable install script pins the resolved version",
 			installedBy: installer.InstallTypeSh,
+			target:      stable,
 			wantTitle:   "Updating azd to 1.28.1 (stable)",
-			wantHeader:  "Updated azd to version 1.28.1! Changes take effect on next invocation.",
+			wantHeader:  pinnedHeader,
 		},
 		{
-			name:        "ps1 install pins the resolved version",
+			name:        "stable ps1 install pins the resolved version",
 			installedBy: installer.InstallTypePs,
+			target:      stable,
 			wantTitle:   "Updating azd to 1.28.1 (stable)",
-			wantHeader:  "Updated azd to version 1.28.1! Changes take effect on next invocation.",
+			wantHeader:  pinnedHeader,
 		},
 		{
-			name:        "deb install pins the resolved version",
+			name:        "stable deb install pins the resolved version",
 			installedBy: installer.InstallTypeDeb,
+			target:      stable,
 			wantTitle:   "Updating azd to 1.28.1 (stable)",
-			wantHeader:  "Updated azd to version 1.28.1! Changes take effect on next invocation.",
+			wantHeader:  pinnedHeader,
 		},
 		{
-			name:         "brew names no version",
-			installedBy:  installer.InstallTypeBrew,
-			wantTitle:    "Updating azd via brew (stable)",
-			wantHeader:   "Updated azd! Changes take effect on next invocation.",
-			wantNoDigits: true,
+			name:        "brew names no version",
+			installedBy: installer.InstallTypeBrew,
+			target:      stable,
+			wantTitle:   "Updating azd via brew (stable)",
+			wantHeader:  unpinnedHeader,
 		},
 		{
-			name:         "winget names no version",
-			installedBy:  installer.InstallTypeWinget,
-			wantTitle:    "Updating azd via winget (stable)",
-			wantHeader:   "Updated azd! Changes take effect on next invocation.",
-			wantNoDigits: true,
+			name:        "winget names no version",
+			installedBy: installer.InstallTypeWinget,
+			target:      stable,
+			wantTitle:   "Updating azd via winget (stable)",
+			wantHeader:  unpinnedHeader,
 		},
 		{
-			name:         "choco names no version",
-			installedBy:  installer.InstallTypeChoco,
-			wantTitle:    "Updating azd via choco (stable)",
-			wantHeader:   "Updated azd! Changes take effect on next invocation.",
-			wantNoDigits: true,
+			name:        "choco names no version",
+			installedBy: installer.InstallTypeChoco,
+			target:      stable,
+			wantTitle:   "Updating azd via choco (stable)",
+			wantHeader:  unpinnedHeader,
+		},
+		{
+			// Daily installs from the rolling release/daily/ folder, which another daily
+			// publish can advance between the check and the download.
+			name:        "daily install script names no version",
+			installedBy: installer.InstallTypeSh,
+			target:      daily,
+			wantTitle:   "Updating azd (daily)",
+			wantHeader:  unpinnedHeader,
+		},
+		{
+			name:        "daily brew names no version",
+			installedBy: installer.InstallTypeBrew,
+			target:      daily,
+			wantTitle:   "Updating azd via brew (daily)",
+			wantHeader:  unpinnedHeader,
 		},
 	}
 
@@ -357,31 +383,18 @@ func Test_UpdateMessages_NameVersionOnlyWhenPinnable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			title := updateTitle(tt.installedBy, target)
-			header := updatedHeader(tt.installedBy, target)
+			title := updateTitle(tt.installedBy, tt.target)
+			header := updatedHeader(tt.installedBy, tt.target)
 
 			require.Equal(t, tt.wantTitle, title)
 			require.Equal(t, tt.wantHeader, header)
 
-			if tt.wantNoDigits {
-				require.NotContains(t, title, target.Version)
-				require.NotContains(t, header, target.Version)
+			if tt.wantHeader == unpinnedHeader {
+				require.NotContains(t, title, tt.target.Version)
+				require.NotContains(t, header, tt.target.Version)
 			}
 		})
 	}
-}
-
-func Test_UpdateMessages_Daily(t *testing.T) {
-	t.Parallel()
-
-	target := &update.VersionInfo{Channel: update.ChannelDaily, Version: "1.29.0-beta.1-daily.6614998"}
-
-	require.Equal(t,
-		"Updating azd to 1.29.0-beta.1-daily.6614998 (daily)",
-		updateTitle(installer.InstallTypeSh, target))
-	require.Equal(t,
-		"Updating azd via brew (daily)",
-		updateTitle(installer.InstallTypeBrew, target))
 }
 
 func Test_UpdateAction_OnlyConfigFlagsSet(t *testing.T) {

--- a/cli/azd/docs/design/azd-update.md
+++ b/cli/azd/docs/design/azd-update.md
@@ -223,11 +223,15 @@ Exceptions:
   in its progress or success messages ("Updating azd via winget (stable)", "Updated azd!"),
   and directs the user to `azd version` to confirm.
 
-**Code**: `pkg/update/manager.go` → `VersionInfo.installVersion()`, `buildDownloadURL()`
+**Code**: `pkg/update/manager.go` → `VersionInfo.installVersion()`, `VersionInfo.validate()`,
+`buildDownloadURL()`
 
 `Manager.Update` takes the `*VersionInfo` returned by `CheckForUpdate` rather than a
 channel, so an install can only ever target the version that was actually resolved and
-reported.
+reported. `Manager.Update` and `Manager.StageUpdate` reject a stable target that carries no
+version: falling back to the rolling `release/stable/` folder would silently reintroduce the
+drift pinning exists to prevent, so the update fails instead of installing a version other
+than the one reported.
 
 #### Windows Update Flow (MSI via `install-azd.ps1`)
 

--- a/cli/azd/docs/design/azd-update.md
+++ b/cli/azd/docs/design/azd-update.md
@@ -229,9 +229,9 @@ Exceptions:
 `Manager.Update` takes the `*VersionInfo` returned by `CheckForUpdate` rather than a
 channel, so an install can only ever target the version that was actually resolved and
 reported. `Manager.Update` and `Manager.StageUpdate` reject a stable target that carries no
-version: falling back to the rolling `release/stable/` folder would silently reintroduce the
-drift pinning exists to prevent, so the update fails instead of installing a version other
-than the one reported.
+version, and any target whose channel is neither `stable` nor `daily`: falling back to the
+rolling `release/stable/` folder would silently reintroduce the drift pinning exists to
+prevent, so the update fails instead of installing a version other than the one reported.
 
 #### Windows Update Flow (MSI via `install-azd.ps1`)
 

--- a/cli/azd/docs/design/azd-update.md
+++ b/cli/azd/docs/design/azd-update.md
@@ -178,9 +178,9 @@ All flags persist their values to config, which can also be set directly via `az
 | `brew` | Homebrew cask: trust azd's source (`brew trust azure/azd`), then `brew install/upgrade --cask azure/azd/azd` (stable) or `azure/azd/azd@daily` (daily). Handles channel switching by uninstalling the current formula or cask and installing the target. |
 | `winget` | Shell out: `winget upgrade Microsoft.Azd` |
 | `choco` | Shell out: `choco upgrade azd` |
-| `install-azd.ps1`, `msi` (Windows) | Shell out: `install-azd.ps1` with backup/restore of running executable |
-| `install-azd.sh` (Linux/macOS) | Shell out: `install-azd.sh` with channel and install folder arguments |
-| `deb`, `rpm` | Direct binary download + replace |
+| `install-azd.ps1`, `msi` (Windows) | Shell out: `install-azd.ps1` with backup/restore of running executable, pinned to the resolved version on stable |
+| `install-azd.sh` (Linux/macOS) | Shell out: `install-azd.sh` with version (pinned on stable) and install folder arguments |
+| `deb`, `rpm` | Direct binary download + replace, pinned to the resolved version on stable |
 
 > **Note**: Linux `deb`/`rpm` packages are standalone files from GitHub Releases — there is no managed apt/dnf repository. These users are treated the same as script-installed users for update purposes.
 
@@ -195,8 +195,39 @@ All flags persist their values to config, which can also be set directly via `az
    - Stable: semver comparison (blang/semver)
    - Daily: build number comparison (extracted from the daily.N suffix)
 4. If no update available → "You're up to date"
-5. Dispatch to the appropriate update method based on install type (see below)
+5. Dispatch to the appropriate update method based on install type (see below),
+   passing the resolved version so the install is pinned to it (see Version pinning)
 ```
+
+#### Version Pinning
+
+Stable installs that azd performs itself download the **exact version resolved in step 2**
+(`release/{VERSION}/`) instead of the rolling `release/stable/` folder.
+
+The rolling folder and the version marker azd reads are published by separate steps of the
+release pipeline, so `release/stable/` can hold a newer build than
+`https://aka.ms/azure-dev/versions/cli/latest` advertises. Installing "whatever is in the
+channel folder" then delivers a different version than the one reported to the user —
+see [#9145](https://github.com/Azure/azure-dev/issues/9145). Per-version folders are
+immutable, so pinning makes the advertised version and the installed version identical by
+construction.
+
+Exceptions:
+
+- **Daily** keeps using the rolling `release/daily/` folder. Daily builds publish their
+  version marker and archives in a single operation, so the folder never advertises a
+  version it cannot serve, and per-version daily archives live outside the release folder
+  the install scripts download from.
+- **Package managers** (`brew`, `winget`, `choco`) cannot be pinned — the package manager
+  decides which version it makes available. For these installs azd does not name a version
+  in its progress or success messages ("Updating azd via winget (stable)", "Updated azd!"),
+  and directs the user to `azd version` to confirm.
+
+**Code**: `pkg/update/manager.go` → `VersionInfo.installVersion()`, `buildDownloadURL()`
+
+`Manager.Update` takes the `*VersionInfo` returned by `CheckForUpdate` rather than a
+channel, so an install can only ever target the version that was actually resolved and
+reported.
 
 #### Windows Update Flow (MSI via `install-azd.ps1`)
 
@@ -211,6 +242,7 @@ Windows updates (for `install-azd.ps1`, `msi`, and other Windows install types) 
    - Copy the backup back as an unlocked safety net at the original path
    - If update fails at any point → restore original from backup automatically
 3. Run install-azd.ps1 with channel-specific arguments
+   - Stable: `-Version '<resolved-version>'` (pinned, see Version Pinning); daily: `-Version 'daily'`
    - Script handles MSI download, verification, and installation
 4. Verify the binary was actually replaced (SHA-256 hash comparison pre vs post)
    - If hashes match → MSI failed silently → abort and restore backup
@@ -224,7 +256,8 @@ For script-based installs (`install-azd.sh`) on Linux/macOS:
 ```
 1. Download install-azd.sh to a temp directory with restrictive permissions (0700)
 2. Make the script executable (0500)
-3. Run: bash install-azd.sh --version <channel> --install-folder <current-install-dir> --symlink-folder ""
+3. Run: bash install-azd.sh --version <resolved-version|daily> --install-folder <current-install-dir> --symlink-folder ""
+   - Stable passes the exact version resolved by the check (see Version Pinning); daily passes "daily"
    - The script handles download, checksum verification, and binary placement
    - Passes through stdin/stdout for sudo prompts if elevation is needed
 4. Done — new version takes effect on next invocation

--- a/cli/azd/docs/design/azd-update.md
+++ b/cli/azd/docs/design/azd-update.md
@@ -214,14 +214,18 @@ construction.
 
 Exceptions:
 
-- **Daily** keeps using the rolling `release/daily/` folder. Daily builds publish their
-  version marker and archives in a single operation, so the folder never advertises a
-  version it cannot serve, and per-version daily archives live outside the release folder
-  the install scripts download from.
+- **Daily** keeps using the rolling `release/daily/` folder — per-version daily archives live
+  outside the release folder the install scripts download from, so there is nothing to pin
+  to. Because another daily publish can advance that folder between the check and the
+  download, azd does not name a version for daily either ("Updating azd (daily)").
 - **Package managers** (`brew`, `winget`, `choco`) cannot be pinned — the package manager
   decides which version it makes available. For these installs azd does not name a version
   in its progress or success messages ("Updating azd via winget (stable)", "Updated azd!"),
   and directs the user to `azd version` to confirm.
+
+A version is reported only when the install is pinned to it — see
+`update.CanPinVersion(installedBy, channel)`, which requires both a self-managed install and
+the stable channel.
 
 **Code**: `pkg/update/manager.go` → `VersionInfo.installVersion()`, `VersionInfo.validate()`,
 `buildDownloadURL()`

--- a/cli/azd/pkg/update/manager.go
+++ b/cli/azd/pkg/update/manager.go
@@ -316,14 +316,23 @@ func (m *Manager) Update(ctx context.Context, target *VersionInfo, writer io.Wri
 // folder instead would silently reintroduce the drift that pinning exists to prevent
 // (Azure/azure-dev#9145). Failing the update is better than installing a version other than
 // the one reported to the user, so an unresolved target is rejected rather than downgraded
-// to an unpinned install.
+// to an unpinned install. An unsupported channel is rejected for the same reason: it has no
+// release folder of its own, so every install method would have to fall back to some other
+// channel's folder to serve it.
 func (v *VersionInfo) validate() error {
 	if v == nil {
 		return fmt.Errorf("no resolved version")
 	}
 
-	if v.Channel == ChannelStable && v.Version == "" {
-		return fmt.Errorf("no resolved version for the %s channel", ChannelStable)
+	switch v.Channel {
+	case ChannelStable:
+		if v.Version == "" {
+			return fmt.Errorf("no resolved version for the %s channel", ChannelStable)
+		}
+	case ChannelDaily:
+		// Daily installs from the rolling folder, so it needs no resolved version.
+	default:
+		return fmt.Errorf("unsupported channel: %s", v.Channel)
 	}
 
 	return nil
@@ -565,7 +574,10 @@ func (m *Manager) updateViaMSI(ctx context.Context, target *VersionInfo, writer 
 
 	// Run the install script synchronously. The MSI overwrites the unlocked
 	// safety copy at the original path with the new version.
-	psArgs := buildInstallScriptArgs(target)
+	psArgs, err := buildInstallScriptArgs(target)
+	if err != nil {
+		return newUpdateError(CodeReplaceFailed, err)
+	}
 
 	// Hash the safety copy before install so we can detect whether the MSI
 	// actually replaced the file.
@@ -1010,6 +1022,23 @@ func IsPackageManagerInstall() bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// CanPinVersion reports whether azd can install an exact version using installedBy.
+//
+// Package managers resolve the version themselves, so azd cannot pin one and must not name
+// a version in its progress or success messages for those installs — it would be promising
+// a version it does not control (Azure/azure-dev#9145).
+//
+// This is broader than [IsPackageManagerInstall], which is about channel support and so
+// excludes brew: brew publishes an azd@daily cask, but it still picks the version.
+func CanPinVersion(installedBy installer.InstallType) bool {
+	switch installedBy {
+	case installer.InstallTypeBrew, installer.InstallTypeWinget, installer.InstallTypeChoco:
+		return false
+	default:
+		return true
 	}
 }
 

--- a/cli/azd/pkg/update/manager.go
+++ b/cli/azd/pkg/update/manager.go
@@ -268,37 +268,70 @@ func parseDailyBuildNumber(version string) (int, error) {
 	return buildNumber, nil
 }
 
-// Update performs the update based on the install method.
-func (m *Manager) Update(ctx context.Context, cfg *UpdateConfig, writer io.Writer) error {
+// Update installs target, which must be the result of [Manager.CheckForUpdate], using the
+// method azd was installed with.
+//
+// Taking the resolved [VersionInfo] rather than a channel keeps the version azd reports and
+// the version azd installs from drifting apart: see [VersionInfo.installVersion].
+//
+// Package manager installs (brew, winget, choco) cannot be pinned — the package manager
+// decides which version it makes available.
+func (m *Manager) Update(ctx context.Context, target *VersionInfo, writer io.Writer) error {
+	if target == nil {
+		return fmt.Errorf("no resolved version to install")
+	}
+
 	installedBy := installer.InstalledBy()
 
 	switch installedBy {
 	case installer.InstallTypeBrew:
-		return m.updateViaBrew(ctx, cfg, writer)
+		return m.updateViaBrew(ctx, target, writer)
 	case installer.InstallTypeWinget:
 		return m.updateViaPackageManager(ctx, "winget", []string{"upgrade", "Microsoft.Azd"}, writer)
 	case installer.InstallTypeChoco:
 		return m.updateViaPackageManager(ctx, "choco", []string{"upgrade", "azd"}, writer)
 	case installer.InstallTypeSh:
 		if runtime.GOOS == "windows" {
-			return m.updateViaMSI(ctx, cfg, writer)
+			return m.updateViaMSI(ctx, target, writer)
 		}
-		return m.updateViaInstallScript(ctx, cfg, writer)
+		return m.updateViaInstallScript(ctx, target, writer)
 	case installer.InstallTypePs, installer.InstallTypeDeb,
 		installer.InstallTypeRpm, installer.InstallTypeUnknown:
 		if runtime.GOOS == "windows" {
-			return m.updateViaMSI(ctx, cfg, writer)
+			return m.updateViaMSI(ctx, target, writer)
 		}
-		return m.updateViaBinaryDownload(ctx, cfg, writer)
+		return m.updateViaBinaryDownload(ctx, target, writer)
 	default:
 		if runtime.GOOS == "windows" {
-			return m.updateViaMSI(ctx, cfg, writer)
+			return m.updateViaMSI(ctx, target, writer)
 		}
-		return m.updateViaBinaryDownload(ctx, cfg, writer)
+		return m.updateViaBinaryDownload(ctx, target, writer)
 	}
 }
 
-func (m *Manager) updateViaBrew(ctx context.Context, cfg *UpdateConfig, writer io.Writer) error {
+// installVersion returns the release folder to install from: either an exact version or the
+// channel's rolling folder. Channels are validated by [ParseChannel] and [CheckForUpdate],
+// so the channel is always `stable` or `daily` here.
+//
+// Stable installs are pinned to the exact version the check resolved. The rolling `stable`
+// folder is updated when a release publishes, while the version marker azd reads is
+// published separately, so installing "whatever is in the stable folder" can silently
+// deliver a version other than the one reported to the user (Azure/azure-dev#9145).
+// Per-version release folders are immutable, so pinning cannot drift.
+//
+// Daily installs keep using the rolling `daily` folder: daily builds publish their version
+// marker and their archives in a single operation, so the folder never advertises a version
+// it cannot serve, and per-version daily archives live outside the release folder the
+// install scripts download from.
+func (v *VersionInfo) installVersion() string {
+	if v.Channel == ChannelStable && v.Version != "" {
+		return v.Version
+	}
+
+	return string(v.Channel)
+}
+
+func (m *Manager) updateViaBrew(ctx context.Context, target *VersionInfo, writer io.Writer) error {
 	fmt.Fprintf(writer, "Checking Homebrew cask installation...\n")
 
 	// Determine which cask is currently installed by checking `brew list --cask`.
@@ -324,7 +357,7 @@ func (m *Manager) updateViaBrew(ctx context.Context, cfg *UpdateConfig, writer i
 		}
 	}
 
-	targetChannel := cfg.Channel
+	targetChannel := target.Channel
 
 	// `azure/azd` is azd's own Homebrew source (the `azure/azd` tap for
 	// github.com/Azure/homebrew-azd, which publishes the `azd` and `azd@daily`
@@ -390,7 +423,7 @@ func (m *Manager) updateViaBrew(ctx context.Context, cfg *UpdateConfig, writer i
 	}
 }
 
-func (m *Manager) updateViaInstallScript(ctx context.Context, cfg *UpdateConfig, writer io.Writer) error {
+func (m *Manager) updateViaInstallScript(ctx context.Context, target *VersionInfo, writer io.Writer) error {
 	fmt.Fprintf(writer, "Updating azd via install script...\n")
 
 	currentPath, err := currentExePath()
@@ -422,7 +455,7 @@ func (m *Manager) updateViaInstallScript(ctx context.Context, cfg *UpdateConfig,
 		return newUpdateError(CodeReplaceFailed, fmt.Errorf("failed to set script permissions: %w", err))
 	}
 
-	versionArg := string(cfg.Channel)
+	versionArg := target.installVersion()
 	runArgs := exec.NewRunArgs("bash", scriptPath,
 		"--version", versionArg,
 		"--install-folder", installFolder,
@@ -432,7 +465,7 @@ func (m *Manager) updateViaInstallScript(ctx context.Context, cfg *UpdateConfig,
 
 	log.Printf("Running install script: bash %s --version %s --install-folder %s --symlink-folder \"\"",
 		scriptPath, versionArg, installFolder)
-	fmt.Fprintf(writer, "Installing azd %s channel to %s...\n", cfg.Channel, installFolder)
+	fmt.Fprintf(writer, "Installing azd %s channel to %s...\n", target.Channel, installFolder)
 
 	result, err := m.commandRunner.Run(ctx, runArgs)
 	if err != nil {
@@ -472,7 +505,7 @@ func (m *Manager) updateViaPackageManager(
 	return nil
 }
 
-func (m *Manager) updateViaMSI(ctx context.Context, cfg *UpdateConfig, writer io.Writer) error {
+func (m *Manager) updateViaMSI(ctx context.Context, target *VersionInfo, writer io.Writer) error {
 	// Verify the install is the standard per-user MSI configuration.
 	// install-azd.ps1 installs with ALLUSERS=2 to %LOCALAPPDATA%\Programs\Azure Dev CLI.
 	// If the current install is non-standard, abort and advise the user.
@@ -509,7 +542,7 @@ func (m *Manager) updateViaMSI(ctx context.Context, cfg *UpdateConfig, writer io
 
 	// Run the install script synchronously. The MSI overwrites the unlocked
 	// safety copy at the original path with the new version.
-	psArgs := buildInstallScriptArgs(cfg.Channel)
+	psArgs := buildInstallScriptArgs(target)
 
 	// Hash the safety copy before install so we can detect whether the MSI
 	// actually replaced the file.
@@ -520,7 +553,7 @@ func (m *Manager) updateViaMSI(ctx context.Context, cfg *UpdateConfig, writer io
 	}
 
 	log.Printf("Running install script: powershell %s", strings.Join(psArgs, " "))
-	fmt.Fprintf(writer, "Installing azd %s channel...\n", cfg.Channel)
+	fmt.Fprintf(writer, "Installing azd %s channel...\n", target.Channel)
 
 	runArgs := exec.NewRunArgs("powershell", psArgs...).
 		WithStdOut(writer).
@@ -550,8 +583,8 @@ func (m *Manager) updateViaMSI(ctx context.Context, cfg *UpdateConfig, writer io
 	return nil
 }
 
-func (m *Manager) updateViaBinaryDownload(ctx context.Context, cfg *UpdateConfig, writer io.Writer) error {
-	downloadURL, err := m.buildDownloadURL(cfg.Channel)
+func (m *Manager) updateViaBinaryDownload(ctx context.Context, target *VersionInfo, writer io.Writer) error {
+	downloadURL, err := m.buildDownloadURL(target)
 	if err != nil {
 		return err
 	}
@@ -607,22 +640,21 @@ func (m *Manager) updateViaBinaryDownload(ctx context.Context, cfg *UpdateConfig
 	return nil
 }
 
-func (m *Manager) buildDownloadURL(channel Channel) (string, error) {
+// buildDownloadURL returns the archive URL to download target from.
+// See [VersionInfo.installVersion] for how the folder is chosen.
+func (m *Manager) buildDownloadURL(target *VersionInfo) (string, error) {
 	platform := runtime.GOOS
 	arch := runtime.GOARCH
 	ext := archiveExtension()
 
-	var folder string
-	switch channel {
-	case ChannelStable:
-		folder = "stable"
-	case ChannelDaily:
-		folder = "daily"
+	switch target.Channel {
+	case ChannelStable, ChannelDaily:
 	default:
-		return "", fmt.Errorf("unsupported channel: %s", channel)
+		return "", fmt.Errorf("unsupported channel: %s", target.Channel)
 	}
 
-	return fmt.Sprintf("%s/%s/azd-%s-%s%s", blobBaseURL, folder, platform, arch, ext), nil
+	return fmt.Sprintf(
+		"%s/%s/azd-%s-%s%s", blobBaseURL, target.installVersion(), platform, arch, ext), nil
 }
 
 func archiveExtension() string {
@@ -1031,9 +1063,13 @@ func HasStagedUpdate() bool {
 	return err == nil && !info.IsDir() && info.Size() > 0
 }
 
-// StageUpdate downloads the latest binary to ~/.azd/staging/ for later apply.
+// StageUpdate downloads target to ~/.azd/staging/ for later apply.
 // This is intended to run in the background without user interaction.
-func (m *Manager) StageUpdate(ctx context.Context, cfg *UpdateConfig) error {
+func (m *Manager) StageUpdate(ctx context.Context, target *VersionInfo) error {
+	if target == nil {
+		return fmt.Errorf("no resolved version to stage")
+	}
+
 	// Only stage for direct binary installs, not package managers
 	if IsPackageManagerInstall() {
 		log.Printf("auto-update: package manager install, skipping staging")
@@ -1047,7 +1083,7 @@ func (m *Manager) StageUpdate(ctx context.Context, cfg *UpdateConfig) error {
 		return nil
 	}
 
-	downloadURL, err := m.buildDownloadURL(cfg.Channel)
+	downloadURL, err := m.buildDownloadURL(target)
 	if err != nil {
 		return err
 	}

--- a/cli/azd/pkg/update/manager.go
+++ b/cli/azd/pkg/update/manager.go
@@ -277,8 +277,8 @@ func parseDailyBuildNumber(version string) (int, error) {
 // Package manager installs (brew, winget, choco) cannot be pinned — the package manager
 // decides which version it makes available.
 func (m *Manager) Update(ctx context.Context, target *VersionInfo, writer io.Writer) error {
-	if target == nil {
-		return fmt.Errorf("no resolved version to install")
+	if err := target.validate(); err != nil {
+		return fmt.Errorf("cannot install update: %w", err)
 	}
 
 	installedBy := installer.InstalledBy()
@@ -309,6 +309,26 @@ func (m *Manager) Update(ctx context.Context, target *VersionInfo, writer io.Wri
 	}
 }
 
+// validate reports whether v is usable as an install target, i.e. whether it is a version
+// [Manager.CheckForUpdate] actually resolved.
+//
+// A stable target with no version cannot be pinned, and installing from the rolling stable
+// folder instead would silently reintroduce the drift that pinning exists to prevent
+// (Azure/azure-dev#9145). Failing the update is better than installing a version other than
+// the one reported to the user, so an unresolved target is rejected rather than downgraded
+// to an unpinned install.
+func (v *VersionInfo) validate() error {
+	if v == nil {
+		return fmt.Errorf("no resolved version")
+	}
+
+	if v.Channel == ChannelStable && v.Version == "" {
+		return fmt.Errorf("no resolved version for the %s channel", ChannelStable)
+	}
+
+	return nil
+}
+
 // installVersion returns the release folder to install from: either an exact version or the
 // channel's rolling folder. Channels are validated by [ParseChannel] and [CheckForUpdate],
 // so the channel is always `stable` or `daily` here.
@@ -323,8 +343,11 @@ func (m *Manager) Update(ctx context.Context, target *VersionInfo, writer io.Wri
 // marker and their archives in a single operation, so the folder never advertises a version
 // it cannot serve, and per-version daily archives live outside the release folder the
 // install scripts download from.
+//
+// Callers must pass a target accepted by [VersionInfo.validate], which guarantees a stable
+// target carries a version, so this never silently falls back to the rolling stable folder.
 func (v *VersionInfo) installVersion() string {
-	if v.Channel == ChannelStable && v.Version != "" {
+	if v.Channel == ChannelStable {
 		return v.Version
 	}
 
@@ -1066,8 +1089,8 @@ func HasStagedUpdate() bool {
 // StageUpdate downloads target to ~/.azd/staging/ for later apply.
 // This is intended to run in the background without user interaction.
 func (m *Manager) StageUpdate(ctx context.Context, target *VersionInfo) error {
-	if target == nil {
-		return fmt.Errorf("no resolved version to stage")
+	if err := target.validate(); err != nil {
+		return fmt.Errorf("cannot stage update: %w", err)
 	}
 
 	// Only stage for direct binary installs, not package managers

--- a/cli/azd/pkg/update/manager.go
+++ b/cli/azd/pkg/update/manager.go
@@ -1025,21 +1025,33 @@ func IsPackageManagerInstall() bool {
 	}
 }
 
-// CanPinVersion reports whether azd can install an exact version using installedBy.
+// UsesPackageManager reports whether azd delegates the install to a package manager
+// (brew, winget, choco) instead of downloading a release artifact itself. Package managers
+// resolve the version themselves, so azd can neither choose nor promise one.
 //
-// Package managers resolve the version themselves, so azd cannot pin one and must not name
-// a version in its progress or success messages for those installs — it would be promising
-// a version it does not control (Azure/azure-dev#9145).
-//
-// This is broader than [IsPackageManagerInstall], which is about channel support and so
-// excludes brew: brew publishes an azd@daily cask, but it still picks the version.
-func CanPinVersion(installedBy installer.InstallType) bool {
+// This differs from [IsPackageManagerInstall], which answers the narrower question of
+// whether the install method can serve the daily channel, and so excludes brew.
+func UsesPackageManager(installedBy installer.InstallType) bool {
 	switch installedBy {
 	case installer.InstallTypeBrew, installer.InstallTypeWinget, installer.InstallTypeChoco:
-		return false
-	default:
 		return true
+	default:
+		return false
 	}
+}
+
+// CanPinVersion reports whether installing channel with installedBy lands on exactly the
+// version the check resolved.
+//
+// Two conditions must hold. azd must control the download — see [UsesPackageManager] — and
+// the channel must publish immutable per-version folders. Only stable does: daily installs
+// from the rolling `release/daily/` folder, which another daily publish can advance between
+// the check and the download.
+//
+// azd names a version in its progress and success messages only when this returns true, so
+// it never reports a version it cannot guarantee it installed (Azure/azure-dev#9145).
+func CanPinVersion(installedBy installer.InstallType, channel Channel) bool {
+	return !UsesPackageManager(installedBy) && channel == ChannelStable
 }
 
 // PackageManagerUninstallCmd returns the uninstall command for the detected package manager.

--- a/cli/azd/pkg/update/manager_test.go
+++ b/cli/azd/pkg/update/manager_test.go
@@ -63,12 +63,22 @@ func TestBuildDownloadURL(t *testing.T) {
 	tests := []struct {
 		name    string
 		channel Channel
+		version string
 		wantErr bool
 		// We check that the URL contains these substrings
 		contains []string
 	}{
 		{
-			name:    "stable",
+			name:    "stable pinned to resolved version",
+			channel: ChannelStable,
+			version: "1.28.1",
+			contains: []string{
+				blobBaseURL + "/1.28.1/",
+				fmt.Sprintf("azd-%s-%s", runtime.GOOS, runtime.GOARCH),
+			},
+		},
+		{
+			name:    "stable without resolved version",
 			channel: ChannelStable,
 			contains: []string{
 				blobBaseURL + "/stable/",
@@ -78,6 +88,7 @@ func TestBuildDownloadURL(t *testing.T) {
 		{
 			name:    "daily",
 			channel: ChannelDaily,
+			version: "1.29.0-beta.1-daily.6614998",
 			contains: []string{
 				blobBaseURL + "/daily/",
 				fmt.Sprintf("azd-%s-%s", runtime.GOOS, runtime.GOARCH),
@@ -92,7 +103,7 @@ func TestBuildDownloadURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := m.buildDownloadURL(tt.channel)
+			got, err := m.buildDownloadURL(&VersionInfo{Channel: tt.channel, Version: tt.version})
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -101,6 +112,46 @@ func TestBuildDownloadURL(t *testing.T) {
 			for _, s := range tt.contains {
 				require.Contains(t, got, s)
 			}
+		})
+	}
+}
+
+// The stable channel folder can hold a newer build than the version marker azd reads,
+// so a stable update must download the exact version that was reported to the user.
+// See https://github.com/Azure/azure-dev/issues/9145.
+func TestBuildDownloadURL_StableDoesNotUseRollingFolder(t *testing.T) {
+	m := NewManager(nil, nil)
+
+	got, err := m.buildDownloadURL(&VersionInfo{Channel: ChannelStable, Version: "1.27.0"})
+	require.NoError(t, err)
+	require.Contains(t, got, blobBaseURL+"/1.27.0/")
+	require.NotContains(t, got, "/stable/")
+}
+
+func TestUpdate_RequiresResolvedVersion(t *testing.T) {
+	m := NewManager(nil, nil)
+
+	require.Error(t, m.Update(t.Context(), nil, &strings.Builder{}))
+	require.Error(t, m.StageUpdate(t.Context(), nil))
+}
+
+func TestInstallVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		channel Channel
+		version string
+		want    string
+	}{
+		{"stable pins the resolved version", ChannelStable, "1.28.1", "1.28.1"},
+		{"stable falls back to the channel", ChannelStable, "", "stable"},
+		{"daily uses the rolling channel", ChannelDaily, "1.29.0-beta.1-daily.6614998", "daily"},
+		{"daily without version", ChannelDaily, "", "daily"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := &VersionInfo{Channel: tt.channel, Version: tt.version}
+			require.Equal(t, tt.want, target.installVersion())
 		})
 	}
 }
@@ -676,7 +727,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 		m := NewManager(mockRunner, nil)
 		var buf bytes.Buffer
-		err := m.updateViaBrew(t.Context(), &UpdateConfig{Channel: ChannelStable}, &buf)
+		err := m.updateViaBrew(t.Context(), &VersionInfo{Channel: ChannelStable}, &buf)
 		require.NoError(t, err)
 		require.Contains(t, buf.String(), "not installed as a Homebrew cask")
 	})
@@ -696,7 +747,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 		m := NewManager(mockRunner, nil)
 		var buf bytes.Buffer
-		err := m.updateViaBrew(t.Context(), &UpdateConfig{Channel: ChannelDaily}, &buf)
+		err := m.updateViaBrew(t.Context(), &VersionInfo{Channel: ChannelDaily}, &buf)
 		require.NoError(t, err)
 		require.Contains(t, buf.String(), "not installed as a Homebrew cask")
 	})
@@ -713,7 +764,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 		m := NewManager(mockRunner, nil)
 		var buf bytes.Buffer
-		err := m.updateViaBrew(t.Context(), &UpdateConfig{Channel: Channel("nightly")}, &buf)
+		err := m.updateViaBrew(t.Context(), &VersionInfo{Channel: Channel("nightly")}, &buf)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unsupported channel")
 	})
@@ -733,7 +784,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 		m := NewManager(mockRunner, nil)
 		var buf bytes.Buffer
-		err := m.updateViaBrew(t.Context(), &UpdateConfig{Channel: ChannelStable}, &buf)
+		err := m.updateViaBrew(t.Context(), &VersionInfo{Channel: ChannelStable}, &buf)
 		require.NoError(t, err)
 		require.Contains(t, buf.String(), "Switching from daily to stable")
 	})
@@ -753,7 +804,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 		m := NewManager(mockRunner, nil)
 		var buf bytes.Buffer
-		err := m.updateViaBrew(t.Context(), &UpdateConfig{Channel: ChannelDaily}, &buf)
+		err := m.updateViaBrew(t.Context(), &VersionInfo{Channel: ChannelDaily}, &buf)
 		require.NoError(t, err)
 		require.Contains(t, buf.String(), "Switching from stable to daily")
 	})
@@ -770,7 +821,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 		m := NewManager(mockRunner, nil)
 		var buf bytes.Buffer
-		err := m.updateViaBrew(t.Context(), &UpdateConfig{Channel: ChannelStable}, &buf)
+		err := m.updateViaBrew(t.Context(), &VersionInfo{Channel: ChannelStable}, &buf)
 		require.Error(t, err)
 		var updateErr *UpdateError
 		require.ErrorAs(t, err, &updateErr)
@@ -789,7 +840,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 		m := NewManager(mockRunner, nil)
 		var buf bytes.Buffer
-		err := m.updateViaBrew(t.Context(), &UpdateConfig{Channel: ChannelStable}, &buf)
+		err := m.updateViaBrew(t.Context(), &VersionInfo{Channel: ChannelStable}, &buf)
 		require.NoError(t, err)
 		require.Contains(t, buf.String(), "Trusting azd's Homebrew source (azure/azd)")
 		require.Contains(t, buf.String(), "Updating azd (stable channel)")
@@ -811,7 +862,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 		m := NewManager(mockRunner, nil)
 		var buf bytes.Buffer
-		err := m.updateViaBrew(t.Context(), &UpdateConfig{Channel: ChannelStable}, &buf)
+		err := m.updateViaBrew(t.Context(), &VersionInfo{Channel: ChannelStable}, &buf)
 		require.NoError(t, err)
 		require.Contains(t, buf.String(), "Updating azd (stable channel)")
 	})
@@ -828,7 +879,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 		m := NewManager(mockRunner, nil)
 		var buf bytes.Buffer
-		err := m.updateViaBrew(t.Context(), &UpdateConfig{Channel: ChannelDaily}, &buf)
+		err := m.updateViaBrew(t.Context(), &VersionInfo{Channel: ChannelDaily}, &buf)
 		require.NoError(t, err)
 		require.Contains(t, buf.String(), "Updating azd (daily channel)")
 	})
@@ -845,7 +896,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 		m := NewManager(mockRunner, nil)
 		var buf bytes.Buffer
-		err := m.updateViaBrew(t.Context(), &UpdateConfig{Channel: ChannelStable}, &buf)
+		err := m.updateViaBrew(t.Context(), &VersionInfo{Channel: ChannelStable}, &buf)
 		require.Error(t, err)
 		var updateErr *UpdateError
 		require.ErrorAs(t, err, &updateErr)
@@ -861,7 +912,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 		m := NewManager(mockRunner, nil)
 		var buf bytes.Buffer
-		err := m.updateViaBrew(t.Context(), &UpdateConfig{Channel: Channel("nightly")}, &buf)
+		err := m.updateViaBrew(t.Context(), &VersionInfo{Channel: Channel("nightly")}, &buf)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unsupported channel")
 	})
@@ -881,7 +932,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 		m := NewManager(mockRunner, nil)
 		var buf bytes.Buffer
-		err := m.updateViaBrew(t.Context(), &UpdateConfig{Channel: ChannelStable}, &buf)
+		err := m.updateViaBrew(t.Context(), &VersionInfo{Channel: ChannelStable}, &buf)
 		require.NoError(t, err)
 	})
 
@@ -900,7 +951,7 @@ func TestUpdateViaBrew(t *testing.T) {
 
 		m := NewManager(mockRunner, nil)
 		var buf bytes.Buffer
-		err := m.updateViaBrew(t.Context(), &UpdateConfig{Channel: ChannelStable}, &buf)
+		err := m.updateViaBrew(t.Context(), &VersionInfo{Channel: ChannelStable}, &buf)
 		require.NoError(t, err)
 	})
 }
@@ -933,20 +984,53 @@ func TestUpdateViaInstallScript(t *testing.T) {
 
 		m := NewManager(mockRunner, client)
 		var buf bytes.Buffer
-		err := m.updateViaInstallScript(t.Context(), &UpdateConfig{Channel: ChannelStable}, &buf)
+		err := m.updateViaInstallScript(t.Context(), &VersionInfo{Channel: ChannelStable, Version: "1.28.1"}, &buf)
 		require.NoError(t, err)
 		require.Contains(t, buf.String(), "Updating azd via install script")
 		require.Contains(t, buf.String(), "Installing azd stable channel")
 
-		// Verify bash was called with correct arguments
+		// Verify bash was called with correct arguments. Stable installs are pinned to the
+		// resolved version so the install can't drift from the version reported to the user.
 		require.Equal(t, "bash", capturedArgs.Cmd)
 		require.True(t, strings.HasSuffix(capturedArgs.Args[0], "install-azd.sh"))
 		require.Equal(t, "--version", capturedArgs.Args[1])
-		require.Equal(t, "stable", capturedArgs.Args[2])
+		require.Equal(t, "1.28.1", capturedArgs.Args[2])
 		require.Equal(t, "--install-folder", capturedArgs.Args[3])
 		require.NotEmpty(t, capturedArgs.Args[4]) // install folder path
 		require.Equal(t, "--symlink-folder", capturedArgs.Args[5])
 		require.Equal(t, "", capturedArgs.Args[6])
+	})
+
+	t.Run("Success_StableWithoutResolvedVersion", func(t *testing.T) {
+		scriptContent := []byte("#!/bin/bash\necho installing")
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(scriptContent)))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(scriptContent)
+		}))
+		defer server.Close()
+
+		client := &http.Client{
+			Transport: &urlRewriteTransport{
+				base:      http.DefaultTransport,
+				targetURL: server.URL,
+			},
+		}
+
+		var capturedArgs exec.RunArgs
+		mockRunner := mockexec.NewMockCommandRunner()
+		mockRunner.When(func(args exec.RunArgs, command string) bool {
+			return args.Cmd == "bash"
+		}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+			capturedArgs = args
+			return exec.NewRunResult(0, "Installation complete", ""), nil
+		})
+
+		m := NewManager(mockRunner, client)
+		var buf bytes.Buffer
+		err := m.updateViaInstallScript(t.Context(), &VersionInfo{Channel: ChannelStable, Version: ""}, &buf)
+		require.NoError(t, err)
+		require.Equal(t, "stable", capturedArgs.Args[2])
 	})
 
 	t.Run("Success_Daily", func(t *testing.T) {
@@ -976,7 +1060,8 @@ func TestUpdateViaInstallScript(t *testing.T) {
 
 		m := NewManager(mockRunner, client)
 		var buf bytes.Buffer
-		err := m.updateViaInstallScript(t.Context(), &UpdateConfig{Channel: ChannelDaily}, &buf)
+		err := m.updateViaInstallScript(
+			t.Context(), &VersionInfo{Channel: ChannelDaily, Version: "1.29.0-beta.1-daily.6614998"}, &buf)
 		require.NoError(t, err)
 		require.Contains(t, buf.String(), "Installing azd daily channel")
 		require.Equal(t, "daily", capturedArgs.Args[2])
@@ -997,7 +1082,7 @@ func TestUpdateViaInstallScript(t *testing.T) {
 
 		m := NewManager(nil, client)
 		var buf bytes.Buffer
-		err := m.updateViaInstallScript(t.Context(), &UpdateConfig{Channel: ChannelStable}, &buf)
+		err := m.updateViaInstallScript(t.Context(), &VersionInfo{Channel: ChannelStable, Version: "1.28.1"}, &buf)
 		require.Error(t, err)
 		var updateErr *UpdateError
 		require.ErrorAs(t, err, &updateErr)
@@ -1027,7 +1112,7 @@ func TestUpdateViaInstallScript(t *testing.T) {
 
 		m := NewManager(mockRunner, client)
 		var buf bytes.Buffer
-		err := m.updateViaInstallScript(t.Context(), &UpdateConfig{Channel: ChannelStable}, &buf)
+		err := m.updateViaInstallScript(t.Context(), &VersionInfo{Channel: ChannelStable, Version: "1.28.1"}, &buf)
 		require.Error(t, err)
 		var updateErr *UpdateError
 		require.ErrorAs(t, err, &updateErr)
@@ -1057,7 +1142,7 @@ func TestUpdateViaInstallScript(t *testing.T) {
 
 		m := NewManager(mockRunner, client)
 		var buf bytes.Buffer
-		err := m.updateViaInstallScript(t.Context(), &UpdateConfig{Channel: ChannelStable}, &buf)
+		err := m.updateViaInstallScript(t.Context(), &VersionInfo{Channel: ChannelStable, Version: "1.28.1"}, &buf)
 		require.Error(t, err)
 		var updateErr *UpdateError
 		require.ErrorAs(t, err, &updateErr)

--- a/cli/azd/pkg/update/manager_test.go
+++ b/cli/azd/pkg/update/manager_test.go
@@ -136,6 +136,12 @@ func TestUpdate_RequiresResolvedVersion(t *testing.T) {
 
 	// Daily installs from the rolling folder, so they don't require a resolved version.
 	require.NoError(t, (&VersionInfo{Channel: ChannelDaily}).validate())
+
+	// An unsupported channel has no release folder of its own, so serving it would mean
+	// falling back to another channel's folder — the unpinned install this prevents.
+	unsupported := &VersionInfo{Channel: Channel("nightly"), Version: "1.28.1"}
+	require.Error(t, m.Update(t.Context(), unsupported, &strings.Builder{}))
+	require.Error(t, m.StageUpdate(t.Context(), unsupported))
 }
 
 func TestInstallVersion(t *testing.T) {

--- a/cli/azd/pkg/update/manager_test.go
+++ b/cli/azd/pkg/update/manager_test.go
@@ -78,14 +78,6 @@ func TestBuildDownloadURL(t *testing.T) {
 			},
 		},
 		{
-			name:    "stable without resolved version",
-			channel: ChannelStable,
-			contains: []string{
-				blobBaseURL + "/stable/",
-				fmt.Sprintf("azd-%s-%s", runtime.GOOS, runtime.GOARCH),
-			},
-		},
-		{
 			name:    "daily",
 			channel: ChannelDaily,
 			version: "1.29.0-beta.1-daily.6614998",
@@ -133,6 +125,17 @@ func TestUpdate_RequiresResolvedVersion(t *testing.T) {
 
 	require.Error(t, m.Update(t.Context(), nil, &strings.Builder{}))
 	require.Error(t, m.StageUpdate(t.Context(), nil))
+
+	// A stable target must carry the version the check resolved. Falling back to the rolling
+	// stable folder would silently reintroduce the drift pinning exists to prevent, so an
+	// unresolved stable target fails the update instead. See
+	// https://github.com/Azure/azure-dev/issues/9145.
+	unresolved := &VersionInfo{Channel: ChannelStable}
+	require.Error(t, m.Update(t.Context(), unresolved, &strings.Builder{}))
+	require.Error(t, m.StageUpdate(t.Context(), unresolved))
+
+	// Daily installs from the rolling folder, so they don't require a resolved version.
+	require.NoError(t, (&VersionInfo{Channel: ChannelDaily}).validate())
 }
 
 func TestInstallVersion(t *testing.T) {
@@ -143,7 +146,6 @@ func TestInstallVersion(t *testing.T) {
 		want    string
 	}{
 		{"stable pins the resolved version", ChannelStable, "1.28.1", "1.28.1"},
-		{"stable falls back to the channel", ChannelStable, "", "stable"},
 		{"daily uses the rolling channel", ChannelDaily, "1.29.0-beta.1-daily.6614998", "daily"},
 		{"daily without version", ChannelDaily, "", "daily"},
 	}
@@ -999,38 +1001,6 @@ func TestUpdateViaInstallScript(t *testing.T) {
 		require.NotEmpty(t, capturedArgs.Args[4]) // install folder path
 		require.Equal(t, "--symlink-folder", capturedArgs.Args[5])
 		require.Equal(t, "", capturedArgs.Args[6])
-	})
-
-	t.Run("Success_StableWithoutResolvedVersion", func(t *testing.T) {
-		scriptContent := []byte("#!/bin/bash\necho installing")
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(scriptContent)))
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(scriptContent)
-		}))
-		defer server.Close()
-
-		client := &http.Client{
-			Transport: &urlRewriteTransport{
-				base:      http.DefaultTransport,
-				targetURL: server.URL,
-			},
-		}
-
-		var capturedArgs exec.RunArgs
-		mockRunner := mockexec.NewMockCommandRunner()
-		mockRunner.When(func(args exec.RunArgs, command string) bool {
-			return args.Cmd == "bash"
-		}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
-			capturedArgs = args
-			return exec.NewRunResult(0, "Installation complete", ""), nil
-		})
-
-		m := NewManager(mockRunner, client)
-		var buf bytes.Buffer
-		err := m.updateViaInstallScript(t.Context(), &VersionInfo{Channel: ChannelStable, Version: ""}, &buf)
-		require.NoError(t, err)
-		require.Equal(t, "stable", capturedArgs.Args[2])
 	})
 
 	t.Run("Success_Daily", func(t *testing.T) {

--- a/cli/azd/pkg/update/msi_unix.go
+++ b/cli/azd/pkg/update/msi_unix.go
@@ -19,6 +19,6 @@ func backupCurrentExe() (string, string, error) {
 func restoreExeFromBackup(_, _ string) error { return nil }
 
 // buildInstallScriptArgs is a no-op on non-Windows platforms.
-func buildInstallScriptArgs(_ Channel) []string {
+func buildInstallScriptArgs(_ *VersionInfo) []string {
 	return nil
 }

--- a/cli/azd/pkg/update/msi_unix.go
+++ b/cli/azd/pkg/update/msi_unix.go
@@ -19,6 +19,6 @@ func backupCurrentExe() (string, string, error) {
 func restoreExeFromBackup(_, _ string) error { return nil }
 
 // buildInstallScriptArgs is a no-op on non-Windows platforms.
-func buildInstallScriptArgs(_ *VersionInfo) []string {
-	return nil
+func buildInstallScriptArgs(_ *VersionInfo) ([]string, error) {
+	return nil, nil
 }

--- a/cli/azd/pkg/update/msi_windows.go
+++ b/cli/azd/pkg/update/msi_windows.go
@@ -162,8 +162,10 @@ func escapeForPSSingleQuote(s string) string {
 // For daily channel, an additional parameter (-InstallFolder) is passed
 // to the script. The install folder and version are escaped for PowerShell single-quoted
 // strings to handle values containing apostrophes (e.g. O'Connor).
+// An unsupported channel is an error rather than a fallback: defaulting to the rolling
+// stable folder would produce the unpinned install this exists to prevent.
 // Returns the arguments to pass to the "powershell" command.
-func buildInstallScriptArgs(target *VersionInfo) []string {
+func buildInstallScriptArgs(target *VersionInfo) ([]string, error) {
 	var scriptArgs string
 	switch target.Channel {
 	case ChannelDaily:
@@ -176,7 +178,7 @@ func buildInstallScriptArgs(target *VersionInfo) []string {
 		scriptArgs = fmt.Sprintf(" -Version '%s'",
 			escapeForPSSingleQuote(target.installVersion()))
 	default:
-		scriptArgs = " -Version 'stable'"
+		return nil, fmt.Errorf("unsupported channel: %s", target.Channel)
 	}
 
 	// Reset PSModulePath to the Windows PowerShell 5.1 system modules directory.
@@ -194,5 +196,5 @@ func buildInstallScriptArgs(target *VersionInfo) []string {
 			"Remove-Item $tmpScript -Force -ErrorAction SilentlyContinue",
 		installScriptURL, scriptArgs,
 	)
-	return []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script}
+	return []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script}, nil
 }

--- a/cli/azd/pkg/update/msi_windows.go
+++ b/cli/azd/pkg/update/msi_windows.go
@@ -169,12 +169,14 @@ func buildInstallScriptArgs(target *VersionInfo) []string {
 	case ChannelDaily:
 		scriptArgs = fmt.Sprintf(" -Version 'daily' -InstallFolder '%s'",
 			escapeForPSSingleQuote(expectedPerUserInstallDir()))
-	default:
+	case ChannelStable:
 		// Pin stable to the resolved version so the MSI comes from the immutable
 		// release/<version>/ folder rather than the rolling release/stable/ folder,
 		// which can already hold a newer build (Azure/azure-dev#9145).
 		scriptArgs = fmt.Sprintf(" -Version '%s'",
 			escapeForPSSingleQuote(target.installVersion()))
+	default:
+		scriptArgs = " -Version 'stable'"
 	}
 
 	// Reset PSModulePath to the Windows PowerShell 5.1 system modules directory.

--- a/cli/azd/pkg/update/msi_windows.go
+++ b/cli/azd/pkg/update/msi_windows.go
@@ -155,20 +155,26 @@ func escapeForPSSingleQuote(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
 }
 
-// buildInstallScriptArgs constructs the PowerShell arguments to run install-azd.ps1.
+// buildInstallScriptArgs constructs the PowerShell arguments to run install-azd.ps1
+// to install target.
 // For all channels, the script is downloaded to a temp directory.
+// The version passed to the script is chosen by [VersionInfo.installVersion].
 // For daily channel, an additional parameter (-InstallFolder) is passed
-// to the script. The install folder is escaped for PowerShell single-quoted strings
-// to handle paths containing apostrophes (e.g. O'Connor).
+// to the script. The install folder and version are escaped for PowerShell single-quoted
+// strings to handle values containing apostrophes (e.g. O'Connor).
 // Returns the arguments to pass to the "powershell" command.
-func buildInstallScriptArgs(channel Channel) []string {
+func buildInstallScriptArgs(target *VersionInfo) []string {
 	var scriptArgs string
-	switch channel {
+	switch target.Channel {
 	case ChannelDaily:
 		scriptArgs = fmt.Sprintf(" -Version 'daily' -InstallFolder '%s'",
 			escapeForPSSingleQuote(expectedPerUserInstallDir()))
 	default:
-		scriptArgs = " -Version 'stable'"
+		// Pin stable to the resolved version so the MSI comes from the immutable
+		// release/<version>/ folder rather than the rolling release/stable/ folder,
+		// which can already hold a newer build (Azure/azure-dev#9145).
+		scriptArgs = fmt.Sprintf(" -Version '%s'",
+			escapeForPSSingleQuote(target.installVersion()))
 	}
 
 	// Reset PSModulePath to the Windows PowerShell 5.1 system modules directory.

--- a/cli/azd/pkg/update/msi_windows_test.go
+++ b/cli/azd/pkg/update/msi_windows_test.go
@@ -56,6 +56,7 @@ func TestBuildInstallScriptArgs(t *testing.T) {
 		name    string
 		channel Channel
 		version string
+		wantErr bool
 		// We check that certain substrings appear in the constructed args
 		wantContains    []string
 		wantNotContains []string
@@ -79,19 +80,12 @@ func TestBuildInstallScriptArgs(t *testing.T) {
 			},
 		},
 		{
-			// Unreachable in practice; channels are validated before an update starts. The
-			// script must still receive a real channel folder, not the unknown name.
-			name:    "unknown channel falls back to stable",
+			// Rejected rather than defaulted: falling back to the rolling stable folder
+			// would be the unpinned install pinning exists to prevent. Unreachable in
+			// practice, since VersionInfo.validate rejects the channel first.
+			name:    "unknown channel is an error",
 			channel: Channel("nightly"),
-			wantContains: []string{
-				"-Command",
-				installScriptURL,
-				"-Version 'stable'",
-			},
-			wantNotContains: []string{
-				"-InstallFolder",
-				"-SkipVerify",
-			},
+			wantErr: true,
 		},
 		{
 			name:    "daily",
@@ -116,7 +110,13 @@ func TestBuildInstallScriptArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := buildInstallScriptArgs(&VersionInfo{Channel: tt.channel, Version: tt.version})
+			args, err := buildInstallScriptArgs(&VersionInfo{Channel: tt.channel, Version: tt.version})
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, args)
+				return
+			}
+			require.NoError(t, err)
 			require.NotNil(t, args)
 			require.True(t, len(args) > 0, "expected non-empty args slice")
 
@@ -153,7 +153,8 @@ func TestEscapeForPSSingleQuote(t *testing.T) {
 func TestBuildInstallScriptArgs_ApostropheInPath(t *testing.T) {
 	t.Setenv("LOCALAPPDATA", `C:\Users\O'Connor\AppData\Local`)
 
-	args := buildInstallScriptArgs(&VersionInfo{Channel: ChannelDaily, Version: "1.29.0-beta.1-daily.6614998"})
+	args, err := buildInstallScriptArgs(&VersionInfo{Channel: ChannelDaily, Version: "1.29.0-beta.1-daily.6614998"})
+	require.NoError(t, err)
 	script := args[4]
 
 	// The apostrophe must be doubled for a valid PowerShell single-quoted string.
@@ -166,7 +167,8 @@ func TestBuildInstallScriptArgs_Structure(t *testing.T) {
 	t.Setenv("LOCALAPPDATA", `C:\Users\testuser\AppData\Local`)
 	expectedDir := expectedPerUserInstallDir()
 
-	args := buildInstallScriptArgs(&VersionInfo{Channel: ChannelStable, Version: "1.28.1"})
+	args, err := buildInstallScriptArgs(&VersionInfo{Channel: ChannelStable, Version: "1.28.1"})
+	require.NoError(t, err)
 
 	require.Equal(t, 5, len(args), "expected exactly 5 args")
 	require.Equal(t, "-NoProfile", args[0])
@@ -184,7 +186,8 @@ func TestBuildInstallScriptArgs_Structure(t *testing.T) {
 	require.NotContains(t, script, "-InstallFolder")
 
 	// Daily downloads to temp file with -Version 'daily'
-	argsDaily := buildInstallScriptArgs(&VersionInfo{Channel: ChannelDaily, Version: "1.29.0-beta.1-daily.6614998"})
+	argsDaily, err := buildInstallScriptArgs(&VersionInfo{Channel: ChannelDaily, Version: "1.29.0-beta.1-daily.6614998"})
+	require.NoError(t, err)
 	require.Equal(t, 5, len(argsDaily))
 	require.Equal(t, "Bypass", argsDaily[2])
 	scriptDaily := argsDaily[4]

--- a/cli/azd/pkg/update/msi_windows_test.go
+++ b/cli/azd/pkg/update/msi_windows_test.go
@@ -55,6 +55,7 @@ func TestBuildInstallScriptArgs(t *testing.T) {
 	tests := []struct {
 		name    string
 		channel Channel
+		version string
 		// We check that certain substrings appear in the constructed args
 		wantContains    []string
 		wantNotContains []string
@@ -62,12 +63,13 @@ func TestBuildInstallScriptArgs(t *testing.T) {
 		{
 			name:    "stable",
 			channel: ChannelStable,
+			version: "1.28.1",
 			wantContains: []string{
 				"-NoProfile",
 				"-ExecutionPolicy", "Bypass",
 				"-Command",
 				installScriptURL,
-				"-Version 'stable'",
+				"-Version '1.28.1'",
 				"Remove-Item",
 				"$env:PSModulePath",
 			},
@@ -77,8 +79,22 @@ func TestBuildInstallScriptArgs(t *testing.T) {
 			},
 		},
 		{
+			name:    "stable without resolved version",
+			channel: ChannelStable,
+			wantContains: []string{
+				"-Command",
+				installScriptURL,
+				"-Version 'stable'",
+			},
+			wantNotContains: []string{
+				"-InstallFolder",
+				"-SkipVerify",
+			},
+		},
+		{
 			name:    "daily",
 			channel: ChannelDaily,
+			version: "1.29.0-beta.1-daily.6614998",
 			wantContains: []string{
 				"-NoProfile",
 				"-ExecutionPolicy", "Bypass",
@@ -98,7 +114,7 @@ func TestBuildInstallScriptArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := buildInstallScriptArgs(tt.channel)
+			args := buildInstallScriptArgs(&VersionInfo{Channel: tt.channel, Version: tt.version})
 			require.NotNil(t, args)
 			require.True(t, len(args) > 0, "expected non-empty args slice")
 
@@ -135,7 +151,7 @@ func TestEscapeForPSSingleQuote(t *testing.T) {
 func TestBuildInstallScriptArgs_ApostropheInPath(t *testing.T) {
 	t.Setenv("LOCALAPPDATA", `C:\Users\O'Connor\AppData\Local`)
 
-	args := buildInstallScriptArgs(ChannelDaily)
+	args := buildInstallScriptArgs(&VersionInfo{Channel: ChannelDaily, Version: "1.29.0-beta.1-daily.6614998"})
 	script := args[4]
 
 	// The apostrophe must be doubled for a valid PowerShell single-quoted string.
@@ -148,7 +164,7 @@ func TestBuildInstallScriptArgs_Structure(t *testing.T) {
 	t.Setenv("LOCALAPPDATA", `C:\Users\testuser\AppData\Local`)
 	expectedDir := expectedPerUserInstallDir()
 
-	args := buildInstallScriptArgs(ChannelStable)
+	args := buildInstallScriptArgs(&VersionInfo{Channel: ChannelStable, Version: "1.28.1"})
 
 	require.Equal(t, 5, len(args), "expected exactly 5 args")
 	require.Equal(t, "-NoProfile", args[0])
@@ -156,17 +172,17 @@ func TestBuildInstallScriptArgs_Structure(t *testing.T) {
 	require.Equal(t, "Bypass", args[2])
 	require.Equal(t, "-Command", args[3])
 
-	// Stable downloads to temp file — passes -Version 'stable' explicitly
+	// Stable downloads to temp file — pinned to the resolved version
 	script := args[4]
 	require.True(t, strings.HasPrefix(script, "$env:PSModulePath"), "script should start with PSModulePath reset")
 	require.Contains(t, script, "Invoke-RestMethod")
 	require.Contains(t, script, installScriptURL)
 	require.Contains(t, script, "Remove-Item")
-	require.Contains(t, script, "-Version 'stable'")
+	require.Contains(t, script, "-Version '1.28.1'")
 	require.NotContains(t, script, "-InstallFolder")
 
 	// Daily downloads to temp file with -Version 'daily'
-	argsDaily := buildInstallScriptArgs(ChannelDaily)
+	argsDaily := buildInstallScriptArgs(&VersionInfo{Channel: ChannelDaily, Version: "1.29.0-beta.1-daily.6614998"})
 	require.Equal(t, 5, len(argsDaily))
 	require.Equal(t, "Bypass", argsDaily[2])
 	scriptDaily := argsDaily[4]
@@ -261,9 +277,9 @@ func TestUpdateViaMSI_NonStandardInstallBlocks(t *testing.T) {
 	mockRunner := mockexec.NewMockCommandRunner()
 	m := NewManager(mockRunner, nil)
 	var buf strings.Builder
-	cfg := &UpdateConfig{Channel: ChannelStable}
+	target := &VersionInfo{Channel: ChannelStable, Version: "1.28.1"}
 
-	err := m.updateViaMSI(t.Context(), cfg, &buf)
+	err := m.updateViaMSI(t.Context(), target, &buf)
 	require.Error(t, err)
 
 	var updateErr *UpdateError

--- a/cli/azd/pkg/update/msi_windows_test.go
+++ b/cli/azd/pkg/update/msi_windows_test.go
@@ -79,8 +79,10 @@ func TestBuildInstallScriptArgs(t *testing.T) {
 			},
 		},
 		{
-			name:    "stable without resolved version",
-			channel: ChannelStable,
+			// Unreachable in practice; channels are validated before an update starts. The
+			// script must still receive a real channel folder, not the unknown name.
+			name:    "unknown channel falls back to stable",
+			channel: Channel("nightly"),
 			wantContains: []string{
 				"-Command",
 				installScriptURL,


### PR DESCRIPTION
Fix #9145

`azd update` reported one version and installed another:

```
Update available: 1.26.0 -> 1.27.0
Updating azd to 1.27.0 (stable)
$ azd version
azd version 1.27.1        <-- not what was reported
```

## Root cause

The update check and the installer read **two different artifacts**:

| step | artifact | mutable? |
| --- | --- | --- |
| `checkStableVersion` | `release/latest/version.txt` (via `aka.ms/azure-dev/versions/cli/latest`) | published separately |
| install (`--version stable` / `-Version 'stable'`) | `release/stable/` | **rolling — overwritten every release** |

`eng/pipelines/templates/stages/publish.yml` publishes them in **separate stages**. Binaries go out in `PublishCLI` → `Publish_Release`, which uploads to `release/$(CLI_VERSION);release/latest` plus `release/stable` for GA. `version.txt` is uploaded much later by `PublishVersionTxt` → `Upload_Version_Txt`, behind the `ReleaseGate` deployment on the manual `package-publish` environment plus `Wait-WinGetPackage.ps1` / `Wait-ChocoPackage.ps1` (both of which `exit 1` on timeout and take the upload down with them).

During that window `release/stable/` already holds the newer build while `version.txt` still advertises the older one, so "install whatever is in the channel folder" silently delivers a different version than the one reported.

Blob timestamps confirm the split is structural rather than incidental:

- **release** channel: `stable` tarball `Jul 23 02:01:57` vs `latest/version.txt` `Jul 23 07:20:36` — **+5h19m**
- **daily** channel (both published in one job): `21:02:43` vs `21:02:49` — **+6s**

### Reproduced live during the 1.29.0 release

The 1.29.0 window was captured end to end while this PR was open:

| event | UTC |
| --- | --- |
| binaries → `release/1.29.0/` and `release/stable/` | Jul 29 **23:38:47** |
| `version.txt` → `release/latest/` and `release/stable/` | Jul 30 **01:52:02** |
| **exposure** | **2h 13m 15s** |

Inside that window, with the pre-fix build (`7d34c7eb9`) on the stable channel:

```
Updating azd to 1.28.1 (stable)
VERBOSE: Downloading build from .../azd/standalone/release/stable/azd-windows-amd64.msi
SUCCESS: Updated azd to version 1.28.1! Changes take effect on next invocation.

$ azd version
azd version 1.29.0 (commit fc06de978b9e9dc98a50ebb601a18b0f9f24071a) (stable)
```

Reported 1.28.1, installed 1.29.0. With this PR's build, same moment, same channel:

```
Updating azd to 1.28.1 (stable)
VERBOSE: Downloading build from .../azd/standalone/release/1.28.1/azd-windows-amd64.msi
SUCCESS: Updated azd to version 1.28.1! Changes take effect on next invocation.

$ azd version
azd version 1.28.1 (commit 3cf6db5881d8b24bb497e1470a972f4e28eb0256) (stable)
```

Note both runs report 1.28.1: the check correctly reflects the gated marker, and once it advanced to 1.29.0 the user is prompted again and gets 1.29.0. The fix changes what is *installed*, not what is detected.

## Fix

Pin self-managed stable installs to the **exact version the check resolved**, downloading from the immutable `release/<version>/` folder instead of the rolling `release/stable/` one.

Rather than threading a version alongside the channel, `Manager.Update` now takes the `*VersionInfo` that `CheckForUpdate` already returns:

```go
- func (m *Manager) Update(ctx context.Context, cfg *UpdateConfig, writer io.Writer) error
+ func (m *Manager) Update(ctx context.Context, target *VersionInfo, writer io.Writer) error
```

`VersionInfo` already carries both `Channel` and `Version`, and the update path only ever used `cfg.Channel` — so this is a parameter *replacement*, not an addition, and it makes a channel/version mismatch unrepresentable. The install can only ever target the version that was actually resolved and reported.

Per-version release folders are published in the same job as the rolling folders and **before** `version.txt` advertises them, so a pinned folder is always present by the time azd can resolve its version.

### Exceptions

- **Daily** keeps using the rolling `release/daily/` folder — per-version daily archives live at `standalone/daily/archive/<version>`, outside the release base URL the install scripts use, so there is nothing to pin to within reach of the installer.
- **Package managers** (`brew`, `winget`, `choco`) cannot be pinned — the package manager decides which version it makes available.

azd names a version in its progress and success messages only when the install is actually pinned to it (`update.CanPinVersion(installedBy, channel)` — self-managed **and** stable). Everything else reports without a version and directs the user to `azd version`:

| install | channel | message |
| --- | --- | --- |
| self-managed | stable | `Updating azd to 1.28.1 (stable)` / `Updated azd to version 1.28.1!` |
| package manager | any | `Updating azd via winget (stable)` / `Updated azd!` |
| self-managed | daily | `Updating azd (daily)` / `Updated azd!` |

Daily is deliberately in the unpinned group: `azcopy copy "release/*"` uploads each blob independently and another daily publish can advance the folder between the check and the download, so naming the resolved version there would reintroduce the very mismatch this PR removes.

### Why pin rather than report what the rolling folder holds

The issue's stated expectation is the mirror image: have the check resolve to whatever `release/stable/` currently serves, so azd reports `1.27.1` and installs `1.27.1`. That was rejected — there is no marker that describes the rolling folder's *current* contents (`release/stable/version.txt` is written by the late job, not with the binaries), so the check would have to infer the version from the archive it downloads, i.e. commit to an install before it can report one. Pinning gets the same consistency from data azd already has. The tradeoff is that a user can sit one release behind until `version.txt` catches up, at which point they are prompted again.

An unresolved stable target is rejected rather than silently unpinned: `Manager.Update` and `Manager.StageUpdate` fail if a stable `VersionInfo` carries no version, since falling back to `release/stable/` would reintroduce exactly the drift this fixes.

## Not addressed here

This makes the **client** resilient. First, though, a note on what is *not* broken:

`version.txt` is published last **on purpose**. `Upload_Version_Txt` sits behind the `package-publish` release gate and waits on `Wait-WinGetPackage.ps1` / `Wait-ChocoPackage.ps1`, so the marker means "this version is installable from every channel, including winget and choco" — not merely "the blobs are up". Advancing it sooner would tell winget and choco users to upgrade to a version their package manager cannot yet resolve.

So the marker's lag is a feature, and the client should keep honouring it. The defect was that azd honoured the gated marker for the version it *reported*, but downloaded from `release/stable/`, which `PublishCLI` updates **ungated**. One gated source, one ungated source. Pinning makes both come from the same gated decision, which restores the contract the pipeline already intends rather than working around it.

Remaining server-side follow-ups:

1. `release/stable/` runs ahead of the announcement for the whole length of the gate — measured at **5h19m** for 1.28.1 and **2h13m** for 1.29.0. Moving the rolling-folder update behind the same gate would close the window at the source. Not required once the client pins, so low priority.
2. A `Wait-*Package.ps1` timeout `exit 1`s and takes `Upload_Version_Txt` down with it, leaving a release whose binaries are published but which is never announced. The gate itself is right; the failure mode is just silent and deserves an alert.
3. Gate the stable check on GA. `Test-ShouldReleasePackageVersion.ps1` gates `release/stable` uploads to GA only, while `release/latest` receives every release including prereleases, so the stable check can also run *ahead* of the stable folder. Note this is **not** fixed by reading `release/stable/version.txt`: the `Upload_Version_Txt` job loops over `release/latest` and (for GA) `release/stable`, uploading the same `version.txt` to both, so the stable marker carries the identical lag.

## Testing

- `TestBuildDownloadURL` — pinned stable / daily / invalid channel
- `TestBuildDownloadURL_StableDoesNotUseRollingFolder` — a stable URL never contains `/stable/`
- `TestInstallVersion` — stable pins, daily stays rolling
- `TestUpdate_RequiresResolvedVersion` — `Update`/`StageUpdate` reject a nil target and an unresolved stable target; daily needs no resolved version
- `TestUpdateViaInstallScript` — `--version 1.28.1` for stable, `daily` for daily
- `TestBuildInstallScriptArgs` — `-Version '1.28.1'` for the stable MSI path; an unknown channel is rejected with an error rather than silently falling back to the rolling folder
- `Test_UpdateMessages_NameVersionOnlyWhenPinnable` — a version is named only for self-managed stable installs; brew/winget/choco and daily never name one

Verified with `go build ./...`, `go vet`, `golangci-lint run` (0 issues), `gofmt -s`, `cspell`, `go test ./pkg/update/...` and `go test ./cmd/ -run 'Update|Version'`.

Also verified against live storage that the pinned layout exists and the installers accept an exact version: `release/1.28.1/{azd-windows-amd64.zip,azd-windows-amd64.msi,azd-linux-amd64.tar.gz,azd-darwin-arm64.zip}` all return 200, `install-azd.sh` builds `$base_url/$version/azd-...`, and `install-azd.ps1` builds `$BaseUrl/$Version/$packageFilename`.
