### PR TITLE
feat: support MODEL_DEPLOYMENT_NAME for AI agents

### DIFF
--- a/cli/azd/docs/environment-variables.md
+++ b/cli/azd/docs/environment-variables.md
@@ -154,7 +154,8 @@ specific version of the tool installed on the machine.
 | `AZURE_AI_PROJECT_PRINCIPAL_ID` | The principal ID associated with the Microsoft Foundry project identity. |
 | `AZURE_AI_ACCOUNT_NAME` | The Microsoft Foundry account name associated with the project. |
 | `AZURE_AI_PROJECT_NAME` | The Microsoft Foundry project name. |
-| `AZURE_AI_MODEL_DEPLOYMENT_NAME` | The default model deployment name used for generated agent code and templates. |
+| `MODEL_DEPLOYMENT_NAME` | The default model deployment name used for generated agent code and templates. |
+| `AZURE_AI_MODEL_DEPLOYMENT_NAME` | Deprecated legacy name read as a fallback when `MODEL_DEPLOYMENT_NAME` is unset, so existing projects continue to work. New projects use `MODEL_DEPLOYMENT_NAME`. |
 | `AZURE_AI_PROJECT_ACR_CONNECTION_NAME` | The Azure Container Registry connection name used by the extension for hosted agents. |
 | `AI_PROJECT_DEPLOYMENTS` | JSON-encoded deployment metadata populated by the extension for agent workflows. |
 | `AI_PROJECT_DEPENDENT_RESOURCES` | JSON-encoded dependent resource metadata populated by the extension for agent workflows. |

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_generate.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_generate.go
@@ -176,11 +176,12 @@ func runEvalGenerate(ctx context.Context, flags *evalGenerateFlags, noPrompt boo
 
 	// When the user hasn't explicitly set --eval-model, use the deployed model.
 	if !flags.evalModelSet && resolved.envName != "" {
-		if v, err := resolved.azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
-			EnvName: resolved.envName,
-			Key:     "AZURE_AI_MODEL_DEPLOYMENT_NAME",
-		}); err == nil && v.Value != "" {
-			flags.evalModel = v.Value
+		if deployedModel := getDeployedModelFromEnv(
+			ctx,
+			resolved.azdClient,
+			resolved.envName,
+		); deployedModel != "" {
+			flags.evalModel = deployedModel
 		}
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_generate_prompts.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_generate_prompts.go
@@ -141,15 +141,11 @@ func promptEvalGenerateOptions(ctx context.Context, resolved *evalResolvedContex
 
 	if !flags.evalModelSet {
 		// Read the deployed model name from the azd environment to use as default.
-		var deployedModel string
-		if resolved.envName != "" {
-			if v, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
-				EnvName: resolved.envName,
-				Key:     "AZURE_AI_MODEL_DEPLOYMENT_NAME",
-			}); err == nil && v.Value != "" {
-				deployedModel = v.Value
-			}
-		}
+		deployedModel := getDeployedModelFromEnv(
+			ctx,
+			azdClient,
+			resolved.envName,
+		)
 
 		selected, err := promptModelSelection(ctx, azdClient, "Select the model for evaluation and generation", deployedModel, resolved.envName)
 		if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_helpers.go
@@ -428,21 +428,33 @@ func promptAllDeployments(ctx context.Context, azdClient *azdext.AzdClient, envN
 	return choices[int(*resp.Value)].Value, nil
 }
 
-// getDeployedModelFromEnv reads the AZURE_AI_MODEL_DEPLOYMENT_NAME from
-// the specified (or current) azd environment. Returns empty string if not available.
+// getDeployedModelFromEnv reads the model deployment name from the
+// specified or current azd environment. The legacy name remains a
+// fallback for projects created by older extension versions.
 func getDeployedModelFromEnv(ctx context.Context, azdClient *azdext.AzdClient, envName string) string {
 	env := getExistingEnvironment(ctx, envName, azdClient)
 	if env == nil {
 		return ""
 	}
-	v, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
-		EnvName: env.Name,
-		Key:     "AZURE_AI_MODEL_DEPLOYMENT_NAME",
-	})
-	if err != nil || v.Value == "" {
-		return ""
+
+	for _, key := range []string{
+		modelDeploymentNameEnvVar,
+		legacyModelDeploymentNameEnvVar,
+	} {
+		value, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+			EnvName: env.Name,
+			Key:     key,
+		})
+		if err != nil {
+			log.Printf("[debug] could not read %s: %v", key, err)
+			continue
+		}
+		if value.Value != "" {
+			return value.Value
+		}
 	}
-	return v.Value
+
+	return ""
 }
 
 // promptDatasetSelection prompts the user to enter a dataset file path or

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/eval_helpers_test.go
@@ -11,6 +11,7 @@ import (
 
 	"azureaiagent/internal/pkg/agents/opt_eval"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -91,6 +92,69 @@ func TestReconcileConfigAgent(t *testing.T) {
 		assert.True(t, changed)
 		assert.Equal(t, "new-v", agent.Version)
 	})
