### PR TITLE
Enforce extension dependency versions match azd core

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -73,6 +73,6 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: cli/azd/go.mod
-      - name: Run mage helper tests (resolveCoverageFile, resolveBaselineFile, resolveChangedFilesForDiff)
+      - name: Run mage helper tests
         working-directory: cli/azd
-        run: go test -tags mage -run '^TestResolve' -v .
+        run: go test -tags mage -run '^Test(Resolve|DependencyVersion)' -v .

--- a/.github/workflows/validate-go-dependency-versions.yml
+++ b/.github/workflows/validate-go-dependency-versions.yml
@@ -1,0 +1,28 @@
+name: validate-go-dependency-versions
+
+on:
+  pull_request:
+    paths:
+      - "cli/azd/go.mod"
+      - "cli/azd/extensions/*/go.mod"
+      - "cli/azd/extensions/*/go.sum"
+      - "cli/azd/dependency-versions.json"
+      - "cli/azd/dependency_versions.go"
+      - "cli/azd/dependency_versions_test.go"
+      - ".github/workflows/validate-go-dependency-versions.yml"
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-dependency-version-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: cli/azd/go.mod
+      - name: Validate dependency version consistency
+        working-directory: cli/azd
+        run: go run github.com/magefile/mage@v1.17.2 checkDependencyVersions

--- a/cli/azd/AGENTS.md
+++ b/cli/azd/AGENTS.md
@@ -418,6 +418,13 @@ Go module version tags (`cli/azd/vX.Y.Z`) are created alongside each CLI release
 
 When cutting a release, `eng/scripts/Update-CliVersion.ps1` automatically updates both `cli/version.txt` and `pkg/azdext/version.go` to keep versions in sync.
 
+### Go Dependency Version Synchronization
+
+`cli/azd/go.mod` is the source of truth for dependencies directly shared by core and first-party Go extensions.
+Run `mage checkDependencyVersions` to validate alignment or `mage syncDependencyVersions` to update unapproved
+mismatches. Temporary exceptions must be exact, issue-linked entries in `dependency-versions.json`. See
+`docs/dependency-version-sync.md` for the policy and workflow.
+
 ## Extensions
 
 First-party azd extensions live in `cli/azd/extensions/`.

--- a/cli/azd/AGENTS.md
+++ b/cli/azd/AGENTS.md
@@ -400,6 +400,13 @@ Go module version tags (`cli/azd/vX.Y.Z`) are created alongside each CLI release
 
 When cutting a release, `eng/scripts/Update-CliVersion.ps1` automatically updates both `cli/version.txt` and `pkg/azdext/version.go` to keep versions in sync.
 
+### Go Dependency Version Synchronization
+
+`cli/azd/go.mod` is the source of truth for dependencies directly shared by core and first-party Go extensions.
+Run `mage checkDependencyVersions` to validate alignment or `mage syncDependencyVersions` to update unapproved
+mismatches. Temporary exceptions must be exact, issue-linked entries in `dependency-versions.json`. See
+`docs/dependency-version-sync.md` for the policy and workflow.
+
 ## Extensions
 
 First-party azd extensions live in `cli/azd/extensions/`.

