### PR TITLE
feat(agents): add initialization_parameters to evaluator YAML config

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config.go
@@ -240,19 +240,22 @@ func datasetRefToAPI(ref *opt_eval.DatasetRef) (*optimize_api.Dataset, error) {
 }
 
 // evaluatorRefs converts a YAML evaluator list into API evaluator references,
-// preserving each evaluator's name and optional version.
+// preserving each evaluator's name, optional version, and initialization_parameters.
 func evaluatorRefs(list opt_eval.EvaluatorList) []optimize_api.EvaluatorRef {
 	if len(list) == 0 {
 		return nil
 	}
 	refs := make([]optimize_api.EvaluatorRef, 0, len(list))
 	for _, e := range list {
-		refs = append(refs, optimize_api.EvaluatorRef{Name: e.Name, Version: e.Version})
+		refs = append(refs, optimize_api.EvaluatorRef{
+			Name:                     e.Name,
+			Version:                  e.Version,
+			InitializationParameters: e.InitializationParameters,
+		})
 	}
 	return refs
 }
 
-// mergeEvaluators appends add to base, skipping entries whose name already
 // exists in base (case-sensitive). Order is preserved: base first, then any
 // new entries from add. Used to layer --evaluator flags on top of config
 // evaluators without dropping the config entries.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_config_test.go
@@ -915,3 +915,59 @@ func TestToRequest_MaxStalls(t *testing.T) {
 	require.NotNil(t, req.Options.MaxStalls)
 	assert.Equal(t, 3, *req.Options.MaxStalls)
 }
