### PR TITLE
fix: prevent Aspire manifest generation hang from MSBuild node reuse

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -181,6 +181,9 @@ overrides:
       - compatResult
       - compatCopy
       - Incompat
+  - filename: pkg/tools/dotnet/dotnet.go
+    words:
+      - MSBUILDDISABLENODEREUSE
   - filename: pkg/output/pretty_table.go
     words:
       - runewidth

--- a/cli/azd/pkg/tools/dotnet/dotnet.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet.go
@@ -202,17 +202,24 @@ func (cli *Cli) PublishAppHostManifest(
 
 	runArgs = runArgs.WithCwd(filepath.Dir(hostProject))
 
+	// Disable MSBuild node reuse for this invocation. `dotnet run --publisher manifest` builds the AppHost via
+	// MSBuild, which by default spawns persistent worker nodes (nodeReuse:true) that survive after `dotnet run`
+	// exits. Those worker nodes inherit the stdout/stderr pipe that azd's command runner reads from, so the pipe
+	// never reaches EOF and cmd.Wait() blocks forever even though the manifest was already produced. This is the
+	// os/exec deadlock described in https://github.com/golang/go/issues/23019 and reported in azd issue #9295
+	// (hangs with 0% CPU on large solutions where many worker nodes are spawned). Disabling node reuse makes the
+	// worker nodes terminate when the build completes, closing the inherited pipe.
+	envArgs := []string{
+		"MSBUILDDISABLENODEREUSE=1",
+	}
+
 	// AppHost may conditionalize their infrastructure based on the environment, so we need to pass the environment when we
 	// are `dotnet run`ing the app host project to produce its manifest.
-	var envArgs []string
-
 	if dotnetEnv != "" {
 		envArgs = append(envArgs, fmt.Sprintf("DOTNET_ENVIRONMENT=%s", dotnetEnv))
 	}
 
-	if envArgs != nil {
-		runArgs = runArgs.WithEnv(envArgs)
-	}
+	runArgs = runArgs.WithEnv(envArgs)
 
 	_, err := cli.commandRunner.Run(ctx, runArgs)
 	if err != nil {

--- a/cli/azd/pkg/tools/dotnet/dotnet_commands_test.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet_commands_test.go
@@ -332,6 +332,8 @@ func Test_Cli_PublishAppHostManifest(t *testing.T) {
 		require.Contains(t, captured.Args, "--output-path")
 		require.Contains(t, captured.Args, "out.json")
 		require.Contains(t, captured.Env, "DOTNET_ENVIRONMENT=Development")
+		// Node reuse must be disabled to avoid the os/exec pipe-inheritance hang (issue #9295).
+		require.Contains(t, captured.Env, "MSBUILDDISABLENODEREUSE=1")
 	})
 
 	t.Run("single file apphost", func(t *testing.T) {
@@ -349,6 +351,7 @@ func Test_Cli_PublishAppHostManifest(t *testing.T) {
 		require.Equal(t, filepath.Dir(hostProject), captured.Cwd)
 		require.Equal(t, "apphost.cs", captured.Args[1])
 		require.NotContains(t, captured.Args, "--project")
+		require.Contains(t, captured.Env, "MSBUILDDISABLENODEREUSE=1")
 	})
 
 	t.Run("run error", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #9295 — `azd init --from-code` and `azd infra generate --force` could hang **indefinitely** (0% CPU, no memory growth) while generating the Aspire AppHost manifest on large solutions, even though the same `dotnet run --publisher manifest` command completes in under a second when run standalone.

## Root cause

This is the classic Go `os/exec` pipe-inheritance deadlock: [golang/go#23019](https://github.com/golang/go/issues/23019).

1. azd's command runner (`pkg/exec/command_runner.go`) captures the child's stdout/stderr into `bytes.Buffer`. Because those aren't `*os.File`, Go creates OS pipes plus background copy goroutines, and `cmd.Wait()` blocks until those goroutines reach **EOF** (i.e. until *all* write handles to the pipe are closed).
2. `dotnet run --publisher manifest` builds the AppHost via MSBuild, which by default spawns persistent worker nodes (`nodeReuse:true`). These worker nodes **inherit** azd's stdout/stderr pipe.
3. When `dotnet run` exits, the manifest is already written — but the persistent worker nodes stay alive (default ~15‑min idle timeout) and keep the pipe's write handle open. EOF never arrives, so `cmd.Wait()` blocks forever. The worker nodes are idle, which is exactly why the reporter saw **0% CPU and 0 memory growth** across every process in the tree.
4. Running the command standalone works because stdout is a console/TTY, not an OS pipe — there is nothing to keep open.

This reproduces more reliably on large solutions (the issue reports ~54 `.csproj` files) and on Windows, because more referenced projects spawn and retain more parallel MSBuild worker nodes, raising the chance one is still holding the pipe when `Wait()` is reached.

## Fix

Set `MSBUILDDISABLENODEREUSE=1` on the manifest-generation invocation. With node reuse disabled, MSBuild worker nodes terminate when the build completes, closing the inherited pipe so `cmd.Wait()` returns normally.

The env var is scoped to this single `PublishAppHostManifest` call, so node reuse remains intact for all other azd dotnet operations (`restore`/`build`/`publish` during `azd up`/`deploy`).

## Performance impact

None meaningful. Node reuse only helps *subsequent* builds reuse warm worker nodes; it does not affect parallelism *within* a build. Since manifest generation runs once per `azd init`/`infra generate` (a cold, single-shot invocation), there are no pre-warmed nodes to lose. Benchmark (AppHost + 40 referenced projects, warm build cache):

| Scenario | Node reuse (default) | `MSBUILDDISABLENODEREUSE=1` |
|---|---|---|
| Cold first-run (realistic azd) | ~8.0 s | ~7.6 s |
| Repeated back-to-back runs | ~4.9 s | ~7.0 s |

The cold-start case (how azd actually invokes it) shows no measurable slowdown. As a bonus, azd no longer leaves dozens of idle MSBuild worker processes behind after a run.

## Testing

- Reproduced the exact deadlock mechanism with a minimal Go program mimicking azd's `bytes.Buffer` capture pattern: `cmd.Wait()` blocked until a grandchild holding the inherited pipe exited.
- Confirmed default `dotnet run --publisher manifest` leaves dozens of `nodeReuse:true` MSBuild workers alive after exit; with the fix, zero worker nodes linger.
- Verified `azd init --from-code` succeeds end-to-end with the fixed binary.
- Added assertions in `Test_Cli_PublishAppHostManifest` that `MSBUILDDISABLENODEREUSE=1` is passed for both project-based and single-file AppHosts.