### PR TITLE
feat(agents): add max_concurrent_agent_runs to YAML config and API

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
@@ -104,6 +104,13 @@ func (c *OptimizeConfig) Validate() error {
 			*c.Options.MaxStalls)
 	}
 
+	if c.Options.MaxConcurrentAgentRuns != nil && *c.Options.MaxConcurrentAgentRuns < 1 {
+		return fmt.Errorf(
+			"options.max_concurrent_agent_runs must be >= 1 (got %d): "+
+				"set 'max_concurrent_agent_runs' under 'options:' in your config file",
+			*c.Options.MaxConcurrentAgentRuns)
+	}
+
 	return nil
 }
 
@@ -131,11 +138,12 @@ func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, []string, e
 		},
 		Evaluators: evaluatorRefs(c.Evaluators),
 		Options: optimize_api.OptimizeOptions{
-			EvalModel:         c.Options.EvalModel,
-			MaxCandidates:     c.Options.MaxCandidates,
-			OptimizationModel: c.Options.OptimizationModel,
-			EvaluationLevel:   c.Options.EvaluationLevel,
-			MaxStalls:         c.Options.MaxStalls,
+			EvalModel:              c.Options.EvalModel,
+			MaxCandidates:          c.Options.MaxCandidates,
+			OptimizationModel:      c.Options.OptimizationModel,
+			EvaluationLevel:        c.Options.EvaluationLevel,
+			MaxStalls:              c.Options.MaxStalls,
+			MaxConcurrentAgentRuns: c.Options.MaxConcurrentAgentRuns,
 		},
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
@@ -104,6 +104,12 @@ func (c *OptimizeConfig) Validate() error {
 			*c.Options.MaxStalls)
 	}
 
+	if c.Options.MaxConcurrentAgentRuns != nil && *c.Options.MaxConcurrentAgentRuns < 1 {
+		return fmt.Errorf(
+			"options.max_concurrent_agent_runs must be >= 1 (got %d): set 'max_concurrent_agent_runs' under 'options:' in your config file",
+			*c.Options.MaxConcurrentAgentRuns)
+	}
+
 	return nil
 }
 
