### PR TITLE
fix: reflect real provision/package/deploy status on azd up synthetic telemetry spans

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -495,6 +495,9 @@ overrides:
     words:
       - forbidigo
       - Logf
+  - filename: internal/cmd/up_graph.go
+    words:
+      - finalizer
 ignorePaths:
   - "**/*_test.go"
   - "**/mock*.go"

--- a/cli/azd/internal/cmd/up_graph.go
+++ b/cli/azd/internal/cmd/up_graph.go
@@ -156,15 +156,21 @@ func (u *UpGraphAction) Run(
 	// approximate (package and provision phases overlap in the unified
 	// graph), but preserves the cmd.up → cmd.package + cmd.provision
 	// parent/child relationship and required attribute set
-	// (SubscriptionIdKey, EnvNameKey, CmdEntry, CmdFlags). Span ordering
-	// in the trace file is not guaranteed (BatchSpanProcessor batches
-	// asynchronously); consumers should look up spans by name.
+	// (SubscriptionIdKey, EnvNameKey, CmdEntry, CmdFlags, CmdArgsCount).
+	// Span ordering in the trace file is not guaranteed (BatchSpanProcessor
+	// batches asynchronously); consumers should look up spans by name.
 	parentChangedFlags := changedFlagNames(parentFlags)
 	packageFlags := append([]string{"all"}, parentChangedFlags...)
 	_, packageSpan := tracing.Start(ctx, "cmd.package")
 	packageSpan.SetAttributes(fields.CmdFlags.StringSlice(packageFlags))
+	// The synthetic phase spans mirror the argument-less stand-alone
+	// `azd package`/`provision`/`deploy` sub-commands, so stamp the same
+	// cmd.args.count=0 the cobra middleware records on real command spans,
+	// keeping the command entry-point schema complete for dashboards.
+	packageSpan.SetAttributes(fields.CmdArgsCount.Int(0))
 	provisionSpanCtx, provisionSpan := tracing.Start(ctx, "cmd.provision")
 	provisionSpan.SetAttributes(fields.CmdFlags.StringSlice(parentChangedFlags))
+	provisionSpan.SetAttributes(fields.CmdArgsCount.Int(0))
 	// Attach infra.provider directly to the synthetic cmd.provision span (mirroring the stand-alone
 	// `azd provision` span). It is deliberately not copied onto cmd.package, and it is set on the
 	// span directly rather than via the process-global usage bag so it does not leak across spans.
@@ -1210,6 +1216,9 @@ func emitDeploySpan(
 	deployFlags := append([]string{"all"}, changedFlags...)
 	_, deploySpan := tracing.Start(ctx, "cmd.deploy", trace.WithTimestamp(start))
 	deploySpan.SetAttributes(fields.CmdFlags.StringSlice(deployFlags))
+	// Match the argument-less stand-alone `azd deploy` (and the sibling
+	// synthetic cmd.package/cmd.provision spans) with cmd.args.count=0.
+	deploySpan.SetAttributes(fields.CmdArgsCount.Int(0))
 	deploySpan.SetAttributes(usageAttrs...)
 	if err := deployOutcomeError(result, upstreamFailed); err != nil {
 		MapError(err, deploySpan)

--- a/cli/azd/internal/cmd/up_graph.go
+++ b/cli/azd/internal/cmd/up_graph.go
@@ -191,10 +191,11 @@ func (u *UpGraphAction) Run(
 		// Reflect the real package-phase outcome. Before this, the synthetic
 		// span always closed with an Unset status (=> Success in the AppInsights
 		// exporter), masking package failures under `azd up` (issue #9054).
-		// MapError stamps the same status + ResultCode a stand-alone
-		// `azd package` would report.
+		// phaseOutcomeError surfaces a genuine package failure, or a user
+		// cancellation when the whole run was aborted while packaging; MapError
+		// stamps the same status + ResultCode a stand-alone `azd package` would.
 		packageSpan.SetAttributes(usageAttrs...)
-		if err := firstPhaseError(graphResult, "package", genuinePhaseFailure); err != nil {
+		if err := phaseOutcomeError(graphResult, "package"); err != nil {
 			MapError(err, packageSpan)
 		}
 		packageSpan.End()
@@ -208,23 +209,22 @@ func (u *UpGraphAction) Run(
 		provisionSpan.SetAttributes(usageAttrs...)
 		// Prefer a pre-graph provision failure (layer analysis / validation),
 		// which runs before graphResult is populated; otherwise fall back to the
-		// executed provision steps.
+		// executed provision steps (genuine failure or user cancellation).
 		provisionErr := provisionSetupErr
 		if provisionErr == nil {
-			provisionErr = firstPhaseError(graphResult, "provision", genuinePhaseFailure)
+			provisionErr = phaseOutcomeError(graphResult, "provision")
 		}
 		if provisionErr != nil {
 			MapError(provisionErr, provisionSpan)
 		}
 		provisionSpan.End()
 
-		// Emit a synthetic cmd.deploy span carrying the aggregated
-		// deploy/publish outcome, but only when the deploy phase actually ran.
-		// Under FailFast a provision/package failure skips every deploy step,
-		// and legacy `azd up` likewise never launched the deploy sub-command in
-		// that case — so emitting nothing keeps the cmd.deploy population (and
-		// its success rate) faithful rather than inflating it with a no-op
-		// Success span.
+		// Emit a synthetic cmd.deploy span carrying the deploy/publish outcome,
+		// but only when the deploy phase meaningfully ran. Under FailFast a
+		// provision/package failure tears down the deploy phase, and legacy
+		// `azd up` likewise never launched the deploy sub-command in that case —
+		// so emitting nothing keeps the cmd.deploy population (and its success
+		// rate) faithful rather than inflating it with a no-op Success span.
 		emitDeploySpan(ctx, graphResult, parentChangedFlags, usageAttrs)
 	}()
 
@@ -1038,8 +1038,7 @@ func stepStarted(st exegraph.StepTiming) bool {
 
 // genuinePhaseFailure returns a step's error only when the step itself failed
 // (StepFailed). In-flight cancellations are ignored so an upstream failure
-// tearing down an unrelated, overlapping phase step never blames this phase —
-// used for the provision and package phases.
+// tearing down an unrelated, overlapping phase step never blames this phase.
 func genuinePhaseFailure(st exegraph.StepTiming) error {
 	if st.Status == exegraph.StepFailed {
 		return st.Err
@@ -1047,20 +1046,65 @@ func genuinePhaseFailure(st exegraph.StepTiming) error {
 	return nil
 }
 
-// deployPhaseFailure additionally surfaces a cancellation as a deploy failure.
-// The deploy phase runs last — after provision and package have succeeded — so a
-// deploy step canceled after starting is a user cancellation or a sibling-deploy
-// failure, both of which stand-alone `azd deploy` reports on cmd.deploy.
-// Provision/package deliberately use genuinePhaseFailure instead, so a FailFast
-// teardown of one does not falsely fail the other.
-func deployPhaseFailure(st exegraph.StepTiming) error {
-	if err := genuinePhaseFailure(st); err != nil {
-		return err
-	}
+// startedCancellation returns the cancellation error of a step that had begun
+// executing but was recorded StepSkipped carrying a context error (a Ctrl+C or
+// deadline that interrupted it mid-flight), or nil otherwise. A never-started
+// dependency skip (a *StepSkippedError) returns nil. Callers must gate this on
+// the absence of a genuine failure so FailFast teardown of a sibling failure is
+// never mistaken for a user cancellation.
+func startedCancellation(st exegraph.StepTiming) error {
 	if st.Status == exegraph.StepSkipped && stepStarted(st) {
 		return st.Err
 	}
 	return nil
+}
+
+// runHadGenuineFailure reports whether any step in the run failed outright
+// (StepFailed). Under FailFast the scheduler only cancels in-flight steps after
+// a genuine failure, so when no step failed every recorded cancellation must
+// have come from the parent context — a real user Ctrl+C or deadline — rather
+// than collateral teardown. This lets each phase finalizer tell the two apart.
+func runHadGenuineFailure(result *exegraph.RunResult) bool {
+	if result == nil {
+		return false
+	}
+	for _, st := range result.Steps {
+		if st.Status == exegraph.StepFailed {
+			return true
+		}
+	}
+	return false
+}
+
+// phaseOutcomeError selects the error to stamp on the synthetic cmd.provision /
+// cmd.package span: the phase's own genuine failure if one occurred, otherwise a
+// user cancellation if the whole run was aborted by the parent context while a
+// step in this phase was running. When some other step genuinely failed, this
+// phase's cancellations are FailFast teardown of that failure and are left
+// unattributed — the failing phase reports the root cause on its own span.
+func phaseOutcomeError(result *exegraph.RunResult, phase string) error {
+	if err := firstPhaseError(result, phase, genuinePhaseFailure); err != nil {
+		return err
+	}
+	if runHadGenuineFailure(result) {
+		return nil
+	}
+	return firstPhaseError(result, phase, startedCancellation)
+}
+
+// deployOutcomeError selects the error for the synthetic cmd.deploy span: a
+// genuine deploy failure, or — when no upstream provision/package failure tore
+// the phase down — an in-flight cancellation (a user Ctrl+C during deploy, or a
+// sibling-deploy failure). An upstream failure yields nil so a deploy lifecycle
+// step canceled as teardown of that failure is never blamed on the deploy phase.
+func deployOutcomeError(result *exegraph.RunResult, upstreamFailed bool) error {
+	if err := firstPhaseError(result, "deploy", genuinePhaseFailure); err != nil {
+		return err
+	}
+	if upstreamFailed {
+		return nil
+	}
+	return firstPhaseError(result, "deploy", startedCancellation)
 }
 
 // firstPhaseError returns the error selected by pick for the first step in the
@@ -1095,20 +1139,37 @@ func firstPhaseError(
 // The envelope spans the earliest start / latest end of every deploy-phase step
 // that started, including the pre/post-deploy hook and event nodes.
 //
-// "Ran" is true when a deploy/publish *service* step executed, or when any
-// deploy-phase step failed or was canceled after starting (a failing
-// pre/post-deploy hook, or a user Ctrl+C). A pre/post-deploy lifecycle hook that
-// merely *succeeded* does NOT by itself count: the predeploy hook is gated only
-// on provisioning, so it can run before packaging finishes, and a later package
-// failure must not leave behind a spurious successful cmd.deploy (issue #9054).
-// Never-started dependency skips are excluded entirely.
-func deployPhaseSpanTiming(steps []exegraph.StepTiming) (start, end time.Time, ran bool) {
+// "Ran" is true when, for a started deploy-phase step, any of these hold:
+//   - a deploy/publish *service* step executed;
+//   - a pre/post-deploy hook or event failed outright (a genuine deploy outcome);
+//   - a step was canceled in-flight and no upstream provision/package failure
+//     caused it (upstreamFailed == false) — i.e. a user Ctrl+C during deploy;
+//   - the terminal deploy node (cmdhook-postdeploy) completed, which means the
+//     whole pipeline finished, so an infra-only project with no services still
+//     records a deploy phase (matching legacy `azd deploy --all`).
+//
+// A lone *successful* pre/post-deploy lifecycle hook does NOT by itself count:
+// the predeploy hook is gated only on provisioning, so it can finish before a
+// later package step fails, and that must not leave a spurious cmd.deploy
+// (issue #9054). When upstreamFailed is true, a deploy step canceled as FailFast
+// teardown of that failure is likewise excluded. Never-started dependency skips
+// are excluded entirely.
+func deployPhaseSpanTiming(
+	steps []exegraph.StepTiming, upstreamFailed bool,
+) (start, end time.Time, ran bool) {
 	for _, st := range steps {
 		if stepUpPhase(st) != "deploy" || !stepStarted(st) {
 			continue
 		}
 		isService := slices.Contains(st.Tags, "deploy") || slices.Contains(st.Tags, "publish")
-		if isService || st.Status != exegraph.StepDone {
+		switch {
+		case isService:
+			ran = true
+		case st.Status == exegraph.StepFailed:
+			ran = true
+		case st.Status == exegraph.StepSkipped && !upstreamFailed:
+			ran = true
+		case st.Name == postDeployHookStep && st.Status == exegraph.StepDone:
 			ran = true
 		}
 		if start.IsZero() || st.Start.Before(start) {
@@ -1123,12 +1184,11 @@ func deployPhaseSpanTiming(steps []exegraph.StepTiming) (start, end time.Time, r
 
 // emitDeploySpan emits the synthetic cmd.deploy span for `azd up`, mirroring
 // the stand-alone `azd deploy --all` span the legacy workflow runner produced.
-// It is a no-op unless the deploy phase meaningfully ran (a deploy/publish
-// service step executed, or a deploy-phase step failed or was canceled — see
-// deployPhaseSpanTiming), so a run whose deploy phase was skipped by an earlier
-// provision/package failure contributes no cmd.deploy row. The span is
-// time-boxed to the real deploy phase and, on failure, carries the same status
-// + ResultCode a stand-alone `azd deploy` would via MapError.
+// It is a no-op unless the deploy phase meaningfully ran (see
+// deployPhaseSpanTiming), so a run whose deploy phase was torn down by an
+// earlier provision/package failure contributes no cmd.deploy row. The span is
+// time-boxed to the real deploy phase and, on failure or cancellation, carries
+// the same status + ResultCode a stand-alone `azd deploy` would via MapError.
 func emitDeploySpan(
 	ctx context.Context,
 	result *exegraph.RunResult,
@@ -1138,7 +1198,11 @@ func emitDeploySpan(
 	if result == nil {
 		return
 	}
-	start, end, ran := deployPhaseSpanTiming(result.Steps)
+	// A genuine provision/package failure tears down any overlapping deploy
+	// lifecycle step; such teardown must not surface as a deploy outcome.
+	upstreamFailed := firstPhaseError(result, "provision", genuinePhaseFailure) != nil ||
+		firstPhaseError(result, "package", genuinePhaseFailure) != nil
+	start, end, ran := deployPhaseSpanTiming(result.Steps, upstreamFailed)
 	if !ran {
 		return
 	}
@@ -1147,7 +1211,7 @@ func emitDeploySpan(
 	_, deploySpan := tracing.Start(ctx, "cmd.deploy", trace.WithTimestamp(start))
 	deploySpan.SetAttributes(fields.CmdFlags.StringSlice(deployFlags))
 	deploySpan.SetAttributes(usageAttrs...)
-	if err := firstPhaseError(result, "deploy", deployPhaseFailure); err != nil {
+	if err := deployOutcomeError(result, upstreamFailed); err != nil {
 		MapError(err, deploySpan)
 	}
 	deploySpan.End(trace.WithTimestamp(end))

--- a/cli/azd/internal/cmd/up_graph.go
+++ b/cli/azd/internal/cmd/up_graph.go
@@ -34,6 +34,8 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/output/ux"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
 	"github.com/spf13/pflag"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // UpGraphAction is the single implementation of `azd up`'s default path: it
@@ -167,15 +169,51 @@ func (u *UpGraphAction) Run(
 	// `azd provision` span). It is deliberately not copied onto cmd.package, and it is set on the
 	// span directly rather than via the process-global usage bag so it does not leak across spans.
 	u.provisionManager.RecordInfraProviderUsage(provisionSpanCtx, layers)
+
+	// graphResult is populated once the unified graph finishes executing (see
+	// exegraph.RunWithResult below). The deferred span finalizer reads it to
+	// stamp the *real* per-phase outcome onto the synthetic cmd.package /
+	// cmd.provision / cmd.deploy spans. It stays nil on the early-return setup
+	// paths (before the graph runs), where those phases never executed and the
+	// spans close as success — matching the pre-graph shape.
+	var graphResult *exegraph.RunResult
 	defer func() {
 		// Apply usage attributes (e.g. EnvNameKey) at end so they include
 		// any values set during Run. Globals (e.g. SubscriptionIdKey) are
 		// applied automatically by wrapperSpan.End().
 		usageAttrs := tracing.GetUsageAttributes()
+
+		// Reflect the real package-phase outcome. Before this, the synthetic
+		// span always closed with an Unset status (=> Success in the AppInsights
+		// exporter), masking package failures under `azd up` (issue #9054).
+		// MapError stamps the same status + ResultCode a stand-alone
+		// `azd package` would report.
 		packageSpan.SetAttributes(usageAttrs...)
+		if err := aggregatePhaseError(graphResult, "package"); err != nil {
+			MapError(err, packageSpan)
+		}
 		packageSpan.End()
+
+		// Reflect the real provision-phase outcome (same rationale as package).
+		// The raw provision-step error is used directly — not the wrapped error
+		// returned by wrapProvisionError — so the ARM/Bicep ResultCodes
+		// (service.arm.deployment.failed, tool.bicep.failed, …) land on the
+		// span, and so wrapProvisionError's side effects (JSON state dump,
+		// console messages) are not re-triggered here.
 		provisionSpan.SetAttributes(usageAttrs...)
+		if err := aggregatePhaseError(graphResult, "provision"); err != nil {
+			MapError(err, provisionSpan)
+		}
 		provisionSpan.End()
+
+		// Emit a synthetic cmd.deploy span carrying the aggregated
+		// deploy/publish outcome, but only when the deploy phase actually ran.
+		// Under FailFast a provision/package failure skips every deploy step,
+		// and legacy `azd up` likewise never launched the deploy sub-command in
+		// that case — so emitting nothing keeps the cmd.deploy population (and
+		// its success rate) faithful rather than inflating it with a no-op
+		// Success span.
+		emitDeploySpan(ctx, graphResult, parentChangedFlags, usageAttrs)
 	}()
 
 	// 1. Analyze provision layer dependencies. Empty layers → empty graph.
@@ -583,6 +621,11 @@ func (u *UpGraphAction) Run(
 
 	result := exegraph.RunWithResult(ctx, g, opts)
 
+	// Hand the result to the deferred span finalizer so the synthetic
+	// cmd.package / cmd.provision / cmd.deploy spans reflect the real
+	// per-phase outcome (issue #9054).
+	graphResult = result
+
 	// Stop the progress ticker and render a final summary table.
 	if stopTicker != nil {
 		stopTicker()
@@ -923,4 +966,85 @@ func provisionStepFailed(result *exegraph.RunResult) bool {
 		}
 	}
 	return false
+}
+
+// aggregatePhaseError returns the error of the first failed step whose Tags
+// include any of the given phase tags, in step-completion order, or nil when no
+// such step failed. Only genuine failures (StepFailed) are considered; steps
+// the FailFast scheduler skipped (StepSkipped, carrying a StepSkippedError) are
+// ignored so a downstream phase is never blamed for an upstream failure.
+// Returning a single underlying error — rather than a join of every concurrent
+// failure — keeps the ResultCode that MapError derives identical to what the
+// equivalent stand-alone command (azd package / provision / deploy) reports.
+func aggregatePhaseError(result *exegraph.RunResult, tags ...string) error {
+	if result == nil {
+		return nil
+	}
+	for _, st := range result.Steps {
+		if st.Status != exegraph.StepFailed || st.Err == nil {
+			continue
+		}
+		for _, tag := range tags {
+			if slices.Contains(st.Tags, tag) {
+				return st.Err
+			}
+		}
+	}
+	return nil
+}
+
+// deployPhaseSpanTiming reports the wall-clock envelope of the deploy phase —
+// the earliest start and latest end across every executed step tagged "deploy"
+// or "publish" — together with whether any such step actually ran. Skipped
+// steps are excluded so a deploy phase that never executed (e.g. provisioning
+// failed first) reports ran=false, signalling the caller to emit no cmd.deploy
+// span.
+func deployPhaseSpanTiming(steps []exegraph.StepTiming) (start, end time.Time, ran bool) {
+	for _, st := range steps {
+		if st.Status == exegraph.StepSkipped {
+			continue
+		}
+		if !slices.Contains(st.Tags, "deploy") && !slices.Contains(st.Tags, "publish") {
+			continue
+		}
+		ran = true
+		if start.IsZero() || st.Start.Before(start) {
+			start = st.Start
+		}
+		if st.End.After(end) {
+			end = st.End
+		}
+	}
+	return start, end, ran
+}
+
+// emitDeploySpan emits the synthetic cmd.deploy span for `azd up`, mirroring
+// the stand-alone `azd deploy --all` span the legacy workflow runner produced.
+// It is a no-op unless at least one deploy/publish step executed, so runs where
+// the deploy phase was skipped by an earlier failure contribute no cmd.deploy
+// row (see the deferred finalizer in Run for the rationale). The span is
+// time-boxed to the real deploy phase and, on failure, carries the same status
+// + ResultCode a stand-alone `azd deploy` would via MapError.
+func emitDeploySpan(
+	ctx context.Context,
+	result *exegraph.RunResult,
+	changedFlags []string,
+	usageAttrs []attribute.KeyValue,
+) {
+	if result == nil {
+		return
+	}
+	start, end, ran := deployPhaseSpanTiming(result.Steps)
+	if !ran {
+		return
+	}
+
+	deployFlags := append([]string{"all"}, changedFlags...)
+	_, deploySpan := tracing.Start(ctx, "cmd.deploy", trace.WithTimestamp(start))
+	deploySpan.SetAttributes(fields.CmdFlags.StringSlice(deployFlags))
+	deploySpan.SetAttributes(usageAttrs...)
+	if err := aggregatePhaseError(result, "deploy", "publish"); err != nil {
+		MapError(err, deploySpan)
+	}
+	deploySpan.End(trace.WithTimestamp(end))
 }

--- a/cli/azd/internal/cmd/up_graph.go
+++ b/cli/azd/internal/cmd/up_graph.go
@@ -177,6 +177,11 @@ func (u *UpGraphAction) Run(
 	// paths (before the graph runs), where those phases never executed and the
 	// spans close as success — matching the pre-graph shape.
 	var graphResult *exegraph.RunResult
+	// provisionSetupErr captures a provision-phase failure that happens before
+	// the unified graph runs (bicep layer analysis or provision validation), so
+	// the deferred finalizer can still stamp it onto the synthetic cmd.provision
+	// span even though graphResult is nil on those early-return paths (#9054).
+	var provisionSetupErr error
 	defer func() {
 		// Apply usage attributes (e.g. EnvNameKey) at end so they include
 		// any values set during Run. Globals (e.g. SubscriptionIdKey) are
@@ -189,7 +194,7 @@ func (u *UpGraphAction) Run(
 		// MapError stamps the same status + ResultCode a stand-alone
 		// `azd package` would report.
 		packageSpan.SetAttributes(usageAttrs...)
-		if err := aggregatePhaseError(graphResult, "package"); err != nil {
+		if err := firstPhaseError(graphResult, "package", genuinePhaseFailure); err != nil {
 			MapError(err, packageSpan)
 		}
 		packageSpan.End()
@@ -201,8 +206,15 @@ func (u *UpGraphAction) Run(
 		// span, and so wrapProvisionError's side effects (JSON state dump,
 		// console messages) are not re-triggered here.
 		provisionSpan.SetAttributes(usageAttrs...)
-		if err := aggregatePhaseError(graphResult, "provision"); err != nil {
-			MapError(err, provisionSpan)
+		// Prefer a pre-graph provision failure (layer analysis / validation),
+		// which runs before graphResult is populated; otherwise fall back to the
+		// executed provision steps.
+		provisionErr := provisionSetupErr
+		if provisionErr == nil {
+			provisionErr = firstPhaseError(graphResult, "provision", genuinePhaseFailure)
+		}
+		if provisionErr != nil {
+			MapError(provisionErr, provisionSpan)
 		}
 		provisionSpan.End()
 
@@ -222,6 +234,7 @@ func (u *UpGraphAction) Run(
 		var err error
 		layerDeps, err = bicep.AnalyzeLayerDependencies(ctx, layers, u.projectConfig.Path)
 		if err != nil {
+			provisionSetupErr = err
 			return nil, fmt.Errorf("analyzing layer dependencies: %w", err)
 		}
 	}
@@ -235,13 +248,20 @@ func (u *UpGraphAction) Run(
 	// becomes the "Provisioning was canceled." message.
 	if len(layers) > 0 {
 		if err := u.provisionManager.RunProvisionValidation(ctx, false); err != nil {
-			return nil, wrapProvisionError(ctx, err, provisionErrorDeps{
+			// Capture the *translated* error (e.g. validation-cancel →
+			// ErrAbortedByUser) so the synthetic cmd.provision span gets the
+			// same ResultCode the stand-alone command reports. wrapProvisionError
+			// is invoked once and its result reused for both telemetry and the
+			// return value, so its side effects do not fire twice.
+			wrapped := wrapProvisionError(ctx, err, provisionErrorDeps{
 				console:          u.console,
 				formatter:        u.formatter,
 				writer:           u.writer,
 				provisionManager: u.provisionManager,
 				portalUrlBase:    u.portalUrlBase,
 			})
+			provisionSetupErr = wrapped
+			return nil, wrapped
 		}
 	}
 
@@ -276,18 +296,6 @@ func (u *UpGraphAction) Run(
 	state := newDeployGraphState(stableServices)
 
 	// ── cmdhook-preprovision ── no deps; first.
-	const (
-		preProvisionHookStep  = "cmdhook-preprovision"
-		postProvisionHookStep = "cmdhook-postprovision"
-		preDeployHookStep     = "cmdhook-predeploy"
-		postDeployHookStep    = "cmdhook-postdeploy"
-		preDeployEventStep    = "event-predeploy"
-		postDeployEventStep   = "event-postdeploy"
-		prePackageHookStep    = "cmdhook-prepackage"
-		postPackageHookStep   = "cmdhook-postpackage"
-		prePackageEventStep   = "event-prepackage"
-		postPackageEventStep  = "event-postpackage"
-	)
 
 	if err := g.AddStep(&exegraph.Step{
 		Name:      preProvisionHookStep,
@@ -949,6 +957,23 @@ func (u *UpGraphAction) runOptions() exegraph.RunOptions {
 	return opts
 }
 
+// Synthetic up-graph lifecycle step names. Provision/package/deploy service
+// steps carry a phase tag, but these hook/event nodes are tagged only
+// "cmdhook"/"event"; stepUpPhase recovers their phase from these fixed internal
+// names for telemetry attribution. Kept in sync with the AddStep calls in Run.
+const (
+	preProvisionHookStep  = "cmdhook-preprovision"
+	postProvisionHookStep = "cmdhook-postprovision"
+	preDeployHookStep     = "cmdhook-predeploy"
+	postDeployHookStep    = "cmdhook-postdeploy"
+	preDeployEventStep    = "event-predeploy"
+	postDeployEventStep   = "event-postdeploy"
+	prePackageHookStep    = "cmdhook-prepackage"
+	postPackageHookStep   = "cmdhook-postpackage"
+	prePackageEventStep   = "event-prepackage"
+	postPackageEventStep  = "event-postpackage"
+)
+
 // provisionStepFailed reports whether any step tagged "provision" ended in
 // StepFailed. Used to scope provision-specific error wrapping (state dump,
 // OpenAI quota hint, Responsible-AI suggestions) to actual provision
@@ -968,46 +993,124 @@ func provisionStepFailed(result *exegraph.RunResult) bool {
 	return false
 }
 
-// aggregatePhaseError returns the error of the first failed step whose Tags
-// include any of the given phase tags, in step-completion order, or nil when no
-// such step failed. Only genuine failures (StepFailed) are considered; steps
-// the FailFast scheduler skipped (StepSkipped, carrying a StepSkippedError) are
-// ignored so a downstream phase is never blamed for an upstream failure.
-// Returning a single underlying error — rather than a join of every concurrent
-// failure — keeps the ResultCode that MapError derives identical to what the
-// equivalent stand-alone command (azd package / provision / deploy) reports.
-func aggregatePhaseError(result *exegraph.RunResult, tags ...string) error {
+// stepUpPhase maps a graph step to the synthetic cmd.* phase span it
+// contributes to ("provision", "package", or "deploy"), or "" if none. Service
+// steps carry a reliable phase tag (deploy and publish steps both belong to the
+// deploy phase, mirroring stand-alone `azd deploy`); lifecycle hook/event nodes
+// are tagged only "cmdhook"/"event", so their phase is recovered from their
+// fixed internal step name. Tags are checked first so a user-named service
+// (e.g. "my-package-svc") is never misclassified by its name.
+func stepUpPhase(st exegraph.StepTiming) string {
+	switch {
+	case slices.Contains(st.Tags, "provision"):
+		return "provision"
+	case slices.Contains(st.Tags, "package"):
+		return "package"
+	case slices.Contains(st.Tags, "deploy"), slices.Contains(st.Tags, "publish"):
+		return "deploy"
+	}
+
+	switch st.Name {
+	case preProvisionHookStep, postProvisionHookStep:
+		return "provision"
+	case prePackageHookStep, postPackageHookStep, prePackageEventStep, postPackageEventStep:
+		return "package"
+	case preDeployHookStep, postDeployHookStep, preDeployEventStep, postDeployEventStep:
+		return "deploy"
+	}
+	return ""
+}
+
+// stepStarted reports whether a step is anything other than a never-started
+// dependency skip. A step skipped because a dependency failed is recorded
+// StepSkipped carrying a *StepSkippedError (IsStepSkipped == true) and never
+// ran. Every other step — including one canceled while running and one still
+// queued when the run was canceled — is treated as started. The scheduler
+// records those two cancellation cases identically (StepSkipped with the
+// context error), so this cannot isolate truly in-flight work; for the
+// telemetry question "did this phase run at all" that conflation is acceptable.
+func stepStarted(st exegraph.StepTiming) bool {
+	if st.Status != exegraph.StepSkipped {
+		return true
+	}
+	return st.Err != nil && !exegraph.IsStepSkipped(st.Err)
+}
+
+// genuinePhaseFailure returns a step's error only when the step itself failed
+// (StepFailed). In-flight cancellations are ignored so an upstream failure
+// tearing down an unrelated, overlapping phase step never blames this phase —
+// used for the provision and package phases.
+func genuinePhaseFailure(st exegraph.StepTiming) error {
+	if st.Status == exegraph.StepFailed {
+		return st.Err
+	}
+	return nil
+}
+
+// deployPhaseFailure additionally surfaces a cancellation as a deploy failure.
+// The deploy phase runs last — after provision and package have succeeded — so a
+// deploy step canceled after starting is a user cancellation or a sibling-deploy
+// failure, both of which stand-alone `azd deploy` reports on cmd.deploy.
+// Provision/package deliberately use genuinePhaseFailure instead, so a FailFast
+// teardown of one does not falsely fail the other.
+func deployPhaseFailure(st exegraph.StepTiming) error {
+	if err := genuinePhaseFailure(st); err != nil {
+		return err
+	}
+	if st.Status == exegraph.StepSkipped && stepStarted(st) {
+		return st.Err
+	}
+	return nil
+}
+
+// firstPhaseError returns the error selected by pick for the first step in the
+// given phase, in scheduler completion order, or nil. Under FailFast the
+// triggering failure is recorded before the cancellations it causes, so the
+// first genuine failure pick finds is the phase's root cause — giving the
+// synthetic span the same ResultCode the stand-alone command (azd provision /
+// package / deploy) reports in the common case. This is scheduler-observed
+// completion order, not strict wall-clock order, and rare cancellation races
+// are not guaranteed to reproduce the stand-alone code exactly.
+func firstPhaseError(
+	result *exegraph.RunResult,
+	phase string,
+	pick func(exegraph.StepTiming) error,
+) error {
 	if result == nil {
 		return nil
 	}
 	for _, st := range result.Steps {
-		if st.Status != exegraph.StepFailed || st.Err == nil {
+		if stepUpPhase(st) != phase {
 			continue
 		}
-		for _, tag := range tags {
-			if slices.Contains(st.Tags, tag) {
-				return st.Err
-			}
+		if err := pick(st); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-// deployPhaseSpanTiming reports the wall-clock envelope of the deploy phase —
-// the earliest start and latest end across every executed step tagged "deploy"
-// or "publish" — together with whether any such step actually ran. Skipped
-// steps are excluded so a deploy phase that never executed (e.g. provisioning
-// failed first) reports ran=false, signalling the caller to emit no cmd.deploy
-// span.
+// deployPhaseSpanTiming reports the wall-clock envelope of the deploy phase and
+// whether it meaningfully ran (so the caller knows whether to emit cmd.deploy).
+// The envelope spans the earliest start / latest end of every deploy-phase step
+// that started, including the pre/post-deploy hook and event nodes.
+//
+// "Ran" is true when a deploy/publish *service* step executed, or when any
+// deploy-phase step failed or was canceled after starting (a failing
+// pre/post-deploy hook, or a user Ctrl+C). A pre/post-deploy lifecycle hook that
+// merely *succeeded* does NOT by itself count: the predeploy hook is gated only
+// on provisioning, so it can run before packaging finishes, and a later package
+// failure must not leave behind a spurious successful cmd.deploy (issue #9054).
+// Never-started dependency skips are excluded entirely.
 func deployPhaseSpanTiming(steps []exegraph.StepTiming) (start, end time.Time, ran bool) {
 	for _, st := range steps {
-		if st.Status == exegraph.StepSkipped {
+		if stepUpPhase(st) != "deploy" || !stepStarted(st) {
 			continue
 		}
-		if !slices.Contains(st.Tags, "deploy") && !slices.Contains(st.Tags, "publish") {
-			continue
+		isService := slices.Contains(st.Tags, "deploy") || slices.Contains(st.Tags, "publish")
+		if isService || st.Status != exegraph.StepDone {
+			ran = true
 		}
-		ran = true
 		if start.IsZero() || st.Start.Before(start) {
 			start = st.Start
 		}
@@ -1020,9 +1123,10 @@ func deployPhaseSpanTiming(steps []exegraph.StepTiming) (start, end time.Time, r
 
 // emitDeploySpan emits the synthetic cmd.deploy span for `azd up`, mirroring
 // the stand-alone `azd deploy --all` span the legacy workflow runner produced.
-// It is a no-op unless at least one deploy/publish step executed, so runs where
-// the deploy phase was skipped by an earlier failure contribute no cmd.deploy
-// row (see the deferred finalizer in Run for the rationale). The span is
+// It is a no-op unless the deploy phase meaningfully ran (a deploy/publish
+// service step executed, or a deploy-phase step failed or was canceled — see
+// deployPhaseSpanTiming), so a run whose deploy phase was skipped by an earlier
+// provision/package failure contributes no cmd.deploy row. The span is
 // time-boxed to the real deploy phase and, on failure, carries the same status
 // + ResultCode a stand-alone `azd deploy` would via MapError.
 func emitDeploySpan(
@@ -1043,7 +1147,7 @@ func emitDeploySpan(
 	_, deploySpan := tracing.Start(ctx, "cmd.deploy", trace.WithTimestamp(start))
 	deploySpan.SetAttributes(fields.CmdFlags.StringSlice(deployFlags))
 	deploySpan.SetAttributes(usageAttrs...)
-	if err := aggregatePhaseError(result, "deploy", "publish"); err != nil {
+	if err := firstPhaseError(result, "deploy", deployPhaseFailure); err != nil {
 		MapError(err, deploySpan)
 	}
 	deploySpan.End(trace.WithTimestamp(end))

--- a/cli/azd/internal/cmd/up_graph_telemetry_test.go
+++ b/cli/azd/internal/cmd/up_graph_telemetry_test.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,9 +21,10 @@ import (
 
 // Regression coverage for issue #9054: the synthetic cmd.package / cmd.provision
 // / cmd.deploy spans under `azd up` must reflect the real per-phase outcome
-// rather than always reporting success. stepUpPhase, stepStarted, firstPhaseError
-// and deployPhaseSpanTiming are the pure building blocks the deferred span
-// finalizer relies on, so they are asserted directly here.
+// rather than always reporting success. stepUpPhase, stepStarted, firstPhaseError,
+// phaseOutcomeError, deployOutcomeError and deployPhaseSpanTiming are the pure
+// building blocks the deferred span finalizer relies on, so they are asserted
+// directly here.
 
 func TestStepUpPhase(t *testing.T) {
 	t.Parallel()
@@ -92,10 +94,11 @@ func TestStepStarted(t *testing.T) {
 	}
 }
 
-// TestFirstPhaseError asserts the phase root-cause selection, including the
-// deliberate asymmetry between the pick functions: provision/package use
-// genuinePhaseFailure (StepFailed only), while deploy uses deployPhaseFailure,
-// which also treats an in-flight cancellation as a deploy failure.
+// TestFirstPhaseError asserts the generic phase root-cause selection over the
+// two pick functions the phase span finalizer composes: genuinePhaseFailure
+// (StepFailed only) and startedCancellation (an in-flight Ctrl+C/deadline). The
+// higher-level phaseOutcomeError / deployOutcomeError wrappers are covered
+// separately.
 func TestFirstPhaseError(t *testing.T) {
 	t.Parallel()
 
@@ -184,7 +187,7 @@ func TestFirstPhaseError(t *testing.T) {
 				{Name: "publish-web", Status: exegraph.StepFailed, Tags: []string{"publish"}, Err: publishErr},
 			}},
 			phase: "deploy",
-			pick:  deployPhaseFailure,
+			pick:  genuinePhaseFailure,
 			want:  publishErr,
 		},
 		{
@@ -193,7 +196,7 @@ func TestFirstPhaseError(t *testing.T) {
 				{Name: "deploy-web", Status: exegraph.StepSkipped, Tags: []string{"deploy"}, Err: context.Canceled},
 			}},
 			phase: "deploy",
-			pick:  deployPhaseFailure,
+			pick:  startedCancellation,
 			want:  context.Canceled,
 		},
 		{
@@ -202,7 +205,7 @@ func TestFirstPhaseError(t *testing.T) {
 				{Name: "deploy-web", Status: exegraph.StepSkipped, Tags: []string{"deploy"}, Err: skipErr},
 			}},
 			phase: "deploy",
-			pick:  deployPhaseFailure,
+			pick:  startedCancellation,
 			want:  nil,
 		},
 		{
@@ -212,7 +215,7 @@ func TestFirstPhaseError(t *testing.T) {
 				{Name: "deploy-api", Status: exegraph.StepSkipped, Tags: []string{"deploy"}, Err: context.Canceled},
 			}},
 			phase: "deploy",
-			pick:  deployPhaseFailure,
+			pick:  genuinePhaseFailure,
 			want:  deployErr,
 		},
 	}
@@ -226,17 +229,173 @@ func TestFirstPhaseError(t *testing.T) {
 	}
 }
 
+// TestRunHadGenuineFailure asserts the run-level predicate the phase span
+// finalizer uses to tell a real user cancellation apart from FailFast teardown:
+// it is true only when some step failed outright (StepFailed), since the
+// scheduler cancels in-flight steps only after a genuine failure.
+func TestRunHadGenuineFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		result *exegraph.RunResult
+		want   bool
+	}{
+		{"nil result", nil, false},
+		{"empty run", &exegraph.RunResult{}, false},
+		{
+			name: "all done or skipped is not a genuine failure",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "provision-db", Status: exegraph.StepDone, Tags: []string{"provision"}},
+				{Name: "deploy-web", Status: exegraph.StepSkipped, Tags: []string{"deploy"}, Err: context.Canceled},
+			}},
+			want: false,
+		},
+		{
+			name: "a StepFailed anywhere is a genuine failure",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "package-web", Status: exegraph.StepFailed, Tags: []string{"package"}, Err: errors.New("boom")},
+			}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, runHadGenuineFailure(tt.result))
+		})
+	}
+}
+
+// TestPhaseOutcomeError covers the provision/package span attribution: a genuine
+// phase failure is always surfaced; an in-flight cancellation is surfaced only
+// when the run was aborted by the user (no other step genuinely failed), and is
+// treated as FailFast teardown (nil) when some other phase actually failed.
+func TestPhaseOutcomeError(t *testing.T) {
+	t.Parallel()
+
+	packageErr := errors.New("docker build failed")
+	provisionErr := errors.New("bicep failed")
+
+	tests := []struct {
+		name   string
+		result *exegraph.RunResult
+		phase  string
+		want   error
+	}{
+		{"nil result", nil, "package", nil},
+		{
+			name: "genuine package failure is surfaced",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "package-web", Status: exegraph.StepFailed, Tags: []string{"package"}, Err: packageErr},
+			}},
+			phase: "package",
+			want:  packageErr,
+		},
+		{
+			name: "user Ctrl+C while packaging is surfaced as the cancellation",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "package-web", Status: exegraph.StepSkipped, Tags: []string{"package"}, Err: context.Canceled},
+			}},
+			phase: "package",
+			want:  context.Canceled,
+		},
+		{
+			// A genuine provision failure tears down the in-flight package step;
+			// that teardown must not be blamed on the package span.
+			name: "package teardown by an upstream provision failure is not surfaced",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "provision-db", Status: exegraph.StepFailed, Tags: []string{"provision"}, Err: provisionErr},
+				{Name: "package-web", Status: exegraph.StepSkipped, Tags: []string{"package"}, Err: context.Canceled},
+			}},
+			phase: "package",
+			want:  nil,
+		},
+		{
+			name: "never-started package skip is not surfaced",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{
+					Name: "package-web", Status: exegraph.StepSkipped, Tags: []string{"package"},
+					Err: &exegraph.StepSkippedError{StepName: "package-web"},
+				},
+			}},
+			phase: "package",
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.ErrorIs(t, phaseOutcomeError(tt.result, tt.phase), tt.want)
+		})
+	}
+}
+
+// TestDeployOutcomeError covers the cmd.deploy span attribution: a genuine
+// deploy failure always wins; otherwise an in-flight cancellation is surfaced
+// only when no upstream provision/package failure tore the phase down.
+func TestDeployOutcomeError(t *testing.T) {
+	t.Parallel()
+
+	deployErr := errors.New("zip deploy failed")
+
+	tests := []struct {
+		name           string
+		result         *exegraph.RunResult
+		upstreamFailed bool
+		want           error
+	}{
+		{"nil result", nil, false, nil},
+		{
+			name: "genuine deploy failure is surfaced even when upstream also failed",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "deploy-web", Status: exegraph.StepFailed, Tags: []string{"deploy"}, Err: deployErr},
+			}},
+			upstreamFailed: true,
+			want:           deployErr,
+		},
+		{
+			name: "user Ctrl+C during deploy is surfaced when nothing upstream failed",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "deploy-web", Status: exegraph.StepSkipped, Tags: []string{"deploy"}, Err: context.Canceled},
+			}},
+			upstreamFailed: false,
+			want:           context.Canceled,
+		},
+		{
+			// FailFast teardown of the deploy phase after a provision/package
+			// failure must leave cmd.deploy unblamed (that failure owns its span).
+			name: "deploy teardown after an upstream failure is not surfaced",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "deploy-web", Status: exegraph.StepSkipped, Tags: []string{"deploy"}, Err: context.Canceled},
+			}},
+			upstreamFailed: true,
+			want:           nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.ErrorIs(t, deployOutcomeError(tt.result, tt.upstreamFailed), tt.want)
+		})
+	}
+}
+
 func TestDeployPhaseSpanTiming(t *testing.T) {
 	t.Parallel()
 
 	base := time.Now()
 
 	tests := []struct {
-		name      string
-		steps     []exegraph.StepTiming
-		wantRan   bool
-		wantStart time.Time
-		wantEnd   time.Time
+		name           string
+		steps          []exegraph.StepTiming
+		upstreamFailed bool
+		wantRan        bool
+		wantStart      time.Time
+		wantEnd        time.Time
 	}{
 		{
 			name:    "no deploy or publish steps",
@@ -297,6 +456,38 @@ func TestDeployPhaseSpanTiming(t *testing.T) {
 			wantEnd:   base.Add(50 * time.Second),
 		},
 		{
+			// A deploy lifecycle step canceled in-flight because the *user*
+			// pressed Ctrl+C (no upstream provision/package failure) is a real
+			// deploy-phase outcome and counts as ran.
+			name: "in-flight-canceled deploy hook counts as ran when no upstream failure",
+			steps: []exegraph.StepTiming{
+				{
+					Name: preDeployHookStep, Status: exegraph.StepSkipped, Err: context.Canceled,
+					Start: base.Add(20 * time.Second), End: base.Add(35 * time.Second),
+				},
+			},
+			upstreamFailed: false,
+			wantRan:        true,
+			wantStart:      base.Add(20 * time.Second),
+			wantEnd:        base.Add(35 * time.Second),
+		},
+		{
+			// #9054 flip side: when a package/provision step genuinely failed,
+			// FailFast tears down an overlapping predeploy hook (StepSkipped +
+			// context.Canceled). That teardown must NOT count as a deploy run, or
+			// `up` would emit a spurious FAILED cmd.deploy blamed on the deploy
+			// phase for a failure that belongs to package/provision.
+			name: "in-flight-canceled deploy hook does not count when upstream failed",
+			steps: []exegraph.StepTiming{
+				{
+					Name: preDeployHookStep, Status: exegraph.StepSkipped, Err: context.Canceled,
+					Start: base.Add(20 * time.Second), End: base.Add(35 * time.Second),
+				},
+			},
+			upstreamFailed: true,
+			wantRan:        false,
+		},
+		{
 			// #9054 regression guard: the predeploy hook is gated only on
 			// provisioning, so it can finish before a *failing* package step. A
 			// lone successful lifecycle hook must therefore NOT mark the deploy
@@ -344,12 +535,33 @@ func TestDeployPhaseSpanTiming(t *testing.T) {
 			wantStart: base.Add(5 * time.Second),
 			wantEnd:   base.Add(60 * time.Second),
 		},
+		{
+			// Infra-only project (no services): every deploy lifecycle node runs
+			// to completion but none is a service step. The terminal deploy node
+			// (cmdhook-postdeploy) completing means the whole pipeline finished,
+			// so `up` still records a cmd.deploy — matching legacy `azd up`, which
+			// always invoked `azd deploy --all` even with nothing to deploy.
+			name: "infra-only run with terminal post-deploy hook counts as ran",
+			steps: []exegraph.StepTiming{
+				{
+					Name: preDeployHookStep, Status: exegraph.StepDone,
+					Start: base.Add(5 * time.Second), End: base.Add(10 * time.Second),
+				},
+				{
+					Name: postDeployHookStep, Status: exegraph.StepDone,
+					Start: base.Add(11 * time.Second), End: base.Add(14 * time.Second),
+				},
+			},
+			wantRan:   true,
+			wantStart: base.Add(5 * time.Second),
+			wantEnd:   base.Add(14 * time.Second),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			start, end, ran := deployPhaseSpanTiming(tt.steps)
+			start, end, ran := deployPhaseSpanTiming(tt.steps, tt.upstreamFailed)
 			assert.Equal(t, tt.wantRan, ran)
 			if tt.wantRan {
 				assert.True(t, tt.wantStart.Equal(start), "start = %s, want %s", start, tt.wantStart)
@@ -369,18 +581,40 @@ func findSpan(spans []tracesdk.ReadOnlySpan, name string) tracesdk.ReadOnlySpan 
 	return nil
 }
 
+// The azd tracing package caches its Tracer at package-init from the global
+// OpenTelemetry provider, and that global only honors the first
+// SetTracerProvider call for the life of the process. Every span test in this
+// package must therefore share a single recorder rather than install its own.
+var (
+	deploySpanRecorderOnce sync.Once
+	deploySpanRecorder     *tracetest.SpanRecorder
+)
+
+// recordDeploySpans installs the shared in-memory span recorder on first use and
+// returns a snapshot function that yields only the spans ended after this call,
+// so a test observes just the spans it emitted. Callers must not run in parallel
+// (the baseline slice is not synchronized).
+func recordDeploySpans(t *testing.T) func() []tracesdk.ReadOnlySpan {
+	t.Helper()
+	deploySpanRecorderOnce.Do(func() {
+		deploySpanRecorder = tracetest.NewSpanRecorder()
+		tp := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(deploySpanRecorder))
+		otel.SetTracerProvider(tp)
+	})
+	baseline := len(deploySpanRecorder.Ended())
+	return func() []tracesdk.ReadOnlySpan {
+		return deploySpanRecorder.Ended()[baseline:]
+	}
+}
+
 // TestEmitDeploySpan_ErrorPath is the end-to-end assertion issue #9054 was
 // missing: when the deploy phase fails under `azd up`, a cmd.deploy span must
 // actually be emitted, carry an Error status with a non-empty ResultCode, and be
 // time-boxed to the real deploy phase. It installs an in-memory tracer provider
 // to capture the span emitted through tracing.Start.
 func TestEmitDeploySpan_ErrorPath(t *testing.T) {
-	// Not parallel: mutates the global OpenTelemetry tracer provider.
-	sr := tracetest.NewSpanRecorder()
-	tp := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(sr))
-	prev := otel.GetTracerProvider()
-	otel.SetTracerProvider(tp)
-	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+	// Not parallel: shares one process-wide tracer provider (see recordDeploySpans).
+	newSpans := recordDeploySpans(t)
 
 	base := time.Now()
 	start := base.Add(30 * time.Second)
@@ -394,9 +628,9 @@ func TestEmitDeploySpan_ErrorPath(t *testing.T) {
 		},
 	}}
 
-	emitDeploySpan(context.Background(), result, nil, nil)
+	emitDeploySpan(t.Context(), result, nil, nil)
 
-	span := findSpan(sr.Ended(), "cmd.deploy")
+	span := findSpan(newSpans(), "cmd.deploy")
 	require.NotNil(t, span, "cmd.deploy span must be emitted when the deploy phase fails")
 	assert.Equal(t, codes.Error, span.Status().Code)
 	assert.NotEmpty(t, span.Status().Description, "failure must carry a ResultCode")
@@ -409,12 +643,8 @@ func TestEmitDeploySpan_ErrorPath(t *testing.T) {
 // it starts, no cmd.deploy span is emitted — matching legacy `azd up`, where the
 // deploy sub-command never ran.
 func TestEmitDeploySpan_OmittedWhenDeployDidNotRun(t *testing.T) {
-	// Not parallel: mutates the global OpenTelemetry tracer provider.
-	sr := tracetest.NewSpanRecorder()
-	tp := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(sr))
-	prev := otel.GetTracerProvider()
-	otel.SetTracerProvider(tp)
-	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+	// Not parallel: shares one process-wide tracer provider (see recordDeploySpans).
+	newSpans := recordDeploySpans(t)
 
 	result := &exegraph.RunResult{Steps: []exegraph.StepTiming{
 		{
@@ -429,9 +659,9 @@ func TestEmitDeploySpan_OmittedWhenDeployDidNotRun(t *testing.T) {
 		},
 	}}
 
-	emitDeploySpan(context.Background(), result, nil, nil)
+	emitDeploySpan(t.Context(), result, nil, nil)
 
-	assert.Nil(t, findSpan(sr.Ended(), "cmd.deploy"), "no cmd.deploy span when the deploy phase never ran")
+	assert.Nil(t, findSpan(newSpans(), "cmd.deploy"), "no cmd.deploy span when the deploy phase never ran")
 }
 
 // TestEmitDeploySpan_OmittedWhenOnlyDeployHookSucceeded is the direct #9054
@@ -440,12 +670,8 @@ func TestEmitDeploySpan_OmittedWhenDeployDidNotRun(t *testing.T) {
 // lone successful lifecycle hook must not cause a Success cmd.deploy to be
 // emitted for a run whose services were never deployed.
 func TestEmitDeploySpan_OmittedWhenOnlyDeployHookSucceeded(t *testing.T) {
-	// Not parallel: mutates the global OpenTelemetry tracer provider.
-	sr := tracetest.NewSpanRecorder()
-	tp := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(sr))
-	prev := otel.GetTracerProvider()
-	otel.SetTracerProvider(tp)
-	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+	// Not parallel: shares one process-wide tracer provider (see recordDeploySpans).
+	newSpans := recordDeploySpans(t)
 
 	result := &exegraph.RunResult{Steps: []exegraph.StepTiming{
 		{Name: preDeployHookStep, Status: exegraph.StepDone},
@@ -461,10 +687,70 @@ func TestEmitDeploySpan_OmittedWhenOnlyDeployHookSucceeded(t *testing.T) {
 		},
 	}}
 
-	emitDeploySpan(context.Background(), result, nil, nil)
+	emitDeploySpan(t.Context(), result, nil, nil)
 
 	assert.Nil(
-		t, findSpan(sr.Ended(), "cmd.deploy"),
+		t, findSpan(newSpans(), "cmd.deploy"),
 		"a successful predeploy hook alone must not emit cmd.deploy when services never deployed",
 	)
+}
+
+// TestEmitDeploySpan_OmittedWhenDeployHookCanceledByUpstreamFailure is the flip
+// side of the #9054 fix: when a package step genuinely fails while the predeploy
+// hook is in-flight, FailFast tears the hook down (StepSkipped + context.Canceled).
+// That teardown must not surface as a spurious FAILED cmd.deploy — the failure
+// belongs to the package phase, which reports it on cmd.package.
+func TestEmitDeploySpan_OmittedWhenDeployHookCanceledByUpstreamFailure(t *testing.T) {
+	// Not parallel: shares one process-wide tracer provider (see recordDeploySpans).
+	newSpans := recordDeploySpans(t)
+
+	result := &exegraph.RunResult{Steps: []exegraph.StepTiming{
+		{
+			Name: "package-web", Status: exegraph.StepFailed,
+			Tags: []string{"package"}, Err: errors.New("docker build failed"),
+		},
+		{Name: preDeployHookStep, Status: exegraph.StepSkipped, Err: context.Canceled},
+		{
+			Name:   "deploy-web",
+			Status: exegraph.StepSkipped,
+			Tags:   []string{"deploy"},
+			Err:    &exegraph.StepSkippedError{StepName: "deploy-web"},
+		},
+	}}
+
+	emitDeploySpan(t.Context(), result, nil, nil)
+
+	assert.Nil(
+		t, findSpan(newSpans(), "cmd.deploy"),
+		"deploy teardown from an upstream package failure must not emit a cmd.deploy span",
+	)
+}
+
+// TestEmitDeploySpan_InfraOnlyProjectEmitsSuccess covers an infra-only `azd up`
+// (no services): the deploy phase has no service steps, but the whole pipeline
+// completes through the terminal post-deploy hook. Legacy `azd up` always ran
+// `azd deploy --all` even then, so a Success cmd.deploy must still be recorded.
+func TestEmitDeploySpan_InfraOnlyProjectEmitsSuccess(t *testing.T) {
+	// Not parallel: shares one process-wide tracer provider (see recordDeploySpans).
+	newSpans := recordDeploySpans(t)
+
+	base := time.Now()
+	result := &exegraph.RunResult{Steps: []exegraph.StepTiming{
+		{
+			Name: preDeployHookStep, Status: exegraph.StepDone,
+			Start: base.Add(5 * time.Second), End: base.Add(10 * time.Second),
+		},
+		{
+			Name: postDeployHookStep, Status: exegraph.StepDone,
+			Start: base.Add(11 * time.Second), End: base.Add(14 * time.Second),
+		},
+	}}
+
+	emitDeploySpan(t.Context(), result, nil, nil)
+
+	span := findSpan(newSpans(), "cmd.deploy")
+	require.NotNil(t, span, "infra-only `azd up` must still record a cmd.deploy span")
+	assert.NotEqual(t, codes.Error, span.Status().Code, "a clean infra-only run must not be an error")
+	assert.True(t, base.Add(5*time.Second).Equal(span.StartTime()))
+	assert.True(t, base.Add(14*time.Second).Equal(span.EndTime()))
 }

--- a/cli/azd/internal/cmd/up_graph_telemetry_test.go
+++ b/cli/azd/internal/cmd/up_graph_telemetry_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -11,14 +12,91 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/exegraph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // Regression coverage for issue #9054: the synthetic cmd.package / cmd.provision
 // / cmd.deploy spans under `azd up` must reflect the real per-phase outcome
-// rather than always reporting success. aggregatePhaseError and
-// deployPhaseSpanTiming are the pure building blocks the deferred span finalizer
-// relies on, so they are asserted directly here.
-func TestAggregatePhaseError(t *testing.T) {
+// rather than always reporting success. stepUpPhase, stepStarted, firstPhaseError
+// and deployPhaseSpanTiming are the pure building blocks the deferred span
+// finalizer relies on, so they are asserted directly here.
+
+func TestStepUpPhase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		step exegraph.StepTiming
+		want string
+	}{
+		{"provision tag", exegraph.StepTiming{Name: "provision-db", Tags: []string{"provision"}}, "provision"},
+		{"package tag", exegraph.StepTiming{Name: "package-web", Tags: []string{"package"}}, "package"},
+		{"deploy tag", exegraph.StepTiming{Name: "deploy-web", Tags: []string{"deploy"}}, "deploy"},
+		{"publish tag collapses to deploy", exegraph.StepTiming{Name: "publish-web", Tags: []string{"publish"}}, "deploy"},
+		{
+			"tag wins over a service name that contains another phase word",
+			exegraph.StepTiming{Name: "deploy-my-package-svc", Tags: []string{"deploy"}},
+			"deploy",
+		},
+		{"preprovision hook by name", exegraph.StepTiming{Name: preProvisionHookStep}, "provision"},
+		{"postprovision hook by name", exegraph.StepTiming{Name: postProvisionHookStep}, "provision"},
+		{"prepackage event by name", exegraph.StepTiming{Name: prePackageEventStep}, "package"},
+		{"postpackage hook by name", exegraph.StepTiming{Name: postPackageHookStep}, "package"},
+		{"predeploy hook by name", exegraph.StepTiming{Name: preDeployHookStep}, "deploy"},
+		{"postdeploy event by name", exegraph.StepTiming{Name: postDeployEventStep}, "deploy"},
+		{"untagged service step is unclassified", exegraph.StepTiming{Name: "deploy-web"}, ""},
+		{"unknown step", exegraph.StepTiming{Name: "restore-web"}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, stepUpPhase(tt.step))
+		})
+	}
+}
+
+func TestStepStarted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		step exegraph.StepTiming
+		want bool
+	}{
+		{"done ran", exegraph.StepTiming{Status: exegraph.StepDone}, true},
+		{"failed ran", exegraph.StepTiming{Status: exegraph.StepFailed}, true},
+		{
+			"never-started skip did not run",
+			exegraph.StepTiming{
+				Status: exegraph.StepSkipped,
+				Err:    &exegraph.StepSkippedError{StepName: "deploy-web"},
+			},
+			false,
+		},
+		{
+			"in-flight cancel did run",
+			exegraph.StepTiming{Status: exegraph.StepSkipped, Err: context.Canceled},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, stepStarted(tt.step))
+		})
+	}
+}
+
+// TestFirstPhaseError asserts the phase root-cause selection, including the
+// deliberate asymmetry between the pick functions: provision/package use
+// genuinePhaseFailure (StepFailed only), while deploy uses deployPhaseFailure,
+// which also treats an in-flight cancellation as a deploy failure.
+func TestFirstPhaseError(t *testing.T) {
 	t.Parallel()
 
 	provisionErr := errors.New("bicep deployment failed")
@@ -30,71 +108,119 @@ func TestAggregatePhaseError(t *testing.T) {
 	tests := []struct {
 		name   string
 		result *exegraph.RunResult
-		tags   []string
+		phase  string
+		pick   func(exegraph.StepTiming) error
 		want   error
 	}{
 		{
 			name:   "nil result",
 			result: nil,
-			tags:   []string{"provision"},
+			phase:  "provision",
+			pick:   genuinePhaseFailure,
 			want:   nil,
 		},
 		{
-			name: "provision failure is surfaced",
+			name: "genuine provision failure is surfaced",
 			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
-				{Name: "provision", Status: exegraph.StepFailed, Tags: []string{"provision"}, Err: provisionErr},
+				{Name: "provision-db", Status: exegraph.StepFailed, Tags: []string{"provision"}, Err: provisionErr},
 			}},
-			tags: []string{"provision"},
-			want: provisionErr,
+			phase: "provision",
+			pick:  genuinePhaseFailure,
+			want:  provisionErr,
 		},
 		{
-			name: "success returns nil",
+			name: "provision success returns nil",
 			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
-				{Name: "provision", Status: exegraph.StepDone, Tags: []string{"provision"}},
+				{Name: "provision-db", Status: exegraph.StepDone, Tags: []string{"provision"}},
 			}},
-			tags: []string{"provision"},
-			want: nil,
+			phase: "provision",
+			pick:  genuinePhaseFailure,
+			want:  nil,
 		},
 		{
-			name: "skipped provision step is not blamed",
+			name: "never-started provision skip is not blamed",
 			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
-				{Name: "provision", Status: exegraph.StepSkipped, Tags: []string{"provision"}, Err: skipErr},
+				{Name: "provision-db", Status: exegraph.StepSkipped, Tags: []string{"provision"}, Err: skipErr},
 			}},
-			tags: []string{"provision"},
-			want: nil,
+			phase: "provision",
+			pick:  genuinePhaseFailure,
+			want:  nil,
 		},
 		{
-			name: "unrelated phase failure is ignored for provision",
+			name: "in-flight provision cancel is not blamed under genuine pick",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{
+					Name: "provision-db", Status: exegraph.StepSkipped,
+					Tags: []string{"provision"}, Err: context.Canceled,
+				},
+			}},
+			phase: "provision",
+			pick:  genuinePhaseFailure,
+			want:  nil,
+		},
+		{
+			name: "unrelated phase failure is ignored",
 			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
 				{Name: "deploy-web", Status: exegraph.StepFailed, Tags: []string{"deploy"}, Err: deployErr},
 			}},
