### PR TITLE
Update GitHub CLI to v2.97.0

### DIFF
--- a/cli/azd/pkg/tools/github/github.go
+++ b/cli/azd/pkg/tools/github/github.go
@@ -39,7 +39,7 @@ func NewGitHubCli(console input.Console, commandRunner exec.CommandRunner) *Cli 
 
 // Version is the minimum version of GitHub cli that we require (and the one we fetch when we fetch gh on
 // behalf of a user).
-var Version semver.Version = semver.MustParse("2.96.0")
+var Version semver.Version = semver.MustParse("2.97.0")
 
 // newGitHubCliImplementation is like NewGitHubCli but allows providing a custom transport for testing.
 func newGitHubCliImplementation(
@@ -683,7 +683,7 @@ func downloadGh(
 		return fmt.Errorf("unsupported platform")
 	}
 
-	// example: https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_arm64.tar.gz
+	// example: https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_linux_arm64.tar.gz
 	ghReleaseUrl := fmt.Sprintf("https://github.com/cli/cli/releases/download/v%s/%s", ghVersion, releaseName)
 
 	log.Printf("downloading github cli release %s -> %s", ghReleaseUrl, releaseName)


### PR DESCRIPTION
Updates the bundled GitHub CLI version from 2.96.0 to 2.97.0.

Fixes #9379

Release: https://github.com/cli/cli/releases/tag/v2.97.0

## Changes

- Bumped `Version` constant in `cli/azd/pkg/tools/github/github.go`