+
+func TestToRequest_EvaluatorInitParamsForwardedToAPI(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent: opt_eval.AgentRef{Name: "agent"},
+			Evaluators: opt_eval.EvaluatorList{
+				{
+					Name:    "builtin.regex_match",
+					Version: "4",
+					InitializationParameters: map[string]any{
+						"patterns": []any{"(?i)Answer:\\s*{{ground_truth}}"},
+					},
+				},
+			},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi","ground_truth":"yes"}`),
+		},
+		Options: &opt_eval.Options{
+			EvalModel:         "gpt-4o-mini",
+			OptimizationModel: "gpt-5",
+		},
+	}
+
+	req, _, err := cfg.ToRequest()
+	require.NoError(t, err)
+	require.Len(t, req.Evaluators, 1)
+	params := req.Evaluators[0].InitializationParameters
+	require.NotNil(t, params, "expected initialization_parameters on evaluator ref")
+	patterns, ok := params["patterns"]
+	require.True(t, ok, "expected patterns key")
+	assert.NotEmpty(t, patterns)
+}
+
+func TestToRequest_EvaluatorInitParamsNilWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &OptimizeConfig{
+		Config: opt_eval.Config{
+			Agent:       opt_eval.AgentRef{Name: "agent"},
+			Evaluators:  opt_eval.EvaluatorList{{Name: "builtin.task_adherence"}},
+			DatasetFile: writeTestFile(t, dir, "ds.jsonl", `{"query":"hi"}`),
+		},
+		Options: &opt_eval.Options{
+			EvalModel:         "gpt-4o-mini",
+			OptimizationModel: "gpt-5",
+		},
+	}
+
+	req, _, err := cfg.ToRequest()
+	require.NoError(t, err)
+	require.Len(t, req.Evaluators, 1)
+	assert.Nil(t, req.Evaluators[0].InitializationParameters)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml.go
@@ -90,10 +90,14 @@ func (c *Config) RemoteDatasetReference() *DatasetRef {
 
 // EvaluatorRef describes an evaluator. It can be a simple string name or a
 // structured entry with name, version, and local_uri.
+// EvaluatorRef describes an evaluator. It can be a simple string name or a
+// structured entry with name, version, local_uri, and initialization_parameters.
 type EvaluatorRef struct {
 	Name     string `yaml:"name" json:"name"`
 	Version  string `yaml:"version,omitempty" json:"version,omitempty"`
 	LocalURI string `yaml:"local_uri,omitempty" json:"local_uri,omitempty"`
+	// InitializationParameters holds evaluator-specific configuration parameters.
+	InitializationParameters map[string]any `yaml:"initialization_parameters,omitempty" json:"-"`
 }
 
 // EvaluatorList is a list of evaluators that supports mixed YAML:
@@ -133,11 +137,11 @@ func (el *EvaluatorList) UnmarshalYAML(value *yaml.Node) error {
 }
 
 // MarshalYAML emits plain strings for simple evaluators and mappings for
-// structured ones (those with version or local_uri).
+// structured ones (those with version, local_uri, or initialization_parameters).
 func (el EvaluatorList) MarshalYAML() (any, error) {
 	nodes := make([]*yaml.Node, 0, len(el))
 	for _, ref := range el {
-		if ref.Version == "" && ref.LocalURI == "" {
+		if ref.Version == "" && ref.LocalURI == "" && len(ref.InitializationParameters) == 0 {
 			// Emit as a plain string.
 			nodes = append(nodes, &yaml.Node{
 				Kind:  yaml.ScalarNode,

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/opt_eval/yaml_test.go
@@ -124,6 +124,56 @@ func TestConfig_RoundTrip_DatasetReference(t *testing.T) {
 	assert.Empty(t, loaded.DatasetFile)
 }
 
+func TestConfig_RoundTrip_EvaluatorInitializationParameters(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	original := &Config{
+		Agent: AgentRef{Name: "agent-x"},
+		Evaluators: EvaluatorList{
+			// Plain evaluator — no init params, should survive as scalar.
+			{Name: "builtin.task_adherence"},
+			// Evaluator with initialization_parameters only (no version/local_uri).
+			// MarshalYAML must emit this as a mapping, not a plain scalar,
+			// otherwise the params are silently dropped on round-trip.
+			{
+				Name: "builtin.regex_match",
+				InitializationParameters: map[string]any{
+					"patterns": []any{"(?i)Answer:\\s*{{ground_truth}}"},
+				},
+			},
+			// Evaluator with both version and init params.
+			{
+				Name:    "custom-quality",
+				Version: "3",
+				InitializationParameters: map[string]any{
+					"threshold": 0.5,
+				},
+			},
+		},
+	}
+
+	require.NoError(t, Write(path, original))
+	loaded, err := Read(path)
+	require.NoError(t, err)
+
+	require.Len(t, loaded.Evaluators, 3)
+
+	// Plain evaluator — no init params.
+	assert.Equal(t, "builtin.task_adherence", loaded.Evaluators[0].Name)
+	assert.Empty(t, loaded.Evaluators[0].InitializationParameters)
+
+	// Init-params-only evaluator — must NOT be lost.
+	assert.Equal(t, "builtin.regex_match", loaded.Evaluators[1].Name)
+	require.NotEmpty(t, loaded.Evaluators[1].InitializationParameters, "initialization_parameters must survive YAML round-trip")
+
+	// Version + init params.
+	assert.Equal(t, "custom-quality", loaded.Evaluators[2].Name)
+	assert.Equal(t, "3", loaded.Evaluators[2].Version)
+	require.NotEmpty(t, loaded.Evaluators[2].InitializationParameters)
+}
+
 // ---------------------------------------------------------------------------
 // DatasetRef.IsLocal / IsRemote — inferred from populated fields
 // ---------------------------------------------------------------------------
@@ -414,4 +464,51 @@ optimization_config:
 
 	// model should be the JSON string, not double-quoted.
 	assert.JSONEq(t, `"gpt-4o"`, string(opts.OptimizationConfig["model"]))
+}
+
+// TestOptions_EvaluatorInitializationParameters verifies initialization_parameters
+// under an evaluator entry is parsed correctly.
+func TestOptions_EvaluatorInitializationParameters(t *testing.T) {
+	t.Parallel()
+
+	input := `
+name: test
+agent:
+  name: my-agent
+evaluators:
+  - name: builtin.regex_match
+    version: "4"
+    initialization_parameters:
+      patterns:
+        - "(?i)Answer:\\s*{{ground_truth}}"
+`
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal([]byte(input), &cfg))
+
+	require.Len(t, cfg.Evaluators, 1)
+	ref := cfg.Evaluators[0]
+	assert.Equal(t, "builtin.regex_match", ref.Name)
+	require.NotNil(t, ref.InitializationParameters)
+	patterns, ok := ref.InitializationParameters["patterns"]
+	require.True(t, ok)
+	assert.NotEmpty(t, patterns)
+}
+
+// TestOptions_EvaluatorInitializationParametersOmitted verifies
+// InitializationParameters is nil when absent.
+func TestOptions_EvaluatorInitializationParametersOmitted(t *testing.T) {
+	t.Parallel()
+
+	input := `
+name: test
+agent:
+  name: my-agent
+evaluators:
+  - name: builtin.task_adherence
+`
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal([]byte(input), &cfg))
+
+	require.Len(t, cfg.Evaluators, 1)
+	assert.Nil(t, cfg.Evaluators[0].InitializationParameters)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/models.go
@@ -77,10 +77,11 @@ type Dataset struct {
 	Items   []json.RawMessage `json:"items,omitempty"`
 }
 
-// EvaluatorRef references an evaluator by name and optional version.
+// EvaluatorRef references an evaluator by name, optional version, and optional initialization_parameters.
 type EvaluatorRef struct {
-	Name    string `json:"name"`
-	Version string `json:"version,omitempty"`
+	Name                     string         `json:"name"`
+	Version                  string         `json:"version,omitempty"`
+	InitializationParameters map[string]any `json:"initialization_parameters,omitempty"`
 }
 
 // SkillDefinition describes a skill attached to an agent.


### PR DESCRIPTION
Closes #9624

## Problem

Evaluators that require configuration parameters (e.g. `builtin.regex_match` which requires `patterns`) couldn't be fully specified from the optimize YAML config. `EvaluatorRef` only had name and version.

## Change

- Added `initialization_parameters map[string]any` to `EvaluatorRef` in the YAML config struct
- Wired it through inline per-evaluator into the `OptimizeRequest` `evaluators` array (the C# API reads `initialization_parameters` per-entry, not from a top-level map)
- Fixed `MarshalYAML`: an evaluator with only `initialization_parameters` (no version/local_uri) was previously emitted as a plain scalar, silently dropping the params on round-trip
- Added `TestConfig_RoundTrip_EvaluatorInitializationParameters` covering plain, init-params-only, and version+init-params cases

## Usage

```yaml
evaluators:
  - name: builtin.regex_match
    initialization_parameters:
      patterns:
        - "(?i)Answer:\\s*{{ground_truth}}"
  - builtin.task_adherence
```