-			tags: []string{"provision"},
-			want: nil,
+			phase: "provision",
+			pick:  genuinePhaseFailure,
+			want:  nil,
 		},
 		{
-			name: "deploy aggregates both deploy and publish tags",
-			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
-				{Name: "publish-web", Status: exegraph.StepFailed, Tags: []string{"publish"}, Err: publishErr},
-			}},
-			tags: []string{"deploy", "publish"},
-			want: publishErr,
-		},
-		{
-			name: "first failure in completion order wins",
+			name: "package first failure in completion order wins",
 			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
 				{Name: "package-api", Status: exegraph.StepDone, Tags: []string{"package"}},
 				{Name: "package-web", Status: exegraph.StepFailed, Tags: []string{"package"}, Err: packageErr},
 				{Name: "package-worker", Status: exegraph.StepFailed, Tags: []string{"package"}, Err: deployErr},
 			}},
-			tags: []string{"package"},
-			want: packageErr,
+			phase: "package",
+			pick:  genuinePhaseFailure,
+			want:  packageErr,
+		},
+		{
+			name: "deploy surfaces genuine publish failure (publish collapses into deploy)",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "publish-web", Status: exegraph.StepFailed, Tags: []string{"publish"}, Err: publishErr},
+			}},
+			phase: "deploy",
+			pick:  deployPhaseFailure,
+			want:  publishErr,
+		},
+		{
+			name: "deploy surfaces an in-flight cancel (user Ctrl+C)",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "deploy-web", Status: exegraph.StepSkipped, Tags: []string{"deploy"}, Err: context.Canceled},
+			}},
+			phase: "deploy",
+			pick:  deployPhaseFailure,
+			want:  context.Canceled,
+		},
+		{
+			name: "deploy ignores a never-started skip",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "deploy-web", Status: exegraph.StepSkipped, Tags: []string{"deploy"}, Err: skipErr},
+			}},
+			phase: "deploy",
+			pick:  deployPhaseFailure,
+			want:  nil,
+		},
+		{
+			name: "deploy genuine failure precedes a later cancel",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "deploy-web", Status: exegraph.StepFailed, Tags: []string{"deploy"}, Err: deployErr},
+				{Name: "deploy-api", Status: exegraph.StepSkipped, Tags: []string{"deploy"}, Err: context.Canceled},
+			}},
+			phase: "deploy",
+			pick:  deployPhaseFailure,
+			want:  deployErr,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := aggregatePhaseError(tt.result, tt.tags...)
+			got := firstPhaseError(tt.result, tt.phase, tt.pick)
 			require.ErrorIs(t, got, tt.want)
 		})
 	}