--- a/cli/azd/dependency-versions.json
+++ b/cli/azd/dependency-versions.json
@@ -1,0 +1,130 @@
+{
+  "overrides": [
+    {
+      "module": "extensions/azure.ai.agents",
+      "dependency": "github.com/Azure/azure-sdk-for-go/sdk/azcore",
+      "version": "v1.21.0",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/azure.ai.agents",
+      "dependency": "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+      "version": "v1.14.0-beta.3",
+      "reason": "The extension temporarily requires the prerelease credential error-reporting behavior.",
+      "issue": "https://github.com/Azure/azure-dev/issues/7732"
+    },
+    {
+      "module": "extensions/azure.ai.agents",
+      "dependency": "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry",
+      "version": "v1.3.0-beta.3",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/azure.ai.agents",
+      "dependency": "github.com/mark3labs/mcp-go",
+      "version": "v0.43.2",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/azure.ai.agents",
+      "dependency": "github.com/spf13/cobra",
+      "version": "v1.10.2",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/azure.ai.finetune",
+      "dependency": "github.com/Azure/azure-sdk-for-go/sdk/azcore",
+      "version": "v1.21.0",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/azure.ai.finetune",
+      "dependency": "github.com/spf13/cobra",
+      "version": "v1.10.2",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/azure.ai.inspector",
+      "dependency": "github.com/spf13/cobra",
+      "version": "v1.10.2",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/azure.ai.models",
+      "dependency": "github.com/spf13/cobra",
+      "version": "v1.10.2",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/azure.ai.projects",
+      "dependency": "github.com/Azure/azure-sdk-for-go/sdk/azcore",
+      "version": "v1.21.0",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/azure.ai.projects",
+      "dependency": "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+      "version": "v1.14.0-beta.3",
+      "reason": "Pre-existing prerelease usage pending alignment to the stable core version.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/azure.ai.skills",
+      "dependency": "github.com/Azure/azure-sdk-for-go/sdk/azcore",
+      "version": "v1.21.0",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/azure.ai.skills",
+      "dependency": "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+      "version": "v1.14.0-beta.3",
+      "reason": "Pre-existing prerelease usage pending alignment to the stable core version.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/azure.ai.skills",
+      "dependency": "github.com/spf13/cobra",
+      "version": "v1.10.2",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/azure.appservice",
+      "dependency": "github.com/Azure/azure-sdk-for-go/sdk/azcore",
+      "version": "v1.21.0",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/azure.appservice",
+      "dependency": "github.com/spf13/cobra",
+      "version": "v1.10.2",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/azure.coding-agent",
+      "dependency": "google.golang.org/grpc",
+      "version": "v1.79.3",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    },
+    {
+      "module": "extensions/microsoft.azd.concurx",
+      "dependency": "github.com/spf13/cobra",
+      "version": "v1.10.2",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
+    }
+  ]
+}

--- a/cli/azd/dependency-versions.json
+++ b/cli/azd/dependency-versions.json
@@ -3,16 +3,16 @@
     {
       "module": "extensions/azure.ai.agents",
       "dependency": "github.com/Azure/azure-sdk-for-go/sdk/azcore",
-      "version": "v1.21.0",
+      "version": "v1.22.0",
       "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
       "issue": "https://github.com/Azure/azure-dev/issues/9297"
     },
     {
       "module": "extensions/azure.ai.agents",
       "dependency": "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
-      "version": "v1.14.0-beta.3",
-      "reason": "The extension temporarily requires the prerelease credential error-reporting behavior.",
-      "issue": "https://github.com/Azure/azure-dev/issues/7732"
+      "version": "v1.14.0",
+      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
+      "issue": "https://github.com/Azure/azure-dev/issues/9297"
     },
     {
       "module": "extensions/azure.ai.agents",
@@ -109,13 +109,6 @@
       "module": "extensions/azure.appservice",
       "dependency": "github.com/spf13/cobra",
       "version": "v1.10.2",
-      "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
-      "issue": "https://github.com/Azure/azure-dev/issues/9297"
-    },
-    {
-      "module": "extensions/azure.coding-agent",
-      "dependency": "google.golang.org/grpc",
-      "version": "v1.79.3",
       "reason": "Pre-existing direct dependency drift pending repository-wide alignment.",
       "issue": "https://github.com/Azure/azure-dev/issues/9297"
     },

