### PR TITLE
Skip container function test on Linux CI

### DIFF
--- a/cli/azd/test/functional/up_test.go
+++ b/cli/azd/test/functional/up_test.go
@@ -235,7 +235,9 @@ func Test_CLI_Up_Down_FuncApp(t *testing.T) {
 func Test_CLI_Up_Down_ContainerFuncApp(t *testing.T) {
 	t.Parallel()
 
-	if ciOS := os.Getenv("AZURE_DEV_CI_OS"); ciOS != "" && ciOS != "lin" {
+	if ciOS := os.Getenv("AZURE_DEV_CI_OS"); ciOS == "lin" {
+		t.Skip("Temporarily skipping on Linux CI due to npm registry connectivity failures during Docker builds")
+	} else if ciOS != "" {
 		t.Skip("Skipping due to docker limitations for non-linux systems on CI")
 	}
 


### PR DESCRIPTION
### Summary

This PR temporarily skips `Test_CLI_Up_Down_ContainerFuncApp` on Linux CI because its Docker image build is failing on npm registry connectivity timeouts. Non-Linux CI remains skipped due to existing Docker limitations, while local runs remain enabled.

### Testing

- Confirmed the targeted functional test skips when `AZURE_DEV_CI_OS=lin`.