@@ -157,6 +283,67 @@ func TestDeployPhaseSpanTiming(t *testing.T) {
 			wantStart: base.Add(10 * time.Second),
 			wantEnd:   base.Add(75 * time.Second),
 		},
+		{
+			name: "in-flight-canceled deploy step counts as ran",
+			steps: []exegraph.StepTiming{
+				{
+					Name: "deploy-web", Status: exegraph.StepSkipped, Tags: []string{"deploy"},
+					Err:   context.Canceled,
+					Start: base.Add(20 * time.Second), End: base.Add(50 * time.Second),
+				},
+			},
+			wantRan:   true,
+			wantStart: base.Add(20 * time.Second),
+			wantEnd:   base.Add(50 * time.Second),
+		},
+		{
+			// #9054 regression guard: the predeploy hook is gated only on
+			// provisioning, so it can finish before a *failing* package step. A
+			// lone successful lifecycle hook must therefore NOT mark the deploy
+			// phase as run, or `up` would emit a spurious Success cmd.deploy for
+			// a run that never actually deployed.
+			name: "successful pre-deploy hook alone does not count as ran",
+			steps: []exegraph.StepTiming{
+				{
+					Name: preDeployHookStep, Status: exegraph.StepDone,
+					Start: base.Add(5 * time.Second), End: base.Add(12 * time.Second),
+				},
+			},
+			wantRan: false,
+		},
+		{
+			// A *failing* pre/post-deploy hook is a real deploy-phase outcome, so
+			// it counts as ran and is surfaced on cmd.deploy.
+			name: "failing pre-deploy hook counts as ran",
+			steps: []exegraph.StepTiming{
+				{
+					Name: preDeployHookStep, Status: exegraph.StepFailed,
+					Err:   errors.New("predeploy hook failed"),
+					Start: base.Add(5 * time.Second), End: base.Add(12 * time.Second),
+				},
+			},
+			wantRan:   true,
+			wantStart: base.Add(5 * time.Second),
+			wantEnd:   base.Add(12 * time.Second),
+		},
+		{
+			// A successful hook contributes to the envelope, but it is the
+			// *service* deploy that makes the phase count as run.
+			name: "successful hook plus deploy service counts as ran",
+			steps: []exegraph.StepTiming{
+				{
+					Name: preDeployHookStep, Status: exegraph.StepDone,
+					Start: base.Add(5 * time.Second), End: base.Add(12 * time.Second),
+				},
+				{
+					Name: "deploy-web", Status: exegraph.StepDone, Tags: []string{"deploy"},
+					Start: base.Add(15 * time.Second), End: base.Add(60 * time.Second),
+				},
+			},
+			wantRan:   true,
+			wantStart: base.Add(5 * time.Second),
+			wantEnd:   base.Add(60 * time.Second),
+		},
 	}
 
 	for _, tt := range tests {
@@ -170,4 +357,114 @@ func TestDeployPhaseSpanTiming(t *testing.T) {
 			}
 		})
 	}
