### PR TITLE
fix: support immutable GitHub OIDC subjects

### DIFF
--- a/cli/azd/pkg/pipeline/github_provider_test.go
+++ b/cli/azd/pkg/pipeline/github_provider_test.go
@@ -194,6 +194,43 @@ func Test_credentialOptions_withOIDCCustomSubject(t *testing.T) {
 		)
 	})
 
+	t.Run("immutable OIDC subjects use API prefix", func(t *testing.T) {
+		mockContext := setupMock(t)
+
+		mockContext.CommandRunner.When(func(args exec.RunArgs, cmd string) bool {
+			return strings.Contains(cmd, "/repos/"+repoSlug+
+				"/actions/oidc/customization/sub")
+		}).Respond(exec.NewRunResult(
+			0,
+			`{"use_default":true,"use_immutable_subject":false,`+
+				`"sub_claim_prefix":`+
+				`"repo:Azure-Samples@1844662/my-repo@599293758"}`,
+			"",
+		))
+
+		provider := createGitHubCiProvider(t, mockContext).(*GitHubCiProvider)
+		opts, err := provider.credentialOptions(
+			t.Context(),
+			repoDetails,
+			provisioning.Options{},
+			AuthTypeFederated,
+			nil,
+		)
+		require.NoError(t, err)
+		require.True(t, opts.EnableFederatedCredentials)
+		require.Len(t, opts.FederatedCredentialOptions, 2)
+
+		require.Equal(t,
+			"repo:Azure-Samples@1844662/my-repo@599293758:pull_request",
+			opts.FederatedCredentialOptions[0].Subject,
+		)
+		require.Equal(t,
+			"repo:Azure-Samples@1844662/my-repo@599293758:"+
+				"ref:refs/heads/main",
+			opts.FederatedCredentialOptions[1].Subject,
+		)
+	})
+
 	t.Run("custom OIDC subjects with ID-based claims", func(t *testing.T) {
 		mockContext := setupMock(t)
 

--- a/cli/azd/pkg/pipeline/github_provider_test.go
+++ b/cli/azd/pkg/pipeline/github_provider_test.go
@@ -231,6 +231,44 @@ func Test_credentialOptions_withOIDCCustomSubject(t *testing.T) {
 		)
 	})
 
