### PR TITLE
fix(extensions): validate source names

### DIFF
--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -1659,7 +1659,7 @@ func normalizeBundleSourceName(name string) string {
 			}
 		}
 	}
-	return strings.Trim(sb.String(), "-")
+	return strings.Trim(sb.String(), "-_")
 }
 
 // resolveSourceLocation registers a direct --source location and rewrites it to

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -174,6 +174,8 @@ Use --output json for a structured report of all upgrade results.`,
 			Use:   "add",
 			Short: "Add an extension source with the specified name",
 			Long: "Add an extension source with the specified name.\n\n" +
+				"Names must contain 1-64 lowercase ASCII letters, digits, hyphens, or underscores, " +
+				"and must begin and end with a letter or digit. The name 'bundle' is reserved.\n\n" +
 				"`azd extension install --source` and `azd extension upgrade --source` also accept " +
 				"a registry URL or file path directly.",
 		},
@@ -1331,6 +1333,13 @@ func (a *extensionInstallAction) prepareBundleInstall(ctx context.Context, bundl
 	if base == "" {
 		base = "bundle"
 	}
+	maxBaseLength := extensions.SourceNameMaxLength - len(suffix) - 1
+	if len(base) > maxBaseLength {
+		base = strings.TrimRight(base[:maxBaseLength], "-_")
+	}
+	if base == "" {
+		base = "bundle"
+	}
 	sourceName := fmt.Sprintf("%s-%s", base, suffix)
 
 	stepMessage := "Extracting extension bundle"
@@ -1746,11 +1755,11 @@ func registerSourceFromLocation(
 			console.Message(ctx, output.WithErrorFormat("Extension source name cannot be empty"))
 			continue
 		}
-		if err := validateSourceName(sourceName); err != nil {
+		if err := extensions.ValidateSourceName(sourceName); err != nil {
 			console.Message(ctx, output.WithErrorFormat(err.Error()))
 			continue
 		}
-		if _, err := sourceManager.Get(ctx, extensions.NormalizeSourceKey(sourceName)); err == nil {
+		if _, err := sourceManager.Get(ctx, sourceName); err == nil {
 			console.Message(ctx, output.WithErrorFormat("Extension source '%s' already exists", sourceName))
 			continue
 		} else if !errors.Is(err, extensions.ErrSourceNotFound) {
@@ -1799,19 +1808,6 @@ func resolveRegisteredSourceName(
 	_, err := sourceManager.Get(ctx, source)
 	if err == nil {
 		return source, true, nil
-	}
-	if !errors.Is(err, extensions.ErrSourceNotFound) {
-		return "", false, fmt.Errorf("failed to resolve extension source %q: %w", source, err)
-	}
-
-	normalizedSource := extensions.NormalizeSourceKey(source)
-	if normalizedSource == source {
-		return "", false, nil
-	}
-
-	_, err = sourceManager.Get(ctx, normalizedSource)
-	if err == nil {
-		return normalizedSource, true, nil
 	}
 	if !errors.Is(err, extensions.ErrSourceNotFound) {
 		return "", false, fmt.Errorf("failed to resolve extension source %q: %w", source, err)
@@ -1876,19 +1872,6 @@ func normalizeUrlLocation(location string) string {
 	return parsed.String()
 }
 
-func validateSourceName(name string) error {
-	if strings.Contains(name, ".") {
-		return errors.New("Extension source name cannot contain '.'")
-	}
-	if strings.ContainsAny(name, `/\`) {
-		return errors.New("Extension source name cannot contain path separators")
-	}
-	if strings.EqualFold(extensions.NormalizeSourceKey(name), extensions.BundleSourceName) {
-		return fmt.Errorf("Extension source name '%s' is reserved", extensions.BundleSourceName)
-	}
-	return nil
-}
-
 func sourceArgKind(source string) string {
 	if source == "" {
 		return "none"
@@ -1924,6 +1907,9 @@ func resolveSourceFilter(
 
 	kind, ok := inferSourceKind(source)
 	if !ok {
+		if err := extensions.ValidateSourceName(source); err != nil {
+			return sourceFilterResolution{}, err
+		}
 		return sourceFilterResolution{source: source}, nil
 	}
 
@@ -3073,7 +3059,13 @@ type extensionSourceAddFlags struct {
 
 func newExtensionSourceAddFlags(cmd *cobra.Command) *extensionSourceAddFlags {
 	flags := &extensionSourceAddFlags{}
-	cmd.Flags().StringVarP(&flags.name, "name", "n", "", "The name of the extension source")
+	cmd.Flags().StringVarP(
+		&flags.name,
+		"name",
+		"n",
+		"",
+		"The source name: 1-64 lowercase letters, digits, hyphens, or underscores.",
+	)
 	cmd.Flags().StringVarP(&flags.location, "location", "l", "", "The location of the extension source")
 	cmd.Flags().StringVarP(&flags.kind,
 		"type", "t", "", "The type of the extension source. Supported types are 'file' and 'url'")
@@ -3104,6 +3096,10 @@ func (a *extensionSourceAddAction) Run(ctx context.Context) (*actions.ActionResu
 	a.console.MessageUxItem(ctx, &ux.MessageTitle{
 		Title: "Add extension source (azd extension source add)",
 	})
+
+	if err := extensions.ValidateSourceName(a.flags.name); err != nil {
+		return nil, err
+	}
 
 	spinnerMessage := "Validating extension source"
 	a.console.ShowSpinner(ctx, spinnerMessage, input.Step)
@@ -3182,7 +3178,7 @@ func (a *extensionSourceRemoveAction) Run(ctx context.Context) (*actions.ActionR
 		Title: "Remove extension source (azd extension source remove)",
 	})
 
-	var key = strings.ToLower(a.args[0])
+	key := a.args[0]
 	spinnerMessage := fmt.Sprintf("Removing extension source (%s)", key)
 	a.console.ShowSpinner(ctx, spinnerMessage, input.Step)
 

--- a/cli/azd/cmd/extension.go
+++ b/cli/azd/cmd/extension.go
@@ -3149,6 +3149,13 @@ type extensionSourceRemoveAction struct {
 	args          []string
 }
 
+func extensionSourceDisplayName(name string) string {
+	if err := extensions.ValidateSourceName(name); err != nil {
+		return fmt.Sprintf("%q", name)
+	}
+	return name
+}
+
 func newExtensionSourceRemoveAction(
 	sourceManager *extensions.SourceManager,
 	console input.Console,
@@ -3179,7 +3186,8 @@ func (a *extensionSourceRemoveAction) Run(ctx context.Context) (*actions.ActionR
 	})
 
 	key := a.args[0]
-	spinnerMessage := fmt.Sprintf("Removing extension source (%s)", key)
+	displayName := extensionSourceDisplayName(key)
+	spinnerMessage := fmt.Sprintf("Removing extension source (%s)", displayName)
 	a.console.ShowSpinner(ctx, spinnerMessage, input.Step)
 
 	err := a.sourceManager.Remove(ctx, key)
@@ -3190,7 +3198,7 @@ func (a *extensionSourceRemoveAction) Run(ctx context.Context) (*actions.ActionR
 
 	return &actions.ActionResult{
 		Message: &actions.ResultMessage{
-			Header: fmt.Sprintf("Removed azd extension source %s", key),
+			Header: fmt.Sprintf("Removed azd extension source %s", displayName),
 			FollowUp: fmt.Sprintf(
 				"Add more extension sources by running %s",
 				output.WithHighLightFormat("azd extension source add <key>"),

--- a/cli/azd/cmd/extension_bundle_test.go
+++ b/cli/azd/cmd/extension_bundle_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -76,6 +77,30 @@ func TestBundleSourceName(t *testing.T) {
 
 	require.Equal(t, "my-ext_1-0-0", bundleSourceName("/tmp/My Ext_1.0.0.zip"))
 	require.Equal(t, "bundle", bundleSourceName("bundle.zip"))
+}
+
+func TestPrepareBundleInstall_LongNameUsesValidTransientSource(t *testing.T) {
+	t.Parallel()
+
+	action, _ := newBundleInstallTestAction(t)
+	zipPath := makeBundleZip(t, []*extensions.ExtensionMetadata{
+		{
+			Id:          "test.ext",
+			DisplayName: "Test Extension",
+			Versions: []extensions.ExtensionVersion{
+				{Version: "1.0.0", Artifacts: map[string]extensions.ExtensionArtifact{
+					"linux/amd64": {URL: "artifacts/ext.tar.gz"},
+				}},
+			},
+		},
+	})
+	longPath := filepath.Join(filepath.Dir(zipPath), strings.Repeat("a", 100)+".zip")
+	require.NoError(t, os.Rename(zipPath, longPath))
+
+	require.NoError(t, action.prepareBundleInstall(t.Context(), longPath))
+	require.NoError(t, extensions.ValidateSourceName(action.bundleSourceName))
+	require.LessOrEqual(t, len(action.bundleSourceName), extensions.SourceNameMaxLength)
+	action.cleanupBundleInstall(t.Context())
 }
 
 func TestCleanupBundleInstall_RemovesTempDir(t *testing.T) {

--- a/cli/azd/cmd/extension_bundle_test.go
+++ b/cli/azd/cmd/extension_bundle_test.go
@@ -64,6 +64,9 @@ func TestNormalizeBundleSourceName(t *testing.T) {
 		"ext_1.0.0":            "ext_1-0-0",
 		"weird@@name!!":        "weird-name",
 		"--leading-trailing--": "leading-trailing",
+		"_leading":             "leading",
+		"trailing_":            "trailing",
+		"___":                  "",
 		"UPPER":                "upper",
 	}
 

--- a/cli/azd/cmd/extension_install_source_test.go
+++ b/cli/azd/cmd/extension_install_source_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/internal"
@@ -15,7 +16,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/extensions"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
-	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
 	"github.com/stretchr/testify/require"
@@ -96,7 +96,7 @@ func TestResolveSourceLocation_ExistingSourceUnchanged(t *testing.T) {
 	require.Equal(t, "my-source", action.flags.source)
 }
 
-func TestResolveSourceLocation_NormalizedExistingSourceUsed(t *testing.T) {
+func TestResolveSourceLocation_InvalidAliasRejected(t *testing.T) {
 	t.Parallel()
 
 	action, _ := newBundleInstallTestAction(t)
@@ -107,8 +107,8 @@ func TestResolveSourceLocation_NormalizedExistingSourceUsed(t *testing.T) {
 	}))
 
 	action.flags.source = "my source"
-	require.NoError(t, action.resolveSourceLocation(t.Context()))
-	require.Equal(t, "my-source", action.flags.source)
+	err := action.resolveSourceLocation(t.Context())
+	require.ErrorIs(t, err, extensions.ErrSourceNameInvalid)
 }
 
 func TestResolveSourceLocation_PlainNameUnchanged(t *testing.T) {
@@ -200,7 +200,7 @@ func TestResolveSourceLocation_InvalidSourceNamePromptsAgain(t *testing.T) {
 	require.NoError(t, action.resolveSourceLocation(t.Context()))
 	require.Equal(t, "local-dev", action.flags.source)
 	require.Equal(t, 2, promptCount)
-	require.Contains(t, console.Output(), output.WithErrorFormat("Extension source name cannot contain '.'"))
+	require.Contains(t, strings.Join(console.Output(), "\n"), "invalid extension source name")
 }
 
 func TestResolveSourceLocation_ExistingSourceNamePromptsAgain(t *testing.T) {

--- a/cli/azd/cmd/extension_source_location_test.go
+++ b/cli/azd/cmd/extension_source_location_test.go
@@ -131,7 +131,7 @@ func TestExtensionList_UnknownRegisteredNameErrors(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestExtensionList_NormalizedRegisteredSourceName(t *testing.T) {
+func TestExtensionList_InvalidSourceAliasErrors(t *testing.T) {
 	t.Parallel()
 
 	mockContext, manager, sourceManager := newSourceLocationTestManager(t)
@@ -153,12 +153,7 @@ func TestExtensionList_NormalizedRegisteredSourceName(t *testing.T) {
 	}
 
 	_, err := action.Run(t.Context())
-	require.NoError(t, err)
-
-	var rows []extensionListItem
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &rows))
-	require.Len(t, rows, 1)
-	require.Equal(t, "my-source", rows[0].Source)
+	require.ErrorIs(t, err, extensions.ErrSourceNameInvalid)
 }
 
 func TestExtensionList_DirectRelativeFileSource(t *testing.T) {
@@ -233,7 +228,7 @@ func TestExtensionShow_DirectUrlSource(t *testing.T) {
 	requireLocationNotRegistered(t, sourceManager, sourceLocationRegistryURL)
 }
 
-func TestExtensionShow_NormalizedRegisteredSourceName(t *testing.T) {
+func TestExtensionShow_InvalidSourceAliasErrors(t *testing.T) {
 	t.Parallel()
 
 	mockContext, manager, sourceManager := newSourceLocationTestManager(t)
@@ -258,7 +253,7 @@ func TestExtensionShow_NormalizedRegisteredSourceName(t *testing.T) {
 	}
 
 	_, err := action.Run(t.Context())
-	require.NoError(t, err)
+	require.ErrorIs(t, err, extensions.ErrSourceNameInvalid)
 }
 
 func TestExtensionShow_UnknownRegisteredNameErrors(t *testing.T) {

--- a/cli/azd/cmd/extension_test.go
+++ b/cli/azd/cmd/extension_test.go
@@ -1388,6 +1388,14 @@ func Test_ExtensionSourceRemoveAction_TooManyArgs(t *testing.T) {
 	assert.ErrorIs(t, err, internal.ErrInvalidFlagCombination)
 }
 
+func TestExtensionSourceDisplayName(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "valid-source", extensionSourceDisplayName("valid-source"))
+	require.Equal(t, `"legacy\nsource"`, extensionSourceDisplayName("legacy\nsource"))
+	require.Equal(t, `"\x1b[31mspoof"`, extensionSourceDisplayName("\x1b[31mspoof"))
+}
+
 func Test_ExtensionSourceValidateAction_NoArgs(t *testing.T) {
 	t.Parallel()
 	action := &extensionSourceValidateAction{args: []string{}}

--- a/cli/azd/cmd/testdata/TestFigSpec.ts
+++ b/cli/azd/cmd/testdata/TestFigSpec.ts
@@ -5958,7 +5958,7 @@ const completionSpec: Fig.Spec = {
 								},
 								{
 									name: ['--name', '-n'],
-									description: 'The name of the extension source',
+									description: 'The source name: 1-64 lowercase letters, digits, hyphens, or underscores.',
 									args: [
 										{
 											name: 'name',

--- a/cli/azd/cmd/testdata/TestUsage-azd-extension-source-add.snap
+++ b/cli/azd/cmd/testdata/TestUsage-azd-extension-source-add.snap
@@ -6,7 +6,7 @@ Usage
 
 Flags
     -l, --location string 	: The location of the extension source
-    -n, --name string     	: The name of the extension source
+    -n, --name string     	: The source name: 1-64 lowercase letters, digits, hyphens, or underscores.
     -t, --type string     	: The type of the extension source. Supported types are 'file' and 'url'
 
 Global Flags

--- a/cli/azd/docs/extensions/extension-framework.md
+++ b/cli/azd/docs/extensions/extension-framework.md
@@ -102,7 +102,7 @@ Displays a list of installed extension sources.
 Adds a new named extension source to the global `azd` configuration.
 
 - `-l, --location` The location of the extension source.
-- `-n, --name` The name of the extension source.
+- `-n, --name` The name of the extension source. Names must contain 1 to 64 lowercase ASCII letters, digits, hyphens, or underscores, and must begin and end with a letter or digit. `bundle` is reserved.
 - `-t, --type` The type of extension source. Supported types are `file` and `url`.
 
 #### `azd extension source remove <name>`

--- a/cli/azd/docs/extensions/extension-resolution-and-versioning.md
+++ b/cli/azd/docs/extensions/extension-resolution-and-versioning.md
@@ -15,6 +15,8 @@ Extension sources are manifests that describe the extensions available for insta
 
 In addition, extensions installed from a [self-contained bundle](#self-contained-bundles) are tagged with a reserved `bundle` source. `bundle` is not a configurable source type and never appears in `azd extension source list` — it simply marks an extension that has no live registry to track updates against. Such extensions are listed with their `bundle` source in `azd extension list` and are skipped by `azd extension upgrade`. The name `bundle` is reserved, so it cannot be used as a user-configured source name.
 
+Source names must contain 1 to 64 lowercase ASCII letters, digits, hyphens, or underscores, and must begin and end with a letter or digit. Invalid names are rejected rather than normalized. If an older configuration contains an invalid name, extension source loading reports the exact entry to remove and re-add.
+
 Sources are configured in `~/.azd/config.json`. You can manage them with the following commands:
 
 ```bash
