### PR TITLE
Improve Azure DevOps setup task version handling

### DIFF
--- a/ext/azuredevops/CHANGELOG.md
+++ b/ext/azuredevops/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.2.1 (2026-08-03)
+
+- Validates requested versions and runs installer scripts with explicit arguments.
+
 ## 1.2.0 (2026-01-14)
 
 - Moving release from manual to pipeline.

--- a/ext/azuredevops/README.md
+++ b/ext/azuredevops/README.md
@@ -4,7 +4,7 @@ This Azure DevOps task allows you to provision resources and deploy your applica
 
 The task installs the Azure Developer CLI on a user-defined Azure Developer CLI version. If the user does not specify a version, latest CLI version is used. Read more about various Azure Developer CLI versions [here](https://github.com/Azure/azure-dev/releases).
 
-- `version` – **Optional** Example: 1.13.0, Default: set to latest azd cli version.
+- `version` – **Optional** Use `latest`, `daily`, or a semantic version such as `1.13.0` or `1.14.0-beta.1`. Defaults to `latest`.
 
 ## Sample pipeline install latest `azd` version
 

--- a/ext/azuredevops/README.md
+++ b/ext/azuredevops/README.md
@@ -4,7 +4,7 @@ This Azure DevOps task allows you to provision resources and deploy your applica
 
 The task installs the Azure Developer CLI on a user-defined Azure Developer CLI version. If the user does not specify a version, latest CLI version is used. Read more about various Azure Developer CLI versions [here](https://github.com/Azure/azure-dev/releases).
 
-- `version` – **Optional** Use `latest`, `daily`, or a semantic version such as `1.13.0` or `1.14.0-beta.1`. Defaults to `latest`.
+- `version` – **Optional** Use `latest`, `stable`, `daily`, or a semantic version such as `1.13.0` or `1.14.0-beta.1`. Defaults to `latest`.
 
 ## Sample pipeline install latest `azd` version
 

--- a/ext/azuredevops/setupAzd/.gitignore
+++ b/ext/azuredevops/setupAzd/.gitignore
@@ -1,4 +1,5 @@
 index.js
+version.js
 node_modules
 .taskkey
 index.js

--- a/ext/azuredevops/setupAzd/index.ts
+++ b/ext/azuredevops/setupAzd/index.ts
@@ -30,7 +30,7 @@ export async function runMain(): Promise<void> {
         if (!isValidVersion(version)) {
             task.setResult(
                 task.TaskResult.Failed,
-                'Version must be latest, daily, or a semantic version such as 1.2.3.',
+                'Version must be latest, stable, daily, or a semantic version such as 1.2.3.',
             )
             return
         }
@@ -56,6 +56,7 @@ export async function runMain(): Promise<void> {
                     ...process.env,
                     AZD_INSTALL_SCRIPT: installScriptPath,
                 },
+                ignoreReturnCode: true,
             })
             if (downloadResult !== 0) {
                 task.setResult(task.TaskResult.Failed, `Failed to download the azd installer. Exit code: ${downloadResult}`)
@@ -72,7 +73,7 @@ export async function runMain(): Promise<void> {
             installer.arg(version)
             installer.arg('-Verbose')
 
-            const installResult = await installer.exec()
+            const installResult = await installer.exec({ ignoreReturnCode: true })
             if (installResult !== 0) {
                 task.setResult(task.TaskResult.Failed, `Failed to install azd. Exit code: ${installResult}`)
                 return
@@ -85,7 +86,7 @@ export async function runMain(): Promise<void> {
             const azdPath = `${localAppData}\\Programs\\Azure Dev CLI\\azd.exe`
             const azd: toolRunner.ToolRunner = task.tool(azdPath)
             azd.arg('version')
-            const versionResult = await azd.exec()
+            const versionResult = await azd.exec({ ignoreReturnCode: true })
             if (versionResult !== 0) {
                 task.setResult(task.TaskResult.Failed, `azd version check failed. Exit code: ${versionResult}`)
                 return
@@ -101,7 +102,7 @@ export async function runMain(): Promise<void> {
             download.arg('https://aka.ms/install-azd.sh')
             download.arg('-o')
             download.arg(installScriptPath)
-            const downloadResult = await download.exec()
+            const downloadResult = await download.exec({ ignoreReturnCode: true })
             if (downloadResult !== 0) {
                 task.setResult(task.TaskResult.Failed, `Failed to download the azd installer. Exit code: ${downloadResult}`)
                 return
@@ -114,7 +115,7 @@ export async function runMain(): Promise<void> {
             installer.arg(version)
             installer.arg('--verbose')
 
-            const installResult = await installer.exec()
+            const installResult = await installer.exec({ ignoreReturnCode: true })
             if (installResult !== 0) {
                 task.setResult(task.TaskResult.Failed, `Failed to install azd. Exit code: ${installResult}`)
                 return
@@ -127,9 +128,9 @@ export async function runMain(): Promise<void> {
     } finally {
         if (tempDirectory) {
             try {
-                await rm(tempDirectory, { recursive: true, force: true })
+                await rm(tempDirectory, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 })
             } catch (err: unknown) {
-                task.setResult(task.TaskResult.Failed, `Failed to clean up installer files: ${errorMessage(err)}`)
+                task.warning(`Failed to clean up installer files: ${errorMessage(err)}`)
             }
         }
     }

--- a/ext/azuredevops/setupAzd/index.ts
+++ b/ext/azuredevops/setupAzd/index.ts
@@ -4,13 +4,7 @@ import * as path from 'path'
 import * as task from 'azure-pipelines-task-lib/task'
 import * as toolRunner from 'azure-pipelines-task-lib/toolrunner'
 
-const numericIdentifier = '(?:0|[1-9]\\d*)'
-const prereleaseIdentifier = `(?:${numericIdentifier}|\\d*[A-Za-z-][0-9A-Za-z-]*)`
-const semanticVersion =
-    `${numericIdentifier}\\.${numericIdentifier}\\.${numericIdentifier}` +
-    `(?:-${prereleaseIdentifier}(?:\\.${prereleaseIdentifier})*)?` +
-    '(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?'
-const validVersionPattern = new RegExp(`^(?:latest|daily|${semanticVersion})$`)
+import { isValidVersion } from './version'
 
 function errorMessage(err: unknown): string {
     return err instanceof Error ? err.message : String(err)
@@ -33,7 +27,7 @@ export async function runMain(): Promise<void> {
             return
         }
         const version = task.getInput('version') || 'latest'
-        if (version.length > 128 || !validVersionPattern.test(version)) {
+        if (!isValidVersion(version)) {
             task.setResult(
                 task.TaskResult.Failed,
                 'Version must be latest, daily, or a semantic version such as 1.2.3.',

--- a/ext/azuredevops/setupAzd/index.ts
+++ b/ext/azuredevops/setupAzd/index.ts
@@ -1,13 +1,30 @@
+import { mkdtemp, rm } from 'fs/promises'
+import * as os from 'os'
+import * as path from 'path'
 import * as task from 'azure-pipelines-task-lib/task'
 import * as toolRunner from 'azure-pipelines-task-lib/toolrunner'
 
+const numericIdentifier = '(?:0|[1-9]\\d*)'
+const prereleaseIdentifier = `(?:${numericIdentifier}|\\d*[A-Za-z-][0-9A-Za-z-]*)`
+const semanticVersion =
+    `${numericIdentifier}\\.${numericIdentifier}\\.${numericIdentifier}` +
+    `(?:-${prereleaseIdentifier}(?:\\.${prereleaseIdentifier})*)?` +
+    '(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?'
+const validVersionPattern = new RegExp(`^(?:latest|daily|${semanticVersion})$`)
+
+function errorMessage(err: unknown): string {
+    return err instanceof Error ? err.message : String(err)
+}
+
 export async function runMain(): Promise<void> {
+    let tempDirectory: string | undefined
+
     try {
         task.setTaskVariable('hasRunMain', 'true')
-        const os = process.platform
+        const platform = os.platform()
         const localAppData = process.env.LocalAppData
         const envPath = process.env.PATH
-        if (os === 'win32' && !localAppData) {
+        if (platform === 'win32' && !localAppData) {
             task.setResult(task.TaskResult.Failed, 'LocalAppData environment variable is not defined.')
             return
         }
@@ -16,20 +33,52 @@ export async function runMain(): Promise<void> {
             return
         }
         const version = task.getInput('version') || 'latest'
+        if (version.length > 128 || !validVersionPattern.test(version)) {
+            task.setResult(
+                task.TaskResult.Failed,
+                'Version must be latest, daily, or a semantic version such as 1.2.3.',
+            )
+            return
+        }
 
-        console.log(`Installing azd version ${version} on ${os}.`)
+        console.log(`Installing azd version ${version} on ${platform}.`)
+        tempDirectory = await mkdtemp(path.join(os.tmpdir(), 'setup-azd-'))
 
-        if (os === 'win32') {
+        if (platform === 'win32') {
+            const installScriptPath = path.join(tempDirectory, 'install-azd.ps1')
             const powershellPath = task.which('powershell', true)
-            const powershell: toolRunner.ToolRunner = task.tool(powershellPath)
-            const installScript = `$scriptPath = "$($env:TEMP)\\install-azd.ps1"; Invoke-RestMethod 'https://aka.ms/install-azd.ps1' -OutFile $scriptPath; . $scriptPath -Version '${version}' -Verbose:$true; Remove-Item $scriptPath`
-            powershell.arg('-NoLogo')
-            powershell.arg('-NoProfile')
-            powershell.arg('-NonInteractive')
-            powershell.arg('-Command')
-            powershell.arg(installScript)
-            
-            const installResult = await powershell.exec()
+            const download: toolRunner.ToolRunner = task.tool(powershellPath)
+            download.arg('-NoLogo')
+            download.arg('-NoProfile')
+            download.arg('-NonInteractive')
+            download.arg('-Command')
+            download.arg(
+                "$ErrorActionPreference = 'Stop'; " +
+                    "Invoke-RestMethod -Uri 'https://aka.ms/install-azd.ps1' -OutFile $env:AZD_INSTALL_SCRIPT",
+            )
+
+            const downloadResult = await download.exec({
+                env: {
+                    ...process.env,
+                    AZD_INSTALL_SCRIPT: installScriptPath,
+                },
+            })
+            if (downloadResult !== 0) {
+                task.setResult(task.TaskResult.Failed, `Failed to download the azd installer. Exit code: ${downloadResult}`)
+                return
+            }
+
+            const installer: toolRunner.ToolRunner = task.tool(powershellPath)
+            installer.arg('-NoLogo')
+            installer.arg('-NoProfile')
+            installer.arg('-NonInteractive')
+            installer.arg('-File')
+            installer.arg(installScriptPath)
+            installer.arg('-Version')
+            installer.arg(version)
+            installer.arg('-Verbose')
+
+            const installResult = await installer.exec()
             if (installResult !== 0) {
                 task.setResult(task.TaskResult.Failed, `Failed to install azd. Exit code: ${installResult}`)
                 return
@@ -49,20 +98,46 @@ export async function runMain(): Promise<void> {
             }
         } else {
             const bashPath = task.which('bash', true)
-            const bash: toolRunner.ToolRunner = task.tool(bashPath)
-            bash.arg('-c')
-            bash.arg(`curl -fsSL https://aka.ms/install-azd.sh | sudo bash -s -- --version ${version} --verbose`)
-            
-            const installResult = await bash.exec()
+            const curlPath = task.which('curl', true)
+            const sudoPath = task.which('sudo', true)
+            const installScriptPath = path.join(tempDirectory, 'install-azd.sh')
+
+            const download: toolRunner.ToolRunner = task.tool(curlPath)
+            download.arg('-fsSL')
+            download.arg('https://aka.ms/install-azd.sh')
+            download.arg('-o')
+            download.arg(installScriptPath)
+            const downloadResult = await download.exec()
+            if (downloadResult !== 0) {
+                task.setResult(task.TaskResult.Failed, `Failed to download the azd installer. Exit code: ${downloadResult}`)
+                return
+            }
+
+            const installer: toolRunner.ToolRunner = task.tool(sudoPath)
+            installer.arg(bashPath)
+            installer.arg(installScriptPath)
+            installer.arg('--version')
+            installer.arg(version)
+            installer.arg('--verbose')
+
+            const installResult = await installer.exec()
             if (installResult !== 0) {
                 task.setResult(task.TaskResult.Failed, `Failed to install azd. Exit code: ${installResult}`)
                 return
             }
         }
-        
+
         console.log(`Successfully installed azd version ${version}.`)
-    } catch (err: any) {
-        task.setResult(task.TaskResult.Failed, err.message)
+    } catch (err: unknown) {
+        task.setResult(task.TaskResult.Failed, errorMessage(err))
+    } finally {
+        if (tempDirectory) {
+            try {
+                await rm(tempDirectory, { recursive: true, force: true })
+            } catch (err: unknown) {
+                task.setResult(task.TaskResult.Failed, `Failed to clean up installer files: ${errorMessage(err)}`)
+            }
+        }
     }
 }
 

--- a/ext/azuredevops/setupAzd/package-lock.json
+++ b/ext/azuredevops/setupAzd/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-azd",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-azd",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.276.0"

--- a/ext/azuredevops/setupAzd/package.json
+++ b/ext/azuredevops/setupAzd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-azd",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/ext/azuredevops/setupAzd/task.json
+++ b/ext/azuredevops/setupAzd/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 1,
         "Minor": 2,
-        "Patch": 0
+        "Patch": 1
     },
     "instanceNameFormat": "Installs azd: $(rootFolder)",
     "inputs": [
@@ -18,7 +18,8 @@
             "name": "version",
             "type": "string",
             "label": "The version of azd to install (default: latest)",
-            "required": false
+            "required": false,
+            "helpMarkDown": "Use `latest`, `daily`, or a semantic version such as `1.13.0` or `1.14.0-beta.1`."
         }
     ],
     "execution": {

--- a/ext/azuredevops/setupAzd/task.json
+++ b/ext/azuredevops/setupAzd/task.json
@@ -19,7 +19,7 @@
             "type": "string",
             "label": "The version of azd to install (default: latest)",
             "required": false,
-            "helpMarkDown": "Use `latest`, `daily`, or a semantic version such as `1.13.0` or `1.14.0-beta.1`."
+            "helpMarkDown": "Use `latest`, `stable`, `daily`, or a semantic version such as `1.13.0` or `1.14.0-beta.1`."
         }
     ],
     "execution": {

--- a/ext/azuredevops/setupAzd/tests/_suite.ts
+++ b/ext/azuredevops/setupAzd/tests/_suite.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as assert from 'assert';
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
+import { isValidVersion } from '../version';
 
 describe('Setup azd task tests', function () {
 
@@ -84,5 +85,35 @@ describe('Setup azd task tests', function () {
         }).catch((error) => {
             done(error);
         });
+    });
+
+    it('should accept supported version formats', function() {
+        const versions = [
+            'latest',
+            'daily',
+            '1.0.0',
+            '1.14.0-beta.1',
+            '1.14.0-beta.1+build.5',
+        ];
+
+        for (const version of versions) {
+            assert.equal(isValidVersion(version), true, `should accept ${version}`);
+        }
+    });
+
+    it('should reject unsupported version formats', function() {
+        const versions = [
+            '01.2.3',
+            '1.02.3',
+            '1.2.03',
+            '1.2.3-01',
+            '1.2',
+            '1.2.3.4',
+            'latest ',
+        ];
+
+        for (const version of versions) {
+            assert.equal(isValidVersion(version), false, `should reject ${version}`);
+        }
     });
 });

--- a/ext/azuredevops/setupAzd/tests/_suite.ts
+++ b/ext/azuredevops/setupAzd/tests/_suite.ts
@@ -114,6 +114,7 @@ describe('Setup azd task tests', function () {
             '1.2',
             '1.2.3.4',
             'latest ',
+            'latest\n',
         ];
 
         for (const version of versions) {

--- a/ext/azuredevops/setupAzd/tests/_suite.ts
+++ b/ext/azuredevops/setupAzd/tests/_suite.ts
@@ -68,4 +68,21 @@ describe('Setup azd task tests', function () {
             done(error);
         });
     });
+
+    it('should reject an invalid version format', function(done: Mocha.Done) {
+        this.timeout(30000);
+
+        const tp: string = path.join(__dirname, 'invalidVersionFormat.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.runAsync().then(() => {
+            assert.equal(tr.succeeded, false, 'should have failed');
+            assert.equal(tr.warningIssues.length, 0, 'should have no warnings');
+            assert.ok(tr.errorIssues.some((issue) => issue.includes('Version must be')), 'should report an invalid version');
+            assert.equal(tr.stdout.indexOf('Installing azd version'), -1, 'should fail before installation');
+            done();
+        }).catch((error) => {
+            done(error);
+        });
+    });
 });

--- a/ext/azuredevops/setupAzd/tests/_suite.ts
+++ b/ext/azuredevops/setupAzd/tests/_suite.ts
@@ -63,7 +63,10 @@ describe('Setup azd task tests', function () {
         tr.runAsync().then(() => {
             assert.equal(tr.succeeded, false, 'should have failed');
             assert.equal(tr.warningIssues.length, 0, 'should have no warnings');
-            assert.ok(tr.errorIssues.length > 0, 'should have at least one error');
+            assert.ok(
+                tr.errorIssues.some((issue) => issue.includes('Failed to install azd. Exit code: 1')),
+                'should report the installer exit code',
+            );
             done();
         }).catch((error) => {
             done(error);
@@ -90,6 +93,7 @@ describe('Setup azd task tests', function () {
     it('should accept supported version formats', function() {
         const versions = [
             'latest',
+            'stable',
             'daily',
             '1.0.0',
             '1.14.0-beta.1',
@@ -115,5 +119,65 @@ describe('Setup azd task tests', function () {
         for (const version of versions) {
             assert.equal(isValidVersion(version), false, `should reject ${version}`);
         }
+    });
+
+    it('should warn when installer cleanup fails', function(done: Mocha.Done) {
+        this.timeout(30000);
+
+        const tp: string = path.join(__dirname, 'cleanupFailure.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.runAsync().then(() => {
+            assert.equal(tr.succeeded, true, 'should have succeeded');
+            assert.equal(tr.errorIssues.length, 0, 'should have no errors');
+            assert.ok(
+                tr.warningIssues.some((issue) => issue.includes('Failed to clean up installer files')),
+                'should report the cleanup warning',
+            );
+            done();
+        }).catch((error) => {
+            done(error);
+        });
+    });
+
+    it('should preserve installer errors when cleanup also fails', function(done: Mocha.Done) {
+        this.timeout(30000);
+
+        const tp: string = path.join(__dirname, 'installAndCleanupFailure.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.runAsync().then(() => {
+            assert.equal(tr.succeeded, false, 'should have failed');
+            assert.ok(
+                tr.errorIssues.some((issue) => issue.includes('Failed to install azd. Exit code: 1')),
+                'should preserve the installer error',
+            );
+            assert.ok(
+                tr.warningIssues.some((issue) => issue.includes('Failed to clean up installer files')),
+                'should report the cleanup warning',
+            );
+            done();
+        }).catch((error) => {
+            done(error);
+        });
+    });
+
+    it('should report download failures with the exit code', function(done: Mocha.Done) {
+        this.timeout(30000);
+
+        const tp: string = path.join(__dirname, 'downloadFailure.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.runAsync().then(() => {
+            assert.equal(tr.succeeded, false, 'should have failed');
+            assert.equal(tr.warningIssues.length, 0, 'should have no warnings');
+            assert.ok(
+                tr.errorIssues.some((issue) => issue.includes('Failed to download the azd installer. Exit code: 1')),
+                'should report the download exit code',
+            );
+            done();
+        }).catch((error) => {
+            done(error);
+        });
     });
 });

--- a/ext/azuredevops/setupAzd/tests/cleanupFailure.ts
+++ b/ext/azuredevops/setupAzd/tests/cleanupFailure.ts
@@ -1,0 +1,47 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import os = require('os');
+import path = require('path');
+
+const taskPath = path.join(__dirname, '..', 'index.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+const tempDirectory = '/tmp/setup-azd-test';
+const installScriptPath = path.join(tempDirectory, 'install-azd.sh');
+
+tmr.registerMock('os', {
+    ...os,
+    platform: () => 'linux',
+});
+tmr.registerMock('fs/promises', {
+    mkdtemp: async () => tempDirectory,
+    rm: async () => {
+        throw new Error('directory is busy');
+    },
+});
+tmr.setInput('version', 'stable');
+
+const answers: ma.TaskLibAnswers = {
+    which: {
+        'bash': '/bin/bash',
+        'curl': '/usr/bin/curl',
+        'sudo': '/usr/bin/sudo',
+    },
+    checkPath: {
+        '/bin/bash': true,
+        '/usr/bin/curl': true,
+        '/usr/bin/sudo': true,
+    },
+    exec: {
+        [`/usr/bin/curl -fsSL https://aka.ms/install-azd.sh -o ${installScriptPath}`]: {
+            code: 0,
+            stdout: 'Downloaded azd installer',
+        },
+        [`/usr/bin/sudo /bin/bash ${installScriptPath} --version stable --verbose`]: {
+            code: 0,
+            stdout: 'azd installed successfully',
+        },
+    },
+};
+
+tmr.setAnswers(answers);
+tmr.run();

--- a/ext/azuredevops/setupAzd/tests/downloadFailure.ts
+++ b/ext/azuredevops/setupAzd/tests/downloadFailure.ts
@@ -1,0 +1,41 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import os = require('os');
+import path = require('path');
+
+const taskPath = path.join(__dirname, '..', 'index.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+const tempDirectory = '/tmp/setup-azd-test';
+const installScriptPath = path.join(tempDirectory, 'install-azd.sh');
+
+tmr.registerMock('os', {
+    ...os,
+    platform: () => 'linux',
+});
+tmr.registerMock('fs/promises', {
+    mkdtemp: async () => tempDirectory,
+    rm: async () => undefined,
+});
+tmr.setInput('version', 'latest');
+
+const answers: ma.TaskLibAnswers = {
+    which: {
+        'bash': '/bin/bash',
+        'curl': '/usr/bin/curl',
+        'sudo': '/usr/bin/sudo',
+    },
+    checkPath: {
+        '/bin/bash': true,
+        '/usr/bin/curl': true,
+        '/usr/bin/sudo': true,
+    },
+    exec: {
+        [`/usr/bin/curl -fsSL https://aka.ms/install-azd.sh -o ${installScriptPath}`]: {
+            code: 1,
+            stdout: 'Download failed',
+        },
+    },
+};
+
+tmr.setAnswers(answers);
+tmr.run();

--- a/ext/azuredevops/setupAzd/tests/installAndCleanupFailure.ts
+++ b/ext/azuredevops/setupAzd/tests/installAndCleanupFailure.ts
@@ -1,0 +1,47 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import os = require('os');
+import path = require('path');
+
+const taskPath = path.join(__dirname, '..', 'index.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+const tempDirectory = '/tmp/setup-azd-test';
+const installScriptPath = path.join(tempDirectory, 'install-azd.sh');
+
+tmr.registerMock('os', {
+    ...os,
+    platform: () => 'linux',
+});
+tmr.registerMock('fs/promises', {
+    mkdtemp: async () => tempDirectory,
+    rm: async () => {
+        throw new Error('directory is busy');
+    },
+});
+tmr.setInput('version', '1.9999999.0');
+
+const answers: ma.TaskLibAnswers = {
+    which: {
+        'bash': '/bin/bash',
+        'curl': '/usr/bin/curl',
+        'sudo': '/usr/bin/sudo',
+    },
+    checkPath: {
+        '/bin/bash': true,
+        '/usr/bin/curl': true,
+        '/usr/bin/sudo': true,
+    },
+    exec: {
+        [`/usr/bin/curl -fsSL https://aka.ms/install-azd.sh -o ${installScriptPath}`]: {
+            code: 0,
+            stdout: 'Downloaded azd installer',
+        },
+        [`/usr/bin/sudo /bin/bash ${installScriptPath} --version 1.9999999.0 --verbose`]: {
+            code: 1,
+            stdout: 'Could not download azd version 1.9999999.0',
+        },
+    },
+};
+
+tmr.setAnswers(answers);
+tmr.run();

--- a/ext/azuredevops/setupAzd/tests/invalidVersion.ts
+++ b/ext/azuredevops/setupAzd/tests/invalidVersion.ts
@@ -1,35 +1,47 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
+import os = require('os');
 import path = require('path');
 
 const taskPath = path.join(__dirname, '..', 'index.js');
 const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+const tempDirectory = '/tmp/setup-azd-test';
+const installScriptPath = path.join(tempDirectory, 'install-azd.sh');
+
+tmr.registerMock('os', {
+    ...os,
+    platform: () => 'linux',
+});
+tmr.registerMock('fs/promises', {
+    mkdtemp: async () => tempDirectory,
+    rm: async () => undefined,
+});
 
 // Set input with an invalid version
 tmr.setInput('version', '1.9999999.0');
 
-// Mock answers - simulate failure for invalid version (Windows and Linux/Mac)
+// Mock answers - simulate failure for an unavailable version
 const answers: ma.TaskLibAnswers = {
     which: {
-        'powershell': 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
-        'bash': '/bin/bash'
+        'bash': '/bin/bash',
+        'curl': '/usr/bin/curl',
+        'sudo': '/usr/bin/sudo',
     },
     checkPath: {
-        'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe': true,
-        '/bin/bash': true
+        '/bin/bash': true,
+        '/usr/bin/curl': true,
+        '/usr/bin/sudo': true,
     },
     exec: {
-        // Windows PowerShell install command - fails with invalid version
-        [`C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoLogo -NoProfile -NonInteractive -Command $scriptPath = "$($env:TEMP)\\install-azd.ps1"; Invoke-RestMethod 'https://aka.ms/install-azd.ps1' -OutFile $scriptPath; . $scriptPath -Version '1.9999999.0' -Verbose:$true; Remove-Item $scriptPath`]: {
-            code: 1,
-            stdout: 'Could not download - version 1.9999999.0 not found'
+        [`/usr/bin/curl -fsSL https://aka.ms/install-azd.sh -o ${installScriptPath}`]: {
+            code: 0,
+            stdout: 'Downloaded azd installer',
         },
-        // Linux/Mac bash install command - fails with invalid version
-        '/bin/bash -c curl -fsSL https://aka.ms/install-azd.sh | sudo bash -s -- --version 1.9999999.0 --verbose': {
+        [`/usr/bin/sudo /bin/bash ${installScriptPath} --version 1.9999999.0 --verbose`]: {
             code: 1,
-            stdout: 'Could not download from https://aka.ms/install-azd.sh - version 1.9999999.0 not found'
-        }
-    }
+            stdout: 'Could not download azd version 1.9999999.0',
+        },
+    },
 };
 
 tmr.setAnswers(answers);

--- a/ext/azuredevops/setupAzd/tests/invalidVersionFormat.ts
+++ b/ext/azuredevops/setupAzd/tests/invalidVersionFormat.ts
@@ -1,0 +1,13 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import os = require('os');
+import path = require('path');
+
+const taskPath = path.join(__dirname, '..', 'index.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.registerMock('os', {
+    ...os,
+    platform: () => 'linux',
+});
+tmr.setInput('version', "latest'; Write-Output unexpected #");
+tmr.run();

--- a/ext/azuredevops/setupAzd/tests/success.ts
+++ b/ext/azuredevops/setupAzd/tests/success.ts
@@ -1,44 +1,47 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
+import os = require('os');
 import path = require('path');
 
 const taskPath = path.join(__dirname, '..', 'index.js');
 const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+const tempDirectory = '/tmp/setup-azd-test';
+const installScriptPath = path.join(tempDirectory, 'install-azd.sh');
+
+tmr.registerMock('os', {
+    ...os,
+    platform: () => 'linux',
+});
+tmr.registerMock('fs/promises', {
+    mkdtemp: async () => tempDirectory,
+    rm: async () => undefined,
+});
 
 // Set input for success scenario (empty version = latest)
 tmr.setInput('version', '');
 
-// Get the mocked LocalAppData path for Windows
-const mockLocalAppData = process.env.LocalAppData || 'C:\\Users\\test\\AppData\\Local';
-const azdExePath = `${mockLocalAppData}\\Programs\\Azure Dev CLI\\azd.exe`;
-
-// Mock answers for tool lookups and executions (Windows and Linux/Mac)
+// Mock answers for tool lookups and executions
 const answers: ma.TaskLibAnswers = {
     which: {
-        'powershell': 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
-        'bash': '/bin/bash'
+        'bash': '/bin/bash',
+        'curl': '/usr/bin/curl',
+        'sudo': '/usr/bin/sudo',
     },
     checkPath: {
-        'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe': true,
-        '/bin/bash': true
+        '/bin/bash': true,
+        '/usr/bin/curl': true,
+        '/usr/bin/sudo': true,
     },
     exec: {
-        // Windows PowerShell install command
-        [`C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoLogo -NoProfile -NonInteractive -Command $scriptPath = "$($env:TEMP)\\install-azd.ps1"; Invoke-RestMethod 'https://aka.ms/install-azd.ps1' -OutFile $scriptPath; . $scriptPath -Version 'latest' -Verbose:$true; Remove-Item $scriptPath`]: {
+        [`/usr/bin/curl -fsSL https://aka.ms/install-azd.sh -o ${installScriptPath}`]: {
             code: 0,
-            stdout: 'azd installed successfully'
+            stdout: 'Downloaded azd installer',
         },
-        // Windows azd version check
-        [`${azdExePath} version`]: {
+        [`/usr/bin/sudo /bin/bash ${installScriptPath} --version latest --verbose`]: {
             code: 0,
-            stdout: 'azd version 1.0.0'
+            stdout: 'azd installed successfully',
         },
-        // Linux/Mac bash install command  
-        '/bin/bash -c curl -fsSL https://aka.ms/install-azd.sh | sudo bash -s -- --version latest --verbose': {
-            code: 0,
-            stdout: 'azd installed successfully'
-        }
-    }
+    },
 };
 
 tmr.setAnswers(answers);

--- a/ext/azuredevops/setupAzd/tests/successVersion.ts
+++ b/ext/azuredevops/setupAzd/tests/successVersion.ts
@@ -1,44 +1,52 @@
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
+import os = require('os');
 import path = require('path');
 
 const taskPath = path.join(__dirname, '..', 'index.js');
 const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+const tempDirectory = '/tmp/setup-azd-test';
+const installScriptPath = path.join(tempDirectory, 'install-azd.ps1');
+
+tmr.registerMock('os', {
+    ...os,
+    platform: () => 'win32',
+});
+tmr.registerMock('fs/promises', {
+    mkdtemp: async () => tempDirectory,
+    rm: async () => undefined,
+});
 
 // Set input for success with specific version
 tmr.setInput('version', '1.0.0');
 
 // Get the mocked LocalAppData path for Windows
 const mockLocalAppData = process.env.LocalAppData || 'C:\\Users\\test\\AppData\\Local';
+process.env.LocalAppData = mockLocalAppData;
 const azdExePath = `${mockLocalAppData}\\Programs\\Azure Dev CLI\\azd.exe`;
 
-// Mock answers for tool lookups and executions (Windows and Linux/Mac)
+// Mock answers for tool lookups and executions
 const answers: ma.TaskLibAnswers = {
     which: {
         'powershell': 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
-        'bash': '/bin/bash'
     },
     checkPath: {
         'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe': true,
-        '/bin/bash': true
     },
     exec: {
-        // Windows PowerShell install command
-        [`C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoLogo -NoProfile -NonInteractive -Command $scriptPath = "$($env:TEMP)\\install-azd.ps1"; Invoke-RestMethod 'https://aka.ms/install-azd.ps1' -OutFile $scriptPath; . $scriptPath -Version '1.0.0' -Verbose:$true; Remove-Item $scriptPath`]: {
+        [`C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoLogo -NoProfile -NonInteractive -Command $ErrorActionPreference = 'Stop'; Invoke-RestMethod -Uri 'https://aka.ms/install-azd.ps1' -OutFile $env:AZD_INSTALL_SCRIPT`]: {
             code: 0,
-            stdout: 'azd version 1.0.0 installed successfully'
+            stdout: 'Downloaded azd installer',
         },
-        // Windows azd version check
+        [`C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoLogo -NoProfile -NonInteractive -File ${installScriptPath} -Version 1.0.0 -Verbose`]: {
+            code: 0,
+            stdout: 'azd version 1.0.0 installed successfully',
+        },
         [`${azdExePath} version`]: {
             code: 0,
-            stdout: 'azd version 1.0.0'
+            stdout: 'azd version 1.0.0',
         },
-        // Linux/Mac bash install command
-        '/bin/bash -c curl -fsSL https://aka.ms/install-azd.sh | sudo bash -s -- --version 1.0.0 --verbose': {
-            code: 0,
-            stdout: 'azd version 1.0.0 installed successfully'
-        }
-    }
+    },
 };
 
 tmr.setAnswers(answers);

--- a/ext/azuredevops/setupAzd/version.ts
+++ b/ext/azuredevops/setupAzd/version.ts
@@ -1,0 +1,11 @@
+const numericIdentifier = '(?:0|[1-9]\\d*)'
+const prereleaseIdentifier = `(?:${numericIdentifier}|\\d*[A-Za-z-][0-9A-Za-z-]*)`
+const semanticVersion =
+    `${numericIdentifier}\\.${numericIdentifier}\\.${numericIdentifier}` +
+    `(?:-${prereleaseIdentifier}(?:\\.${prereleaseIdentifier})*)?` +
+    '(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?'
+const validVersionPattern = new RegExp(`^(?:latest|daily|${semanticVersion})$`)
+
+export function isValidVersion(version: string): boolean {
+    return version.length <= 128 && validVersionPattern.test(version)
+}

--- a/ext/azuredevops/setupAzd/version.ts
+++ b/ext/azuredevops/setupAzd/version.ts
@@ -4,7 +4,8 @@ const semanticVersion =
     `${numericIdentifier}\\.${numericIdentifier}\\.${numericIdentifier}` +
     `(?:-${prereleaseIdentifier}(?:\\.${prereleaseIdentifier})*)?` +
     '(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?'
-const validVersionPattern = new RegExp(`^(?:latest|daily|${semanticVersion})$`)
+// Keep aliases aligned with the versions supported by cli/installer/install-azd.*.
+const validVersionPattern = new RegExp(`^(?:latest|stable|daily|${semanticVersion})$`)
 
 export function isValidVersion(version: string): boolean {
     return version.length <= 128 && validVersionPattern.test(version)

--- a/ext/azuredevops/setupAzd/version.ts
+++ b/ext/azuredevops/setupAzd/version.ts
@@ -8,5 +8,5 @@ const semanticVersion =
 const validVersionPattern = new RegExp(`^(?:latest|stable|daily|${semanticVersion})$`)
 
 export function isValidVersion(version: string): boolean {
-    return version.length <= 128 && validVersionPattern.test(version)
+    return version.length <= 128 && validVersionPattern.exec(version)?.[0] === version
 }

--- a/ext/azuredevops/vss-extension.json
+++ b/ext/azuredevops/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "azd",
     "name": "Install azd",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "publisher": "ms-azuretools",
     "targets": [
         {


### PR DESCRIPTION
Fixes #9403

Updates the Azure DevOps `setup-azd` task to preserve the installer-supported `latest`, `stable`, `daily`, and semantic version forms while making version handling consistent across Windows, Linux, and macOS.

- Rejects unsupported formats before downloading.
- Downloads installer scripts to an isolated temporary directory.
- Invokes installer scripts with explicit process arguments on each platform.
- Retries temporary-file cleanup and reports cleanup failures without changing the install result.
- Preserves task-specific exit-code errors for download, install, and version checks.
- Adds direct coverage for aliases, prerelease versions, build metadata, rejected formats, and cleanup failure paths.

The default remains `latest`.