### PR TITLE
feat(foundry): support infrastructure provisioning layers

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/README.md
+++ b/cli/azd/extensions/azure.ai.agents/README.md
@@ -142,6 +142,10 @@ Details:
   falls back to the default behavior and the next invoke starts a fresh session
   on the new version.
 
+## Customize infrastructure
+
+Use `azd ai agent init --infra` to generate editable Foundry Bicep or Terraform. Existing project infrastructure is preserved as a separate layer. See [Customize Foundry infrastructure with `--infra`](docs/infrastructure-eject.md) for migration behavior, file-conflict rules, resource-group ownership, layer dependencies, and limitations.
+
 ## Private networking for `host: azure.ai.project`
 
 Foundry project services can be provisioned as network-secured, VNet-bound accounts by adding a `network:` block to the `host: azure.ai.project` service in `azure.yaml`. The `azure.ai.projects` extension owns that service and the `microsoft.foundry` provider; this extension still authors the block during agent init. See [Private networking for `host: azure.ai.project`](docs/private-networking.md) for the schema reference, BYO-image requirements, and VNet deployment cheatsheet.

--- a/cli/azd/extensions/azure.ai.agents/docs/infrastructure-eject.md
+++ b/cli/azd/extensions/azure.ai.agents/docs/infrastructure-eject.md
@@ -1,0 +1,104 @@
+# Customize Foundry infrastructure with `--infra`
+
+`azd ai agent init --infra` generates editable infrastructure-as-code for the
+`host: azure.ai.project` service in `azure.yaml`.
+
+```bash
+# Generate Bicep (default)
+azd ai agent init --infra
+
+# Choose the format explicitly
+azd ai agent init --infra=bicep
+azd ai agent init --infra=terraform
+```
+
+Use eject when you need to customize resources beyond the service-level
+configuration in `azure.yaml`. Future `azd provision` runs use the generated
+files.
+
+## Project layouts
+
+- A new or Foundry-only project uses the root `infra/` layout.
+- A project with existing infrastructure keeps that infrastructure as a named
+  layer and receives a separate Foundry layer under `infra/foundry`.
+- An existing layered project receives a `foundry` layer when one is not
+  already declared.
+- A compatible existing `foundry` layer uses its declared `path` and `module`.
+
+For example, ejecting into a project with existing Bicep produces:
+
+```yaml
+infra:
+  layers:
+    - name: infra
+      path: infra
+      provider: bicep
+    - name: foundry
+      path: infra/foundry
+      provider: microsoft.foundry
+```
+
+The existing `infra/main.bicep` remains unchanged.
+
+## Existing files
+
+Eject never overwrites generated-file collisions.
+
+- When `infra/foundry` exists but no `foundry` layer is declared, unrelated
+  files are preserved and generated files are merged only when their paths do
+  not collide.
+- When a `foundry` layer is already declared, its target must be empty. Edit
+  its existing files directly instead of ejecting again.
+- Generation and installation are staged so failures do not leave a partial
+  generated tree or rewrite `azure.yaml`.
+
+## Resource group ownership
+
+A Foundry layer uses `AZURE_FOUNDRY_RESOURCE_GROUP`, which defaults to:
+
+```text
+rg-<environment>-foundry
+```
+
+Set a custom group before the first provision:
+
+```bash
+azd env set AZURE_FOUNDRY_RESOURCE_GROUP <name>
+```
+
+For safety, `azd down` deletes the layer resource group only when azd recorded
+that it created the group and the live Azure group is tagged for the current
+environment. Otherwise teardown intentionally refuses deletion so a user-owned
+group is not removed.
+
+## Layer dependencies
+
+The Foundry layer is independent by default. Dependency analysis currently
+skips custom providers such as `microsoft.foundry`, so add `dependsOn` when the
+generated Foundry parameters consume outputs or hook-written values from
+another layer:
+
+```yaml
+infra:
+  layers:
+    - name: network
+      path: infra/network
+      provider: bicep
+    - name: foundry
+      path: infra/foundry
+      provider: microsoft.foundry
+      dependsOn:
+        - network
+```
+
+Without this edge, independent layers may provision concurrently and the
+Foundry layer can read an empty or stale environment value.
+
+## Limitations
+
+- Terraform eject does not support a service with a private `network:` block;
+  use Bicep for private networking.
+- Brownfield services that set `endpoint:` reuse an existing Foundry project
+  and cannot eject infrastructure for that externally owned resource.
+- Eject preserves the existing root infrastructure mapping during migration;
+  custom properties remain the project owner's responsibility.

--- a/cli/azd/extensions/azure.ai.agents/docs/private-networking.md
+++ b/cli/azd/extensions/azure.ai.agents/docs/private-networking.md
@@ -178,7 +178,7 @@ The synthesized template covers the common private-networking shapes. When you n
 azd ai agent init --infra
 ```
 
-Eject reads `network:` from the `host: azure.ai.project` service and writes the full Bicep tree: `infra/main.bicep`, `infra/modules/{resources,network,subnet,private-endpoint-dns,acr}.bicep`, and `infra/main.parameters.json`. `${VAR}` placeholders are preserved in the generated parameters file and resolved from the azd environment at provision time. `azure.yaml` is left unchanged: `infra.provider` stays `microsoft.foundry`.
+Eject reads `network:` from the `host: azure.ai.project` service and writes the full Bicep tree. For a Foundry-only project, it writes `infra/main.bicep`, `infra/modules/{resources,network,subnet,private-endpoint-dns,acr}.bicep`, and `infra/main.parameters.json`. If the project already has infrastructure, azd preserves it and adds a separate `infra/foundry` layer with the same file layout and its own `AZURE_FOUNDRY_RESOURCE_GROUP`. `${VAR}` placeholders are preserved in the generated parameters file and resolved from the azd environment at provision time.
 
 ```bash
 azd provision --no-prompt

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/azure/azure-dev/cli/azd/pkg/environment/azdcontext"
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
@@ -2004,8 +2005,18 @@ func hasFoundryProviderDeclared(proj *azdext.ProjectConfig) bool {
 		return proj.Infra.Provider == project.FoundryProviderName
 	}
 
-	raw, err := os.ReadFile(filepath.Join(proj.Path, "azure.yaml")) //nolint:gosec // project path is from azd
-	if err != nil {
+	var raw []byte
+	for _, name := range azdcontext.ProjectFileNames {
+		data, err := os.ReadFile(filepath.Join(proj.Path, name)) //nolint:gosec // project path is from azd
+		if err == nil {
+			raw = data
+			break
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return proj.Infra.Provider == project.FoundryProviderName
+		}
+	}
+	if raw == nil {
 		return proj.Infra.Provider == project.FoundryProviderName
 	}
 	var doc struct {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -79,7 +79,8 @@ type initFlags struct {
 	// noPrompt is resolved from the extension context (--no-prompt / AZD_NO_PROMPT)
 	// and is not registered as a CLI flag on the init command itself.
 	noPrompt bool
-	// infra selects the IaC flavor to eject from azure.yaml into ./infra/.
+	// infra selects the IaC flavor to eject from azure.yaml. Existing projects
+	// may receive a dedicated infra/foundry provisioning layer.
 	// Empty means the flag was not passed (bicepless default, no files). A bare
 	// `--infra` resolves to "bicep" via the flag's NoOptDefVal; `--infra=terraform`
 	// and `--infra=bicep` are explicit. The eject runs after a fresh init or
@@ -1599,9 +1600,11 @@ from code-deploy ZIP packaging (uses .gitignore syntax).`,
 			"Required together with --no-prompt when init would otherwise need confirmation.")
 
 	cmd.Flags().StringVar(&flags.infra, "infra", "",
-		"Eject infrastructure-as-code from azure.yaml into ./infra/. "+
+		"Eject infrastructure-as-code from azure.yaml. Existing infrastructure is preserved and "+
+			"Foundry files are generated as a separate infra/foundry layer. "+
 			"A bare --infra ejects Bicep; --infra=terraform ejects Terraform and sets "+
-			"infra.provider: terraform; --infra=bicep is explicit Bicep. "+
+			"the Foundry layer provider to terraform; Bicep keeps the microsoft.foundry provider. "+
+			"--infra=bicep is explicit Bicep. "+
 			"When azure.yaml already declares a Foundry project service, runs as a standalone "+
 			"eject and skips the init prompts; otherwise init runs first and the eject follows it.")
 	// NoOptDefVal makes a bare `--infra` resolve to "bicep" while still allowing
@@ -1844,8 +1847,8 @@ func ensureProject(
 			if _, statErr := os.Stat(infraDir); os.IsNotExist(statErr) {
 				fmt.Printf("%s", output.WithWarningFormat(
 					"No infra/ directory found in the project, and azure.yaml does not declare "+
-						"'infra.provider: %s'. If you need Azure infrastructure for deployment, "+
-						"set that provider in azure.yaml, or run "+
+						"the '%s' provider. If you need Azure infrastructure for deployment, "+
+						"declare that provider in azure.yaml, or run "+
 						"'azd ai agent init --infra' to generate an infra/ directory.\n",
 					project.FoundryProviderName,
 				))
@@ -1990,13 +1993,45 @@ func writeFoundryProvider(ctx context.Context, azdClient *azdext.AzdClient) erro
 	return nil
 }
 
-// hasFoundryProviderDeclared reports whether azure.yaml already
-// declares this extension's provisioning provider.
+// hasFoundryProviderDeclared reports whether azure.yaml declares the Foundry
+// provider at the root or on an infrastructure layer. Project().Get exposes
+// only root infra options today, so inspect the project file for layers.
 func hasFoundryProviderDeclared(proj *azdext.ProjectConfig) bool {
 	if proj == nil || proj.Infra == nil {
 		return false
 	}
-	return proj.Infra.Provider == project.FoundryProviderName
+	if proj.Path == "" {
+		return proj.Infra.Provider == project.FoundryProviderName
+	}
+
+	raw, err := os.ReadFile(filepath.Join(proj.Path, "azure.yaml")) //nolint:gosec // project path is from azd
+	if err != nil {
+		return proj.Infra.Provider == project.FoundryProviderName
+	}
+	var doc struct {
+		Infra struct {
+			Provider string `yaml:"provider"`
+			Layers   []struct {
+				Provider string `yaml:"provider"`
+			} `yaml:"layers"`
+		} `yaml:"infra"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return proj.Infra.Provider == project.FoundryProviderName
+	}
+	if doc.Infra.Provider == project.FoundryProviderName && len(doc.Infra.Layers) == 0 {
+		return true
+	}
+	for _, layer := range doc.Infra.Layers {
+		provider := layer.Provider
+		if provider == "" {
+			provider = doc.Infra.Provider
+		}
+		if provider == project.FoundryProviderName {
+			return true
+		}
+	}
+	return false
 }
 
 func getExistingEnvironment(ctx context.Context, envName string, azdClient *azdext.AzdClient) *azdext.Environment {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_templates_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_templates_helpers.go
@@ -141,12 +141,16 @@ func promptInitMode(ctx context.Context, azdClient *azdext.AzdClient, noPrompt b
 
 // dirIsEmpty reports whether dir contains no entries at all.
 func dirIsEmpty(dir string) (bool, error) {
-	entries, err := os.ReadDir(dir)
+	f, err := os.Open(dir) //nolint:gosec // caller supplies a project directory
 	if err != nil {
 		return false, err
 	}
-
-	return len(entries) == 0, nil
+	defer f.Close()
+	_, err = f.Readdirnames(1)
+	if errors.Is(err, io.EOF) {
+		return true, nil
+	}
+	return false, err
 }
 
 // fetchAgentTemplates retrieves the agent template catalog from the remote

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"maps"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"text/template"
 
 	"azureaiagent/internal/exterrors"
+	projectpaths "azureaiagent/internal/pkg/paths"
 	"azureaiagent/internal/project"
 	"azureaiagent/internal/synthesis"
 
@@ -27,12 +29,30 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-// ejectArtifact records one file the eject step produced under ./infra/.
+const (
+	defaultInfraPath       = "infra"
+	defaultInfraModule     = "main"
+	foundryInfraLayerName  = "foundry"
+	foundryInfraLayerPath  = "infra/foundry"
+	foundryTerraformMarker = ".azd-foundry"
+	foundryTerraformV1     = "terraform-v1\n"
+)
+
+// ejectArtifact records one file the eject step produced.
 // Paths are forward-slash relative to projectRoot so the success output is
 // stable across operating systems.
 type ejectArtifact struct {
 	relPath string // e.g. "infra/main.bicep"
 	bytes   int    // size of the file just written
+}
+
+type infraEjectPlan struct {
+	targetDir         string
+	targetPath        string
+	module            string
+	layer             bool
+	updatedYAML       []byte
+	updateDescription string
 }
 
 // validateStandaloneEjectArgs refuses init-driving inputs that the
@@ -450,28 +470,21 @@ func ejectInfraAfterInit(provider string) error {
 	return ejectInfra(projectRoot, provider)
 }
 
-// ejectInfra synthesizes the embedded Bicep templates from azure.yaml and
-// ejectInfra synthesizes infrastructure templates from azure.yaml and writes
-// them into projectRoot/infra/. Invoked by `azd ai agent init --infra[=<provider>]`
-// either after a fresh init or as a standalone eject on an existing project.
+// ejectInfra synthesizes infrastructure templates from azure.yaml. A project
+// that already owns infrastructure is migrated to infra.layers and receives a
+// dedicated Foundry layer under infra/foundry; a Foundry-only project keeps the
+// legacy infra/ layout.
 //
 // provider selects the IaC flavor:
 //
-//   - "bicep": copies the embedded Bicep tree + main.parameters.json. azure.yaml
-//     is NOT modified (the microsoft.foundry provider compiles the on-disk Bicep).
-//   - "terraform": copies the embedded .tf module + a generated main.tfvars.json,
-//     then stamps `infra.provider: terraform` so azd-core's built-in Terraform
-//     provider handles provisioning. This is the one path that mutates azure.yaml.
+//   - "bicep": azd-core's Bicep provider compiles the on-disk Bicep.
+//   - "terraform": azd-core's built-in Terraform provider handles the layer.
 //
 // Refuse conditions (provider-independent):
 //
 //   - azure.yaml is missing -> CodeInfraEjectAzureYamlMissing
 //   - no service has a Foundry host -> CodeInfraEjectNoFoundryService
-//   - azure.yaml declares infra.layers -> CodeInfraEjectLayersUnsupported
-//   - azure.yaml declares a non-default infra.path -> CodeInfraEjectCustomInfraPath
-//   - azure.yaml declares a non-default infra.module -> CodeInfraEjectCustomModule
-//   - Bicep eject conflicts with infra.provider -> CodeInfraEjectProviderConflict
-//   - ./infra/ already exists -> CodeInfraEjectExists
+//   - a generated destination file already exists -> CodeInfraEjectExists
 //
 // On success it prints the summary block and returns nil.
 func ejectInfra(projectRoot, provider string) error {
@@ -484,25 +497,11 @@ func ejectInfra(projectRoot, provider string) error {
 	if err != nil {
 		return err
 	}
-
-	// Checked before anything is written: eject cannot preserve layers, the
-	// Terraform path drops infra.path, and Bicep leaves an existing provider
-	// unchanged. Any of those could make azd ignore or orphan user-owned IaC.
-	if err := ensureNoInfraLayers(rawYAML); err != nil {
+	plan, err := planInfraEject(projectRoot, rawYAML, provider)
+	if err != nil {
 		return err
 	}
-	if err := ensureDefaultInfraPath(rawYAML); err != nil {
-		return err
-	}
-	if err := ensureDefaultInfraModule(rawYAML); err != nil {
-		return err
-	}
-	if err := ensureCompatibleInfraProvider(rawYAML, provider); err != nil {
-		return err
-	}
-
-	infraDir := filepath.Join(projectRoot, defaultInfraDirName)
-	if err := ensureInfraDirAbsent(projectRoot); err != nil {
+	if err := validateEjectTarget(projectRoot, plan); err != nil {
 		return err
 	}
 
@@ -555,88 +554,838 @@ func ejectInfra(projectRoot, provider string) error {
 		}
 	}
 
-	// Eject writes the whole infra/ tree or none of it: if any writer fails
-	// after MkdirAll, remove the partial directory so the next run isn't blocked
-	// by the "./infra/ already exists" refuse above and the command stays
-	// retryable without manual cleanup.
-	var ejectErr error
+	// Generate away from the destination, then install only after every file is
+	// ready. This lets a layered eject merge into an existing infra/ tree without
+	// exposing partial files or deleting user-owned content on failure.
+	stageDir, err := os.MkdirTemp(projectRoot, ".azd-foundry-infra-*")
+	if err != nil {
+		return exterrors.Internal(
+			exterrors.CodeInfraEjectWriteFailed,
+			fmt.Sprintf("create infrastructure staging directory: %s", err),
+		)
+	}
+	defer os.RemoveAll(stageDir)
+
+	var written []ejectArtifact
 	if provider == project.TerraformProviderName {
-		ejectErr = ejectTerraform(projectRoot, infraDir, res.Parameters)
+		written, err = ejectTerraform(stageDir, plan.targetPath, plan.module, plan.layer, res.Parameters)
 	} else {
-		ejectErr = ejectBicep(infraDir, res.Parameters)
+		written, err = ejectBicep(stageDir, plan.targetPath, plan.module, plan.layer, res.Parameters)
 	}
-	if ejectErr != nil {
-		_ = os.RemoveAll(infraDir)
-	}
-	return ejectErr
-}
-
-// ejectBicep writes the embedded Bicep tree plus the synthesized
-// main.parameters.json into infraDir and prints the summary. It does not
-// modify azure.yaml; the declared infra.provider is left unchanged.
-func ejectBicep(infraDir string, params map[string]any) error {
-	written, err := writeEmbeddedTemplates(infraDir)
 	if err != nil {
 		return err
 	}
 
-	paramsArtifact, err := writeParametersFile(infraDir, params)
+	rollback, err := installStagedInfra(stageDir, plan)
 	if err != nil {
 		return err
 	}
-	written = append(written, paramsArtifact)
+	if plan.updatedYAML != nil {
+		unchanged, err := azureYAMLUnchanged(yamlPath, rawYAML)
+		if err != nil {
+			rollback()
+			return exterrors.Internal(
+				exterrors.CodeInfraEjectWriteFailed,
+				fmt.Sprintf("re-read azure.yaml before infrastructure update: %s", err),
+			)
+		}
+		if !unchanged {
+			rollback()
+			return exterrors.Validation(
+				exterrors.CodeInfraEjectAzureYamlChanged,
+				"azure.yaml changed while infrastructure files were being generated; eject removed its generated files",
+				"review the concurrent changes and run `azd ai agent init --infra` again",
+			)
+		}
+		if err := azdext.WriteFileAtomic(yamlPath, plan.updatedYAML, 0); err != nil {
+			rollback()
+			return exterrors.Internal(
+				exterrors.CodeInfraEjectWriteFailed,
+				fmt.Sprintf("write azure.yaml after infrastructure eject: %s", err),
+			)
+		}
+	}
 	slices.SortFunc(written, func(a, b ejectArtifact) int {
 		return strings.Compare(a.relPath, b.relPath)
 	})
-
-	printEjectSummary(written, project.BicepProviderName)
+	printEjectSummary(written, plan.targetPath, plan.updateDescription)
 	return nil
 }
 
+func azureYAMLUnchanged(path string, expected []byte) (bool, error) {
+	current, err := os.ReadFile(path) //nolint:gosec // path is the active project's azure.yaml
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(current, expected), nil
+}
+
+// ejectBicep writes the embedded Bicep tree plus the synthesized
+// parameters file into infraDir.
+func ejectBicep(
+	infraDir string,
+	artifactRoot string,
+	module string,
+	layer bool,
+	params map[string]any,
+) ([]ejectArtifact, error) {
+	written, err := writeEmbeddedTemplates(infraDir, artifactRoot, module, layer)
+	if err != nil {
+		return nil, err
+	}
+
+	paramsArtifact, err := writeParametersFile(infraDir, artifactRoot, module, layer, params)
+	if err != nil {
+		return nil, err
+	}
+	written = append(written, paramsArtifact)
+	return written, nil
+}
+
 // ejectTerraform writes the embedded Terraform module plus the generated
-// main.tfvars.json into infraDir, stamps `infra.provider: terraform` onto
-// azure.yaml so azd-core's Terraform provider takes over provisioning, and
-// prints the summary.
+// tfvars file into infraDir.
 //
 // acr.tf is written only when an agent uses docker: (includeAcr). outputs.tf is
 // generated to match: the ACR outputs are included only when acr.tf is present,
 // and omitted entirely otherwise.
-func ejectTerraform(projectRoot, infraDir string, params map[string]any) error {
+func ejectTerraform(
+	infraDir string,
+	artifactRoot string,
+	module string,
+	layer bool,
+	params map[string]any,
+) ([]ejectArtifact, error) {
 	includeAcr, _ := params["includeAcr"].(bool)
 
-	written, err := writeEmbeddedTerraformTemplates(infraDir, includeAcr)
+	written, err := writeEmbeddedTerraformTemplates(infraDir, artifactRoot, includeAcr)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	outputsArtifact, err := writeOutputsFile(infraDir, includeAcr)
+	markerArtifact, err := writeFoundryTerraformMarker(infraDir, artifactRoot)
 	if err != nil {
-		return err
+		return nil, err
+	}
+	written = append(written, markerArtifact)
+
+	outputsArtifact, err := writeOutputsFile(infraDir, artifactRoot, includeAcr, layer)
+	if err != nil {
+		return nil, err
 	}
 	written = append(written, outputsArtifact)
 
-	tfvarsArtifact, err := writeTfvarsFile(infraDir, params)
+	tfvarsArtifact, err := writeTfvarsFile(infraDir, artifactRoot, module, layer, params)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	written = append(written, tfvarsArtifact)
+	return written, nil
+}
 
-	// Stamp the provider so `azd provision` dispatches to azd-core's Terraform
-	// provider instead of this extension's microsoft.foundry provider. Done
-	// after the files land so a stamp failure does not leave azure.yaml
-	// pointing at an infra/ that was never written.
-	if err := stampInfraProvider(projectRoot, project.TerraformProviderName); err != nil {
-		// Best-effort cleanup so a half-ejected project isn't left behind.
-		_ = os.RemoveAll(infraDir)
-		return err
+func writeFoundryTerraformMarker(infraDir, artifactRoot string) (ejectArtifact, error) {
+	dst := filepath.Join(infraDir, foundryTerraformMarker)
+	//nolint:gosec // G306: generated marker is intended to be readable by project tooling
+	if err := os.WriteFile(dst, []byte(foundryTerraformV1), 0o644); err != nil {
+		return ejectArtifact{}, exterrors.Internal(
+			exterrors.CodeInfraEjectWriteFailed,
+			fmt.Sprintf("write Terraform Foundry marker: %s", err),
+		)
+	}
+	return ejectArtifact{
+		relPath: filepath.ToSlash(filepath.Join(artifactRoot, foundryTerraformMarker)),
+		bytes:   len(foundryTerraformV1),
+	}, nil
+}
+
+func planInfraEject(projectRoot string, rawYAML []byte, provider string) (*infraEjectPlan, error) {
+	if provider != project.BicepProviderName && provider != project.TerraformProviderName {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidParameter,
+			fmt.Sprintf("unsupported infrastructure provider %q", provider),
+			"pass --infra=bicep or --infra=terraform",
+		)
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(rawYAML, &root); err != nil {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidAzureYaml,
+			fmt.Sprintf("parse azure.yaml: %s", err),
+			"verify azure.yaml is valid YAML",
+		)
+	}
+	if len(root.Content) == 0 || root.Content[0].Kind != yaml.MappingNode {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidAzureYaml,
+			"azure.yaml is not a YAML mapping at the top level",
+			"verify azure.yaml is a valid azd project file",
+		)
 	}
 
-	slices.SortFunc(written, func(a, b ejectArtifact) int {
-		return strings.Compare(a.relPath, b.relPath)
-	})
+	doc := root.Content[0]
+	infra := mappingValue(doc, "infra")
+	if infra == nil {
+		infra = newMappingNode()
+		doc.Content = append(doc.Content, newScalarNode("infra"), infra)
+	}
+	if infra.Kind != yaml.MappingNode {
+		return nil, invalidInfraForEject("infra must be a mapping")
+	}
+	for _, key := range []string{"path", "module", "provider"} {
+		if value := mappingValue(infra, key); value != nil && value.Kind != yaml.ScalarNode {
+			return nil, invalidInfraForEject(fmt.Sprintf("infra.%s must be a string", key))
+		}
+	}
 
-	printEjectSummary(written, project.TerraformProviderName)
+	layers := mappingValue(infra, "layers")
+	if layers != nil {
+		return planLayeredInfraEject(projectRoot, &root, infra, layers, provider)
+	}
+	return planSingleInfraEject(projectRoot, &root, infra, provider)
+}
+
+func planSingleInfraEject(
+	projectRoot string,
+	root *yaml.Node,
+	infra *yaml.Node,
+	provider string,
+) (*infraEjectPlan, error) {
+	existingProvider := mappingScalar(infra, "provider")
+	existingName := mappingScalar(infra, "name")
+	existingPath := mappingScalar(infra, "path")
+	existingModule := mappingScalar(infra, "module")
+	effectivePath := existingPath
+	if effectivePath == "" {
+		effectivePath = defaultInfraPath
+	}
+	effectiveModule := existingModule
+	if effectiveModule == "" {
+		effectiveModule = defaultInfraModule
+	}
+	effectiveProvider := existingProvider
+	if effectiveProvider == "" {
+		effectiveProvider = project.BicepProviderName
+	}
+
+	existingDir := resolveInfraPath(projectRoot, effectivePath)
+	info, statErr := os.Stat(existingDir)
+	dirExists := statErr == nil
+	if statErr != nil && !errors.Is(statErr, fs.ErrNotExist) {
+		return nil, fmt.Errorf("stat infrastructure path %s: %w", existingDir, statErr)
+	}
+	if dirExists && !info.IsDir() {
+		return nil, ejectExistsError(filepath.ToSlash(effectivePath))
+	}
+
+	hasEntrypoint := hasInfrastructureEntrypoint(
+		existingDir,
+		effectiveProvider,
+		effectiveModule,
+	)
+	customProvider := existingProvider != "" &&
+		existingProvider != project.BicepProviderName &&
+		existingProvider != project.TerraformProviderName &&
+		existingProvider != project.FoundryProviderName
+	if existingProvider == project.FoundryProviderName && hasEntrypoint {
+		return nil, foundryInfraExistsError(filepath.ToSlash(effectivePath), false)
+	}
+	if existingProvider == project.TerraformProviderName {
+		foundryTerraform, err := isFoundryTerraformInfra(existingDir, effectiveModule)
+		if err != nil {
+			return nil, err
+		}
+		if foundryTerraform {
+			return nil, foundryInfraExistsError(filepath.ToSlash(effectivePath), false)
+		}
+	}
+	if existingProvider != "" &&
+		(existingProvider == project.BicepProviderName || existingProvider == project.TerraformProviderName) &&
+		!hasEntrypoint {
+		return nil, invalidInfraForEject(
+			fmt.Sprintf("infrastructure declares provider %q but path %q contains no matching entry point",
+				existingProvider, effectivePath),
+		)
+	}
+	userOwned := existingProvider != project.FoundryProviderName && (hasEntrypoint || customProvider)
+	if !userOwned {
+		if dirExists && !customProvider {
+			empty, err := isDirectoryEmpty(existingDir)
+			if err != nil {
+				return nil, err
+			}
+			if !empty {
+				return nil, invalidInfraForEject(
+					fmt.Sprintf("infrastructure path %q contains files but no detectable entry point", effectivePath),
+				)
+			}
+		}
+		changed := false
+		wantedProvider := project.FoundryProviderName
+		if provider == project.TerraformProviderName {
+			wantedProvider = project.TerraformProviderName
+		}
+		if existingProvider != wantedProvider {
+			setMappingScalar(infra, "provider", wantedProvider)
+			changed = true
+		}
+
+		plan := &infraEjectPlan{
+			targetDir:  existingDir,
+			targetPath: filepath.ToSlash(effectivePath),
+			module:     effectiveModule,
+			layer:      false,
+		}
+		if changed {
+			updated, err := marshalAzureYAML(root)
+			if err != nil {
+				return nil, err
+			}
+			plan.updatedYAML = updated
+			plan.updateDescription = fmt.Sprintf("infra.provider: %s", wantedProvider)
+		}
+		return plan, nil
+	}
+	if sameInfraPath(effectivePath, foundryInfraLayerPath) {
+		return nil, invalidInfraForEject(
+			fmt.Sprintf("existing infrastructure already uses the Foundry layer path %q", foundryInfraLayerPath),
+		)
+	}
+
+	existingLayer := cloneMappingNode(infra)
+	if existingName == "" {
+		existingName = defaultInfraPath
+	}
+	if existingName == foundryInfraLayerName {
+		return nil, invalidInfraForEject(
+			fmt.Sprintf("existing infrastructure name %q conflicts with the Foundry layer name", existingName),
+		)
+	}
+	setMappingScalar(existingLayer, "name", existingName)
+	setMappingScalar(existingLayer, "path", filepath.ToSlash(effectivePath))
+	setMappingScalar(existingLayer, "provider", effectiveProvider)
+	removeMappingKey(existingLayer, "layers")
+
+	foundryLayer := newInfraLayerNode(
+		foundryInfraLayerName,
+		foundryInfraLayerPath,
+		foundryLayerProvider(provider),
+		nil,
+	)
+	infra.Content = nil
+	infra.Content = append(infra.Content,
+		newScalarNode("layers"),
+		&yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq", Content: []*yaml.Node{existingLayer, foundryLayer}},
+	)
+	updated, err := marshalAzureYAML(root)
+	if err != nil {
+		return nil, err
+	}
+	return &infraEjectPlan{
+		targetDir:         resolveInfraPath(projectRoot, foundryInfraLayerPath),
+		targetPath:        foundryInfraLayerPath,
+		module:            defaultInfraModule,
+		layer:             true,
+		updatedYAML:       updated,
+		updateDescription: "infra.layers",
+	}, nil
+}
+
+func planLayeredInfraEject(
+	projectRoot string,
+	root *yaml.Node,
+	infra *yaml.Node,
+	layers *yaml.Node,
+	provider string,
+) (*infraEjectPlan, error) {
+	if layers.Kind != yaml.SequenceNode {
+		return nil, invalidInfraForEject("infra.layers must be a sequence")
+	}
+
+	var foundryLayer *yaml.Node
+	rootProvider := mappingScalar(infra, "provider")
+	existingLayerNames := make([]string, 0, len(layers.Content))
+	for _, layer := range layers.Content {
+		if layer.Kind != yaml.MappingNode {
+			return nil, invalidInfraForEject("each infra.layers entry must be a mapping")
+		}
+		for _, key := range []string{"name", "path", "module", "provider"} {
+			if value := mappingValue(layer, key); value != nil && value.Kind != yaml.ScalarNode {
+				return nil, invalidInfraForEject(
+					fmt.Sprintf("infra.layers[].%s must be a string", key),
+				)
+			}
+		}
+		name := mappingScalar(layer, "name")
+		if name == "" {
+			return nil, invalidInfraForEject("each infra.layers entry must declare a name")
+		}
+		if mappingScalar(layer, "path") == "" {
+			return nil, invalidInfraForEject(fmt.Sprintf("infra layer %q must declare path", name))
+		}
+		if slices.Contains(existingLayerNames, name) ||
+			(foundryLayer != nil && mappingScalar(foundryLayer, "name") == name) {
+			return nil, invalidInfraForEject(fmt.Sprintf("duplicate infrastructure layer name %q", name))
+		}
+		layerProvider := mappingScalar(layer, "provider")
+		effectiveLayerProvider := layerProvider
+		if effectiveLayerProvider == "" {
+			effectiveLayerProvider = rootProvider
+		}
+		if effectiveLayerProvider == project.FoundryProviderName && name != foundryInfraLayerName {
+			return nil, invalidInfraForEject(
+				fmt.Sprintf("Foundry infrastructure already exists as layer %q; eject expects the Foundry layer name %q",
+					name, foundryInfraLayerName),
+			)
+		}
+		if name == foundryInfraLayerName &&
+			(effectiveLayerProvider == project.FoundryProviderName ||
+				effectiveLayerProvider == project.BicepProviderName ||
+				effectiveLayerProvider == project.TerraformProviderName) {
+			if foundryLayer != nil {
+				return nil, invalidInfraForEject("multiple Foundry infrastructure layers are declared")
+			}
+			foundryLayer = layer
+			continue
+		}
+		if name == foundryInfraLayerName {
+			return nil, invalidInfraForEject(
+				fmt.Sprintf("layer name %q is reserved for Foundry infrastructure", foundryInfraLayerName),
+			)
+		}
+		existingLayerNames = append(existingLayerNames, name)
+	}
+	if foundryLayer != nil && len(existingLayerNames) == 0 {
+		return nil, invalidInfraForEject(
+			"infra.layers contains only a Foundry layer; use a root infra configuration for a Foundry-only project",
+		)
+	}
+	if foundryLayer == nil && len(existingLayerNames) == 0 {
+		return nil, invalidInfraForEject("infra.layers must contain at least one existing infrastructure layer")
+	}
+	if foundryLayer != nil {
+		for _, layer := range layers.Content {
+			if layer == foundryLayer {
+				continue
+			}
+			if sameInfraPath(mappingScalar(layer, "path"), mappingScalar(foundryLayer, "path")) {
+				return nil, invalidInfraForEject(
+					fmt.Sprintf("infra layer %q already uses the Foundry layer path %q",
+						mappingScalar(layer, "name"), mappingScalar(foundryLayer, "path")),
+				)
+			}
+		}
+	}
+	changed := false
+	if foundryLayer == nil {
+		for _, layer := range layers.Content {
+			if sameInfraPath(mappingScalar(layer, "path"), foundryInfraLayerPath) {
+				return nil, invalidInfraForEject(
+					fmt.Sprintf("infra layer %q already uses path %q",
+						mappingScalar(layer, "name"), foundryInfraLayerPath),
+				)
+			}
+		}
+		foundryLayer = newInfraLayerNode(
+			foundryInfraLayerName,
+			foundryInfraLayerPath,
+			foundryLayerProvider(provider),
+			nil,
+		)
+		layers.Content = append(layers.Content, foundryLayer)
+		changed = true
+	}
+
+	targetPath := mappingScalar(foundryLayer, "path")
+	if targetPath == "" {
+		return nil, invalidInfraForEject(
+			fmt.Sprintf("Foundry infrastructure layer %q must declare path", mappingScalar(foundryLayer, "name")),
+		)
+	}
+	module := mappingScalar(foundryLayer, "module")
+	if module == "" {
+		module = defaultInfraModule
+	}
+	wantedProvider := foundryLayerProvider(provider)
+	currentProvider := mappingScalar(foundryLayer, "provider")
+	if currentProvider == "" {
+		currentProvider = rootProvider
+	}
+	if currentProvider == "" {
+		return nil, invalidInfraForEject(
+			fmt.Sprintf(
+				"Foundry infrastructure layer %q must declare provider explicitly",
+				mappingScalar(foundryLayer, "name"),
+			),
+		)
+	}
+	if currentProvider != "" && currentProvider != wantedProvider {
+		return nil, invalidInfraForEject(
+			fmt.Sprintf(
+				"Foundry infrastructure layer %q already uses provider %q",
+				mappingScalar(foundryLayer, "name"),
+				currentProvider,
+			),
+		)
+	}
+	if mappingScalar(foundryLayer, "provider") != wantedProvider {
+		setMappingScalar(foundryLayer, "provider", wantedProvider)
+		changed = true
+	}
+
+	targetDir := resolveInfraPath(projectRoot, targetPath)
+	info, statErr := os.Stat(targetDir)
+	if statErr != nil && !errors.Is(statErr, fs.ErrNotExist) {
+		return nil, fmt.Errorf("stat Foundry infrastructure path %s: %w", targetDir, statErr)
+	}
+	if statErr == nil && !info.IsDir() {
+		return nil, ejectExistsError(filepath.ToSlash(targetPath))
+	}
+	if hasInfrastructureEntrypoint(targetDir, wantedProvider, module) {
+		return nil, foundryInfraExistsError(filepath.ToSlash(targetPath), true)
+	}
+	if statErr == nil {
+		empty, err := isDirectoryEmpty(targetDir)
+		if err != nil {
+			return nil, err
+		}
+		if !empty {
+			return nil, foundryInfraExistsError(filepath.ToSlash(targetPath), true)
+		}
+	}
+	plan := &infraEjectPlan{
+		targetDir:  targetDir,
+		targetPath: filepath.ToSlash(targetPath),
+		module:     module,
+		layer:      true,
+	}
+	if changed {
+		updated, err := marshalAzureYAML(root)
+		if err != nil {
+			return nil, err
+		}
+		plan.updatedYAML = updated
+		plan.updateDescription = "infra.layers"
+	}
+	return plan, nil
+}
+
+func validateEjectTarget(projectRoot string, plan *infraEjectPlan) error {
+	if plan == nil || strings.TrimSpace(plan.targetDir) == "" {
+		return invalidInfraForEject("Foundry infrastructure path is empty")
+	}
+	if plan.module == "" || plan.module == "." || plan.module == ".." ||
+		filepath.Base(plan.module) != plan.module || strings.ContainsAny(plan.module, `/\\`) {
+		return invalidInfraForEject(
+			fmt.Sprintf("Foundry infrastructure module %q must be a file name without path separators", plan.module),
+		)
+	}
+	if filepath.Ext(plan.module) != "" {
+		return invalidInfraForEject(
+			fmt.Sprintf("Foundry infrastructure module %q must not include a file extension", plan.module),
+		)
+	}
+	safeTarget, err := projectpaths.Join(projectRoot, plan.targetPath)
+	if err != nil {
+		return invalidInfraForEject(fmt.Sprintf("invalid Foundry infrastructure path %q: %s", plan.targetPath, err))
+	}
+	plan.targetDir = safeTarget
+	if info, err := os.Stat(plan.targetDir); err == nil && !info.IsDir() {
+		return ejectExistsError(plan.targetPath)
+	} else if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("stat Foundry infrastructure path %s: %w", plan.targetDir, err)
+	}
 	return nil
+}
+
+func installStagedInfra(stageDir string, plan *infraEjectPlan) (func(), error) {
+	type stagedFile struct {
+		src string
+		dst string
+	}
+	var files []stagedFile
+	err := filepath.WalkDir(stageDir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(stageDir, path)
+		if err != nil {
+			return err
+		}
+		dst := filepath.Join(plan.targetDir, rel)
+		if _, err := os.Lstat(dst); err == nil {
+			return ejectExistsError(filepath.ToSlash(filepath.Join(plan.targetPath, rel)))
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("stat infrastructure destination %s: %w", dst, err)
+		}
+		files = append(files, stagedFile{src: path, dst: dst})
+		return nil
+	})
+	if err != nil {
+		return func() {}, err
+	}
+
+	createdFiles := make([]string, 0, len(files))
+	createdDirs := []string{}
+	rollback := func() {
+		for _, path := range createdFiles {
+			_ = os.Remove(path)
+		}
+		for i := len(createdDirs) - 1; i >= 0; i-- {
+			_ = os.Remove(createdDirs[i])
+		}
+	}
+
+	for _, file := range files {
+		parent := filepath.Dir(file.dst)
+		missing, err := missingDirectories(parent)
+		if err != nil {
+			rollback()
+			return func() {}, err
+		}
+		//nolint:gosec // G301: ejected infra directories must be readable/traversable by IDEs, Git, and CI
+		if err := os.MkdirAll(parent, 0o755); err != nil {
+			rollback()
+			return func() {}, exterrors.Internal(
+				exterrors.CodeInfraEjectWriteFailed,
+				fmt.Sprintf("create infrastructure directory %s: %s", parent, err),
+			)
+		}
+		createdDirs = append(createdDirs, missing...)
+		if err := azdext.CopyFileAtomic(file.src, file.dst, 0o644); err != nil {
+			rollback()
+			return func() {}, exterrors.Internal(
+				exterrors.CodeInfraEjectWriteFailed,
+				fmt.Sprintf("install infrastructure file %s: %s", file.dst, err),
+			)
+		}
+		createdFiles = append(createdFiles, file.dst)
+	}
+	return rollback, nil
+}
+
+func missingDirectories(path string) ([]string, error) {
+	var missing []string
+	for current := path; ; current = filepath.Dir(current) {
+		info, err := os.Lstat(current)
+		switch {
+		case err == nil:
+			if !info.IsDir() {
+				return nil, fmt.Errorf("infrastructure parent path %s is not a directory", current)
+			}
+			slices.Reverse(missing)
+			return missing, nil
+		case errors.Is(err, fs.ErrNotExist):
+			missing = append(missing, current)
+		default:
+			return nil, fmt.Errorf("stat infrastructure parent path %s: %w", current, err)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil, fmt.Errorf("no existing parent directory for infrastructure path %s", path)
+		}
+	}
+}
+
+func newInfraLayerNode(name, path, provider string, dependsOn []string) *yaml.Node {
+	layer := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+		Content: []*yaml.Node{
+			newScalarNode("name"), newScalarNode(name),
+			newScalarNode("path"), newScalarNode(filepath.ToSlash(path)),
+			newScalarNode("provider"), newScalarNode(provider),
+		},
+	}
+	if len(dependsOn) > 0 {
+		dependencies := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+		for _, dependency := range dependsOn {
+			dependencies.Content = append(dependencies.Content, newScalarNode(dependency))
+		}
+		layer.Content = append(layer.Content, newScalarNode("dependsOn"), dependencies)
+	}
+	return layer
+}
+
+func foundryLayerProvider(ejectProvider string) string {
+	if ejectProvider == project.TerraformProviderName {
+		return project.TerraformProviderName
+	}
+	return project.FoundryProviderName
+}
+
+func cloneMappingNode(node *yaml.Node) *yaml.Node {
+	return cloneYAMLNode(node, make(map[*yaml.Node]*yaml.Node))
+}
+
+func cloneYAMLNode(node *yaml.Node, clones map[*yaml.Node]*yaml.Node) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+	if clone, ok := clones[node]; ok {
+		return clone
+	}
+	clone := *node
+	clones[node] = &clone
+	clone.Content = make([]*yaml.Node, len(node.Content))
+	for i, child := range node.Content {
+		clone.Content[i] = cloneYAMLNode(child, clones)
+	}
+	clone.Alias = cloneYAMLNode(node.Alias, clones)
+	return &clone
+}
+
+func resolveInfraPath(projectRoot, path string) string {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(projectRoot, filepath.FromSlash(path))
+}
+
+func sameInfraPath(a, b string) bool {
+	left := filepath.Clean(filepath.FromSlash(a))
+	right := filepath.Clean(filepath.FromSlash(b))
+	return strings.EqualFold(left, right)
+}
+
+func hasInfrastructureEntrypoint(infraDir, provider, module string) bool {
+	switch provider {
+	case project.BicepProviderName, project.FoundryProviderName:
+		return fileExists(filepath.Join(infraDir, module+".bicep")) ||
+			fileExists(filepath.Join(infraDir, module+".bicepparam"))
+	case project.TerraformProviderName:
+		entries, err := os.ReadDir(infraDir)
+		if err != nil {
+			return false
+		}
+		return slices.ContainsFunc(entries, func(entry os.DirEntry) bool {
+			return !entry.IsDir() && strings.HasSuffix(entry.Name(), ".tf")
+		})
+	default:
+		info, err := os.Stat(infraDir)
+		return err == nil && info.IsDir()
+	}
+}
+
+func isFoundryTerraformInfra(infraDir, module string) (bool, error) {
+	markerPath := filepath.Join(infraDir, foundryTerraformMarker)
+	markerInfo, err := os.Lstat(markerPath)
+	if err == nil {
+		if !markerInfo.Mode().IsRegular() {
+			return false, invalidFoundryTerraformMarker(markerPath, "marker is not a regular file")
+		}
+		marker, err := os.ReadFile(markerPath) //nolint:gosec // validated project infra marker
+		if err != nil {
+			return false, invalidFoundryTerraformMarker(markerPath, err.Error())
+		}
+		if string(marker) != foundryTerraformV1 {
+			return false, invalidFoundryTerraformMarker(markerPath, "marker version is unsupported or edited")
+		}
+		return true, nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return false, invalidFoundryTerraformMarker(markerPath, err.Error())
+	}
+
+	// Legacy ejects predate the marker. Require both the generated tfvars file
+	// and distinctive Foundry resource declarations; either signal alone is
+	// common in user-authored Terraform projects.
+	if !fileExists(filepath.Join(infraDir, module+".tfvars.json")) {
+		return false, nil
+	}
+	main, err := os.ReadFile(filepath.Join(infraDir, "main.tf")) //nolint:gosec // project infrastructure path
+	if err != nil {
+		return false, nil
+	}
+	source := string(main)
+	return strings.Contains(source, `resource "azapi_resource" "foundry_account"`) &&
+		strings.Contains(source, `resource "azapi_resource" "project"`) &&
+		strings.Contains(source, "Microsoft.CognitiveServices/accounts") &&
+		strings.Contains(source, "Microsoft.CognitiveServices/accounts/projects"), nil
+}
+
+func invalidFoundryTerraformMarker(path, reason string) error {
+	return exterrors.Validation(
+		exterrors.CodeInfraEjectMarkerInvalid,
+		fmt.Sprintf("Foundry ownership marker %q cannot be used: %s; eject did not modify the infrastructure",
+			filepath.ToSlash(path), reason),
+		"restore the marker from source control or use an azure.ai.agents version that supports it. "+
+			"If this is intentionally user-owned Terraform, remove the marker only after verifying the infrastructure",
+	)
+}
+
+func isDirectoryEmpty(path string) (bool, error) {
+	dir, err := os.Open(path) //nolint:gosec // path is validated as the project infrastructure directory
+	if err != nil {
+		return false, fmt.Errorf("open infrastructure path %s: %w", path, err)
+	}
+	defer dir.Close()
+	_, err = dir.Readdirnames(1)
+	if errors.Is(err, io.EOF) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read infrastructure path %s: %w", path, err)
+	}
+	return false, nil
+}
+
+func marshalAzureYAML(root *yaml.Node) ([]byte, error) {
+	out, err := yaml.Marshal(root)
+	if err != nil {
+		return nil, exterrors.Internal(
+			exterrors.CodeInfraEjectWriteFailed,
+			fmt.Sprintf("marshal azure.yaml after infrastructure eject: %s", err),
+		)
+	}
+	return out, nil
+}
+
+func invalidInfraForEject(message string) error {
+	return exterrors.Validation(
+		exterrors.CodeInvalidAzureYaml,
+		message,
+		"fix the infra configuration in azure.yaml and run the command again",
+	)
+}
+
+func ejectExistsError(path string) error {
+	return exterrors.Validation(
+		exterrors.CodeInfraEjectExists,
+		fmt.Sprintf("`./%s` already exists", filepath.ToSlash(path)),
+		"remove the conflicting path or edit the existing infrastructure manually. To use another Foundry path, "+
+			"first declare an infra.layers entry named 'foundry' with a different project-relative path in azure.yaml",
+	)
+}
+
+func foundryInfraExistsError(path string, layer bool) error {
+	location := "Foundry infrastructure"
+	suggestion := "remove the existing generated Foundry infrastructure before ejecting it again, or edit it manually"
+	if layer {
+		location = fmt.Sprintf("Foundry infrastructure layer %q", foundryInfraLayerName)
+		suggestion += ". To use another path, change the project-relative path on the 'foundry' entry in infra.layers"
+	}
+	return exterrors.Validation(
+		exterrors.CodeInfraEjectExists,
+		fmt.Sprintf("%s already exists at `./%s`; eject did not overwrite it", location, filepath.ToSlash(path)),
+		suggestion,
+	)
+}
+
+func newMappingNode() *yaml.Node {
+	return &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+}
+
+func newScalarNode(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+}
+
+func mappingScalar(mapping *yaml.Node, key string) string {
+	value := mappingValue(mapping, key)
+	if value == nil || value.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return strings.TrimSpace(value.Value)
 }
 
 // findFoundryServiceForEject scans azure.yaml for the azure.ai.project service
