### PR TITLE
fix(infra): infer custom provider parameter dependencies

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/docs/infrastructure-eject.md
+++ b/cli/azd/extensions/azure.ai.agents/docs/infrastructure-eject.md
@@ -73,10 +73,11 @@ group is not removed.
 
 ## Layer dependencies
 
-The Foundry layer is independent by default. Dependency analysis currently
-skips custom providers such as `microsoft.foundry`, so add `dependsOn` when the
-generated Foundry parameters consume outputs or hook-written values from
-another layer:
+The Foundry layer is independent by default. Azd analyzes generated parameter
+references such as `${AZURE_VNET_ID}` and orders the Foundry layer after a
+Bicep layer that produces the matching output. Add `dependsOn` when a
+dependency cannot be inferred from parameter references, such as a value
+written by another layer's hook:
 
 ```yaml
 infra:
@@ -91,8 +92,9 @@ infra:
         - network
 ```
 
-Without this edge, independent layers may provision concurrently and the
-Foundry layer can read an empty or stale environment value.
+Without an inferred or explicit edge, independent layers provision
+concurrently and the Foundry layer can read an empty or stale environment
+value.
 
 ## Limitations
 

--- a/cli/azd/pkg/infra/provisioning/bicep/layer_deps.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/layer_deps.go
@@ -26,6 +26,19 @@ func isBicepLayer(layer provisioning.Options) bool {
 		layer.Provider == provisioning.Bicep
 }
 
+// mayUseStandardParameters reports whether probing for standard
+// .bicepparam/.parameters.json files is appropriate. Missing files are a
+// no-op; built-in non-Bicep providers remain opaque to preserve their existing
+// behavior.
+func mayUseStandardParameters(layer provisioning.Options) bool {
+	switch layer.Provider {
+	case provisioning.Terraform, provisioning.Pulumi, provisioning.Arm, provisioning.Test:
+		return false
+	default:
+		return true
+	}
+}
+
 // Package-level compiled regexes for output and env-var reference extraction.
 var (
 	bicepOutputRe   = regexp.MustCompile(`(?m)^\s*output\s+(\w+)\s+`)
@@ -178,13 +191,12 @@ func AnalyzeLayerDependencies(
 		}
 	}
 
