### PR TITLE
feat: default new agents to invocations protocol 2.0.0

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -904,7 +904,7 @@ type protocolInfo struct {
 // knownProtocols lists the protocols offered during init, in display order.
 var knownProtocols = []protocolInfo{
 	{Name: "responses", Version: "2.0.0"},
-	{Name: "invocations", Version: "1.0.0"},
+	{Name: "invocations", Version: "2.0.0"},
 	{Name: "invocations_ws", Version: "2.0.0"},
 	// "activity" is the canonical protocol name (legacy alias: "activity_protocol").
 	// The version selects the platform's internal container route ("v1"/"1.0.0" ->

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go
@@ -595,7 +595,7 @@ func TestPromptProtocols_FlagValues(t *testing.T) {
 			name:          "invocations only",
 			flagProtocols: []string{"invocations"},
 			wantProtocols: []agent_yaml.ProtocolVersionRecord{
-				{Protocol: "invocations", Version: "1.0.0"},
+				{Protocol: "invocations", Version: "2.0.0"},
 			},
 		},
 		{
@@ -610,7 +610,7 @@ func TestPromptProtocols_FlagValues(t *testing.T) {
 			flagProtocols: []string{"responses", "invocations"},
 			wantProtocols: []agent_yaml.ProtocolVersionRecord{
 				{Protocol: "responses", Version: "2.0.0"},
-				{Protocol: "invocations", Version: "1.0.0"},
+				{Protocol: "invocations", Version: "2.0.0"},
 			},
 		},
 		{
@@ -624,7 +624,7 @@ func TestPromptProtocols_FlagValues(t *testing.T) {
 			flagProtocols: []string{"responses", "responses", "invocations"},
 			wantProtocols: []agent_yaml.ProtocolVersionRecord{
 				{Protocol: "responses", Version: "2.0.0"},
-				{Protocol: "invocations", Version: "1.0.0"},
+				{Protocol: "invocations", Version: "2.0.0"},
 			},
 		},
 		{
@@ -753,7 +753,7 @@ func TestPromptProtocols_Interactive(t *testing.T) {
 			},
 			wantProtocols: []agent_yaml.ProtocolVersionRecord{
 				{Protocol: "responses", Version: "2.0.0"},
-				{Protocol: "invocations", Version: "1.0.0"},
+				{Protocol: "invocations", Version: "2.0.0"},
 			},
 		},
 		{

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -367,6 +367,28 @@ func TestSynthesizeImageManifestFile_UsesFlagProtocols(t *testing.T) {
 	require.Equal(t, "2.0.0", containerAgent.Protocols[0].Version)
 }
 
+func TestSynthesizeImageManifestFile_UsesInvocationsProtocol(t *testing.T) {
+	t.Parallel()
+
+	const agentName = "my-agent"
+	const image = "myacr.azurecr.io/agents/my-agent:v1"
+
+	manifestPath, cleanup, err := synthesizeImageManifestFile(agentName, image, []string{"invocations"})
+	require.NoError(t, err)
+	defer cleanup()
+
+	content, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+	template, err := agent_yaml.ExtractAgentDefinition(content)
+	require.NoError(t, err)
+
+	containerAgent, ok := template.(agent_yaml.ContainerAgent)
+	require.True(t, ok, "synthesized template should be a ContainerAgent, got %T", template)
+	require.Equal(t, []agent_yaml.ProtocolVersionRecord{
+		{Protocol: "invocations", Version: "2.0.0"},
+	}, containerAgent.Protocols)
+}
+
 func TestSynthesizeImageManifestFile_RejectsUnknownProtocol(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #9153

## Why

`invocations` was the last protocol still pinned to `1.0.0` in `azd ai agent init`. `responses`, `invocations_ws`, and `activity` all moved to `2.0.0` already, so new agents were opting into a stale contract for no reason.

## Approach

The defaults live in one `knownProtocols` table that feeds **both** init paths (local code and `--image`), so a single entry change keeps them consistent.

- **Existing manifests are untouched.** Projects pinning `1.0.0` keep deploying as authored — no silent upgrade.
- **No client-side changes needed.** azd routes on protocol *name*, never version; the version is a pass-through string in the hosted-agent request body.

## Validation

| Scenario | Result |
| --- | --- |
| Local-code init with `--no-prompt --protocol invocations` | Generated `invocations/2.0.0` |
| BYO-image init with `--no-prompt --protocol invocations` | Preserved the image and generated `invocations/2.0.0` |
| Interactive local-code init selecting `responses` and `invocations` | Generated both protocols at `2.0.0` |