@@ -736,7 +1485,12 @@ func findFoundryServiceForEject(raw []byte) (string, error) {
 //     project, main.bicep never references brownfield.bicep, and the
 //     provider's brownfield path always loads the embedded
 //     synthesis.BrownfieldARMTemplate() instead of anything under infra/.
-func writeEmbeddedTemplates(infraDir string) (_ []ejectArtifact, retErr error) {
+func writeEmbeddedTemplates(
+	infraDir string,
+	artifactRoot string,
+	module string,
+	layer bool,
+) (_ []ejectArtifact, retErr error) {
 	//nolint:gosec // G301: ejected infra/ directory must be readable/traversable by IDEs, Git, and CI
 	if err := os.MkdirAll(infraDir, 0o755); err != nil {
 		return nil, exterrors.Internal(
@@ -767,7 +1521,11 @@ func writeEmbeddedTemplates(infraDir string) (_ []ejectArtifact, retErr error) {
 			return err
 		}
 		// embed.FS always returns forward slashes; normalize for the OS.
-		dst := filepath.Join(infraDir, filepath.FromSlash(rel))
+		dstRel := rel
+		if rel == "main.bicep" {
+			dstRel = module + ".bicep"
+		}
+		dst := filepath.Join(infraDir, filepath.FromSlash(dstRel))
 
 		if d.IsDir() {
 			//nolint:gosec // G301: ejected infra/ subdirectories must remain readable/traversable
@@ -791,7 +1549,7 @@ func writeEmbeddedTemplates(infraDir string) (_ []ejectArtifact, retErr error) {
 			return err
 		}
 		artifacts = append(artifacts, ejectArtifact{
-			relPath: filepath.ToSlash(filepath.Join("infra", rel)),
+			relPath: filepath.ToSlash(filepath.Join(artifactRoot, dstRel)),
 			bytes:   len(data),
 		})
 		return nil
@@ -813,13 +1571,29 @@ func writeEmbeddedTemplates(infraDir string) (_ []ejectArtifact, retErr error) {
 // supplied by the provider at `azd provision`. The result is a partial
 // parameters file -- enough for `bicep build` to validate, not for a
 // standalone `az deployment sub create`.
-func writeParametersFile(infraDir string, params map[string]any) (ejectArtifact, error) {
+func writeParametersFile(
+	infraDir string,
+	artifactRoot string,
+	module string,
+	layer bool,
+	params map[string]any,
+) (ejectArtifact, error) {
 	type paramValue struct {
 		Value any `json:"value"`
 	}
 	wrapped := map[string]paramValue{}
 	for k, v := range params {
 		wrapped[k] = paramValue{Value: v}
+	}
+	if layer {
+		wrapped["resourceGroupName"] = paramValue{
+			Value: "${AZURE_FOUNDRY_RESOURCE_GROUP=rg-${AZURE_ENV_NAME}-foundry}",
+		}
+		wrapped["location"] = paramValue{Value: "${AZURE_LOCATION}"}
+		wrapped["foundryProjectName"] = paramValue{Value: "${AZURE_AI_PROJECT_NAME=${AZURE_ENV_NAME}}"}
+		wrapped["resourceTokenSalt"] = paramValue{Value: "${AZURE_RESOURCE_TOKEN_SALT}"}
+		wrapped["principalId"] = paramValue{Value: "${AZURE_PRINCIPAL_ID}"}
+		wrapped["principalType"] = paramValue{Value: "${AZURE_PRINCIPAL_TYPE}"}
 	}
 
 	doc := map[string]any{
@@ -839,7 +1613,8 @@ func writeParametersFile(infraDir string, params map[string]any) (ejectArtifact,
 	// json.MarshalIndent omits a trailing newline; add one for editors/POSIX tools.
 	data = append(data, '\n')
 
-	dst := filepath.Join(infraDir, "main.parameters.json")
+	filename := module + ".parameters.json"
+	dst := filepath.Join(infraDir, filename)
 	//nolint:gosec // G306: ejected parameters file is intended to be human-readable
 	if err := os.WriteFile(dst, data, 0o644); err != nil {
 		return ejectArtifact{}, exterrors.Internal(
@@ -848,7 +1623,7 @@ func writeParametersFile(infraDir string, params map[string]any) (ejectArtifact,
 		)
 	}
 	return ejectArtifact{
-		relPath: "infra/main.parameters.json",
+		relPath: filepath.ToSlash(filepath.Join(artifactRoot, filename)),
 		bytes:   len(data),
 	}, nil
 }
@@ -864,7 +1639,11 @@ func writeParametersFile(infraDir string, params map[string]any) (ejectArtifact,
 // Files that are not verbatim copies are skipped here and produced elsewhere:
 // outputs.tf is rendered from outputs.tf.tmpl by writeOutputsFile, and
 // main.tfvars.json is generated by writeTfvarsFile, so neither goes stale.
-func writeEmbeddedTerraformTemplates(infraDir string, includeAcr bool) (_ []ejectArtifact, retErr error) {
+func writeEmbeddedTerraformTemplates(
+	infraDir string,
+	artifactRoot string,
+	includeAcr bool,
+) (_ []ejectArtifact, retErr error) {
 	//nolint:gosec // G301: ejected infra/ directory must be readable/traversable by IDEs, Git, and CI
 	if err := os.MkdirAll(infraDir, 0o755); err != nil {
 		return nil, exterrors.Internal(
@@ -920,7 +1699,7 @@ func writeEmbeddedTerraformTemplates(infraDir string, includeAcr bool) (_ []ejec
 			)
 		}
 		artifacts = append(artifacts, ejectArtifact{
-			relPath: filepath.ToSlash(filepath.Join("infra", name)),
+			relPath: filepath.ToSlash(filepath.Join(artifactRoot, name)),
 			bytes:   len(data),
 		})
 	}
@@ -932,7 +1711,12 @@ func writeEmbeddedTerraformTemplates(infraDir string, includeAcr bool) (_ []ejec
 // The ACR outputs are included only when includeAcr is true (acr.tf was
 // written); otherwise they are omitted entirely, since Terraform resolves
 // resource references statically and acr.tf's resources are not present.
-func writeOutputsFile(infraDir string, includeAcr bool) (ejectArtifact, error) {
+func writeOutputsFile(
+	infraDir string,
+	artifactRoot string,
+	includeAcr bool,
+	layer bool,
+) (ejectArtifact, error) {
 	const tmplPath = "templates/terraform/outputs.tf.tmpl"
 	raw, err := fs.ReadFile(synthesis.TerraformTemplatesFS(), tmplPath)
 	if err != nil {
@@ -957,6 +1741,29 @@ func writeOutputsFile(infraDir string, includeAcr bool) (ejectArtifact, error) {
 			fmt.Sprintf("render outputs template: %s", err),
 		)
 	}
+	if layer {
+		const resourceGroupOutput = "output \"AZURE_RESOURCE_GROUP\" {"
+		contents := buf.String()
+		start := strings.Index(contents, resourceGroupOutput)
+		if start < 0 || strings.Index(contents[start+len(resourceGroupOutput):], resourceGroupOutput) >= 0 {
+			return ejectArtifact{}, exterrors.Internal(
+				exterrors.CodeInfraEjectWriteFailed,
+				"render outputs.tf: expected exactly one AZURE_RESOURCE_GROUP output",
+			)
+		}
+		end := strings.Index(contents[start:], "}")
+		if end < 0 {
+			return ejectArtifact{}, exterrors.Internal(
+				exterrors.CodeInfraEjectWriteFailed,
+				"render outputs.tf: malformed AZURE_RESOURCE_GROUP output",
+			)
+		}
+		end += start + len("}")
+		for end < len(contents) && (contents[end] == '\r' || contents[end] == '\n') {
+			end++
+		}
+		buf = *bytes.NewBufferString(contents[:start] + contents[end:])
+	}
 
 	dst := filepath.Join(infraDir, "outputs.tf")
 	//nolint:gosec // G306: ejected Terraform sources are intended to be human-readable
@@ -967,7 +1774,7 @@ func writeOutputsFile(infraDir string, includeAcr bool) (ejectArtifact, error) {
 		)
 	}
 	return ejectArtifact{
-		relPath: "infra/outputs.tf",
+		relPath: filepath.ToSlash(filepath.Join(artifactRoot, "outputs.tf")),
 		bytes:   buf.Len(),
 	}, nil
 }
@@ -981,7 +1788,13 @@ func writeOutputsFile(infraDir string, includeAcr bool) (ejectArtifact, error) {
 //
 // include_acr is NOT written: whether ACR is provisioned is decided at eject
 // time by the presence of acr.tf, not by a Terraform variable.
-func writeTfvarsFile(infraDir string, params map[string]any) (ejectArtifact, error) {
+func writeTfvarsFile(
+	infraDir string,
+	artifactRoot string,
+	module string,
+	layer bool,
+	params map[string]any,
+) (ejectArtifact, error) {
 	// Static keys carry ${...} placeholders azd resolves from the environment.
 	// json.MarshalIndent sorts map keys alphabetically, so the generated file is
 	// deterministic; the placeholder values are JSON strings azd env-substitutes.
@@ -993,6 +1806,10 @@ func writeTfvarsFile(infraDir string, params map[string]any) (ejectArtifact, err
 		"foundry_project_name": "${AZURE_AI_PROJECT_NAME}",
 		"principal_id":         "${AZURE_PRINCIPAL_ID}",
 		"resource_token_salt":  "${AZURE_RESOURCE_TOKEN_SALT}",
+	}
+	if layer {
+		doc["resource_group_name"] = "${AZURE_FOUNDRY_RESOURCE_GROUP=rg-${AZURE_ENV_NAME}-foundry}"
+		doc["foundry_project_name"] = "${AZURE_AI_PROJECT_NAME=${AZURE_ENV_NAME}}"
 	}
 
 	// deployments and connections are the only synthesizer-derived values
@@ -1033,7 +1850,8 @@ func writeTfvarsFile(infraDir string, params map[string]any) (ejectArtifact, err
 	// json.MarshalIndent omits a trailing newline; add one for editors/POSIX tools.
 	data = append(data, '\n')
 
-	dst := filepath.Join(infraDir, "main.tfvars.json")
+	filename := module + ".tfvars.json"
+	dst := filepath.Join(infraDir, filename)
 	//nolint:gosec // G306: ejected tfvars file is intended to be human-readable
 	if err := os.WriteFile(dst, data, 0o644); err != nil {
 		return ejectArtifact{}, exterrors.Internal(
@@ -1042,67 +1860,9 @@ func writeTfvarsFile(infraDir string, params map[string]any) (ejectArtifact, err
 		)
 	}
 	return ejectArtifact{
-		relPath: "infra/main.tfvars.json",
+		relPath: filepath.ToSlash(filepath.Join(artifactRoot, filename)),
 		bytes:   len(data),
 	}, nil
-}
-
-// stampInfraProvider sets `infra.provider: <provider>` in azure.yaml, creating
-// the infra: block if absent and dropping any starter `infra.path`. Eject runs
-// as a standalone command without an AzdClient, so this is an in-place YAML
-// edit (the Bicep path leaves azure.yaml untouched; only Terraform stamps a
-// provider so azd-core takes over provisioning).
-func stampInfraProvider(projectRoot, provider string) error {
-	yamlPath := filepath.Join(projectRoot, "azure.yaml")
-	//nolint:gosec // G304: azure.yaml under the caller-supplied azd project root
-	raw, err := os.ReadFile(yamlPath)
-	if err != nil {
-		return fmt.Errorf("read azure.yaml for provider stamp: %w", err)
-	}
-
-	var root yaml.Node
-	if err := yaml.Unmarshal(raw, &root); err != nil {
-		return exterrors.Validation(
-			exterrors.CodeInvalidAzureYaml,
-			fmt.Sprintf("parse azure.yaml: %s", err),
-			"verify azure.yaml is valid YAML",
-		)
-	}
-	if len(root.Content) == 0 || root.Content[0].Kind != yaml.MappingNode {
-		return exterrors.Validation(
-			exterrors.CodeInvalidAzureYaml,
-			"azure.yaml is not a YAML mapping at the top level",
-			"verify azure.yaml is a valid azd project file",
-		)
-	}
-
-	doc := root.Content[0]
-	infra := mappingValue(doc, "infra")
-	if infra == nil {
-		infra = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
-		doc.Content = append(doc.Content,
-			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "infra"},
-			infra,
-		)
-	}
-	setMappingScalar(infra, "provider", provider)
-	removeMappingKey(infra, "path")
-
-	out, err := yaml.Marshal(&root)
-	if err != nil {
-		return exterrors.Internal(
-			exterrors.CodeInfraEjectWriteFailed,
-			fmt.Sprintf("marshal azure.yaml after provider stamp: %s", err),
-		)
-	}
-	//nolint:gosec // G306: azure.yaml is a human-edited project file
-	if err := os.WriteFile(yamlPath, out, 0o644); err != nil {
-		return exterrors.Internal(
-			exterrors.CodeInfraEjectWriteFailed,
-			fmt.Sprintf("write azure.yaml after provider stamp: %s", err),
-		)
-	}
-	return nil
 }
 
 // mappingValue returns the value node for key in a YAML mapping node, or nil.
@@ -1146,9 +1906,9 @@ func removeMappingKey(m *yaml.Node, key string) {
 	}
 }
 
-// printEjectSummary renders the user-facing success block to stdout. For the
-// Terraform provider it also notes that infra.provider was set in azure.yaml.
-func printEjectSummary(written []ejectArtifact, provider string) {
+// printEjectSummary renders the user-facing success block to stdout and notes
+// any azure.yaml provider/layer update.
+func printEjectSummary(written []ejectArtifact, targetPath string, updateDescription string) {
 	fmt.Println()
 	fmt.Println("Generating infrastructure files from azure.yaml...")
 	fmt.Println()
@@ -1156,11 +1916,11 @@ func printEjectSummary(written []ejectArtifact, provider string) {
 		fmt.Printf("  %s %s\n", color.GreenString("Created"), a.relPath)
 	}
 	fmt.Println()
-	if provider == project.TerraformProviderName {
-		fmt.Printf("  %s azure.yaml (infra.provider: terraform)\n", color.GreenString("Updated"))
+	if updateDescription != "" {
+		fmt.Printf("  %s azure.yaml (%s)\n", color.GreenString("Updated"), updateDescription)
 		fmt.Println()
 	}
-	fmt.Println("Future provisions will read from ./infra/.")
+	fmt.Printf("Future provisions will read the Foundry layer from ./%s/.\n", filepath.ToSlash(targetPath))
 	fmt.Println()
 	fmt.Println("Next steps:")
 	fmt.Println("  azd provision    Apply changes")

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"maps"
 	"os"
@@ -53,6 +52,29 @@ type infraEjectPlan struct {
 	layer             bool
 	updatedYAML       []byte
 	updateDescription string
+}
+
+type infraTargetState struct {
+	dir    string
+	exists bool
+	empty  bool
+}
+
+type infraConfig struct {
+	root         *yaml.Node
+	infra        *yaml.Node
+	layersNode   *yaml.Node
+	rootProvider string
+	layers       []infraLayer
+}
+
+type infraLayer struct {
+	node              *yaml.Node
+	name              string
+	path              string
+	module            string
+	provider          string
+	effectiveProvider string
 }
 
 // validateStandaloneEjectArgs refuses init-driving inputs that the
@@ -391,10 +413,8 @@ type infraGate struct {
 // existing project and give me its IaC" stays a single step instead of failing
 // with "nothing to eject".
 //
-// The one refusal kept up front is a pre-existing ./infra/: init cannot clear
-// it, so failing here beats mutating azure.yaml and then refusing on the
-// trailing eject. Projects that use a custom infra.path, infra.layers, or an
-// incompatible provider are refused on both branches for the same reason.
+// Infrastructure compatibility is handled by the layer-aware eject planner.
+// The gate only decides whether init must add a Foundry service first.
 func resolveInfraGate(provider string) (infraGate, error) {
 	projectRoot, err := azdext.GetProjectDir()
 	if errors.Is(err, azdext.ErrProjectNotFound) {
@@ -416,30 +436,9 @@ func resolveInfraGate(provider string) (infraGate, error) {
 		return infraGate{}, err
 	}
 
-	if err := ensureNoInfraLayers(rawYAML); err != nil {
-		return infraGate{}, err
-	}
-	if err := ensureDefaultInfraPath(rawYAML); err != nil {
-		return infraGate{}, err
-	}
-	if err := ensureDefaultInfraModule(rawYAML); err != nil {
-		return infraGate{}, err
-	}
-	if err := ensureCompatibleInfraProvider(rawYAML, provider); err != nil {
-		return infraGate{}, err
-	}
-
 	if hasFoundry {
 		return infraGate{standaloneEject: true, projectRoot: projectRoot}, nil
 	}
-
-	// The trailing eject writes ./infra/, and init cannot clear a directory that
-	// is already there. Refuse now rather than mutating azure.yaml and adding an
-	// azd environment first and only then refusing.
-	if err := ensureInfraDirAbsent(projectRoot); err != nil {
-		return infraGate{}, err
-	}
-
 	return infraGate{projectRoot: projectRoot}, nil
 }
 
@@ -501,7 +500,7 @@ func ejectInfra(projectRoot, provider string) error {
 	if err != nil {
 		return err
 	}
-	if err := validateEjectTarget(projectRoot, plan); err != nil {
+	if err := validateEjectTarget(plan); err != nil {
 		return err
 	}
 
@@ -704,6 +703,17 @@ func planInfraEject(projectRoot string, rawYAML []byte, provider string) (*infra
 			"pass --infra=bicep or --infra=terraform",
 		)
 	}
+	config, err := parseInfraConfig(rawYAML)
+	if err != nil {
+		return nil, err
+	}
+	if config.layersNode == nil {
+		return planRootInfraEject(projectRoot, config, provider)
+	}
+	return planLayeredInfraEject(projectRoot, config, provider)
+}
+
+func parseInfraConfig(rawYAML []byte) (*infraConfig, error) {
 	var root yaml.Node
 	if err := yaml.Unmarshal(rawYAML, &root); err != nil {
 		return nil, exterrors.Validation(
@@ -719,7 +729,6 @@ func planInfraEject(projectRoot string, rawYAML []byte, provider string) (*infra
 			"verify azure.yaml is a valid azd project file",
 		)
 	}
-
 	doc := root.Content[0]
 	infra := mappingValue(doc, "infra")
 	if infra == nil {
@@ -729,345 +738,249 @@ func planInfraEject(projectRoot string, rawYAML []byte, provider string) (*infra
 	if infra.Kind != yaml.MappingNode {
 		return nil, invalidInfraForEject("infra must be a mapping")
 	}
-	for _, key := range []string{"path", "module", "provider"} {
+	for _, key := range []string{"name", "path", "module", "provider"} {
 		if value := mappingValue(infra, key); value != nil && value.Kind != yaml.ScalarNode {
 			return nil, invalidInfraForEject(fmt.Sprintf("infra.%s must be a string", key))
 		}
 	}
-
-	layers := mappingValue(infra, "layers")
-	if layers != nil {
-		return planLayeredInfraEject(projectRoot, &root, infra, layers, provider)
+	config := &infraConfig{
+		root:         &root,
+		infra:        infra,
+		layersNode:   mappingValue(infra, "layers"),
+		rootProvider: mappingScalar(infra, "provider"),
 	}
-	return planSingleInfraEject(projectRoot, &root, infra, provider)
+	if config.layersNode == nil {
+		return config, nil
+	}
+	if config.layersNode.Kind != yaml.SequenceNode {
+		return nil, invalidInfraForEject("infra.layers must be a sequence")
+	}
+	seen := make(map[string]struct{}, len(config.layersNode.Content))
+	for _, node := range config.layersNode.Content {
+		if node.Kind != yaml.MappingNode {
+			return nil, invalidInfraForEject("each infra.layers entry must be a mapping")
+		}
+		for _, key := range []string{"name", "path", "module", "provider"} {
+			if value := mappingValue(node, key); value != nil && value.Kind != yaml.ScalarNode {
+				return nil, invalidInfraForEject(fmt.Sprintf("infra.layers[].%s must be a string", key))
+			}
+		}
+		layer := infraLayer{
+			node:     node,
+			name:     mappingScalar(node, "name"),
+			path:     mappingScalar(node, "path"),
+			module:   mappingScalar(node, "module"),
+			provider: mappingScalar(node, "provider"),
+		}
+		name := layer.name
+		if name == "" {
+			return nil, invalidInfraForEject("each infra.layers entry must declare a name")
+		}
+		if layer.path == "" {
+			return nil, invalidInfraForEject(fmt.Sprintf("infra layer %q must declare path", name))
+		}
+		if _, ok := seen[name]; ok {
+			return nil, invalidInfraForEject(fmt.Sprintf("duplicate infrastructure layer name %q", name))
+		}
+		seen[name] = struct{}{}
+		layer.effectiveProvider = layer.provider
+		if layer.effectiveProvider == "" {
+			layer.effectiveProvider = config.rootProvider
+		}
+		config.layers = append(config.layers, layer)
+	}
+	return config, nil
 }
 
-func planSingleInfraEject(
-	projectRoot string,
-	root *yaml.Node,
-	infra *yaml.Node,
-	provider string,
-) (*infraEjectPlan, error) {
-	existingProvider := mappingScalar(infra, "provider")
-	existingName := mappingScalar(infra, "name")
-	existingPath := mappingScalar(infra, "path")
-	existingModule := mappingScalar(infra, "module")
-	effectivePath := existingPath
-	if effectivePath == "" {
-		effectivePath = defaultInfraPath
+func planRootInfraEject(projectRoot string, config *infraConfig, provider string) (*infraEjectPlan, error) {
+	root := infraLayer{
+		node:              config.infra,
+		name:              valueOrDefault(mappingScalar(config.infra, "name"), defaultInfraPath),
+		path:              valueOrDefault(mappingScalar(config.infra, "path"), defaultInfraPath),
+		module:            valueOrDefault(mappingScalar(config.infra, "module"), defaultInfraModule),
+		provider:          config.rootProvider,
+		effectiveProvider: valueOrDefault(config.rootProvider, project.BicepProviderName),
 	}
-	effectiveModule := existingModule
-	if effectiveModule == "" {
-		effectiveModule = defaultInfraModule
+	target, err := inspectInfraTarget(projectRoot, root.path)
+	if err != nil {
+		return nil, err
 	}
-	effectiveProvider := existingProvider
-	if effectiveProvider == "" {
-		effectiveProvider = project.BicepProviderName
+	userOwned, err := rootInfraUserOwned(root, target)
+	if err != nil {
+		return nil, err
 	}
-
-	existingDir := resolveInfraPath(projectRoot, effectivePath)
-	info, statErr := os.Stat(existingDir)
-	dirExists := statErr == nil
-	if statErr != nil && !errors.Is(statErr, fs.ErrNotExist) {
-		return nil, fmt.Errorf("stat infrastructure path %s: %w", existingDir, statErr)
-	}
-	if dirExists && !info.IsDir() {
-		return nil, ejectExistsError(filepath.ToSlash(effectivePath))
-	}
-
-	hasEntrypoint := hasInfrastructureEntrypoint(
-		existingDir,
-		effectiveProvider,
-		effectiveModule,
-	)
-	customProvider := existingProvider != "" &&
-		existingProvider != project.BicepProviderName &&
-		existingProvider != project.TerraformProviderName &&
-		existingProvider != project.FoundryProviderName
-	if existingProvider == project.FoundryProviderName && hasEntrypoint {
-		return nil, foundryInfraExistsError(filepath.ToSlash(effectivePath), false)
-	}
-	if existingProvider == project.TerraformProviderName {
-		foundryTerraform, err := isFoundryTerraformInfra(existingDir, effectiveModule)
-		if err != nil {
-			return nil, err
-		}
-		if foundryTerraform {
-			return nil, foundryInfraExistsError(filepath.ToSlash(effectivePath), false)
-		}
-	}
-	if existingProvider != "" &&
-		(existingProvider == project.BicepProviderName || existingProvider == project.TerraformProviderName) &&
-		!hasEntrypoint {
-		return nil, invalidInfraForEject(
-			fmt.Sprintf("infrastructure declares provider %q but path %q contains no matching entry point",
-				existingProvider, effectivePath),
-		)
-	}
-	userOwned := existingProvider != project.FoundryProviderName && (hasEntrypoint || customProvider)
 	if !userOwned {
-		if dirExists && !customProvider {
-			empty, err := isDirectoryEmpty(existingDir)
-			if err != nil {
-				return nil, err
-			}
-			if !empty {
-				return nil, invalidInfraForEject(
-					fmt.Sprintf("infrastructure path %q contains files but no detectable entry point", effectivePath),
-				)
-			}
-		}
-		changed := false
-		wantedProvider := project.FoundryProviderName
-		if provider == project.TerraformProviderName {
-			wantedProvider = project.TerraformProviderName
-		}
-		if existingProvider != wantedProvider {
-			setMappingScalar(infra, "provider", wantedProvider)
-			changed = true
-		}
-
-		plan := &infraEjectPlan{
-			targetDir:  existingDir,
-			targetPath: filepath.ToSlash(effectivePath),
-			module:     effectiveModule,
-			layer:      false,
-		}
+		wanted := foundryLayerProvider(provider)
+		changed := root.provider != wanted
 		if changed {
-			updated, err := marshalAzureYAML(root)
-			if err != nil {
-				return nil, err
-			}
-			plan.updatedYAML = updated
-			plan.updateDescription = fmt.Sprintf("infra.provider: %s", wantedProvider)
+			setMappingScalar(config.infra, "provider", wanted)
 		}
-		return plan, nil
+		return newInfraEjectPlan(config, target, root.path, root.module, false, changed,
+			fmt.Sprintf("infra.provider: %s", wanted))
 	}
-	if sameInfraPath(effectivePath, foundryInfraLayerPath) {
+	if sameInfraPath(root.path, foundryInfraLayerPath) {
 		return nil, invalidInfraForEject(
 			fmt.Sprintf("existing infrastructure already uses the Foundry layer path %q", foundryInfraLayerPath),
 		)
 	}
-
-	existingLayer := cloneMappingNode(infra)
-	if existingName == "" {
-		existingName = defaultInfraPath
-	}
-	if existingName == foundryInfraLayerName {
+	if root.name == foundryInfraLayerName {
 		return nil, invalidInfraForEject(
-			fmt.Sprintf("existing infrastructure name %q conflicts with the Foundry layer name", existingName),
+			fmt.Sprintf("existing infrastructure name %q conflicts with the Foundry layer name", root.name),
 		)
 	}
-	setMappingScalar(existingLayer, "name", existingName)
-	setMappingScalar(existingLayer, "path", filepath.ToSlash(effectivePath))
-	setMappingScalar(existingLayer, "provider", effectiveProvider)
+	existingLayerValue := *config.infra
+	existingLayer := &existingLayerValue
+	setMappingScalar(existingLayer, "name", root.name)
+	setMappingScalar(existingLayer, "path", filepath.ToSlash(root.path))
+	setMappingScalar(existingLayer, "provider", root.effectiveProvider)
 	removeMappingKey(existingLayer, "layers")
-
-	foundryLayer := newInfraLayerNode(
-		foundryInfraLayerName,
-		foundryInfraLayerPath,
-		foundryLayerProvider(provider),
-		nil,
-	)
-	infra.Content = nil
-	infra.Content = append(infra.Content,
+	foundryLayer := newInfraLayerNode(foundryInfraLayerName, foundryInfraLayerPath, foundryLayerProvider(provider))
+	config.infra.Content = []*yaml.Node{
 		newScalarNode("layers"),
 		&yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq", Content: []*yaml.Node{existingLayer, foundryLayer}},
-	)
-	updated, err := marshalAzureYAML(root)
+	}
+	foundryTarget, err := inspectInfraTarget(projectRoot, foundryInfraLayerPath)
 	if err != nil {
 		return nil, err
 	}
-	return &infraEjectPlan{
-		targetDir:         resolveInfraPath(projectRoot, foundryInfraLayerPath),
-		targetPath:        foundryInfraLayerPath,
-		module:            defaultInfraModule,
-		layer:             true,
-		updatedYAML:       updated,
-		updateDescription: "infra.layers",
-	}, nil
+	return newInfraEjectPlan(config, foundryTarget, foundryInfraLayerPath, defaultInfraModule, true, true, "infra.layers")
 }
 
-func planLayeredInfraEject(
-	projectRoot string,
-	root *yaml.Node,
-	infra *yaml.Node,
-	layers *yaml.Node,
-	provider string,
-) (*infraEjectPlan, error) {
-	if layers.Kind != yaml.SequenceNode {
-		return nil, invalidInfraForEject("infra.layers must be a sequence")
-	}
-
-	var foundryLayer *yaml.Node
-	rootProvider := mappingScalar(infra, "provider")
-	existingLayerNames := make([]string, 0, len(layers.Content))
-	for _, layer := range layers.Content {
-		if layer.Kind != yaml.MappingNode {
-			return nil, invalidInfraForEject("each infra.layers entry must be a mapping")
-		}
-		for _, key := range []string{"name", "path", "module", "provider"} {
-			if value := mappingValue(layer, key); value != nil && value.Kind != yaml.ScalarNode {
-				return nil, invalidInfraForEject(
-					fmt.Sprintf("infra.layers[].%s must be a string", key),
-				)
-			}
-		}
-		name := mappingScalar(layer, "name")
-		if name == "" {
-			return nil, invalidInfraForEject("each infra.layers entry must declare a name")
-		}
-		if mappingScalar(layer, "path") == "" {
-			return nil, invalidInfraForEject(fmt.Sprintf("infra layer %q must declare path", name))
-		}
-		if slices.Contains(existingLayerNames, name) ||
-			(foundryLayer != nil && mappingScalar(foundryLayer, "name") == name) {
-			return nil, invalidInfraForEject(fmt.Sprintf("duplicate infrastructure layer name %q", name))
-		}
-		layerProvider := mappingScalar(layer, "provider")
-		effectiveLayerProvider := layerProvider
-		if effectiveLayerProvider == "" {
-			effectiveLayerProvider = rootProvider
-		}
-		if effectiveLayerProvider == project.FoundryProviderName && name != foundryInfraLayerName {
+func planLayeredInfraEject(projectRoot string, config *infraConfig, provider string) (*infraEjectPlan, error) {
+	var foundry *infraLayer
+	for i := range config.layers {
+		layer := &config.layers[i]
+		if layer.effectiveProvider == project.FoundryProviderName && layer.name != foundryInfraLayerName {
 			return nil, invalidInfraForEject(
 				fmt.Sprintf("Foundry infrastructure already exists as layer %q; eject expects the Foundry layer name %q",
-					name, foundryInfraLayerName),
+					layer.name, foundryInfraLayerName),
 			)
 		}
-		if name == foundryInfraLayerName &&
-			(effectiveLayerProvider == project.FoundryProviderName ||
-				effectiveLayerProvider == project.BicepProviderName ||
-				effectiveLayerProvider == project.TerraformProviderName) {
-			if foundryLayer != nil {
-				return nil, invalidInfraForEject("multiple Foundry infrastructure layers are declared")
-			}
-			foundryLayer = layer
+		if layer.name != foundryInfraLayerName {
 			continue
 		}
-		if name == foundryInfraLayerName {
+		if !isFoundryLayerProvider(layer.effectiveProvider) {
 			return nil, invalidInfraForEject(
 				fmt.Sprintf("layer name %q is reserved for Foundry infrastructure", foundryInfraLayerName),
 			)
 		}
-		existingLayerNames = append(existingLayerNames, name)
+		foundry = layer
 	}
-	if foundryLayer != nil && len(existingLayerNames) == 0 {
+	if foundry != nil && len(config.layers) == 1 {
 		return nil, invalidInfraForEject(
 			"infra.layers contains only a Foundry layer; use a root infra configuration for a Foundry-only project",
 		)
 	}
-	if foundryLayer == nil && len(existingLayerNames) == 0 {
+	if len(config.layers) == 0 {
 		return nil, invalidInfraForEject("infra.layers must contain at least one existing infrastructure layer")
 	}
-	if foundryLayer != nil {
-		for _, layer := range layers.Content {
-			if layer == foundryLayer {
-				continue
-			}
-			if sameInfraPath(mappingScalar(layer, "path"), mappingScalar(foundryLayer, "path")) {
-				return nil, invalidInfraForEject(
-					fmt.Sprintf("infra layer %q already uses the Foundry layer path %q",
-						mappingScalar(layer, "name"), mappingScalar(foundryLayer, "path")),
-				)
-			}
-		}
-	}
 	changed := false
-	if foundryLayer == nil {
-		for _, layer := range layers.Content {
-			if sameInfraPath(mappingScalar(layer, "path"), foundryInfraLayerPath) {
-				return nil, invalidInfraForEject(
-					fmt.Sprintf("infra layer %q already uses path %q",
-						mappingScalar(layer, "name"), foundryInfraLayerPath),
-				)
-			}
-		}
-		foundryLayer = newInfraLayerNode(
-			foundryInfraLayerName,
-			foundryInfraLayerPath,
-			foundryLayerProvider(provider),
-			nil,
-		)
-		layers.Content = append(layers.Content, foundryLayer)
+	if foundry == nil {
+		node := newInfraLayerNode(foundryInfraLayerName, foundryInfraLayerPath, foundryLayerProvider(provider))
+		config.layersNode.Content = append(config.layersNode.Content, node)
+		config.layers = append(config.layers, infraLayer{
+			node: node, name: foundryInfraLayerName, path: foundryInfraLayerPath,
+			provider: foundryLayerProvider(provider), effectiveProvider: foundryLayerProvider(provider),
+		})
+		foundry = &config.layers[len(config.layers)-1]
 		changed = true
-	}
-
-	targetPath := mappingScalar(foundryLayer, "path")
-	if targetPath == "" {
-		return nil, invalidInfraForEject(
-			fmt.Sprintf("Foundry infrastructure layer %q must declare path", mappingScalar(foundryLayer, "name")),
-		)
-	}
-	module := mappingScalar(foundryLayer, "module")
-	if module == "" {
-		module = defaultInfraModule
 	}
 	wantedProvider := foundryLayerProvider(provider)
-	currentProvider := mappingScalar(foundryLayer, "provider")
-	if currentProvider == "" {
-		currentProvider = rootProvider
-	}
-	if currentProvider == "" {
+	if foundry.effectiveProvider == "" {
 		return nil, invalidInfraForEject(
-			fmt.Sprintf(
-				"Foundry infrastructure layer %q must declare provider explicitly",
-				mappingScalar(foundryLayer, "name"),
-			),
+			fmt.Sprintf("Foundry infrastructure layer %q must declare provider explicitly", foundry.name),
 		)
 	}
-	if currentProvider != "" && currentProvider != wantedProvider {
+	if foundry.effectiveProvider != wantedProvider {
 		return nil, invalidInfraForEject(
-			fmt.Sprintf(
-				"Foundry infrastructure layer %q already uses provider %q",
-				mappingScalar(foundryLayer, "name"),
-				currentProvider,
-			),
+			fmt.Sprintf("Foundry infrastructure layer %q already uses provider %q", foundry.name, foundry.effectiveProvider),
 		)
 	}
-	if mappingScalar(foundryLayer, "provider") != wantedProvider {
-		setMappingScalar(foundryLayer, "provider", wantedProvider)
+	if foundry.provider != wantedProvider {
+		setMappingScalar(foundry.node, "provider", wantedProvider)
 		changed = true
 	}
+	for i := range config.layers {
+		layer := &config.layers[i]
+		if layer != foundry && sameInfraPath(layer.path, foundry.path) {
+			return nil, invalidInfraForEject(
+				fmt.Sprintf("infra layer %q already uses the Foundry layer path %q", layer.name, foundry.path),
+			)
+		}
+	}
+	target, err := inspectInfraTarget(projectRoot, foundry.path)
+	if err != nil {
+		return nil, err
+	}
+	if target.exists && !target.empty ||
+		hasInfrastructureEntrypoint(target.dir, wantedProvider, valueOrDefault(foundry.module, defaultInfraModule)) {
+		return nil, foundryInfraExistsError(filepath.ToSlash(foundry.path), true)
+	}
+	return newInfraEjectPlan(config, target, foundry.path, valueOrDefault(foundry.module, defaultInfraModule),
+		true, changed, "infra.layers")
+}
 
-	targetDir := resolveInfraPath(projectRoot, targetPath)
-	info, statErr := os.Stat(targetDir)
-	if statErr != nil && !errors.Is(statErr, fs.ErrNotExist) {
-		return nil, fmt.Errorf("stat Foundry infrastructure path %s: %w", targetDir, statErr)
+func rootInfraUserOwned(layer infraLayer, target infraTargetState) (bool, error) {
+	hasEntrypoint := hasInfrastructureEntrypoint(target.dir, layer.effectiveProvider, layer.module)
+	if layer.provider == project.FoundryProviderName && hasEntrypoint {
+		return false, foundryInfraExistsError(filepath.ToSlash(layer.path), false)
 	}
-	if statErr == nil && !info.IsDir() {
-		return nil, ejectExistsError(filepath.ToSlash(targetPath))
-	}
-	if hasInfrastructureEntrypoint(targetDir, wantedProvider, module) {
-		return nil, foundryInfraExistsError(filepath.ToSlash(targetPath), true)
-	}
-	if statErr == nil {
-		empty, err := isDirectoryEmpty(targetDir)
+	if layer.provider == project.TerraformProviderName {
+		foundry, err := isFoundryTerraformInfra(target.dir, layer.module)
 		if err != nil {
-			return nil, err
+			return false, err
 		}
-		if !empty {
-			return nil, foundryInfraExistsError(filepath.ToSlash(targetPath), true)
+		if foundry {
+			return false, foundryInfraExistsError(filepath.ToSlash(layer.path), false)
 		}
 	}
+	builtIn := layer.provider == project.BicepProviderName || layer.provider == project.TerraformProviderName
+	if layer.provider != "" && builtIn && !hasEntrypoint {
+		return false, invalidInfraForEject(fmt.Sprintf(
+			"infrastructure declares provider %q but path %q contains no matching entry point", layer.provider, layer.path))
+	}
+	custom := layer.provider != "" && !builtIn && layer.provider != project.FoundryProviderName
+	if !hasEntrypoint && !custom && target.exists && !target.empty {
+		return false, invalidInfraForEject(
+			fmt.Sprintf("infrastructure path %q contains files but no detectable entry point", layer.path))
+	}
+	return layer.provider != project.FoundryProviderName && (hasEntrypoint || custom), nil
+}
+
+func newInfraEjectPlan(
+	config *infraConfig,
+	target infraTargetState,
+	path, module string,
+	layer, changed bool,
+	description string,
+) (*infraEjectPlan, error) {
 	plan := &infraEjectPlan{
-		targetDir:  targetDir,
-		targetPath: filepath.ToSlash(targetPath),
-		module:     module,
-		layer:      true,
+		targetDir: target.dir, targetPath: filepath.ToSlash(path), module: module, layer: layer,
 	}
 	if changed {
-		updated, err := marshalAzureYAML(root)
+		updated, err := marshalAzureYAML(config.root)
 		if err != nil {
 			return nil, err
 		}
-		plan.updatedYAML = updated
-		plan.updateDescription = "infra.layers"
+		plan.updatedYAML, plan.updateDescription = updated, description
 	}
 	return plan, nil
 }
 
-func validateEjectTarget(projectRoot string, plan *infraEjectPlan) error {
+func valueOrDefault(value, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return fallback
+}
+
+func isFoundryLayerProvider(provider string) bool {
+	return provider == project.FoundryProviderName ||
+		provider == project.BicepProviderName ||
+		provider == project.TerraformProviderName
+}
+
+func validateEjectTarget(plan *infraEjectPlan) error {
 	if plan == nil || strings.TrimSpace(plan.targetDir) == "" {
 		return invalidInfraForEject("Foundry infrastructure path is empty")
 	}
@@ -1082,113 +995,88 @@ func validateEjectTarget(projectRoot string, plan *infraEjectPlan) error {
 			fmt.Sprintf("Foundry infrastructure module %q must not include a file extension", plan.module),
 		)
 	}
-	safeTarget, err := projectpaths.Join(projectRoot, plan.targetPath)
-	if err != nil {
-		return invalidInfraForEject(fmt.Sprintf("invalid Foundry infrastructure path %q: %s", plan.targetPath, err))
-	}
-	plan.targetDir = safeTarget
-	if info, err := os.Stat(plan.targetDir); err == nil && !info.IsDir() {
-		return ejectExistsError(plan.targetPath)
-	} else if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("stat Foundry infrastructure path %s: %w", plan.targetDir, err)
-	}
 	return nil
 }
 
 func installStagedInfra(stageDir string, plan *infraEjectPlan) (func(), error) {
-	type stagedFile struct {
-		src string
-		dst string
-	}
-	var files []stagedFile
-	err := filepath.WalkDir(stageDir, func(path string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if entry.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(stageDir, path)
-		if err != nil {
-			return err
-		}
-		dst := filepath.Join(plan.targetDir, rel)
-		if _, err := os.Lstat(dst); err == nil {
-			return ejectExistsError(filepath.ToSlash(filepath.Join(plan.targetPath, rel)))
-		} else if !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("stat infrastructure destination %s: %w", dst, err)
-		}
-		files = append(files, stagedFile{src: path, dst: dst})
-		return nil
-	})
+	parent := filepath.Dir(plan.targetDir)
+	existingParent, err := existingDirectory(parent)
 	if err != nil {
 		return func() {}, err
 	}
-
-	createdFiles := make([]string, 0, len(files))
-	createdDirs := []string{}
-	rollback := func() {
-		for _, path := range createdFiles {
-			_ = os.Remove(path)
-		}
-		for i := len(createdDirs) - 1; i >= 0; i-- {
-			_ = os.Remove(createdDirs[i])
-		}
+	//nolint:gosec // G301: ejected infra directories must be readable/traversable by IDEs, Git, and CI
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return func() {}, infraInstallError("create infrastructure parent directory", err)
 	}
 
-	for _, file := range files {
-		parent := filepath.Dir(file.dst)
-		missing, err := missingDirectories(parent)
+	restoreEmptyTarget := false
+	if info, err := os.Lstat(plan.targetDir); err == nil {
+		if !info.IsDir() {
+			return func() {}, ejectExistsError(plan.targetPath)
+		}
+		empty, err := dirIsEmpty(plan.targetDir)
 		if err != nil {
-			rollback()
-			return func() {}, err
+			return func() {}, fmt.Errorf("inspect infrastructure destination %s: %w", plan.targetDir, err)
 		}
-		//nolint:gosec // G301: ejected infra directories must be readable/traversable by IDEs, Git, and CI
-		if err := os.MkdirAll(parent, 0o755); err != nil {
-			rollback()
-			return func() {}, exterrors.Internal(
-				exterrors.CodeInfraEjectWriteFailed,
-				fmt.Sprintf("create infrastructure directory %s: %s", parent, err),
-			)
+		if !empty {
+			return func() {}, foundryInfraExistsError(plan.targetPath, plan.layer)
 		}
-		createdDirs = append(createdDirs, missing...)
-		if err := azdext.CopyFileAtomic(file.src, file.dst, 0o644); err != nil {
-			rollback()
-			return func() {}, exterrors.Internal(
-				exterrors.CodeInfraEjectWriteFailed,
-				fmt.Sprintf("install infrastructure file %s: %s", file.dst, err),
-			)
+		if err := os.Remove(plan.targetDir); err != nil {
+			return func() {}, infraInstallError("prepare empty infrastructure destination", err)
 		}
-		createdFiles = append(createdFiles, file.dst)
+		restoreEmptyTarget = true
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return func() {}, fmt.Errorf("stat infrastructure destination %s: %w", plan.targetDir, err)
 	}
-	return rollback, nil
+
+	if err := os.Rename(stageDir, plan.targetDir); err != nil {
+		if restoreEmptyTarget {
+			_ = os.Mkdir(plan.targetDir, 0o755)
+		}
+		removeEmptyParents(parent, existingParent)
+		return func() {}, infraInstallError("install infrastructure directory", err)
+	}
+	return func() {
+		_ = os.RemoveAll(plan.targetDir)
+		if restoreEmptyTarget {
+			_ = os.Mkdir(plan.targetDir, 0o755)
+		}
+		removeEmptyParents(parent, existingParent)
+	}, nil
 }
 
-func missingDirectories(path string) ([]string, error) {
-	var missing []string
+func infraInstallError(action string, err error) error {
+	return exterrors.Internal(exterrors.CodeInfraEjectWriteFailed, fmt.Sprintf("%s: %s", action, err))
+}
+
+func existingDirectory(path string) (string, error) {
 	for current := path; ; current = filepath.Dir(current) {
 		info, err := os.Lstat(current)
-		switch {
-		case err == nil:
+		if err == nil {
 			if !info.IsDir() {
-				return nil, fmt.Errorf("infrastructure parent path %s is not a directory", current)
+				return "", fmt.Errorf("infrastructure parent path %s is not a directory", current)
 			}
-			slices.Reverse(missing)
-			return missing, nil
-		case errors.Is(err, fs.ErrNotExist):
-			missing = append(missing, current)
-		default:
-			return nil, fmt.Errorf("stat infrastructure parent path %s: %w", current, err)
+			return current, nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("stat infrastructure parent path %s: %w", current, err)
 		}
 		parent := filepath.Dir(current)
 		if parent == current {
-			return nil, fmt.Errorf("no existing parent directory for infrastructure path %s", path)
+			return "", fmt.Errorf("no existing parent directory for infrastructure path %s", path)
 		}
 	}
 }
 
-func newInfraLayerNode(name, path, provider string, dependsOn []string) *yaml.Node {
-	layer := &yaml.Node{
+func removeEmptyParents(path, stop string) {
+	for path != stop {
+		_ = os.Remove(path)
+		path = filepath.Dir(path)
+	}
+}
+
+func newInfraLayerNode(name, path, provider string) *yaml.Node {
+	return &yaml.Node{
 		Kind: yaml.MappingNode,
 		Tag:  "!!map",
 		Content: []*yaml.Node{
@@ -1197,14 +1085,6 @@ func newInfraLayerNode(name, path, provider string, dependsOn []string) *yaml.No
 			newScalarNode("provider"), newScalarNode(provider),
 		},
 	}
-	if len(dependsOn) > 0 {
-		dependencies := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
-		for _, dependency := range dependsOn {
-			dependencies.Content = append(dependencies.Content, newScalarNode(dependency))
-		}
-		layer.Content = append(layer.Content, newScalarNode("dependsOn"), dependencies)
-	}
-	return layer
 }
 
 func foundryLayerProvider(ejectProvider string) string {
@@ -1214,32 +1094,28 @@ func foundryLayerProvider(ejectProvider string) string {
 	return project.FoundryProviderName
 }
 
-func cloneMappingNode(node *yaml.Node) *yaml.Node {
-	return cloneYAMLNode(node, make(map[*yaml.Node]*yaml.Node))
-}
-
-func cloneYAMLNode(node *yaml.Node, clones map[*yaml.Node]*yaml.Node) *yaml.Node {
-	if node == nil {
-		return nil
+func inspectInfraTarget(projectRoot, path string) (infraTargetState, error) {
+	dir, err := projectpaths.Join(projectRoot, path)
+	if err != nil {
+		return infraTargetState{}, invalidInfraForEject(
+			fmt.Sprintf("invalid Foundry infrastructure path %q: %s", path, err),
+		)
 	}
-	if clone, ok := clones[node]; ok {
-		return clone
+	info, err := os.Stat(dir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return infraTargetState{dir: dir}, nil
 	}
-	clone := *node
-	clones[node] = &clone
-	clone.Content = make([]*yaml.Node, len(node.Content))
-	for i, child := range node.Content {
-		clone.Content[i] = cloneYAMLNode(child, clones)
+	if err != nil {
+		return infraTargetState{}, fmt.Errorf("stat infrastructure path %s: %w", dir, err)
 	}
-	clone.Alias = cloneYAMLNode(node.Alias, clones)
-	return &clone
-}
-
-func resolveInfraPath(projectRoot, path string) string {
-	if filepath.IsAbs(path) {
-		return filepath.Clean(path)
+	if !info.IsDir() {
+		return infraTargetState{}, ejectExistsError(filepath.ToSlash(path))
 	}
-	return filepath.Join(projectRoot, filepath.FromSlash(path))
+	empty, err := dirIsEmpty(dir)
+	if err != nil {
+		return infraTargetState{}, fmt.Errorf("inspect infrastructure path %s: %w", dir, err)
+	}
+	return infraTargetState{dir: dir, exists: true, empty: empty}, nil
 }
 
 func sameInfraPath(a, b string) bool {
@@ -1312,22 +1188,6 @@ func invalidFoundryTerraformMarker(path, reason string) error {
 		"restore the marker from source control or use an azure.ai.agents version that supports it. "+
 			"If this is intentionally user-owned Terraform, remove the marker only after verifying the infrastructure",
 	)
-}
-
-func isDirectoryEmpty(path string) (bool, error) {
-	dir, err := os.Open(path) //nolint:gosec // path is validated as the project infrastructure directory
-	if err != nil {
-		return false, fmt.Errorf("open infrastructure path %s: %w", path, err)
-	}
-	defer dir.Close()
-	_, err = dir.Readdirnames(1)
-	if errors.Is(err, io.EOF) {
-		return true, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("read infrastructure path %s: %w", path, err)
-	}
-	return false, nil
 }
 
 func marshalAzureYAML(root *yaml.Node) ([]byte, error) {
@@ -1603,29 +1463,8 @@ func writeParametersFile(
 		"parameters":     wrapped,
 	}
 
-	data, err := json.MarshalIndent(doc, "", "  ")
-	if err != nil {
-		return ejectArtifact{}, exterrors.Internal(
-			exterrors.CodeInfraEjectWriteFailed,
-			fmt.Sprintf("marshal main.parameters.json: %s", err),
-		)
-	}
-	// json.MarshalIndent omits a trailing newline; add one for editors/POSIX tools.
-	data = append(data, '\n')
-
 	filename := module + ".parameters.json"
-	dst := filepath.Join(infraDir, filename)
-	//nolint:gosec // G306: ejected parameters file is intended to be human-readable
-	if err := os.WriteFile(dst, data, 0o644); err != nil {
-		return ejectArtifact{}, exterrors.Internal(
-			exterrors.CodeInfraEjectWriteFailed,
-			fmt.Sprintf("write main.parameters.json: %s", err),
-		)
-	}
-	return ejectArtifact{
-		relPath: filepath.ToSlash(filepath.Join(artifactRoot, filename)),
-		bytes:   len(data),
-	}, nil
+	return writeJSONArtifact(infraDir, artifactRoot, filename, doc)
 }
 
 // writeEmbeddedTerraformTemplates copies the static *.tf files under the
@@ -1735,36 +1574,15 @@ func writeOutputsFile(
 	}
 
 	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, struct{ IncludeAcr bool }{IncludeAcr: includeAcr}); err != nil {
+	if err := tmpl.Execute(&buf, struct {
+		IncludeAcr bool
+		Layer      bool
+	}{IncludeAcr: includeAcr, Layer: layer}); err != nil {
 		return ejectArtifact{}, exterrors.Internal(
 			exterrors.CodeInfraEjectWriteFailed,
 			fmt.Sprintf("render outputs template: %s", err),
 		)
 	}
-	if layer {
-		const resourceGroupOutput = "output \"AZURE_RESOURCE_GROUP\" {"
-		contents := buf.String()
-		start := strings.Index(contents, resourceGroupOutput)
-		if start < 0 || strings.Index(contents[start+len(resourceGroupOutput):], resourceGroupOutput) >= 0 {
-			return ejectArtifact{}, exterrors.Internal(
-				exterrors.CodeInfraEjectWriteFailed,
-				"render outputs.tf: expected exactly one AZURE_RESOURCE_GROUP output",
-			)
-		}
-		end := strings.Index(contents[start:], "}")
-		if end < 0 {
-			return ejectArtifact{}, exterrors.Internal(
-				exterrors.CodeInfraEjectWriteFailed,
-				"render outputs.tf: malformed AZURE_RESOURCE_GROUP output",
-			)
-		}
-		end += start + len("}")
-		for end < len(contents) && (contents[end] == '\r' || contents[end] == '\n') {
-			end++
-		}
-		buf = *bytes.NewBufferString(contents[:start] + contents[end:])
-	}
-
 	dst := filepath.Join(infraDir, "outputs.tf")
 	//nolint:gosec // G306: ejected Terraform sources are intended to be human-readable
 	if err := os.WriteFile(dst, buf.Bytes(), 0o644); err != nil {
@@ -1840,23 +1658,27 @@ func writeTfvarsFile(
 		connectionCredentials,
 	)
 
-	data, err := json.MarshalIndent(doc, "", "  ")
+	filename := module + ".tfvars.json"
+	return writeJSONArtifact(infraDir, artifactRoot, filename, doc)
+}
+
+func writeJSONArtifact(infraDir, artifactRoot, filename string, value any) (ejectArtifact, error) {
+	data, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
 		return ejectArtifact{}, exterrors.Internal(
 			exterrors.CodeInfraEjectWriteFailed,
-			fmt.Sprintf("marshal main.tfvars.json: %s", err),
+			fmt.Sprintf("marshal %s: %s", filename, err),
 		)
 	}
 	// json.MarshalIndent omits a trailing newline; add one for editors/POSIX tools.
 	data = append(data, '\n')
 
-	filename := module + ".tfvars.json"
 	dst := filepath.Join(infraDir, filename)
-	//nolint:gosec // G306: ejected tfvars file is intended to be human-readable
+	//nolint:gosec // G306: ejected JSON is intended to be human-readable
 	if err := os.WriteFile(dst, data, 0o644); err != nil {
 		return ejectArtifact{}, exterrors.Internal(
 			exterrors.CodeInfraEjectWriteFailed,
-			fmt.Sprintf("write main.tfvars.json: %s", err),
+			fmt.Sprintf("write %s: %s", filename, err),
 		)
 	}
 	return ejectArtifact{

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra.go
@@ -17,7 +17,7 @@ import (
 	"text/template"
 
 	"azureaiagent/internal/exterrors"
-	projectpaths "azureaiagent/internal/pkg/paths"
+	projectPaths "azureaiagent/internal/pkg/paths"
 	"azureaiagent/internal/project"
 	"azureaiagent/internal/synthesis"
 
@@ -50,6 +50,7 @@ type infraEjectPlan struct {
 	targetPath        string
 	module            string
 	layer             bool
+	mergeExisting     bool
 	updatedYAML       []byte
 	updateDescription string
 }
@@ -838,13 +839,18 @@ func planRootInfraEject(projectRoot string, config *infraConfig, provider string
 	foundryLayer := newInfraLayerNode(foundryInfraLayerName, foundryInfraLayerPath, foundryLayerProvider(provider))
 	config.infra.Content = []*yaml.Node{
 		newScalarNode("layers"),
-		&yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq", Content: []*yaml.Node{existingLayer, foundryLayer}},
+		{Kind: yaml.SequenceNode, Tag: "!!seq", Content: []*yaml.Node{existingLayer, foundryLayer}},
 	}
 	foundryTarget, err := inspectInfraTarget(projectRoot, foundryInfraLayerPath)
 	if err != nil {
 		return nil, err
 	}
-	return newInfraEjectPlan(config, foundryTarget, foundryInfraLayerPath, defaultInfraModule, true, true, "infra.layers")
+	plan, err := newInfraEjectPlan(
+		config, foundryTarget, foundryInfraLayerPath, defaultInfraModule, true, true, "infra.layers")
+	if plan != nil {
+		plan.mergeExisting = foundryTarget.exists
+	}
+	return plan, err
 }
 
 func planLayeredInfraEject(projectRoot string, config *infraConfig, provider string) (*infraEjectPlan, error) {
@@ -876,6 +882,7 @@ func planLayeredInfraEject(projectRoot string, config *infraConfig, provider str
 		return nil, invalidInfraForEject("infra.layers must contain at least one existing infrastructure layer")
 	}
 	changed := false
+	newLayer := foundry == nil
 	if foundry == nil {
 		node := newInfraLayerNode(foundryInfraLayerName, foundryInfraLayerPath, foundryLayerProvider(provider))
 		config.layersNode.Content = append(config.layersNode.Content, node)
@@ -913,12 +920,16 @@ func planLayeredInfraEject(projectRoot string, config *infraConfig, provider str
 	if err != nil {
 		return nil, err
 	}
-	if target.exists && !target.empty ||
-		hasInfrastructureEntrypoint(target.dir, wantedProvider, valueOrDefault(foundry.module, defaultInfraModule)) {
+	if !newLayer && (target.exists && !target.empty ||
+		hasInfrastructureEntrypoint(target.dir, wantedProvider, valueOrDefault(foundry.module, defaultInfraModule))) {
 		return nil, foundryInfraExistsError(filepath.ToSlash(foundry.path), true)
 	}
-	return newInfraEjectPlan(config, target, foundry.path, valueOrDefault(foundry.module, defaultInfraModule),
+	plan, err := newInfraEjectPlan(config, target, foundry.path, valueOrDefault(foundry.module, defaultInfraModule),
 		true, changed, "infra.layers")
+	if plan != nil {
+		plan.mergeExisting = newLayer && target.exists
+	}
+	return plan, err
 }
 
 func rootInfraUserOwned(layer infraLayer, target infraTargetState) (bool, error) {
@@ -1000,6 +1011,9 @@ func validateEjectTarget(plan *infraEjectPlan) error {
 }
 
 func installStagedInfra(stageDir string, plan *infraEjectPlan) (func(), error) {
+	if plan.mergeExisting {
+		return mergeStagedInfra(stageDir, plan)
+	}
 	parent := filepath.Dir(plan.targetDir)
 	existingParent, err := existingDirectory(parent)
 	if err != nil {
@@ -1032,6 +1046,7 @@ func installStagedInfra(stageDir string, plan *infraEjectPlan) (func(), error) {
 
 	if err := os.Rename(stageDir, plan.targetDir); err != nil {
 		if restoreEmptyTarget {
+			//nolint:gosec // G301: restore the readable/traversable empty project directory removed above
 			_ = os.Mkdir(plan.targetDir, 0o755)
 		}
 		removeEmptyParents(parent, existingParent)
@@ -1040,10 +1055,60 @@ func installStagedInfra(stageDir string, plan *infraEjectPlan) (func(), error) {
 	return func() {
 		_ = os.RemoveAll(plan.targetDir)
 		if restoreEmptyTarget {
+			//nolint:gosec // G301: restore the readable/traversable empty project directory removed above
 			_ = os.Mkdir(plan.targetDir, 0o755)
 		}
 		removeEmptyParents(parent, existingParent)
 	}, nil
+}
+
+func mergeStagedInfra(stageDir string, plan *infraEjectPlan) (func(), error) {
+	type stagedFile struct {
+		src string
+		dst string
+	}
+	var files []stagedFile
+	err := filepath.WalkDir(stageDir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(stageDir, path)
+		if err != nil {
+			return err
+		}
+		dst := filepath.Join(plan.targetDir, rel)
+		if _, err := os.Lstat(dst); err == nil {
+			return ejectExistsError(filepath.ToSlash(filepath.Join(plan.targetPath, rel)))
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("stat infrastructure destination %s: %w", dst, err)
+		}
+		files = append(files, stagedFile{src: path, dst: dst})
+		return nil
+	})
+	if err != nil {
+		return func() {}, err
+	}
+
+	createdFiles := make([]string, 0, len(files))
+	rollback := func() {
+		for i := len(createdFiles) - 1; i >= 0; i-- {
+			_ = os.Remove(createdFiles[i])
+			removeEmptyParents(filepath.Dir(createdFiles[i]), plan.targetDir)
+		}
+	}
+	for _, file := range files {
+		//nolint:gosec // G301: generated infrastructure directories must be readable by project tooling
+		if err := os.MkdirAll(filepath.Dir(file.dst), 0o755); err != nil {
+			rollback()
+			return func() {}, infraInstallError("create infrastructure directory", err)
+		}
+		if err := azdext.CopyFileAtomic(file.src, file.dst, 0o644); err != nil {
+			rollback()
+			return func() {}, infraInstallError("install infrastructure file", err)
+		}
+		createdFiles = append(createdFiles, file.dst)
+	}
+	return rollback, nil
 }
 
 func infraInstallError(action string, err error) error {
@@ -1096,7 +1161,7 @@ func foundryLayerProvider(ejectProvider string) string {
 }
 
 func inspectInfraTarget(projectRoot, path string) (infraTargetState, error) {
-	dir, err := projectpaths.Join(projectRoot, path)
+	dir, err := projectPaths.Join(projectRoot, path)
 	if err != nil {
 		return infraTargetState{}, invalidInfraForEject(
 			fmt.Sprintf("invalid Foundry infrastructure path %q: %s", path, err),
@@ -1452,7 +1517,7 @@ func writeParametersFile(
 		}
 		wrapped["location"] = paramValue{Value: "${AZURE_LOCATION}"}
 		wrapped["foundryProjectName"] = paramValue{Value: "${AZURE_AI_PROJECT_NAME=${AZURE_ENV_NAME}}"}
-		wrapped["resourceTokenSalt"] = paramValue{Value: "${AZURE_RESOURCE_TOKEN_SALT}"}
+		wrapped["resourceTokenSalt"] = paramValue{Value: "${AZD_RESOURCE_TOKEN_SALT}"}
 		wrapped["principalId"] = paramValue{Value: "${AZURE_PRINCIPAL_ID}"}
 		wrapped["principalType"] = paramValue{Value: "${AZURE_PRINCIPAL_TYPE}"}
 	}
@@ -1603,7 +1668,7 @@ func writeOutputsFile(
 // environment at provision time. The synthesizer-known values `deployments`
 // and `connections` are written literally; deploy-time inputs (location,
 // resource_group_name, foundry_project_name, principal_id, subscription_id,
-// environment_name, resource_token_salt) are left as ${AZURE_*} placeholders.
+// environment_name, resource_token_salt) are left as azd environment placeholders.
 //
 // include_acr is NOT written: whether ACR is provisioned is decided at eject
 // time by the presence of acr.tf, not by a Terraform variable.
@@ -1617,18 +1682,18 @@ func writeTfvarsFile(
 	// Static keys carry ${...} placeholders azd resolves from the environment.
 	// json.MarshalIndent sorts map keys alphabetically, so the generated file is
 	// deterministic; the placeholder values are JSON strings azd env-substitutes.
-	doc := map[string]any{
+	doc := map[string]any{ //nolint:gosec // G101: environment placeholder names, not credentials
 		"subscription_id":      "${AZURE_SUBSCRIPTION_ID}",
 		"location":             "${AZURE_LOCATION}",
 		"resource_group_name":  "${AZURE_RESOURCE_GROUP}",
 		"environment_name":     "${AZURE_ENV_NAME}",
 		"foundry_project_name": "${AZURE_AI_PROJECT_NAME}",
 		"principal_id":         "${AZURE_PRINCIPAL_ID}",
-		"resource_token_salt":  "${AZURE_RESOURCE_TOKEN_SALT}",
+		"resource_token_salt":  "${AZD_RESOURCE_TOKEN_SALT}",
 	}
 	if layer {
 		doc["resource_group_name"] = "${AZURE_FOUNDRY_RESOURCE_GROUP=rg-${AZURE_ENV_NAME}-foundry}"
-		doc["foundry_project_name"] = "${AZURE_AI_PROJECT_NAME=${AZURE_ENV_NAME}}"
+		doc["foundry_project_name"] = "${AZURE_AI_PROJECT_NAME=}"
 	}
 
 	// deployments and connections are the only synthesizer-derived values

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra.go
@@ -487,6 +487,7 @@ func ejectInfraAfterInit(provider string) error {
 //
 // On success it prints the summary block and returns nil.
 func ejectInfra(projectRoot, provider string) error {
+	yamlPath := filepath.Join(projectRoot, "azure.yaml")
 	rawYAML, err := readProjectAzureYAML(projectRoot)
 	if err != nil {
 		return err

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
@@ -800,23 +800,6 @@ services:
 	assert.Equal(t, "// conflict\n", string(conflict))
 }
 
-func TestCloneMappingNode_DeepClonesNestedValues(t *testing.T) {
-	t.Parallel()
-	var root yaml.Node
-	require.NoError(t, yaml.Unmarshal([]byte("config:\n  nested:\n    enabled: true\n"), &root))
-	original := root.Content[0]
-	clone := cloneMappingNode(original)
-
-	cloneConfig := mappingValue(clone, "config")
-	cloneNested := mappingValue(cloneConfig, "nested")
-	setMappingScalar(cloneNested, "enabled", "false")
-
-	originalConfig := mappingValue(original, "config")
-	originalNested := mappingValue(originalConfig, "nested")
-	assert.Equal(t, "true", mappingScalar(originalNested, "enabled"))
-	assert.Equal(t, "false", mappingScalar(cloneNested, "enabled"))
-}
-
 func TestEjectInfra_RefusesFoundryLayerOutsideProject(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
@@ -67,26 +67,781 @@ func TestEjectInfra_RefusesWhenAzureYamlMissing(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "infra/ must not be created on refusal")
 }
 
-func TestEjectInfra_RefusesWhenInfraExists(t *testing.T) {
+func TestEjectInfra_MigratesExistingInfraToLayers(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), validFoundryAzureYAML)
-	// Pre-create infra/ -- contents don't matter, even an empty dir refuses.
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"),
+		strings.Replace(validFoundryAzureYAML, "provider: microsoft.foundry", "provider: bicep", 1))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "infra"), 0o750))
+	mustWriteFile(t, filepath.Join(dir, "infra", "main.bicep"), "// existing infrastructure\n")
+
+	err := ejectInfra(dir, "bicep")
+	require.NoError(t, err)
+
+	existing, err := os.ReadFile(filepath.Join(dir, "infra", "main.bicep")) //nolint:gosec // temp test path
+	require.NoError(t, err)
+	assert.Equal(t, "// existing infrastructure\n", string(existing))
+	assert.FileExists(t, filepath.Join(dir, "infra", "foundry", "main.bicep"))
+
+	raw, err := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec // temp test path
+	require.NoError(t, err)
+	var doc struct {
+		Infra struct {
+			Provider string `yaml:"provider"`
+			Layers   []struct {
+				Name      string   `yaml:"name"`
+				Path      string   `yaml:"path"`
+				Provider  string   `yaml:"provider"`
+				DependsOn []string `yaml:"dependsOn"`
+			} `yaml:"layers"`
+		} `yaml:"infra"`
+	}
+	require.NoError(t, yaml.Unmarshal(raw, &doc))
+	assert.Empty(t, doc.Infra.Provider)
+	require.Len(t, doc.Infra.Layers, 2)
+	assert.Equal(t, "infra", doc.Infra.Layers[0].Name)
+	assert.Equal(t, "infra", doc.Infra.Layers[0].Path)
+	assert.Equal(t, "bicep", doc.Infra.Layers[0].Provider)
+	assert.Equal(t, "foundry", doc.Infra.Layers[1].Name)
+	assert.Equal(t, "infra/foundry", doc.Infra.Layers[1].Path)
+	assert.Equal(t, "microsoft.foundry", doc.Infra.Layers[1].Provider)
+	assert.Empty(t, doc.Infra.Layers[0].DependsOn)
+	assert.Empty(t, doc.Infra.Layers[1].DependsOn)
+
+	params, err := os.ReadFile(filepath.Join(dir, "infra", "foundry", "main.parameters.json")) //nolint:gosec
+	require.NoError(t, err)
+	var paramsDoc struct {
+		Parameters map[string]struct {
+			Value any `json:"value"`
+		} `json:"parameters"`
+	}
+	require.NoError(t, json.Unmarshal(params, &paramsDoc))
+	assert.Equal(t, "${AZURE_LOCATION}", paramsDoc.Parameters["location"].Value)
+	assert.Equal(t, "${AZURE_AI_PROJECT_NAME=${AZURE_ENV_NAME}}", paramsDoc.Parameters["foundryProjectName"].Value)
+	assert.Equal(t, "${AZURE_FOUNDRY_RESOURCE_GROUP=rg-${AZURE_ENV_NAME}-foundry}",
+		paramsDoc.Parameters["resourceGroupName"].Value)
+}
+
+func TestEjectInfra_PreservesExistingInfraNameWhenMigratingToLayers(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), `name: my-project
+infra:
+  name: existing
+  provider: bicep
+  path: infra/existing
+services:
+  my-foundry:
+    host: azure.ai.project
+`)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "infra", "existing"), 0o750))
+	mustWriteFile(t, filepath.Join(dir, "infra", "existing", "main.bicep"), "// existing\n")
+
+	require.NoError(t, ejectInfra(dir, "bicep"))
+	raw, err := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec
+	require.NoError(t, err)
+	var doc struct {
+		Infra struct {
+			Layers []struct {
+				Name      string   `yaml:"name"`
+				Provider  string   `yaml:"provider"`
+				DependsOn []string `yaml:"dependsOn"`
+			} `yaml:"layers"`
+		} `yaml:"infra"`
+	}
+	require.NoError(t, yaml.Unmarshal(raw, &doc))
+	require.Len(t, doc.Infra.Layers, 2)
+	assert.Equal(t, "existing", doc.Infra.Layers[0].Name)
+	assert.Equal(t, "foundry", doc.Infra.Layers[1].Name)
+	assert.Equal(t, "microsoft.foundry", doc.Infra.Layers[1].Provider)
+	assert.Empty(t, doc.Infra.Layers[1].DependsOn)
+}
+
+func TestEjectInfra_PreservesAllExistingInfraPropertiesWhenMigratingToLayers(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), `name: my-project
+infra:
+  name: existing
+  provider: custom.platform
+  path: infra/existing
+  module: platform
+  deploymentStacks:
+    actionOnUnmanage:
+      resources: delete
+  config:
+    nested:
+      enabled: true
+  futureProperty:
+    value: preserved
+services:
+  my-foundry:
+    host: azure.ai.project
+`)
+
+	require.NoError(t, ejectInfra(dir, "bicep"))
+	raw, err := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec
+	require.NoError(t, err)
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(raw, &doc))
+	infra := doc["infra"].(map[string]any)
+	layers := infra["layers"].([]any)
+	existing := layers[0].(map[string]any)
+	assert.Equal(t, "existing", existing["name"])
+	assert.Equal(t, "infra/existing", existing["path"])
+	assert.Equal(t, "custom.platform", existing["provider"])
+	assert.Equal(t, "platform", existing["module"])
+	assert.Equal(t, "delete", existing["deploymentStacks"].(map[string]any)["actionOnUnmanage"].(map[string]any)["resources"])
+	assert.Equal(t, true, existing["config"].(map[string]any)["nested"].(map[string]any)["enabled"])
+	assert.Equal(t, "preserved", existing["futureProperty"].(map[string]any)["value"])
+}
+
+func TestEjectInfra_ExistingFoundryLayerReportsAlreadyExists(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	yamlBody := `name: my-project
+infra:
+  provider: bicep
+  layers:
+    - name: app
+      path: infra/app
+    - name: foundry
+      path: infra/foundry
+      provider: microsoft.foundry
+services:
+  my-foundry:
+    host: azure.ai.project
+`
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), yamlBody)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "infra", "foundry"), 0o750))
+	mustWriteFile(t, filepath.Join(dir, "infra", "foundry", "main.bicep"), "// existing Foundry\n")
 
 	err := ejectInfra(dir, "bicep")
 	require.Error(t, err)
-
 	localErr, ok := errors.AsType[*azdext.LocalError](err)
-	require.True(t, ok, "expected structured azdext.LocalError, got %T", err)
+	require.True(t, ok)
 	assert.Equal(t, exterrors.CodeInfraEjectExists, localErr.Code)
-	assert.Contains(t, localErr.Message, "./infra/")
-	assert.Contains(t, localErr.Suggestion, "delete ./infra/")
+	assert.Contains(t, localErr.Message, "Foundry infrastructure layer \"foundry\" already exists")
+	assert.Contains(t, localErr.Message, "./infra/foundry")
+}
 
-	// Pre-existing infra/ must not be wiped by the refusal.
-	info, err := os.Stat(filepath.Join(dir, "infra"))
-	require.NoError(t, err, "pre-existing infra/ must survive refusal")
-	assert.True(t, info.IsDir())
+func TestEjectInfra_RefusesFoundryProviderUnderDifferentLayerName(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	yamlBody := `name: my-project
+infra:
+  provider: bicep
+  layers:
+    - name: app
+      path: infra/app
+    - name: ai
+      path: infra/ai
+      provider: microsoft.foundry
+services:
+  my-foundry:
+    host: azure.ai.project
+`
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), yamlBody)
+
+	err := ejectInfra(dir, "bicep")
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Contains(t, localErr.Message, "already exists as layer \"ai\"")
+	assert.NoDirExists(t, filepath.Join(dir, "infra", "foundry"))
+}
+
+func TestEjectInfra_RefusesEditedGeneratedTerraformRoot(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	yamlBody := `name: my-project
+infra:
+  provider: terraform
+services:
+  my-foundry:
+    host: azure.ai.project
+`
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), yamlBody)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "infra"), 0o750))
+	mustWriteFile(t, filepath.Join(dir, "infra", "main.tf"), "# edited generated terraform\n")
+	mustWriteFile(t, filepath.Join(dir, "infra", "main.tfvars.json"), "{}\n")
+	mustWriteFile(t, filepath.Join(dir, "infra", foundryTerraformMarker), foundryTerraformV1)
+
+	err := ejectInfra(dir, "terraform")
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeInfraEjectExists, localErr.Code)
+	assert.Contains(t, localErr.Message, "Foundry infrastructure already exists")
+	assert.NoDirExists(t, filepath.Join(dir, "infra", "foundry"))
+}
+
+func TestEjectInfra_MigratesOrdinaryTerraformProjectWithTfvars(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), `name: my-project
+infra:
+  provider: terraform
+services:
+  my-foundry:
+    host: azure.ai.project
+`)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "infra"), 0o750))
+	mustWriteFile(t, filepath.Join(dir, "infra", "main.tf"), "resource \"azurerm_resource_group\" \"app\" {}\n")
+	mustWriteFile(t, filepath.Join(dir, "infra", "main.tfvars.json"), "{}\n")
+
+	require.NoError(t, ejectInfra(dir, "terraform"))
+	assert.FileExists(t, filepath.Join(dir, "infra", "main.tf"))
+	assert.FileExists(t, filepath.Join(dir, "infra", "foundry", "main.tf"))
+	assert.FileExists(t, filepath.Join(dir, "infra", "foundry", foundryTerraformMarker))
+	raw, err := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "provider: terraform")
+	assert.Contains(t, string(raw), "path: infra/foundry")
+}
+
+func TestEjectInfra_RefusesUnknownTerraformMarker(t *testing.T) {
+	for _, marker := range []string{"terraform-v2\n", "edited\n", ""} {
+		t.Run(strings.TrimSpace(marker), func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			yamlBody := `name: my-project
+infra:
+  provider: terraform
+services:
+  my-foundry:
+    host: azure.ai.project
+`
+			mustWriteFile(t, filepath.Join(dir, "azure.yaml"), yamlBody)
+			require.NoError(t, os.MkdirAll(filepath.Join(dir, "infra"), 0o750))
+			mustWriteFile(t, filepath.Join(dir, "infra", "main.tf"), "# user edited\n")
+			mustWriteFile(t, filepath.Join(dir, "infra", foundryTerraformMarker), marker)
+
+			err := ejectInfra(dir, "terraform")
+			require.Error(t, err)
+			localErr, ok := errors.AsType[*azdext.LocalError](err)
+			require.True(t, ok)
+			assert.Equal(t, exterrors.CodeInfraEjectMarkerInvalid, localErr.Code)
+			assert.Contains(t, localErr.Message, "unsupported or edited")
+			assert.NoDirExists(t, filepath.Join(dir, "infra", "foundry"))
+			raw, readErr := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec
+			require.NoError(t, readErr)
+			assert.Equal(t, yamlBody, string(raw))
+		})
+	}
+}
+
+func TestEjectInfra_RefusesNonRegularTerraformMarker(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), `name: my-project
+infra:
+  provider: terraform
+services:
+  my-foundry:
+    host: azure.ai.project
+`)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "infra", foundryTerraformMarker), 0o750))
+	mustWriteFile(t, filepath.Join(dir, "infra", "main.tf"), "# user edited\n")
+
+	err := ejectInfra(dir, "terraform")
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeInfraEjectMarkerInvalid, localErr.Code)
+	assert.Contains(t, localErr.Message, "not a regular file")
+}
+
+func TestEjectInfra_RefusesExplicitFilelessBuiltInProvider(t *testing.T) {
+	for _, provider := range []string{"bicep", "terraform"} {
+		t.Run(provider, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			yamlBody := `name: my-project
+infra:
+  provider: ` + provider + `
+services:
+  my-foundry:
+    host: azure.ai.project
+`
+			mustWriteFile(t, filepath.Join(dir, "azure.yaml"), yamlBody)
+
+			err := ejectInfra(dir, "bicep")
+			require.Error(t, err)
+			localErr, ok := errors.AsType[*azdext.LocalError](err)
+			require.True(t, ok)
+			assert.Equal(t, exterrors.CodeInvalidAzureYaml, localErr.Code)
+			assert.Contains(t, localErr.Message, "contains no matching entry point")
+			assert.NoDirExists(t, filepath.Join(dir, "infra", "foundry"))
+			raw, readErr := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec
+			require.NoError(t, readErr)
+			assert.Equal(t, yamlBody, string(raw))
+		})
+	}
+}
+
+func TestEjectInfra_RefusesExistingFoundryEject(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), validFoundryAzureYAML)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "infra"), 0o750))
+	mustWriteFile(t, filepath.Join(dir, "infra", "main.bicep"), "// existing project bicep\n")
+
+	err := ejectInfra(dir, "bicep")
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeInfraEjectExists, localErr.Code)
+	assert.Contains(t, localErr.Message, "Foundry infrastructure already exists")
+	assert.Contains(t, localErr.Message, "./infra")
+	existing, err := os.ReadFile(filepath.Join(dir, "infra", "main.bicep")) //nolint:gosec // temp test path
+	require.NoError(t, err)
+	assert.Equal(t, "// existing project bicep\n", string(existing))
+	assert.NoDirExists(t, filepath.Join(dir, "infra", "foundry"))
+}
+
+func TestEjectInfra_FoundryProjectWithEmptyInfraDirectoryUsesLegacyLayout(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), validFoundryAzureYAML)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "infra"), 0o750))
+
+	require.NoError(t, ejectInfra(dir, "bicep"))
+	assert.FileExists(t, filepath.Join(dir, "infra", "main.bicep"))
+	assert.NoDirExists(t, filepath.Join(dir, "infra", "foundry"))
+
+	raw, err := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec // temp test path
+	require.NoError(t, err)
+	assert.Equal(t, validFoundryAzureYAML, string(raw))
+}
+
+func TestEjectInfra_RefusesNonEmptyInfraWithoutEntrypoint(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), validFoundryAzureYAML)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "infra"), 0o750))
+	mustWriteFile(t, filepath.Join(dir, "infra", "README.md"), "user-owned infrastructure notes\n")
+
+	err := ejectInfra(dir, "bicep")
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeInvalidAzureYaml, localErr.Code)
+	assert.Contains(t, localErr.Message, "no detectable entry point")
+	assert.NoFileExists(t, filepath.Join(dir, "infra", "main.bicep"))
+}
+
+func TestEjectInfra_AppendsFoundryLayer(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), `name: my-project
+infra:
+  provider: bicep
+  layers:
+    - name: platform
+      path: infra/platform
+      module: platform
+services:
+  my-foundry:
+    host: azure.ai.project
+`)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "infra", "platform"), 0o750))
+	mustWriteFile(t, filepath.Join(dir, "infra", "platform", "platform.bicep"), "// platform\n")
+
+	require.NoError(t, ejectInfra(dir, "bicep"))
+	assert.FileExists(t, filepath.Join(dir, "infra", "foundry", "main.bicep"))
+
+	raw, err := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec // temp test path
+	require.NoError(t, err)
+	var doc struct {
+		Infra struct {
+			Provider string `yaml:"provider"`
+			Layers   []struct {
+				Name      string   `yaml:"name"`
+				Path      string   `yaml:"path"`
+				Module    string   `yaml:"module"`
+				Provider  string   `yaml:"provider"`
+				DependsOn []string `yaml:"dependsOn"`
+			} `yaml:"layers"`
+		} `yaml:"infra"`
+	}
+	require.NoError(t, yaml.Unmarshal(raw, &doc))
+	assert.Equal(t, "bicep", doc.Infra.Provider)
+	require.Len(t, doc.Infra.Layers, 2)
+	assert.Equal(t, "platform", doc.Infra.Layers[0].Name)
+	assert.Equal(t, "platform", doc.Infra.Layers[0].Module)
+	assert.Equal(t, "foundry", doc.Infra.Layers[1].Name)
+	assert.Equal(t, "infra/foundry", doc.Infra.Layers[1].Path)
+	assert.Equal(t, "microsoft.foundry", doc.Infra.Layers[1].Provider)
+	assert.Empty(t, doc.Infra.Layers[0].DependsOn)
+	assert.Empty(t, doc.Infra.Layers[1].DependsOn)
+}
+
+func TestEjectInfra_RefusesExistingLayerWithoutPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	yamlBody := `name: my-project
+infra:
+  provider: bicep
+  layers:
+    - name: app
+services:
+  my-foundry:
+    host: azure.ai.project
+`
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), yamlBody)
+
+	err := ejectInfra(dir, "bicep")
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeInvalidAzureYaml, localErr.Code)
+	assert.Contains(t, localErr.Message, "must declare path")
+	assert.NoDirExists(t, filepath.Join(dir, "infra", "foundry"))
+	raw, readErr := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec
+	require.NoError(t, readErr)
+	assert.Equal(t, yamlBody, string(raw))
+}
+
+func TestEjectInfra_MigratesFilelessCustomProviderToLayer(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), `name: my-project
+infra:
+  provider: custom.platform
+services:
+  my-foundry:
+    host: azure.ai.project
+`)
+
+	require.NoError(t, ejectInfra(dir, "bicep"))
+	raw, err := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "provider: custom.platform")
+	assert.Contains(t, string(raw), "provider: microsoft.foundry")
+	assert.FileExists(t, filepath.Join(dir, "infra", "foundry", "main.bicep"))
+}
+
+func TestEjectInfra_HonorsExistingBicepLayerPathAndModule(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), `name: my-project
+infra:
+  provider: bicep
+  layers:
+    - name: app
+      path: infra/app
+    - name: foundry
+      path: custom/foundry
+      module: project
+      provider: microsoft.foundry
+      dependsOn: [app]
+services:
+  my-foundry:
+    host: azure.ai.project
+`)
+
+	require.NoError(t, ejectInfra(dir, "bicep"))
+	assert.FileExists(t, filepath.Join(dir, "custom", "foundry", "project.bicep"))
+	assert.FileExists(t, filepath.Join(dir, "custom", "foundry", "project.parameters.json"))
+	assert.NoFileExists(t, filepath.Join(dir, "custom", "foundry", "main.bicep"))
+}
+
+func TestEjectInfra_RefusesNonEmptyDeclaredFoundryTarget(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	yamlBody := `name: my-project
+infra:
+  provider: bicep
+  layers:
+    - name: app
+      path: infra/app
+    - name: foundry
+      path: custom/foundry
+      provider: microsoft.foundry
+services:
+  my-foundry:
+    host: azure.ai.project
+`
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), yamlBody)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "custom", "foundry"), 0o750))
+	mustWriteFile(t, filepath.Join(dir, "custom", "foundry", "README.md"), "user content\n")
+
+	err := ejectInfra(dir, "bicep")
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeInfraEjectExists, localErr.Code)
+	assert.Contains(t, localErr.Message, "Foundry infrastructure layer \"foundry\" already exists")
+	assert.NoFileExists(t, filepath.Join(dir, "custom", "foundry", "main.bicep"))
+}
+
+func TestAzureYAMLUnchanged(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "azure.yaml")
+	mustWriteFile(t, path, "name: original\n")
+
+	unchanged, err := azureYAMLUnchanged(path, []byte("name: original\n"))
+	require.NoError(t, err)
+	assert.True(t, unchanged)
+
+	mustWriteFile(t, path, "name: changed\n")
+	unchanged, err = azureYAMLUnchanged(path, []byte("name: original\n"))
+	require.NoError(t, err)
+	assert.False(t, unchanged)
+}
+
+func TestEjectInfra_RefusesInheritedBicepFoundryLayerProvider(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), `name: my-project
+infra:
+  provider: bicep
+  layers:
+    - name: app
+      path: infra/app
+    - name: foundry
+      path: infra/foundry
+services:
+  my-foundry:
+    host: azure.ai.project
+`)
+
+	err := ejectInfra(dir, "bicep")
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Contains(t, localErr.Message, "already uses provider \"bicep\"")
+	assert.NoDirExists(t, filepath.Join(dir, "infra", "foundry"))
+	raw, err := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "microsoft.foundry")
+}
+
+func TestEjectInfra_AppendsIndependentFoundryLayer(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), `name: my-project
+infra:
+  provider: bicep
+  layers:
+    - name: network
+      path: infra/network
+    - name: app
+      path: infra/app
+      dependsOn: [network]
+services:
+  my-foundry:
+    host: azure.ai.project
+`)
+
+	require.NoError(t, ejectInfra(dir, "bicep"))
+	raw, err := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec // temp test path
+	require.NoError(t, err)
+	var doc struct {
+		Infra struct {
+			Layers []struct {
+				Name      string   `yaml:"name"`
+				DependsOn []string `yaml:"dependsOn"`
+			} `yaml:"layers"`
+		} `yaml:"infra"`
+	}
+	require.NoError(t, yaml.Unmarshal(raw, &doc))
+	require.Len(t, doc.Infra.Layers, 3)
+	assert.Empty(t, doc.Infra.Layers[0].DependsOn)
+	assert.Equal(t, []string{"network"}, doc.Infra.Layers[1].DependsOn)
+	assert.Empty(t, doc.Infra.Layers[2].DependsOn)
+}
+
+func TestEjectInfra_PreservesExistingLayerHooksAndDependencies(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), `name: my-project
+infra:
+  provider: bicep
+  layers:
+    - name: network
+      path: infra/network
+      hooks:
+        postprovision:
+          - run: azd env set VNET_ID value
+    - name: app
+      path: infra/app
+      dependsOn: [network]
+services:
+  my-foundry:
+    host: azure.ai.project
+`)
+
+	require.NoError(t, ejectInfra(dir, "bicep"))
+	raw, err := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec // temp test path
+	require.NoError(t, err)
+	var doc struct {
+		Infra struct {
+			Layers []struct {
+				Name      string   `yaml:"name"`
+				DependsOn []string `yaml:"dependsOn"`
+				Hooks     map[string][]struct {
+					Run string `yaml:"run"`
+				} `yaml:"hooks"`
+			} `yaml:"layers"`
+		} `yaml:"infra"`
+	}
+	require.NoError(t, yaml.Unmarshal(raw, &doc))
+	require.Len(t, doc.Infra.Layers, 3)
+	assert.Equal(t, "azd env set VNET_ID value", doc.Infra.Layers[0].Hooks["postprovision"][0].Run)
+	assert.Empty(t, doc.Infra.Layers[0].DependsOn)
+	assert.Equal(t, []string{"network"}, doc.Infra.Layers[1].DependsOn)
+	assert.Empty(t, doc.Infra.Layers[2].DependsOn)
+}
+
+func TestEjectInfra_RefusesChangingExistingBicepLayerProvider(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	yamlBody := `name: my-project
+infra:
+  provider: bicep
+  layers:
+    - name: app
+      path: infra/app
+    - name: foundry
+      path: infra/foundry
+      provider: bicep
+services:
+  my-foundry:
+    host: azure.ai.project
+`
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), yamlBody)
+
+	err := ejectInfra(dir, "terraform")
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeInvalidAzureYaml, localErr.Code)
+	assert.Contains(t, localErr.Message, "already uses provider")
+	assert.NoDirExists(t, filepath.Join(dir, "infra", "foundry"))
+}
+
+func TestEjectInfra_RefusesExistingBicepFoundryLayer(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), `name: my-project
+infra:
+  provider: bicep
+  layers:
+    - name: app
+      path: infra/app
+    - name: foundry
+      path: infra/foundry
+      provider: bicep
+services:
+  my-foundry:
+    host: azure.ai.project
+`)
+
+	err := ejectInfra(dir, "bicep")
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Contains(t, localErr.Message, "already uses provider \"bicep\"")
+	assert.NoDirExists(t, filepath.Join(dir, "infra", "foundry"))
+}
+
+func TestEjectInfra_AllowsNestedFoundryLayerPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), `name: my-project
+infra:
+  provider: bicep
+  layers:
+    - name: app
+      path: infra
+services:
+  my-foundry:
+    host: azure.ai.project
+`)
+
+	require.NoError(t, ejectInfra(dir, "bicep"))
+	assert.FileExists(t, filepath.Join(dir, "infra", "foundry", "main.bicep"))
+}
+
+func TestEjectInfra_RefusesGeneratedFileConflictWithoutUpdatingAzureYaml(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	yamlBody := `name: my-project
+infra:
+  provider: bicep
+  layers:
+    - name: app
+      path: infra/app
+services:
+  my-foundry:
+    host: azure.ai.project
+`
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), yamlBody)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "infra", "foundry"), 0o750))
+	mustWriteFile(t, filepath.Join(dir, "infra", "foundry", "main.bicep"), "// conflict\n")
+
+	err := ejectInfra(dir, "bicep")
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeInfraEjectExists, localErr.Code)
+	assert.Contains(t, localErr.Message, "Foundry infrastructure layer \"foundry\" already exists")
+	assert.Contains(t, localErr.Message, "./infra/foundry")
+	assert.Contains(t, localErr.Suggestion, "project-relative path")
+	assert.Contains(t, localErr.Suggestion, "'foundry' entry in infra.layers")
+
+	raw, readErr := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec // temp test path
+	require.NoError(t, readErr)
+	assert.Equal(t, yamlBody, string(raw))
+	conflict, readErr := os.ReadFile(filepath.Join(dir, "infra", "foundry", "main.bicep")) //nolint:gosec
+	require.NoError(t, readErr)
+	assert.Equal(t, "// conflict\n", string(conflict))
+}
+
+func TestCloneMappingNode_DeepClonesNestedValues(t *testing.T) {
+	t.Parallel()
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte("config:\n  nested:\n    enabled: true\n"), &root))
+	original := root.Content[0]
+	clone := cloneMappingNode(original)
+
+	cloneConfig := mappingValue(clone, "config")
+	cloneNested := mappingValue(cloneConfig, "nested")
+	setMappingScalar(cloneNested, "enabled", "false")
+
+	originalConfig := mappingValue(original, "config")
+	originalNested := mappingValue(originalConfig, "nested")
+	assert.Equal(t, "true", mappingScalar(originalNested, "enabled"))
+	assert.Equal(t, "false", mappingScalar(cloneNested, "enabled"))
+}
+
+func TestEjectInfra_RefusesFoundryLayerOutsideProject(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), `name: my-project
+infra:
+  layers:
+    - name: app
+      path: infra/app
+      provider: bicep
+    - name: foundry
+      path: ../foundry
+      provider: microsoft.foundry
+      dependsOn: [app]
+services:
+  my-foundry:
+    host: azure.ai.project
+`)
+
+	err := ejectInfra(dir, "bicep")
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeInvalidAzureYaml, localErr.Code)
+	assert.Contains(t, localErr.Message, "must not contain '..'")
+	assert.NoDirExists(t, filepath.Join(filepath.Dir(dir), "foundry"))
 }
 
 func TestEjectInfra_RefusesWhenNoFoundryService(t *testing.T) {
@@ -227,7 +982,7 @@ func TestEjectInfra_HappyPath_WritesExpectedFiles(t *testing.T) {
 	assert.Contains(t, stdout, "infra/main.bicep")
 	assert.Contains(t, stdout, "infra/modules/acr.bicep")
 	assert.Contains(t, stdout, "infra/main.parameters.json")
-	assert.Contains(t, stdout, "Future provisions will read from ./infra/")
+	assert.Contains(t, stdout, "Future provisions will read the Foundry layer from ./infra/")
 	assert.Contains(t, stdout, "Next steps:")
 	assert.Contains(t, stdout, "azd provision")
 
@@ -517,10 +1272,8 @@ services:
 
 func TestEjectInfra_RefusesWhenInfraIsAFile(t *testing.T) {
 	t.Parallel()
-	// Pre-existing `infra` as a regular file (not a directory) hits the
-	// same "already exists" refusal as a pre-existing directory. os.Stat
-	// can't tell the caller's intent apart, and overwriting a user file
-	// silently would violate "no implicit destruction of user-owned files".
+	// Pre-existing `infra` as a regular file cannot be used as the generated
+	// directory and must never be overwritten.
 	dir := t.TempDir()
 	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), validFoundryAzureYAML)
 	mustWriteFile(t, filepath.Join(dir, "infra"), "this is a file, not a dir")
@@ -538,6 +1291,34 @@ func TestEjectInfra_RefusesWhenInfraIsAFile(t *testing.T) {
 	got, err := os.ReadFile(filepath.Join(dir, "infra")) //nolint:gosec // G304: test file path from t.TempDir()
 	require.NoError(t, err)
 	assert.Equal(t, "this is a file, not a dir", string(got))
+}
+
+func TestEjectInfra_RefusesSymlinkedFoundryPath(t *testing.T) {
+	t.Parallel()
+	projectRoot := t.TempDir()
+	outside := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, "infra"), 0o750))
+	if err := os.Symlink(outside, filepath.Join(projectRoot, "infra", "foundry")); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+	mustWriteFile(t, filepath.Join(projectRoot, "azure.yaml"), `name: my-project
+infra:
+  layers:
+    - name: app
+      path: infra/app
+      provider: bicep
+services:
+  my-foundry:
+    host: azure.ai.project
+`)
+
+	err := ejectInfra(projectRoot, "bicep")
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeInvalidAzureYaml, localErr.Code)
+	assert.Contains(t, localErr.Message, "escapes project root")
+	assert.NoFileExists(t, filepath.Join(outside, "main.bicep"))
 }
 
 func TestValidateStandaloneEjectArgs(t *testing.T) {
@@ -1615,7 +2396,7 @@ func TestEjectInfra_Terraform_HappyPath_WritesExpectedFiles(t *testing.T) {
 	})
 
 	// Every embedded .tf under templates/terraform/ should be on disk under