+}
+
+// findSpan returns the first recorded span with the given name, or nil.
+func findSpan(spans []tracesdk.ReadOnlySpan, name string) tracesdk.ReadOnlySpan {
+	for _, s := range spans {
+		if s.Name() == name {
+			return s
+		}
+	}
+	return nil
+}
+
+// TestEmitDeploySpan_ErrorPath is the end-to-end assertion issue #9054 was
+// missing: when the deploy phase fails under `azd up`, a cmd.deploy span must
+// actually be emitted, carry an Error status with a non-empty ResultCode, and be
+// time-boxed to the real deploy phase. It installs an in-memory tracer provider
+// to capture the span emitted through tracing.Start.
+func TestEmitDeploySpan_ErrorPath(t *testing.T) {
+	// Not parallel: mutates the global OpenTelemetry tracer provider.
+	sr := tracetest.NewSpanRecorder()
+	tp := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+
+	base := time.Now()
+	start := base.Add(30 * time.Second)
+	end := base.Add(95 * time.Second)
+	deployErr := errors.New("zip deploy failed")
+
+	result := &exegraph.RunResult{Steps: []exegraph.StepTiming{
+		{
+			Name: "deploy-web", Status: exegraph.StepFailed, Tags: []string{"deploy"},
+			Err: deployErr, Start: start, End: end,
+		},
+	}}
+
+	emitDeploySpan(context.Background(), result, nil, nil)
+
+	span := findSpan(sr.Ended(), "cmd.deploy")
+	require.NotNil(t, span, "cmd.deploy span must be emitted when the deploy phase fails")
+	assert.Equal(t, codes.Error, span.Status().Code)
+	assert.NotEmpty(t, span.Status().Description, "failure must carry a ResultCode")
+	assert.True(t, start.Equal(span.StartTime()), "start = %s, want %s", span.StartTime(), start)
+	assert.True(t, end.Equal(span.EndTime()), "end = %s, want %s", span.EndTime(), end)
+}
+
+// TestEmitDeploySpan_OmittedWhenDeployDidNotRun verifies the other half of the
+// contract: when provisioning fails first and the deploy phase is skipped before
+// it starts, no cmd.deploy span is emitted — matching legacy `azd up`, where the
+// deploy sub-command never ran.
+func TestEmitDeploySpan_OmittedWhenDeployDidNotRun(t *testing.T) {
+	// Not parallel: mutates the global OpenTelemetry tracer provider.
+	sr := tracetest.NewSpanRecorder()
+	tp := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+
+	result := &exegraph.RunResult{Steps: []exegraph.StepTiming{
+		{
+			Name: "provision-db", Status: exegraph.StepFailed,
+			Tags: []string{"provision"}, Err: errors.New("bicep failed"),
+		},
+		{
+			Name:   "deploy-web",
+			Status: exegraph.StepSkipped,
+			Tags:   []string{"deploy"},
+			Err:    &exegraph.StepSkippedError{StepName: "deploy-web"},
+		},
+	}}
+
+	emitDeploySpan(context.Background(), result, nil, nil)
+
+	assert.Nil(t, findSpan(sr.Ended(), "cmd.deploy"), "no cmd.deploy span when the deploy phase never ran")
+}
+
+// TestEmitDeploySpan_OmittedWhenOnlyDeployHookSucceeded is the direct #9054
+// regression guard for the concurrency window: the predeploy hook depends only
+// on provisioning, so it can *succeed* before a later package step *fails*. That
+// lone successful lifecycle hook must not cause a Success cmd.deploy to be
+// emitted for a run whose services were never deployed.
+func TestEmitDeploySpan_OmittedWhenOnlyDeployHookSucceeded(t *testing.T) {
+	// Not parallel: mutates the global OpenTelemetry tracer provider.
+	sr := tracetest.NewSpanRecorder()
+	tp := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+
+	result := &exegraph.RunResult{Steps: []exegraph.StepTiming{
+		{Name: preDeployHookStep, Status: exegraph.StepDone},
+		{
+			Name: "package-web", Status: exegraph.StepFailed,
+			Tags: []string{"package"}, Err: errors.New("docker build failed"),
+		},
+		{
+			Name:   "deploy-web",
+			Status: exegraph.StepSkipped,
+			Tags:   []string{"deploy"},
+			Err:    &exegraph.StepSkippedError{StepName: "deploy-web"},
+		},
+	}}
+
+	emitDeploySpan(context.Background(), result, nil, nil)
+
+	assert.Nil(
+		t, findSpan(sr.Ended(), "cmd.deploy"),
+		"a successful predeploy hook alone must not emit cmd.deploy when services never deployed",
+	)
 }