+}
+
+func TestGetDeployedModelFromEnv(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		values map[string]string
+		want   string
+	}{
+		{
+			name: "new name takes precedence",
+			values: map[string]string{
+				"MODEL_DEPLOYMENT_NAME":          "new-deployment",
+				"AZURE_AI_MODEL_DEPLOYMENT_NAME": "legacy-deployment",
+			},
+			want: "new-deployment",
+		},
+		{
+			name: "legacy name remains a fallback",
+			values: map[string]string{
+				"AZURE_AI_MODEL_DEPLOYMENT_NAME": "legacy-deployment",
+			},
+			want: "legacy-deployment",
+		},
+		{
+			name: "empty new value uses legacy value",
+			values: map[string]string{
+				"MODEL_DEPLOYMENT_NAME":          "",
+				"AZURE_AI_MODEL_DEPLOYMENT_NAME": "legacy-deployment",
+			},
+			want: "legacy-deployment",
+		},
+		{
+			name:   "missing names return empty",
+			values: map[string]string{},
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := &azdext.Environment{Name: "dev"}
+			envServer := &testEnvironmentServiceServer{
+				environments: map[string]*azdext.Environment{"dev": env},
+				current:      env,
+				values:       map[string]map[string]string{"dev": tt.values},
+			}
+			azdClient := newTestAzdClient(
+				t,
+				envServer,
+				&testWorkflowServiceServer{},
+			)
+
+			assert.Equal(
+				t,
+				tt.want,
+				getDeployedModelFromEnv(t.Context(), azdClient, "dev"),
+			)
+		})
+	}
 }
 
 // ---- statusLabelAndColor ----

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -929,6 +929,10 @@ func runInitFromAzureYaml(
 		return err
 	}
 
+	if err := migrateLegacyModelDeploymentEnvReferences("."); err != nil {
+		return err
+	}
+
 	// Defensive: the sample should already declare `infra.provider:
 	// microsoft.foundry`, but stamp it if missing so provisioning stays
 	// bicep-less by default.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -1038,12 +1038,12 @@ func runInitFromAzureYaml(
 			}
 		}
 
-		// Persist the first referenced deployment name as AZURE_AI_MODEL_DEPLOYMENT_NAME.
+		// Persist the first referenced deployment name for agent code.
 		setEnv := func(ctx context.Context, key, value string) error {
 			return setEnvValue(ctx, azdClient, env.Name, key, value)
 		}
 		if err := persistFirstDeploymentName(ctx, setEnv, referencedDeployments); err != nil {
-			return fmt.Errorf("failed to set AZURE_AI_MODEL_DEPLOYMENT_NAME: %w", err)
+			return fmt.Errorf("failed to set %s: %w", modelDeploymentNameEnvVar, err)
 		}
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
@@ -342,6 +342,112 @@ func TestProjectManifestExists(t *testing.T) {
 	})
 }
 