@@ -131,11 +137,12 @@ func (c *OptimizeConfig) ToRequest() (*optimize_api.OptimizeRequest, []string, e
 		},
 		Evaluators: evaluatorRefs(c.Evaluators),
 		Options: optimize_api.OptimizeOptions{
-			EvalModel:         c.Options.EvalModel,
-			MaxCandidates:     c.Options.MaxCandidates,
-			OptimizationModel: c.Options.OptimizationModel,
-			EvaluationLevel:   c.Options.EvaluationLevel,
-			MaxStalls:         c.Options.MaxStalls,
+			EvalModel:              c.Options.EvalModel,
+			MaxCandidates:          c.Options.MaxCandidates,
+			OptimizationModel:      c.Options.OptimizationModel,
+			EvaluationLevel:        c.Options.EvaluationLevel,
+			MaxStalls:              c.Options.MaxStalls,
+			MaxConcurrentAgentRuns: c.Options.MaxConcurrentAgentRuns,
 		},
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
@@ -411,6 +411,93 @@ func TestValidate_MaxStallsPositiveIsAccepted(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidate_MaxConcurrentAgentRunsZeroIsRejected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent"},
+			Evaluators:  opt_eval.EvaluatorList{{Name: "builtin.task_adherence"}},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
+		},
+		Options: &opt_eval.Options{
+			EvalModel:              "gpt-4o-mini",
+			OptimizationModel:      "gpt-5",
+			MaxConcurrentAgentRuns: new(0),
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max_concurrent_agent_runs must be >= 1")
+}
+
+func TestValidate_MaxConcurrentAgentRunsPositiveIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent"},
+			Evaluators:  opt_eval.EvaluatorList{{Name: "builtin.task_adherence"}},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
+		},
+		Options: &opt_eval.Options{
+			EvalModel:              "gpt-4o-mini",
+			OptimizationModel:      "gpt-5",
+			MaxConcurrentAgentRuns: new(8),
+		},
+	}
+
+	err := cfg.Validate()
+	require.NoError(t, err)
+}
+
+func TestToRequest_MaxConcurrentAgentRunsForwardedToAPI(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent"},
+			Evaluators:  opt_eval.EvaluatorList{{Name: "builtin.task_adherence"}},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
+		},
+		Options: &opt_eval.Options{
+			EvalModel:              "gpt-4o-mini",
+			OptimizationModel:      "gpt-5",
+			MaxConcurrentAgentRuns: new(8),
+		},
+	}
+
+	req, _, err := cfg.ToRequest()
+	require.NoError(t, err)
+	require.NotNil(t, req.Options.MaxConcurrentAgentRuns)
+	assert.Equal(t, 8, *req.Options.MaxConcurrentAgentRuns)
+}
+
+func TestToRequest_MaxConcurrentAgentRunsNilWhenOmitted(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent"},
+			Evaluators:  opt_eval.EvaluatorList{{Name: "builtin.task_adherence"}},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
+		},
+		Options: &opt_eval.Options{
+			EvalModel:         "gpt-4o-mini",
+			OptimizationModel: "gpt-5",
+		},
+	}
+
+	req, _, err := cfg.ToRequest()
+	require.NoError(t, err)
+	assert.Nil(t, req.Options.MaxConcurrentAgentRuns)
+}
+
 func TestLoadOptimizeConfig_FileNotFound(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
@@ -411,6 +411,94 @@ func TestValidate_MaxStallsPositiveIsAccepted(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidate_MaxConcurrentAgentRunsZeroIsRejected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent"},
+			Evaluators:  opt_eval.EvaluatorList{{Name: "builtin.task_adherence"}},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
+		},
+		Options: &opt_eval.Options{
+			EvalModel:              "gpt-4o-mini",
+			OptimizationModel:      "gpt-5",
+			MaxConcurrentAgentRuns: new(0),
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max_concurrent_agent_runs must be >= 1")
+}
+
+func TestValidate_MaxConcurrentAgentRunsPositiveIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent"},
+			Evaluators:  opt_eval.EvaluatorList{{Name: "builtin.task_adherence"}},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
+		},
+		Options: &opt_eval.Options{
+			EvalModel:              "gpt-4o-mini",
+			OptimizationModel:      "gpt-5",
+			MaxConcurrentAgentRuns: new(8),
+		},
+	}
+
+	err := cfg.Validate()
+	require.NoError(t, err)
+}
+
+func TestToRequest_MaxConcurrentAgentRunsForwardedToAPI(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	n := 8
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent"},
+			Evaluators:  opt_eval.EvaluatorList{{Name: "builtin.task_adherence"}},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
+		},
+		Options: &opt_eval.Options{
+			EvalModel:              "gpt-4o-mini",
+			OptimizationModel:      "gpt-5",
+			MaxConcurrentAgentRuns: &n,
+		},
+	}
+
+	req, _, err := cfg.ToRequest()
+	require.NoError(t, err)
+	require.NotNil(t, req.Options.MaxConcurrentAgentRuns)
+	assert.Equal(t, 8, *req.Options.MaxConcurrentAgentRuns)
+}
+
+func TestToRequest_MaxConcurrentAgentRunsNilWhenOmitted(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent"},
+			Evaluators:  opt_eval.EvaluatorList{{Name: "builtin.task_adherence"}},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
+		},
+		Options: &opt_eval.Options{
+			EvalModel:         "gpt-4o-mini",
+			OptimizationModel: "gpt-5",
+		},
+	}
+
+	req, _, err := cfg.ToRequest()
+	require.NoError(t, err)
+	assert.Nil(t, req.Options.MaxConcurrentAgentRuns)
+}
+
 func TestLoadOptimizeConfig_FileNotFound(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
@@ -488,6 +488,12 @@ type Options struct {
 	// (iterations that do not improve over the current best score) before
 	// the optimizer stops early. When nil the service default is used.
 	MaxStalls *int `yaml:"max_stalls,omitempty"`
+	// MaxConcurrentAgentRuns is the maximum number of agent invocations the
+	// evaluation service executes concurrently for each evaluation run.
+	// Values greater than 1 parallelize row evaluation, which significantly
+	// reduces wall-clock time for large datasets. When nil the service
+	// default (sequential) is used.
+	MaxConcurrentAgentRuns *int `yaml:"max_concurrent_agent_runs,omitempty"`
 }
 
 // Read reads a YAML config file (eval or optimize format).

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
@@ -484,6 +484,12 @@ type Options struct {
 	// (iterations that do not improve over the current best score) before
 	// the optimizer stops early. When nil the service default is used.
 	MaxStalls *int `yaml:"max_stalls,omitempty"`
+	// MaxConcurrentAgentRuns is the maximum number of agent invocations the
+	// evaluation service executes concurrently for each evaluation run.
+	// Values greater than 1 parallelise row evaluation, which significantly
+	// reduces wall-clock time for large datasets. When nil the service
+	// default (sequential) is used.
+	MaxConcurrentAgentRuns *int `yaml:"max_concurrent_agent_runs,omitempty"`
 }
 
 // Read reads a YAML config file (eval or optimize format).

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml_test.go
@@ -416,6 +416,38 @@ max_stalls: 3
 	assert.Equal(t, 3, *opts.MaxStalls)
 }
 