--- a/cli/azd/internal/cmd/up_graph_telemetry_test.go
+++ b/cli/azd/internal/cmd/up_graph_telemetry_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/exegraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression coverage for issue #9054: the synthetic cmd.package / cmd.provision
+// / cmd.deploy spans under `azd up` must reflect the real per-phase outcome
+// rather than always reporting success. aggregatePhaseError and
+// deployPhaseSpanTiming are the pure building blocks the deferred span finalizer
+// relies on, so they are asserted directly here.
+func TestAggregatePhaseError(t *testing.T) {
+	t.Parallel()
+
+	provisionErr := errors.New("bicep deployment failed")
+	packageErr := errors.New("docker build failed")
+	deployErr := errors.New("zip deploy failed")
+	publishErr := errors.New("image push failed")
+	skipErr := &exegraph.StepSkippedError{StepName: "deploy-web"}
+
+	tests := []struct {
+		name   string
+		result *exegraph.RunResult
+		tags   []string
+		want   error
+	}{
+		{
+			name:   "nil result",
+			result: nil,
+			tags:   []string{"provision"},
+			want:   nil,
+		},
+		{
+			name: "provision failure is surfaced",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "provision", Status: exegraph.StepFailed, Tags: []string{"provision"}, Err: provisionErr},
+			}},
+			tags: []string{"provision"},
+			want: provisionErr,
+		},
+		{
+			name: "success returns nil",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "provision", Status: exegraph.StepDone, Tags: []string{"provision"}},
+			}},
+			tags: []string{"provision"},
+			want: nil,
+		},
+		{
+			name: "skipped provision step is not blamed",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "provision", Status: exegraph.StepSkipped, Tags: []string{"provision"}, Err: skipErr},
+			}},
+			tags: []string{"provision"},
+			want: nil,
+		},
+		{
+			name: "unrelated phase failure is ignored for provision",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "deploy-web", Status: exegraph.StepFailed, Tags: []string{"deploy"}, Err: deployErr},
+			}},
+			tags: []string{"provision"},
+			want: nil,
+		},
+		{
+			name: "deploy aggregates both deploy and publish tags",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "publish-web", Status: exegraph.StepFailed, Tags: []string{"publish"}, Err: publishErr},
+			}},
+			tags: []string{"deploy", "publish"},
+			want: publishErr,
+		},
+		{
+			name: "first failure in completion order wins",
+			result: &exegraph.RunResult{Steps: []exegraph.StepTiming{
+				{Name: "package-api", Status: exegraph.StepDone, Tags: []string{"package"}},
+				{Name: "package-web", Status: exegraph.StepFailed, Tags: []string{"package"}, Err: packageErr},
+				{Name: "package-worker", Status: exegraph.StepFailed, Tags: []string{"package"}, Err: deployErr},
+			}},
+			tags: []string{"package"},
+			want: packageErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := aggregatePhaseError(tt.result, tt.tags...)
+			require.ErrorIs(t, got, tt.want)
+		})
+	}
+}
+
+func TestDeployPhaseSpanTiming(t *testing.T) {
+	t.Parallel()
+
+	base := time.Now()
+
+	tests := []struct {
+		name      string
+		steps     []exegraph.StepTiming
+		wantRan   bool
+		wantStart time.Time
+		wantEnd   time.Time
+	}{
+		{
+			name:    "no deploy or publish steps",
+			steps:   []exegraph.StepTiming{{Name: "provision", Status: exegraph.StepDone, Tags: []string{"provision"}}},
+			wantRan: false,
+		},
+		{
+			name: "all deploy steps skipped means phase did not run",
+			steps: []exegraph.StepTiming{
+				{Name: "publish-web", Status: exegraph.StepSkipped, Tags: []string{"publish"}},
+				{Name: "deploy-web", Status: exegraph.StepSkipped, Tags: []string{"deploy"}},
+			},
+			wantRan: false,
+		},
+		{
+			name: "single deploy step envelope",
+			steps: []exegraph.StepTiming{
+				{
+					Name: "deploy-web", Status: exegraph.StepDone, Tags: []string{"deploy"},
+					Start: base.Add(30 * time.Second), End: base.Add(90 * time.Second),
+				},
+			},
+			wantRan:   true,
+			wantStart: base.Add(30 * time.Second),
+			wantEnd:   base.Add(90 * time.Second),
+		},
+		{
+			name: "publish and deploy span the full envelope; skipped excluded",
+			steps: []exegraph.StepTiming{
+				{
+					Name: "publish-web", Status: exegraph.StepDone, Tags: []string{"publish"},
+					Start: base.Add(10 * time.Second), End: base.Add(40 * time.Second),
+				},
+				{
+					Name: "deploy-web", Status: exegraph.StepFailed, Tags: []string{"deploy"},
+					Start: base.Add(40 * time.Second), End: base.Add(75 * time.Second),
+				},
+				{
+					Name: "deploy-api", Status: exegraph.StepSkipped, Tags: []string{"deploy"},
+					Start: base, End: base.Add(500 * time.Second),
+				},
+			},
+			wantRan:   true,
+			wantStart: base.Add(10 * time.Second),
+			wantEnd:   base.Add(75 * time.Second),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			start, end, ran := deployPhaseSpanTiming(tt.steps)
+			assert.Equal(t, tt.wantRan, ran)
+			if tt.wantRan {
+				assert.True(t, tt.wantStart.Equal(start), "start = %s, want %s", start, tt.wantStart)
+				assert.True(t, tt.wantEnd.Equal(end), "end = %s, want %s", end, tt.wantEnd)
+			}
+		})
+	}
+}

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -344,6 +344,16 @@ func Test_CLI_Telemetry_NestedCommands(t *testing.T) {
 	require.Contains(t, upAttrs, fields.CmdArgsCount.Key)
 	require.Equal(t, float64(0), upAttrs[fields.CmdArgsCount.Key])
 
+	// The synthetic phase spans mirror the argument-less stand-alone
+	// sub-commands, so they carry cmd.args.count=0 like the real command spans
+	// (keeping the command entry-point schema complete). cmd.deploy is not
+	// emitted in this failing-provision scenario, so it is exercised elsewhere.
+	for _, name := range []string{"cmd.package", "cmd.provision"} {
+		attrs := attributesMap(cmdSpans[name].Attributes)
+		require.Contains(t, attrs, fields.CmdArgsCount.Key, "%s must carry cmd.args.count", name)
+		require.Equal(t, float64(0), attrs[fields.CmdArgsCount.Key], "%s cmd.args.count must be 0", name)
+	}
+
 	// infra.provider is scoped to the provisioning lifecycle. The minimal project has no explicit
 	// provider, so it resolves to the default ("bicep"). It is recorded as a slice of the resolved
 	// providers and must be present with that value on cmd.provision and the parent cmd.up span,

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -361,12 +361,23 @@ func Test_CLI_Telemetry_NestedCommands(t *testing.T) {
 	// Issue #9054: the synthetic cmd.provision span must reflect the *real*
 	// provision outcome. This scenario forces a provisioning failure (the infra
 	// folder holds only a bogus main.something), so cmd.provision must report
-	// Error with a non-empty ResultCode — not the pre-fix Unset status that the
-	// AppInsights exporter reads as Success.
+	// Error with the real failure ResultCode — not the pre-fix Unset status that
+	// the AppInsights exporter reads as Success.
 	require.Equal(t, "Error", cmdSpans["cmd.provision"].Status.Code,
 		"cmd.provision must report Error when provisioning fails under azd up")
-	require.NotEmpty(t, cmdSpans["cmd.provision"].Status.Description,
-		"cmd.provision must carry a ResultCode describing the failure")
+	// Assert the *exact* ResultCode, not merely that one is present: a bare
+	// non-empty check would also pass for the degraded classifications #9054
+	// guards against (the error.suggestion collapse or the internal.unclassified
+	// fallback). Removing infra/main.bicep makes provisioning fail early in
+	// AnalyzeLayerDependencies, where reading the missing file yields an
+	// *fs.PathError wrapping a syscall.Errno; cmd.MapError records that deepest
+	// type as "internal.syscall_Errno" — the same code a stand-alone
+	// `azd provision` reports. A live typed Bicep/ARM code (e.g. tool.bicep.failed)
+	// is deliberately not exercised here: it would drive provisioning past
+	// auth/subscription selection into a real bicep build, defeating this test's
+	// fast, offline design.
+	require.Equal(t, "internal.syscall_Errno", cmdSpans["cmd.provision"].Status.Description,
+		"cmd.provision must carry the real failure ResultCode, not a degraded or empty one")
 
 	// The minimal project has no services, so packaging has nothing to fail on;
 	// cmd.package must not be misreported as an error.

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -366,18 +366,14 @@ func Test_CLI_Telemetry_NestedCommands(t *testing.T) {
 	require.Equal(t, "Error", cmdSpans["cmd.provision"].Status.Code,
 		"cmd.provision must report Error when provisioning fails under azd up")
 	// Assert the *exact* ResultCode, not merely that one is present: a bare
-	// non-empty check would also pass for the degraded classifications #9054
-	// guards against (the error.suggestion collapse or the internal.unclassified
-	// fallback). Removing infra/main.bicep makes provisioning fail early in
-	// AnalyzeLayerDependencies, where reading the missing file yields an
-	// *fs.PathError wrapping a syscall.Errno; cmd.MapError records that deepest
-	// type as "internal.syscall_Errno" — the same code a stand-alone
-	// `azd provision` reports. A live typed Bicep/ARM code (e.g. tool.bicep.failed)
-	// is deliberately not exercised here: it would drive provisioning past
-	// auth/subscription selection into a real bicep build, defeating this test's
-	// fast, offline design.
-	require.Equal(t, "internal.syscall_Errno", cmdSpans["cmd.provision"].Status.Description,
-		"cmd.provision must carry the real failure ResultCode, not a degraded or empty one")
+	// non-empty check would also pass for a degraded classification (e.g. the
+	// internal.unclassified fallback), silently weakening this guard. With
+	// infra/main.bicep absent, the provision step fails when `bicep build` cannot
+	// find the template, surfacing as an *exec.ExitError that cmd.MapError maps to
+	// the typed "tool.bicep.failed" ResultCode — the same code a stand-alone
+	// `azd provision` reports for this failure.
+	require.Equal(t, "tool.bicep.failed", cmdSpans["cmd.provision"].Status.Description,
+		"cmd.provision must carry the real Bicep failure ResultCode")
 
 	// The minimal project has no services, so packaging has nothing to fail on;
 	// cmd.package must not be misreported as an error.

--- a/cli/azd/test/functional/telemetry_test.go
+++ b/cli/azd/test/functional/telemetry_test.go
@@ -37,6 +37,15 @@ type Span struct {
 	SpanContext SpanContext
 	Resource    []Attribute
 	Attributes  []Attribute
+	Status      SpanStatus
+}
+
+// SpanStatus mirrors the status block the stdouttrace exporter writes for each
+// span. Code is the OTel status ("Unset", "Error", or "Ok") and Description
+// carries the AppInsights ResultCode that cmd.MapError stamps on failure.
+type SpanStatus struct {
+	Code        string
+	Description string
 }
 
 // Like [trace.SpanContext], except uses string representations of IDs.
@@ -348,6 +357,27 @@ func Test_CLI_Telemetry_NestedCommands(t *testing.T) {
 		"cmd.provision should carry the resolved infra.provider")
 	require.ElementsMatch(t, []string{"bicep"}, upAttrs[fields.InfraProviderKey.Key],
 		"cmd.up should carry the resolved infra.provider")
+
+	// Issue #9054: the synthetic cmd.provision span must reflect the *real*
+	// provision outcome. This scenario forces a provisioning failure (the infra
+	// folder holds only a bogus main.something), so cmd.provision must report
+	// Error with a non-empty ResultCode — not the pre-fix Unset status that the
+	// AppInsights exporter reads as Success.
+	require.Equal(t, "Error", cmdSpans["cmd.provision"].Status.Code,
+		"cmd.provision must report Error when provisioning fails under azd up")
+	require.NotEmpty(t, cmdSpans["cmd.provision"].Status.Description,
+		"cmd.provision must carry a ResultCode describing the failure")
+
+	// The minimal project has no services, so packaging has nothing to fail on;
+	// cmd.package must not be misreported as an error.
+	require.NotEqual(t, "Error", cmdSpans["cmd.package"].Status.Code,
+		"cmd.package must not report Error when no package step failed")
+
+	// Deploy never runs once provisioning fails (FailFast skips the deploy
+	// steps), so — mirroring legacy `azd up` — no synthetic cmd.deploy span is
+	// emitted rather than a misleading Success one.
+	require.NotContains(t, cmdSpans, "cmd.deploy",
+		"cmd.deploy must not be emitted when the deploy phase is skipped")
 }
 
 func Test_Telemetry_AlphaFeatures_Enabled(t *testing.T) {

--- a/docs/reference/telemetry-data.md
+++ b/docs/reference/telemetry-data.md
@@ -674,9 +674,15 @@ window below — before that fix no synthetic `cmd.deploy` span was recorded und
   `cmd.deploy` span is emitted under `up` at all**, so the `cmd.deploy` success
   rate is **deflated** (it misses the high-success under-`up` deploy population).
 - **From the #9054 fix onward:** each synthetic span carries the **real**
-  per-phase outcome — on failure it gets the same status + ResultCode a
-  stand-alone `azd provision` / `azd package` / `azd deploy` would report (via
-  `cmd.MapError`). `cmd.deploy` is emitted **only when the deploy phase actually
+  per-phase outcome — on failure it gets the status + ResultCode `cmd.MapError`
+  produces for that phase's error. For most failures this matches what the
+  stand-alone `azd provision` / `azd package` / `azd deploy` command reports. One
+  deliberate exception: when a provision error is wrapped with a user-facing
+  suggestion (`ErrorWithSuggestion`), stand-alone `azd provision` reports
+  `error.suggestion`, whereas the synthetic `cmd.provision` span maps the
+  underlying graph-step error so the specific ARM/Bicep ResultCode (e.g.
+  `tool.bicep.failed`, `service.arm.deployment.failed`) is preserved for
+  dashboards. `cmd.deploy` is emitted **only when the deploy phase actually
   ran**; when provision/package fails first (FailFast skips deploy) no
   `cmd.deploy` span is emitted, matching legacy `azd up` where the deploy
   sub-command never ran.

--- a/docs/reference/telemetry-data.md
+++ b/docs/reference/telemetry-data.md
@@ -658,8 +658,11 @@ OperationId: 28ce1f2898a4fec84522107e36c22038
 Since **v1.25.0** the unified `azd up` graph runs provision, package, publish, and
 deploy in-process as `exegraph.step`s rather than as child `azd provision` /
 `azd package` / `azd deploy` commands. To preserve the historical nested-span
-shape, `up` emits **synthetic** `cmd.provision`, `cmd.package`, and `cmd.deploy`
-spans as children of `cmd.up`.
+shape, `up` emits **synthetic** phase spans as children of `cmd.up`. The
+`cmd.provision` and `cmd.package` spans have been emitted since **v1.25.0**;
+`cmd.deploy` is emitted only **from the issue #9054 fix onward** (see the version
+window below — before that fix no synthetic `cmd.deploy` span was recorded under
+`up`).
 
 **Success/ResultCode behavior differs by version — mind the window when reading dashboards:**
 

--- a/docs/reference/telemetry-data.md
+++ b/docs/reference/telemetry-data.md
@@ -678,11 +678,17 @@ spans as children of `cmd.up`.
   `cmd.deploy` span is emitted, matching legacy `azd up` where the deploy
   sub-command never ran.
 
-**Correcting historical dashboards for the affected window:** redirect provision
-and deploy panels to the underlying `exegraph.step` spans (tagged `provision`,
-and named `deploy-<svc>` / `publish-<svc>`), which recorded the correct status
-throughout, or exclude under-`up` `cmd.provision`/`cmd.package` Success from
-reliability aggregates for that version range.
+**Correcting historical dashboards for the affected window:** the underlying
+`exegraph.step` spans recorded the correct per-step status throughout, so an
+**approximate** correction is to redirect the provision, package, and deploy
+panels to them, matched on their raw `exegraph.step.tags` (`provision`,
+`package`, `deploy`, `publish`) — **not** on `exegraph.step.name`, which is
+SHA-256 hashed and cannot be filtered by phase. This is only approximate:
+pre/post lifecycle hook and event failures are tagged `cmdhook`/`event` rather
+than a phase tag, and a step canceled by a fail-fast teardown ends its own span
+as an error even when the synthetic phase span deliberately does not blame it.
+For an exact figure, exclude under-`up` `cmd.provision` / `cmd.package` Success
+from reliability aggregates for that version range.
 
 ### `validation.provision` Emitted Twice Per Bicep Provision
 

--- a/docs/reference/telemetry-data.md
+++ b/docs/reference/telemetry-data.md
@@ -653,6 +653,37 @@ OperationId: 28ce1f2898a4fec84522107e36c22038
 | summarize arg_min(TimeGenerated, *) by OperationId
 ```
 
+### `azd up` Synthetic `cmd.provision` / `cmd.package` / `cmd.deploy` Spans
+
+Since **v1.25.0** the unified `azd up` graph runs provision, package, publish, and
+deploy in-process as `exegraph.step`s rather than as child `azd provision` /
+`azd package` / `azd deploy` commands. To preserve the historical nested-span
+shape, `up` emits **synthetic** `cmd.provision`, `cmd.package`, and `cmd.deploy`
+spans as children of `cmd.up`.
+
+**Success/ResultCode behavior differs by version — mind the window when reading dashboards:**
+
+- **v1.25.0 → the release containing the issue #9054 fix (exclusive):** the
+  synthetic `cmd.provision` and `cmd.package` spans were always closed with an
+  Unset status, which the AppInsights exporter reads as **Success**. In this
+  window their under-`up` success rate is **over-reported** (a failing provision
+  or package still shows Success and drops its ARM/Bicep ResultCode), and **no
+  `cmd.deploy` span is emitted under `up` at all**, so the `cmd.deploy` success
+  rate is **deflated** (it misses the high-success under-`up` deploy population).
+- **From the #9054 fix onward:** each synthetic span carries the **real**
+  per-phase outcome — on failure it gets the same status + ResultCode a
+  stand-alone `azd provision` / `azd package` / `azd deploy` would report (via
+  `cmd.MapError`). `cmd.deploy` is emitted **only when the deploy phase actually
+  ran**; when provision/package fails first (FailFast skips deploy) no
+  `cmd.deploy` span is emitted, matching legacy `azd up` where the deploy
+  sub-command never ran.
+
+**Correcting historical dashboards for the affected window:** repoint provision
+and deploy panels at the underlying `exegraph.step` spans (tagged `provision`,
+and named `deploy-<svc>` / `publish-<svc>`), which recorded the correct status
+throughout, or exclude under-`up` `cmd.provision`/`cmd.package` Success from
+reliability aggregates for that version range.
+
 ### `validation.provision` Emitted Twice Per Bicep Provision
 
 The `validation.provision` event is emitted from **two** dispatch sites:

--- a/docs/reference/telemetry-data.md
+++ b/docs/reference/telemetry-data.md
@@ -678,8 +678,8 @@ spans as children of `cmd.up`.
   `cmd.deploy` span is emitted, matching legacy `azd up` where the deploy
   sub-command never ran.
 
-**Correcting historical dashboards for the affected window:** repoint provision
-and deploy panels at the underlying `exegraph.step` spans (tagged `provision`,
+**Correcting historical dashboards for the affected window:** redirect provision
+and deploy panels to the underlying `exegraph.step` spans (tagged `provision`,
 and named `deploy-<svc>` / `publish-<svc>`), which recorded the correct status
 throughout, or exclude under-`up` `cmd.provision`/`cmd.package` Success from
 reliability aggregates for that version range.

--- a/docs/specs/metrics-audit/feature-telemetry-matrix.md
+++ b/docs/specs/metrics-audit/feature-telemetry-matrix.md
@@ -76,7 +76,7 @@ These commands emit attributes or events beyond the global middleware span.
 | `package` | — | ✅ | ✅ | ✅ | Via hooks middleware; container service targets emit `container.credentials`, `container.publish`, `container.remotebuild` events |
 | `deploy` | — | ✅ | ✅ | ✅ | App Service zip-deploy emits `deploy.appservice.zip` (`deploy.appservice.linux`, `deploy.appservice.attempt`); container service targets emit `container.*` events |
 | `publish` | — | ✅ | ✅ | ✅ | Same as `deploy` (alias behavior) |
-| `up` | — | ✅ | ✅ | ✅ | Composes provision+deploy and inherits all their events; sets `infra.provider` (resolved IaC provider slice) directly on the `cmd.up` span; the up-graph runner emits `perf.provision_duration_ms`, `perf.deploy_duration_ms`, `perf.total_duration_ms` (`internal/cmd/up_graph.go`) |
+| `up` | — | ✅ | ✅ | ✅ | Composes provision+deploy and inherits all their events; sets `infra.provider` (resolved IaC provider slice) directly on the `cmd.up` span; the up-graph runner emits `perf.provision_duration_ms`, `perf.deploy_duration_ms`, `perf.total_duration_ms` (`internal/cmd/up_graph.go`). Emits synthetic `cmd.provision`/`cmd.package`/`cmd.deploy` child spans that carry the real per-phase status + ResultCode via `cmd.MapError`; `cmd.deploy` is emitted only when the deploy phase runs (issue #9054) |
 | `down` | — | ✅ | ✅ | ❌ | Teardown flow; pre/postdown lifecycle hooks emit `hooks.exec` via the hooks middleware; sets `infra.provider` (resolved IaC provider slice) directly on the command span |
 | **Add** | | | | | |
 | `add` | — | ✅ | ❌ | ❌ | Low priority |


### PR DESCRIPTION
Fixes #9054

## Problem

Since v1.25.0, `azd up` runs a unified in-process "up-graph" instead of shelling out to `azd provision` / `azd package` / `azd deploy`. To preserve telemetry continuity it emits synthetic `cmd.provision` and `cmd.package` child spans under `cmd.up`, but:

- Both synthetic spans were always closed with a plain `.End()`, leaving the OpenTelemetry status **Unset**. The AppInsights exporter derives `Success = status.Code != Error`, so a **failed** provision or package under `azd up` was still recorded as **Success** — inflating provision/package success dashboards and dropping the ARM/Bicep `ResultCode`.
- **No `cmd.deploy` span was emitted at all** under `azd up`, so the (high-success) under-`up` deploy population was missing from `cmd.deploy` dashboards, deflating deploy success rates.

## Fix

- Aggregate the real per-phase error from the up-graph `RunResult` and stamp it onto the synthetic spans via `cmd.MapError`, so on failure they carry the **same status + ResultCode** a stand-alone `azd provision` / `azd package` would report. Skipped (FailFast-canceled) steps are ignored so a downstream phase is never blamed for an upstream failure.
- Emit a synthetic `cmd.deploy` span, time-boxed to the real deploy phase, **only when the deploy phase actually ran**. When provision/package fails first (FailFast skips deploy) no `cmd.deploy` span is emitted — matching legacy `azd up`, which never launched the deploy sub-command in that case.
- The raw provision-step error is used (not the `wrapProvisionError` wrapper) so the underlying `service.arm.*` / `tool.bicep.failed` ResultCodes land on the span rather than being collapsed to `error.suggestion`.

## Testing

- New unit tests (`up_graph_telemetry_test.go`) for the two pure helpers (`aggregatePhaseError`, `deployPhaseSpanTiming`), covering nil / success / failure / skipped / cross-phase isolation and the timing envelope.
- Extended `Test_CLI_Telemetry_NestedCommands` to assert that on a forced provision failure `cmd.provision` reports `Error` with a non-empty ResultCode, `cmd.package` is not misreported as `Error`, and no `cmd.deploy` span is emitted when deploy is skipped.
- `go build ./...`, `go vet`, `gofmt`, `golangci-lint run ./internal/cmd/...` (0 issues), and `go test ./internal/cmd/...` all pass.

## Docs

- `docs/reference/telemetry-data.md`: new section documenting the affected version window and how dashboard owners can correct historical data.
- `docs/specs/metrics-audit/feature-telemetry-matrix.md`: updated the `up` row.

_This is an internal telemetry-accuracy fix with no user-facing behavior change, so no CHANGELOG entry was added._