+func TestMigrateLegacyModelDeploymentEnvReferences(t *testing.T) {
+	projectDir := t.TempDir()
+	manifest := `name: foundry-legacy
+notes: AZURE_AI_MODEL_DEPLOYMENT_NAME
+services:
+  agent:
+    host: azure.ai.agent
+    kind: hosted
+    environmentVariables:
+      - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+        value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}
+      - name: MODEL_WITH_DEFAULT
+        value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME:-gpt-4o-mini}
+  connection:
+    host: azure.ai.connection
+    metadata:
+      model: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}
+`
+	manifestPath := filepath.Join(projectDir, "azure.yaml")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0600))
+
+	require.NoError(t, migrateLegacyModelDeploymentEnvReferences(projectDir))
+	migrated, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+	migratedText := string(migrated)
+	require.Contains(t, migratedText, "name: MODEL_DEPLOYMENT_NAME")
+	require.Contains(t, migratedText, "value: ${MODEL_DEPLOYMENT_NAME}")
+	require.Contains(t, migratedText, "value: ${MODEL_DEPLOYMENT_NAME:-gpt-4o-mini}")
+	require.Contains(t, migratedText, "notes: AZURE_AI_MODEL_DEPLOYMENT_NAME")
+	require.Contains(t, migratedText, "model: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}")
+	require.NotContains(t, migratedText, "name: AZURE_AI_MODEL_DEPLOYMENT_NAME")
+
+	require.NoError(t, migrateLegacyModelDeploymentEnvReferences(projectDir))
+	migratedAgain, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+	require.Equal(t, migrated, migratedAgain)
+}
+
+func TestMigrateLegacyModelDeploymentEnvReferences_RefFile(t *testing.T) {
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, "agent.yaml"),
+		[]byte(`kind: hosted
+environmentVariables:
+  - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+    value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME:-gpt-4o-mini}
+`),
+		0600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, "azure.yaml"),
+		[]byte(`name: foundry-legacy
+services:
+  agent:
+    host: azure.ai.agent
+    $ref: ./agent.yaml
+`),
+		0600,
+	))
+
+	require.NoError(t, migrateLegacyModelDeploymentEnvReferences(projectDir))
+	refContent, err := os.ReadFile(filepath.Join(projectDir, "agent.yaml"))
+	require.NoError(t, err)
+	require.Contains(t, string(refContent), "name: MODEL_DEPLOYMENT_NAME")
+	require.Contains(t, string(refContent), "${MODEL_DEPLOYMENT_NAME:-gpt-4o-mini}")
+}
+
+func TestMigrateLegacyModelDeploymentEnvReferences_ConfiguresNewName(t *testing.T) {
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, "azure.yaml"),
+		[]byte(`name: foundry-legacy
+services:
+  agent:
+    host: azure.ai.agent
+    kind: hosted
+    environmentVariables:
+      - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+        value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}
+`),
+		0600,
+	))
+	require.NoError(t, migrateLegacyModelDeploymentEnvReferences(projectDir))
+
+	envServer := &testEnvironmentServiceServer{
+		values: map[string]map[string]string{
+			"dev": {
+				modelDeploymentNameEnvVar: "gpt-4o-mini",
+			},
+		},
+	}
+	promptServer := &testPromptServiceServer{}
+	azdClient := newTestAzdClient(t, envServer, &testWorkflowServiceServer{}, promptServer)
+
+	require.NoError(t, configureAzureYamlEnvironmentVariables(
+		t.Context(),
+		azdClient,
+		"dev",
+		projectDir,
+		false,
+	))
+	require.Empty(t, promptServer.promptRequests)
+	require.Equal(t, "gpt-4o-mini", envServer.values["dev"][modelDeploymentNameEnvVar])
+	require.NotContains(t, envServer.values["dev"], legacyModelDeploymentNameEnvVar)
+}
+
 func TestEnsureStagedAzureYaml_NormalizesAzureYml(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "azure.yml"), []byte("name: foundry-simple\n"), 0600))

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"azureaiagent/internal/exterrors"
@@ -391,22 +392,104 @@ environmentVariables:
 `),
 		0600,
 	))
+	manifestContent := []byte("name: foundry-legacy\r\n" +
+		"services:\r\n" +
+		"  agent:\r\n" +
+		"    host: azure.ai.agent\r\n" +
+		"    $ref: ./agent.yaml\r\n")
 	require.NoError(t, os.WriteFile(
 		filepath.Join(projectDir, "azure.yaml"),
-		[]byte(`name: foundry-legacy
-services:
-  agent:
-    host: azure.ai.agent
-    $ref: ./agent.yaml
-`),
+		manifestContent,
 		0600,
 	))
 
 	require.NoError(t, migrateLegacyModelDeploymentEnvReferences(projectDir))
+	manifestContentAfter, err := os.ReadFile(filepath.Join(projectDir, "azure.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, manifestContent, manifestContentAfter)
 	refContent, err := os.ReadFile(filepath.Join(projectDir, "agent.yaml"))
 	require.NoError(t, err)
 	require.Contains(t, string(refContent), "name: MODEL_DEPLOYMENT_NAME")
 	require.Contains(t, string(refContent), "${MODEL_DEPLOYMENT_NAME:-gpt-4o-mini}")
+}
+
+func TestMigrateLegacyModelDeploymentEnvReferences_ServiceEnvMap(t *testing.T) {
+	projectDir := t.TempDir()
+	manifest := `name: foundry-legacy
+services:
+  agent:
+    host: azure.ai.agent
+    kind: hosted
+    env:
+      AZURE_AI_MODEL_DEPLOYMENT_NAME: ${AZURE_AI_MODEL_DEPLOYMENT_NAME:-gpt-4o-mini}
+      OTHER_VALUE: prefix-${AZURE_AI_MODEL_DEPLOYMENT_NAME}
+  agent-conflict:
+    host: azure.ai.agent
+    kind: hosted
+    env:
+      MODEL_DEPLOYMENT_NAME: ${MODEL_DEPLOYMENT_NAME}
+      AZURE_AI_MODEL_DEPLOYMENT_NAME: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}
+`
+	manifestPath := filepath.Join(projectDir, "azure.yaml")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0600))
+
+	require.NoError(t, migrateLegacyModelDeploymentEnvReferences(projectDir))
+	migrated, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+	migratedText := string(migrated)
+	require.Contains(t, migratedText,
+		"MODEL_DEPLOYMENT_NAME: ${MODEL_DEPLOYMENT_NAME:-gpt-4o-mini}")
+	require.Contains(t, migratedText,
+		"OTHER_VALUE: prefix-${MODEL_DEPLOYMENT_NAME}")
+	require.NotContains(t, migratedText, "AZURE_AI_MODEL_DEPLOYMENT_NAME")
+
+	migratedBeforeSecondRun := slices.Clone(migrated)
+	require.NoError(t, migrateLegacyModelDeploymentEnvReferences(projectDir))
+	migratedAgain, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+	require.Equal(t, migratedBeforeSecondRun, migratedAgain)
+}
+
+func TestMigrateLegacyModelDeploymentEnvReferences_NestedRefPreservesAncestors(t *testing.T) {
+	projectDir := t.TempDir()
+	rootContent := []byte("name: foundry-legacy\r\n" +
+		"services:\r\n" +
+		"  agent:\r\n" +
+		"    host: azure.ai.agent\r\n" +
+		"    $ref: ./agent.yaml\r\n")
+	agentContent := []byte("$ref: ./config.yaml\r\n")
+	configContent := []byte(`kind: hosted
+environmentVariables:
+  - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+    value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}
+`)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, "azure.yaml"),
+		rootContent,
+		0600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, "agent.yaml"),
+		agentContent,
+		0600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, "config.yaml"),
+		[]byte(configContent),
+		0600,
+	))
+
+	require.NoError(t, migrateLegacyModelDeploymentEnvReferences(projectDir))
+	rootAfter, err := os.ReadFile(filepath.Join(projectDir, "azure.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, rootContent, rootAfter)
+	agentAfter, err := os.ReadFile(filepath.Join(projectDir, "agent.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, agentContent, agentAfter)
+	configAfter, err := os.ReadFile(filepath.Join(projectDir, "config.yaml"))
+	require.NoError(t, err)
+	require.Contains(t, string(configAfter), "name: MODEL_DEPLOYMENT_NAME")
+	require.Contains(t, string(configAfter), "value: ${MODEL_DEPLOYMENT_NAME}")
 }
 
 func TestMigrateLegacyModelDeploymentEnvReferences_ConfiguresNewName(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_env.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_env.go
@@ -238,11 +238,9 @@ func migrateLegacyModelDeploymentEnvReferences(projectDir string) error {
 		}
 
 		for _, refPath := range localAzureYamlRefPaths(service, projectDir) {
-			refChanged, err := migrateLegacyModelDeploymentEnvFile(refPath, visited)
-			if err != nil {
+			if _, err := migrateLegacyModelDeploymentEnvFile(refPath, visited); err != nil {
 				return err
 			}
-			changed = changed || refChanged
 		}
 	}
 
@@ -316,11 +314,9 @@ func migrateLegacyModelDeploymentEnvFile(
 			document.Content[0],
 			filepath.Dir(path),
 		) {
-			refChanged, err := migrateLegacyModelDeploymentEnvFile(refPath, visited)
-			if err != nil {
+			if _, err := migrateLegacyModelDeploymentEnvFile(refPath, visited); err != nil {
 				return false, err
 			}
-			changed = changed || refChanged
 		}
 	}
 
@@ -396,6 +392,10 @@ func migrateLegacyModelDeploymentEnvNode(node *yaml.Node) bool {
 				changed = migrateLegacyModelDeploymentEnvVariables(value) || changed
 				continue
 			}
+			if key.Value == "env" {
+				changed = migrateLegacyModelDeploymentEnvMap(value) || changed
+				continue
+			}
 			changed = migrateLegacyModelDeploymentEnvNode(value) || changed
 		}
 		return changed
@@ -444,6 +444,46 @@ func migrateLegacyModelDeploymentEnvVariables(node *yaml.Node) bool {
 			}
 		}
 		i++
+	}
+	return changed
+}
+
+func migrateLegacyModelDeploymentEnvMap(node *yaml.Node) bool {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return false
+	}
+
+	hasNewName := false
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == modelDeploymentNameEnvVar {
+			hasNewName = true
+			break
+		}
+	}
+
+	changed := false
+	for i := 0; i < len(node.Content); {
+		key := node.Content[i]
+		value := node.Content[i+1]
+		if key.Value == legacyModelDeploymentNameEnvVar {
+			if hasNewName {
+				node.Content = slices.Delete(node.Content, i, i+2)
+				changed = true
+				continue
+			}
+			key.Value = modelDeploymentNameEnvVar
+			hasNewName = true
+			changed = true
+		}
+
+		if value.Kind == yaml.ScalarNode {
+			migrated, replaced := replaceLegacyModelDeploymentEnvReferences(value.Value)
+			if replaced {
+				value.Value = migrated
+				changed = true
+			}
+		}
+		i += 2
 	}
 	return changed
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_env.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_env.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"azureaiagent/internal/exterrors"
@@ -191,6 +192,287 @@ func configureAzureYamlEnvironmentVariables(
 	}
 
 	return nil
+}
+
+// migrateLegacyModelDeploymentEnvReferences migrates agent configs.
+func migrateLegacyModelDeploymentEnvReferences(projectDir string) error {
+	manifestPath := filepath.Join(projectDir, "azure.yaml")
+	//nolint:gosec // trusted project root
+	content, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("reading adopted azure.yaml for migration: %w", err)
+	}
+
+	var document yaml.Node
+	if err := yaml.Unmarshal(content, &document); err != nil {
+		return fmt.Errorf("parsing adopted azure.yaml for migration: %w", err)
+	}
+	if len(document.Content) == 0 {
+		return nil
+	}
+
+	services := yamlMappingValue(document.Content[0], "services")
+	if services == nil || services.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	manifestPath, err = filepath.Abs(manifestPath)
+	if err != nil {
+		return fmt.Errorf("resolving adopted azure.yaml path: %w", err)
+	}
+	visited := map[string]struct{}{manifestPath: {}}
+	changed := false
+
+	for i := 0; i+1 < len(services.Content); i += 2 {
+		service := services.Content[i+1]
+		isAgent, err := isAzureYamlAgentService(service, projectDir)
+		if err != nil {
+			return fmt.Errorf("inspecting adopted agent service: %w", err)
+		}
+		if !isAgent {
+			continue
+		}
+
+		if migrateLegacyModelDeploymentEnvNode(service) {
+			changed = true
+		}
+
+		for _, refPath := range localAzureYamlRefPaths(service, projectDir) {
+			refChanged, err := migrateLegacyModelDeploymentEnvFile(refPath, visited)
+			if err != nil {
+				return err
+			}
+			changed = changed || refChanged
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	updated, err := yaml.Marshal(&document)
+	if err != nil {
+		return fmt.Errorf("encoding migrated azure.yaml: %w", err)
+	}
+	//nolint:gosec // trusted project manifest
+	if err := os.WriteFile(manifestPath, updated, 0o600); err != nil {
+		return fmt.Errorf("writing migrated azure.yaml: %w", err)
+	}
+	return nil
+}
+
+func isAzureYamlAgentService(service *yaml.Node, projectDir string) (bool, error) {
+	if service == nil || service.Kind != yaml.MappingNode {
+		return false, nil
+	}
+
+	if host, ok := foundryAzureYamlServiceHost(service); ok {
+		return host == AiAgentHost, nil
+	}
+	if !hasAzureYamlFileRef(service) {
+		return false, nil
+	}
+
+	var raw map[string]any
+	if err := service.Decode(&raw); err != nil {
+		return false, fmt.Errorf("decoding service for migration: %w", err)
+	}
+	resolved, err := foundry.ResolveFileRefs(raw, projectDir)
+	if err != nil {
+		return false, fmt.Errorf("resolving service references for migration: %w", err)
+	}
+	host, _ := resolved["host"].(string)
+	return host == AiAgentHost, nil
+}
+
+func migrateLegacyModelDeploymentEnvFile(
+	path string,
+	visited map[string]struct{},
+) (bool, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return false, fmt.Errorf("resolving referenced agent config %q: %w", path, err)
+	}
+	if _, ok := visited[path]; ok {
+		return false, nil
+	}
+	visited[path] = struct{}{}
+
+	//nolint:gosec // trusted project configuration
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false, fmt.Errorf("reading referenced agent config %q: %w", path, err)
+	}
+
+	var document yaml.Node
+	if err := yaml.Unmarshal(content, &document); err != nil {
+		return false, fmt.Errorf("parsing referenced agent config %q: %w", path, err)
+	}
+
+	changed := false
+	if len(document.Content) > 0 {
+		changed = migrateLegacyModelDeploymentEnvNode(document.Content[0])
+		for _, refPath := range localAzureYamlRefPaths(
+			document.Content[0],
+			filepath.Dir(path),
+		) {
+			refChanged, err := migrateLegacyModelDeploymentEnvFile(refPath, visited)
+			if err != nil {
+				return false, err
+			}
+			changed = changed || refChanged
+		}
+	}
+
+	if !changed {
+		return false, nil
+	}
+
+	updated, err := yaml.Marshal(&document)
+	if err != nil {
+		return false, fmt.Errorf("encoding referenced agent config %q: %w", path, err)
+	}
+	//nolint:gosec // trusted project $ref
+	if err := os.WriteFile(path, updated, 0o600); err != nil {
+		return false, fmt.Errorf("writing referenced agent config %q: %w", path, err)
+	}
+	return true, nil
+}
+
+func localAzureYamlRefPaths(node *yaml.Node, baseDir string) []string {
+	var paths []string
+	collectLocalAzureYamlRefPaths(node, baseDir, &paths)
+	return paths
+}
+
+func collectLocalAzureYamlRefPaths(node *yaml.Node, baseDir string, paths *[]string) {
+	if node == nil {
+		return
+	}
+
+	switch node.Kind {
+	case yaml.DocumentNode, yaml.SequenceNode:
+		for _, child := range node.Content {
+			collectLocalAzureYamlRefPaths(child, baseDir, paths)
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i]
+			value := node.Content[i+1]
+			if key.Value == "$ref" && value.Kind == yaml.ScalarNode {
+				ref := strings.TrimSpace(value.Value)
+				if ref != "" && !strings.Contains(ref, "://") {
+					if !filepath.IsAbs(ref) {
+						ref = filepath.Join(baseDir, ref)
+					}
+					*paths = append(*paths, filepath.Clean(ref))
+				}
+			}
+			collectLocalAzureYamlRefPaths(value, baseDir, paths)
+		}
+	case yaml.AliasNode:
+		collectLocalAzureYamlRefPaths(node.Alias, baseDir, paths)
+	}
+}
+
+func migrateLegacyModelDeploymentEnvNode(node *yaml.Node) bool {
+	if node == nil {
+		return false
+	}
+
+	switch node.Kind {
+	case yaml.DocumentNode, yaml.SequenceNode:
+		changed := false
+		for _, child := range node.Content {
+			changed = migrateLegacyModelDeploymentEnvNode(child) || changed
+		}
+		return changed
+	case yaml.MappingNode:
+		changed := false
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i]
+			value := node.Content[i+1]
+			if key.Value == "environmentVariables" {
+				changed = migrateLegacyModelDeploymentEnvVariables(value) || changed
+				continue
+			}
+			changed = migrateLegacyModelDeploymentEnvNode(value) || changed
+		}
+		return changed
+	case yaml.AliasNode:
+		return migrateLegacyModelDeploymentEnvNode(node.Alias)
+	default:
+		return false
+	}
+}
+
+func migrateLegacyModelDeploymentEnvVariables(node *yaml.Node) bool {
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return false
+	}
+
+	hasNewName := false
+	for _, item := range node.Content {
+		name := yamlMappingValue(item, "name")
+		if name != nil && name.Value == modelDeploymentNameEnvVar {
+			hasNewName = true
+			break
+		}
+	}
+
+	changed := false
+	for i := 0; i < len(node.Content); {
+		item := node.Content[i]
+		name := yamlMappingValue(item, "name")
+		if name != nil && name.Value == legacyModelDeploymentNameEnvVar {
+			if hasNewName {
+				node.Content = slices.Delete(node.Content, i, i+1)
+				changed = true
+				continue
+			}
+			name.Value = modelDeploymentNameEnvVar
+			hasNewName = true
+			changed = true
+		}
+
+		value := yamlMappingValue(item, "value")
+		if value != nil && value.Kind == yaml.ScalarNode {
+			migrated, replaced := replaceLegacyModelDeploymentEnvReferences(value.Value)
+			if replaced {
+				value.Value = migrated
+				changed = true
+			}
+		}
+		i++
+	}
+	return changed
+}
+
+func replaceLegacyModelDeploymentEnvReferences(value string) (string, bool) {
+	references := findEnvironmentReferences(value)
+	var builder strings.Builder
+	last := 0
+	replaced := false
+	for _, reference := range references {
+		if reference.Name != legacyModelDeploymentNameEnvVar {
+			continue
+		}
+		builder.WriteString(value[last:reference.Start])
+		original := value[reference.Start:reference.End]
+		builder.WriteString(strings.Replace(
+			original,
+			"${"+legacyModelDeploymentNameEnvVar,
+			"${"+modelDeploymentNameEnvVar,
+			1,
+		))
+		last = reference.End
+		replaced = true
+	}
+	if !replaced {
+		return value, false
+	}
+	builder.WriteString(value[last:])
+	return builder.String(), true
 }
 
 func findAzureYamlEnvironmentReferences(content []byte, projectDir string) ([]azureYamlEnvironmentReference, error) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -60,7 +60,14 @@ type FoundryDeploymentInfo struct {
 	SkuCapacity int
 }
 
-const foundryProjectResourceType = "Microsoft.CognitiveServices/accounts/projects"
+const (
+	foundryProjectResourceType = "Microsoft.CognitiveServices/accounts/projects"
+	modelDeploymentNameEnvVar  = "MODEL_DEPLOYMENT_NAME"
+	modelDeploymentNameEnvRef  = "${" + modelDeploymentNameEnvVar + "}"
+
+	// Read fallback for projects created by older versions.
+	legacyModelDeploymentNameEnvVar = "AZURE_AI_MODEL_DEPLOYMENT_NAME"
+)
 
 // setEnvValue sets a single environment variable in the azd environment.
 func setEnvValue(ctx context.Context, azdClient *azdext.AzdClient, envName, key, value string) error {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -564,12 +564,18 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 		// (azd does not create/upsert it) — it is referenced via the agent env
 		// var and verified at deploy time. So do not append to a.deploymentDetails.
 		definition.EnvironmentVariables = appendEnvVar(definition.EnvironmentVariables, agent_yaml.EnvironmentVariable{
-			Name:  "AZURE_AI_MODEL_DEPLOYMENT_NAME",
-			Value: "${AZURE_AI_MODEL_DEPLOYMENT_NAME}",
+			Name:  modelDeploymentNameEnvVar,
+			Value: modelDeploymentNameEnvRef,
 		})
 
-		if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "AZURE_AI_MODEL_DEPLOYMENT_NAME", existingDeployment.Name); err != nil {
-			return nil, fmt.Errorf("failed to set AZURE_AI_MODEL_DEPLOYMENT_NAME: %w", err)
+		if err := setEnvValue(
+			ctx,
+			a.azdClient,
+			a.environment.Name,
+			modelDeploymentNameEnvVar,
+			existingDeployment.Name,
+		); err != nil {
+			return nil, fmt.Errorf("failed to set %s: %w", modelDeploymentNameEnvVar, err)
 		}
 
 		// Existing deployment chosen — clear any prior
@@ -602,12 +608,18 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 		a.needsProvision = true
 
 		definition.EnvironmentVariables = appendEnvVar(definition.EnvironmentVariables, agent_yaml.EnvironmentVariable{
-			Name:  "AZURE_AI_MODEL_DEPLOYMENT_NAME",
-			Value: "${AZURE_AI_MODEL_DEPLOYMENT_NAME}",
+			Name:  modelDeploymentNameEnvVar,
+			Value: modelDeploymentNameEnvRef,
 		})
 
-		if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "AZURE_AI_MODEL_DEPLOYMENT_NAME", modelDetails.ModelName); err != nil {
-			return nil, fmt.Errorf("failed to set AZURE_AI_MODEL_DEPLOYMENT_NAME: %w", err)
+		if err := setEnvValue(
+			ctx,
+			a.azdClient,
+			a.environment.Name,
+			modelDeploymentNameEnvVar,
+			modelDetails.ModelName,
+		); err != nil {
+			return nil, fmt.Errorf("failed to set %s: %w", modelDeploymentNameEnvVar, err)
 		}
 
 		// New model deployment configured — record that the

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code_test.go
@@ -497,7 +497,7 @@ func TestCreateDefinitionFromLocalAgent_NoPromptMissingAzureContextDefers(t *tes
 	}
 	if definition.EnvironmentVariables != nil {
 		for _, envVar := range *definition.EnvironmentVariables {
-			if envVar.Name == "AZURE_AI_MODEL_DEPLOYMENT_NAME" {
+			if envVar.Name == "MODEL_DEPLOYMENT_NAME" {
 				t.Fatalf("deferred model configuration should not add %s", envVar.Name)
 			}
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models.go
@@ -1072,10 +1072,10 @@ func (a *InitAction) ProcessModels(ctx context.Context, manifest *agent_yaml.Age
 	}
 
 	deploymentDetails := []project.Deployment{}
-	// referencedDeployments holds every selected deployment (new AND existing).
-	// It drives the env-var reference (AZURE_AI_MODEL_DEPLOYMENT_NAME) so an
-	// existing-only selection still records the model name, while only NEW
-	// deployments land in deploymentDetails (azure.yaml declarations).
+	// referencedDeployments includes every selected deployment.
+	// It drives the MODEL_DEPLOYMENT_NAME reference so existing-only
+	// selections still record the model name. Only new deployments
+	// land in deploymentDetails (azure.yaml declarations).
 	referencedDeployments := []project.Deployment{}
 	paramValues := agent_yaml.ParameterValues{}
 	// anyModelProcessed tracks whether we encountered at least one
@@ -1159,7 +1159,7 @@ func (a *InitAction) ProcessModels(ctx context.Context, manifest *agent_yaml.Age
 		return setEnvValue(ctx, a.azdClient, a.environment.Name, key, value)
 	}
 	if err := persistFirstDeploymentName(ctx, setEnv, referencedDeployments); err != nil {
-		return nil, nil, fmt.Errorf("failed to set AZURE_AI_MODEL_DEPLOYMENT_NAME: %w", err)
+		return nil, nil, fmt.Errorf("failed to set %s: %w", modelDeploymentNameEnvVar, err)
 	}
 
 	// Update the AI_AGENT_PENDING_PROVISION signal based on the
@@ -1183,9 +1183,8 @@ func (a *InitAction) ProcessModels(ctx context.Context, manifest *agent_yaml.Age
 // envValueSetter writes a single key-value pair to the azd environment.
 type envValueSetter func(ctx context.Context, key, value string) error
 
-// persistFirstDeploymentName persists the first deployment's name as
-// AZURE_AI_MODEL_DEPLOYMENT_NAME so templates and agent code can reference it.
-// It is a no-op when the deployments slice is empty.
+// persistFirstDeploymentName stores the first deployment name for
+// templates and agent code. It is a no-op for an empty slice.
 func persistFirstDeploymentName(
 	ctx context.Context,
 	setEnv envValueSetter,
@@ -1195,5 +1194,5 @@ func persistFirstDeploymentName(
 		return nil
 	}
 
-	return setEnv(ctx, "AZURE_AI_MODEL_DEPLOYMENT_NAME", deployments[0].Name)
+	return setEnv(ctx, modelDeploymentNameEnvVar, deployments[0].Name)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_models_test.go
@@ -224,7 +224,7 @@ func TestPersistFirstDeploymentName(t *testing.T) {
 				{Name: "gpt-4o"},
 			},
 			wantCalled: true,
-			wantKey:    "AZURE_AI_MODEL_DEPLOYMENT_NAME",
+			wantKey:    "MODEL_DEPLOYMENT_NAME",
 			wantValue:  "gpt-4o",
 		},
 		{
@@ -234,7 +234,7 @@ func TestPersistFirstDeploymentName(t *testing.T) {
 				{Name: "text-embedding-ada-002"},
 			},
 			wantCalled: true,
-			wantKey:    "AZURE_AI_MODEL_DEPLOYMENT_NAME",
+			wantKey:    "MODEL_DEPLOYMENT_NAME",
 			wantValue:  "gpt-4o",
 		},
 		{
@@ -244,7 +244,7 @@ func TestPersistFirstDeploymentName(t *testing.T) {
 			},
 			setEnvErr:  errors.New("grpc unavailable"),
 			wantCalled: true,
-			wantKey:    "AZURE_AI_MODEL_DEPLOYMENT_NAME",
+			wantKey:    "MODEL_DEPLOYMENT_NAME",
 			wantValue:  "gpt-4o",
 			wantErr:    true,
 		},

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state_test.go
@@ -927,7 +927,7 @@ environment_variables:
 			manifest: `kind: hostedAgent
 environment_variables:
   - name: MODEL
