### PR TITLE
fix(azure.ai.agents): preserve hosted agent deployment error classification

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/AGENTS.md
+++ b/cli/azd/extensions/azure.ai.agents/AGENTS.md
@@ -139,6 +139,7 @@ func runCommand() error {
 Prefer the dedicated helpers instead of hand-rolling conversions:
 
 - `exterrors.ServiceFromAzure(err, operation)` for `azcore.ResponseError`
+- `exterrors.FromHost(err, operation, context)` for azd host gRPC service calls
 - `exterrors.FromAiService(err, fallbackCode)` for azd host AI service calls
 - `exterrors.FromPrompt(err, contextMessage)` for prompt failures
 

--- a/cli/azd/extensions/azure.ai.agents/internal/exterrors/errors.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/exterrors/errors.go
@@ -17,9 +17,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
@@ -98,18 +100,55 @@ func Internal(code, message string) error {
 	}
 }
 
+// Service returns a structured service failure with operation-specific telemetry context.
+func Service(operation, code, message, serviceName, suggestion string) *azdext.ServiceError {
+	if code == "" {
+		code = "failed"
+	}
+	return &azdext.ServiceError{
+		Message:     message,
+		ErrorCode:   fmt.Sprintf("%s.%s", operation, code),
+		ServiceName: serviceName,
+		Suggestion:  suggestion,
+	}
+}
+
+// InternalFromError preserves an existing structured error or cancellation and otherwise
+// classifies err as an internal failure with operation context.
+func InternalFromError(err error, code, contextMessage string) error {
+	if err == nil {
+		return nil
+	}
+	if structured := structuredError(err); structured != nil {
+		return structured
+	}
+	if IsCancellation(err) {
+		return Cancelled(fmt.Sprintf("%s was cancelled", contextMessage))
+	}
+	return Internal(code, fmt.Sprintf("%s: %s", contextMessage, err))
+}
+
 // ---------------------------------------------------------------------------
 // Azure / gRPC error converters
 // ---------------------------------------------------------------------------
 
 // ServiceFromAzure wraps an [azcore.ResponseError] into an [azdext.ServiceError] with operation context.
