### PR TITLE
fix: validate hosted agent environment names

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/README.md
+++ b/cli/azd/extensions/azure.ai.agents/README.md
@@ -70,6 +70,11 @@ services:
       LOG_LEVEL: debug
 ```
 
+Hosted Agent Service environment variable names must start with a letter or
+underscore and contain only letters, digits, or underscores. For example,
+`API_KEY` is valid, while `api-key` is not. `azd deploy` validates these names
+before contacting Foundry Agent Service.
+
 ## Content safety policies
 
 A hosted agent can be bound to an Azure AI Content Safety (RAI) policy so every

--- a/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
@@ -43,6 +43,10 @@ const (
 	CodeInvalidPositionalArg      = "invalid_positional_arg"
 )
 
+// CodeInvalidEnvironmentVariableName identifies a hosted-agent
+// environment variable name rejected by the service contract.
+const CodeInvalidEnvironmentVariableName = "invalid_environment_variable_name"
+
 // Error codes commonly used for dependency errors.
 //
 // These are usually paired with [Dependency] when required external

--- a/cli/azd/extensions/azure.ai.agents/internal/project/deploy_precheck.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/deploy_precheck.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"fmt"
+	"maps"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"azureaiagent/internal/exterrors"
+	"azureaiagent/internal/pkg/agents/agent_yaml"
+)
+
+var environmentVariableNamePattern = regexp.MustCompile(
+	`^[A-Za-z_][A-Za-z0-9_]*$`,
+)
+
+func validateEnvironmentVariableNames(
+	serviceEnvironment map[string]string,
+	agentEnvironment *[]agent_yaml.EnvironmentVariable,
+) error {
+	invalidNames := map[string]struct{}{}
+	for name := range serviceEnvironment {
+		if !environmentVariableNamePattern.MatchString(name) {
+			invalidNames[name] = struct{}{}
+		}
+	}
+	if agentEnvironment != nil {
+		for _, variable := range *agentEnvironment {
+			if !environmentVariableNamePattern.MatchString(variable.Name) {
+				invalidNames[variable.Name] = struct{}{}
+			}
+		}
+	}
+
+	if len(invalidNames) == 0 {
+		return nil
+	}
+
+	names := slices.Sorted(maps.Keys(invalidNames))
+	quotedNames := make([]string, len(names))
+	for i, name := range names {
+		quotedNames[i] = strconv.Quote(name)
+	}
+
+	noun := "name"
+	verb := "is"
+	if len(names) > 1 {
+		noun = "names"
+		verb = "are"
+	}
+
+	return exterrors.Validation(
+		exterrors.CodeInvalidEnvironmentVariableName,
+		fmt.Sprintf(
+			"environment variable %s %s %s invalid. Names must start "+
+				"with a letter or underscore, and contain only letters, "+
+				"digits, or underscores",
+			noun,
+			strings.Join(quotedNames, ", "),
+			verb,
+		),
+		"rename the invalid environment variables in azure.yaml or "+
+			"agent.yaml, then run `azd deploy` again",
+	)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/deploy_precheck_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/deploy_precheck_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package project
+
+import (
+	"errors"
+	"testing"
+
+	"azureaiagent/internal/exterrors"
+	"azureaiagent/internal/pkg/agents/agent_yaml"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestValidateEnvironmentVariableNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		serviceEnvironment map[string]string
+		agentEnvironment   *[]agent_yaml.EnvironmentVariable
+		wantInvalid        []string
+	}{
+		{
+			name: "accepts supported names",
+			serviceEnvironment: map[string]string{
+				"API_URL": "",
+				"_TOKEN2": "",
+				"name":    "",
+			},
+			agentEnvironment: &[]agent_yaml.EnvironmentVariable{
+				{Name: "LEGACY_VALUE"},
+			},
+		},
+		{
+			name: "rejects invalid service name",
+			serviceEnvironment: map[string]string{
+				"function-api-base-url": "",
+			},
+			wantInvalid: []string{"function-api-base-url"},
+		},
+		{
+			name: "rejects invalid legacy names",
+			agentEnvironment: &[]agent_yaml.EnvironmentVariable{
+				{Name: "9TOKEN"},
+				{Name: "API.URL"},
+			},
+			wantInvalid: []string{"9TOKEN", "API.URL"},
+		},
+		{
+			name: "rejects empty name",
+			agentEnvironment: &[]agent_yaml.EnvironmentVariable{
+				{Name: ""},
+			},
+			wantInvalid: []string{""},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateEnvironmentVariableNames(
+				test.serviceEnvironment,
+				test.agentEnvironment,
+			)
+			if len(test.wantInvalid) == 0 {
+				require.NoError(t, err)
+				return
+			}
+
+			localErr, ok := errors.AsType[*azdext.LocalError](err)
+			require.True(t, ok)
+			require.Equal(
+				t,
+				exterrors.CodeInvalidEnvironmentVariableName,
+				localErr.Code,
+			)
+			for _, name := range test.wantInvalid {
+				require.Contains(t, localErr.Message, name)
+			}
+		})
+	}
+}
+
+func TestDeployBlocksInvalidEnvironmentVariableName(t *testing.T) {
+	t.Parallel()
+
+	props, err := structpb.NewStruct(map[string]any{
+		"kind": "hosted",
+		"name": "test-agent",
+	})
+	require.NoError(t, err)
+
+	serviceConfig := &azdext.ServiceConfig{
+		Name: "agent",
+		Environment: map[string]string{
+			"function-api-base-url": "https://example.test",
+		},
+		AdditionalProperties: props,
+	}
+	provider := &AgentServiceTargetProvider{
+		deployContextReady: true,
+	}
+
+	result, err := provider.Deploy(
+		t.Context(),
+		serviceConfig,
+		&azdext.ServiceContext{},
+		nil,
+		func(string) {},
+	)
+
+	require.Nil(t, result)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	require.Equal(
+		t,
+		exterrors.CodeInvalidEnvironmentVariableName,
+		localErr.Code,
+	)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1130,6 +1130,26 @@ func (p *AgentServiceTargetProvider) Deploy(
 		return nil, err
 	}
 	serviceConfig = p.serviceConfig
+
+	agentDef, isContainerAgent, err := p.loadContainerAgentDefinition()
+	if err != nil {
+		return nil, err
+	}
+	if !isContainerAgent {
+		return nil, exterrors.Validation(
+			exterrors.CodeUnsupportedAgentKind,
+			"unsupported agent kind in agent.yaml",
+			"use a supported kind: 'hosted'",
+		)
+	}
+
+	if err := validateEnvironmentVariableNames(
+		serviceConfig.GetEnvironment(),
+		agentDef.EnvironmentVariables,
+	); err != nil {
+		return nil, err
+	}
+
 	// Ensure Foundry project is loaded
 	if err := p.ensureFoundryProject(ctx); err != nil {
 		return nil, err
@@ -1180,18 +1200,6 @@ func (p *AgentServiceTargetProvider) Deploy(
 		ctx, serviceTargetConfig, azdEnv["FOUNDRY_PROJECT_ENDPOINT"], progress,
 	); err != nil {
 		return nil, err
-	}
-
-	agentDef, isContainerAgent, err := p.loadContainerAgentDefinition()
-	if err != nil {
-		return nil, err
-	}
-	if !isContainerAgent {
-		return nil, exterrors.Validation(
-			exterrors.CodeUnsupportedAgentKind,
-			"unsupported agent kind in agent.yaml",
-			"use a supported kind: 'hosted'",
-		)
 	}
 
 	// Branch: code deploy vs container deploy


### PR DESCRIPTION
## Why this is needed

Hosted Agent Service rejects invalid environment variable names only after the deploy request reaches the service. This produces a late failure and makes the configuration problem harder to diagnose.

## Approach

- Validate environment variable names from `azure.yaml` and legacy `agent.yaml` against the service rule before hosted-agent deployment calls.
- Return the existing structured extension validation error `invalid_environment_variable_name`, preserving standard error telemetry without adding new telemetry fields.
- Run the check at the extension service-target `Deploy` entry point so the change stays scoped to the hosted-agent extension; package, publish, and target-resource resolution behavior remain unchanged.
- Document the naming rule and cover accepted, rejected, and deploy-blocking cases with tests.

## E2E validation

| Command | Scenario | Result |
| --- | --- | --- |
| `azd up --no-prompt` | Invalid name `function-api-base-url` | PASS (expected validation block; no hosted-agent version was created) |
| `azd deploy --no-prompt` | Valid name `FUNCTION_API_BASE_URL` | PASS; hosted agent became `active` |
| `azd up --no-prompt` | Valid hosted-agent project and environment variable name | PASS |

The invalid-name run returned: `environment variable name "function-api-base-url" is invalid. Names must start with a letter or underscore, and contain only letters, digits, or underscores.`

Closes: #9440