### PR TITLE
training: Align training job yaml schema with new command job schema

### DIFF
--- a/cli/azd/extensions/azure.ai.training/internal/cmd/init_template.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/init_template.go
@@ -73,23 +73,17 @@ description: Sample job created by 'azd ai training init'
 command: echo "hello world"
 environment: <user to add>
 compute: <user to add>
+
 resources:
   instance_count: 1
-  instance_type: <user to add>
-  properties:
-    AISuperComputer:
-      imageVersion: ""
-      slaTier: <user to add>
-      priority: <user to add>
 `
 
 // scaffoldDefaultJobYaml writes a starter commandJob template to
 // <workingDir>/config/job.yaml. The template contains <user to add>
 // placeholders for fields that are environment-specific (compute,
-// environment image, instance_type, slaTier, priority); the user is
-// expected to edit these before running 'job submit'. No-op (with a
-// notice) if the file already exists, so re-running 'init' doesn't
-// clobber user edits.
+// environment); the user is expected to edit these before running
+// 'job submit'. No-op (with a notice) if the file already exists, so
+// re-running 'init' doesn't clobber user edits.
 func scaffoldDefaultJobYaml(workingDir string) error {
 	yamlPath := filepath.Join(workingDir, "config", "job.yaml")
 

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/init_template.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/init_template.go
@@ -73,23 +73,26 @@ description: Sample job created by 'azd ai training init'
 command: echo "hello world"
 environment: <user to add>
 compute: <user to add>
+
+# Optional: choose one of the two ways to size the job.
+#   capacity_unit_count — total cores across the allocation (1, 2, 4, 8 or multiple of 8).
+#     The service picks the smallest SKU that fits and slices nodes as needed (partial SKU).
+#   resources.instance_count — whole nodes of the compute cluster's full SKU.
+#     Default when nothing is set: instance_count = 1.
+# capacity_unit_count: 4
 resources:
   instance_count: 1
-  instance_type: <user to add>
-  properties:
-    AISuperComputer:
-      imageVersion: ""
-      slaTier: <user to add>
-      priority: <user to add>
+
+# Optional: job scheduling priority (Regular | Low | High). Default: Regular.
+# priority: Regular
 `
 
 // scaffoldDefaultJobYaml writes a starter commandJob template to
 // <workingDir>/config/job.yaml. The template contains <user to add>
 // placeholders for fields that are environment-specific (compute,