-// If the error is not an azcore.ResponseError, it returns a generic internal [azdext.LocalError].
+// It also preserves existing structured errors and authentication failures.
 func ServiceFromAzure(err error, operation string) error {
+	if err == nil {
+		return nil
+	}
+	if structured := structuredError(err); structured != nil {
+		return structured
+	}
 	var respErr *azcore.ResponseError
 	if errors.As(err, &respErr) {
 		serviceName := ""
 		if respErr.RawResponse != nil && respErr.RawResponse.Request != nil {
 			serviceName = respErr.RawResponse.Request.Host
+			if serviceName == "" && respErr.RawResponse.Request.URL != nil {
+				serviceName = respErr.RawResponse.Request.URL.Hostname()
+			}
 		}
 		code := respErr.ErrorCode
 		if code == "" {
@@ -125,7 +164,59 @@ func ServiceFromAzure(err error, operation string) error {
 	if IsCancellation(err) {
 		return Cancelled(fmt.Sprintf("%s was cancelled", operation))
 	}
+	if _, ok := errors.AsType[*azidentity.AuthenticationFailedError](err); ok {
+		return Auth(CodeAuthFailed, err.Error(), "run `azd auth login` to authenticate")
+	}
 	return Internal(operation, fmt.Sprintf("%s: %s", operation, err.Error()))
+}
+
+// FromHost converts an error returned by an azd host gRPC service. Service metadata
+// transported in gRPC details is preserved and prefixed with the current operation.
+func FromHost(err error, operation, contextMessage string) error {
+	if err == nil {
+		return nil
+	}
+	if structured := structuredError(err); structured != nil {
+		return structured
+	}
+	if IsCancellation(err) {
+		return Cancelled(fmt.Sprintf("%s was cancelled", contextMessage))
+	}
+
+	st, ok := azdext.GRPCStatusFromError(err)
+	if !ok {
+		return Internal(operation, fmt.Sprintf("%s: %s", contextMessage, err))
+	}
+	if st.Code() == codes.Unauthenticated {
+		return authFromGrpcMessage(st.Message())
+	}
+
+	actionable := azdext.ActionableErrorDetailFromError(err)
+	if serviceDetail := serviceErrorDetailFromStatus(st); serviceDetail != nil {
+		code := serviceDetail.GetErrorCode()
+		if code == "" && serviceDetail.GetStatusCode() > 0 {
+			code = strconv.Itoa(int(serviceDetail.GetStatusCode()))
+		}
+
+		serviceErr := Service(
+			operation,
+			code,
+			fmt.Sprintf("%s: %s", contextMessage, st.Message()),
+			serviceDetail.GetServiceName(),
+			"",
+		)
+		serviceErr.StatusCode = int(serviceDetail.GetStatusCode())
+		if actionable != nil {
+			serviceErr.Suggestion = actionable.GetSuggestion()
+			serviceErr.Links = azdext.UnwrapErrorLinks(actionable.GetLinks())
+		}
+		return serviceErr
+	}
+	if actionable != nil {
+		return err
+	}
+
+	return Internal(operation, fmt.Sprintf("%s: %s", contextMessage, st.Message()))
 }
 
 // FromAiService wraps a gRPC error returned by an azd host AI service call
@@ -194,6 +285,30 @@ func authFromGrpcMessage(msg string) error {
 		return Auth(CodeLoginExpired, msg, "run `azd auth login` to acquire a new token")
 	}
 	return Auth(CodeAuthFailed, msg, "run `azd auth login` to authenticate")
+}
+
+func structuredError(err error) error {
+	if serviceErr, ok := errors.AsType[*azdext.ServiceError](err); ok {
+		return serviceErr
+	}
+	if localErr, ok := errors.AsType[*azdext.LocalError](err); ok {
+		return localErr
+	}
+	return nil
+}
+
+// serviceErrorDetailFromStatus is kept local until azure.ai.agents can consume an
+// azd version that includes azdext.ServiceErrorDetailFromStatus.
+func serviceErrorDetailFromStatus(st *status.Status) *azdext.ServiceErrorDetail {
+	if st == nil {
+		return nil
+	}
+	for _, detail := range st.Details() {
+		if serviceErr, ok := detail.(*azdext.ServiceErrorDetail); ok {
+			return serviceErr
+		}
+	}
+	return nil
 }
 
 // IsCancellation checks if an error represents user cancellation

--- a/cli/azd/extensions/azure.ai.agents/internal/exterrors/errors_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/exterrors/errors_test.go
@@ -6,14 +6,92 @@ package exterrors
 import (
 	"context"
 	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+func TestServiceFromAzure(t *testing.T) {
+	responseErr := &azcore.ResponseError{
+		StatusCode: http.StatusTooManyRequests,
+		ErrorCode:  "TooManyRequests",
+		RawResponse: &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Status:     "429 Too Many Requests",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"code":"TooManyRequests"}}`)),
+			Request: &http.Request{
+				Method: http.MethodPost,
+				URL: &url.URL{
+					Scheme: "https",
+					Host:   "sample.services.ai.azure.com",
+				},
+			},
+		},
+	}
+
+	result := ServiceFromAzure(responseErr, OpCreateAgent)
+
+	var serviceErr *azdext.ServiceError
+	require.ErrorAs(t, result, &serviceErr)
+	assert.Equal(t, "create_agent.TooManyRequests", serviceErr.ErrorCode)
+	assert.Equal(t, http.StatusTooManyRequests, serviceErr.StatusCode)
+	assert.Equal(t, "sample.services.ai.azure.com", serviceErr.ServiceName)
+}
+
+func TestServiceFromAzurePreservesStructuredError(t *testing.T) {
+	expected := &azdext.LocalError{
+		Message:  "invalid input",
+		Code:     "invalid_input",
+		Category: azdext.LocalErrorCategoryValidation,
+	}
+
+	assert.Same(t, expected, ServiceFromAzure(expected, OpCreateAgent))
+}
+
+func TestFromHostPreservesServiceDetails(t *testing.T) {
+	st := status.New(codes.Unknown, "request failed")
+	withDetails, err := st.WithDetails(
+		&azdext.ServiceErrorDetail{
+			ErrorCode:   "AuthorizationFailed",
+			StatusCode:  http.StatusForbidden,
+			ServiceName: "management.azure.com",
+		},
+		&azdext.ActionableErrorDetail{
+			Suggestion: "request the required role and retry",
+		},
+	)
+	require.NoError(t, err)
+
+	result := FromHost(withDetails.Err(), OpContainerPublish, "container publish failed")
+
+	var serviceErr *azdext.ServiceError
+	require.ErrorAs(t, result, &serviceErr)
+	assert.Equal(t, "container_publish.AuthorizationFailed", serviceErr.ErrorCode)
+	assert.Equal(t, http.StatusForbidden, serviceErr.StatusCode)
+	assert.Equal(t, "management.azure.com", serviceErr.ServiceName)
+	assert.Equal(t, "request the required role and retry", serviceErr.Suggestion)
+	assert.Contains(t, serviceErr.Message, "container publish failed")
+}
+
+func TestInternalFromErrorPreservesStructuredError(t *testing.T) {
+	expected := &azdext.LocalError{
+		Message:  "missing dependency",
+		Code:     "missing_dependency",
+		Category: azdext.LocalErrorCategoryDependency,
+	}
+
+	assert.Same(t, expected, InternalFromError(expected, OpContainerPackage, "code packaging failed"))
+}
 
 func TestFromAiService(t *testing.T) {
 	tests := []struct {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -2655,7 +2655,7 @@ func (p *AgentServiceTargetProvider) waitForAgentActive(
 	}
 
 	// Timeout
-	if lastVersion == nil && lastPollErr != nil {
+	if lastPollErr != nil {
 		return nil, exterrors.ServiceFromAzure(lastPollErr, exterrors.OpCreateAgent)
 	}
 	lastStatus := "unknown"
@@ -2674,7 +2674,7 @@ func (p *AgentServiceTargetProvider) waitForAgentActive(
 func agentDeploymentFailedError(versionResp *agent_api.AgentVersionObject, serviceName string) error {
 	code := "failed"
 	errMsg := "agent deployment failed"
-	suggestion := "run `azd ai agent show` to view the structured deploy error and follow the linked troubleshooting guide"
+	suggestion := "run `azd ai agent show` to inspect the latest deployment status"
 	if versionResp.Error != nil {
 		code = versionResp.Error.Code
 		errMsg = fmt.Sprintf("agent deployment failed: [%s] %s", code, versionResp.Error.Message)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -88,6 +88,14 @@ func buildResponsesProtocolURL(projectEndpoint, agentName string) string {
 	)
 }
 
+func endpointHost(endpoint string) string {
+	u, err := url.Parse(strings.TrimSpace(endpoint))
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
+}
+
 // buildInvocationsProtocolURL builds the per-agent HTTPS URL for the "invocations" protocol.
 func buildInvocationsProtocolURL(projectEndpoint, agentName string) string {
 	return fmt.Sprintf(
@@ -636,7 +644,7 @@ func (p *AgentServiceTargetProvider) Package(
 		progress("Packaging code")
 		zipPath, sha256Hex, err := p.packageCodeDeploy(ctx, serviceConfig)
 		if err != nil {
-			return nil, exterrors.Internal(exterrors.OpContainerPackage, fmt.Sprintf("code packaging failed: %s", err))
+			return nil, exterrors.InternalFromError(err, exterrors.OpContainerPackage, "code packaging failed")
 		}
 
 		return &azdext.ServicePackageResult{
@@ -701,7 +709,7 @@ func (p *AgentServiceTargetProvider) Package(
 				Container().
 				Build(ctx, buildRequest)
 			if err != nil {
-				return nil, exterrors.Internal(exterrors.OpContainerBuild, fmt.Sprintf("container build failed: %s", err))
+				return nil, exterrors.FromHost(err, exterrors.OpContainerBuild, "container build failed")
 			}
 
 			serviceContext.Build = append(serviceContext.Build, buildResponse.Result.Artifacts...)
@@ -715,7 +723,7 @@ func (p *AgentServiceTargetProvider) Package(
 			Container().
 			Package(ctx, packageRequest)
 		if err != nil {
-			return nil, exterrors.Internal(exterrors.OpContainerPackage, fmt.Sprintf("container package failed: %s", err))
+			return nil, exterrors.FromHost(err, exterrors.OpContainerPackage, "container package failed")
 		}
 
 		newArtifacts = append(newArtifacts, packageResponse.Result.Artifacts...)
@@ -807,11 +815,7 @@ func classifyContainerPublishError(err error) error {
 		)
 	}
 
-	if actionable := azdext.ActionableErrorDetailFromError(err); actionable != nil && actionable.GetSuggestion() != "" {
-		return err
-	}
-
-	return exterrors.Internal(exterrors.OpContainerPublish, fmt.Sprintf("container publish failed: %s", err))
+	return exterrors.FromHost(err, exterrors.OpContainerPublish, "container publish failed")
 }
 
 // acrPermissionSuggestionFor is the user-facing remediation text for
@@ -1215,12 +1219,18 @@ func (p *AgentServiceTargetProvider) Deploy(
 
 	// Poll until agent version is active
 	if result.agentVersion.Status != "active" {
+		projectEndpoint := azdEnv["FOUNDRY_PROJECT_ENDPOINT"]
 		agentClient := agent_api.NewAgentClient(
-			azdEnv["FOUNDRY_PROJECT_ENDPOINT"],
+			projectEndpoint,
 			p.credential,
 		)
 		polledVersion, pollErr := p.waitForAgentActive(
-			ctx, agentClient, result.agentName, result.agentVersion.Version, progress,
+			ctx,
+			agentClient,
+			endpointHost(projectEndpoint),
+			result.agentName,
+			result.agentVersion.Version,
+			progress,
 		)
 		if pollErr != nil {
 			return nil, pollErr
@@ -2258,9 +2268,9 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 	var agentResp *agent_api.AgentObject
 
 	if getErr != nil {
-		// Only fall back to create on 404; propagate other errors (auth, 5xx, network)
+		// Only fall back to create on 404; classify every other service response.
 		if respErr, ok := errors.AsType[*azcore.ResponseError](getErr); !ok || respErr.StatusCode != http.StatusNotFound {
-			return nil, fmt.Errorf("failed to check if agent exists: %w", getErr)
+			return nil, exterrors.ServiceFromAzure(getErr, exterrors.OpCreateAgent)
 		}
 		// Agent doesn't exist — create
 		fmt.Fprintf(os.Stderr, "Creating new agent: %s\n", agentDef.Name)
@@ -2268,10 +2278,7 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 			ctx, agentDef.Name, versionRequest, zipData, sha256Hex, agent_api.AgentEndpointAPIVersion,
 		)
 		if err != nil {
-			return nil, exterrors.Internal(
-				exterrors.CodeAgentCreateFailed,
-				fmt.Sprintf("failed to create agent from ZIP: %s; check the agent definition and try again", err),
-			)
+			return nil, exterrors.ServiceFromAzure(err, exterrors.OpCreateAgent)
 		}
 	} else {
 		// Agent exists — update
@@ -2280,10 +2287,7 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 			ctx, agentDef.Name, versionRequest, zipData, sha256Hex, agent_api.AgentEndpointAPIVersion,
 		)
 		if err != nil {
-			return nil, exterrors.Internal(
-				exterrors.CodeAgentCreateFailed,
-				fmt.Sprintf("failed to update agent from ZIP: %s; check the agent definition and try again", err),
-			)
+			return nil, exterrors.ServiceFromAzure(err, exterrors.OpCreateAgent)
 		}
 	}
 
@@ -2586,6 +2590,7 @@ func AgentPlaygroundURL(projectResourceID, agentName, agentVersion string) (stri
 func (p *AgentServiceTargetProvider) waitForAgentActive(
 	ctx context.Context,
 	agentClient *agent_api.AgentClient,
+	serviceName string,
 	agentName string,
 	version string,
 	progress azdext.ProgressReporter,
@@ -2602,6 +2607,7 @@ func (p *AgentServiceTargetProvider) waitForAgentActive(
 	var consecutiveActive int
 	var consecutiveFailed int
 	var lastVersion *agent_api.AgentVersionObject
+	var lastPollErr error
 
 	for time.Now().Before(deadline) {
 		select {
@@ -2615,12 +2621,14 @@ func (p *AgentServiceTargetProvider) waitForAgentActive(
 
 		versionResp, err := agentClient.GetAgentVersion(ctx, agentName, version, agent_api.AgentEndpointAPIVersion)
 		if err != nil {
+			lastPollErr = err
 			fmt.Fprintf(os.Stderr, "  Warning: poll failed: %s\n", err)
 			// Reset counters on error — don't count transient failures
 			consecutiveActive = 0
 			consecutiveFailed = 0
 			continue
 		}
+		lastPollErr = nil
 		lastVersion = versionResp
 
 		switch versionResp.Status {
@@ -2636,14 +2644,7 @@ func (p *AgentServiceTargetProvider) waitForAgentActive(
 			consecutiveFailed++
 			consecutiveActive = 0
 			if consecutiveFailed >= confirmCount {
-				errMsg := "agent deployment failed"
-				if versionResp.Error != nil {
-					errMsg = fmt.Sprintf("agent deployment failed: [%s] %s", versionResp.Error.Code, versionResp.Error.Message)
-				}
-				if versionResp.RequestID != "" {
-					errMsg += fmt.Sprintf(" (request-id: %s)", versionResp.RequestID)
-				}
-				return nil, exterrors.Internal(exterrors.CodeAgentCreateFailed, errMsg)
+				return nil, agentDeploymentFailedError(versionResp, serviceName)
 			}
 			fmt.Fprintf(os.Stderr, "  Status: failed (confirming...)\n")
 		default:
@@ -2654,14 +2655,38 @@ func (p *AgentServiceTargetProvider) waitForAgentActive(
 	}
 
 	// Timeout
+	if lastVersion == nil && lastPollErr != nil {
+		return nil, exterrors.ServiceFromAzure(lastPollErr, exterrors.OpCreateAgent)
+	}
 	lastStatus := "unknown"
 	if lastVersion != nil {
 		lastStatus = lastVersion.Status
 	}
-	return nil, exterrors.Internal(
-		exterrors.CodeAgentCreateFailed,
+	return nil, exterrors.Service(
+		exterrors.OpCreateAgent,
+		"timeout",
 		fmt.Sprintf("agent deployment timed out (last status: %s); check agent status manually", lastStatus),
+		serviceName,
+		"run `azd ai agent show` to inspect the latest deployment status",
 	)
+}
+
+func agentDeploymentFailedError(versionResp *agent_api.AgentVersionObject, serviceName string) error {
+	code := "failed"
+	errMsg := "agent deployment failed"
+	suggestion := "run `azd ai agent show` to view the structured deploy error and follow the linked troubleshooting guide"
+	if versionResp.Error != nil {
+		code = versionResp.Error.Code
+		errMsg = fmt.Sprintf("agent deployment failed: [%s] %s", code, versionResp.Error.Message)
+		if remediation, ok := nextstep.RemediationForUserErrorCode(nextstep.UserErrorCode(code)); ok {
+			suggestion = fmt.Sprintf("run `%s` to %s", remediation.Command, remediation.Description)
+		}
+	}
+	if versionResp.RequestID != "" {
+		errMsg += fmt.Sprintf(" (request-id: %s)", versionResp.RequestID)
+	}
+
+	return exterrors.Service(exterrors.OpCreateAgent, code, errMsg, serviceName, suggestion)
 }
 
 // createAgent creates a new version of the agent using the API

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -97,6 +97,37 @@ func TestWriteExistingAgentVersionWarningIfPresentSkipsErrors(t *testing.T) {
 	require.False(t, wroteWarning)
 }
 
+func TestAgentDeploymentFailedErrorPreservesServiceDetails(t *testing.T) {
+	t.Parallel()
+
+	err := agentDeploymentFailedError(&agent_api.AgentVersionObject{
+		Error: &agent_api.AgentVersionError{
+			Code:    string(nextstep.UserErrorImage),
+			Message: "the image could not be started",
+		},
+		RequestID: "request-id",
+	}, "sample.services.ai.azure.com")
+
+	serviceErr, ok := errors.AsType[*azdext.ServiceError](err)
+	require.True(t, ok)
+	require.Equal(t, "create_agent.ImageError", serviceErr.ErrorCode)
+	require.Equal(t, "sample.services.ai.azure.com", serviceErr.ServiceName)
+	require.Contains(t, serviceErr.Message, "[ImageError] the image could not be started")
+	require.Contains(t, serviceErr.Message, "request-id")
+	require.Contains(t, serviceErr.Suggestion, "azd ai agent monitor --type system --follow")
+}
+
+func TestAgentDeploymentFailedErrorUsesFallbackCode(t *testing.T) {
+	t.Parallel()
+
+	err := agentDeploymentFailedError(&agent_api.AgentVersionObject{}, "sample.services.ai.azure.com")
+
+	serviceErr, ok := errors.AsType[*azdext.ServiceError](err)
+	require.True(t, ok)
+	require.Equal(t, "create_agent.failed", serviceErr.ErrorCode)
+	require.Contains(t, serviceErr.Suggestion, "azd ai agent show")
+}
+
 func TestGetServiceKey_NormalizesToolboxNames(t *testing.T) {
 	t.Parallel()
 
@@ -1817,6 +1848,26 @@ func TestPublish_PreservesNonACRHostActionableGuidance(t *testing.T) {
 	actionable := azdext.ActionableErrorDetailFromError(err)
 	require.NotNil(t, actionable)
 	require.Equal(t, suggestion, actionable.GetSuggestion())
+}
+
+func TestPublish_PreservesHostServiceDetails(t *testing.T) {
+	t.Parallel()
+
+	st := status.New(codes.Unknown, "registry request failed")
+	withDetails, err := st.WithDetails(&azdext.ServiceErrorDetail{
+		ErrorCode:   "TooManyRequests",
+		StatusCode:  429,
+		ServiceName: "management.azure.com",
+	})
+	require.NoError(t, err)
+
+	publishErr := publishWithContainerError(t, withDetails.Err())
+
+	serviceErr, ok := errors.AsType[*azdext.ServiceError](publishErr)
+	require.True(t, ok)
+	require.Equal(t, "container_publish.TooManyRequests", serviceErr.ErrorCode)
+	require.Equal(t, 429, serviceErr.StatusCode)
+	require.Equal(t, "management.azure.com", serviceErr.ServiceName)
 }
 
 func publishWithContainerError(t *testing.T, publishErr error) error {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -125,7 +125,11 @@ func TestAgentDeploymentFailedErrorUsesFallbackCode(t *testing.T) {
 	serviceErr, ok := errors.AsType[*azdext.ServiceError](err)
 	require.True(t, ok)
 	require.Equal(t, "create_agent.failed", serviceErr.ErrorCode)
-	require.Contains(t, serviceErr.Suggestion, "azd ai agent show")
+	require.Equal(
+		t,
+		"run `azd ai agent show` to inspect the latest deployment status",
+		serviceErr.Suggestion,
+	)
 }
 
 func TestGetServiceKey_NormalizesToolboxNames(t *testing.T) {


### PR DESCRIPTION
## Summary

- Preserve structured Azure service errors during hosted agent create, update, and deployment polling.
- Classify hosted deployment `ImageError`, `CodeError`, and `ProvisioningError` with stable operation-specific service codes and remediation guidance.
- Preserve actionable host errors and classify container build/package/publish failures through the extension-side error helper when metadata is available.
- Add regression coverage for Azure response errors, host errors, and async deployment failures.

## Scope

This PR intentionally contains only the `azure.ai.agents` extension changes. The separate azd core gRPC `ServiceErrorDetail` transport change is not included. Without that core change, ordinary container service errors returned over host gRPC may still lack service status/code metadata; auth, actionable, and extension-local classification improvements remain covered here.

## E2E Test Results

| Command | Result | Outcome |
| --- | --- | --- |
| `azd package agent --no-prompt` | PASS | Final hosted-agent source packaged successfully. |
| `azd deploy agent --no-prompt` | PASS | Hosted code agent reached active status. |
| `azd up --no-prompt` | PASS | Parent provision/package/deploy lifecycle completed successfully. |

During setup, Foundry returned a `CodeError` for a missing Python dependency manifest. The CLI preserved the provider classification and remediation guidance; after correcting the fixture, the same deploy command reached active status.