+// TestOptions_MaxConcurrentAgentRuns verifies the max_concurrent_agent_runs key
+// populates MaxConcurrentAgentRuns.
+func TestOptions_MaxConcurrentAgentRuns(t *testing.T) {
+	t.Parallel()
+
+	input := `
+eval_model: gpt-4.1
+optimization_model: gpt-5
+max_concurrent_agent_runs: 8
+`
+	var opts Options
+	require.NoError(t, yaml.Unmarshal([]byte(input), &opts))
+
+	require.NotNil(t, opts.MaxConcurrentAgentRuns)
+	assert.Equal(t, 8, *opts.MaxConcurrentAgentRuns)
+}
+
+// TestOptions_MaxConcurrentAgentRunsOmitted verifies MaxConcurrentAgentRuns is nil
+// when the key is absent.
+func TestOptions_MaxConcurrentAgentRunsOmitted(t *testing.T) {
+	t.Parallel()
+
+	input := `
+eval_model: gpt-4.1
+optimization_model: gpt-5
+`
+	var opts Options
+	require.NoError(t, yaml.Unmarshal([]byte(input), &opts))
+
+	assert.Nil(t, opts.MaxConcurrentAgentRuns)
+}
+
 func TestOptions_OptimizationConfig_NativeYAML(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml_test.go
@@ -366,6 +366,38 @@ max_stalls: 3
 	assert.Equal(t, 3, *opts.MaxStalls)
 }
 