-	// ./infra/, plus the generated main.tfvars.json. Bicep artifacts must NOT
+	// ./infra/, plus the generated marker and main.tfvars.json. Bicep artifacts must NOT
 	// be present.
 	expected := []string{
 		filepath.Join("infra", "provider.tf"),
@@ -1625,6 +2406,7 @@ func TestEjectInfra_Terraform_HappyPath_WritesExpectedFiles(t *testing.T) {
 		filepath.Join("infra", "connections.tf"),
 		filepath.Join("infra", "outputs.tf"),
 		filepath.Join("infra", "main.tfvars.json"),
+		filepath.Join("infra", foundryTerraformMarker),
 	}
 	for _, rel := range expected {
 		info, err := os.Stat(filepath.Join(dir, rel))
@@ -1648,6 +2430,18 @@ func TestEjectInfra_Terraform_HappyPath_WritesExpectedFiles(t *testing.T) {
 	assert.Contains(t, stdout, "infra/main.tfvars.json")
 	assert.Contains(t, stdout, "infra.provider: terraform")
 	assert.Contains(t, stdout, "azd provision")
+
+	rawYAML, err := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec // G304: test path from t.TempDir()
+	require.NoError(t, err)
+	var projectDoc struct {
+		Infra struct {
+			Provider string `yaml:"provider"`
+			Layers   []any  `yaml:"layers"`
+		} `yaml:"infra"`
+	}
+	require.NoError(t, yaml.Unmarshal(rawYAML, &projectDoc))
+	assert.Equal(t, "terraform", projectDoc.Infra.Provider)
+	assert.Empty(t, projectDoc.Infra.Layers)
 
 	// This fixture has a docker: agent, so acr.tf is present and the generated
 	// outputs.tf must reference the registry resources (not empty strings).
@@ -1708,6 +2502,7 @@ func TestEjectInfra_Terraform_TfvarsShape(t *testing.T) {
 	assert.Equal(t, "${AZURE_AI_PROJECT_NAME}", doc["foundry_project_name"])
 	assert.Equal(t, "${AZURE_SUBSCRIPTION_ID}", doc["subscription_id"])
 	assert.Equal(t, "${AZURE_PRINCIPAL_ID}", doc["principal_id"])
+	assert.NotContains(t, doc, "create_resource_group")
 
 	// include_acr is NOT written to tfvars; the ACR decision is the presence of
 	// acr.tf at eject time, not a Terraform variable.
@@ -1822,7 +2617,7 @@ services:
 	assert.NotContains(t, string(outputs), "AZURE_CONTAINER_REGISTRY_RESOURCE_ID")
 	assert.NotContains(t, string(outputs), "AZURE_AI_PROJECT_ACR_CONNECTION_NAME")
 	// The non-ACR outputs are still present.
-	assert.Contains(t, string(outputs), "AZURE_RESOURCE_GROUP")
+	assert.Contains(t, string(outputs), "AZURE_FOUNDRY_RESOURCE_GROUP")
 	assert.Contains(t, string(outputs), "FOUNDRY_PROJECT_ENDPOINT")
 
 	// main.tf must not carry any ACR leftovers (e.g. container_registry_name).
@@ -1839,23 +2634,30 @@ services:
 	assert.NotContains(t, doc, "include_acr")
 }
 
-func TestEjectInfra_Terraform_RefusesWhenInfraExists(t *testing.T) {
+func TestEjectInfra_Terraform_MigratesExistingInfraToLayers(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), validFoundryAzureYAML)
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"),
+		strings.Replace(validFoundryAzureYAML, "provider: microsoft.foundry", "provider: bicep", 1))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "infra"), 0o750))
+	mustWriteFile(t, filepath.Join(dir, "infra", "main.bicep"), "// existing infrastructure\n")
 
 	err := ejectInfra(dir, "terraform")
