### PR TITLE
fix(ai-agents): monitor agents outside azd projects

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/helpers_test.go
@@ -476,11 +476,15 @@ func TestIsTerminal_NonTTY(t *testing.T) {
 type helpersProjectServer struct {
 	azdext.UnimplementedProjectServiceServer
 	project *azdext.ProjectConfig
+	err     error
 }
 
 func (s *helpersProjectServer) Get(
 	_ context.Context, _ *azdext.EmptyRequest,
 ) (*azdext.GetProjectResponse, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
 	return &azdext.GetProjectResponse{Project: s.project}, nil
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor.go
@@ -162,8 +162,15 @@ func resolveMonitorAgentInfo(
 	if err == nil {
 		return info, nil
 	}
-	if name != "" && isMissingAzdProjectError(err) {
-		return &AgentServiceInfo{AgentName: name}, nil
+	if isMissingAzdProjectError(err) {
+		if name != "" {
+			return &AgentServiceInfo{AgentName: name}, nil
+		}
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidAgentName,
+			"agent name is required outside an azd project",
+			"pass <agent-name> as the positional argument, or run from an azd project",
+		)
 	}
 	return nil, err
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor.go
@@ -8,11 +8,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"azureaiagent/internal/exterrors"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type monitorFlags struct {
@@ -47,9 +50,13 @@ specify one explicitly with --session-id.
 Use --follow to stream logs in real-time, or omit it to fetch recent logs and exit.
 This is useful for troubleshooting agent issues or monitoring agent behavior.
 
-The agent name and version are resolved automatically from the azure.yaml service
-configuration and the current azd environment. Optionally specify the service name
-(from azure.yaml) as a positional argument when multiple agent services exist.
+When run from an azd project, the agent name and version are resolved from the
+azure.yaml service configuration and current azd environment. Optionally specify
+the service name as a positional argument when multiple agent services exist.
+
+Outside an azd project, the positional value is treated as the hosted agent name.
+The Foundry project endpoint is resolved from the global project context configured
+by azd ai project set, or from FOUNDRY_PROJECT_ENDPOINT.
 
 For agents configured with header-based isolation, pass --user-identity
 when streaming session logs.`,
@@ -58,6 +65,9 @@ when streaming session logs.`,
 
   # Monitor logs for a specific agent service
   azd ai agent monitor my-agent
+
+  # Monitor a hosted agent outside an azd project
+  azd ai agent monitor my-agent --session-id <session-id>
 
   # Stream logs for a specific session
   azd ai agent monitor --session-id <session-id>
@@ -85,7 +95,7 @@ when streaming session logs.`,
 			}
 			defer azdClient.Close()
 
-			info, err := resolveAgentServiceFromProject(ctx, azdClient, flags.name, extCtx.NoPrompt)
+			info, err := resolveMonitorAgentInfo(ctx, azdClient, flags.name, extCtx.NoPrompt)
 			if err != nil {
 				return err
 			}
@@ -100,19 +110,17 @@ when streaming session logs.`,
 
 			agentContext, err := newAgentContext(ctx, "", "", info.AgentName, info.Version)
 			if err != nil {
-				return err
+				return monitorEndpointError(err)
 			}
 
 			// Resolve session ID for session-based logstream.
 			if flags.sessionID == "" {
-				var sessionID string
-				if info.AgentEndpoint != "" {
-					sessionID = resolveMonitorSession(
-						ctx,
-						buildRemoteAgentKeyFromEndpoint(info.AgentEndpoint),
-						legacyKeysForRemote(info.AgentName)...,
-					)
-				}
+				sessionID := resolveMonitorSession(
+					ctx,
+					azdClient,
+					monitorAgentKey(info, agentContext.ProjectEndpoint),
+					legacyKeysForRemote(info.AgentName)...,
+				)
 				if sessionID == "" {
 					return exterrors.Validation(
 						exterrors.CodeInvalidSessionId,
@@ -142,6 +150,59 @@ when streaming session logs.`,
 	addUserIdentityFlag(cmd, &flags.userIdentityFlags)
 
 	return cmd
+}
+
+func resolveMonitorAgentInfo(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	name string,
+	noPrompt bool,
+) (*AgentServiceInfo, error) {
+	info, err := resolveAgentServiceFromProject(ctx, azdClient, name, noPrompt)
+	if err == nil {
+		return info, nil
+	}
+	if name != "" && isMissingAzdProjectError(err) {
+		return &AgentServiceInfo{AgentName: name}, nil
+	}
+	return nil, err
+}
+
+func isMissingAzdProjectError(err error) bool {
+	for current := err; current != nil; current = errors.Unwrap(current) {
+		st, ok := status.FromError(current)
+		if !ok {
+			continue
+		}
+		message := strings.ToLower(st.Message())
+		missingProject := strings.Contains(message, "no project exists") ||
+			strings.Contains(message, "project not found")
+		if missingProject && (st.Code() == codes.NotFound || st.Code() == codes.Unknown) {
+			return true
+		}
+	}
+	return false
+}
+
+func monitorAgentKey(info *AgentServiceInfo, projectEndpoint string) string {
+	if info.AgentEndpoint != "" {
+		return buildRemoteAgentKeyFromEndpoint(info.AgentEndpoint)
+	}
+	return buildAgentKey(projectEndpoint, info.AgentName, info.Version, false)
+}
+
+func monitorEndpointError(err error) error {
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	if !ok || localErr.Code != exterrors.CodeMissingProjectEndpoint {
+		return err
+	}
+
+	return exterrors.Dependency(
+		exterrors.CodeMissingProjectEndpoint,
+		"no Foundry project endpoint is configured",
+		"set a default with `azd ai project set <project-endpoint>` to monitor outside an azd project, "+
+			"or run from a directory containing azure.yaml with FOUNDRY_PROJECT_ENDPOINT set in the active azd environment",
+	)
 }
 
 // Run executes the monitor command logic.
@@ -200,12 +261,15 @@ func validateMonitorFlags(flags *monitorFlags) error {
 
 // resolveMonitorSession resolves the session ID from the config store.
 // Returns the session ID if available, or empty string if not found.
-func resolveMonitorSession(ctx context.Context, agentKey string, legacyKeys ...string) string {
-	azdClient, err := azdext.NewAzdClient()
-	if err != nil {
+func resolveMonitorSession(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	agentKey string,
+	legacyKeys ...string,
+) string {
+	if azdClient == nil {
 		return ""
 	}
-	defer azdClient.Close()
 
 	// Try to trigger migration from legacy file if it exists.
 	migrateFromLegacyFile(ctx, azdClient)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor_test.go
@@ -196,7 +196,12 @@ func TestResolveMonitorAgentInfo_RequiresNameWithoutProject(t *testing.T) {
 
 	_, err := resolveMonitorAgentInfo(t.Context(), azdClient, "", true)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "failed to get project config")
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeInvalidAgentName, localErr.Code)
+	assert.Equal(t, "agent name is required outside an azd project", localErr.Message)
+	assert.Contains(t, localErr.Suggestion, "<agent-name>")
+	assert.Contains(t, localErr.Suggestion, "run from an azd project")
 }
 
 func TestResolveMonitorAgentInfo_DoesNotHideProjectTransportFailure(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/monitor_test.go
@@ -5,12 +5,18 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"azureaiagent/internal/exterrors"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestMonitorCommand_AcceptsPositionalArg(t *testing.T) {
@@ -114,6 +120,203 @@ func TestMonitorCommand_SessionFlagRegistered(t *testing.T) {
 	f := cmd.Flags().Lookup("session-id")
 	require.NotNil(t, f, "--session-id flag should be registered")
 	assert.Equal(t, "s", f.Shorthand)
+}
+
+func TestResolveMonitorAgentInfo_PrefersProjectService(t *testing.T) {
+	t.Parallel()
+
+	projectServer := &helpersProjectServer{project: &azdext.ProjectConfig{
+		Services: map[string]*azdext.ServiceConfig{
+			"service-key": {
+				Name: "service-key",
+				Host: AiAgentHost,
+			},
+		},
+	}}
+	envServer := &testEnvironmentServiceServer{
+		current: &azdext.Environment{Name: "test"},
+		values: map[string]map[string]string{"test": {
+			"AGENT_SERVICE_KEY_NAME":    "deployed-agent",
+			"AGENT_SERVICE_KEY_VERSION": "7",
+			"AGENT_SERVICE_KEY_ENDPOINT": "https://account.services.ai.azure.com/api/projects/project/" +
+				"agents/deployed-agent/versions/7",
+		}},
+	}
+	azdClient := newHelpersTestAzdClient(
+		t, projectServer, &helpersPromptServer{}, envServer,
+	)
+
+	info, err := resolveMonitorAgentInfo(t.Context(), azdClient, "service-key", true)
+	require.NoError(t, err)
+	assert.Equal(t, "service-key", info.ServiceName)
+	assert.Equal(t, "deployed-agent", info.AgentName)
+	assert.Equal(t, "7", info.Version)
+	assert.Contains(t, info.AgentEndpoint, "/agents/deployed-agent/versions/7")
+}
+
+func TestResolveMonitorAgentInfo_UsesDirectNameWithoutProject(t *testing.T) {
+	t.Parallel()
+
+	projectServer := &helpersProjectServer{
+		err: status.Error(codes.Unknown, "no project exists; to create a new project, run `azd init`"),
+	}
+	azdClient := newHelpersTestAzdClient(t, projectServer, &helpersPromptServer{})
+
+	info, err := resolveMonitorAgentInfo(t.Context(), azdClient, "hosted-agent", true)
+	require.NoError(t, err)
+	assert.Empty(t, info.ServiceName)
+	assert.Equal(t, "hosted-agent", info.AgentName)
+}
+
+func TestResolveMonitorAgentInfo_DoesNotUseDirectNameInsideProject(t *testing.T) {
+	t.Parallel()
+
+	projectServer := &helpersProjectServer{project: &azdext.ProjectConfig{
+		Services: map[string]*azdext.ServiceConfig{
+			"service-key": {
+				Name: "service-key",
+				Host: AiAgentHost,
+			},
+		},
+	}}
+	azdClient := newHelpersTestAzdClient(t, projectServer, &helpersPromptServer{})
+
+	_, err := resolveMonitorAgentInfo(t.Context(), azdClient, "hosted-agent", true)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no azure.ai.agent service named 'hosted-agent'")
+}
+
+func TestResolveMonitorAgentInfo_RequiresNameWithoutProject(t *testing.T) {
+	t.Parallel()
+
+	projectServer := &helpersProjectServer{
+		err: status.Error(codes.Unknown, "no project exists; to create a new project, run `azd init`"),
+	}
+	azdClient := newHelpersTestAzdClient(t, projectServer, &helpersPromptServer{})
+
+	_, err := resolveMonitorAgentInfo(t.Context(), azdClient, "", true)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to get project config")
+}
+
+func TestResolveMonitorAgentInfo_DoesNotHideProjectTransportFailure(t *testing.T) {
+	t.Parallel()
+
+	projectServer := &helpersProjectServer{
+		err: status.Error(codes.Unavailable, "project service unavailable"),
+	}
+	azdClient := newHelpersTestAzdClient(t, projectServer, &helpersPromptServer{})
+
+	_, err := resolveMonitorAgentInfo(t.Context(), azdClient, "hosted-agent", true)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "project service unavailable")
+}
+
+func TestIsMissingAzdProjectError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "current host error",
+			err:  status.Error(codes.Unknown, "no project exists; run `azd init`"),
+			want: true,
+		},
+		{
+			name: "future not found code",
+			err:  status.Error(codes.NotFound, "project not found"),
+			want: true,
+		},
+		{
+			name: "unrelated not found",
+			err:  status.Error(codes.NotFound, "service not found"),
+			want: false,
+		},
+		{
+			name: "transport failure",
+			err:  status.Error(codes.Unavailable, "connection refused"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isMissingAzdProjectError(tt.err))
+		})
+	}
+}
+
+func TestMonitorAgentKey(t *testing.T) {
+	t.Parallel()
+
+	projectEndpoint := "https://account.services.ai.azure.com/api/projects/project"
+
+	t.Run("uses project endpoint for direct hosted name", func(t *testing.T) {
+		t.Parallel()
+
+		info := &AgentServiceInfo{AgentName: "hosted-agent"}
+		assert.Equal(
+			t,
+			buildAgentKey(projectEndpoint, "hosted-agent", "", false),
+			monitorAgentKey(info, projectEndpoint),
+		)
+	})
+
+	t.Run("prefers deployed agent endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		agentEndpoint := projectEndpoint + "/agents/deployed-agent/versions/7"
+		info := &AgentServiceInfo{
+			AgentName:     "deployed-agent",
+			Version:       "7",
+			AgentEndpoint: agentEndpoint,
+		}
+		assert.Equal(
+			t,
+			buildRemoteAgentKeyFromEndpoint(agentEndpoint),
+			monitorAgentKey(info, "https://different.example.com/api/projects/other"),
+		)
+	})
+}
+
+func TestMonitorEndpointError_AddsOutsideProjectGuidance(t *testing.T) {
+	t.Parallel()
+
+	err := monitorEndpointError(noProjectEndpointError())
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Equal(t, exterrors.CodeMissingProjectEndpoint, localErr.Code)
+	assert.Equal(t, "no Foundry project endpoint is configured", localErr.Message)
+	assert.Contains(t, localErr.Suggestion, "azd ai project set")
+	assert.Contains(t, localErr.Suggestion, "azure.yaml")
+}
+
+func TestResolveMonitorSession_UsesDirectAgentKey(t *testing.T) {
+	t.Parallel()
+
+	userConfig := newInvokeUserConfigServer()
+	azdClient := newInvokeTestAzdClient(t, userConfig)
+	agentKey := buildAgentKey(
+		"https://account.services.ai.azure.com/api/projects/project",
+		"hosted-agent",
+		"",
+		false,
+	)
+	userConfig.setJSON(t, configPath("sessions"), map[string]string{
+		agentKey: "persisted-session",
+	})
+
+	sessionID := resolveMonitorSession(
+		t.Context(),
+		azdClient,
+		agentKey,
+		legacyKeysForRemote("hosted-agent")...,
+	)
+	assert.Equal(t, "persisted-session", sessionID)
 }
 
 func TestMonitorCommand_FollowFlagRegistered(t *testing.T) {


### PR DESCRIPTION
## Summary
- allow `azd ai agent monitor <agent-name>` to target a hosted agent outside an azd project
- preserve existing `azure.yaml` service and environment resolution when a project is available
- derive the remote session key from the resolved Foundry project endpoint so persisted sessions work outside a project
- provide monitor-specific endpoint guidance and document the new command behavior

## Validation
- `go test ./... -count=1`
- `go build ./...`
- `golangci-lint run ./internal/cmd/...`

Fixes #9469