### PR TITLE
test: fix interactive Azure AI Agents live E2E tests in CI

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/tests/e2e-live/tier2_live_test.go
+++ b/cli/azd/extensions/azure.ai.agents/tests/e2e-live/tier2_live_test.go
@@ -128,7 +128,10 @@ func newRunner(t *testing.T, mode string) *runner {
 	setupConfigDir(t, configDir)
 
 	env := withoutGitHubTokenEnv(os.Environ())
-	env = append(env, "AZD_CONFIG_DIR="+configDir)
+	env = append(env,
+		"AZD_CONFIG_DIR="+configDir,
+		"AZD_NON_INTERACTIVE=false",
+	)
 	if tenant := os.Getenv("E2E_TENANT"); tenant != "" {
 		env = append(env, "AZURE_TENANT_ID="+tenant)
 	}

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -129,8 +129,9 @@ extends:
               # missing extensions, so both must be installed before provisioning.
               # The config is generated FROM extension.yaml via yq so manifest
               # fields (capabilities, namespace, usage, ...) cannot drift from a
-              # hand-maintained copy here; only test-specific fields (path, source,
-              # sentinel version) are injected.
+              # hand-maintained copy here; only test-specific fields (path and source)
+              # are injected. Version is preserved so generated project constraints
+              # validate the local build.
               - bash: |
                   set -euo pipefail
                   # Map the agent architecture to azd's expected binary suffix so
@@ -171,7 +172,7 @@ extends:
                           "providers": $agents.providers,
                           "displayName": $agents.displayName,
                           "description": $agents.description,
-                          "version": "0.0.0-test",
+                          "version": $agents.version,
                           "usage": $agents.usage,
                           "path": "extensions/azure.ai.agents/" + env(AGENTS_BIN_NAME),
                           "source": "azd"
@@ -183,7 +184,7 @@ extends:
                           "providers": $projects.providers,
                           "displayName": $projects.displayName,
                           "description": $projects.description,
-                          "version": "0.0.0-test",
+                          "version": $projects.version,
                           "usage": $projects.usage,
                           "path": "extensions/azure.ai.projects/" + env(PROJECTS_BIN_NAME),
                           "source": "azd"


### PR DESCRIPTION
Supersedes fork PR #9501 so the Azure DevOps live access pipeline can access the required service endpoint/secrets.

Source PR: https://github.com/Azure/azure-dev/pull/9501
Follow-up PR into this upstream branch: https://github.com/Azure/azure-dev/pull/9506

## What changed

1. Force the live E2E child `azd ai agent init` process to stay interactive in CI by setting `AZD_NON_INTERACTIVE=false` in the test environment. This opt-out is needed because azd auto-enables no-prompt mode under CI/agent detection, while this test intentionally drives interactive prompts through a PTY.
2. Preserve the `azure.ai.agents` and `azure.ai.projects` versions from `extension.yaml` when generating the temporary installed-extension config in the live pipeline. The pipeline still points to the locally built binaries, but generated project constraints now validate against the manifest version instead of the old `0.0.0-test` sentinel.

## Validation

- Static PR checks passed.
- Live ADO pipeline passed on this non-fork PR: https://dev.azure.com/azure-sdk/590cfd2a-581c-4dcb-a12e-6568ce786175/_build/results?buildId=6679681
- `Run Tier 2 live golden path` succeeded.
- `TestTier2Live/code` passed.
- `TestTier2Live/container` passed.

Note: the ADO job/stage may show `succeededWithIssues` only because of the auto-injected Secure Supply Chain Analysis task; the product E2E task itself succeeded.



Fixes #9530