-	require.Error(t, err)
-	localErr, ok := errors.AsType[*azdext.LocalError](err)
-	require.True(t, ok, "expected structured azdext.LocalError, got %T", err)
-	assert.Equal(t, exterrors.CodeInfraEjectExists, localErr.Code)
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(dir, "infra", "foundry", "main.tf"))
+	tfvars, err := os.ReadFile(filepath.Join(dir, "infra", "foundry", "main.tfvars.json")) //nolint:gosec
+	require.NoError(t, err)
+	var tfvarsDoc map[string]any
+	require.NoError(t, json.Unmarshal(tfvars, &tfvarsDoc))
+	assert.NotContains(t, tfvarsDoc, "create_resource_group")
+	assert.Equal(t, "${AZURE_FOUNDRY_RESOURCE_GROUP=rg-${AZURE_ENV_NAME}-foundry}",
+		tfvarsDoc["resource_group_name"])
+	assert.Equal(t, "${AZURE_AI_PROJECT_NAME=${AZURE_ENV_NAME}}", tfvarsDoc["foundry_project_name"])
 
-	// The refusal must fire before azure.yaml is touched: provider stays foundry.
 	raw, err := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec // G304: test file path from t.TempDir()
 	require.NoError(t, err)
-	assert.Contains(t, string(raw), "provider: microsoft.foundry",
-		"azure.yaml must not be stamped when eject refuses")
+	assert.Contains(t, string(raw), "path: infra/foundry")
+	assert.Contains(t, string(raw), "provider: terraform")
 }
 
 func TestEjectInfra_Terraform_RefusesWhenNetworkDeclared(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
@@ -1897,9 +1897,7 @@ func TestEnsureCompatibleInfraProvider(t *testing.T) {
 	}
 }
 