--- a/cli/azd/dependency_versions.go
+++ b/cli/azd/dependency_versions.go
@@ -1,0 +1,389 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build mage
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+const dependencyVersionConfigFile = "dependency-versions.json"
+
+var dependencyIssuePattern = regexp.MustCompile(
+	`^https://github\.com/Azure/azure-dev/issues/[1-9][0-9]*$`,
+)
+
+type dependencyVersionConfig struct {
+	Overrides []dependencyVersionOverride `json:"overrides"`
+}
+
+type dependencyVersionOverride struct {
+	Module     string `json:"module"`
+	Dependency string `json:"dependency"`
+	Version    string `json:"version"`
+	Reason     string `json:"reason"`
+	Issue      string `json:"issue"`
+}
+
+type goModFile struct {
+	Require []goModRequirement
+}
+
+type goModRequirement struct {
+	Path     string
+	Version  string
+	Indirect bool
+}
+
+type dependencyVersionMismatch struct {
+	ModulePath   string
+	GoModPath    string
+	Dependency   string
+	CoreVersion  string
+	FoundVersion string
+	Override     *dependencyVersionOverride
+}
+
+type dependencyVersionReport struct {
+	Mismatches     []dependencyVersionMismatch
+	StaleOverrides []dependencyVersionOverride
+}
+
+// CheckDependencyVersions verifies that dependencies directly required by both azd core and a
+// first-party extension use the same version. Temporary exceptions must be declared in
+// dependency-versions.json.
+//
+// Usage: mage checkDependencyVersions
+func CheckDependencyVersions() error {
+	azdDir, err := dependencyVersionAzdDir()
+	if err != nil {
+		return err
+	}
+	return checkDependencyVersions(azdDir, os.Stdout)
+}
+
+func checkDependencyVersions(azdDir string, w io.Writer) error {
+	report, err := analyzeDependencyVersions(azdDir)
+	if err != nil {
+		return err
+	}
+	printDependencyVersionReport(w, report)
+	if len(report.Mismatches) > 0 || len(report.StaleOverrides) > 0 {
+		return errors.New("dependency version validation failed")
+	}
+
+	fmt.Fprintln(w, "All shared direct dependency versions match azd core.")
+	return nil
+}
+
+// SyncDependencyVersions updates unapproved extension dependency mismatches to the versions
+// selected by azd core, then runs go mod tidy in each changed extension module.
+//
+// Usage: mage syncDependencyVersions
+func SyncDependencyVersions() error {
+	azdDir, err := dependencyVersionAzdDir()
+	if err != nil {
+		return err
+	}
+	return syncDependencyVersions(azdDir, os.Stdout)
+}
+
+func syncDependencyVersions(azdDir string, w io.Writer) error {
+	report, err := analyzeDependencyVersions(azdDir)
+	if err != nil {
+		return err
+	}
+	if len(report.StaleOverrides) > 0 {
+		printDependencyVersionReport(w, report)
+		return errors.New("remove stale dependency overrides before synchronizing")
+	}
+
+	changedModules := map[string]bool{}
+	for _, mismatch := range report.Mismatches {
+		moduleDir := filepath.Dir(filepath.Join(azdDir, filepath.FromSlash(mismatch.GoModPath)))
+		requirement := mismatch.Dependency + "@" + mismatch.CoreVersion
+		if err := runDependencyGoCommand(moduleDir, w, "mod", "edit", "-require="+requirement); err != nil {
+			return fmt.Errorf("updating %s in %s: %w", mismatch.Dependency, mismatch.ModulePath, err)
+		}
+		changedModules[moduleDir] = true
+		fmt.Fprintf(
+			w,
+			"Updated %s in %s: %s -> %s\n",
+			mismatch.Dependency,
+			mismatch.ModulePath,
+			mismatch.FoundVersion,
+			mismatch.CoreVersion,
+		)
+	}
+
+	moduleDirs := slices.Sorted(maps.Keys(changedModules))
+	for _, moduleDir := range moduleDirs {
+		if err := runDependencyGoCommand(moduleDir, w, "mod", "tidy"); err != nil {
+			return fmt.Errorf("running go mod tidy in %s: %w", moduleDir, err)
+		}
+	}
+
+	if len(changedModules) == 0 {
+		fmt.Fprintln(w, "No dependency versions needed synchronization.")
+		return nil
+	}
+
+	finalReport, err := analyzeDependencyVersions(azdDir)
+	if err != nil {
+		return err
+	}
+	printDependencyVersionReport(w, finalReport)
+	if len(finalReport.Mismatches) > 0 || len(finalReport.StaleOverrides) > 0 {
+		return errors.New("dependency versions remain inconsistent after synchronization")
+	}
+
+	fmt.Fprintf(w, "Synchronized dependency versions in %d extension module(s).\n", len(changedModules))
+	return nil
+}
+
+func dependencyVersionAzdDir() (string, error) {
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(repoRoot, "cli", "azd"), nil
+}
+
+func analyzeDependencyVersions(azdDir string) (*dependencyVersionReport, error) {
+	config, err := loadDependencyVersionConfig(azdDir)
+	if err != nil {
+		return nil, err
+	}
+	overrides, err := validateDependencyVersionOverrides(config.Overrides)
+	if err != nil {
+		return nil, err
+	}
+
+	coreMod, err := loadGoModFile(filepath.Join(azdDir, "go.mod"))
+	if err != nil {
+		return nil, fmt.Errorf("reading azd core go.mod: %w", err)
+	}
+	coreVersions := map[string]string{}
+	for _, requirement := range coreMod.Require {
+		if !requirement.Indirect {
+			coreVersions[requirement.Path] = requirement.Version
+		}
+	}
+
+	goModPaths, err := extensionGoModPaths(azdDir)
+	if err != nil {
+		return nil, err
+	}
+
+	report := &dependencyVersionReport{}
+	usedOverrides := map[string]bool{}
+	for _, goModPath := range goModPaths {
+		mod, err := loadGoModFile(filepath.Join(azdDir, filepath.FromSlash(goModPath)))
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", goModPath, err)
+		}
+		modulePath := filepath.ToSlash(filepath.Dir(goModPath))
+		for _, requirement := range mod.Require {
+			if requirement.Indirect {
+				continue
+			}
+			coreVersion, managed := coreVersions[requirement.Path]
+			if !managed || requirement.Version == coreVersion {
+				continue
+			}
+
+			key := dependencyOverrideKey(modulePath, requirement.Path)
+			override := overrides[key]
+			if override != nil && override.Version == requirement.Version {
+				usedOverrides[key] = true
+				continue
+			}
+			report.Mismatches = append(report.Mismatches, dependencyVersionMismatch{
+				ModulePath:   modulePath,
+				GoModPath:    goModPath,
+				Dependency:   requirement.Path,
+				CoreVersion:  coreVersion,
+				FoundVersion: requirement.Version,
+				Override:     override,
+			})
+		}
+	}
+
+	for key, override := range overrides {
+		if !usedOverrides[key] {
+			report.StaleOverrides = append(report.StaleOverrides, *override)
+		}
+	}
+	sortDependencyVersionReport(report)
+	return report, nil
+}
+
+func loadDependencyVersionConfig(azdDir string) (*dependencyVersionConfig, error) {
+	path := filepath.Join(azdDir, dependencyVersionConfigFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", dependencyVersionConfigFile, err)
+	}
+
+	var config dependencyVersionConfig
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&config); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", dependencyVersionConfigFile, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = errors.New("multiple JSON values")
+		}
+		return nil, fmt.Errorf("parsing %s: unexpected trailing content: %w", dependencyVersionConfigFile, err)
+	}
+	return &config, nil
+}
+
+func validateDependencyVersionOverrides(
+	entries []dependencyVersionOverride,
+) (map[string]*dependencyVersionOverride, error) {
+	overrides := make(map[string]*dependencyVersionOverride, len(entries))
+	for i := range entries {
+		override := &entries[i]
+		override.Module = filepath.ToSlash(filepath.Clean(override.Module))
+		if override.Module == "." || strings.HasPrefix(override.Module, "../") ||
+			!strings.HasPrefix(override.Module, "extensions/") {
+			return nil, fmt.Errorf("override module %q must be under extensions/", override.Module)
+		}
+		if override.Dependency == "" || override.Version == "" || override.Reason == "" || override.Issue == "" {
+			return nil, fmt.Errorf(
+				"override for %s in %s must include dependency, version, reason, and issue",
+				override.Dependency,
+				override.Module,
+			)
+		}
+		if !dependencyIssuePattern.MatchString(override.Issue) {
+			return nil, fmt.Errorf(
+				"override for %s in %s must link to an Azure/azure-dev issue",
+				override.Dependency,
+				override.Module,
+			)
+		}
+		key := dependencyOverrideKey(override.Module, override.Dependency)
+		if _, exists := overrides[key]; exists {
+			return nil, fmt.Errorf("duplicate dependency override for %s in %s", override.Dependency, override.Module)
+		}
+		overrides[key] = override
+	}
+	return overrides, nil
+}
+
+func extensionGoModPaths(azdDir string) ([]string, error) {
+	extensionsDir := filepath.Join(azdDir, "extensions")
+	entries, err := os.ReadDir(extensionsDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading extensions directory: %w", err)
+	}
+
+	var paths []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		goModPath := filepath.Join(extensionsDir, entry.Name(), "go.mod")
+		if _, err := os.Stat(goModPath); err == nil {
+			paths = append(paths, filepath.ToSlash(filepath.Join("extensions", entry.Name(), "go.mod")))
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("checking %s: %w", goModPath, err)
+		}
+	}
+	slices.Sort(paths)
+	return paths, nil
+}
+
+func loadGoModFile(path string) (*goModFile, error) {
+	cmd := exec.Command("go", "mod", "edit", "-json", path)
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+
+	var mod goModFile
+	if err := json.Unmarshal(output, &mod); err != nil {
+		return nil, fmt.Errorf("decoding go mod edit output: %w", err)
+	}
+	return &mod, nil
+}
+
+func runDependencyGoCommand(dir string, w io.Writer, args ...string) error {
+	cmd := exec.Command("go", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("go %s failed: %w", strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+func printDependencyVersionReport(w io.Writer, report *dependencyVersionReport) {
+	for _, mismatch := range report.Mismatches {
+		message := fmt.Sprintf(
+			"%s uses %s, but azd core requires %s",
+			mismatch.Dependency,
+			mismatch.FoundVersion,
+			mismatch.CoreVersion,
+		)
+		if mismatch.Override != nil {
+			message += fmt.Sprintf("; the configured override only allows %s", mismatch.Override.Version)
+		}
+		fmt.Fprintf(w, "ERROR: %s: %s\n", mismatch.GoModPath, message)
+		if os.Getenv("GITHUB_ACTIONS") == "true" {
+			fmt.Fprintf(w, "::error file=cli/azd/%s::%s\n", mismatch.GoModPath, message)
+		}
+	}
+	for _, override := range report.StaleOverrides {
+		message := fmt.Sprintf(
+			"stale override for %s in %s; remove or update it",
+			override.Dependency,
+			override.Module,
+		)
+		fmt.Fprintf(w, "ERROR: %s\n", message)
+		if os.Getenv("GITHUB_ACTIONS") == "true" {
+			fmt.Fprintf(w, "::error file=cli/azd/%s::%s\n", dependencyVersionConfigFile, message)
+		}
+	}
+	if len(report.Mismatches) > 0 {
+		fmt.Fprintln(w, "Run 'cd cli/azd && mage syncDependencyVersions' to align unapproved mismatches.")
+	}
+}
+
+func sortDependencyVersionReport(report *dependencyVersionReport) {
+	slices.SortFunc(report.Mismatches, func(a, b dependencyVersionMismatch) int {
+		if result := strings.Compare(a.ModulePath, b.ModulePath); result != 0 {
+			return result
+		}
+		return strings.Compare(a.Dependency, b.Dependency)
+	})
+	slices.SortFunc(report.StaleOverrides, func(a, b dependencyVersionOverride) int {
+		if result := strings.Compare(a.Module, b.Module); result != 0 {
+			return result
+		}
+		return strings.Compare(a.Dependency, b.Dependency)
+	})
+}
+
+func dependencyOverrideKey(modulePath, dependency string) string {
+	return modulePath + "\x00" + dependency
+}

--- a/cli/azd/dependency_versions_test.go
+++ b/cli/azd/dependency_versions_test.go
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build mage
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testSharedDependency = "example.com/shared"
+
+func TestDependencyVersionAligned(t *testing.T) {
+	azdDir := newDependencyVersionTestRepo(t, "v1.2.0", "v1.2.0", nil)
+
+	report, err := analyzeDependencyVersions(azdDir)
+	if err != nil {
+		t.Fatalf("analyze dependency versions: %v", err)
+	}
+	if len(report.Mismatches) != 0 {
+		t.Fatalf("expected no mismatches, got %#v", report.Mismatches)
+	}
+	if len(report.StaleOverrides) != 0 {
+		t.Fatalf("expected no stale overrides, got %#v", report.StaleOverrides)
+	}
+}
+
+func TestDependencyVersionIgnoresIndirectRequirements(t *testing.T) {
+	azdDir := newDependencyVersionTestRepo(t, "v1.2.0", "v1.1.0", nil)
+	writeTestFile(t, filepath.Join(azdDir, "extensions", "test.extension", "go.mod"), `module example.com/extension
+
+go 1.26.0
+
+require example.com/shared v1.1.0 // indirect
+`)
+
+	report, err := analyzeDependencyVersions(azdDir)
+	if err != nil {
+		t.Fatalf("analyze dependency versions: %v", err)
+	}
+	if len(report.Mismatches) != 0 {
+		t.Fatalf("expected indirect requirement to be ignored, got %#v", report.Mismatches)
+	}
+}
+
+func TestDependencyVersionReportsMismatch(t *testing.T) {
+	azdDir := newDependencyVersionTestRepo(t, "v1.2.0", "v1.1.0", nil)
+
+	var output bytes.Buffer
+	err := checkDependencyVersions(azdDir, &output)
+	if err == nil {
+		t.Fatal("expected dependency version validation to fail")
+	}
+	if !strings.Contains(output.String(), "example.com/shared uses v1.1.0, but azd core requires v1.2.0") {
+		t.Fatalf("unexpected output:\n%s", output.String())
+	}
+}
+
+func TestDependencyVersionAllowsExactOverride(t *testing.T) {
+	override := dependencyVersionOverride{
+		Module:     "extensions/test.extension",
+		Dependency: testSharedDependency,
+		Version:    "v1.1.0",
+		Reason:     "The extension temporarily requires the older API.",
+		Issue:      "https://github.com/Azure/azure-dev/issues/9297",
+	}
+	azdDir := newDependencyVersionTestRepo(t, "v1.2.0", "v1.1.0", []dependencyVersionOverride{override})
+
+	report, err := analyzeDependencyVersions(azdDir)
+	if err != nil {
+		t.Fatalf("analyze dependency versions: %v", err)
+	}
+	if len(report.Mismatches) != 0 || len(report.StaleOverrides) != 0 {
+		t.Fatalf("expected override to allow mismatch, got %#v", report)
+	}
+}
+
+func TestDependencyVersionReportsStaleOverride(t *testing.T) {
+	override := dependencyVersionOverride{
+		Module:     "extensions/test.extension",
+		Dependency: testSharedDependency,
+		Version:    "v1.1.0",
+		Reason:     "The extension temporarily requires the older API.",
+		Issue:      "https://github.com/Azure/azure-dev/issues/9297",
+	}
+	azdDir := newDependencyVersionTestRepo(t, "v1.2.0", "v1.2.0", []dependencyVersionOverride{override})
+
+	report, err := analyzeDependencyVersions(azdDir)
+	if err != nil {
+		t.Fatalf("analyze dependency versions: %v", err)
+	}
+	if len(report.StaleOverrides) != 1 {
+		t.Fatalf("expected one stale override, got %#v", report.StaleOverrides)
+	}
+}
+
+func TestDependencyVersionRejectsInvalidOverrideIssue(t *testing.T) {
+	override := dependencyVersionOverride{
+		Module:     "extensions/test.extension",
+		Dependency: testSharedDependency,
+		Version:    "v1.1.0",
+		Reason:     "The extension temporarily requires the older API.",
+		Issue:      "https://example.com/issues/1",
+	}
+	azdDir := newDependencyVersionTestRepo(t, "v1.2.0", "v1.1.0", []dependencyVersionOverride{override})
+
+	_, err := analyzeDependencyVersions(azdDir)
+	if err == nil || !strings.Contains(err.Error(), "must link to an Azure/azure-dev issue") {
+		t.Fatalf("expected invalid issue error, got %v", err)
+	}
+}
+
+func TestDependencyVersionRejectsTrailingConfigContent(t *testing.T) {
+	azdDir := newDependencyVersionTestRepo(t, "v1.2.0", "v1.2.0", nil)
+	writeTestFile(
+		t,
+		filepath.Join(azdDir, dependencyVersionConfigFile),
+		`{"overrides": []} {"overrides": []}`,
+	)
+
+	_, err := analyzeDependencyVersions(azdDir)
+	if err == nil || !strings.Contains(err.Error(), "unexpected trailing content") {
+		t.Fatalf("expected trailing content error, got %v", err)
+	}
+}
+
+func TestDependencyVersionSyncsMismatch(t *testing.T) {
+	azdDir := newDependencyVersionTestRepo(t, "v1.2.0", "v1.1.0", nil)
+	sharedDir := filepath.Join(filepath.Dir(azdDir), "shared")
+	writeTestFile(t, filepath.Join(sharedDir, "go.mod"), `module example.com/shared
+
+go 1.26.0
+`)
+	writeTestFile(t, filepath.Join(sharedDir, "shared.go"), "package shared\n")
+
+	extensionDir := filepath.Join(azdDir, "extensions", "test.extension")
+	writeTestFile(t, filepath.Join(extensionDir, "main.go"), `package extension
+
+import _ "example.com/shared"
+`)
+	writeTestFile(t, filepath.Join(extensionDir, "go.mod"), `module example.com/extension
+
+go 1.26.0
+
+require example.com/shared v1.1.0
+
+replace example.com/shared => ../../../shared
+`)
+
+	var output bytes.Buffer
+	if err := syncDependencyVersions(azdDir, &output); err != nil {
+		t.Fatalf("sync dependency versions: %v\n%s", err, output.String())
+	}
+
+	mod, err := loadGoModFile(filepath.Join(extensionDir, "go.mod"))
+	if err != nil {
+		t.Fatalf("load synchronized go.mod: %v", err)
+	}
+	if len(mod.Require) != 1 || mod.Require[0].Version != "v1.2.0" {
+		t.Fatalf("expected synchronized v1.2.0 requirement, got %#v", mod.Require)
+	}
+}
+
+func newDependencyVersionTestRepo(
+	t *testing.T,
+	coreVersion string,
+	extensionVersion string,
+	overrides []dependencyVersionOverride,
+) string {
+	t.Helper()
+	azdDir := filepath.Join(t.TempDir(), "cli", "azd")
+	writeTestFile(t, filepath.Join(azdDir, "go.mod"), `module example.com/core
+
+go 1.26.0
+
+require example.com/shared `+coreVersion+`
+`)
+	writeTestFile(t, filepath.Join(azdDir, "extensions", "test.extension", "go.mod"), `module example.com/extension
+
+go 1.26.0
+
+require example.com/shared `+extensionVersion+`
+`)
+
+	config, err := json.Marshal(dependencyVersionConfig{Overrides: overrides})
+	if err != nil {
+		t.Fatalf("marshal dependency version config: %v", err)
+	}
+	writeTestFile(t, filepath.Join(azdDir, dependencyVersionConfigFile), string(config))
+	return azdDir
+}
+
+func writeTestFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create directory for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/cli/azd/docs/dependency-version-sync.md
+++ b/cli/azd/docs/dependency-version-sync.md
@@ -1,0 +1,39 @@
+# Go dependency version synchronization
+
+`cli/azd/go.mod` is the source of truth for dependencies shared by azd core and
+first-party Go extensions.
+
+When an extension directly requires a dependency that is also directly required
+by core, both modules must use the same version. This prevents an extension from
+silently moving ahead of or falling behind the dependency version tested by
+core. Indirect requirements are not checked because `go mod tidy` derives them
+from each module's dependency graph.
+
+## Check and synchronize versions
+
+Run these commands from `cli/azd`:
+
+```bash
+mage checkDependencyVersions
+mage syncDependencyVersions
+```
+
+The check command reports mismatches without changing files. The sync command
+updates unapproved mismatches to the versions in the core `go.mod` and runs
+`go mod tidy` in each changed extension.
+
+## Temporary overrides
+
+If an extension cannot align with core, add an entry to
+`dependency-versions.json`. An override must:
+
+- identify the extension and dependency;
+- pin the exact exceptional version;
+- explain why the exception is required; and
+- link to an `Azure/azure-dev` issue tracking its removal.
+
+Overrides are temporary. Validation fails when an override no longer matches an
+active version difference, ensuring stale entries are removed.
+
+When an extension needs a newer dependency, prefer upgrading core and every
+other extension that directly requires the dependency in the same change.


### PR DESCRIPTION
## Summary

- add repository-native Mage commands to validate and synchronize dependency versions shared by azd core and first-party Go extensions
- enforce `cli/azd/go.mod` as the source of truth for dependencies directly required by both core and an extension
- add exact, reasoned, issue-linked temporary overrides for existing dependency drift
- add CI enforcement, tests, and contributor documentation

Addresses #9297.

## Enforcement rules

- Extension versions must exactly match core; both newer and older versions fail validation.
- If an extension needs a newer version, core and every extension directly using that dependency should be upgraded together.
- Temporary exceptions must pin the exact extension version, explain the reason, and link to an `Azure/azure-dev` tracking issue.
- Overrides become validation errors when they are stale or no longer match the active difference.
- Indirect requirements are excluded because they are derived independently by each module's dependency graph and `go mod tidy`.

## Commands

```bash
cd cli/azd
mage checkDependencyVersions
mage syncDependencyVersions
```

## Existing drift

The initial policy file records 18 pre-existing direct dependency mismatches as temporary overrides. This blocks new unapproved drift immediately without mixing repository-wide dependency upgrades into the tooling change.

## Validation

- `go test -tags mage .`
- `go run github.com/magefile/mage@v1.17.2 checkDependencyVersions`
