### PR TITLE
Expand CODEOWNERS for TestFigSpec.ts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,9 +10,10 @@
 # ── CLI installer ─────────────────────────────────────────────────────────────
 /cli/installer/                             @danieljurek @vhvb1989 @tg-msft @RickWinter
 
-# ── CLI extensions registry - anyone added to this can approve extension publishing, provided they pass the `ext-registry-check` workflow.
+# ── CLI extensions registry and test snapshots - anyone added to this can approve extension publishing, provided they pass the `ext-registry-check` workflow.
 /cli/azd/extensions/registry.json           @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft @XiaofuHuang @achauhan-scc @anchenyi @glharper @huimiu @hund030 @kingernupur @saanikaguptamicrosoft @therealjohn @trangevi @trrwilson
 /cli/azd/extensions/registry.dev.json       @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft @XiaofuHuang @achauhan-scc @anchenyi @glharper @huimiu @hund030 @kingernupur @saanikaguptamicrosoft @therealjohn @trangevi @trrwilson
+/cli/azd/cmd/testdata/TestFigSpec.ts        @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft @XiaofuHuang @achauhan-scc @anchenyi @glharper @huimiu @hund030 @kingernupur @saanikaguptamicrosoft @therealjohn @trangevi @trrwilson
 
 # ── CLI extensions (AI) ──────────────────────────────────────────────────────
 /cli/azd/extensions/azure.ai.agents/        @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030


### PR DESCRIPTION
This PR expands CODEOWNERS for TestFigSpec.ts so Foundry team can approve more registry updates without core team approval.

Follow-up to https://github.com/Azure/azure-dev/pull/9377, which relaxed the `ext-registry-check` but missed the corresponding CODEOWNERS update.