-// The gate refuses a project that keeps its IaC elsewhere on both branches:
-// standalone eject and the init fall-through both end in ejectInfra.
-func TestResolveInfraGate_RefusesCustomInfraPath(t *testing.T) {
+func TestResolveInfraGate_AllowsCustomInfraPath(t *testing.T) {
 	tests := []struct {
 		name string
 		yaml string
@@ -1935,19 +1933,14 @@ services:
 			require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, "myinfra"), 0o750))
 			t.Chdir(projectRoot)
 
-			_, err := resolveInfraGate("bicep")
-			require.Error(t, err)
-			localErr, ok := errors.AsType[*azdext.LocalError](err)
-			require.True(t, ok, "expected *azdext.LocalError, got %T", err)
-			assert.Equal(t, exterrors.CodeInfraEjectCustomInfraPath, localErr.Code)
-			assert.Contains(t, localErr.Message, "myinfra")
+			gate, err := resolveInfraGate("bicep")
+			require.NoError(t, err)
+			assert.Equal(t, tt.name == "project that already declares a foundry service", gate.standaloneEject)
 		})
 	}
 }
 
-// Terraform eject stamps infra.provider and removes infra.path. Refusing before
-// anything is written is what keeps a project's own IaC from being orphaned.
-func TestEjectInfra_Terraform_RefusesCustomInfraPath(t *testing.T) {
+func TestEjectInfra_Terraform_HonorsCustomInfraPath(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	azureYAML := `name: my-project
@@ -1959,20 +1952,12 @@ services:
 `
 	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), azureYAML)
 
-	err := ejectInfra(dir, "terraform")
-	require.Error(t, err)
-	localErr, ok := errors.AsType[*azdext.LocalError](err)
-	require.True(t, ok, "expected *azdext.LocalError, got %T", err)
-	assert.Equal(t, exterrors.CodeInfraEjectCustomInfraPath, localErr.Code)
-
-	assert.NoDirExists(t, filepath.Join(dir, "infra"))
-	raw, readErr := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec // G304: test path from t.TempDir()
-	require.NoError(t, readErr)
-	assert.Equal(t, azureYAML, string(raw),
-		"a refused eject must not stamp infra.provider or drop the declared infra.path")
+	require.NoError(t, ejectInfra(dir, "terraform"))
+	assert.FileExists(t, filepath.Join(dir, "myinfra", "main.tf"))
+	assert.FileExists(t, filepath.Join(dir, "myinfra", "main.tfvars.json"))
 }
 
-func TestResolveInfraGate_RefusesInfraLayers(t *testing.T) {
+func TestResolveInfraGate_AllowsInfraLayers(t *testing.T) {
 	tests := []struct {
 		name string
 		host string
@@ -1997,17 +1982,14 @@ services:
 `, tt.host))
 			t.Chdir(projectRoot)
 
-			_, err := resolveInfraGate("terraform")
-			require.Error(t, err)
-			localErr, ok := errors.AsType[*azdext.LocalError](err)
-			require.True(t, ok, "expected *azdext.LocalError, got %T", err)
-			assert.Equal(t, exterrors.CodeInfraEjectLayersUnsupported, localErr.Code)
-			assert.NoDirExists(t, filepath.Join(projectRoot, "infra"))
+			gate, err := resolveInfraGate("terraform")
+			require.NoError(t, err)
+			assert.Equal(t, tt.host == "azure.ai.project", gate.standaloneEject)
 		})
 	}
 }
 
-func TestResolveInfraGate_RefusesBicepWithTerraformProvider(t *testing.T) {
+func TestResolveInfraGate_DefersProviderCompatibility(t *testing.T) {
 	tests := []struct {
 		name string
 		host string
@@ -2029,17 +2011,14 @@ services:
 `, tt.host))
 			t.Chdir(projectRoot)
 
-			_, err := resolveInfraGate("bicep")
-			require.Error(t, err)
-			localErr, ok := errors.AsType[*azdext.LocalError](err)
-			require.True(t, ok, "expected *azdext.LocalError, got %T", err)
-			assert.Equal(t, exterrors.CodeInfraEjectProviderConflict, localErr.Code)
-			assert.NoDirExists(t, filepath.Join(projectRoot, "infra"))
+			gate, err := resolveInfraGate("bicep")
+			require.NoError(t, err)
+			assert.Equal(t, tt.host == "azure.ai.project", gate.standaloneEject)
 		})
 	}
 }
 
-func TestResolveInfraGate_RefusesCustomInfraModule(t *testing.T) {
+func TestResolveInfraGate_AllowsCustomInfraModule(t *testing.T) {
 	t.Setenv("AZD_EXEC_PROJECT_DIR", "")
 	projectRoot := t.TempDir()
 	mustWriteFile(t, filepath.Join(projectRoot, "azure.yaml"), `name: my-project
@@ -2051,15 +2030,12 @@ services:
 `)
 	t.Chdir(projectRoot)
 
-	_, err := resolveInfraGate("bicep")
-	require.Error(t, err)
-	localErr, ok := errors.AsType[*azdext.LocalError](err)
-	require.True(t, ok, "expected *azdext.LocalError, got %T", err)
-	assert.Equal(t, exterrors.CodeInfraEjectCustomModule, localErr.Code)
-	assert.NoDirExists(t, filepath.Join(projectRoot, "infra"))
+	gate, err := resolveInfraGate("bicep")
+	require.NoError(t, err)
+	assert.False(t, gate.standaloneEject)
 }
 
-func TestEjectInfra_RefusesInfraLayers(t *testing.T) {
+func TestEjectInfra_RefusesOnlyFoundryLayer(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	azureYAML := `name: my-project
@@ -2078,7 +2054,7 @@ services:
 	require.Error(t, err)
 	localErr, ok := errors.AsType[*azdext.LocalError](err)
 	require.True(t, ok, "expected *azdext.LocalError, got %T", err)
-	assert.Equal(t, exterrors.CodeInfraEjectLayersUnsupported, localErr.Code)
+	assert.Equal(t, exterrors.CodeInvalidAzureYaml, localErr.Code)
 	assert.NoDirExists(t, filepath.Join(dir, "infra"))
 
 	raw, readErr := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec // G304: test path from t.TempDir()
@@ -2086,7 +2062,7 @@ services:
 	assert.Equal(t, azureYAML, string(raw), "a refused eject must not rewrite the provider or layers")
 }
 
-func TestEjectInfra_RefusesCustomInfraModule(t *testing.T) {
+func TestEjectInfra_HonorsCustomInfraModule(t *testing.T) {
 	t.Parallel()
 	for _, provider := range []string{"bicep", "terraform"} {
 		t.Run(provider, func(t *testing.T) {
@@ -2101,16 +2077,13 @@ services:
 `
 			mustWriteFile(t, filepath.Join(dir, "azure.yaml"), azureYAML)
 
-			err := ejectInfra(dir, provider)
-			require.Error(t, err)
-			localErr, ok := errors.AsType[*azdext.LocalError](err)
-			require.True(t, ok, "expected *azdext.LocalError, got %T", err)
-			assert.Equal(t, exterrors.CodeInfraEjectCustomModule, localErr.Code)
-			assert.NoDirExists(t, filepath.Join(dir, "infra"))
-
-			raw, readErr := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec // G304: test path
-			require.NoError(t, readErr)
-			assert.Equal(t, azureYAML, string(raw), "a refused eject must not rewrite infra.module")
+			require.NoError(t, ejectInfra(dir, provider))
+			if provider == "bicep" {
+				assert.FileExists(t, filepath.Join(dir, "infra", "platform.bicep"))
+				assert.FileExists(t, filepath.Join(dir, "infra", "platform.parameters.json"))
+			} else {
+				assert.FileExists(t, filepath.Join(dir, "infra", "platform.tfvars.json"))
+			}
 		})
 	}
 }
@@ -2131,7 +2104,7 @@ services:
 	require.Error(t, err)
 	localErr, ok := errors.AsType[*azdext.LocalError](err)
 	require.True(t, ok, "expected *azdext.LocalError, got %T", err)
-	assert.Equal(t, exterrors.CodeInfraEjectProviderConflict, localErr.Code)
+	assert.Equal(t, exterrors.CodeInvalidAzureYaml, localErr.Code)
 	assert.NoDirExists(t, filepath.Join(dir, "infra"))
 }
 
@@ -2178,11 +2151,7 @@ func TestResolveInfraGate_NoProjectRunsInit(t *testing.T) {
 	assert.Empty(t, gate.projectRoot, "no project root to eject from yet")
 }
 