-    value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME:-gpt-4o-mini}
+    value: ${MODEL_DEPLOYMENT_NAME:-gpt-4o-mini}
 `,
 			wantRefs: nil,
 		},
@@ -938,7 +938,7 @@ environment_variables:
   - name: ENDPOINT
     value: ${FOUNDRY_PROJECT_ENDPOINT}
   - name: MODEL
-    value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME:-gpt-4o-mini}
+    value: ${MODEL_DEPLOYMENT_NAME:-gpt-4o-mini}
 `,
 			wantRefs: []string{"FOUNDRY_PROJECT_ENDPOINT"},
 		},
@@ -1156,7 +1156,7 @@ environment_variables:
   - name: ENDPOINT
     value: ${FOUNDRY_PROJECT_ENDPOINT}
   - name: MODEL
-    value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}
+    value: ${MODEL_DEPLOYMENT_NAME}
   - name: KEY
     value: ${MY_API_KEY}
   - name: STATIC
@@ -1171,7 +1171,7 @@ environment_variables:
 	require.NoError(t, os.WriteFile(
 		filepath.Join(projectRoot, "infra", "main.bicep"),
 		[]byte(`output FOUNDRY_PROJECT_ENDPOINT string = ''
-output AZURE_AI_MODEL_DEPLOYMENT_NAME string = ''
+output MODEL_DEPLOYMENT_NAME string = ''
 `),
 		0o600,
 	))