+// TestOptions_MaxConcurrentAgentRuns verifies the max_concurrent_agent_runs key
+// populates MaxConcurrentAgentRuns.
+func TestOptions_MaxConcurrentAgentRuns(t *testing.T) {
+	t.Parallel()
+
+	input := `
+eval_model: gpt-4.1
+optimization_model: gpt-5
+max_concurrent_agent_runs: 8
+`
+	var opts Options
+	require.NoError(t, yaml.Unmarshal([]byte(input), &opts))
+
+	require.NotNil(t, opts.MaxConcurrentAgentRuns)
+	assert.Equal(t, 8, *opts.MaxConcurrentAgentRuns)
+}
+
+// TestOptions_MaxConcurrentAgentRunsOmitted verifies MaxConcurrentAgentRuns is nil
+// when the key is absent.
+func TestOptions_MaxConcurrentAgentRunsOmitted(t *testing.T) {
+	t.Parallel()
+
+	input := `
+eval_model: gpt-4.1
+optimization_model: gpt-5
+`
+	var opts Options
+	require.NoError(t, yaml.Unmarshal([]byte(input), &opts))
+
+	assert.Nil(t, opts.MaxConcurrentAgentRuns)
+}
+
 func TestOptions_OptimizationConfig_NativeYAML(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
@@ -117,6 +117,9 @@ type OptimizeOptions struct {
 	// MaxStalls is the maximum number of consecutive non-improving iterations
 	// before the optimizer stops early. Omitted when nil (service default applies).
 	MaxStalls *int `json:"max_stalls,omitempty"`
+	// MaxConcurrentAgentRuns is the maximum number of agent invocations the
+	// evaluation service executes concurrently. Omitted when nil (service default applies).
+	MaxConcurrentAgentRuns *int `json:"max_concurrent_agent_runs,omitempty"`
 }
 
 // --- Response models ---

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
@@ -116,6 +116,9 @@ type OptimizeOptions struct {
 	// MaxStalls is the maximum number of consecutive non-improving iterations
 	// before the optimizer stops early. Omitted when nil (service default applies).
 	MaxStalls *int `json:"max_stalls,omitempty"`
+	// MaxConcurrentAgentRuns is the maximum number of agent invocations the
+	// evaluation service executes concurrently. Omitted when nil (service default applies).
+	MaxConcurrentAgentRuns *int `json:"max_concurrent_agent_runs,omitempty"`
 }
 
 // --- Response models ---

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models_test.go
@@ -31,10 +31,11 @@ func TestOptimizeRequest_RoundTrip(t *testing.T) {
 			{Name: "relevance", Version: "1"},
 		},
 		Options: OptimizeOptions{
-			MaxCandidates:     new(5),
-			EvalModel:         "gpt-4o-mini",
-			OptimizationModel: "gpt-4o",
-			MaxStalls:         new(3),
+			MaxCandidates:          new(5),
+			EvalModel:              "gpt-4o-mini",
+			OptimizationModel:      "gpt-4o",
+			MaxStalls:              new(3),
+			MaxConcurrentAgentRuns: new(8),
 		},
 	}
 
@@ -47,7 +48,7 @@ func TestOptimizeRequest_RoundTrip(t *testing.T) {
 		`"agent"`, `"agent_name"`, `"agent_version"`,
 		`"train_dataset"`, `"type"`, `"items"`, `"evaluators"`,
 		`"options"`, `"eval_model"`, `"max_candidates"`,
-		`"optimization_model"`, `"max_stalls"`,
+		`"optimization_model"`, `"max_stalls"`, `"max_concurrent_agent_runs"`,
 		`"ground_truth"`,
 	} {
 		assert.True(t, strings.Contains(s, field), "JSON should contain %s", field)
@@ -67,6 +68,8 @@ func TestOptimizeRequest_RoundTrip(t *testing.T) {
 	assert.Equal(t, "gpt-4o-mini", got.Options.EvalModel)
 	require.NotNil(t, got.Options.MaxStalls)
 	assert.Equal(t, 3, *got.Options.MaxStalls)
+	require.NotNil(t, got.Options.MaxConcurrentAgentRuns)
+	assert.Equal(t, 8, *got.Options.MaxConcurrentAgentRuns)
 }
 
 func TestOptimizeJobStatus_RoundTrip(t *testing.T) {


### PR DESCRIPTION
Closes #9625

## Problem

Evaluating large datasets sequentially takes O(n×t) time and frequently hits the 6-hour FAOS job timeout. The evaluation service already supports parallel agent invocations via the `item_generation_params.max_concurrency` field, but there was no way to set this from the optimize YAML config.

## Change

Add `max_concurrent_agent_runs` (YAML-only, no CLI flag, following the same policy as `max_stalls`) to:

1. `opt_eval.Options` struct (yaml.go) — YAML key `max_concurrent_agent_runs`
2. `optimize_api.OptimizeOptions` struct (models.go) — JSON key `max_concurrent_agent_runs`
3. `OptimizeConfig.ToRequest()` (optimize_config.go) — forwarded to API
4. `OptimizeConfig.Validate()` — rejects values < 1

## Usage

```yaml
options:
  eval_model: gpt-4.1
  optimization_model: gpt-5
  max_concurrent_agent_runs: 8   # run 8 agent calls in parallel per eval
```

## Tests

8 new tests covering: YAML parsing (present/absent), Validate rejection of 0, Validate acceptance of positive values, ToRequest forwarding to API, ToRequest nil when omitted. `TestOptimizeRequest_RoundTrip` extended with `max_concurrent_agent_runs` field and JSON tag assertion.