+	t.Run("custom immutable OIDC subjects use API prefix", func(t *testing.T) {
+		mockContext := setupMock(t)
+
+		mockContext.CommandRunner.When(func(args exec.RunArgs, cmd string) bool {
+			return strings.Contains(cmd, "/repos/"+repoSlug+
+				"/actions/oidc/customization/sub")
+		}).Respond(exec.NewRunResult(
+			0,
+			`{"use_default":false,"use_immutable_subject":true,`+
+				`"sub_claim_prefix":`+
+				`"repo:Azure-Samples@1844662/my-repo@599293758",`+
+				`"include_claim_keys":["repo","context"]}`,
+			"",
+		))
+
+		provider := createGitHubCiProvider(t, mockContext).(*GitHubCiProvider)
+		opts, err := provider.credentialOptions(
+			t.Context(),
+			repoDetails,
+			provisioning.Options{},
+			AuthTypeFederated,
+			nil,
+		)
+		require.NoError(t, err)
+		require.True(t, opts.EnableFederatedCredentials)
+		require.Len(t, opts.FederatedCredentialOptions, 2)
+
+		require.Equal(t,
+			"repo:Azure-Samples@1844662/my-repo@599293758:pull_request",
+			opts.FederatedCredentialOptions[0].Subject,
+		)
+		require.Equal(t,
+			"repo:Azure-Samples@1844662/my-repo@599293758:"+
+				"ref:refs/heads/main",
+			opts.FederatedCredentialOptions[1].Subject,
+		)
+	})
+
 	t.Run("custom OIDC subjects with ID-based claims", func(t *testing.T) {
 		mockContext := setupMock(t)
 

--- a/cli/azd/pkg/tools/github/oidc.go
+++ b/cli/azd/pkg/tools/github/oidc.go
@@ -13,8 +13,10 @@ import (
 // OIDCSubjectConfig represents the OIDC subject claim customization
 // returned by the GitHub Actions OIDC customization API.
 type OIDCSubjectConfig struct {
-	UseDefault       bool     `json:"use_default"`
-	IncludeClaimKeys []string `json:"include_claim_keys"`
+	UseDefault          bool     `json:"use_default"`
+	IncludeClaimKeys    []string `json:"include_claim_keys"`
+	UseImmutableSubject bool     `json:"use_immutable_subject"`
+	SubClaimPrefix      string   `json:"sub_claim_prefix"`
 }
 
 // RepoInfo holds GitHub API repository metadata needed for OIDC subject construction.
@@ -107,9 +109,12 @@ func (cli *Cli) GetRepoInfo(
 // pre-fetched. The suffix is the trailing part of the subject, e.g.
 // "ref:refs/heads/main" or "pull_request".
 //
-// If oidcConfig is nil or UseDefault is true, the default GitHub format is used:
+// If oidcConfig is nil or UseDefault is true, the default GitHub format is used.
+// When GitHub returns SubClaimPrefix, it is the authoritative repository prefix
+// and may include immutable owner and repository IDs:
 //
 //	repo:{owner}/{repo}:{suffix}
+//	repo:{owner}@{owner_id}/{repo}@{repo_id}:{suffix}
 //
 // For custom configs, claim keys are mapped to values and joined.
 // The special "context" claim key represents the dynamic trailing part of
@@ -123,6 +128,13 @@ func BuildOIDCSubject(
 	suffix string,
 ) (string, error) {
 	if oidcConfig == nil || oidcConfig.UseDefault {
+		if oidcConfig != nil && oidcConfig.SubClaimPrefix != "" {
+			return fmt.Sprintf(
+				"%s:%s",
+				strings.TrimSuffix(oidcConfig.SubClaimPrefix, ":"),
+				suffix,
+			), nil
+		}
 		return fmt.Sprintf("repo:%s:%s", repoSlug, suffix), nil
 	}
 

--- a/cli/azd/pkg/tools/github/oidc.go
+++ b/cli/azd/pkg/tools/github/oidc.go
@@ -146,6 +146,10 @@ func BuildOIDCSubject(
 	}
 
 	var parts []string
+	if oidcConfig.SubClaimPrefix != "" {
+		parts = append(parts, strings.TrimSuffix(oidcConfig.SubClaimPrefix, ":"))
+	}
+
 	for _, key := range oidcConfig.IncludeClaimKeys {
 		switch key {
 		case "repository_owner_id":
@@ -193,9 +197,11 @@ func BuildOIDCSubject(
 		case "repo":
 			// "repo" is the short-form repository claim used in default format
 			// subjects: "repo:owner/name".
-			parts = append(parts,
-				fmt.Sprintf("repo:%s", repoSlug),
-			)
+			if oidcConfig.SubClaimPrefix == "" {
+				parts = append(parts,
+					fmt.Sprintf("repo:%s", repoSlug),
+				)
+			}
 		default:
 			return "", fmt.Errorf(
 				"unsupported OIDC claim key %q in subject"+

--- a/cli/azd/pkg/tools/github/oidc_test.go
+++ b/cli/azd/pkg/tools/github/oidc_test.go
@@ -48,6 +48,18 @@ func TestBuildOIDCSubject(t *testing.T) {
 			want:       "repo:Azure-Samples/my-repo:pull_request",
 		},
 		{
+			name:     "use_default with subject prefix uses returned prefix",
+			repoSlug: repoSlug,
+			repoInfo: repoInfo,
+			oidcConfig: &OIDCSubjectConfig{
+				UseDefault:     true,
+				SubClaimPrefix: "repo:Azure-Samples@1844662/my-repo@599293758",
+			},
+			suffix: "ref:refs/heads/main",
+			want: "repo:Azure-Samples@1844662/my-repo@599293758:" +
+				"ref:refs/heads/main",
+		},
+		{
 			name:     "custom owner_id and repo_id claims",
 			repoSlug: repoSlug,
 			repoInfo: repoInfo,
@@ -225,6 +237,12 @@ func TestGetOIDCSubjectConfig(t *testing.T) {
 
 	defaultConfig := OIDCSubjectConfig{UseDefault: true}
 	defaultJSON, _ := json.Marshal(defaultConfig)
+	immutableConfig := OIDCSubjectConfig{
+		UseDefault:          true,
+		UseImmutableSubject: true,
+		SubClaimPrefix:      "repo:Azure-Samples@1844662/my-repo@599293758",
+	}
+	immutableJSON, _ := json.Marshal(immutableConfig)
 
 	tests := []struct {
 		name     string
@@ -255,6 +273,18 @@ func TestGetOIDCSubjectConfig(t *testing.T) {
 				))
 			},
 			wantConf: &defaultConfig,
+		},
+		{
+			name: "repo-level immutable subject fields are returned",
+			setup: func(mc *mocks.MockContext) {
+				mc.CommandRunner.When(func(args exec.RunArgs, cmd string) bool {
+					return strings.Contains(cmd, "/repos/"+repoSlug+
+						"/actions/oidc/customization/sub")
+				}).Respond(exec.NewRunResult(
+					0, string(immutableJSON), "",
+				))
+			},
+			wantConf: &immutableConfig,
 		},
 		{
 			name: "repo 404 returns default (no org fallback)",

--- a/cli/azd/pkg/tools/github/oidc_test.go
+++ b/cli/azd/pkg/tools/github/oidc_test.go
@@ -181,6 +181,22 @@ func TestBuildOIDCSubject(t *testing.T) {
 			want:   "repo:Azure-Samples/my-repo:ref:refs/heads/main",
 		},
 		{
+			name:     "custom immutable repo and context use returned prefix",
+			repoSlug: repoSlug,
+			repoInfo: repoInfo,
+			oidcConfig: &OIDCSubjectConfig{
+				UseDefault:     false,
+				SubClaimPrefix: "repo:Azure-Samples@1844662/my-repo@599293758",
+				IncludeClaimKeys: []string{
+					"repo",
+					"context",
+				},
+			},
+			suffix: "ref:refs/heads/main",
+			want: "repo:Azure-Samples@1844662/my-repo@599293758:" +
+				"ref:refs/heads/main",
+		},
+		{
 			name:     "repo claim key without context",
 			repoSlug: repoSlug,
 			repoInfo: repoInfo,


### PR DESCRIPTION
Fixes #9382

## Context

GitHub announced immutable subject claims for GitHub Actions OIDC tokens and automatically enables the new format for repositories created after July 15, 2026:

https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/

The previous subject format was:

```text
repo:OWNER/REPO:ref:refs/heads/BRANCH
```

The immutable format includes stable owner and repository IDs:

```text
repo:OWNER@OWNER-ID/REPO@REPO-ID:ref:refs/heads/BRANCH
```

`azd pipeline config` queried the repository OIDC configuration but ignored the new `sub_claim_prefix` response field. It therefore created a legacy name-based federated credential even when the GitHub Actions token used an immutable subject, causing `AADSTS700213` during pipeline authentication.

## Changes

- Parse `use_immutable_subject` and `sub_claim_prefix` from GitHub's repository OIDC configuration response.
- Treat a returned `sub_claim_prefix` as authoritative for default subject templates.
- Append the appropriate branch or pull-request context to the returned prefix.
- Preserve the legacy `repo:OWNER/REPO` fallback when GitHub does not return a prefix.
- Preserve existing custom `include_claim_keys` subject construction.
- Add regression coverage using the response shape observed in the issue reproduction.

## Compatibility

The implementation does not infer behavior from repository creation dates. Existing repositories can opt in, and repository renames or transfers can also activate immutable subjects. The repository OIDC API response is used as the source of truth, supporting both old and new repositories.

## Testing

- `go test ./pkg/tools/github ./pkg/pipeline`
- Confirmed manually with the local reproduction from #9382; the generated federated credential subject matches the subject presented by GitHub Actions and pipeline authentication succeeds.