@@ -1185,8 +1185,8 @@ output AZURE_AI_MODEL_DEPLOYMENT_NAME string = ''
 			},
 		},
 		values: map[string]string{
-			// AZURE_AI_MODEL_DEPLOYMENT_NAME is set; the other two are not.
-			"dev/AZURE_AI_MODEL_DEPLOYMENT_NAME": "gpt-4o-mini",
+			// MODEL_DEPLOYMENT_NAME is set; the other two are not.
+			"dev/MODEL_DEPLOYMENT_NAME": "gpt-4o-mini",
 		},
 	}
 
@@ -1292,7 +1292,7 @@ environment_variables:
   - name: ENDPOINT
     value: ${FOUNDRY_PROJECT_ENDPOINT}
   - name: MODEL
-    value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME:-gpt-4o-mini}
+    value: ${MODEL_DEPLOYMENT_NAME:-gpt-4o-mini}
   - name: KEY
     value: ${MY_API_KEY:-dev-fallback}
 `),
@@ -1314,8 +1314,8 @@ environment_variables:
 				"echo": {Name: "echo", Host: agentHost, RelativePath: "echo"},
 			},
 		},
-		// Intentionally leave AZURE_AI_MODEL_DEPLOYMENT_NAME and MY_API_KEY
-		// unset; defaulted refs must not surface them as missing.
+		// MODEL_DEPLOYMENT_NAME and MY_API_KEY are intentionally unset.
+		// Defaulted refs must not surface them as missing.
 		values: map[string]string{},
 	}
 

--- a/cli/azd/test/functional/ai_agents/ai_agent_recording_test.go
+++ b/cli/azd/test/functional/ai_agents/ai_agent_recording_test.go
@@ -201,14 +201,14 @@ func Test_AIAgent_Init_NoPrompt_WithProject(t *testing.T) {
 	require.NoError(t, err)
 	envStr := string(envContent)
 	// Pin to the exact value produced by manifest resources[0].id resolution.
-	require.Contains(t, envStr, `AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-4.1"`,
+	require.Contains(t, envStr, `MODEL_DEPLOYMENT_NAME="gpt-4.1"`,
 		"model deployment should be resolved from manifest resource id via ARM catalog")
 
 	// Cross-check: azure.yaml should have the resolved model value inline, not ${...} placeholder.
 	azureYamlContent, err := os.ReadFile(filepath.Join(projectDir, "azure.yaml"))
 	require.NoError(t, err)
 	azureYamlStr := string(azureYamlContent)