@@ -298,7 +300,7 @@ An extension only qualifies when the version `azd` would select publishes the pr
 ~/.azd/cache/extensions/<source-name>.json
 ```
 
-Each source has its own cache file. The filename is derived from the source name by lowercasing it and replacing any characters outside `[a-zA-Z0-9._-]` with `_`. For example, a source named `"My Source!"` would be cached as `my_source_.json`.
+Each source has its own cache file. Because configured source names use the canonical format described above, the source name maps directly to a unique cache filename.
 
 ### Default TTL
 
@@ -410,7 +412,7 @@ When `latest` is specified (or the version is omitted), `azd` selects the **high
 
 ## Dev/Experimental Extension Registry
 
-The dev (experimental) registry is a separate extension source for bleeding-edge, pre-release, and community-contributed extensions that have not yet been promoted to the official `azd` registry. It lives alongside the main registry in the `azure-dev` repository and is served via a dedicated aka.ms link. While `azd` and `dev` are the official source names, the extension source system supports adding custom sources with any name via `azd extension source add`.
+The dev (experimental) registry is a separate extension source for bleeding-edge, pre-release, and community-contributed extensions that have not yet been promoted to the official `azd` registry. It lives alongside the main registry in the `azure-dev` repository and is served via a dedicated aka.ms link. While `azd` and `dev` are the official source names, custom source names must follow the canonical source-name format.
 
 | Property | Main Registry | Dev Registry |
 |----------|---------------|--------------|

--- a/cli/azd/pkg/extensions/registry_cache.go
+++ b/cli/azd/pkg/extensions/registry_cache.go
@@ -36,7 +36,7 @@ var (
 	ErrCacheExpired = errors.New("cache expired")
 	// ErrCacheNotFound indicates no cache file exists
 	ErrCacheNotFound = errors.New("cache not found")
-	// sourceNameSanitizer replaces unsafe filename characters
+	// sourceNameSanitizer defensively handles legacy source names that predate validation.
 	sourceNameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
 )
 
@@ -90,7 +90,8 @@ func getCacheTTL() time.Duration {
 	return defaultCacheTTL
 }
 
-// sanitizeSourceName converts a source name to a safe filename
+// sanitizeSourceName converts a source name to a safe filename.
+// Canonical configured source names pass through unchanged.
 func sanitizeSourceName(sourceName string) string {
 	// Replace unsafe characters with underscores
 	safe := sourceNameSanitizer.ReplaceAllString(sourceName, "_")

--- a/cli/azd/pkg/extensions/source_manager.go
+++ b/cli/azd/pkg/extensions/source_manager.go
@@ -296,11 +296,11 @@ func ValidateSourceName(name string) error {
 func validateConfiguredSource(key string, source *SourceConfig) error {
 	if err := ValidateSourceName(key); err != nil {
 		return fmt.Errorf(
-			"configured extension source %q has an invalid name: %w; remove it with "+
-				"`azd extension source remove %q` and add it again with a valid name",
+			"configured extension source %q has an invalid name: %w; run "+
+				"`azd extension source remove <source-name>` using the exact name shown above, "+
+				"then add it again with a valid name",
 			key,
 			err,
-			key,
 		)
 	}
 	if source == nil {
@@ -308,21 +308,21 @@ func validateConfiguredSource(key string, source *SourceConfig) error {
 	}
 	if err := ValidateSourceName(source.Name); err != nil {
 		return fmt.Errorf(
-			"configured extension source %q has an invalid stored name %q: %w; remove it with "+
-				"`azd extension source remove %q` and add it again with a valid name",
+			"configured extension source %q has an invalid stored name %q: %w; run "+
+				"`azd extension source remove <source-name>` using the source key shown above, "+
+				"then add it again with a valid name",
 			key,
 			source.Name,
 			err,
-			key,
 		)
 	}
 	if source.Name != key {
 		return fmt.Errorf(
-			"configured extension source key %q does not match its stored name %q; remove it with "+
-				"`azd extension source remove %q` and add it again",
+			"configured extension source key %q does not match its stored name %q; run "+
+				"`azd extension source remove <source-name>` using the source key shown above, "+
+				"then add it again",
 			key,
 			source.Name,
-			key,
 		)
 	}
 	return nil

--- a/cli/azd/pkg/extensions/source_manager.go
+++ b/cli/azd/pkg/extensions/source_manager.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -126,9 +127,9 @@ func (sm *SourceManager) Remove(ctx context.Context, name string) error {
 		return fmt.Errorf("unable to parse extension sources")
 	}
 
-	matches := sourceKeysMatchingName(sourceMap, name, false)
+	matches := sourcePathsMatchingName(sourceMap, name, false)
 	if len(matches) == 0 {
-		matches = sourceKeysMatchingName(sourceMap, name, true)
+		matches = sourcePathsMatchingName(sourceMap, name, true)
 	}
 	if len(matches) == 0 {
 		return fmt.Errorf("extension source '%s' not found, %w", name, ErrSourceNotFound)
@@ -137,7 +138,7 @@ func (sm *SourceManager) Remove(ctx context.Context, name string) error {
 		return fmt.Errorf("extension source name '%s' matches multiple configured sources", name)
 	}
 
-	delete(sourceMap, matches[0])
+	deleteSourcePath(sourceMap, matches[0])
 	if err := config.Set(baseConfigKey, sourceMap); err != nil {
 		return fmt.Errorf("unable to remove extension source '%s': %w", name, err)
 	}
@@ -165,24 +166,16 @@ func (sm *SourceManager) List(ctx context.Context) ([]*SourceConfig, error) {
 		if !ok {
 			return nil, fmt.Errorf("unable to parse extension sources")
 		}
-		for key, rawSource := range sourceMap {
-			var sourceConfig *SourceConfig
-
-			jsonBytes, err := json.Marshal(rawSource)
-			if err != nil {
-				return nil, fmt.Errorf("unable to parse source '%s': %w", key, err)
-			}
-
-			err = json.Unmarshal(jsonBytes, &sourceConfig)
-			if err != nil {
-				return nil, fmt.Errorf("unable to parse source '%s': %w", key, err)
-			}
-
-			if err := validateConfiguredSource(key, sourceConfig); err != nil {
+		sourceEntries, err := configuredSourceEntries(sourceMap)
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range sourceEntries {
+			if err := validateConfiguredSource(entry.name, entry.config); err != nil {
 				return nil, err
 			}
 
-			allSourceConfigs = append(allSourceConfigs, sourceConfig)
+			allSourceConfigs = append(allSourceConfigs, entry.config)
 		}
 	} else {
 		defaultSource := &SourceConfig{
@@ -328,8 +321,67 @@ func validateConfiguredSource(key string, source *SourceConfig) error {
 	return nil
 }
 
-func sourceKeysMatchingName(sourceMap map[string]any, name string, ignoreCase bool) []string {
-	matches := []string{}
+type configuredSourceEntry struct {
+	name   string
+	path   []string
+	config *SourceConfig
+}
+
+func configuredSourceEntries(sourceMap map[string]any) ([]configuredSourceEntry, error) {
+	entries := []configuredSourceEntry{}
+	if err := walkConfiguredSources(sourceMap, nil, func(entry configuredSourceEntry) {
+		entries = append(entries, entry)
+	}); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func walkConfiguredSources(
+	sourceMap map[string]any,
+	parentPath []string,
+	visit func(configuredSourceEntry),
+) error {
+	for _, key := range slices.Sorted(maps.Keys(sourceMap)) {
+		rawSource := sourceMap[key]
+		path := append(slices.Clone(parentPath), key)
+		name := strings.Join(path, ".")
+
+		if nested, ok := rawSource.(map[string]any); ok && !isSourceConfigMap(nested) {
+			if err := walkConfiguredSources(nested, path, visit); err != nil {
+				return err
+			}
+			continue
+		}
+
+		var sourceConfig *SourceConfig
+		jsonBytes, err := json.Marshal(rawSource)
+		if err != nil {
+			return fmt.Errorf("unable to parse source '%s': %w", name, err)
+		}
+		if err := json.Unmarshal(jsonBytes, &sourceConfig); err != nil {
+			return fmt.Errorf("unable to parse source '%s': %w", name, err)
+		}
+
+		visit(configuredSourceEntry{
+			name:   name,
+			path:   path,
+			config: sourceConfig,
+		})
+	}
+
+	return nil
+}
+
+func isSourceConfigMap(value map[string]any) bool {
+	_, hasName := value["name"].(string)
+	_, hasType := value["type"].(string)
+	_, hasLocation := value["location"].(string)
+	return hasName || hasType || hasLocation
+}
+
+func sourcePathsMatchingName(sourceMap map[string]any, name string, ignoreCase bool) [][]string {
+	matches := [][]string{}
 	equal := func(a, b string) bool {
 		if ignoreCase {
 			return strings.EqualFold(a, b)
@@ -337,21 +389,27 @@ func sourceKeysMatchingName(sourceMap map[string]any, name string, ignoreCase bo
 		return a == b
 	}
 
-	for key, rawSource := range sourceMap {
-		if equal(key, name) {
-			matches = append(matches, key)
-			continue
+	_ = walkConfiguredSources(sourceMap, nil, func(entry configuredSourceEntry) {
+		if equal(entry.name, name) || entry.config != nil && equal(entry.config.Name, name) {
+			matches = append(matches, entry.path)
 		}
-
-		jsonBytes, err := json.Marshal(rawSource)
-		if err != nil {
-			continue
-		}
-		var source SourceConfig
-		if err := json.Unmarshal(jsonBytes, &source); err == nil && equal(source.Name, name) {
-			matches = append(matches, key)
-		}
-	}
+	})
 
 	return matches
+}
+
+func deleteSourcePath(sourceMap map[string]any, path []string) bool {
+	if len(path) == 1 {
+		delete(sourceMap, path[0])
+		return len(sourceMap) == 0
+	}
+
+	nested, ok := sourceMap[path[0]].(map[string]any)
+	if !ok {
+		return false
+	}
+	if deleteSourcePath(nested, path[1:]) {
+		delete(sourceMap, path[0])
+	}
+	return len(sourceMap) == 0
 }

--- a/cli/azd/pkg/extensions/source_manager.go
+++ b/cli/azd/pkg/extensions/source_manager.go
@@ -30,6 +30,9 @@ const (
 	baseConfigKey      string = "extension.sources"
 	installedConfigKey string = "extension.installed"
 
+	// SourceNameMaxLength is the maximum number of ASCII characters in an extension source name.
+	SourceNameMaxLength = 64
+
 	// BundleSourceName is the reserved source recorded for extensions installed
 	// from a self-contained bundle (.zip). The bundle's own source is ephemeral
 	// and removed after install, so the extension is marked with this name; it has
@@ -40,6 +43,7 @@ const (
 var (
 	ErrSourceNotFound    = errors.New("extension source not found")
 	ErrSourceExists      = errors.New("extension source already exists")
+	ErrSourceNameInvalid = errors.New("invalid extension source name")
 	ErrSourceTypeInvalid = errors.New("invalid extension source type")
 	ErrSourceReserved    = errors.New("extension source name is reserved")
 )
@@ -88,51 +92,53 @@ func (sm *SourceManager) Get(ctx context.Context, name string) (*SourceConfig, e
 
 // Add adds a new extension source.
 func (sm *SourceManager) Add(ctx context.Context, name string, source *SourceConfig) error {
-	newKey := NormalizeSourceKey(name)
-
-	if strings.EqualFold(newKey, BundleSourceName) {
-		return fmt.Errorf(
-			"'%s' is reserved for extensions installed from a self-contained bundle, %w",
-			BundleSourceName, ErrSourceReserved,
-		)
+	if err := ValidateSourceName(name); err != nil {
+		return err
 	}
 
-	existing, err := sm.Get(ctx, newKey)
+	existing, err := sm.Get(ctx, name)
 	if existing != nil && err == nil {
 		return fmt.Errorf("extension source '%s' already exists, %w", name, ErrSourceExists)
 	}
-
-	if source.Name == "" {
-		source.Name = name
+	if err != nil && !errors.Is(err, ErrSourceNotFound) {
+		return fmt.Errorf("checking extension source '%s': %w", name, err)
 	}
 
-	source.Name = newKey
+	source.Name = name
 
 	return sm.addInternal(source)
 }
 
 // Remove removes an extension source.
 func (sm *SourceManager) Remove(ctx context.Context, name string) error {
-	name = NormalizeSourceKey(name)
-
-	_, err := sm.Get(ctx, name)
-	if err != nil && errors.Is(err, ErrSourceNotFound) {
-		return fmt.Errorf("extension source '%s' not found, %w", name, err)
-	}
-
 	config, err := sm.configManager.Load()
 	if err != nil {
 		return fmt.Errorf("unable to load user configuration: %w", err)
 	}
 
-	path := fmt.Sprintf("%s.%s", baseConfigKey, name)
-	_, ok := config.Get(path)
+	rawSources, ok := config.Get(baseConfigKey)
 	if !ok {
-		return nil
+		return fmt.Errorf("extension source '%s' not found, %w", name, ErrSourceNotFound)
 	}
 
-	err = config.Unset(path)
-	if err != nil {
+	sourceMap, ok := rawSources.(map[string]any)
+	if !ok {
+		return fmt.Errorf("unable to parse extension sources")
+	}
+
+	matches := sourceKeysMatchingName(sourceMap, name, false)
+	if len(matches) == 0 {
+		matches = sourceKeysMatchingName(sourceMap, name, true)
+	}
+	if len(matches) == 0 {
+		return fmt.Errorf("extension source '%s' not found, %w", name, ErrSourceNotFound)
+	}
+	if len(matches) > 1 {
+		return fmt.Errorf("extension source name '%s' matches multiple configured sources", name)
+	}
+
+	delete(sourceMap, matches[0])
+	if err := config.Set(baseConfigKey, sourceMap); err != nil {
 		return fmt.Errorf("unable to remove extension source '%s': %w", name, err)
 	}
 
@@ -155,7 +161,10 @@ func (sm *SourceManager) List(ctx context.Context) ([]*SourceConfig, error) {
 
 	rawSources, ok := config.Get(baseConfigKey)
 	if ok {
-		sourceMap := rawSources.(map[string]any)
+		sourceMap, ok := rawSources.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("unable to parse extension sources")
+		}
 		for key, rawSource := range sourceMap {
 			var sourceConfig *SourceConfig
 
@@ -167,6 +176,10 @@ func (sm *SourceManager) List(ctx context.Context) ([]*SourceConfig, error) {
 			err = json.Unmarshal(jsonBytes, &sourceConfig)
 			if err != nil {
 				return nil, fmt.Errorf("unable to parse source '%s': %w", key, err)
+			}
+
+			if err := validateConfiguredSource(key, sourceConfig); err != nil {
+				return nil, err
 			}
 
 			allSourceConfigs = append(allSourceConfigs, sourceConfig)
@@ -247,10 +260,98 @@ func (sm *SourceManager) addInternal(source *SourceConfig) error {
 	return nil
 }
 
-// NormalizeSourceKey normalizes an extension source name for use in configuration keys.
-func NormalizeSourceKey(key string) string {
-	key = strings.ToLower(key)
-	key = strings.ReplaceAll(key, " ", "-")
+// ValidateSourceName validates a source name for configuration and command-line use.
+func ValidateSourceName(name string) error {
+	if len(name) == 0 || len(name) > SourceNameMaxLength {
+		return fmt.Errorf(
+			"%w: must be between 1 and %d characters",
+			ErrSourceNameInvalid,
+			SourceNameMaxLength,
+		)
+	}
+	if strings.EqualFold(name, BundleSourceName) {
+		return fmt.Errorf(
+			"'%s' is reserved for extensions installed from a self-contained bundle, %w",
+			BundleSourceName,
+			ErrSourceReserved,
+		)
+	}
+	for i, char := range []byte(name) {
+		if char >= 'a' && char <= 'z' || char >= '0' && char <= '9' {
+			continue
+		}
+		if (char == '-' || char == '_') && i > 0 && i < len(name)-1 {
+			continue
+		}
+		return fmt.Errorf(
+			"%w: must use lowercase ASCII letters, digits, hyphens, or underscores "+
+				"and begin and end with a letter or digit",
+			ErrSourceNameInvalid,
+		)
+	}
 
-	return key
+	return nil
+}
+
+func validateConfiguredSource(key string, source *SourceConfig) error {
+	if err := ValidateSourceName(key); err != nil {
+		return fmt.Errorf(
+			"configured extension source %q has an invalid name: %w; remove it with "+
+				"`azd extension source remove %q` and add it again with a valid name",
+			key,
+			err,
+			key,
+		)
+	}
+	if source == nil {
+		return fmt.Errorf("configured extension source %q is empty", key)
+	}
+	if err := ValidateSourceName(source.Name); err != nil {
+		return fmt.Errorf(
+			"configured extension source %q has an invalid stored name %q: %w; remove it with "+
+				"`azd extension source remove %q` and add it again with a valid name",
+			key,
+			source.Name,
+			err,
+			key,
+		)
+	}
+	if source.Name != key {
+		return fmt.Errorf(
+			"configured extension source key %q does not match its stored name %q; remove it with "+
+				"`azd extension source remove %q` and add it again",
+			key,
+			source.Name,
+			key,
+		)
+	}
+	return nil
+}
+
+func sourceKeysMatchingName(sourceMap map[string]any, name string, ignoreCase bool) []string {
+	matches := []string{}
+	equal := func(a, b string) bool {
+		if ignoreCase {
+			return strings.EqualFold(a, b)
+		}
+		return a == b
+	}
+
+	for key, rawSource := range sourceMap {
+		if equal(key, name) {
+			matches = append(matches, key)
+			continue
+		}
+
+		jsonBytes, err := json.Marshal(rawSource)
+		if err != nil {
+			continue
+		}
+		var source SourceConfig
+		if err := json.Unmarshal(jsonBytes, &source); err == nil && equal(source.Name, name) {
+			matches = append(matches, key)
+		}
+	}
+
+	return matches
 }

--- a/cli/azd/pkg/extensions/source_manager_test.go
+++ b/cli/azd/pkg/extensions/source_manager_test.go
@@ -4,6 +4,8 @@
 package extensions
 
 import (
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
@@ -120,6 +122,26 @@ func TestSourceManager_Remove(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrSourceNotFound)
 	})
+
+	t.Run("RemoveLegacyInvalidName", func(t *testing.T) {
+		legacyConfig := config.NewEmptyConfig()
+		err := legacyConfig.Set(baseConfigKey, map[string]any{
+			"legacy.source": SourceConfig{
+				Name:     "legacy.source",
+				Type:     SourceKindUrl,
+				Location: "http://example.com",
+			},
+		})
+		require.NoError(t, err)
+		mockContext.ConfigManager.WithConfig(legacyConfig)
+
+		err = sourceManager.Remove(ctx, "legacy.source")
+		require.NoError(t, err)
+
+		sources, ok := legacyConfig.GetMap(baseConfigKey)
+		require.True(t, ok)
+		require.NotContains(t, sources, "legacy.source")
+	})
 }
 
 func TestSourceManager_List(t *testing.T) {
@@ -146,11 +168,144 @@ func TestSourceManager_List(t *testing.T) {
 	require.Equal(t, expected, *sources[0])
 }
 
-func TestNormalizeSourceKey(t *testing.T) {
+func TestValidateSourceName(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, "my-source", NormalizeSourceKey("My Source"))
-	require.Equal(t, "my.source", NormalizeSourceKey("My.Source"))
+	tests := []struct {
+		name      string
+		source    string
+		targetErr error
+	}{
+		{name: "single letter", source: "a"},
+		{name: "letters and digits", source: "registry2"},
+		{name: "hyphen", source: "local-dev"},
+		{name: "underscore", source: "team_registry"},
+		{name: "maximum length", source: strings.Repeat("a", SourceNameMaxLength)},
+		{name: "empty", source: "", targetErr: ErrSourceNameInvalid},
+		{name: "too long", source: strings.Repeat("a", SourceNameMaxLength+1), targetErr: ErrSourceNameInvalid},
+		{name: "uppercase", source: "Dev", targetErr: ErrSourceNameInvalid},
+		{name: "space", source: "my source", targetErr: ErrSourceNameInvalid},
+		{name: "dot", source: "my.source", targetErr: ErrSourceNameInvalid},
+		{name: "leading hyphen", source: "-dev", targetErr: ErrSourceNameInvalid},
+		{name: "trailing hyphen", source: "dev-", targetErr: ErrSourceNameInvalid},
+		{name: "leading underscore", source: "_dev", targetErr: ErrSourceNameInvalid},
+		{name: "trailing underscore", source: "dev_", targetErr: ErrSourceNameInvalid},
+		{name: "path separator", source: "foo/bar", targetErr: ErrSourceNameInvalid},
+		{name: "shell operator", source: "foo;rm", targetErr: ErrSourceNameInvalid},
+		{name: "unicode", source: "dév", targetErr: ErrSourceNameInvalid},
+		{name: "reserved bundle", source: BundleSourceName, targetErr: ErrSourceReserved},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSourceName(tt.source)
+			if tt.targetErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tt.targetErr)
+		})
+	}
+}
+
+func TestSourceManager_ListRejectsInvalidConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		key     string
+		source  SourceConfig
+		errText string
+	}{
+		{
+			name: "invalid key",
+			key:  "legacy.source",
+			source: SourceConfig{
+				Name:     "legacy.source",
+				Type:     SourceKindUrl,
+				Location: "http://example.com",
+			},
+			errText: "configured extension source \"legacy.source\" has an invalid name",
+		},
+		{
+			name: "invalid stored name",
+			key:  "legacy-source",
+			source: SourceConfig{
+				Name:     "Legacy Source",
+				Type:     SourceKindUrl,
+				Location: "http://example.com",
+			},
+			errText: "has an invalid stored name",
+		},
+		{
+			name: "mismatched name",
+			key:  "source-one",
+			source: SourceConfig{
+				Name:     "source-two",
+				Type:     SourceKindUrl,
+				Location: "http://example.com",
+			},
+			errText: "does not match its stored name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockContext := mocks.NewMockContext(t.Context())
+			mockConfig := config.NewEmptyConfig()
+			require.NoError(t, mockConfig.Set(baseConfigKey, map[string]any{tt.key: tt.source}))
+			mockContext.ConfigManager.WithConfig(mockConfig)
+
+			sourceManager := NewSourceManager(
+				mockContext.Container,
+				config.NewUserConfigManager(mockContext.ConfigManager),
+				mockContext.HttpClient,
+			)
+			_, err := sourceManager.List(t.Context())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errText)
+		})
+	}
+}
+
+func TestSourceManager_AddRejectsInvalidNameWithoutMutation(t *testing.T) {
+	t.Parallel()
+
+	mockContext := mocks.NewMockContext(t.Context())
+	mockConfig := config.NewEmptyConfig()
+	mockContext.ConfigManager.WithConfig(mockConfig)
+	sourceManager := NewSourceManager(
+		mockContext.Container,
+		config.NewUserConfigManager(mockContext.ConfigManager),
+		mockContext.HttpClient,
+	)
+	source := &SourceConfig{
+		Name:     "original",
+		Type:     SourceKindUrl,
+		Location: "http://example.com",
+	}
+
+	err := sourceManager.Add(t.Context(), "Invalid Name", source)
+	require.ErrorIs(t, err, ErrSourceNameInvalid)
+	require.Equal(t, "original", source.Name)
+	_, ok := mockConfig.Get(baseConfigKey)
+	require.False(t, ok)
+}
+
+func TestValidSourceNamesHaveDistinctCachePaths(t *testing.T) {
+	t.Parallel()
+
+	manager := &RegistryCacheManager{cacheDir: t.TempDir()}
+	names := []string{"source-one", "source_one", "source1"}
+	paths := map[string]struct{}{}
+	for _, name := range names {
+		require.NoError(t, ValidateSourceName(name))
+		path := manager.getCacheFilePath(name)
+		require.Equal(t, name+".json", filepath.Base(path))
+		_, exists := paths[path]
+		require.False(t, exists)
+		paths[path] = struct{}{}
+	}
 }
 
 func TestSourceManager_CreateSource_Bundle(t *testing.T) {

--- a/cli/azd/pkg/extensions/source_manager_test.go
+++ b/cli/azd/pkg/extensions/source_manager_test.go
@@ -264,6 +264,7 @@ func TestSourceManager_ListRejectsInvalidConfiguration(t *testing.T) {
 			_, err := sourceManager.List(t.Context())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.errText)
+			require.NotContains(t, err.Error(), "remove "+tt.key)
 		})
 	}
 }

--- a/cli/azd/pkg/extensions/source_manager_test.go
+++ b/cli/azd/pkg/extensions/source_manager_test.go
@@ -142,6 +142,34 @@ func TestSourceManager_Remove(t *testing.T) {
 		require.True(t, ok)
 		require.NotContains(t, sources, "legacy.source")
 	})
+
+	t.Run("RemoveNestedLegacySourceOnly", func(t *testing.T) {
+		legacyConfig := config.NewEmptyConfig()
+		require.NoError(t, legacyConfig.Set("extension.sources.foo.bar", SourceConfig{
+			Name:     "foo.bar",
+			Type:     SourceKindUrl,
+			Location: "http://example.com/bar",
+		}))
+		require.NoError(t, legacyConfig.Set("extension.sources.foo.baz", SourceConfig{
+			Name:     "foo.baz",
+			Type:     SourceKindUrl,
+			Location: "http://example.com/baz",
+		}))
+		mockContext.ConfigManager.WithConfig(legacyConfig)
+
+		_, err := sourceManager.List(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `"foo.bar"`)
+		require.NotContains(t, err.Error(), `source "foo"`)
+
+		require.NoError(t, sourceManager.Remove(ctx, "foo.bar"))
+
+		_, exists := legacyConfig.Get("extension.sources.foo.bar")
+		require.False(t, exists)
+		remaining, exists := legacyConfig.Get("extension.sources.foo.baz")
+		require.True(t, exists)
+		require.NotNil(t, remaining)
+	})
 }
 
 func TestSourceManager_List(t *testing.T) {


### PR DESCRIPTION
Closes #9383

### Summary

This PR enforces a canonical, shell-safe format for extension source names and provides deterministic handling for legacy invalid configuration. It is the bottom layer of stack #9453; #9452 builds the source-category telemetry feature on top.

### Issue

Source names were silently normalized and then reused in dot-delimited configuration keys, cache filenames, and copy-and-paste commands. Different inputs could collide, and unsafe legacy values could be rendered directly in terminal output.

### Design decisions

The naming grammar is intentionally narrower than a generic display name because source names are identifiers used across shell arguments, configuration paths, and filenames. A single lowercase ASCII format makes those representations one-to-one and avoids adding separate escaping or encoding rules to every consumer.

- **Reject instead of normalize:** silently converting `My Source` to `my-source` hides user mistakes and allows distinct inputs to converge on the same identifier. Existing lookups remain case-insensitive, but new persisted names must already be canonical.
- **Validate in `SourceManager`:** command-only validation would leave package callers able to persist unsafe names. The manager is the shared persistence boundary, while command prompts reuse the same validator for immediate feedback.
- **Fail on invalid legacy configuration:** automatically renaming entries could collide, change scripts unexpectedly, or orphan installed-extension references. The affected population is very small, so the safer deterministic behaviour is to identify the exact entry and require an explicit remove and re-add.
- **Keep legacy removal permissive:** `source remove` reads and edits the raw source map rather than using dot-delimited paths, so it can repair names that normal loading now rejects, including dotted names.
- **Use a 64-character limit:** this is ample for a human-readable source identifier while keeping generated commands, configuration, and cache paths bounded. It does not constrain source URLs or filesystem locations.
- **Reserve `bundle`:** bundle installs use this durable marker after their transient source is removed. Allowing a configured source with the same name would make update behaviour ambiguous.

### Changes

- Requires 1 to 64 lowercase ASCII letters, digits, hyphens, or underscores, with a letter or digit at both ends.
- Rejects invalid names at the package boundary instead of silently normalizing them, while keeping `bundle` reserved.
- Reports legacy invalid configuration with a supported remove-and-re-add path, including removal of names containing dots or other formerly accepted characters.
- Escapes invalid legacy names before rendering them in terminal progress or result messages.
- Ensures every valid source name maps directly to a unique cache filename.
- Updates command help, extension documentation, and generated usage snapshots.

### Behaviour at a glance

| Scenario | Before | After |
|---|---|---|
| `My Source` | Persisted as `my-source` | Rejected with the canonical naming rules |
| `foo.bar` | Could create nested configuration and cache ambiguity | Rejected |
| Legacy invalid source | Could block normal loading without a reliable CLI repair path | Loading reports the entry; `source remove` can delete the raw legacy key |
| Unsafe legacy terminal value | Rendered directly | Rendered as an escaped quoted value |

### Compatibility

Telemetry indicates that non-default sources are uncommon, custom sources are rarer, and most custom names already satisfy this grammar. The intentional break is therefore limited to a small edge case, with a deterministic repair path instead of migration logic that could silently choose the wrong name.

### Testing

Covered source-name boundaries and invalid characters, reserved names, legacy invalid and mismatched configuration, legacy removal, cache identity, direct-location registration, bundle-generated names, terminal escaping, command behaviour, help snapshots, linting, and spelling checks.
