### PR TITLE
fix(azure.ai.agents): suggest `azd ai project set`, not the removed command

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/project_endpoint.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/project_endpoint.go
@@ -127,7 +127,7 @@ func noProjectEndpointError() error {
 	return exterrors.Dependency(
 		exterrors.CodeMissingProjectEndpoint,
 		"no Foundry project endpoint resolved",
-		"persist a workspace default with `azd ai agent project set <endpoint>`, "+
+		"persist a workspace default with `azd ai project set <endpoint>`, "+
 			"or set FOUNDRY_PROJECT_ENDPOINT in the active azd environment, "+
 			"or export FOUNDRY_PROJECT_ENDPOINT in your shell",
 	)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/project_endpoint_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/project_endpoint_test.go
@@ -105,4 +105,11 @@ func TestNoProjectEndpointError(t *testing.T) {
 	require.ErrorAs(t, err, &localErr)
 	assert.Equal(t, exterrors.CodeMissingProjectEndpoint, localErr.Code)
 	assert.Equal(t, azdext.LocalErrorCategoryDependency, localErr.Category)
+
+	// The suggestion must name the command that actually exists. `azd ai agent
+	// project set` was removed and now lives in azure.ai.projects as
+	// `azd ai project set`, which writes the same config key this extension
+	// reads (projectsExtensionContextPath). See issue #9331.
+	assert.Contains(t, localErr.Suggestion, "azd ai project set")
+	assert.NotContains(t, localErr.Suggestion, "azd ai agent project set")
 }


### PR DESCRIPTION
Fixes #9331

## Problem

When `azure.ai.agents` can't resolve a Foundry project endpoint, `noProjectEndpointError()` returned a suggestion telling the user to run:

```
azd ai agent project set <endpoint>
```

That command no longer exists — it moved to the `azure.ai.projects` extension as `azd ai project set`. A user following the suggestion hits `unknown command`, with no path forward.

This was a missed spot when the command moved. Every peer extension already emits the correct text:

| File | Suggested command |
|---|---|
| `azure.ai.projects/internal/cmd/project_endpoint.go:135` | `azd ai project set` |
| `azure.ai.connections/internal/foundry/projectctx/validator.go:108` | `azd ai project set` |
| `azure.ai.toolboxes/internal/foundry/projectctx/validator.go:108` | `azd ai project set` |
| `azure.ai.skills/internal/cmd/endpoint.go:191` | `azd ai project set` |
| `azure.ai.agents/internal/cmd/project_endpoint.go:130` | `azd ai agent project set` ❌ |

This extension's own `project_context_store.go:19` already describes the command as *removed*, so only the user-facing string was stale.

## Fix

One-line change to the suggestion text.

The new suggestion is also **functionally** correct here, not just cosmetically: `azd ai project set` persists to `extensions.ai-projects.context`, and `getProjectContext` (`project_context_store.go`) already reads that key as the canonical source, ahead of the legacy fallback. So a user who follows the corrected suggestion actually unblocks themselves.

## Regression coverage

`TestNoProjectEndpointError` previously asserted only the error code and category, which is why this drifted unnoticed. It now also asserts the suggestion names `azd ai project set` and does not contain `azd ai agent project set`.

Verified the assertion is meaningful — `"azd ai agent project set"` does **not** contain `"azd ai project set"` as a substring, so the new `assert.Contains` fails against the old string.

## Validation

From `cli/azd/extensions/azure.ai.agents`:

- `go build ./...` — clean
- `go test ./internal/cmd/ -count=1` — ok (full package, 22.0s)
- `gofmt -s -l ./internal` — no output
- `golangci-lint run ./internal/cmd/...` — 0 issues

## Notes

- Extension-only change; no core `cli/azd` changes, so this needs no core release.
- No `go.mod` / `go.sum` changes.
- Per `cli/azd/AGENTS.md`, `CHANGELOG.md` is intentionally left to the release/version-bump PR.