-	require.NotContains(t, azureYamlStr, "${AZURE_AI_MODEL_DEPLOYMENT_NAME}",
+	require.NotContains(t, azureYamlStr, "${MODEL_DEPLOYMENT_NAME}",
 		"azure.yaml should have resolved model name, not azd env placeholder")
 }
 

--- a/cli/azd/test/functional/ai_agents/testdata/manifests/foundry-toolbox.yaml
+++ b/cli/azd/test/functional/ai_agents/testdata/manifests/foundry-toolbox.yaml
@@ -15,11 +15,11 @@ template:
     - protocol: responses
       version: 1.0.0
   environment_variables:
-    - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
-      value: "{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}"
+    - name: MODEL_DEPLOYMENT_NAME
+      value: "{{MODEL_DEPLOYMENT_NAME}}"
     - name: TOOLBOX_ENDPOINT
       value: "{{TOOLBOX_ENDPOINT}}"
 resources:
   - kind: model
     id: gpt-4.1
-    name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+    name: MODEL_DEPLOYMENT_NAME


### PR DESCRIPTION
Closes #7822

## Why this change is needed

The `azure.ai.agents` extension currently uses the Azure-specific `AZURE_AI_MODEL_DEPLOYMENT_NAME` name for generated agent configuration and model defaults. The extension should use the generic `MODEL_DEPLOYMENT_NAME` contract for new projects and templates, while existing projects using the old name must continue to work.