-// A project with no Foundry service now runs the whole init flow before
-// ejecting, so the ./infra/ conflict has to surface up front instead of after
-// the user has answered every prompt. The existing tree usually belongs to the
-// project's own services, so the refusal must offer the non-destructive path.
-func TestResolveInfraGate_RefusesExistingInfraBeforeRunningInit(t *testing.T) {
+func TestResolveInfraGate_AllowsExistingInfraBeforeRunningInit(t *testing.T) {
 	t.Setenv("AZD_EXEC_PROJECT_DIR", "")
 	projectRoot := t.TempDir()
 	mustWriteFile(t, filepath.Join(projectRoot, "azure.yaml"), `name: my-project
@@ -2193,17 +2162,10 @@ services:
 	require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, "infra"), 0o750))
 	t.Chdir(projectRoot)
 
-	_, err := resolveInfraGate("bicep")
-	require.Error(t, err)
-	localErr, ok := errors.AsType[*azdext.LocalError](err)
-	require.True(t, ok, "expected *azdext.LocalError, got %T", err)
-	assert.Equal(t, exterrors.CodeInfraEjectExists, localErr.Code)
-	assert.Contains(t, localErr.Suggestion, "without --infra",
-		"the non-destructive path has to be offered, and offered first")
-	assert.Less(t,
-		strings.Index(localErr.Suggestion, "without --infra"),
-		strings.Index(localErr.Suggestion, "delete ./infra/"),
-		"never lead with deleting IaC the extension may not have authored")
+	gate, err := resolveInfraGate("bicep")
+	require.NoError(t, err)
+	assert.False(t, gate.standaloneEject)
+	assert.Equal(t, projectRoot, gate.projectRoot)
 }
 
 func TestResolveInfraGate_PropagatesInvalidFoundryConfiguration(t *testing.T) {
@@ -2334,38 +2296,6 @@ services:
 	require.NoError(t, err)
 	assert.Contains(t, string(raw), "host: containerapp")
 	assert.Contains(t, string(raw), "host: azure.ai.project")
-}
-
-// The pre-existing ./infra/ refusal moved into the gate, so it now fires before
-// the user is walked through init. Asserted at the command level because the
-// ordering is what the gate exists for.
-func TestInitInfra_ExistingProjectWithPreexistingInfraRefusesUpFront(t *testing.T) {
-	t.Setenv("AZD_EXEC_PROJECT_DIR", "")
-	projectRoot := t.TempDir()
-	mustWriteFile(t, filepath.Join(projectRoot, "azure.yaml"), `name: my-project
-services:
-  web:
-    host: containerapp
-`)
-	require.NoError(t, os.MkdirAll(filepath.Join(projectRoot, "infra"), 0o750))
-	t.Chdir(projectRoot)
-
-	cmd := newInitCommand(&azdext.ExtensionContext{})
-	cmd.SetArgs([]string{"--infra"})
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(io.Discard)
-
-	var execErr error
-	withCapturedStdout(t, func() {
-		execErr = cmd.Execute()
-	})
-
-	require.Error(t, execErr)
-	localErr, ok := errors.AsType[*azdext.LocalError](execErr)
-	require.True(t, ok, "expected *azdext.LocalError, got %T", execErr)
-	assert.NotEqual(t, exterrors.CodeInfraEjectNoFoundryService, localErr.Code,
-		"--infra must no longer refuse a project that simply has no agent service yet")
-	assert.Equal(t, exterrors.CodeInfraEjectExists, localErr.Code)
 }
 
 func TestEjectInfra_Terraform_HappyPath_WritesExpectedFiles(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
@@ -120,6 +120,7 @@ func TestEjectInfra_MigratesExistingInfraToLayers(t *testing.T) {
 	assert.Equal(t, "${AZURE_AI_PROJECT_NAME=${AZURE_ENV_NAME}}", paramsDoc.Parameters["foundryProjectName"].Value)
 	assert.Equal(t, "${AZURE_FOUNDRY_RESOURCE_GROUP=rg-${AZURE_ENV_NAME}-foundry}",
 		paramsDoc.Parameters["resourceGroupName"].Value)
+	assert.Equal(t, "${AZD_RESOURCE_TOKEN_SALT}", paramsDoc.Parameters["resourceTokenSalt"].Value)
 }
 
 func TestEjectInfra_PreservesExistingInfraNameWhenMigratingToLayers(t *testing.T) {
@@ -764,6 +765,30 @@ services:
 	assert.FileExists(t, filepath.Join(dir, "infra", "foundry", "main.bicep"))
 }
 
+func TestEjectInfra_MergesNonConflictingUndeclaredFoundryDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	yamlBody := `name: my-project
+infra:
+  provider: bicep
+  layers:
+    - name: app
+      path: infra/app
+services:
+  my-foundry:
+    host: azure.ai.project
+`
+	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), yamlBody)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "infra", "foundry"), 0o750))
+	mustWriteFile(t, filepath.Join(dir, "infra", "foundry", "README.md"), "keep me\n")
+
+	require.NoError(t, ejectInfra(dir, "bicep"))
+	assert.FileExists(t, filepath.Join(dir, "infra", "foundry", "main.bicep"))
+	readme, err := os.ReadFile(filepath.Join(dir, "infra", "foundry", "README.md")) //nolint:gosec
+	require.NoError(t, err)
+	assert.Equal(t, "keep me\n", string(readme))
+}
+
 func TestEjectInfra_RefusesGeneratedFileConflictWithoutUpdatingAzureYaml(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -786,10 +811,7 @@ services:
 	localErr, ok := errors.AsType[*azdext.LocalError](err)
 	require.True(t, ok)
 	assert.Equal(t, exterrors.CodeInfraEjectExists, localErr.Code)
-	assert.Contains(t, localErr.Message, "Foundry infrastructure layer \"foundry\" already exists")
-	assert.Contains(t, localErr.Message, "./infra/foundry")
-	assert.Contains(t, localErr.Suggestion, "project-relative path")
-	assert.Contains(t, localErr.Suggestion, "'foundry' entry in infra.layers")
+	assert.Contains(t, localErr.Message, "./infra/foundry/main.bicep")
 
 	raw, readErr := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec // temp test path
 	require.NoError(t, readErr)
@@ -2564,7 +2586,8 @@ func TestEjectInfra_Terraform_MigratesExistingInfraToLayers(t *testing.T) {
 	assert.NotContains(t, tfvarsDoc, "create_resource_group")
 	assert.Equal(t, "${AZURE_FOUNDRY_RESOURCE_GROUP=rg-${AZURE_ENV_NAME}-foundry}",
 		tfvarsDoc["resource_group_name"])
-	assert.Equal(t, "${AZURE_AI_PROJECT_NAME=${AZURE_ENV_NAME}}", tfvarsDoc["foundry_project_name"])
+	assert.Equal(t, "${AZURE_AI_PROJECT_NAME=}", tfvarsDoc["foundry_project_name"])
+	assert.Equal(t, "${AZD_RESOURCE_TOKEN_SALT}", tfvarsDoc["resource_token_salt"])
 
 	raw, err := os.ReadFile(filepath.Join(dir, "azure.yaml")) //nolint:gosec // G304: test file path from t.TempDir()
 	require.NoError(t, err)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_infra_test.go
@@ -157,7 +157,7 @@ services:
 	assert.Empty(t, doc.Infra.Layers[1].DependsOn)
 }
 
-func TestEjectInfra_PreservesAllExistingInfraPropertiesWhenMigratingToLayers(t *testing.T) {
+func TestEjectInfra_PreservesAllRootInfraProperties(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	mustWriteFile(t, filepath.Join(dir, "azure.yaml"), `name: my-project
@@ -184,8 +184,7 @@ services:
 	require.NoError(t, err)
 	var doc map[string]any
 	require.NoError(t, yaml.Unmarshal(raw, &doc))
-	infra := doc["infra"].(map[string]any)
-	layers := infra["layers"].([]any)
+	layers := doc["infra"].(map[string]any)["layers"].([]any)
 	existing := layers[0].(map[string]any)
 	assert.Equal(t, "existing", existing["name"])
 	assert.Equal(t, "infra/existing", existing["path"])

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -60,10 +60,10 @@ func TestInitCommand_ForceFlag(t *testing.T) {
 // TestHasFoundryProviderDeclared covers the predicate ensureProject
 // uses to suppress the "missing infra/" warning.
 func TestHasFoundryProviderDeclared(t *testing.T) {
-	layeredProject := func(t *testing.T, body string) *azdext.ProjectConfig {
+	layeredProject := func(t *testing.T, filename, body string) *azdext.ProjectConfig {
 		t.Helper()
 		dir := t.TempDir()
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte(body), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, filename), []byte(body), 0o600))
 		return &azdext.ProjectConfig{Path: dir, Infra: &azdext.InfraOptions{Provider: "bicep"}}
 	}
 	cases := []struct {
@@ -90,7 +90,7 @@ func TestHasFoundryProviderDeclared(t *testing.T) {
 		},
 		{
 			name: "bicep eject layer is not foundry provider",
-			proj: layeredProject(t, `name: test
+			proj: layeredProject(t, "azure.yaml", `name: test
 infra:
   layers:
     - name: app
@@ -101,6 +101,18 @@ infra:
       provider: bicep
 `),
 			want: false,
+		},
+		{
+			name: "foundry layer in azure.yml",
+			proj: layeredProject(t, "azure.yml", `name: test
+infra:
+  provider: bicep
+  layers:
+    - name: foundry
+      path: infra/foundry
+      provider: microsoft.foundry
+`),
+			want: true,
 		},
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -60,6 +60,12 @@ func TestInitCommand_ForceFlag(t *testing.T) {
 // TestHasFoundryProviderDeclared covers the predicate ensureProject
 // uses to suppress the "missing infra/" warning.
 func TestHasFoundryProviderDeclared(t *testing.T) {
+	layeredProject := func(t *testing.T, body string) *azdext.ProjectConfig {
+		t.Helper()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte(body), 0o600))
+		return &azdext.ProjectConfig{Path: dir, Infra: &azdext.InfraOptions{Provider: "bicep"}}
+	}
 	cases := []struct {
 		name string
 		proj *azdext.ProjectConfig
@@ -81,6 +87,20 @@ func TestHasFoundryProviderDeclared(t *testing.T) {
 			name: "matches",
 			proj: &azdext.ProjectConfig{Infra: &azdext.InfraOptions{Provider: project.FoundryProviderName}},
 			want: true,
+		},
+		{
+			name: "bicep eject layer is not foundry provider",
+			proj: layeredProject(t, `name: test
+infra:
+  layers:
+    - name: app
+      path: infra/app
+      provider: bicep
+    - name: foundry
+      path: infra/foundry
+      provider: bicep
+`),
+			want: false,
 		},
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
@@ -232,6 +232,8 @@ const (
 	CodeInfraEjectNoFoundryService        = "infra_eject_no_foundry_service"
 	CodeInfraEjectMultipleFoundryServices = "infra_eject_multiple_foundry_services"
 	CodeInfraEjectAzureYamlMissing        = "infra_eject_azure_yaml_missing"
+	CodeInfraEjectAzureYamlChanged        = "infra_eject_azure_yaml_changed"
+	CodeInfraEjectMarkerInvalid           = "infra_eject_marker_invalid"
 	CodeInfraEjectWriteFailed             = "infra_eject_write_failed"
 	CodeInfraEjectConflictingArguments    = "infra_eject_conflicting_arguments"
 	CodeInfraEjectNetworkUnsupported      = "infra_eject_network_unsupported"

--- a/cli/azd/extensions/azure.ai.agents/internal/project/provisioning_provider.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/provisioning_provider.go
@@ -5,14 +5,13 @@ package project
 
 import "slices"
 
-// FoundryProviderName is the value written to `infra.provider` in
-// azure.yaml by `azd ai agent init` and looked up by azd's provider
-// resolver to dispatch provisioning to azure.ai.projects.
+// FoundryProviderName is the value written to an infra provider field in
+// azure.yaml by `azd ai agent init` and looked up by azd's provider resolver.
 const FoundryProviderName = "microsoft.foundry"
 
 // BicepProviderName and TerraformProviderName are azd-core's built-in
-// provisioning providers. `azd ai agent init --infra=terraform` stamps
-// TerraformProviderName onto azure.yaml so azd-core's Terraform provider
+// provisioning providers. `azd ai agent init --infra=terraform` uses
+// TerraformProviderName for the Foundry layer so azd-core's Terraform provider
 // (not this extension's microsoft.foundry provider) handles provisioning.
 const (
 	BicepProviderName     = "bicep"

--- a/cli/azd/extensions/azure.ai.agents/internal/synthesis/templates/main.arm.json
+++ b/cli/azd/extensions/azure.ai.agents/internal/synthesis/templates/main.arm.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.44.1.10279",
-      "templateHash": "10316642581792918930"
+      "version": "0.45.15.27210",
+      "templateHash": "1699321523334639873"
     }
   },
   "definitions": {
@@ -346,8 +346,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "9277725728848811858"
+              "version": "0.45.15.27210",
+              "templateHash": "8110487961768042532"
             }
           },
           "definitions": {
@@ -736,8 +736,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "9033097500563316958"
+                      "version": "0.45.15.27210",
+                      "templateHash": "18361164219559996781"
                     }
                   },
                   "parameters": {
@@ -830,8 +830,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "9706203844896299767"
+                              "version": "0.45.15.27210",
+                              "templateHash": "11947348622491745192"
                             }
                           },
                           "parameters": {
@@ -915,8 +915,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "9706203844896299767"
+                              "version": "0.45.15.27210",
+                              "templateHash": "11947348622491745192"
                             }
                           },
                           "parameters": {
@@ -1050,8 +1050,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "2948233716175969636"
+                      "version": "0.45.15.27210",
+                      "templateHash": "1414665861706683761"
                     }
                   },
                   "parameters": {
@@ -1221,8 +1221,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "17191653749134434458"
+                      "version": "0.45.15.27210",
+                      "templateHash": "7461045817315422644"
                     }
                   },
                   "parameters": {
@@ -1448,8 +1448,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "487447368010536336"
+                      "version": "0.45.15.27210",
+                      "templateHash": "14839319862176027437"
                     }
                   },
                   "definitions": {
@@ -1626,6 +1626,10 @@
   },
   "outputs": {
     "AZURE_RESOURCE_GROUP": {
+      "type": "string",
+      "value": "[parameters('resourceGroupName')]"
+    },
+    "AZURE_FOUNDRY_RESOURCE_GROUP": {
       "type": "string",
       "value": "[parameters('resourceGroupName')]"
     },

--- a/cli/azd/extensions/azure.ai.agents/internal/synthesis/templates/main.bicep
+++ b/cli/azd/extensions/azure.ai.agents/internal/synthesis/templates/main.bicep
@@ -160,7 +160,8 @@ module resources 'modules/resources.bicep' = {
 
 // Outputs
 
-output AZURE_RESOURCE_GROUP string = resourceGroup.name
+output AZURE_RESOURCE_GROUP string = resourceGroupName
+output AZURE_FOUNDRY_RESOURCE_GROUP string = resourceGroupName
 output AZURE_AI_PROJECT_ID string = resources.outputs.AZURE_AI_PROJECT_ID
 output AZURE_AI_ACCOUNT_NAME string = resources.outputs.AZURE_AI_ACCOUNT_NAME
 output AZURE_AI_PROJECT_NAME string = resources.outputs.AZURE_AI_PROJECT_NAME

--- a/cli/azd/extensions/azure.ai.agents/internal/synthesis/templates/terraform/outputs.tf.tmpl
+++ b/cli/azd/extensions/azure.ai.agents/internal/synthesis/templates/terraform/outputs.tf.tmpl
@@ -1,9 +1,11 @@
 # Outputs consumed by azd. Each value is written into the azd environment, so
 # the names must stay stable.
 
+{{ if not .Layer }}
 output "AZURE_RESOURCE_GROUP" {
   value = local.resource_group_name
 }
+{{ end }}
 
 output "AZURE_FOUNDRY_RESOURCE_GROUP" {
   value = local.resource_group_name

--- a/cli/azd/extensions/azure.ai.agents/internal/synthesis/templates/terraform/outputs.tf.tmpl
+++ b/cli/azd/extensions/azure.ai.agents/internal/synthesis/templates/terraform/outputs.tf.tmpl
@@ -2,7 +2,11 @@
 # the names must stay stable.
 
 output "AZURE_RESOURCE_GROUP" {
-  value = azurerm_resource_group.this.name
+  value = local.resource_group_name
+}
+
+output "AZURE_FOUNDRY_RESOURCE_GROUP" {
+  value = local.resource_group_name
 }
 
 output "AZURE_AI_PROJECT_ID" {

--- a/cli/azd/extensions/azure.ai.projects/internal/exterrors/codes.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/exterrors/codes.go
@@ -45,6 +45,7 @@ const (
 	OpArmDeploymentCreate       = "arm_deployment_create"
 	OpArmDeploymentGet          = "arm_deployment_get"
 	OpArmDeploymentWhatIf       = "arm_deployment_what_if"
+	OpResourceGroupGet          = "resource_group_get"
 	OpResourceGroupDelete       = "resource_group_delete"
 	OpCognitiveAccountList      = "cognitive_account_list"
 	OpCognitiveAccountPurge     = "cognitive_account_purge"

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider.go
@@ -1005,7 +1005,6 @@ func (p *FoundryProvisioningProvider) State(
 	if err != nil {
 		return nil, err
 	}
-
 	name := p.deploymentName()
 	resp, err := client.GetAtSubscriptionScope(ctx, name, nil)
 	if err != nil {
@@ -1073,6 +1072,13 @@ func (p *FoundryProvisioningProvider) Deploy(
 	if err != nil {
 		return nil, err
 	}
+	resourceGroupExisted := false
+	if p.isLayer && !resourceGroupIDMatches(p.foundryRGOwnerID, p.subID, p.rgName) {
+		resourceGroupExisted, err = p.resourceGroupExists(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	name := p.deploymentName()
 	progress(fmt.Sprintf("Starting ARM deployment %q...", name))
@@ -1088,8 +1094,9 @@ func (p *FoundryProvisioningProvider) Deploy(
 	}
 
 	progress("Foundry deployment complete")
-	if p.isLayer && p.foundryRGOwnerID == "" {
-		p.foundryRGOwnerID = ownedLayerResourceGroupID(resp.Properties, p.subID, p.rgName)
+	if p.isLayer {
+		p.foundryRGOwnerID = resolveLayerResourceGroupOwnership(
+			p.foundryRGOwnerID, p.subID, p.rgName, resourceGroupExisted, resp.Properties)
 	}
 
 	return &azdext.ProvisioningDeployResult{
@@ -1741,6 +1748,9 @@ func (p *FoundryProvisioningProvider) Destroy(
 		if err := verifyLayerResourceGroupOwnership(p.foundryRGOwnerID, p.subID, p.rgName); err != nil {
 			return nil, err
 		}
+		if err := p.verifyLayerResourceGroupAzureOwnership(ctx); err != nil {
+			return nil, err
+		}
 	}
 
 	if !options.GetForce() {
@@ -2302,11 +2312,80 @@ func ownedLayerResourceGroupID(
 }
 
 func verifyLayerResourceGroupOwnership(ownerID, subscriptionID, resourceGroup string) error {
-	wantedID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", subscriptionID, resourceGroup)
-	if ownerID != "" && strings.EqualFold(strings.TrimSuffix(ownerID, "/"), wantedID) {
+	if resourceGroupIDMatches(ownerID, subscriptionID, resourceGroup) {
 		return nil
 	}
 	return layerResourceGroupOwnershipError(resourceGroup, "the azd environment does not record ownership of this group")
+}
+
+func resourceGroupIDMatches(resourceID, subscriptionID, resourceGroup string) bool {
+	wantedID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", subscriptionID, resourceGroup)
+	return resourceID != "" && strings.EqualFold(strings.TrimSuffix(resourceID, "/"), wantedID)
+}
+
+func resolveLayerResourceGroupOwnership(
+	currentID, subscriptionID, resourceGroup string,
+	resourceGroupExisted bool,
+	properties *armresources.DeploymentPropertiesExtended,
+) string {
+	if resourceGroupIDMatches(currentID, subscriptionID, resourceGroup) {
+		return currentID
+	}
+	if resourceGroupExisted {
+		return ""
+	}
+	return ownedLayerResourceGroupID(properties, subscriptionID, resourceGroup)
+}
+
+func (p *FoundryProvisioningProvider) resourceGroupExists(ctx context.Context) (bool, error) {
+	factory, err := armresources.NewClientFactory(p.subID, p.credential, nil)
+	if err != nil {
+		return false, exterrors.Internal(
+			exterrors.CodeAzdClientFailed,
+			fmt.Sprintf("create armresources client for resource-group existence check: %s", err),
+		)
+	}
+	_, err = factory.NewResourceGroupsClient().Get(ctx, p.rgName, nil)
+	if err == nil {
+		return true, nil
+	}
+	if isNotFound(err) {
+		return false, nil
+	}
+	return false, exterrors.ServiceFromAzure(err, exterrors.OpResourceGroupGet)
+}
+
+func (p *FoundryProvisioningProvider) verifyLayerResourceGroupAzureOwnership(ctx context.Context) error {
+	if err := p.ensureCredential(ctx); err != nil {
+		return err
+	}
+	factory, err := armresources.NewClientFactory(p.subID, p.credential, nil)
+	if err != nil {
+		return exterrors.Internal(
+			exterrors.CodeAzdClientFailed,
+			fmt.Sprintf("create armresources client for resource-group ownership check: %s", err),
+		)
+	}
+	resp, err := factory.NewResourceGroupsClient().Get(ctx, p.rgName, nil)
+	if err != nil {
+		if isNotFound(err) {
+			return nil
+		}
+		return exterrors.ServiceFromAzure(err, exterrors.OpResourceGroupGet)
+	}
+	return verifyLayerResourceGroupTags(resp.Tags, p.envName, p.rgName)
+}
+
+func verifyLayerResourceGroupTags(tags map[string]*string, environmentName, resourceGroup string) error {
+	for key, value := range tags {
+		if strings.EqualFold(key, "azd-env-name") && value != nil && *value == environmentName {
+			return nil
+		}
+	}
+	return layerResourceGroupOwnershipError(
+		resourceGroup,
+		fmt.Sprintf("the Azure resource group is not tagged for azd environment %q", environmentName),
+	)
 }
 
 func layerResourceGroupOwnershipError(resourceGroup, reason string) error {

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider.go
@@ -702,10 +702,8 @@ func (p *FoundryProvisioningProvider) normalizeOutputs(
 			outputs = map[string]*azdext.ProvisioningOutputParameter{}
 		}
 		delete(outputs, envKeyResourceGroup)
-		if p.foundryRGOwnerID != "" {
-			outputs[envKeyFoundryRGOwner] = &azdext.ProvisioningOutputParameter{
-				Type: "string", Value: p.foundryRGOwnerID,
-			}
+		outputs[envKeyFoundryRGOwner] = &azdext.ProvisioningOutputParameter{
+			Type: "string", Value: p.foundryRGOwnerID,
 		}
 	}
 	return outputs

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider.go
@@ -48,6 +48,7 @@ const (
 	envKeyLocation       = "AZURE_LOCATION"
 	envKeyResourceGroup  = "AZURE_RESOURCE_GROUP"
 	envKeyFoundryRG      = "AZURE_FOUNDRY_RESOURCE_GROUP"
+	envKeyFoundryRGOwner = "AZD_FOUNDRY_RESOURCE_GROUP_ID"
 	envKeyTenantID       = "AZURE_TENANT_ID"
 	envKeyProjectName    = "AZURE_AI_PROJECT_NAME"
 	envKeyPrincipalID    = "AZURE_PRINCIPAL_ID"
@@ -83,6 +84,7 @@ type FoundryProvisioningProvider struct {
 	location                    string
 	rgName                      string
 	rgExplicit                  bool // active resource-group env key came from env, not the default
+	foundryRGOwnerID            string
 	foundryName                 string
 	principalID                 string
 	credential                  azcore.TokenCredential
@@ -246,7 +248,6 @@ func (p *FoundryProvisioningProvider) Initialize(
 			"set infra.layers[].module to the module base name",
 		)
 	}
-	p.isLayer = strings.TrimSpace(options.GetName()) != ""
 	p.virtualEnv = maps.Clone(options.GetVirtualEnv())
 
 	rawYAML, azureYamlPath, err := readProjectFile(projectRoot)
@@ -267,6 +268,15 @@ func (p *FoundryProvisioningProvider) Initialize(
 	if err := validateFoundryProviderLayers(rawYAML); err != nil {
 		return err
 	}
+	config, err := parseFoundryInfraConfig(rawYAML)
+	if err != nil {
+		return exterrors.Validation(
+			exterrors.CodeInvalidAzureYaml,
+			fmt.Sprintf("parse azure.yaml infrastructure layers: %s", err),
+			"verify azure.yaml is valid YAML",
+		)
+	}
+	p.isLayer = config.hasFoundryLayer(strings.TrimSpace(options.GetName()))
 
 	svcName, err := findFoundryProjectService(rawYAML)
 	if err != nil {
@@ -687,8 +697,16 @@ func (p *FoundryProvisioningProvider) withTenantOutput(
 func (p *FoundryProvisioningProvider) normalizeOutputs(
 	outputs map[string]*azdext.ProvisioningOutputParameter,
 ) map[string]*azdext.ProvisioningOutputParameter {
-	if p.isLayer && outputs != nil {
+	if p.isLayer {
+		if outputs == nil {
+			outputs = map[string]*azdext.ProvisioningOutputParameter{}
+		}
 		delete(outputs, envKeyResourceGroup)
+		if p.foundryRGOwnerID != "" {
+			outputs[envKeyFoundryRGOwner] = &azdext.ProvisioningOutputParameter{
+				Type: "string", Value: p.foundryRGOwnerID,
+			}
+		}
 	}
 	return outputs
 }
@@ -795,6 +813,15 @@ func (p *FoundryProvisioningProvider) resolveEnv(ctx context.Context) error {
 		log.Printf("[debug] %s not set; defaulting to %q", rgKey, p.rgName)
 	} else {
 		p.rgExplicit = true
+	}
+	if p.isLayer {
+		if p.foundryRGOwnerID, err = get(envKeyFoundryRGOwner); err != nil {
+			return exterrors.Dependency(
+				exterrors.CodeEnvironmentValuesFailed,
+				fmt.Sprintf("read %s from azd environment %q: %s", envKeyFoundryRGOwner, p.envName, err),
+				"verify the azd environment is accessible, then retry",
+			)
+		}
 	}
 
 	if p.foundryName, err = get(envKeyProjectName); err != nil {
@@ -1061,6 +1088,9 @@ func (p *FoundryProvisioningProvider) Deploy(
 	}
 
 	progress("Foundry deployment complete")
+	if p.isLayer && p.foundryRGOwnerID == "" {
+		p.foundryRGOwnerID = ownedLayerResourceGroupID(resp.Properties, p.subID, p.rgName)
+	}
 
 	return &azdext.ProvisioningDeployResult{
 		Deployment: &azdext.ProvisioningDeployment{
@@ -1708,11 +1738,7 @@ func (p *FoundryProvisioningProvider) Destroy(
 		)
 	}
 	if p.isLayer {
-		client, err := p.deploymentsClient(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if err := verifyLayerResourceGroupOwnership(ctx, client, p.deploymentName(), p.subID, p.rgName); err != nil {
+		if err := verifyLayerResourceGroupOwnership(p.foundryRGOwnerID, p.subID, p.rgName); err != nil {
 			return nil, err
 		}
 	}
@@ -2009,6 +2035,7 @@ func invalidatedEnvKeysResult() *azdext.ProvisioningDestroyResult {
 			"AZURE_AI_PROJECT_CONNECTION_NAMES",
 			"AZURE_AI_PROJECT_CONNECTIONS_PROJECT_ENDPOINT",
 			"AZURE_FOUNDRY_RESOURCE_GROUP",
+			envKeyFoundryRGOwner,
 		},
 	}
 }
@@ -2261,37 +2288,25 @@ func deploymentOutputs(p *armresources.DeploymentPropertiesExtended) any {
 	return p.Outputs
 }
 
-type subscriptionDeploymentGetter interface {
-	GetAtSubscriptionScope(
-		context.Context,
-		string,
-		*armresources.DeploymentsClientGetAtSubscriptionScopeOptions,
-	) (armresources.DeploymentsClientGetAtSubscriptionScopeResponse, error)
+func ownedLayerResourceGroupID(
+	properties *armresources.DeploymentPropertiesExtended,
+	subscriptionID, resourceGroup string,
+) string {
+	wantedID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", subscriptionID, resourceGroup)
+	for _, resource := range deploymentResources(properties) {
+		if resource != nil && resource.ID != nil && strings.EqualFold(strings.TrimSuffix(*resource.ID, "/"), wantedID) {
+			return wantedID
+		}
+	}
+	return ""
 }
 
-func verifyLayerResourceGroupOwnership(
-	ctx context.Context,
-	client subscriptionDeploymentGetter,
-	deploymentName, subscriptionID, resourceGroup string,
-) error {
-	resp, err := client.GetAtSubscriptionScope(ctx, deploymentName, nil)
-	if err != nil {
-		if !isNotFound(err) {
-			return exterrors.ServiceFromAzure(err, exterrors.OpArmDeploymentGet)
-		}
-		return layerResourceGroupOwnershipError(resourceGroup, "the Foundry deployment was not found")
-	}
-
+func verifyLayerResourceGroupOwnership(ownerID, subscriptionID, resourceGroup string) error {
 	wantedID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", subscriptionID, resourceGroup)
-	for _, resource := range deploymentResources(resp.Properties) {
-		if resource != nil && resource.ID != nil && strings.EqualFold(strings.TrimSuffix(*resource.ID, "/"), wantedID) {
-			return nil
-		}
+	if ownerID != "" && strings.EqualFold(strings.TrimSuffix(ownerID, "/"), wantedID) {
+		return nil
 	}
-	return layerResourceGroupOwnershipError(
-		resourceGroup,
-		"the Foundry deployment does not record that it created this resource group",
-	)
+	return layerResourceGroupOwnershipError(resourceGroup, "the azd environment does not record ownership of this group")
 }
 
 func layerResourceGroupOwnershipError(resourceGroup, reason string) error {
@@ -2336,6 +2351,10 @@ type foundryInfraConfig struct {
 	rootProvider  string
 	foundryLayers []string
 	hasLayers     bool
+}
+
+func (c foundryInfraConfig) hasFoundryLayer(name string) bool {
+	return name != "" && slices.Contains(c.foundryLayers, name)
 }
 
 func parseFoundryInfraConfig(rawYAML []byte) (foundryInfraConfig, error) {

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider.go
@@ -47,6 +47,7 @@ const (
 	envKeySubscriptionID = "AZURE_SUBSCRIPTION_ID"
 	envKeyLocation       = "AZURE_LOCATION"
 	envKeyResourceGroup  = "AZURE_RESOURCE_GROUP"
+	envKeyFoundryRG      = "AZURE_FOUNDRY_RESOURCE_GROUP"
 	envKeyTenantID       = "AZURE_TENANT_ID"
 	envKeyProjectName    = "AZURE_AI_PROJECT_NAME"
 	envKeyPrincipalID    = "AZURE_PRINCIPAL_ID"
@@ -62,14 +63,18 @@ const (
 // FoundryProvisioningProvider implements azdext.ProvisioningProvider for
 // the service whose host is FoundryProjectHost. By default it deploys
 // the extension's pre-compiled ARM template (no bicep CLI required). When
-// ./infra/main.bicep or ./infra/main.bicepparam exists on disk (e.g. after
-// `azd ai agent init --infra`), it compiles that Bicep at runtime instead
+// the configured <path>/<module>.bicep or .bicepparam exists on disk (e.g.
+// after `azd ai agent init --infra`), it compiles that Bicep at runtime instead
 // and the user owns the parameter contract. See ondisk_template.go.
 type FoundryProvisioningProvider struct {
 	azdClient *azdext.AzdClient
 
 	// Populated by Initialize.
 	projectPath                 string
+	infraPath                   string
+	infraModule                 string
+	isLayer                     bool
+	virtualEnv                  map[string]string
 	synthResult                 *synthesis.Result // nil when onDiskSource != nil
 	serviceEnvironments         map[string]map[string]string
 	connectionEnvironmentScopes map[string]bool
@@ -77,13 +82,13 @@ type FoundryProvisioningProvider struct {
 	subID                       string
 	location                    string
 	rgName                      string
-	rgExplicit                  bool // AZURE_RESOURCE_GROUP came from env, not the rg-<env> default
+	rgExplicit                  bool // active resource-group env key came from env, not the default
 	foundryName                 string
 	principalID                 string
 	credential                  azcore.TokenCredential
 	tenantID                    string          // resolved lazily by ensureCredential; surfaced as AZURE_TENANT_ID
 	armTemplate                 map[string]any  // embedded ARM JSON; nil when onDiskSource is set
-	onDiskSource                *templateSource // non-nil when ./infra/main.{bicep,bicepparam} exists
+	onDiskSource                *templateSource // non-nil when configured on-disk Bicep exists
 
 	// brownfieldEndpoint is the existing project endpoint when the foundry
 	// service sets endpoint: (bring-your-own). When non-empty the provider skips
@@ -148,9 +153,103 @@ func (p *FoundryProvisioningProvider) Initialize(
 				options.GetProvider(), FoundryProviderName),
 		)
 	}
-	p.projectPath = projectPath
+	projectRoot, err := filepath.Abs(projectPath)
+	if err != nil {
+		return exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			fmt.Sprintf("resolve project path %q: %s", projectPath, err),
+			"verify the project path and Foundry infrastructure layer path",
+		)
+	}
+	projectRoot = filepath.Clean(projectRoot)
+	p.projectPath = projectRoot
+	configuredInfraPath := strings.TrimSpace(options.GetPath())
+	if configuredInfraPath == "" {
+		configuredInfraPath = onDiskInfraDir
+	}
+	if filepath.IsAbs(configuredInfraPath) {
+		return exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			fmt.Sprintf("Foundry infrastructure path %q must be project-relative", options.GetPath()),
+			"set infra.layers[].path to a project-relative directory",
+		)
+	}
+	if slices.Contains(strings.FieldsFunc(filepath.ToSlash(configuredInfraPath), func(r rune) bool { return r == '/' }), "..") {
+		return exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			fmt.Sprintf("Foundry infrastructure path %q must not contain '..'", options.GetPath()),
+			"set infra.layers[].path to a directory inside the project",
+		)
+	}
+	infraPath := filepath.Join(projectRoot, configuredInfraPath)
+	relInfraPath, err := filepath.Rel(projectRoot, infraPath)
+	if err != nil || relInfraPath == "." || relInfraPath == ".." ||
+		strings.HasPrefix(relInfraPath, ".."+string(filepath.Separator)) {
+		return exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			fmt.Sprintf("Foundry infrastructure path %q must be inside the project", options.GetPath()),
+			"set infra.layers[].path to a project-relative directory",
+		)
+	}
+	rootReal, rootErr := filepath.EvalSymlinks(projectRoot)
+	existingPath := infraPath
+	for {
+		if _, statErr := os.Lstat(existingPath); statErr == nil {
+			break
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return exterrors.Validation(
+				exterrors.CodeInvalidServiceConfig,
+				fmt.Sprintf("inspect Foundry infrastructure path %q: %s", options.GetPath(), statErr),
+				"verify the Foundry infrastructure layer path",
+			)
+		}
+		parent := filepath.Dir(existingPath)
+		if parent == existingPath {
+			break
+		}
+		existingPath = parent
+	}
+	existingReal, existingErr := filepath.EvalSymlinks(existingPath)
+	if rootErr != nil || existingErr != nil {
+		return exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			fmt.Sprintf("resolve Foundry infrastructure path %q", options.GetPath()),
+			"verify the project and Foundry infrastructure layer paths",
+		)
+	}
+	relRealPath, err := filepath.Rel(rootReal, existingReal)
+	if err != nil || relRealPath == ".." || strings.HasPrefix(relRealPath, ".."+string(filepath.Separator)) {
+		return exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			fmt.Sprintf("Foundry infrastructure path %q escapes the project through a symbolic link", options.GetPath()),
+			"set infra.layers[].path to a directory inside the project",
+		)
+	}
+	p.infraPath = infraPath
+	p.infraModule = strings.TrimSpace(options.GetModule())
+	if p.infraModule == "" {
+		p.infraModule = onDiskModule
+	}
+	if p.infraModule == "." || p.infraModule == ".." ||
+		filepath.Base(p.infraModule) != p.infraModule ||
+		strings.ContainsAny(p.infraModule, `/\\`) {
+		return exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			fmt.Sprintf("Foundry infrastructure module %q must be a file name", p.infraModule),
+			"set infra.layers[].module to a file name without path separators",
+		)
+	}
+	if filepath.Ext(p.infraModule) != "" {
+		return exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			fmt.Sprintf("Foundry infrastructure module %q must not include a file extension", p.infraModule),
+			"set infra.layers[].module to the module base name",
+		)
+	}
+	p.isLayer = strings.TrimSpace(options.GetName()) != ""
+	p.virtualEnv = maps.Clone(options.GetVirtualEnv())
 
-	rawYAML, azureYamlPath, err := readProjectFile(projectPath)
+	rawYAML, azureYamlPath, err := readProjectFile(projectRoot)
 	if err != nil {
 		return exterrors.Validation(
 			exterrors.CodeInvalidAzureYaml,
@@ -165,6 +264,9 @@ func (p *FoundryProvisioningProvider) Initialize(
 			"verify azure.yaml or azure.yml exists at the project root",
 		)
 	}
+	if err := validateFoundryProviderLayers(rawYAML); err != nil {
+		return err
+	}
 
 	svcName, err := findFoundryProjectService(rawYAML)
 	if err != nil {
@@ -175,7 +277,7 @@ func (p *FoundryProvisioningProvider) Initialize(
 	// so it needs no subscription or location. Detect it up front so
 	// the environment can be resolved before any service values are
 	// read.
-	endpoint, err := foundryServiceEndpointAtRoot(rawYAML, projectPath, svcName)
+	endpoint, err := foundryServiceEndpointAtRoot(rawYAML, projectRoot, svcName)
 	if err != nil {
 		return exterrors.Validation(
 			exterrors.CodeInvalidAzureYaml,
@@ -195,7 +297,7 @@ func (p *FoundryProvisioningProvider) Initialize(
 			ServiceName:     svcName,
 			AcceptedHosts:   FoundryProvisioningServiceHosts,
 			PreserveVarRefs: true,
-			ProjectRoot:     projectPath,
+			ProjectRoot:     projectRoot,
 		})
 		if validationErr != nil &&
 			!errors.Is(validationErr, synthesis.ErrEndpointBrownfield) {
@@ -204,7 +306,7 @@ func (p *FoundryProvisioningProvider) Initialize(
 	}
 
 	p.connectionEnvironmentScopes, err =
-		synthesis.ConnectionEnvironmentScopes(rawYAML, projectPath)
+		synthesis.ConnectionEnvironmentScopes(rawYAML, projectRoot)
 	if err != nil {
 		return exterrors.Validation(
 			exterrors.CodeInvalidAzureYaml,
@@ -238,13 +340,13 @@ func (p *FoundryProvisioningProvider) Initialize(
 	// Detect on-disk Bicep before synthesizing. Stat-only; no compile here.
 	if onDisk {
 		log.Printf("[debug] foundry provider: on-disk Bicep detected under %s; "+
-			"skipping synthesizer", filepath.Join(projectPath, onDiskInfraDir))
+			"skipping synthesizer", p.infraPath)
 		// endpoint: (brownfield) reuse skips provisioning even on the on-disk
 		// path; connect to the existing project instead of compiling Bicep.
 		if endpoint != "" {
 			if err := warnNetworkIgnoredInBrownfield(
 				rawYAML,
-				projectPath,
+				projectRoot,
 				svcName,
 			); err != nil {
 				return exterrors.Validation(
@@ -265,7 +367,7 @@ func (p *FoundryProvisioningProvider) Initialize(
 		AcceptedHosts:       FoundryProvisioningServiceHosts,
 		Env:                 p.networkEnvMap(ctx),
 		ServiceEnvironments: p.serviceEnvironments,
-		ProjectRoot:         projectPath,
+		ProjectRoot:         projectRoot,
 	})
 	switch {
 	case errors.Is(err, synthesis.ErrEndpointBrownfield):
@@ -273,7 +375,7 @@ func (p *FoundryProvisioningProvider) Initialize(
 		// network: has no effect in brownfield mode; warn if both are present.
 		if err := warnNetworkIgnoredInBrownfield(
 			rawYAML,
-			projectPath,
+			projectRoot,
 			svcName,
 		); err != nil {
 			return exterrors.Validation(
@@ -339,31 +441,34 @@ func foundrySynthesisError(serviceName string, err error) error {
 // require resolveEnv to have run; on any failure it returns nil and the
 // synthesizer falls back to the process environment.
 func (p *FoundryProvisioningProvider) networkEnvMap(ctx context.Context) map[string]string {
+	out := make(map[string]string, len(p.virtualEnv))
+	maps.Copy(out, p.virtualEnv)
 	if p.azdClient == nil {
 		log.Printf("[debug] foundry provider: no azd client; network ${VAR} uses process env only")
-		return nil
+		return out
 	}
 
 	envClient := p.azdClient.Environment()
 	if envClient == nil {
 		log.Printf("[debug] foundry provider: no environment client; network ${VAR} uses process env only")
-		return nil
+		return out
 	}
 	curr, err := envClient.GetCurrent(ctx, &azdext.EmptyRequest{})
 	if err != nil || curr.GetEnvironment() == nil {
 		log.Printf("[debug] foundry provider: no current azd environment (%v); "+
 			"network ${VAR} uses process env only", err)
-		return nil
+		return out
 	}
 	resp, err := envClient.GetValues(ctx, &azdext.GetEnvironmentRequest{Name: curr.GetEnvironment().GetName()})
 	if err != nil {
 		log.Printf("[debug] foundry provider: GetValues failed (%s); network ${VAR} uses process env only", err)
-		return nil
+		return out
 	}
-	out := make(map[string]string, len(resp.GetKeyValues()))
 	for _, kv := range resp.GetKeyValues() {
 		if kv != nil {
-			out[kv.Key] = kv.Value
+			if _, planned := out[kv.Key]; !planned {
+				out[kv.Key] = kv.Value
+			}
 		}
 	}
 	return out
@@ -454,11 +559,29 @@ func warnNetworkIgnoredInBrownfield(
 	return nil
 }
 
-// or infra/main.bicep exists under p.projectPath. Stat-only.
+// or <module>.bicep exists under the configured layer path. Stat-only.
 func (p *FoundryProvisioningProvider) onDiskTemplatePresent() bool {
-	infraDir := filepath.Join(p.projectPath, onDiskInfraDir)
-	return fileExistsAt(filepath.Join(infraDir, onDiskBicepParamFile)) ||
-		fileExistsAt(filepath.Join(infraDir, onDiskBicepFile))
+	infraPath := p.onDiskInfraPath()
+	module := p.onDiskModuleName()
+	return fileExistsAt(filepath.Join(infraPath, module+".bicepparam")) ||
+		fileExistsAt(filepath.Join(infraPath, module+".bicep"))
+}
+
+// onDiskInfraPath returns the path supplied for the active provisioning layer,
+// falling back to the legacy root infra directory for older callers and tests.
+func (p *FoundryProvisioningProvider) onDiskInfraPath() string {
+	if p.infraPath != "" {
+		return p.infraPath
+	}
+	return filepath.Join(p.projectPath, onDiskInfraDir)
+}
+
+// onDiskModuleName returns the active layer module or the legacy main module.
+func (p *FoundryProvisioningProvider) onDiskModuleName() string {
+	if p.infraModule != "" {
+		return p.infraModule
+	}
+	return onDiskModule
 }
 
 func foundryServiceEndpointAtRoot(
@@ -531,8 +654,8 @@ func brownfieldOutputs(endpoint string) map[string]*azdext.ProvisioningOutputPar
 	return outputs
 }
 
-// defaultResourceGroupName returns the resource group azd provisions into when
-// AZURE_RESOURCE_GROUP is unset, matching azd's standard rg-<env> convention.
+// defaultResourceGroupName returns the default resource group azd provisions
+// into, matching azd's standard rg-<env> convention.
 func defaultResourceGroupName(envName string) string {
 	return "rg-" + envName
 }
@@ -557,6 +680,15 @@ func (p *FoundryProvisioningProvider) withTenantOutput(
 		outputs["AZURE_AI_PROJECT_CONNECTIONS_PROJECT_ENDPOINT"] = &azdext.ProvisioningOutputParameter{
 			Type: "string", Value: endpoint.Value,
 		}
+	}
+	return outputs
+}
+
+func (p *FoundryProvisioningProvider) normalizeOutputs(
+	outputs map[string]*azdext.ProvisioningOutputParameter,
+) map[string]*azdext.ProvisioningOutputParameter {
+	if p.isLayer && outputs != nil {
+		delete(outputs, envKeyResourceGroup)
 	}
 	return outputs
 }
@@ -594,6 +726,9 @@ func (p *FoundryProvisioningProvider) resolveEnv(ctx context.Context) error {
 	p.envName = currEnv.Environment.Name
 
 	get := func(key string) (string, error) {
+		if value := strings.TrimSpace(p.virtualEnv[key]); value != "" {
+			return value, nil
+		}
 		resp, err := envClient.GetValue(ctx, &azdext.GetEnvRequest{
 			EnvName: p.envName,
 			Key:     key,
@@ -637,25 +772,53 @@ func (p *FoundryProvisioningProvider) resolveEnv(ctx context.Context) error {
 		}
 	}
 
-	if p.rgName, err = get(envKeyResourceGroup); err != nil || p.rgName == "" {
+	rgKey := envKeyResourceGroup
+	if p.isLayer {
+		rgKey = envKeyFoundryRG
+	}
+	if p.rgName, err = get(rgKey); err != nil {
+		return exterrors.Dependency(
+			exterrors.CodeEnvironmentValuesFailed,
+			fmt.Sprintf("read %s from azd environment %q: %s", rgKey, p.envName, err),
+			"verify the azd environment is accessible, then retry",
+		)
+	}
+	if p.rgName == "" {
 		// Default to rg-<env>, matching azd's standard Bicep provisioning,
 		// instead of failing. The subscription-scoped template creates the
 		// resource group when it doesn't exist yet. rgExplicit stays false so
 		// Destroy refuses to delete a group this provider never provisioned.
 		p.rgName = defaultResourceGroupName(p.envName)
-		log.Printf("[debug] %s not set; defaulting to %q", envKeyResourceGroup, p.rgName)
+		if p.isLayer {
+			p.rgName += "-foundry"
+		}
+		log.Printf("[debug] %s not set; defaulting to %q", rgKey, p.rgName)
 	} else {
 		p.rgExplicit = true
 	}
 
-	if p.foundryName, err = get(envKeyProjectName); err != nil || p.foundryName == "" {
+	if p.foundryName, err = get(envKeyProjectName); err != nil {
+		return exterrors.Dependency(
+			exterrors.CodeEnvironmentValuesFailed,
+			fmt.Sprintf("read %s from azd environment %q: %s", envKeyProjectName, p.envName, err),
+			"verify the azd environment is accessible, then retry",
+		)
+	}
+	if p.foundryName == "" {
 		// Default to the azd environment name.
 		p.foundryName = sanitizeFoundryName(p.envName)
 		log.Printf("[debug] %s not set; defaulting to %q", envKeyProjectName, p.foundryName)
 	}
 
 	// principalId is optional; when empty the bicep skips the developer role assignment.
-	if p.principalID, _ = get(envKeyPrincipalID); p.principalID == "" {
+	if p.principalID, err = get(envKeyPrincipalID); err != nil {
+		return exterrors.Dependency(
+			exterrors.CodeEnvironmentValuesFailed,
+			fmt.Sprintf("read %s from azd environment %q: %s", envKeyPrincipalID, p.envName, err),
+			"verify the azd environment is accessible, then retry",
+		)
+	}
+	if p.principalID == "" {
 		log.Printf("[debug] %s not set; skipping developer role assignment", envKeyPrincipalID)
 	}
 
@@ -806,12 +969,11 @@ func (p *FoundryProvisioningProvider) State(
 	if p.brownfieldEndpoint != "" {
 		return &azdext.ProvisioningStateResult{
 			State: &azdext.ProvisioningState{
-				Outputs:   p.withTenantOutput(brownfieldOutputs(p.brownfieldEndpoint)),
+				Outputs:   p.normalizeOutputs(p.withTenantOutput(brownfieldOutputs(p.brownfieldEndpoint))),
 				Resources: []*azdext.ProvisioningResource{},
 			},
 		}, nil
 	}
-
 	client, err := p.deploymentsClient(ctx)
 	if err != nil {
 		return nil, err
@@ -834,7 +996,7 @@ func (p *FoundryProvisioningProvider) State(
 
 	return &azdext.ProvisioningStateResult{
 		State: &azdext.ProvisioningState{
-			Outputs:   p.withTenantOutput(armOutputsToProto(deploymentOutputs(resp.Properties))),
+			Outputs:   p.normalizeOutputs(p.withTenantOutput(armOutputsToProto(deploymentOutputs(resp.Properties)))),
 			Resources: armResourcesToProto(deploymentResources(resp.Properties)),
 		},
 	}, nil
@@ -903,7 +1065,7 @@ func (p *FoundryProvisioningProvider) Deploy(
 	return &azdext.ProvisioningDeployResult{
 		Deployment: &azdext.ProvisioningDeployment{
 			Parameters: armInputsToProto(src.parameters),
-			Outputs:    p.withTenantOutput(armOutputsToProto(deploymentOutputs(resp.Properties))),
+			Outputs:    p.normalizeOutputs(p.withTenantOutput(armOutputsToProto(deploymentOutputs(resp.Properties)))),
 		},
 	}, nil
 }
@@ -968,7 +1130,7 @@ func (p *FoundryProvisioningProvider) deployBrownfield(
 		}
 		return &azdext.ProvisioningDeployResult{
 			Deployment: &azdext.ProvisioningDeployment{
-				Outputs: p.withTenantOutput(brownfieldOutputs(p.brownfieldEndpoint)),
+				Outputs: p.normalizeOutputs(p.withTenantOutput(brownfieldOutputs(p.brownfieldEndpoint))),
 			},
 		}, nil
 	}
@@ -1033,7 +1195,7 @@ func (p *FoundryProvisioningProvider) deployBrownfield(
 
 	return &azdext.ProvisioningDeployResult{
 		Deployment: &azdext.ProvisioningDeployment{
-			Outputs: p.withTenantOutput(outputs),
+			Outputs: p.normalizeOutputs(p.withTenantOutput(outputs)),
 		},
 	}, nil
 }
@@ -1253,6 +1415,9 @@ func (p *FoundryProvisioningProvider) resolveBrownfieldTarget(ctx context.Contex
 
 // envValue reads a single value from the active azd environment, trimmed.
 func (p *FoundryProvisioningProvider) envValue(ctx context.Context, key string) (string, error) {
+	if value := strings.TrimSpace(p.virtualEnv[key]); value != "" {
+		return value, nil
+	}
 	resp, err := p.azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
 		EnvName: p.envName,
 		Key:     key,
@@ -1297,9 +1462,10 @@ func (p *FoundryProvisioningProvider) resolveTemplate(
 ) (*templateSource, error) {
 	if p.onDiskSource == nil && p.onDiskTemplatePresent() {
 		progress("Compiling on-disk Bicep templates...")
-		src, err := loadOnDiskTemplateWithEnvironment(
+		src, err := loadOnDiskTemplateAtWithEnvironment(
 			ctx,
-			p.projectPath,
+			p.onDiskInfraPath(),
+			p.onDiskModuleName(),
 			p.bicepCli(),
 			onDiskEnvironment{
 				project:           p.envValues(ctx),
@@ -1337,7 +1503,8 @@ func (p *FoundryProvisioningProvider) resolveTemplate(
 		return nil, exterrors.Validation(
 			exterrors.CodeOnDiskTemplateMissing,
 			"on-disk Bicep template is no longer present and no embedded template is loaded",
-			"restore infra/main.bicep (or main.bicepparam) or re-run init without --infra",
+			fmt.Sprintf("restore %s (or its .bicepparam file) or re-run init without --infra",
+				filepath.Join(p.onDiskInfraPath(), p.onDiskModuleName()+".bicep")),
 		)
 	}
 
@@ -1381,8 +1548,14 @@ func (p *FoundryProvisioningProvider) envValues(ctx context.Context) map[string]
 		envKeySubscriptionID: p.subID,
 		envKeyLocation:       p.location,
 		envKeyResourceGroup:  p.rgName,
+		envKeyFoundryRG:      p.rgName,
 		envKeyProjectName:    p.foundryName,
 		envKeyPrincipalID:    p.principalID,
+	}
+	for key, value := range p.virtualEnv {
+		if _, canonical := out[key]; !canonical {
+			out[key] = value
+		}
 	}
 	// Also surface the broader azd env. Best-effort: fall back to the
 	// canonical values above if the env service is unavailable.
@@ -1484,7 +1657,10 @@ func (p *FoundryProvisioningProvider) Preview(
 //     deleting, mirroring the built-in bicep provider. Under --no-prompt (or
 //     with no azd host attached) there is nothing to prompt, so deletion falls
 //     back to requiring an explicit --force choice via a structured error.
-//   - Force == true: delete every model deployment under the resource group's
+//   - A named infra.layers entry uses its isolated Foundry resource group, so
+//     teardown cannot remove resources owned by sibling layers.
+//   - Force == true on the legacy root provider: delete every model deployment
+//     under the resource group's
 //     Cognitive Services accounts, then delete the resource group (Foundry
 //     account, project, and any ACR). Deployments must go first: Azure refuses
 //     to delete an account that still has them, which would roll the RG delete
@@ -1513,19 +1689,32 @@ func (p *FoundryProvisioningProvider) Destroy(
 		return &azdext.ProvisioningDestroyResult{}, nil
 	}
 
-	// Fail closed when AZURE_RESOURCE_GROUP was never set: rgName is the rg-<env>
+	// Fail closed when the active resource-group key was never set: rgName is the rg-<env>
 	// default the provider made up, not a group it provisioned. Deleting it could
 	// wipe an unrelated group that happens to match a common env name like "dev".
 	// Check this before prompting so we never ask the user to confirm a deletion
 	// we are going to refuse anyway.
 	if !p.rgExplicit {
+		rgKey := envKeyResourceGroup
+		if p.isLayer {
+			rgKey = envKeyFoundryRG
+		}
 		return nil, exterrors.Validation(
 			exterrors.CodeMissingResourceGroup,
 			fmt.Sprintf("%s is not set, so this provider has no record of a resource group "+
-				"it provisioned; refusing to delete the assumed default %q", envKeyResourceGroup, p.rgName),
+				"it provisioned; refusing to delete the assumed default %q", rgKey, p.rgName),
 			fmt.Sprintf("set the group to delete with `azd env set %s <name>` if it was provisioned here",
-				envKeyResourceGroup),
+				rgKey),
 		)
+	}
+	if p.isLayer {
+		client, err := p.deploymentsClient(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if err := verifyLayerResourceGroupOwnership(ctx, client, p.deploymentName(), p.subID, p.rgName); err != nil {
+			return nil, err
+		}
 	}
 
 	if !options.GetForce() {
@@ -1537,7 +1726,6 @@ func (p *FoundryProvisioningProvider) Destroy(
 			return nil, exterrors.Cancelled("destroy cancelled")
 		}
 	}
-
 	if err := p.ensureCredential(ctx); err != nil {
 		return nil, err
 	}
@@ -1820,6 +2008,7 @@ func invalidatedEnvKeysResult() *azdext.ProvisioningDestroyResult {
 			"AZURE_AI_PROJECT_ACR_CONNECTION_NAME",
 			"AZURE_AI_PROJECT_CONNECTION_NAMES",
 			"AZURE_AI_PROJECT_CONNECTIONS_PROJECT_ENDPOINT",
+			"AZURE_FOUNDRY_RESOURCE_GROUP",
 		},
 	}
 }
@@ -1852,6 +2041,9 @@ func (p *FoundryProvisioningProvider) PlannedOutputs(
 ) ([]*azdext.ProvisioningPlannedOutput, error) {
 	out := make([]*azdext.ProvisioningPlannedOutput, 0, len(canonicalOutputNames))
 	for _, name := range canonicalOutputNames {
+		if p.isLayer && name == envKeyResourceGroup {
+			continue
+		}
 		out = append(out, &azdext.ProvisioningPlannedOutput{Name: name})
 	}
 	return out, nil
@@ -1859,9 +2051,7 @@ func (p *FoundryProvisioningProvider) PlannedOutputs(
 
 // canonicalOutputNames is the source of truth for the env-var names the
 // foundry deployment populates. Names must match the `output <NAME>`
-// declarations in internal/synthesis/templates/main.bicep (including
-// AZURE_RESOURCE_GROUP, which the subscription-scoped template emits as the
-// name of the resource group it creates).
+// declarations in internal/synthesis/templates/main.bicep.
 //
 // ARM's management SDK mangles output-name casing (e.g. AZURE_AI_PROJECT_ID
 // comes back as azurE_AI_PROJECT_ID). armOutputsToProto restores the
@@ -1871,6 +2061,7 @@ var canonicalOutputNames = []string{
 	"AZURE_AI_ACCOUNT_NAME",
 	"AZURE_AI_PROJECT_NAME",
 	"AZURE_RESOURCE_GROUP",
+	"AZURE_FOUNDRY_RESOURCE_GROUP",
 	"AZURE_OPENAI_ENDPOINT",
 	"FOUNDRY_PROJECT_ENDPOINT",
 	"AZURE_CONTAINER_REGISTRY_ENDPOINT",
@@ -1903,6 +2094,8 @@ func (p *FoundryProvisioningProvider) deploymentsClient(ctx context.Context) (*a
 // deploymentName is stable per azd env and capped at ARM's 64-character limit.
 // The project-path hash separates projects sharing an env name; an env-name hash
 // preserves that identity when the readable env-name segment must be truncated.
+// Hashing the project root rather than the layer path keeps the name stable
+// across a root-to-layer migration.
 func (p *FoundryProvisioningProvider) deploymentName() string {
 	pathHash := fnv.New32a()
 	_, _ = pathHash.Write([]byte(p.projectPath))
@@ -2066,6 +2259,114 @@ func deploymentOutputs(p *armresources.DeploymentPropertiesExtended) any {
 		return nil
 	}
 	return p.Outputs
+}
+
+type subscriptionDeploymentGetter interface {
+	GetAtSubscriptionScope(
+		context.Context,
+		string,
+		*armresources.DeploymentsClientGetAtSubscriptionScopeOptions,
+	) (armresources.DeploymentsClientGetAtSubscriptionScopeResponse, error)
+}
+
+func verifyLayerResourceGroupOwnership(
+	ctx context.Context,
+	client subscriptionDeploymentGetter,
+	deploymentName, subscriptionID, resourceGroup string,
+) error {
+	resp, err := client.GetAtSubscriptionScope(ctx, deploymentName, nil)
+	if err != nil {
+		if !isNotFound(err) {
+			return exterrors.ServiceFromAzure(err, exterrors.OpArmDeploymentGet)
+		}
+		return layerResourceGroupOwnershipError(resourceGroup, "the Foundry deployment was not found")
+	}
+
+	wantedID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", subscriptionID, resourceGroup)
+	for _, resource := range deploymentResources(resp.Properties) {
+		if resource != nil && resource.ID != nil && strings.EqualFold(strings.TrimSuffix(*resource.ID, "/"), wantedID) {
+			return nil
+		}
+	}
+	return layerResourceGroupOwnershipError(
+		resourceGroup,
+		"the Foundry deployment does not record that it created this resource group",
+	)
+}
+
+func layerResourceGroupOwnershipError(resourceGroup, reason string) error {
+	return exterrors.Validation(
+		exterrors.CodeMissingResourceGroup,
+		fmt.Sprintf("refusing to delete Foundry layer resource group %q: %s", resourceGroup, reason),
+		"restore the original Foundry deployment state or delete only resources you have verified manually",
+	)
+}
+
+func validateFoundryProviderLayers(rawYAML []byte) error {
+	config, err := parseFoundryInfraConfig(rawYAML)
+	if err != nil {
+		return exterrors.Validation(
+			exterrors.CodeInvalidAzureYaml,
+			fmt.Sprintf("parse azure.yaml infrastructure layers: %s", err),
+			"verify azure.yaml is valid YAML",
+		)
+	}
+
+	if config.hasLayers && config.rootProvider == FoundryProviderName {
+		return exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			fmt.Sprintf("infra.provider is %q while infra.layers is also declared; the root Foundry provider "+
+				"cannot be combined with named layers", FoundryProviderName),
+			"move existing infrastructure into explicitly named layers with their own providers, then keep one "+
+				"Foundry layer using microsoft.foundry",
+		)
+	}
+	if len(config.foundryLayers) > 1 {
+		return exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			fmt.Sprintf("multiple infrastructure layers use provider %q: %s",
+				FoundryProviderName, strings.Join(config.foundryLayers, ", ")),
+			"use microsoft.foundry for only one infrastructure layer",
+		)
+	}
+	return nil
+}
+
+type foundryInfraConfig struct {
+	rootProvider  string
+	foundryLayers []string
+	hasLayers     bool
+}
+
+func parseFoundryInfraConfig(rawYAML []byte) (foundryInfraConfig, error) {
+	var doc struct {
+		Infra struct {
+			Provider string `yaml:"provider"`
+			Layers   []struct {
+				Name     string `yaml:"name"`
+				Provider string `yaml:"provider"`
+			} `yaml:"layers"`
+		} `yaml:"infra"`
+	}
+	if err := yaml.Unmarshal(rawYAML, &doc); err != nil {
+		return foundryInfraConfig{}, err
+	}
+
+	config := foundryInfraConfig{
+		rootProvider: strings.TrimSpace(doc.Infra.Provider),
+		hasLayers:    len(doc.Infra.Layers) > 0,
+	}
+	config.foundryLayers = make([]string, 0, len(doc.Infra.Layers))
+	for _, layer := range doc.Infra.Layers {
+		provider := strings.TrimSpace(layer.Provider)
+		if provider == "" {
+			provider = config.rootProvider
+		}
+		if provider == FoundryProviderName {
+			config.foundryLayers = append(config.foundryLayers, layer.Name)
+		}
+	}
+	return config, nil
 }
 
 // deploymentResources returns OutputResources from a possibly-nil properties.

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider_resolveenv_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider_resolveenv_test.go
@@ -144,6 +144,44 @@ func TestResolveEnv_PromptsAndPersistsSubscriptionAndLocation(t *testing.T) {
 		"location should be persisted to the azd environment")
 }
 
+func TestResolveEnv_UsesVirtualEnvFromPreviousLayer(t *testing.T) {
+	env := &resolveEnvStubEnvServer{envName: "foundry-layer", get: map[string]string{}}
+	prompt := &resolveEnvStubPromptServer{}
+	client := newResolveEnvTestClient(t, env, prompt)
+
+	p := &FoundryProvisioningProvider{
+		azdClient: client,
+		isLayer:   true,
+		virtualEnv: map[string]string{
+			envKeySubscriptionID: "00000000-0000-0000-0000-000000000001",
+			envKeyLocation:       "westus2",
+			envKeyFoundryRG:      "rg-platform-foundry",
+		},
+	}
+	require.NoError(t, p.resolveEnv(t.Context()))
+
+	assert.Equal(t, "00000000-0000-0000-0000-000000000001", p.subID)
+	assert.Equal(t, "westus2", p.location)
+	assert.Equal(t, "rg-platform-foundry", p.rgName)
+	assert.Zero(t, prompt.subscriptionN)
+	assert.Zero(t, prompt.locationN)
+}
+
+func TestResolveEnv_LayerDefaultResourceGroupIsNotPersistedOrOwned(t *testing.T) {
+	env := &resolveEnvStubEnvServer{envName: "foundry-layer", get: map[string]string{
+		envKeySubscriptionID: "00000000-0000-0000-0000-000000000001",
+		envKeyLocation:       "westus2",
+	}}
+	client := newResolveEnvTestClient(t, env, &resolveEnvStubPromptServer{})
+
+	p := &FoundryProvisioningProvider{azdClient: client, isLayer: true}
+	require.NoError(t, p.resolveEnv(t.Context()))
+
+	assert.Equal(t, "rg-foundry-layer-foundry", p.rgName)
+	assert.False(t, p.rgExplicit)
+	assert.NotContains(t, env.set, envKeyFoundryRG)
+}
+
 func TestResolveEnv_NoPromptSubscriptionReturnsActionableError(t *testing.T) {
 	// Under `--no-prompt` the azd host returns a "prompt required" error. The
 	// provider must surface an actionable suggestion naming the env var so CI
@@ -288,6 +326,29 @@ func TestResolveEnv_LocationReadErrorSurfaces(t *testing.T) {
 	var local *azdext.LocalError
 	require.ErrorAs(t, err, &local)
 	assert.Equal(t, exterrors.CodeEnvironmentValuesFailed, local.Code)
+}
+
+func TestResolveEnv_OptionalValueReadErrorsSurface(t *testing.T) {
+	for _, key := range []string{envKeyFoundryRG, envKeyProjectName, envKeyPrincipalID} {
+		t.Run(key, func(t *testing.T) {
+			env := &resolveEnvStubEnvServer{
+				envName: "foundry-layer",
+				get: map[string]string{
+					envKeySubscriptionID: "00000000-0000-0000-0000-000000000001",
+					envKeyLocation:       "westus2",
+				},
+				getErr: map[string]error{key: status.Error(codes.Internal, "env read failed")},
+			}
+			client := newResolveEnvTestClient(t, env, &resolveEnvStubPromptServer{})
+			p := &FoundryProvisioningProvider{azdClient: client, isLayer: true}
+
+			err := p.resolveEnv(t.Context())
+			require.Error(t, err)
+			var local *azdext.LocalError
+			require.ErrorAs(t, err, &local)
+			assert.Equal(t, exterrors.CodeEnvironmentValuesFailed, local.Code)
+		})
+	}
 }
 
 func TestResolveEnv_EmptyLocationResponseReturnsError(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider_resolveenv_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider_resolveenv_test.go
@@ -167,6 +167,21 @@ func TestResolveEnv_UsesVirtualEnvFromPreviousLayer(t *testing.T) {
 	assert.Zero(t, prompt.locationN)
 }
 
+func TestResolveEnv_LoadsLayerResourceGroupOwnership(t *testing.T) {
+	const ownerID = "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg-platform-foundry"
+	env := &resolveEnvStubEnvServer{envName: "foundry-layer", get: map[string]string{
+		envKeySubscriptionID: "00000000-0000-0000-0000-000000000001",
+		envKeyLocation:       "westus2",
+		envKeyFoundryRG:      "rg-platform-foundry",
+		envKeyFoundryRGOwner: ownerID,
+	}}
+	client := newResolveEnvTestClient(t, env, &resolveEnvStubPromptServer{})
+	p := &FoundryProvisioningProvider{azdClient: client, isLayer: true}
+
+	require.NoError(t, p.resolveEnv(t.Context()))
+	assert.Equal(t, ownerID, p.foundryRGOwnerID)
+}
+
 func TestResolveEnv_LayerDefaultResourceGroupIsNotPersistedOrOwned(t *testing.T) {
 	env := &resolveEnvStubEnvServer{envName: "foundry-layer", get: map[string]string{
 		envKeySubscriptionID: "00000000-0000-0000-0000-000000000001",
@@ -329,7 +344,7 @@ func TestResolveEnv_LocationReadErrorSurfaces(t *testing.T) {
 }
 
 func TestResolveEnv_OptionalValueReadErrorsSurface(t *testing.T) {
-	for _, key := range []string{envKeyFoundryRG, envKeyProjectName, envKeyPrincipalID} {
+	for _, key := range []string{envKeyFoundryRG, envKeyFoundryRGOwner, envKeyProjectName, envKeyPrincipalID} {
 		t.Run(key, func(t *testing.T) {
 			env := &resolveEnvStubEnvServer{
 				envName: "foundry-layer",

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider_test.go
@@ -689,6 +689,45 @@ func TestVerifyLayerResourceGroupOwnership(t *testing.T) {
 	}
 }
 
+func TestVerifyLayerResourceGroupTags(t *testing.T) {
+	require.NoError(t, verifyLayerResourceGroupTags(
+		map[string]*string{"azd-env-name": new("dev")}, "dev", "rg-foundry"))
+	require.NoError(t, verifyLayerResourceGroupTags(
+		map[string]*string{"AZD-ENV-NAME": new("dev")}, "dev", "rg-foundry"))
+
+	for _, tags := range []map[string]*string{
+		nil,
+		{"azd-env-name": nil},
+		{"azd-env-name": new("prod")},
+	} {
+		err := verifyLayerResourceGroupTags(tags, "dev", "rg-foundry")
+		require.Error(t, err)
+		var local *azdext.LocalError
+		require.ErrorAs(t, err, &local)
+		assert.Contains(t, local.Message, "not tagged")
+	}
+}
+
+func TestResolveLayerResourceGroupOwnership(t *testing.T) {
+	const (
+		subscriptionID = "00000000-0000-0000-0000-000000000001"
+		resourceGroup  = "rg-foundry"
+	)
+	ownedID := "/subscriptions/" + subscriptionID + "/resourceGroups/" + resourceGroup
+	properties := &armresources.DeploymentPropertiesExtended{
+		OutputResources: []*armresources.ResourceReference{{ID: new(ownedID)}},
+	}
+
+	assert.Equal(t, ownedID, resolveLayerResourceGroupOwnership(
+		ownedID, subscriptionID, resourceGroup, true, nil), "repeat provision preserves ownership")
+	assert.Empty(t, resolveLayerResourceGroupOwnership(
+		"/subscriptions/other/resourceGroups/old", subscriptionID, resourceGroup, true, properties),
+		"changing to an existing group must clear stale ownership")
+	assert.Equal(t, ownedID, resolveLayerResourceGroupOwnership(
+		"/subscriptions/other/resourceGroups/old", subscriptionID, resourceGroup, false, properties),
+		"changing to an absent group may establish ownership after creation")
+}
+
 func TestValidateFoundryProviderLayers(t *testing.T) {
 	require.NoError(t, validateFoundryProviderLayers([]byte(`infra:
   provider: bicep

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider_test.go
@@ -4,7 +4,6 @@
 package provisioning
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -23,19 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type stubSubscriptionDeploymentGetter struct {
-	resp armresources.DeploymentsClientGetAtSubscriptionScopeResponse
-	err  error
-}
-
-func (s *stubSubscriptionDeploymentGetter) GetAtSubscriptionScope(
-	context.Context,
-	string,
-	*armresources.DeploymentsClientGetAtSubscriptionScopeOptions,
-) (armresources.DeploymentsClientGetAtSubscriptionScopeResponse, error) {
-	return s.resp, s.err
-}
 
 func TestFindFoundryProjectService(t *testing.T) {
 	tests := []struct {
@@ -670,35 +656,31 @@ func TestVerifyLayerResourceGroupOwnership(t *testing.T) {
 		subscriptionID = "00000000-0000-0000-0000-000000000001"
 		resourceGroup  = "rg-foundry"
 	)
-	response := func(ids ...string) armresources.DeploymentsClientGetAtSubscriptionScopeResponse {
+	properties := func(ids ...string) *armresources.DeploymentPropertiesExtended {
 		resources := make([]*armresources.ResourceReference, 0, len(ids))
 		for _, id := range ids {
 			resources = append(resources, &armresources.ResourceReference{ID: new(id)})
 		}
-		return armresources.DeploymentsClientGetAtSubscriptionScopeResponse{
-			DeploymentExtended: armresources.DeploymentExtended{
-				Properties: &armresources.DeploymentPropertiesExtended{OutputResources: resources},
-			},
-		}
+		return &armresources.DeploymentPropertiesExtended{OutputResources: resources}
 	}
 
 	ownedID := "/subscriptions/" + subscriptionID + "/resourceGroups/" + resourceGroup
-	require.NoError(t, verifyLayerResourceGroupOwnership(
-		t.Context(), &stubSubscriptionDeploymentGetter{resp: response(ownedID)},
-		"deployment", subscriptionID, resourceGroup))
+	assert.Equal(t, ownedID, ownedLayerResourceGroupID(properties(ownedID), subscriptionID, resourceGroup))
+	require.NoError(t, verifyLayerResourceGroupOwnership(ownedID, subscriptionID, resourceGroup))
+	require.NoError(t, verifyLayerResourceGroupOwnership(strings.ToUpper(ownedID)+"/", subscriptionID, resourceGroup))
 
 	for _, tt := range []struct {
-		name string
-		resp armresources.DeploymentsClientGetAtSubscriptionScopeResponse
+		name    string
+		ownerID string
+		props   *armresources.DeploymentPropertiesExtended
 	}{
-		{name: "no output resources"},
-		{name: "only resources inside group", resp: response(ownedID + "/providers/Microsoft.Storage/storageAccounts/a")},
-		{name: "different group", resp: response("/subscriptions/" + subscriptionID + "/resourceGroups/other")},
+		{name: "no ownership marker"},
+		{name: "only resource inside group", props: properties(ownedID + "/providers/Microsoft.Storage/storageAccounts/a")},
+		{name: "different group", ownerID: "/subscriptions/" + subscriptionID + "/resourceGroups/other"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			err := verifyLayerResourceGroupOwnership(
-				t.Context(), &stubSubscriptionDeploymentGetter{resp: tt.resp},
-				"deployment", subscriptionID, resourceGroup)
+			assert.Empty(t, ownedLayerResourceGroupID(tt.props, subscriptionID, resourceGroup))
+			err := verifyLayerResourceGroupOwnership(tt.ownerID, subscriptionID, resourceGroup)
 			require.Error(t, err)
 			var local *azdext.LocalError
 			require.ErrorAs(t, err, &local)
@@ -727,6 +709,25 @@ func TestValidateFoundryProviderLayers(t *testing.T) {
 	require.ErrorAs(t, err, &local)
 	assert.Equal(t, exterrors.CodeInvalidServiceConfig, local.Code)
 	assert.Contains(t, local.Message, "root Foundry provider")
+}
+
+func TestFoundryInfraConfig_HasFoundryLayer(t *testing.T) {
+	root, err := parseFoundryInfraConfig([]byte(`infra:
+  name: root-name
+  provider: microsoft.foundry
+`))
+	require.NoError(t, err)
+	assert.False(t, root.hasFoundryLayer("root-name"))
+
+	layered, err := parseFoundryInfraConfig([]byte(`infra:
+  provider: bicep
+  layers:
+    - name: foundry
+      provider: microsoft.foundry
+`))
+	require.NoError(t, err)
+	assert.True(t, layered.hasFoundryLayer("foundry"))
+	assert.False(t, layered.hasFoundryLayer(""))
 }
 
 func TestEncodeParamValue(t *testing.T) {
@@ -1312,13 +1313,17 @@ func TestWithTenantOutput(t *testing.T) {
 
 func TestNormalizeOutputs_LayerOmitsRootResourceGroup(t *testing.T) {
 	t.Parallel()
-	p := &FoundryProvisioningProvider{isLayer: true}
+	p := &FoundryProvisioningProvider{
+		isLayer:          true,
+		foundryRGOwnerID: "/subscriptions/sub/resourceGroups/rg-foundry",
+	}
 	got := p.normalizeOutputs(map[string]*azdext.ProvisioningOutputParameter{
 		envKeyResourceGroup: {Type: "string", Value: "rg-foundry"},
 		envKeyFoundryRG:     {Type: "string", Value: "rg-foundry"},
 	})
 	assert.NotContains(t, got, envKeyResourceGroup)
 	assert.Contains(t, got, envKeyFoundryRG)
+	assert.Equal(t, p.foundryRGOwnerID, got[envKeyFoundryRGOwner].Value)
 }
 
 func TestEnvValues_IncludesCanonicalKeysEvenWithoutAzdClient(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider_test.go
@@ -1365,6 +1365,14 @@ func TestNormalizeOutputs_LayerOmitsRootResourceGroup(t *testing.T) {
 	assert.Equal(t, p.foundryRGOwnerID, got[envKeyFoundryRGOwner].Value)
 }
 
+func TestNormalizeOutputs_LayerClearsStaleResourceGroupOwnership(t *testing.T) {
+	t.Parallel()
+	p := &FoundryProvisioningProvider{isLayer: true}
+	got := p.normalizeOutputs(nil)
+	require.Contains(t, got, envKeyFoundryRGOwner)
+	assert.Equal(t, "", got[envKeyFoundryRGOwner].Value)
+}
+
 func TestEnvValues_IncludesCanonicalKeysEvenWithoutAzdClient(t *testing.T) {
 	t.Parallel()
 	// envValues must always include the canonical AZURE_* keys

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/foundry_provisioning_provider_test.go
@@ -4,6 +4,7 @@
 package provisioning
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -22,6 +23,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type stubSubscriptionDeploymentGetter struct {
+	resp armresources.DeploymentsClientGetAtSubscriptionScopeResponse
+	err  error
+}
+
+func (s *stubSubscriptionDeploymentGetter) GetAtSubscriptionScope(
+	context.Context,
+	string,
+	*armresources.DeploymentsClientGetAtSubscriptionScopeOptions,
+) (armresources.DeploymentsClientGetAtSubscriptionScopeResponse, error) {
+	return s.resp, s.err
+}
 
 func TestFindFoundryProjectService(t *testing.T) {
 	tests := []struct {
@@ -617,6 +631,7 @@ func TestDeploymentName_StableForEnv(t *testing.T) {
 	// Different project paths sharing an env name must not collide.
 	other := &FoundryProvisioningProvider{envName: "dev", projectPath: "/proj/b"}
 	assert.NotEqual(t, first, other.deploymentName())
+
 }
 
 func TestDeploymentName_LongEnvironmentName(t *testing.T) {
@@ -648,6 +663,70 @@ func TestDeploymentOutputsResources_NilSafe(t *testing.T) {
 	}
 	assert.NotNil(t, deploymentOutputs(props))
 	assert.Len(t, deploymentResources(props), 1)
+}
+
+func TestVerifyLayerResourceGroupOwnership(t *testing.T) {
+	const (
+		subscriptionID = "00000000-0000-0000-0000-000000000001"
+		resourceGroup  = "rg-foundry"
+	)
+	response := func(ids ...string) armresources.DeploymentsClientGetAtSubscriptionScopeResponse {
+		resources := make([]*armresources.ResourceReference, 0, len(ids))
+		for _, id := range ids {
+			resources = append(resources, &armresources.ResourceReference{ID: new(id)})
+		}
+		return armresources.DeploymentsClientGetAtSubscriptionScopeResponse{
+			DeploymentExtended: armresources.DeploymentExtended{
+				Properties: &armresources.DeploymentPropertiesExtended{OutputResources: resources},
+			},
+		}
+	}
+
+	ownedID := "/subscriptions/" + subscriptionID + "/resourceGroups/" + resourceGroup
+	require.NoError(t, verifyLayerResourceGroupOwnership(
+		t.Context(), &stubSubscriptionDeploymentGetter{resp: response(ownedID)},
+		"deployment", subscriptionID, resourceGroup))
+
+	for _, tt := range []struct {
+		name string
+		resp armresources.DeploymentsClientGetAtSubscriptionScopeResponse
+	}{
+		{name: "no output resources"},
+		{name: "only resources inside group", resp: response(ownedID + "/providers/Microsoft.Storage/storageAccounts/a")},
+		{name: "different group", resp: response("/subscriptions/" + subscriptionID + "/resourceGroups/other")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifyLayerResourceGroupOwnership(
+				t.Context(), &stubSubscriptionDeploymentGetter{resp: tt.resp},
+				"deployment", subscriptionID, resourceGroup)
+			require.Error(t, err)
+			var local *azdext.LocalError
+			require.ErrorAs(t, err, &local)
+			assert.Contains(t, local.Message, "refusing to delete")
+		})
+	}
+}
+
+func TestValidateFoundryProviderLayers(t *testing.T) {
+	require.NoError(t, validateFoundryProviderLayers([]byte(`infra:
+  provider: bicep
+  layers:
+    - name: app
+      provider: bicep
+    - name: foundry
+      provider: microsoft.foundry
+`)))
+
+	err := validateFoundryProviderLayers([]byte(`infra:
+  provider: microsoft.foundry
+  layers:
+    - name: first
+`))
+	require.Error(t, err)
+	var local *azdext.LocalError
+	require.ErrorAs(t, err, &local)
+	assert.Equal(t, exterrors.CodeInvalidServiceConfig, local.Code)
+	assert.Contains(t, local.Message, "root Foundry provider")
 }
 
 func TestEncodeParamValue(t *testing.T) {
@@ -888,7 +967,7 @@ func TestOnDiskTemplatePresent(t *testing.T) {
 	// main.bicep alone: true.
 	bicepDir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(bicepDir, onDiskInfraDir), 0o750))
-	require.NoError(t, os.WriteFile(filepath.Join(bicepDir, onDiskInfraDir, onDiskBicepFile), []byte("// b"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(bicepDir, onDiskInfraDir, onDiskModule+".bicep"), []byte("// b"), 0o600))
 	p = &FoundryProvisioningProvider{projectPath: bicepDir}
 	assert.True(t, p.onDiskTemplatePresent(),
 		"main.bicep present -> true")
@@ -896,11 +975,38 @@ func TestOnDiskTemplatePresent(t *testing.T) {
 	// main.bicepparam alone: true.
 	bicepparamDir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(bicepparamDir, onDiskInfraDir), 0o750))
-	bicepparamPath := filepath.Join(bicepparamDir, onDiskInfraDir, onDiskBicepParamFile)
+	bicepparamPath := filepath.Join(bicepparamDir, onDiskInfraDir, onDiskModule+".bicepparam")
 	require.NoError(t, os.WriteFile(bicepparamPath, []byte("// bp"), 0o600))
 	p = &FoundryProvisioningProvider{projectPath: bicepparamDir}
 	assert.True(t, p.onDiskTemplatePresent(),
 		"main.bicepparam present -> true")
+
+	// Layer path/module override: the provider must not fall back to root infra.
+	customDir := t.TempDir()
+	layerDir := filepath.Join(customDir, "infra", "foundry")
+	require.NoError(t, os.MkdirAll(layerDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(layerDir, "project.bicep"), []byte("// b"), 0o600))
+	p = &FoundryProvisioningProvider{
+		projectPath: customDir,
+		infraPath:   layerDir,
+		infraModule: "project",
+	}
+	assert.True(t, p.onDiskTemplatePresent(), "custom layer path and module -> true")
+}
+
+func TestInitialize_RejectsAbsoluteLayerPath(t *testing.T) {
+	t.Parallel()
+	projectRoot := t.TempDir()
+	p := &FoundryProvisioningProvider{}
+	err := p.Initialize(t.Context(), projectRoot, &azdext.ProvisioningOptions{
+		Provider: FoundryProviderName,
+		Path:     filepath.Join(projectRoot, "infra", "foundry"),
+	})
+	require.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeInvalidServiceConfig, localErr.Code)
+	assert.Contains(t, localErr.Message, "project-relative")
 }
 
 func TestResolveTemplate_FallsBackToEmbeddedWhenNoOnDisk(t *testing.T) {
@@ -944,7 +1050,7 @@ func TestResolveTemplate_PrefersOnDiskWhenPresent(t *testing.T) {
 	dir := t.TempDir()
 	infraDir := filepath.Join(dir, onDiskInfraDir)
 	require.NoError(t, os.MkdirAll(infraDir, 0o750))
-	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskBicepFile),
+	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskModule+".bicep"),
 		[]byte("// fake bicep, never actually compiled by the stub"), 0o600))
 
 	// Plant a user parameters file with one literal value so we can
@@ -957,7 +1063,7 @@ func TestResolveTemplate_PrefersOnDiskWhenPresent(t *testing.T) {
     "userOnly": { "value": "from-user" }
   }
 }`
-	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskParamsFile), []byte(params), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskModule+".parameters.json"), []byte(params), 0o600))
 
 	// Pre-bake the on-disk source so we don't need a live bicep CLI.
 	// (resolveTemplate skips the loadOnDiskTemplate call when
@@ -981,7 +1087,7 @@ func TestResolveTemplate_PrefersOnDiskWhenPresent(t *testing.T) {
 				"location": map[string]any{"value": "user-supplied-location"},
 				"userOnly": map[string]any{"value": "from-user"},
 			},
-			sourcePath: filepath.Join(infraDir, onDiskBicepFile),
+			sourcePath: filepath.Join(infraDir, onDiskModule+".bicep"),
 		},
 	}
 
@@ -992,7 +1098,7 @@ func TestResolveTemplate_PrefersOnDiskWhenPresent(t *testing.T) {
 	assert.Equal(t, templateModeBicep, got.mode, "on-disk Bicep mode wins")
 	assert.Equal(t, "ondisk", got.armTemplate["$schema"],
 		"on-disk template is returned, not the embedded one")
-	assert.Equal(t, filepath.Join(infraDir, onDiskBicepFile), got.sourcePath)
+	assert.Equal(t, filepath.Join(infraDir, onDiskModule+".bicep"), got.sourcePath)
 
 	// Merge precedence: user wins on 'location'.
 	loc := got.parameters["location"].(map[string]any)
@@ -1204,6 +1310,17 @@ func TestWithTenantOutput(t *testing.T) {
 	})
 }
 
+func TestNormalizeOutputs_LayerOmitsRootResourceGroup(t *testing.T) {
+	t.Parallel()
+	p := &FoundryProvisioningProvider{isLayer: true}
+	got := p.normalizeOutputs(map[string]*azdext.ProvisioningOutputParameter{
+		envKeyResourceGroup: {Type: "string", Value: "rg-foundry"},
+		envKeyFoundryRG:     {Type: "string", Value: "rg-foundry"},
+	})
+	assert.NotContains(t, got, envKeyResourceGroup)
+	assert.Contains(t, got, envKeyFoundryRG)
+}
+
 func TestEnvValues_IncludesCanonicalKeysEvenWithoutAzdClient(t *testing.T) {
 	t.Parallel()
 	// envValues must always include the canonical AZURE_* keys
@@ -1217,14 +1334,21 @@ func TestEnvValues_IncludesCanonicalKeysEvenWithoutAzdClient(t *testing.T) {
 		rgName:      "my-rg",
 		foundryName: "fp",
 		principalID: "pid",
+		virtualEnv: map[string]string{
+			"PLATFORM_OUTPUT": "planned-value",
+			envKeyLocation:    "stale-planned-location",
+		},
 		// azdClient intentionally nil
 	}
 	got := p.envValues(t.Context())
 	assert.Equal(t, "sub-id", got[envKeySubscriptionID])
 	assert.Equal(t, "westus2", got[envKeyLocation])
 	assert.Equal(t, "my-rg", got[envKeyResourceGroup])
+	assert.Equal(t, "my-rg", got[envKeyFoundryRG])
 	assert.Equal(t, "fp", got[envKeyProjectName])
 	assert.Equal(t, "pid", got[envKeyPrincipalID])
+	assert.Equal(t, "planned-value", got["PLATFORM_OUTPUT"])
+	assert.Equal(t, "westus2", got[envKeyLocation], "canonical values take precedence over virtual env")
 }
 
 func TestCollectPurgeableAccounts(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/ondisk_template.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/ondisk_template.go
@@ -19,15 +19,14 @@ import (
 	"github.com/drone/envsubst"
 )
 
-// Hard-coded relative locations for the on-disk Bicep tree the user owns
-// after running `azd ai agent init --infra`. azure.yaml's infra.path /
-// infra.module overrides are deliberately not honored; the eject writer
-// hard-codes these same paths.
+// Default locations for the on-disk Bicep tree. A provisioning layer can
+// override both through its path and module options.
 const (
 	onDiskInfraDir       = "infra"
-	onDiskBicepFile      = "main.bicep"
-	onDiskBicepParamFile = "main.bicepparam"
-	onDiskParamsFile     = "main.parameters.json"
+	onDiskModule         = "main"
+	onDiskBicepFile      = onDiskModule + ".bicep"
+	onDiskBicepParamFile = onDiskModule + ".bicepparam"
+	onDiskParamsFile     = onDiskModule + ".parameters.json"
 )
 
 // templateMode records which on-disk source was used, for telemetry /
@@ -115,9 +114,45 @@ func loadOnDiskTemplateWithEnvironment(
 	compiler bicepCompiler,
 	environment onDiskEnvironment,
 ) (*templateSource, error) {
-	infraDir := filepath.Join(projectPath, onDiskInfraDir)
-	bicepparamPath := filepath.Join(infraDir, onDiskBicepParamFile)
-	bicepPath := filepath.Join(infraDir, onDiskBicepFile)
+	return loadOnDiskTemplateAtWithEnvironment(
+		ctx,
+		filepath.Join(projectPath, onDiskInfraDir),
+		onDiskModule,
+		compiler,
+		environment,
+	)
+}
+
+// loadOnDiskTemplateAt loads a Bicep module from an explicit provisioning
+// layer path and module name.
+func loadOnDiskTemplateAt(
+	ctx context.Context,
+	infraDir string,
+	module string,
+	compiler bicepCompiler,
+	envValues map[string]string,
+) (*templateSource, error) {
+	return loadOnDiskTemplateAtWithEnvironment(
+		ctx,
+		infraDir,
+		module,
+		compiler,
+		onDiskEnvironment{project: envValues},
+	)
+}
+
+func loadOnDiskTemplateAtWithEnvironment(
+	ctx context.Context,
+	infraDir string,
+	module string,
+	compiler bicepCompiler,
+	environment onDiskEnvironment,
+) (*templateSource, error) {
+	if module == "" {
+		module = onDiskModule
+	}
+	bicepparamPath := filepath.Join(infraDir, module+".bicepparam")
+	bicepPath := filepath.Join(infraDir, module+".bicep")
 
 	switch {
 	case fileExistsAt(bicepparamPath):
@@ -128,7 +163,7 @@ func loadOnDiskTemplateWithEnvironment(
 			environment.project,
 		)
 	case fileExistsAt(bicepPath):
-		paramsPath := filepath.Join(infraDir, onDiskParamsFile)
+		paramsPath := filepath.Join(infraDir, module+".parameters.json")
 		return loadFromBicep(
 			ctx,
 			bicepPath,

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/ondisk_template_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/ondisk_template_test.go
@@ -97,7 +97,7 @@ func TestLoadOnDiskTemplate_BicepOnly(t *testing.T) {
 	dir := t.TempDir()
 	infraDir := filepath.Join(dir, onDiskInfraDir)
 	require.NoError(t, os.MkdirAll(infraDir, 0o750))
-	bicepPath := filepath.Join(infraDir, onDiskBicepFile)
+	bicepPath := filepath.Join(infraDir, onDiskModule+".bicep")
 	require.NoError(t, os.WriteFile(bicepPath, []byte("// fake bicep\n"), 0o600))
 
 	stub := &stubCompiler{buildResult: bicep.BuildResult{Compiled: minimalARMTemplate()}}
@@ -124,14 +124,14 @@ func TestLoadOnDiskTemplate_BicepWithParams(t *testing.T) {
 	dir := t.TempDir()
 	infraDir := filepath.Join(dir, onDiskInfraDir)
 	require.NoError(t, os.MkdirAll(infraDir, 0o750))
-	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskBicepFile), []byte("// bicep\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskModule+".bicep"), []byte("// bicep\n"), 0o600))
 
 	params := minimalARMParametersFile(t, map[string]any{
 		"location":           "${AZURE_LOCATION}", // ${VAR} resolved
 		"foundryProjectName": "my-project",        // literal
 		"shouldDrop":         "${UNSET_VAR}",      // unresolved -> dropped
 	})
-	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskParamsFile), []byte(params), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskModule+".parameters.json"), []byte(params), 0o600))
 
 	stub := &stubCompiler{buildResult: bicep.BuildResult{Compiled: minimalARMTemplate()}}
 	envValues := map[string]string{"AZURE_LOCATION": "eastus"}
@@ -253,14 +253,33 @@ func TestLoadOnDiskTemplate_ConnectionServiceScopes(t *testing.T) {
 	assert.Equal(t, "project-key", asMap(credentials["legacy"])["key"])
 }
 
+func TestLoadOnDiskTemplateAt_CustomPathAndModule(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join(t.TempDir(), "infra", "foundry")
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	bicepPath := filepath.Join(dir, "project.bicep")
+	require.NoError(t, os.WriteFile(bicepPath, []byte("// custom module\n"), 0o600))
+	params := minimalARMParametersFile(t, map[string]any{"location": "eastus"})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "project.parameters.json"), []byte(params), 0o600))
+	stub := &stubCompiler{buildResult: bicep.BuildResult{Compiled: minimalARMTemplate()}}
+
+	got, err := loadOnDiskTemplateAt(t.Context(), dir, "project", stub, nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, bicepPath, got.sourcePath)
+	require.Len(t, stub.buildCalls, 1)
+	assert.Equal(t, bicepPath, stub.buildCalls[0])
+	require.Contains(t, got.parameters, "location")
+}
+
 func TestLoadOnDiskTemplate_BicepparamPrecedence(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	infraDir := filepath.Join(dir, onDiskInfraDir)
 	require.NoError(t, os.MkdirAll(infraDir, 0o750))
 	// Both .bicep and .bicepparam present; .bicepparam must win.
-	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskBicepFile), []byte("// bicep"), 0o600))
-	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskBicepParamFile), []byte("// bicepparam"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskModule+".bicep"), []byte("// bicep"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskModule+".bicepparam"), []byte("// bicepparam"), 0o600))
 
 	envelope, err := json.Marshal(map[string]string{
 		"templateJson": minimalARMTemplate(),
@@ -276,7 +295,7 @@ func TestLoadOnDiskTemplate_BicepparamPrecedence(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, templateModeBicepParam, got.mode)
-	assert.Equal(t, filepath.Join(infraDir, onDiskBicepParamFile), got.sourcePath)
+	assert.Equal(t, filepath.Join(infraDir, onDiskModule+".bicepparam"), got.sourcePath)
 
 	// .bicepparam path is taken exclusively.
 	require.Len(t, stub.buildParamCalls, 1)
@@ -296,7 +315,7 @@ func TestLoadOnDiskTemplate_CompileError(t *testing.T) {
 	dir := t.TempDir()
 	infraDir := filepath.Join(dir, onDiskInfraDir)
 	require.NoError(t, os.MkdirAll(infraDir, 0o750))
-	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskBicepFile), []byte("// broken bicep"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskModule+".bicep"), []byte("// broken bicep"), 0o600))
 
 	stub := &stubCompiler{buildErr: errors.New("bicep error BCP068: expected resource type string at line 3")}
 
@@ -319,7 +338,7 @@ func TestLoadOnDiskTemplate_InvalidJSONFromBicep(t *testing.T) {
 	dir := t.TempDir()
 	infraDir := filepath.Join(dir, onDiskInfraDir)
 	require.NoError(t, os.MkdirAll(infraDir, 0o750))
-	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskBicepFile), []byte("// bicep"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(infraDir, onDiskModule+".bicep"), []byte("// bicep"), 0o600))
 
 	// Bicep "succeeds" but returns junk (defensive case; shouldn't
 	// happen in practice, but we surface it clearly).

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/provisioning_provider.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/provisioning_provider.go
@@ -6,7 +6,7 @@ package provisioning
 import "slices"
 
 // FoundryProviderName is the value written to an infra provider field in
-// azure.yaml and looked up by azd's provider resolver to dispatch provisioning
+// azure.yaml and looked up by the azd provider resolver to dispatch provisioning
 // to this extension.
 const FoundryProviderName = "microsoft.foundry"
 

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/provisioning_provider.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/provisioning_provider.go
@@ -5,14 +5,14 @@ package provisioning
 
 import "slices"
 
-// FoundryProviderName is the value written to `infra.provider` in
-// azure.yaml by `azd ai agent init` and looked up by azd's provider
-// resolver to dispatch provisioning to this extension.
+// FoundryProviderName is the value written to an infra provider field in
+// azure.yaml and looked up by azd's provider resolver to dispatch provisioning
+// to this extension.
 const FoundryProviderName = "microsoft.foundry"
 
 // BicepProviderName and TerraformProviderName are azd-core's built-in
-// provisioning providers. `azd ai agent init --infra=terraform` stamps
-// TerraformProviderName onto azure.yaml so azd-core's Terraform provider
+// provisioning providers. `azd ai agent init --infra=terraform` uses
+// TerraformProviderName for the Foundry layer so azd-core's Terraform provider
 // (not this extension's microsoft.foundry provider) handles provisioning.
 const (
 	BicepProviderName     = "bicep"

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/resource_group_location_check.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/resource_group_location_check.go
@@ -6,6 +6,7 @@ package provisioning
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"azure.ai.projects/internal/azure"
@@ -87,7 +88,8 @@ func (c *ResourceGroupLocationCheck) Validate(
 	// installed) an existing resource group in a different region is perfectly
 	// valid, so running the check there would raise a false positive. Skip
 	// unless the current project actually provisions through microsoft.foundry.
-	if !c.usesFoundryProvider(ctx) {
+	usesFoundry, usesFoundryLayer := c.foundryProviderUsage(ctx)
+	if !usesFoundry {
 		return empty, nil
 	}
 
@@ -140,7 +142,14 @@ func (c *ResourceGroupLocationCheck) Validate(
 
 	resourceGroup, ok := valCtx.ResourceGroup()
 	resourceGroup = strings.TrimSpace(resourceGroup)
-	if !ok || resourceGroup == "" {
+	resourceGroupKey := envKeyResourceGroup
+	if usesFoundryLayer {
+		resourceGroupKey = envKeyFoundryRG
+		resourceGroup = envValueOrEmpty(ctx, envClient, envName, envKeyFoundryRG)
+		if resourceGroup == "" {
+			resourceGroup = defaultResourceGroupName(envName) + "-foundry"
+		}
+	} else if !ok || resourceGroup == "" {
 		resourceGroup = envValueOrEmpty(ctx, envClient, envName, "AZURE_RESOURCE_GROUP")
 	}
 	if resourceGroup == "" {
@@ -158,7 +167,13 @@ func (c *ResourceGroupLocationCheck) Validate(
 		return empty, nil
 	}
 
-	return evaluateResourceGroupLocation(resourceGroup, existingLocation, location, subscriptionID), nil
+	return evaluateResourceGroupLocation(
+		resourceGroup,
+		existingLocation,
+		location,
+		subscriptionID,
+		resourceGroupKey,
+	), nil
 }
 
 // armResourceGroupLocation is the production resourceGroupLocationLookup. It
@@ -209,7 +224,7 @@ func (c *ResourceGroupLocationCheck) armResourceGroupLocation(
 // differ. The comparison and message construction are isolated here so they can be
 // unit-tested without Azure access.
 func evaluateResourceGroupLocation(
-	resourceGroup, existingLocation, requestedLocation, subscriptionID string,
+	resourceGroup, existingLocation, requestedLocation, subscriptionID, resourceGroupKey string,
 ) *azdext.ValidationCheckResponse {
 	if strings.EqualFold(existingLocation, requestedLocation) {
 		return &azdext.ValidationCheckResponse{}
@@ -225,10 +240,10 @@ func evaluateResourceGroupLocation(
 	suggestion := fmt.Sprintf(
 		"Resolve the conflict before provisioning by choosing one of the following:\n"+
 			"  • Use the existing region:          azd env set AZURE_LOCATION %s\n"+
-			"  • Target a different resource group: azd env set AZURE_RESOURCE_GROUP <new-name>\n"+
+			"  • Target a different resource group: azd env set %s <new-name>\n"+
 			"  • Delete the resource group if it is no longer needed: "+
 			"az group delete --name %q --subscription %s",
-		existingLocation, resourceGroup, subscriptionID,
+		existingLocation, resourceGroupKey, resourceGroup, subscriptionID,
 	)
 
 	return &azdext.ValidationCheckResponse{
@@ -243,17 +258,31 @@ func evaluateResourceGroupLocation(
 	}
 }
 
-// usesFoundryProvider reports whether the current azd project provisions through
-// the microsoft.foundry provider (azure.yaml `infra.provider: microsoft.foundry`).
+// foundryProviderUsage reports whether the project uses microsoft.foundry and
+// whether that use comes from a named infrastructure layer.
 // It is best-effort: when the project configuration cannot be read it returns
-// false so the check is skipped rather than risk a false positive on a project
-// that has nothing to do with Foundry agents.
-func (c *ResourceGroupLocationCheck) usesFoundryProvider(ctx context.Context) bool {
+// the root provider reported by azd, or false when no reliable signal exists.
+func (c *ResourceGroupLocationCheck) foundryProviderUsage(ctx context.Context) (bool, bool) {
 	resp, err := c.azdClient.Project().Get(ctx, &azdext.EmptyRequest{})
 	if err != nil || resp.GetProject() == nil {
-		return false
+		return false, false
 	}
-	return resp.GetProject().GetInfra().GetProvider() == FoundryProviderName
+	rootProvider := resp.GetProject().GetInfra().GetProvider()
+	projectPath := resp.GetProject().GetPath()
+	if projectPath == "" || !filepath.IsAbs(projectPath) {
+		return rootProvider == FoundryProviderName, false
+	}
+	rawYAML, projectFile, err := readProjectFile(projectPath)
+	if err != nil || projectFile == "" {
+		return rootProvider == FoundryProviderName, false
+	}
+	config, err := parseFoundryInfraConfig(rawYAML)
+	if err != nil {
+		return rootProvider == FoundryProviderName, false
+	}
+	usesLayer := len(config.foundryLayers) > 0
+	usesRoot := config.rootProvider == FoundryProviderName && !config.hasLayers
+	return usesRoot || usesLayer, usesLayer
 }
 
 // isBrownfieldFoundryProject reports whether the current project's Foundry

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/resource_group_location_check_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/resource_group_location_check_test.go
@@ -18,19 +18,22 @@ func TestEvaluateResourceGroupLocation(t *testing.T) {
 	)
 
 	t.Run("matching regions produce no results", func(t *testing.T) {
-		resp := evaluateResourceGroupLocation(resourceGroup, "eastus", "eastus", subscriptionID)
+		resp := evaluateResourceGroupLocation(
+			resourceGroup, "eastus", "eastus", subscriptionID, envKeyResourceGroup)
 		require.NotNil(t, resp)
 		assert.Empty(t, resp.Results)
 	})
 
 	t.Run("region comparison is case-insensitive", func(t *testing.T) {
-		resp := evaluateResourceGroupLocation(resourceGroup, "EastUS", "eastus", subscriptionID)
+		resp := evaluateResourceGroupLocation(
+			resourceGroup, "EastUS", "eastus", subscriptionID, envKeyResourceGroup)
 		require.NotNil(t, resp)
 		assert.Empty(t, resp.Results)
 	})
 
 	t.Run("mismatched regions produce a blocking error result with guidance", func(t *testing.T) {
-		resp := evaluateResourceGroupLocation(resourceGroup, "eastus", "westus2", subscriptionID)
+		resp := evaluateResourceGroupLocation(
+			resourceGroup, "eastus", "westus2", subscriptionID, envKeyResourceGroup)
 		require.NotNil(t, resp)
 		require.Len(t, resp.Results, 1)
 
@@ -58,11 +61,21 @@ func TestEvaluateResourceGroupLocation(t *testing.T) {
 
 	t.Run("resource group name with shell metacharacters is quoted in the delete command", func(t *testing.T) {
 		const parenRG = "rg(test)"
-		resp := evaluateResourceGroupLocation(parenRG, "eastus", "westus2", subscriptionID)
+		resp := evaluateResourceGroupLocation(
+			parenRG, "eastus", "westus2", subscriptionID, envKeyResourceGroup)
 		require.NotNil(t, resp)
 		require.Len(t, resp.Results, 1)
 
 		// Without quoting, "az group delete --name rg(test)" is a shell syntax error.
 		assert.Contains(t, resp.Results[0].Suggestion, `az group delete --name "rg(test)"`)
+	})
+
+	t.Run("layer guidance uses the Foundry resource group key", func(t *testing.T) {
+		resp := evaluateResourceGroupLocation(
+			resourceGroup, "eastus", "westus2", subscriptionID, envKeyFoundryRG)
+		require.NotNil(t, resp)
+		require.Len(t, resp.Results, 1)
+		assert.Contains(t, resp.Results[0].Suggestion, "azd env set "+envKeyFoundryRG)
+		assert.NotContains(t, resp.Results[0].Suggestion, "azd env set "+envKeyResourceGroup+" ")
 	})
 }

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/resource_group_location_check_validate_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/resource_group_location_check_validate_test.go
@@ -89,7 +89,8 @@ func newValidateTestClient(
 func writeAzureYAML(t *testing.T, endpoint string) string {
 	t.Helper()
 	dir := t.TempDir()
-	body := "name: rgloc-test\nservices:\n  ai-project:\n    host: " + FoundryProjectHost + "\n"
+	body := "name: rgloc-test\ninfra:\n  provider: " + FoundryProviderName +
+		"\nservices:\n  ai-project:\n    host: " + FoundryProjectHost + "\n"
 	if endpoint != "" {
 		body += "    endpoint: " + endpoint + "\n"
 	}
@@ -118,11 +119,21 @@ func TestValidate_Gates(t *testing.T) {
 	const sub = "00000000-0000-0000-0000-000000000000"
 
 	t.Run("skips non-foundry provider without looking up the resource group", func(t *testing.T) {
+		dir := writeAzureYAML(t, "")
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte(`name: rgloc-test
+infra:
+  provider: bicep
+services:
+  ai-project:
+    host: azure.ai.project
+`), 0o600))
 		proj := &validateStubProjectServer{project: &azdext.ProjectConfig{
-			Path:  writeAzureYAML(t, ""),
+			Path:  dir,
 			Infra: &azdext.InfraOptions{Provider: "bicep"},
 		}}
-		env := &validateStubEnvServer{envName: "rgloc-test", get: map[string]string{}}
+		env := &validateStubEnvServer{envName: "rgloc-test", get: map[string]string{
+			envKeyFoundryRG: "rg-foundry-layer",
+		}}
 		client := newValidateTestClient(t, proj, env)
 
 		var called bool
@@ -273,6 +284,40 @@ services:
 		require.NoError(t, err)
 		assert.Empty(t, resp.Results)
 		assert.False(t, called, "lookup must not run without both subscription and location")
+	})
+
+	t.Run("runs for foundry provisioning layer", func(t *testing.T) {
+		dir := writeAzureYAML(t, "")
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte(`name: rgloc-test
+infra:
+  provider: bicep
+  layers:
+    - name: app
+      path: infra/app
+    - name: foundry
+      path: infra/foundry
+      provider: microsoft.foundry
+services:
+  ai-project:
+    host: azure.ai.project
+`), 0o600))
+		proj := &validateStubProjectServer{project: &azdext.ProjectConfig{
+			Path:  dir,
+			Infra: &azdext.InfraOptions{Provider: "bicep"},
+		}}
+		env := &validateStubEnvServer{envName: "rgloc-test", get: map[string]string{}}
+		client := newValidateTestClient(t, proj, env)
+
+		var called bool
+		c := &ResourceGroupLocationCheck{azdClient: client}
+		c.resourceGroupLocation = func(context.Context, string, string) (string, bool, error) {
+			called = true
+			return "eastus", true, nil
+		}
+
+		_, err := c.Validate(t.Context(), provisionContext(sub, "westus2", "rg-x"), &azdext.ValidationCheckRequest{})
+		require.NoError(t, err)
+		assert.True(t, called, "resource group lookup must run for a Foundry layer")
 	})
 }
 

--- a/cli/azd/extensions/azure.ai.projects/internal/synthesis/templates/main.arm.json
+++ b/cli/azd/extensions/azure.ai.projects/internal/synthesis/templates/main.arm.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.44.1.10279",
-      "templateHash": "10316642581792918930"
+      "version": "0.45.15.27210",
+      "templateHash": "1699321523334639873"
     }
   },
   "definitions": {
@@ -346,8 +346,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.44.1.10279",
-              "templateHash": "9277725728848811858"
+              "version": "0.45.15.27210",
+              "templateHash": "8110487961768042532"
             }
           },
           "definitions": {
@@ -736,8 +736,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "9033097500563316958"
+                      "version": "0.45.15.27210",
+                      "templateHash": "18361164219559996781"
                     }
                   },
                   "parameters": {
@@ -830,8 +830,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "9706203844896299767"
+                              "version": "0.45.15.27210",
+                              "templateHash": "11947348622491745192"
                             }
                           },
                           "parameters": {
@@ -915,8 +915,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.44.1.10279",
-                              "templateHash": "9706203844896299767"
+                              "version": "0.45.15.27210",
+                              "templateHash": "11947348622491745192"
                             }
                           },
                           "parameters": {
@@ -1050,8 +1050,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "2948233716175969636"
+                      "version": "0.45.15.27210",
+                      "templateHash": "1414665861706683761"
                     }
                   },
                   "parameters": {
@@ -1221,8 +1221,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "17191653749134434458"
+                      "version": "0.45.15.27210",
+                      "templateHash": "7461045817315422644"
                     }
                   },
                   "parameters": {
@@ -1448,8 +1448,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.44.1.10279",
-                      "templateHash": "487447368010536336"
+                      "version": "0.45.15.27210",
+                      "templateHash": "14839319862176027437"
                     }
                   },
                   "definitions": {
@@ -1626,6 +1626,10 @@
   },
   "outputs": {
     "AZURE_RESOURCE_GROUP": {
+      "type": "string",
+      "value": "[parameters('resourceGroupName')]"
+    },
+    "AZURE_FOUNDRY_RESOURCE_GROUP": {
       "type": "string",
       "value": "[parameters('resourceGroupName')]"
     },

--- a/cli/azd/extensions/azure.ai.projects/internal/synthesis/templates/main.bicep
+++ b/cli/azd/extensions/azure.ai.projects/internal/synthesis/templates/main.bicep
@@ -160,7 +160,8 @@ module resources 'modules/resources.bicep' = {
 
 // Outputs
 
-output AZURE_RESOURCE_GROUP string = resourceGroup.name
+output AZURE_RESOURCE_GROUP string = resourceGroupName
+output AZURE_FOUNDRY_RESOURCE_GROUP string = resourceGroupName
 output AZURE_AI_PROJECT_ID string = resources.outputs.AZURE_AI_PROJECT_ID
 output AZURE_AI_ACCOUNT_NAME string = resources.outputs.AZURE_AI_ACCOUNT_NAME
 output AZURE_AI_PROJECT_NAME string = resources.outputs.AZURE_AI_PROJECT_NAME

--- a/cli/azd/extensions/azure.ai.projects/internal/synthesis/templates/terraform/outputs.tf.tmpl
+++ b/cli/azd/extensions/azure.ai.projects/internal/synthesis/templates/terraform/outputs.tf.tmpl
@@ -1,9 +1,11 @@
 # Outputs consumed by azd. Each value is written into the azd environment, so
 # the names must stay stable.
 
+{{ if not .Layer }}
 output "AZURE_RESOURCE_GROUP" {
   value = local.resource_group_name
 }
+{{ end }}
 
 output "AZURE_FOUNDRY_RESOURCE_GROUP" {
   value = local.resource_group_name

--- a/cli/azd/extensions/azure.ai.projects/internal/synthesis/templates/terraform/outputs.tf.tmpl
+++ b/cli/azd/extensions/azure.ai.projects/internal/synthesis/templates/terraform/outputs.tf.tmpl
@@ -2,7 +2,11 @@
 # the names must stay stable.
 
 output "AZURE_RESOURCE_GROUP" {
-  value = azurerm_resource_group.this.name
+  value = local.resource_group_name
+}
+
+output "AZURE_FOUNDRY_RESOURCE_GROUP" {
+  value = local.resource_group_name
 }
 
 output "AZURE_AI_PROJECT_ID" {

--- a/schemas/alpha/azure.yaml.json
+++ b/schemas/alpha/azure.yaml.json
@@ -94,9 +94,26 @@
                                 "title": "Name of the default module within the Azure provisioning templates",
                                 "description": "Optional. The name of the Azure provisioning module used when provisioning resources. (Default: main)"
                             },
+                            "provider": {
+                                "type": "string",
+                                "title": "Type of infrastructure provisioning provider",
+                                "description": "Optional. The infrastructure provisioning provider for this layer. Inherits infra.provider when omitted. Built-in values are 'bicep' and 'terraform'; extensions may register additional providers.",
+                                "pattern": "^[a-z0-9.]+$",
+                                "examples": [
+                                    "bicep",
+                                    "terraform",
+                                    "microsoft.foundry"
+                                ]
+                            },
                              "deploymentStacks": {
                                  "$ref": "#/definitions/deploymentStacksConfig"
                              },
+                            "config": {
+                                "type": "object",
+                                "title": "Provider-specific configuration",
+                                "description": "Optional. Configuration passed to the infrastructure provisioning provider.",
+                                "additionalProperties": true
+                            },
                             "dependsOn": {
                                 "type": "array",
                                 "title": "Layer names this layer must wait for",

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -102,9 +102,6 @@
                                     "microsoft.foundry"
                                 ]
                             },
-                            "deploymentStacks": {
-                                "$ref": "#/definitions/deploymentStacksConfig"
-                            },
                             "config": {
                                 "type": "object",
                                 "title": "Provider-specific configuration",

--- a/schemas/v1.0/azure.yaml.json
+++ b/schemas/v1.0/azure.yaml.json
@@ -91,6 +91,26 @@
                                 "title": "Name of the default module within the Azure provisioning templates",
                                 "description": "Optional. The name of the Azure provisioning module used when provisioning resources. (Default: main)"
                             },
+                            "provider": {
+                                "type": "string",
+                                "title": "Type of infrastructure provisioning provider",
+                                "description": "Optional. The infrastructure provisioning provider for this layer. Inherits infra.provider when omitted. Built-in values are 'bicep' and 'terraform'; extensions may register additional providers.",
+                                "pattern": "^[a-z0-9.]+$",
+                                "examples": [
+                                    "bicep",
+                                    "terraform",
+                                    "microsoft.foundry"
+                                ]
+                            },
+                            "deploymentStacks": {
+                                "$ref": "#/definitions/deploymentStacksConfig"
+                            },
+                            "config": {
+                                "type": "object",
+                                "title": "Provider-specific configuration",
+                                "description": "Optional. Configuration passed to the infrastructure provisioning provider.",
+                                "additionalProperties": true
+                            },
                             "dependsOn": {
                                 "type": "array",
                                 "title": "Layer names this layer must wait for",


### PR DESCRIPTION
## Summary

Fixes #9126. Implements the infrastructure-layer approach from design spec #9363 so Foundry IaC can be ejected into projects that already own infrastructure without merging or overwriting their files.

## Changes

- **`azd ai agent init --infra`**: migrates existing root infrastructure to `infra.layers` and adds an isolated Foundry Bicep or Terraform layer with conflict-safe, atomic installation.
- **`microsoft.foundry` provider**: supports layer paths, modules, virtual environment outputs, isolated resource groups, and durable ownership checks across repeated provisions and teardown.
- **`azure.yaml` schemas and templates**: expose per-layer providers/configuration and keep generated Bicep, Terraform, and environment outputs aligned.

## Manual Validation

- Built and installed the branch extensions, ejected Bicep into a project with an existing platform layer, and provisioned both layers in the Foundry Dev Tools TTL subscription.
- Ran `azd provision` a second time, confirmed `AZD_FOUNDRY_RESOURCE_GROUP_ID` persisted, then ran `azd down --force --purge`; both resource groups were deleted and the ownership marker was cleared.