-	// Phase 2 — Discover input env-var references and build edges.
-	// Non-Bicep layers are skipped: they have no .bicep/.bicepparam/
-	// .parameters.json files to scan for env-var references. Their
-	// dependencies must be declared via explicit dependsOn in azure.yaml.
+	// Phase 2 — Discover input env-var references and build edges for Bicep and
+	// extension providers that use standard parameter files. Built-in non-Bicep
+	// providers retain their existing explicit-dependency behavior.
 	var safeFallback []int
 	for i, layer := range layers {
-		if !isBicepLayer(layer) {
+		if !mayUseStandardParameters(layer) {
 			continue
 		}
 		refs, hasUnknown := discoverParamEnvRefs(ctx, resolved[i], projectPath)
@@ -466,17 +478,18 @@ func discoverParamEnvRefs(
 		hasUnknown = true
 	}
 
-	// Always scan the .bicep file for param defaults that call
-	// readEnvironmentVariable. These are independent of the param file
-	// and silently dropped when only parameter files are inspected.
-	if bicepContent, err := readFileWithContext(ctx,
-		resolveBicepPath(opts, projectPath),
-	); err == nil {
-		r, u := extractBicepParamReadEnvRefs(bicepContent)
-		merge(r, u)
-	} else if !os.IsNotExist(err) {
-		log.Printf("warning: failed to read %s: %v, using safe fallback", resolveBicepPath(opts, projectPath), err)
-		hasUnknown = true
+	if isBicepLayer(opts) {
+		// Bicep parameter defaults are independent of the parameter file and
+		// otherwise silently missed.
+		if bicepContent, err := readFileWithContext(ctx,
+			resolveBicepPath(opts, projectPath),
+		); err == nil {
+			r, u := extractBicepParamReadEnvRefs(bicepContent)
+			merge(r, u)
+		} else if !os.IsNotExist(err) {
+			log.Printf("warning: failed to read %s: %v, using safe fallback", resolveBicepPath(opts, projectPath), err)
+			hasUnknown = true
+		}
 	}
 
 	return refs, hasUnknown

--- a/cli/azd/pkg/infra/provisioning/bicep/layer_deps_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/layer_deps_test.go
@@ -42,6 +42,25 @@ func TestAnalyzeLayerDependencies_SingleLayer(t *testing.T) {
 	require.Equal(t, [][]int{{0}}, result.Levels)
 }
 
+func TestAnalyzeLayerDependencies_NoLayers(t *testing.T) {
+	result, err := AnalyzeLayerDependencies(t.Context(), nil, t.TempDir())
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+func TestAnalyzeLayerDependencies_MissingBicepSource(t *testing.T) {
+	dir := t.TempDir()
+	mkTestDir(t, filepath.Join(dir, "missing"))
+	mkTestDir(t, filepath.Join(dir, "terraform"))
+
+	layers := []provisioning.Options{
+		{Name: "missing", Path: "missing", Module: "main", Provider: provisioning.Bicep},
+		{Name: "terraform", Path: "terraform", Module: "main", Provider: provisioning.Terraform},
+	}
+	_, err := AnalyzeLayerDependencies(t.Context(), layers, dir)
+	require.ErrorContains(t, err, "extracting outputs for layer \"missing\"")
+}
+
 func TestAnalyzeLayerDependencies_NoDependencies(t *testing.T) {
 	dir := t.TempDir()
 
@@ -701,6 +720,35 @@ func TestDiscoverParamEnvRefs_NonExistentDirectory(t *testing.T) {
 	_ = hasUnknown // accept either true or false
 }
 
+func TestDiscoverParamEnvRefs_ReadErrorsUseSafeFallback(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider provisioning.ProviderKind
+		badPath  string
+	}{
+		{name: "custom bicepparam", provider: "custom", badPath: "main.bicepparam"},
+		{name: "custom parameters JSON", provider: "custom", badPath: "main.parameters.json"},
+		{name: "Bicep source", provider: provisioning.Bicep, badPath: "main.bicep"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			// A directory at the expected file path produces a read error that is
+			// distinct from a missing optional parameter file on every platform.
+			mkTestDir(t, filepath.Join(dir, tt.badPath))
+
+			refs, hasUnknown := discoverParamEnvRefs(t.Context(), provisioning.Options{
+				Path:     dir,
+				Module:   "main",
+				Provider: tt.provider,
+			}, dir)
+			require.Empty(t, refs)
+			require.True(t, hasUnknown)
+		})
+	}
+}
+
 func TestStripBicepLineComments(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -882,6 +930,49 @@ func TestAnalyzeLayerDependencies_FoundryConsumesBicepOutput(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, [][]int{{0}, {1}}, result.Levels)
 	require.Equal(t, []int{0}, result.Edges[1])
+}
+
+func TestAnalyzeLayerDependencies_CustomProviderBicepparamConsumesBicepOutput(t *testing.T) {
+	dir := t.TempDir()
+	producerDir := filepath.Join(dir, "producer")
+	consumerDir := filepath.Join(dir, "consumer")
+	mkTestDir(t, producerDir)
+	mkTestDir(t, consumerDir)
+	writeTestFile(t, filepath.Join(producerDir, "main.bicep"),
+		"output PRODUCER_ID string = 'id'\n")
+	writeTestFile(t, filepath.Join(consumerDir, "main.bicepparam"),
+		"using './main.bicep'\nparam id = readEnvironmentVariable('PRODUCER_ID')\n")
+
+	layers := []provisioning.Options{
+		{Name: "producer", Path: "producer", Module: "main", Provider: provisioning.Bicep},
+		{Name: "consumer", Path: "consumer", Module: "main", Provider: "custom"},
+	}
+	result, err := AnalyzeLayerDependencies(t.Context(), layers, dir)
+	require.NoError(t, err)
+	require.Equal(t, [][]int{{0}, {1}}, result.Levels)
+	require.Equal(t, []int{0}, result.Edges[1])
+}
+
+func TestAnalyzeLayerDependencies_CustomProviderUnknownReferenceUsesSafeFallback(t *testing.T) {
+	dir := t.TempDir()
+	producerDir := filepath.Join(dir, "producer")
+	consumerDir := filepath.Join(dir, "consumer")
+	mkTestDir(t, producerDir)
+	mkTestDir(t, consumerDir)
+	writeTestFile(t, filepath.Join(producerDir, "main.bicep"),
+		"output PRODUCER_ID string = 'id'\n")
+	writeTestFile(t, filepath.Join(consumerDir, "main.bicepparam"),
+		"using './main.bicep'\nvar envName = 'PRODUCER_ID'\nparam id = readEnvironmentVariable(envName)\n")
+
+	layers := []provisioning.Options{
+		{Name: "producer", Path: "producer", Module: "main", Provider: provisioning.Bicep},
+		{Name: "consumer", Path: "consumer", Module: "main", Provider: "custom"},
+	}
+	result, err := AnalyzeLayerDependencies(t.Context(), layers, dir)
+	require.NoError(t, err)
+	require.Equal(t, [][]int{{0}, {1}}, result.Levels)
+	require.Equal(t, []int{0}, result.Edges[1])
+	require.Equal(t, []int{1}, result.SafeFallbackLayers)
 }
 
 func TestAnalyzeLayerDependencies_TerraformParametersRemainOpaque(t *testing.T) {

--- a/cli/azd/pkg/infra/provisioning/bicep/layer_deps_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/layer_deps_test.go
@@ -884,7 +884,7 @@ func TestAnalyzeLayerDependencies_FoundryConsumesBicepOutput(t *testing.T) {
 	require.Equal(t, []int{0}, result.Edges[1])
 }
 
-func TestAnalyzeLayerDependencies_TerraformTfvarsRemainOpaque(t *testing.T) {
+func TestAnalyzeLayerDependencies_TerraformParametersRemainOpaque(t *testing.T) {
 	dir := t.TempDir()
 	networkDir := filepath.Join(dir, "network")
 	terraformDir := filepath.Join(dir, "terraform")
@@ -892,8 +892,8 @@ func TestAnalyzeLayerDependencies_TerraformTfvarsRemainOpaque(t *testing.T) {
 	mkTestDir(t, terraformDir)
 	writeTestFile(t, filepath.Join(networkDir, "main.bicep"),
 		"output AZURE_VNET_ID string = 'id'\n")
-	writeTestFile(t, filepath.Join(terraformDir, "main.tfvars.json"),
-		`{"vnet_id":"${AZURE_VNET_ID}"}`)
+	writeTestFile(t, filepath.Join(terraformDir, "main.parameters.json"),
+		`{"parameters":{"vnetId":{"value":"${AZURE_VNET_ID}"}}}`)
 
 	layers := []provisioning.Options{
 		{Name: "network", Path: "network", Module: "main", Provider: provisioning.Bicep},

--- a/cli/azd/pkg/infra/provisioning/bicep/layer_deps_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/layer_deps_test.go
@@ -863,6 +863,48 @@ func TestAnalyzeLayerDependencies_MixedProviders(t *testing.T) {
 	require.Contains(t, result.Edges[1], 0)
 }
 
+func TestAnalyzeLayerDependencies_FoundryConsumesBicepOutput(t *testing.T) {
+	dir := t.TempDir()
+	networkDir := filepath.Join(dir, "network")
+	foundryDir := filepath.Join(dir, "foundry")
+	mkTestDir(t, networkDir)
+	mkTestDir(t, foundryDir)
+	writeTestFile(t, filepath.Join(networkDir, "main.bicep"),
+		"output AZURE_VNET_ID string = 'id'\n")
+	writeTestFile(t, filepath.Join(foundryDir, "main.parameters.json"),
+		`{"parameters":{"vnetId":{"value":"${AZURE_VNET_ID}"}}}`)
+
+	layers := []provisioning.Options{
+		{Name: "network", Path: "network", Module: "main", Provider: provisioning.Bicep},
+		{Name: "foundry", Path: "foundry", Module: "main", Provider: "microsoft.foundry"},
+	}
+	result, err := AnalyzeLayerDependencies(t.Context(), layers, dir)
+	require.NoError(t, err)
+	require.Equal(t, [][]int{{0}, {1}}, result.Levels)
+	require.Equal(t, []int{0}, result.Edges[1])
+}
+
+func TestAnalyzeLayerDependencies_TerraformTfvarsRemainOpaque(t *testing.T) {
+	dir := t.TempDir()
+	networkDir := filepath.Join(dir, "network")
+	terraformDir := filepath.Join(dir, "terraform")
+	mkTestDir(t, networkDir)
+	mkTestDir(t, terraformDir)
+	writeTestFile(t, filepath.Join(networkDir, "main.bicep"),
+		"output AZURE_VNET_ID string = 'id'\n")
+	writeTestFile(t, filepath.Join(terraformDir, "main.tfvars.json"),
+		`{"vnet_id":"${AZURE_VNET_ID}"}`)
+
+	layers := []provisioning.Options{
+		{Name: "network", Path: "network", Module: "main", Provider: provisioning.Bicep},
+		{Name: "terraform", Path: "terraform", Module: "main", Provider: provisioning.Terraform},
+	}
+	result, err := AnalyzeLayerDependencies(t.Context(), layers, dir)
+	require.NoError(t, err)
+	require.Equal(t, [][]int{{0, 1}}, result.Levels)
+	require.Empty(t, result.Edges)
+}
+
 // TestIsBicepLayer verifies the helper classifies providers correctly.
 func TestIsBicepLayer(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Fixes #9529. Custom provisioning layers can currently run alongside Bicep producers and consume empty or stale output values because their standard parameter references are not analyzed.

## Changes

- **`layer dependency analysis`**: scan `.bicepparam` and `.parameters.json` inputs for extension providers while preserving opaque handling for Terraform, Pulumi, ARM, and test providers.
- **`tests`**: cover inferred Foundry-to-Bicep ordering and unchanged Terraform behavior.
- **`Foundry eject docs`**: document inferred parameter dependencies and when explicit `dependsOn` remains necessary.

## Manual Validation

- Provisioned a live two-layer project without `dependsOn`; the Bicep producer completed before the `microsoft.foundry` layer, whose ARM deployment received `producer-completed` instead of the seeded stale value.