## Approach

New initialization and adoption flows write only `MODEL_DEPLOYMENT_NAME`. Model lookups prefer the new name and fall back to `AZURE_AI_MODEL_DEPLOYMENT_NAME` when it is unset, preserving existing projects without duplicating legacy values into newly generated configuration. When an older unified `azure.yaml` is adopted, the extension migrates only the old model variable declarations and references in `azure.ai.agent` environment-variable blocks, including local `$ref` files and defaulted references. This keeps the adopted project aligned with the new name without rewriting unrelated YAML or modifying existing projects outside the adoption flow.

Related evaluation flows, templates, tests, and environment-variable documentation are updated together.

## E2E Testing
Here `-e` selects the isolated azd environment for each scenario.

| Scenario | Command | Result / observed output |
| --- | --- | --- |
| Fresh init | `azd -e pr9505-fresh-init ai agent init ...` | **PASS**; generated `MODEL_DEPLOYMENT_NAME`, value `gpt-4o-mini`, exit `0`. |
| Legacy adoption | `azd -e pr9505-legacy-adoption ai agent init ...` | **PASS**; migrated agent references to `MODEL_DEPLOYMENT_NAME`, preserved unrelated root text, exit `0`. Re-adoption was also **PASS**. |
| Deployment | `azd -e pr9505-fresh-init deploy pr9505-e2e-agent --no-prompt` | **PASS**; hosted agent became active and command reported `SUCCESS`. |
| Eval generation | `azd -e pr9505-fresh-init ai agent eval generate ...` | **PASS**; dataset/evaluator generation completed and `Eval suite created`. |
| Legacy fallback | Same eval flow with only `AZURE_AI_MODEL_DEPLOYMENT_NAME` set | **PASS**; evaluator generation completed and `Eval suite created`. |
| Optimize submission | `azd -e pr9505-fresh-init ai agent optimize ... --optimize-model gpt-5 --no-wait` | **PASS**; job accepted with status `queued`. The job was canceled during cleanup; no candidate was deployed. |