### PR TITLE
Fix Aspire manifest generation with CLI bundle

### DIFF
--- a/cli/azd/pkg/tools/dotnet/dotnet.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet.go
@@ -211,6 +211,9 @@ func (cli *Cli) PublishAppHostManifest(
 	// worker nodes terminate when the build completes, closing the inherited pipe.
 	envArgs := []string{
 		"MSBUILDDISABLENODEREUSE=1",
+		// AspireUseCliBundle enables an MSBuild run hook that delegates `dotnet run` to `aspire run`.
+		// Manifest generation must run the AppHost directly because `aspire run` is a long-running command.
+		"ASPIRE_SUPPRESS_CLI_RUN_HOOK=true",
 	}
 
 	// AppHost may conditionalize their infrastructure based on the environment, so we need to pass the environment when we

--- a/cli/azd/pkg/tools/dotnet/dotnet_commands_test.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet_commands_test.go
@@ -334,6 +334,7 @@ func Test_Cli_PublishAppHostManifest(t *testing.T) {
 		require.Contains(t, captured.Env, "DOTNET_ENVIRONMENT=Development")
 		// Node reuse must be disabled to avoid the os/exec pipe-inheritance hang (issue #9295).
 		require.Contains(t, captured.Env, "MSBUILDDISABLENODEREUSE=1")
+		require.Contains(t, captured.Env, "ASPIRE_SUPPRESS_CLI_RUN_HOOK=true")
 	})
 
 	t.Run("single file apphost", func(t *testing.T) {
@@ -352,6 +353,7 @@ func Test_Cli_PublishAppHostManifest(t *testing.T) {
 		require.Equal(t, "apphost.cs", captured.Args[1])
 		require.NotContains(t, captured.Args, "--project")
 		require.Contains(t, captured.Env, "MSBUILDDISABLENODEREUSE=1")
+		require.Contains(t, captured.Env, "ASPIRE_SUPPRESS_CLI_RUN_HOOK=true")
 	})
 
 	t.Run("run error", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- suppress the Aspire CLI MSBuild run hook while azd generates an AppHost manifest
- keep CLI-bundle dependency resolution enabled for AppHosts using `AspireUseCliBundle=true`
- cover project-based and single-file AppHost manifest invocations

## Root cause

Aspire 13.5 preview temporarily defaulted `AspireUseCliBundle` to `true`. That enables an MSBuild run hook which rewrites azd's `dotnet run --publisher manifest` invocation to `aspire run`.

The manifest is written, but `aspire run` remains active to orchestrate the AppHost, so azd waits indefinitely under the `Scanning app code in current directory` spinner.

Setting `ASPIRE_SUPPRESS_CLI_RUN_HOOK=true` for manifest generation keeps the invocation on the direct AppHost publishing path and allows it to exit normally.

## Validation

Reproduced with:

- .NET SDK `10.0.301`
- Aspire CLI and AppHost SDK `13.5.0-preview.1.26324.7`
- one generated Aspire starter AppHost

The unpatched azd detected the AppHost and timed out during manifest generation. The patched azd completed initialization and generated `azure.yaml` both from the AppHost directory and from the solution root.

Fixes #9455