-// environment image, instance_type, slaTier, priority); the user is
-// expected to edit these before running 'job submit'. No-op (with a
-// notice) if the file already exists, so re-running 'init' doesn't
-// clobber user edits.
+// environment); the user is expected to edit these before running
+// 'job submit'. No-op (with a notice) if the file already exists, so
+// re-running 'init' doesn't clobber user edits.
 func scaffoldDefaultJobYaml(workingDir string) error {
 	yamlPath := filepath.Join(workingDir, "config", "job.yaml")
 

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/job_show.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/job_show.go
@@ -386,24 +386,17 @@ func printJobDetails(d *jobDetails) {
 		_ = w.Flush()
 	}
 
-	// Resources — only show when the user did NOT submit gpuCount.
-	// When gpuCount is set, the backend ignores the resources block (it picks the
-	// SKU based on the compute target), so showing it here would be misleading.
-	if props.GPUCount == 0 && props.Resources != nil {
+	// Resources — on submit only instance_count is set (the service infers the
+	// SKU from the compute cluster); on Get Job the service echoes what it
+	// inferred (instance_type, slaTier), so display whatever comes back.
+	if props.Resources != nil && (props.Resources.InstanceCount > 0 || props.Resources.InstanceType != "") {
 		fmt.Println()
 		w = tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		if props.Resources.InstanceCount > 0 {
-			fmt.Fprintf(
-				w, "Instance Count:\t%d\n", props.Resources.InstanceCount,
-			)
+			fmt.Fprintf(w, "Instance Count:\t%d\n", props.Resources.InstanceCount)
 		}
 		if props.Resources.InstanceType != "" {
-			fmt.Fprintf(
-				w, "Instance Type:\t%s\n", props.Resources.InstanceType,
-			)
-		}
-		if props.Resources.ShmSize != "" {
-			fmt.Fprintf(w, "Shared Memory:\t%s\n", props.Resources.ShmSize)
+			fmt.Fprintf(w, "Instance Type:\t%s\n", props.Resources.InstanceType)
 		}
 		_ = w.Flush()
 	}
@@ -488,15 +481,17 @@ func printComputeSection(d *jobDetails) {
 		if c.InstanceCount > 0 {
 			fmt.Fprintf(w, "Nodes:\t%d\n", c.InstanceCount)
 		}
-		// Prefer the user-submitted gpuCount (from Get Job) when present — for
-		// partial-SKU jobs it reflects the actual allocation. Otherwise fall back
-		// to the SKU GPU count reported by run history.
+		// GPUs: prefer the top-level GPUCount from Get Job, otherwise use what run history reports.
 		if d.Job.Properties.GPUCount > 0 {
 			fmt.Fprintf(w, "GPUs:\t%d\n", d.Job.Properties.GPUCount)
 		} else if c.GPUCount > 0 {
 			fmt.Fprintf(w, "GPUs:\t%d\n", c.GPUCount)
 		}
-		if c.Priority != "" {
+		// Priority: prefer the top-level Priority from Get Job, otherwise use
+		// whatever run history reports.
+		if d.Job.Properties.Priority != "" {
+			fmt.Fprintf(w, "Priority:\t%s\n", d.Job.Properties.Priority)
+		} else if c.Priority != "" {
 			fmt.Fprintf(w, "Priority:\t%s\n", c.Priority)
 		}
 	}

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/job_show.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/job_show.go
@@ -386,25 +386,13 @@ func printJobDetails(d *jobDetails) {
 		_ = w.Flush()
 	}
 
-	// Resources — only show when the user did NOT submit gpuCount.
-	// When gpuCount is set, the backend ignores the resources block (it picks the
-	// SKU based on the compute target), so showing it here would be misleading.
-	if props.GPUCount == 0 && props.Resources != nil {
+	// Resources — only instance_count is meaningful; instance_type / slaTier / AISuperComputer
+	// have been removed from the wire and the service now infers the SKU from the compute
+	// cluster. Partial-SKU allocation is surfaced via capacityUnitCount in the Compute section.
+	if props.Resources != nil && props.Resources.InstanceCount > 0 {
 		fmt.Println()
 		w = tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		if props.Resources.InstanceCount > 0 {
-			fmt.Fprintf(
-				w, "Instance Count:\t%d\n", props.Resources.InstanceCount,
-			)
-		}
-		if props.Resources.InstanceType != "" {
-			fmt.Fprintf(
-				w, "Instance Type:\t%s\n", props.Resources.InstanceType,
-			)
-		}
-		if props.Resources.ShmSize != "" {
-			fmt.Fprintf(w, "Shared Memory:\t%s\n", props.Resources.ShmSize)
-		}
+		fmt.Fprintf(w, "Instance Count:\t%d\n", props.Resources.InstanceCount)
 		_ = w.Flush()
 	}
 
@@ -488,15 +476,21 @@ func printComputeSection(d *jobDetails) {
 		if c.InstanceCount > 0 {
 			fmt.Fprintf(w, "Nodes:\t%d\n", c.InstanceCount)
 		}
-		// Prefer the user-submitted gpuCount (from Get Job) when present — for
-		// partial-SKU jobs it reflects the actual allocation. Otherwise fall back
-		// to the SKU GPU count reported by run history.
-		if d.Job.Properties.GPUCount > 0 {
-			fmt.Fprintf(w, "GPUs:\t%d\n", d.Job.Properties.GPUCount)
+		// Prefer the user-submitted capacityUnitCount (from Get Job) when present — for
+		// partial-SKU jobs it reflects the actual allocation. Fall back to the SKU GPU
+		// count reported by run history for older jobs that pre-date capacityUnitCount.
+		if d.Job.Properties.CapacityUnitCount > 0 {
+			fmt.Fprintf(w, "Capacity Units:\t%d\n", d.Job.Properties.CapacityUnitCount)
+		} else if c.CapacityUnitCount > 0 {
+			fmt.Fprintf(w, "Capacity Units:\t%d\n", c.CapacityUnitCount)
 		} else if c.GPUCount > 0 {
 			fmt.Fprintf(w, "GPUs:\t%d\n", c.GPUCount)
 		}
-		if c.Priority != "" {
+		// Priority: prefer the top-level user-submitted field (new shape), then fall
+		// back to whatever run history reports (older AISuperComputer nesting).
+		if d.Job.Properties.Priority != "" {
+			fmt.Fprintf(w, "Priority:\t%s\n", d.Job.Properties.Priority)
+		} else if c.Priority != "" {
 			fmt.Fprintf(w, "Priority:\t%s\n", c.Priority)
 		}
 	}

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/job_show.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/job_show.go
@@ -386,13 +386,18 @@ func printJobDetails(d *jobDetails) {
 		_ = w.Flush()
 	}
 
-	// Resources — only instance_count is meaningful; instance_type / slaTier / AISuperComputer
-	// have been removed from the wire and the service now infers the SKU from the compute
-	// cluster. Partial-SKU allocation is surfaced via capacityUnitCount in the Compute section.
-	if props.Resources != nil && props.Resources.InstanceCount > 0 {
+	// Resources — on submit only instance_count is set (the service infers the
+	// SKU from the compute cluster); on Get Job the service echoes what it
+	// inferred (instance_type, slaTier), so display whatever comes back.
+	if props.Resources != nil && (props.Resources.InstanceCount > 0 || props.Resources.InstanceType != "") {
 		fmt.Println()
 		w = tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintf(w, "Instance Count:\t%d\n", props.Resources.InstanceCount)
+		if props.Resources.InstanceCount > 0 {
+			fmt.Fprintf(w, "Instance Count:\t%d\n", props.Resources.InstanceCount)
+		}
+		if props.Resources.InstanceType != "" {
+			fmt.Fprintf(w, "Instance Type:\t%s\n", props.Resources.InstanceType)
+		}
 		_ = w.Flush()
 	}
 
@@ -476,9 +481,8 @@ func printComputeSection(d *jobDetails) {
 		if c.InstanceCount > 0 {
 			fmt.Fprintf(w, "Nodes:\t%d\n", c.InstanceCount)
 		}
-		// Prefer the user-submitted capacityUnitCount (from Get Job) when present — for
-		// partial-SKU jobs it reflects the actual allocation. Fall back to the SKU GPU
-		// count reported by run history for older jobs that pre-date capacityUnitCount.
+		// Capacity Units: prefer the top-level CapacityUnitCount from Get Job,
+		// then whatever run history reports, then the SKU-level GPU count.
 		if d.Job.Properties.CapacityUnitCount > 0 {
 			fmt.Fprintf(w, "Capacity Units:\t%d\n", d.Job.Properties.CapacityUnitCount)
 		} else if c.CapacityUnitCount > 0 {
@@ -486,8 +490,8 @@ func printComputeSection(d *jobDetails) {
 		} else if c.GPUCount > 0 {
 			fmt.Fprintf(w, "GPUs:\t%d\n", c.GPUCount)
 		}
-		// Priority: prefer the top-level user-submitted field (new shape), then fall
-		// back to whatever run history reports (older AISuperComputer nesting).
+		// Priority: prefer the top-level Priority from Get Job, otherwise use
+		// whatever run history reports.
 		if d.Job.Properties.Priority != "" {
 			fmt.Fprintf(w, "Priority:\t%s\n", d.Job.Properties.Priority)
 		} else if c.Priority != "" {

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/job_submit.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/job_submit.go
@@ -181,6 +181,7 @@ func buildJobResource(def *utils.JobDefinition) *models.JobResource {
 		EnvironmentImageReference: def.Environment,
 		ComputeID:                 def.Compute,
 		GPUCount:                  def.GPUCount,
+		Priority:                  def.Priority,
 		UserAssignedIdentityID:    def.Identity,
 		CodeID:                    def.Code,
 		EnvironmentVariables:      def.EnvironmentVariables,
@@ -229,14 +230,14 @@ func buildJobResource(def *utils.JobDefinition) *models.JobResource {
 		job.Distribution = buildDistribution(def.Distribution)
 	}
 
-	// Resources — prefer structured resources block, fall back to flat instance_count
-	if def.Resources != nil {
+	// Resources — only instance_count survives on the wire. instance_type, slaTier and the
+	// AISuperComputer sub-block are now inferred by the service from the compute cluster;
+	// priority is a top-level CommandJob field; partial GPU allocation is expressed via the
+	// top-level gpu_count field. Accept instance_count from either the structured resources
+	// block or the flat top-level field.
+	if def.Resources != nil && def.Resources.InstanceCount > 0 {
 		job.Resources = &models.ResourceConfig{
 			InstanceCount: def.Resources.InstanceCount,
-			InstanceType:  def.Resources.InstanceType,
-			ShmSize:       def.Resources.ShmSize,
-			DockerArgs:    def.Resources.DockerArgs,
-			Properties:    def.Resources.Properties,
 		}
 	} else if def.InstanceCount > 0 {
 		job.Resources = &models.ResourceConfig{

--- a/cli/azd/extensions/azure.ai.training/internal/cmd/job_submit.go
+++ b/cli/azd/extensions/azure.ai.training/internal/cmd/job_submit.go
@@ -162,7 +162,8 @@ func buildJobResource(def *utils.JobDefinition) *models.JobResource {
 		Command:                   def.Command,
 		EnvironmentImageReference: def.Environment,
 		ComputeID:                 def.Compute,
-		GPUCount:                  def.GPUCount,
+		CapacityUnitCount:         def.CapacityUnitCount,
+		Priority:                  def.Priority,
 		UserAssignedIdentityID:    def.Identity,
 		CodeID:                    def.Code,
 		EnvironmentVariables:      def.EnvironmentVariables,
@@ -209,14 +210,14 @@ func buildJobResource(def *utils.JobDefinition) *models.JobResource {
 		job.Distribution = buildDistribution(def.Distribution)
 	}
 
-	// Resources — prefer structured resources block, fall back to flat instance_count
-	if def.Resources != nil {
+	// Resources — only instance_count survives on the wire. instance_type, slaTier and the
+	// AISuperComputer sub-block are now inferred by the service from the compute cluster;
+	// priority is a top-level CommandJob field; partial-SKU is expressed via top-level
+	// capacity_unit_count. Accept instance_count from either the structured resources block
+	// or the flat top-level field.
+	if def.Resources != nil && def.Resources.InstanceCount > 0 {
 		job.Resources = &models.ResourceConfig{
 			InstanceCount: def.Resources.InstanceCount,
-			InstanceType:  def.Resources.InstanceType,
-			ShmSize:       def.Resources.ShmSize,
-			DockerArgs:    def.Resources.DockerArgs,
-			Properties:    def.Resources.Properties,
 		}
 	} else if def.InstanceCount > 0 {
 		job.Resources = &models.ResourceConfig{

--- a/cli/azd/extensions/azure.ai.training/internal/utils/yaml_parser.go
+++ b/cli/azd/extensions/azure.ai.training/internal/utils/yaml_parser.go
@@ -30,6 +30,7 @@ type JobDefinition struct {
 	Resources             *ResourceDefinition          `yaml:"resources"`
 	InstanceCount         int                          `yaml:"instance_count"`
 	GPUCount              int                          `yaml:"gpu_count"`
+	Priority              string                       `yaml:"priority"`
 	EnvironmentVariables  map[string]string            `yaml:"environment_variables"`
 	Identity              string                       `yaml:"identity"`
 	StorageConnectionName string                       `yaml:"storage_connection_name"`
@@ -78,12 +79,12 @@ type ServiceDefinition struct {
 }
 
 // ResourceDefinition represents the compute resource configuration in a YAML job definition.
+// Only instance_count is honored; instance_type, slaTier, priority and the AISuperComputer
+// properties block have been removed — the service now infers the SKU from the compute
+// cluster, priority is a top-level job field, and users specify partial GPU allocations
+// via the top-level gpu_count field (GPU clusters only).
 type ResourceDefinition struct {
-	InstanceCount int            `yaml:"instance_count"`
-	InstanceType  string         `yaml:"instance_type"`
-	ShmSize       string         `yaml:"shm_size"`
-	DockerArgs    string         `yaml:"docker_args"`
-	Properties    map[string]any `yaml:"properties"`
+	InstanceCount int `yaml:"instance_count"`
 }
 
 // InputDefinition represents an input in the YAML job definition.

--- a/cli/azd/extensions/azure.ai.training/internal/utils/yaml_parser.go
+++ b/cli/azd/extensions/azure.ai.training/internal/utils/yaml_parser.go
@@ -29,7 +29,8 @@ type JobDefinition struct {
 	Distribution         *DistributionDefinition      `yaml:"distribution"`
 	Resources            *ResourceDefinition          `yaml:"resources"`
 	InstanceCount        int                          `yaml:"instance_count"`
-	GPUCount             int                          `yaml:"gpu_count"`
+	CapacityUnitCount    int                          `yaml:"capacity_unit_count"`
+	Priority             string                       `yaml:"priority"`
 	EnvironmentVariables map[string]string            `yaml:"environment_variables"`
 	Identity             string                       `yaml:"identity"`
 	Timeout              string                       `yaml:"timeout"`
@@ -77,12 +78,12 @@ type ServiceDefinition struct {
 }
 
 // ResourceDefinition represents the compute resource configuration in a YAML job definition.
+// Only instance_count is honored; instance_type, slaTier, priority and the AISuperComputer
+// properties block have been removed — the service now infers the SKU from the compute
+// cluster, priority is a top-level job field, and users specify partial capacity via the
+// top-level capacity_unit_count field.
 type ResourceDefinition struct {
-	InstanceCount int            `yaml:"instance_count"`
-	InstanceType  string         `yaml:"instance_type"`
-	ShmSize       string         `yaml:"shm_size"`
-	DockerArgs    string         `yaml:"docker_args"`
-	Properties    map[string]any `yaml:"properties"`
+	InstanceCount int `yaml:"instance_count"`
 }
 
 // InputDefinition represents an input in the YAML job definition.

--- a/cli/azd/extensions/azure.ai.training/pkg/models/common.go
+++ b/cli/azd/extensions/azure.ai.training/pkg/models/common.go
@@ -44,7 +44,11 @@ type Distribution struct {
 	WorkerNodeAdditionalArgs string `json:"workerNodeAdditionalArgs,omitempty"`
 }
 
-// ResourceConfig represents compute resource specifications.
+// ResourceConfig represents compute resource specifications on the wire.
+// On submit, callers only need to set InstanceCount — the service infers the
+// SKU (InstanceType, slaTier, and other properties) from the compute cluster.
+// On Get Job the service echoes what it inferred, so all fields are available
+// on the read path.
 type ResourceConfig struct {
 	InstanceCount int            `json:"instanceCount,omitempty"`
 	InstanceType  string         `json:"instanceType,omitempty"`

--- a/cli/azd/extensions/azure.ai.training/pkg/models/common.go
+++ b/cli/azd/extensions/azure.ai.training/pkg/models/common.go
@@ -45,12 +45,16 @@ type Distribution struct {
 }
 
 // ResourceConfig represents compute resource specifications on the wire.
-// Only instanceCount is honored; instance_type, slaTier, priority and the AISuperComputer
-// properties block have been removed — the service now infers the SKU from the compute
-// cluster, priority is a top-level CommandJob field, and users specify partial capacity via
-// the top-level capacityUnitCount field.
+// On submit, callers only need to set InstanceCount — the service infers the
+// SKU (InstanceType, slaTier, and other properties) from the compute cluster.
+// On Get Job the service echoes what it inferred, so all fields are available
+// on the read path.
 type ResourceConfig struct {
-	InstanceCount int `json:"instanceCount,omitempty"`
+	InstanceCount int            `json:"instanceCount,omitempty"`
+	InstanceType  string         `json:"instanceType,omitempty"`
+	ShmSize       string         `json:"shmSize,omitempty"`
+	DockerArgs    string         `json:"dockerArgs,omitempty"`
+	Properties    map[string]any `json:"properties,omitempty"`
 }
 
 // JobServiceRequest is the request-side shape for a job service (e.g., SSH).

--- a/cli/azd/extensions/azure.ai.training/pkg/models/common.go
+++ b/cli/azd/extensions/azure.ai.training/pkg/models/common.go
@@ -44,13 +44,13 @@ type Distribution struct {
 	WorkerNodeAdditionalArgs string `json:"workerNodeAdditionalArgs,omitempty"`
 }
 
-// ResourceConfig represents compute resource specifications.
+// ResourceConfig represents compute resource specifications on the wire.
+// Only instanceCount is honored; instance_type, slaTier, priority and the AISuperComputer
+// properties block have been removed — the service now infers the SKU from the compute
+// cluster, priority is a top-level CommandJob field, and users specify partial capacity via
+// the top-level capacityUnitCount field.
 type ResourceConfig struct {
-	InstanceCount int            `json:"instanceCount,omitempty"`
-	InstanceType  string         `json:"instanceType,omitempty"`
-	ShmSize       string         `json:"shmSize,omitempty"`
-	DockerArgs    string         `json:"dockerArgs,omitempty"`
-	Properties    map[string]any `json:"properties,omitempty"`
+	InstanceCount int `json:"instanceCount,omitempty"`
 }
 
 // JobServiceRequest is the request-side shape for a job service (e.g., SSH).

--- a/cli/azd/extensions/azure.ai.training/pkg/models/history.go
+++ b/cli/azd/extensions/azure.ai.training/pkg/models/history.go
@@ -49,13 +49,13 @@ type RunHistoryUser struct {
 
 // RunHistoryCompute represents compute details from run history.
 type RunHistoryCompute struct {
-	Target        string `json:"target,omitempty"`
-	TargetType    string `json:"targetType,omitempty"`
-	VMSize        string `json:"vmSize,omitempty"`
-	InstanceType  string `json:"instanceType,omitempty"`
-	InstanceCount int    `json:"instanceCount,omitempty"`
-	GPUCount      int    `json:"gpuCount,omitempty"`
-	Priority      string `json:"priority,omitempty"`
+	Target            string `json:"target,omitempty"`
+	TargetType        string `json:"targetType,omitempty"`
+	VMSize            string `json:"vmSize,omitempty"`
+	InstanceType      string `json:"instanceType,omitempty"`
+	InstanceCount     int    `json:"instanceCount,omitempty"`
+	GPUCount          int    `json:"gpuCount,omitempty"`
+	Priority          string `json:"priority,omitempty"`
 }
 
 // RunHistoryAsset represents an input or output asset reference in run history.

--- a/cli/azd/extensions/azure.ai.training/pkg/models/history.go
+++ b/cli/azd/extensions/azure.ai.training/pkg/models/history.go
@@ -49,13 +49,13 @@ type RunHistoryUser struct {
 
 // RunHistoryCompute represents compute details from run history.
 type RunHistoryCompute struct {
-	Target            string `json:"target,omitempty"`
-	TargetType        string `json:"targetType,omitempty"`
-	VMSize            string `json:"vmSize,omitempty"`
-	InstanceType      string `json:"instanceType,omitempty"`
-	InstanceCount     int    `json:"instanceCount,omitempty"`
-	GPUCount          int    `json:"gpuCount,omitempty"`
-	Priority          string `json:"priority,omitempty"`
+	Target        string `json:"target,omitempty"`
+	TargetType    string `json:"targetType,omitempty"`
+	VMSize        string `json:"vmSize,omitempty"`
+	InstanceType  string `json:"instanceType,omitempty"`
+	InstanceCount int    `json:"instanceCount,omitempty"`
+	GPUCount      int    `json:"gpuCount,omitempty"`
+	Priority      string `json:"priority,omitempty"`
 }
 
 // RunHistoryAsset represents an input or output asset reference in run history.

--- a/cli/azd/extensions/azure.ai.training/pkg/models/history.go
+++ b/cli/azd/extensions/azure.ai.training/pkg/models/history.go
@@ -48,8 +48,6 @@ type RunHistoryUser struct {
 }
 
 // RunHistoryCompute represents compute details from run history.
-// GPUCount is retained for backward-compat reads of pre-capacityUnitCount jobs;
-// new jobs report their allocation via CapacityUnitCount instead.
 type RunHistoryCompute struct {
 	Target            string `json:"target,omitempty"`
 	TargetType        string `json:"targetType,omitempty"`

--- a/cli/azd/extensions/azure.ai.training/pkg/models/history.go
+++ b/cli/azd/extensions/azure.ai.training/pkg/models/history.go
@@ -48,14 +48,17 @@ type RunHistoryUser struct {
 }
 
 // RunHistoryCompute represents compute details from run history.
+// GPUCount is retained for backward-compat reads of pre-capacityUnitCount jobs;
+// new jobs report their allocation via CapacityUnitCount instead.
 type RunHistoryCompute struct {
-	Target        string `json:"target,omitempty"`
-	TargetType    string `json:"targetType,omitempty"`
-	VMSize        string `json:"vmSize,omitempty"`
-	InstanceType  string `json:"instanceType,omitempty"`
-	InstanceCount int    `json:"instanceCount,omitempty"`
-	GPUCount      int    `json:"gpuCount,omitempty"`
-	Priority      string `json:"priority,omitempty"`
+	Target            string `json:"target,omitempty"`
+	TargetType        string `json:"targetType,omitempty"`
+	VMSize            string `json:"vmSize,omitempty"`
+	InstanceType      string `json:"instanceType,omitempty"`
+	InstanceCount     int    `json:"instanceCount,omitempty"`
+	CapacityUnitCount int    `json:"capacityUnitCount,omitempty"`
+	GPUCount          int    `json:"gpuCount,omitempty"`
+	Priority          string `json:"priority,omitempty"`
 }
 
 // RunHistoryAsset represents an input or output asset reference in run history.

--- a/cli/azd/extensions/azure.ai.training/pkg/models/job.go
+++ b/cli/azd/extensions/azure.ai.training/pkg/models/job.go
@@ -24,6 +24,7 @@ type CommandJob struct {
 	CodeID                    string               `json:"codeId,omitempty"`
 	ComputeID                 string               `json:"computeId,omitempty"`
 	GPUCount                  int                  `json:"gpuCount,omitempty"`
+	Priority                  string               `json:"priority,omitempty"`
 	UserAssignedIdentityID    string               `json:"userAssignedIdentityId,omitempty"`
 	Inputs                    map[string]JobInput  `json:"inputs,omitempty"`
 	Outputs                   map[string]JobOutput `json:"outputs,omitempty"`

--- a/cli/azd/extensions/azure.ai.training/pkg/models/job.go
+++ b/cli/azd/extensions/azure.ai.training/pkg/models/job.go
@@ -23,7 +23,8 @@ type CommandJob struct {
 	EnvironmentImageReference string               `json:"environmentImageReference,omitempty"`
 	CodeID                    string               `json:"codeId,omitempty"`
 	ComputeID                 string               `json:"computeId,omitempty"`
-	GPUCount                  int                  `json:"gpuCount,omitempty"`
+	CapacityUnitCount         int                  `json:"capacityUnitCount,omitempty"`
+	Priority                  string               `json:"priority,omitempty"`
 	UserAssignedIdentityID    string               `json:"userAssignedIdentityId,omitempty"`
 	Inputs                    map[string]JobInput  `json:"inputs,omitempty"`
 	Outputs                   map[string]JobOutput `json:"outputs,omitempty"`


### PR DESCRIPTION
### Notes
- Samples updated: https://github.com/microsoft-foundry/foundry-samples-pr/pull/926
- Aligns the training extension with Foundry's new job submission shape.

### Testing
- Bare CPU — no priority, no gpu_count
<img width="1060" height="558" alt="image" src="https://github.com/user-attachments/assets/5c87ca8b-c28a-4f2a-8f46-e0e5d891ea2d" />

- CPU with top-level priority: high
<img width="994" height="434" alt="image" src="https://github.com/user-attachments/assets/52122fd7-925f-4184-bfd8-b20245df7d29" />

- GPU with gpu_count: 2, no resources block
<img width="1031" height="461" alt="image" src="https://github.com/user-attachments/assets/bc11142b-e9e1-41ec-8783-778174036e9c" />
