### PR TITLE
Warn before initializing from archived template repositories

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -620,7 +620,23 @@ func registerCommonDependencies(container *ioc.NestedContainer) {
 		return security.NewManager(cwd)
 	})
 
-	container.MustRegisterSingleton(repository.NewInitializer)
+	container.MustRegisterSingleton(func(
+		console input.Console,
+		gitCli *git.Cli,
+		dotnetCli *dotnet.Cli,
+		features *alpha.FeatureManager,
+		lazyEnvManager *lazy.Lazy[environment.Manager],
+		transport policy.Transporter,
+	) *repository.Initializer {
+		return repository.NewInitializerWithRepositoryStatusChecker(
+			console,
+			gitCli,
+			dotnetCli,
+			features,
+			lazyEnvManager,
+			repository.NewGitHubRepositoryStatusChecker(transport),
+		)
+	})
 	container.MustRegisterSingleton(alpha.NewFeaturesManager)
 	container.MustRegisterSingleton(config.NewUserConfigManager)
 	container.MustRegisterSingleton(config.NewManager)

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -257,6 +257,7 @@ func (i *initAction) Run(ctx context.Context) (_ *actions.ActionResult, retErr e
 	// or pass "." to use the current directory (preserving existing behavior).
 	createdProjectDir := ""
 	originalWd := wd
+	cleanupProjectDir := false
 
 	if isTemplateInit {
 		targetDir, err := i.resolveTargetDirectory(wd)
@@ -308,7 +309,7 @@ func (i *initAction) Run(ctx context.Context) (_ *actions.ActionResult, retErr e
 			// Only remove the directory if we created it — don't delete
 			// pre-existing directories the user pointed at.
 			defer func() {
-				if retErr != nil {
+				if retErr != nil || cleanupProjectDir {
 					_ = os.Chdir(originalWd)
 					if !dirExistedBefore {
 						_ = os.RemoveAll(createdProjectDir)
@@ -424,6 +425,10 @@ func (i *initAction) Run(ctx context.Context) (_ *actions.ActionResult, retErr e
 		tracing.SetUsageAttributes(fields.InitMethod.String("template"))
 		template, err := i.initializeTemplate(ctx, azdCtx)
 		if err != nil {
+			if errors.Is(err, repository.ErrArchivedTemplateDeclined) {
+				cleanupProjectDir = true
+				return initCancelledResult(), nil
+			}
 			return nil, err
 		}
 

--- a/cli/azd/cmd/init.go
+++ b/cli/azd/cmd/init.go
@@ -427,7 +427,8 @@ func (i *initAction) Run(ctx context.Context) (_ *actions.ActionResult, retErr e
 		if err != nil {
 			if errors.Is(err, repository.ErrArchivedTemplateDeclined) {
 				cleanupProjectDir = true
-				return initCancelledResult(), nil
+				i.console.Message(ctx, output.WithWarningFormat("CANCELLED: Initialization stopped."))
+				return nil, nil
 			}
 			return nil, err
 		}

--- a/cli/azd/cmd/init_test.go
+++ b/cli/azd/cmd/init_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/internal/agent/consent"
+	"github.com/azure/azure-dev/cli/azd/internal/repository"
 	"github.com/azure/azure-dev/cli/azd/pkg/account"
 	"github.com/azure/azure-dev/cli/azd/pkg/alpha"
 	"github.com/azure/azure-dev/cli/azd/pkg/config"
@@ -152,6 +153,47 @@ func TestInitNoPromptRequiresMode(t *testing.T) {
 				"should not return InitNoPromptError when --template and --environment are both set")
 		}
 	})
+}
+
+func TestInitArchivedTemplateDeclinedCleansCreatedDirectory(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+	mockContext.Console.SetTerminal(true)
+	mockContext.Console.WhenConfirm(func(options input.ConsoleOptions) bool {
+		return options.Message == "Do you want to continue using this archived template?" &&
+			options.DefaultValue == false
+	}).Respond(false)
+
+	flags := &initFlags{
+		templatePath: "Azure-Samples/todo-csharp-sql-swa-func",
+		global:       &internal.GlobalCommandOptions{},
+	}
+	flags.EnvironmentName = "archive-test"
+
+	action := setupInitAction(t, mockContext, flags)
+	action.repoInitializer = repository.NewInitializerWithRepositoryStatusChecker(
+		mockContext.Console,
+		action.gitCli,
+		nil,
+		nil,
+		nil,
+		archivedRepositoryStatusChecker{},
+	)
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	targetDir := filepath.Join(wd, "todo-csharp-sql-swa-func")
+
+	result, err := action.Run(t.Context())
+
+	require.NoError(t, err)
+	require.Equal(t, "Init cancelled.", result.Message.Header)
+	require.NoDirExists(t, targetDir)
+}
+
+type archivedRepositoryStatusChecker struct{}
+
+func (archivedRepositoryStatusChecker) Check(context.Context, string) (*repository.RepositoryStatus, error) {
+	return &repository.RepositoryStatus{Archived: true}, nil
 }
 
 func TestInitFailFastMissingEnvNonInteractive(t *testing.T) {

--- a/cli/azd/cmd/init_test.go
+++ b/cli/azd/cmd/init_test.go
@@ -159,7 +159,7 @@ func TestInitArchivedTemplateDeclinedCleansCreatedDirectory(t *testing.T) {
 	mockContext := mocks.NewMockContext(t.Context())
 	mockContext.Console.SetTerminal(true)
 	mockContext.Console.WhenConfirm(func(options input.ConsoleOptions) bool {
-		return options.Message == "Do you want to continue using this archived template?" &&
+		return options.Message == "Continue using this archived template?" &&
 			options.DefaultValue == false
 	}).Respond(false)
 
@@ -186,7 +186,8 @@ func TestInitArchivedTemplateDeclinedCleansCreatedDirectory(t *testing.T) {
 	result, err := action.Run(t.Context())
 
 	require.NoError(t, err)
-	require.Equal(t, "Init cancelled.", result.Message.Header)
+	require.Nil(t, result)
+	require.Contains(t, strings.Join(mockContext.Console.Output(), "\n"), "CANCELLED: Initialization stopped.")
 	require.NoDirExists(t, targetDir)
 }
 

--- a/cli/azd/docs/environment-variables.md
+++ b/cli/azd/docs/environment-variables.md
@@ -132,6 +132,20 @@ specific version of the tool installed on the machine.
 | `AZD_PACK_TOOL_PATH` | The `pack` tool override path. The direct path to `pack` or `pack.exe`. |
 | `AZD_COPILOT_CLI_PATH` | The Copilot CLI tool override path. When set, skips automatic download and uses the specified path. |
 
+### GitHub Repository Access
+
+These GitHub-compatible variables are used when `azd init --template` checks repository metadata before cloning.
+Metadata requests are unauthenticated when no matching token is set.
+
+| Variable | Description |
+| --- | --- |
+| `GH_TOKEN` | Token used to request repository metadata from `github.com`. Takes precedence over `GITHUB_TOKEN`. |
+| `GITHUB_TOKEN` | Token used to request repository metadata from `github.com` when `GH_TOKEN` is not set. |
+| `GH_HOST` | GitHub Enterprise host recognized for repository metadata checks. |
+| `GITHUB_SERVER_URL` | GitHub server URL recognized for repository metadata checks when `GH_HOST` is not set. |
+| `GH_ENTERPRISE_TOKEN` | Token used to request repository metadata from a recognized GitHub Enterprise host. Takes precedence over `GITHUB_ENTERPRISE_TOKEN`. |
+| `GITHUB_ENTERPRISE_TOKEN` | Token used to request repository metadata from a recognized GitHub Enterprise host when `GH_ENTERPRISE_TOKEN` is not set. |
+
 ## Extension Configuration
 
 | Variable | Description |

--- a/cli/azd/docs/environment-variables.md
+++ b/cli/azd/docs/environment-variables.md
@@ -139,12 +139,12 @@ Metadata requests are unauthenticated when no matching token is set.
 
 | Variable | Description |
 | --- | --- |
-| `GH_TOKEN` | Token used to request repository metadata from `github.com`. Takes precedence over `GITHUB_TOKEN`. |
-| `GITHUB_TOKEN` | Token used to request repository metadata from `github.com` when `GH_TOKEN` is not set. |
+| `GH_TOKEN` | Token used to request repository metadata from `github.com` and GitHub Enterprise Cloud `*.ghe.com` hosts. Takes precedence over `GITHUB_TOKEN`. |
+| `GITHUB_TOKEN` | Token used to request repository metadata from `github.com` and `*.ghe.com` when `GH_TOKEN` is not set. |
 | `GH_HOST` | GitHub Enterprise host recognized for repository metadata checks. |
 | `GITHUB_SERVER_URL` | GitHub server URL recognized for repository metadata checks when `GH_HOST` is not set. |
-| `GH_ENTERPRISE_TOKEN` | Token used to request repository metadata from a recognized GitHub Enterprise host. Takes precedence over `GITHUB_ENTERPRISE_TOKEN`. |
-| `GITHUB_ENTERPRISE_TOKEN` | Token used to request repository metadata from a recognized GitHub Enterprise host when `GH_ENTERPRISE_TOKEN` is not set. |
+| `GH_ENTERPRISE_TOKEN` | Token used to request repository metadata from a recognized GitHub Enterprise Server host. Takes precedence over `GITHUB_ENTERPRISE_TOKEN`. |
+| `GITHUB_ENTERPRISE_TOKEN` | Token used for a recognized GitHub Enterprise Server host when `GH_ENTERPRISE_TOKEN` is not set. |
 
 ## Extension Configuration
 

--- a/cli/azd/internal/cmd/errors_test.go
+++ b/cli/azd/internal/cmd/errors_test.go
@@ -1195,6 +1195,7 @@ func Test_PackageLevelErrorsMapped(t *testing.T) {
 		"ErrUnsupportedScriptType": "pkg/ext: hook script validation, caught before command level",
 
 		// Errors that are always caught/handled before reaching MapError
+		"ErrArchivedTemplateDeclined":          "caught in cmd/init.go and converted to a successful cancellation result",
 		"ErrEnsureEnvPreReqBicepCompileFailed": "caught in cmd/env.go and cmd/up.go before reaching telemetry",
 		"ErrAzdOperationsNotEnabled":           "caught in pkg/project/dotnet_importer.go before reaching telemetry",
 		"ErrAzCliSecretNotFound":               "caught in pkg/cmdsubst before reaching telemetry",

--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -236,9 +236,8 @@ func (i *Initializer) confirmArchivedTemplate(ctx context.Context, templateURL s
 	)
 
 	if i.console.IsNoPromptMode() {
-		return fmt.Errorf(
-			"template repository %s is archived and requires confirmation; rerun without --no-prompt",
-			templateURL,
+		return errors.New(
+			"template repository is archived and requires confirmation; rerun without --no-prompt",
 		)
 	}
 

--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -227,12 +227,12 @@ func (i *Initializer) confirmArchivedTemplate(ctx context.Context, templateURL s
 	i.console.Message(
 		ctx,
 		output.WithWarningFormat(
-			"WARNING: This template repository is archived and is no longer actively maintained.",
+			"WARNING: This template repository is archived and no longer maintained.",
 		),
 	)
 	i.console.Message(
 		ctx,
-		"It may not receive dependency updates, compatibility fixes, security patches, or support.\n",
+		"It may not receive dependency updates, compatibility fixes, or security patches.\n",
 	)
 
 	if i.console.IsNoPromptMode() {
@@ -243,7 +243,7 @@ func (i *Initializer) confirmArchivedTemplate(ctx context.Context, templateURL s
 	}
 
 	confirmed, err := i.console.Confirm(ctx, input.ConsoleOptions{
-		Message:      "Do you want to continue using this archived template?",
+		Message:      "Continue using this archived template?",
 		DefaultValue: false,
 	})
 	if err != nil {

--- a/cli/azd/internal/repository/initializer.go
+++ b/cli/azd/internal/repository/initializer.go
@@ -48,6 +48,7 @@ type Initializer struct {
 	dotnetCli      *dotnet.Cli
 	features       *alpha.FeatureManager
 	lazyEnvManager *lazy.Lazy[environment.Manager]
+	statusChecker  RepositoryStatusChecker
 }
 
 func NewInitializer(
@@ -66,6 +67,25 @@ func NewInitializer(
 	}
 }
 
+// NewInitializerWithRepositoryStatusChecker creates an initializer that checks repository metadata before cloning.
+func NewInitializerWithRepositoryStatusChecker(
+	console input.Console,
+	gitCli *git.Cli,
+	dotnetCli *dotnet.Cli,
+	features *alpha.FeatureManager,
+	lazyEnvManager *lazy.Lazy[environment.Manager],
+	statusChecker RepositoryStatusChecker,
+) *Initializer {
+	initializer := NewInitializer(console, gitCli, dotnetCli, features, lazyEnvManager)
+	initializer.statusChecker = statusChecker
+	return initializer
+}
+
+var (
+	// ErrArchivedTemplateDeclined indicates that the user chose not to initialize from an archived repository.
+	ErrArchivedTemplateDeclined = errors.New("archived template repository declined by user")
+)
+
 // Initializes a local repository in the project directory from a remote repository or local template directory.
 //
 // A confirmation prompt is displayed for any existing files to be overwritten.
@@ -75,18 +95,6 @@ func (i *Initializer) Initialize(
 	template *templates.Template,
 	templateBranch string) error {
 	var err error
-
-	staging, err := os.MkdirTemp("", "az-dev-template")
-
-	if err != nil {
-		return fmt.Errorf("creating temp folder: %w", err)
-	}
-
-	// Attempt to remove the temporary directory we cloned the template into, but don't fail the
-	// overall operation if we can't.
-	defer func() {
-		_ = os.RemoveAll(staging)
-	}()
 
 	target := azdCtx.ProjectDirectory()
 
@@ -106,6 +114,21 @@ func (i *Initializer) Initialize(
 				target, templateUrl)
 		}
 	}
+
+	if err := i.confirmArchivedTemplate(ctx, templateUrl); err != nil {
+		return err
+	}
+
+	staging, err := os.MkdirTemp("", "az-dev-template")
+	if err != nil {
+		return fmt.Errorf("creating temp folder: %w", err)
+	}
+
+	// Attempt to remove the temporary directory we cloned the template into, but don't fail the
+	// overall operation if we can't.
+	defer func() {
+		_ = os.RemoveAll(staging)
+	}()
 
 	var stepMessage string
 	if templates.IsLocalPath(templateUrl) {
@@ -179,6 +202,55 @@ func (i *Initializer) Initialize(
 	err = i.gitInitialize(ctx, target, filesWithExecPerms, isEmpty)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (i *Initializer) confirmArchivedTemplate(ctx context.Context, templateURL string) error {
+	if i.statusChecker == nil {
+		return nil
+	}
+
+	status, err := i.statusChecker.Check(ctx, templateURL)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		log.Printf("unable to verify template repository archive status: %v", err)
+		return nil
+	}
+	if status == nil || !status.Archived {
+		return nil
+	}
+
+	i.console.Message(
+		ctx,
+		output.WithWarningFormat(
+			"WARNING: This template repository is archived and is no longer actively maintained.",
+		),
+	)
+	i.console.Message(
+		ctx,
+		"It may not receive dependency updates, compatibility fixes, security patches, or support.\n",
+	)
+
+	if i.console.IsNoPromptMode() {
+		return fmt.Errorf(
+			"template repository %s is archived and requires confirmation; rerun without --no-prompt",
+			templateURL,
+		)
+	}
+
+	confirmed, err := i.console.Confirm(ctx, input.ConsoleOptions{
+		Message:      "Do you want to continue using this archived template?",
+		DefaultValue: false,
+	})
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		return ErrArchivedTemplateDeclined
 	}
 
 	return nil

--- a/cli/azd/internal/repository/repository_status.go
+++ b/cli/azd/internal/repository/repository_status.go
@@ -35,8 +35,13 @@ type RepositoryStatusChecker interface {
 
 type githubRepositoryStatusChecker struct {
 	transport      policy.Transporter
-	hosts          map[string]string
+	hosts          map[string]githubHostConfig
 	requestTimeout time.Duration
+}
+
+type githubHostConfig struct {
+	apiBaseURL string
+	token      string
 }
 
 // NewGitHubRepositoryStatusChecker creates a checker for GitHub-hosted repositories.
@@ -45,17 +50,21 @@ func NewGitHubRepositoryStatusChecker(transport policy.Transporter) RepositorySt
 		transport = http.DefaultClient
 	}
 
-	hosts := map[string]string{
-		"github.com": firstSetEnvironmentVariable("GH_TOKEN", "GITHUB_TOKEN"),
+	cloudToken := firstSetEnvironmentVariable("GH_TOKEN", "GITHUB_TOKEN")
+	enterpriseServerToken := firstSetEnvironmentVariable("GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN")
+	hosts := map[string]githubHostConfig{
+		"github.com": {
+			apiBaseURL: "https://api.github.com",
+			token:      cloudToken,
+		},
 	}
-	enterpriseToken := firstSetEnvironmentVariable("GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN")
 	if host := normalizeGitHubHost(os.Getenv("GH_HOST")); host != "" && host != "github.com" {
-		hosts[host] = enterpriseToken
+		hosts[host] = githubHostConfiguration(host, cloudToken, enterpriseServerToken)
 	}
 	if serverURL := os.Getenv("GITHUB_SERVER_URL"); serverURL != "" {
 		if parsed, err := url.Parse(serverURL); err == nil {
 			if host := normalizeGitHubHost(parsed.Hostname()); host != "" && host != "github.com" {
-				hosts[host] = enterpriseToken
+				hosts[host] = githubHostConfiguration(host, cloudToken, enterpriseServerToken)
 			}
 		}
 	}
@@ -76,10 +85,8 @@ func (c *githubRepositoryStatusChecker) Check(
 		return nil, nil
 	}
 
-	apiURL := fmt.Sprintf("https://%s/api/v3/repos/%s", host, slug)
-	if host == "github.com" {
-		apiURL = fmt.Sprintf("https://api.github.com/repos/%s", slug)
-	}
+	hostConfig := c.hosts[host]
+	apiURL := fmt.Sprintf("%s/repos/%s", hostConfig.apiBaseURL, slug)
 
 	requestCtx, cancel := context.WithTimeout(ctx, c.requestTimeout)
 	defer cancel()
@@ -91,7 +98,7 @@ func (c *githubRepositoryStatusChecker) Check(
 
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "azd")
-	if token := c.hosts[host]; token != "" {
+	if token := hostConfig.token; token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
@@ -117,7 +124,7 @@ func (c *githubRepositoryStatusChecker) Check(
 
 func parseGitHubRepositoryURL(
 	repositoryURL string,
-	knownHosts map[string]string,
+	knownHosts map[string]githubHostConfig,
 ) (host string, slug string, ok bool) {
 	var path string
 
@@ -161,6 +168,24 @@ func parseGitHubRepositoryURL(
 func normalizeGitHubHost(host string) string {
 	host = strings.ToLower(strings.TrimSpace(host))
 	return strings.TrimPrefix(host, "www.")
+}
+
+func githubHostConfiguration(host, cloudToken, enterpriseServerToken string) githubHostConfig {
+	// GitHub Enterprise Cloud data-residency hosts use the same GH_TOKEN/GITHUB_TOKEN
+	// variables as github.com and expose their REST API at api.<tenant>.ghe.com.
+	if strings.HasSuffix(host, ".ghe.com") {
+		return githubHostConfig{
+			apiBaseURL: "https://api." + host,
+			token:      cloudToken,
+		}
+	}
+
+	// Custom GitHub Enterprise Server hosts use GH_ENTERPRISE_TOKEN/GITHUB_ENTERPRISE_TOKEN
+	// and serve the REST API below /api/v3 on the configured host.
+	return githubHostConfig{
+		apiBaseURL: "https://" + host + "/api/v3",
+		token:      enterpriseServerToken,
+	}
 }
 
 func firstSetEnvironmentVariable(names ...string) string {

--- a/cli/azd/internal/repository/repository_status.go
+++ b/cli/azd/internal/repository/repository_status.go
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+const (
+	maxRepositoryMetadataSize = 1 << 20
+	repositoryMetadataTimeout = 5 * time.Second
+)
+
+// RepositoryStatus contains hosting-provider metadata relevant to template initialization.
+type RepositoryStatus struct {
+	Archived bool
+}
+
+// RepositoryStatusChecker retrieves repository metadata when the hosting provider supports it.
+type RepositoryStatusChecker interface {
+	// Check returns nil when the repository host is not supported.
+	Check(ctx context.Context, repositoryURL string) (*RepositoryStatus, error)
+}
+
+type githubRepositoryStatusChecker struct {
+	transport      policy.Transporter
+	hosts          map[string]string
+	requestTimeout time.Duration
+}
+
+// NewGitHubRepositoryStatusChecker creates a checker for GitHub-hosted repositories.
+func NewGitHubRepositoryStatusChecker(transport policy.Transporter) RepositoryStatusChecker {
+	if transport == nil {
+		transport = http.DefaultClient
+	}
+
+	hosts := map[string]string{
+		"github.com": firstSetEnvironmentVariable("GH_TOKEN", "GITHUB_TOKEN"),
+	}
+	enterpriseToken := firstSetEnvironmentVariable("GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN")
+	if host := normalizeGitHubHost(os.Getenv("GH_HOST")); host != "" && host != "github.com" {
+		hosts[host] = enterpriseToken
+	}
+	if serverURL := os.Getenv("GITHUB_SERVER_URL"); serverURL != "" {
+		if parsed, err := url.Parse(serverURL); err == nil {
+			if host := normalizeGitHubHost(parsed.Hostname()); host != "" && host != "github.com" {
+				hosts[host] = enterpriseToken
+			}
+		}
+	}
+
+	return &githubRepositoryStatusChecker{
+		transport:      transport,
+		hosts:          hosts,
+		requestTimeout: repositoryMetadataTimeout,
+	}
+}
+
+func (c *githubRepositoryStatusChecker) Check(
+	ctx context.Context,
+	repositoryURL string,
+) (*RepositoryStatus, error) {
+	host, slug, ok := parseGitHubRepositoryURL(repositoryURL, c.hosts)
+	if !ok {
+		return nil, nil
+	}
+
+	apiURL := fmt.Sprintf("https://%s/api/v3/repos/%s", host, slug)
+	if host == "github.com" {
+		apiURL = fmt.Sprintf("https://api.github.com/repos/%s", slug)
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, c.requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating GitHub repository metadata request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "azd")
+	if token := c.hosts[host]; token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := c.transport.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("requesting GitHub repository metadata: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("requesting GitHub repository metadata: HTTP %d", resp.StatusCode)
+	}
+
+	var metadata struct {
+		Archived bool `json:"archived"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxRepositoryMetadataSize)).Decode(&metadata); err != nil {
+		return nil, fmt.Errorf("decoding GitHub repository metadata: %w", err)
+	}
+
+	return &RepositoryStatus{Archived: metadata.Archived}, nil
+}
+
+func parseGitHubRepositoryURL(
+	repositoryURL string,
+	knownHosts map[string]string,
+) (host string, slug string, ok bool) {
+	var path string
+
+	if after, ok0 := strings.CutPrefix(repositoryURL, "git@"); ok0 {
+		hostAndPath := after
+		host, path, ok = strings.Cut(hostAndPath, ":")
+		if !ok {
+			return "", "", false
+		}
+	} else {
+		parsed, err := url.Parse(repositoryURL)
+		if err != nil {
+			return "", "", false
+		}
+
+		switch parsed.Scheme {
+		case "http", "https", "ssh", "git":
+		default:
+			return "", "", false
+		}
+
+		host = parsed.Hostname()
+		path = parsed.Path
+	}
+
+	host = normalizeGitHubHost(host)
+	if _, known := knownHosts[host]; !known {
+		return "", "", false
+	}
+
+	path = strings.Trim(strings.TrimSpace(path), "/")
+	path = strings.TrimSuffix(path, ".git")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+
+	return host, url.PathEscape(parts[0]) + "/" + url.PathEscape(parts[1]), true
+}
+
+func normalizeGitHubHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return strings.TrimPrefix(host, "www.")
+}
+
+func firstSetEnvironmentVariable(names ...string) string {
+	for _, name := range names {
+		if token := os.Getenv(name); token != "" {
+			return token
+		}
+	}
+
+	return ""
+}

--- a/cli/azd/internal/repository/repository_status.go
+++ b/cli/azd/internal/repository/repository_status.go
@@ -58,10 +58,11 @@ func NewGitHubRepositoryStatusChecker(transport policy.Transporter) RepositorySt
 			token:      cloudToken,
 		},
 	}
-	if host := normalizeGitHubHost(os.Getenv("GH_HOST")); host != "" && host != "github.com" {
+	host := normalizeGitHubHost(os.Getenv("GH_HOST"))
+	if host != "" && host != "github.com" {
 		hosts[host] = githubHostConfiguration(host, cloudToken, enterpriseServerToken)
-	}
-	if serverURL := os.Getenv("GITHUB_SERVER_URL"); serverURL != "" {
+	} else if host == "" {
+		serverURL := os.Getenv("GITHUB_SERVER_URL")
 		if parsed, err := url.Parse(serverURL); err == nil {
 			if host := normalizeGitHubHost(parsed.Hostname()); host != "" && host != "github.com" {
 				hosts[host] = githubHostConfiguration(host, cloudToken, enterpriseServerToken)

--- a/cli/azd/internal/repository/repository_status_test.go
+++ b/cli/azd/internal/repository/repository_status_test.go
@@ -144,7 +144,7 @@ func TestInitializerConfirmArchivedTemplate(t *testing.T) {
 	t.Run("ArchivedRepositoryAccepted", func(t *testing.T) {
 		console := mockinput.NewMockConsole()
 		console.WhenConfirm(func(options input.ConsoleOptions) bool {
-			require.Equal(t, "Do you want to continue using this archived template?", options.Message)
+			require.Equal(t, "Continue using this archived template?", options.Message)
 			require.Equal(t, false, options.DefaultValue)
 			return true
 		}).Respond(true)
@@ -157,8 +157,9 @@ func TestInitializerConfirmArchivedTemplate(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Contains(t, console.Output()[0], "WARNING:")
-		require.Contains(t, console.Output()[0], "no longer actively maintained")
+		require.Contains(t, console.Output()[0], "archived and no longer maintained")
 		require.Contains(t, console.Output()[1], "security patches")
+		require.NotContains(t, console.Output()[1], "support")
 	})
 
 	t.Run("ArchivedRepositoryDeclined", func(t *testing.T) {

--- a/cli/azd/internal/repository/repository_status_test.go
+++ b/cli/azd/internal/repository/repository_status_test.go
@@ -185,10 +185,14 @@ func TestInitializerConfirmArchivedTemplate(t *testing.T) {
 			statusChecker: &fakeRepositoryStatusChecker{status: &RepositoryStatus{Archived: true}},
 		}
 
-		err := initializer.confirmArchivedTemplate(t.Context(), "https://github.com/contoso/template")
+		err := initializer.confirmArchivedTemplate(
+			t.Context(),
+			"https://secret-token@github.com/contoso/template",
+		)
 
 		require.ErrorContains(t, err, "requires confirmation")
 		require.ErrorContains(t, err, "rerun without --no-prompt")
+		require.NotContains(t, err.Error(), "secret-token")
 	})
 
 	t.Run("MetadataFailureContinues", func(t *testing.T) {

--- a/cli/azd/internal/repository/repository_status_test.go
+++ b/cli/azd/internal/repository/repository_status_test.go
@@ -1,0 +1,199 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package repository
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockhttp"
+	"github.com/azure/azure-dev/cli/azd/test/mocks/mockinput"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitHubRepositoryStatusChecker(t *testing.T) {
+	t.Run("ArchivedGitHubRepository", func(t *testing.T) {
+		mockTransport := mockhttp.NewMockHttpUtil()
+		mockTransport.When(func(req *http.Request) bool {
+			return req.Method == http.MethodGet &&
+				req.URL.String() == "https://api.github.com/repos/Azure-Samples/todo-csharp-sql-swa-func"
+		}).RespondFn(func(req *http.Request) (*http.Response, error) {
+			return mocks.CreateHttpResponseWithBody(req, http.StatusOK, map[string]any{
+				"archived": true,
+			})
+		})
+
+		checker := NewGitHubRepositoryStatusChecker(mockTransport)
+		status, err := checker.Check(
+			t.Context(),
+			"https://github.com/Azure-Samples/todo-csharp-sql-swa-func.git",
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		require.True(t, status.Archived)
+	})
+
+	t.Run("GitHubEnterpriseRepository", func(t *testing.T) {
+		t.Setenv("GH_HOST", "github.contoso.com")
+		mockTransport := mockhttp.NewMockHttpUtil()
+		mockTransport.When(func(req *http.Request) bool {
+			return req.URL.String() == "https://github.contoso.com/api/v3/repos/contoso/template"
+		}).RespondFn(func(req *http.Request) (*http.Response, error) {
+			return mocks.CreateHttpResponseWithBody(req, http.StatusOK, map[string]any{
+				"archived": false,
+			})
+		})
+
+		checker := NewGitHubRepositoryStatusChecker(mockTransport)
+		status, err := checker.Check(t.Context(), "git@github.contoso.com:contoso/template.git")
+
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		require.False(t, status.Archived)
+	})
+
+	t.Run("UnsupportedRepositoryHost", func(t *testing.T) {
+		checker := NewGitHubRepositoryStatusChecker(mockhttp.NewMockHttpUtil())
+		status, err := checker.Check(t.Context(), "https://gitlab.com/contoso/template")
+
+		require.NoError(t, err)
+		require.Nil(t, status)
+	})
+
+	t.Run("MetadataRequestFailure", func(t *testing.T) {
+		mockTransport := mockhttp.NewMockHttpUtil()
+		mockTransport.When(func(req *http.Request) bool {
+			return true
+		}).RespondFn(func(req *http.Request) (*http.Response, error) {
+			return mocks.CreateEmptyHttpResponse(req, http.StatusForbidden)
+		})
+
+		checker := NewGitHubRepositoryStatusChecker(mockTransport)
+		status, err := checker.Check(t.Context(), "https://github.com/contoso/template")
+
+		require.ErrorContains(t, err, "HTTP 403")
+		require.Nil(t, status)
+	})
+
+	t.Run("MetadataRequestTimeout", func(t *testing.T) {
+		mockTransport := mockhttp.NewMockHttpUtil()
+		mockTransport.When(func(req *http.Request) bool {
+			return true
+		}).RespondFn(func(req *http.Request) (*http.Response, error) {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		})
+
+		checker := NewGitHubRepositoryStatusChecker(mockTransport).(*githubRepositoryStatusChecker)
+		checker.requestTimeout = time.Millisecond
+		status, err := checker.Check(t.Context(), "https://github.com/contoso/template")
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Nil(t, status)
+	})
+}
+
+func TestInitializerConfirmArchivedTemplate(t *testing.T) {
+	t.Run("ActiveRepositoryContinuesWithoutPrompt", func(t *testing.T) {
+		console := mockinput.NewMockConsole()
+		initializer := &Initializer{
+			console:       console,
+			statusChecker: &fakeRepositoryStatusChecker{status: &RepositoryStatus{}},
+		}
+
+		err := initializer.confirmArchivedTemplate(t.Context(), "https://github.com/contoso/template")
+
+		require.NoError(t, err)
+		require.Empty(t, console.Output())
+	})
+
+	t.Run("ArchivedRepositoryAccepted", func(t *testing.T) {
+		console := mockinput.NewMockConsole()
+		console.WhenConfirm(func(options input.ConsoleOptions) bool {
+			require.Equal(t, "Do you want to continue using this archived template?", options.Message)
+			require.Equal(t, false, options.DefaultValue)
+			return true
+		}).Respond(true)
+		initializer := &Initializer{
+			console:       console,
+			statusChecker: &fakeRepositoryStatusChecker{status: &RepositoryStatus{Archived: true}},
+		}
+
+		err := initializer.confirmArchivedTemplate(t.Context(), "https://github.com/contoso/template")
+
+		require.NoError(t, err)
+		require.Contains(t, console.Output()[0], "WARNING:")
+		require.Contains(t, console.Output()[0], "no longer actively maintained")
+		require.Contains(t, console.Output()[1], "security patches")
+	})
+
+	t.Run("ArchivedRepositoryDeclined", func(t *testing.T) {
+		console := mockinput.NewMockConsole()
+		console.WhenConfirm(func(options input.ConsoleOptions) bool {
+			return options.DefaultValue == false
+		}).Respond(false)
+		initializer := &Initializer{
+			console:       console,
+			statusChecker: &fakeRepositoryStatusChecker{status: &RepositoryStatus{Archived: true}},
+		}
+
+		err := initializer.confirmArchivedTemplate(t.Context(), "https://github.com/contoso/template")
+
+		require.ErrorIs(t, err, ErrArchivedTemplateDeclined)
+	})
+
+	t.Run("ArchivedRepositoryNoPrompt", func(t *testing.T) {
+		console := mockinput.NewMockConsole()
+		console.SetNoPromptMode(true)
+		initializer := &Initializer{
+			console:       console,
+			statusChecker: &fakeRepositoryStatusChecker{status: &RepositoryStatus{Archived: true}},
+		}
+
+		err := initializer.confirmArchivedTemplate(t.Context(), "https://github.com/contoso/template")
+
+		require.ErrorContains(t, err, "requires confirmation")
+		require.ErrorContains(t, err, "rerun without --no-prompt")
+	})
+
+	t.Run("MetadataFailureContinues", func(t *testing.T) {
+		console := mockinput.NewMockConsole()
+		initializer := &Initializer{
+			console:       console,
+			statusChecker: &fakeRepositoryStatusChecker{err: errors.New("rate limited")},
+		}
+
+		err := initializer.confirmArchivedTemplate(t.Context(), "https://github.com/contoso/template")
+
+		require.NoError(t, err)
+		require.Empty(t, console.Output())
+	})
+
+	t.Run("CancellationStopsInitialization", func(t *testing.T) {
+		console := mockinput.NewMockConsole()
+		initializer := &Initializer{
+			console:       console,
+			statusChecker: &fakeRepositoryStatusChecker{err: context.Canceled},
+		}
+
+		err := initializer.confirmArchivedTemplate(t.Context(), "https://github.com/contoso/template")
+
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+type fakeRepositoryStatusChecker struct {
+	status *RepositoryStatus
+	err    error
+}
+
+func (f *fakeRepositoryStatusChecker) Check(context.Context, string) (*RepositoryStatus, error) {
+	return f.status, f.err
+}

--- a/cli/azd/internal/repository/repository_status_test.go
+++ b/cli/azd/internal/repository/repository_status_test.go
@@ -19,6 +19,8 @@ import (
 
 func TestGitHubRepositoryStatusChecker(t *testing.T) {
 	t.Run("ArchivedGitHubRepository", func(t *testing.T) {
+		t.Setenv("GH_TOKEN", "")
+		t.Setenv("GITHUB_TOKEN", "")
 		mockTransport := mockhttp.NewMockHttpUtil()
 		mockTransport.When(func(req *http.Request) bool {
 			return req.Method == http.MethodGet &&
@@ -40,11 +42,14 @@ func TestGitHubRepositoryStatusChecker(t *testing.T) {
 		require.True(t, status.Archived)
 	})
 
-	t.Run("GitHubEnterpriseRepository", func(t *testing.T) {
+	t.Run("GitHubEnterpriseServerRepository", func(t *testing.T) {
 		t.Setenv("GH_HOST", "github.contoso.com")
+		t.Setenv("GH_TOKEN", "cloud-token")
+		t.Setenv("GH_ENTERPRISE_TOKEN", "server-token")
 		mockTransport := mockhttp.NewMockHttpUtil()
 		mockTransport.When(func(req *http.Request) bool {
-			return req.URL.String() == "https://github.contoso.com/api/v3/repos/contoso/template"
+			return req.URL.String() == "https://github.contoso.com/api/v3/repos/contoso/template" &&
+				req.Header.Get("Authorization") == "Bearer server-token"
 		}).RespondFn(func(req *http.Request) (*http.Response, error) {
 			return mocks.CreateHttpResponseWithBody(req, http.StatusOK, map[string]any{
 				"archived": false,
@@ -57,6 +62,28 @@ func TestGitHubRepositoryStatusChecker(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, status)
 		require.False(t, status.Archived)
+	})
+
+	t.Run("GitHubEnterpriseCloudRepository", func(t *testing.T) {
+		t.Setenv("GH_HOST", "octocorp.ghe.com")
+		t.Setenv("GH_TOKEN", "cloud-token")
+		t.Setenv("GH_ENTERPRISE_TOKEN", "server-token")
+		mockTransport := mockhttp.NewMockHttpUtil()
+		mockTransport.When(func(req *http.Request) bool {
+			return req.URL.String() == "https://api.octocorp.ghe.com/repos/contoso/template" &&
+				req.Header.Get("Authorization") == "Bearer cloud-token"
+		}).RespondFn(func(req *http.Request) (*http.Response, error) {
+			return mocks.CreateHttpResponseWithBody(req, http.StatusOK, map[string]any{
+				"archived": true,
+			})
+		})
+
+		checker := NewGitHubRepositoryStatusChecker(mockTransport)
+		status, err := checker.Check(t.Context(), "https://octocorp.ghe.com/contoso/template")
+
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		require.True(t, status.Archived)
 	})
 
 	t.Run("UnsupportedRepositoryHost", func(t *testing.T) {

--- a/cli/azd/internal/repository/repository_status_test.go
+++ b/cli/azd/internal/repository/repository_status_test.go
@@ -86,6 +86,32 @@ func TestGitHubRepositoryStatusChecker(t *testing.T) {
 		require.True(t, status.Archived)
 	})
 
+	t.Run("GitHubHostTakesPrecedenceOverServerURL", func(t *testing.T) {
+		t.Setenv("GH_HOST", "github.primary.contoso.com")
+		t.Setenv("GITHUB_SERVER_URL", "https://github.fallback.contoso.com")
+		t.Setenv("GH_ENTERPRISE_TOKEN", "server-token")
+		mockTransport := mockhttp.NewMockHttpUtil()
+		mockTransport.When(func(req *http.Request) bool {
+			return req.URL.String() == "https://github.primary.contoso.com/api/v3/repos/contoso/template"
+		}).RespondFn(func(req *http.Request) (*http.Response, error) {
+			require.NotEmpty(t, req.Header.Get("Authorization"))
+			return mocks.CreateHttpResponseWithBody(req, http.StatusOK, map[string]any{
+				"archived": false,
+			})
+		})
+
+		checker := NewGitHubRepositoryStatusChecker(mockTransport)
+		status, err := checker.Check(t.Context(), "https://github.primary.contoso.com/contoso/template")
+
+		require.NoError(t, err)
+		require.NotNil(t, status)
+
+		status, err = checker.Check(t.Context(), "https://github.fallback.contoso.com/contoso/template")
+
+		require.NoError(t, err)
+		require.Nil(t, status)
+	})
+
 	t.Run("UnsupportedRepositoryHost", func(t *testing.T) {
 		checker := NewGitHubRepositoryStatusChecker(mockhttp.NewMockHttpUtil())
 		status, err := checker.Check(t.Context(), "https://gitlab.com/contoso/template")

--- a/cli/azd/test/functional/init_test.go
+++ b/cli/azd/test/functional/init_test.go
@@ -310,7 +310,7 @@ func Test_CLI_Init_CanUseTemplate(t *testing.T) {
 	cli.Env = append(os.Environ(), "AZURE_LOCATION=eastus2")
 
 	// The template is archived, so accept the warning before providing the environment name.
-	_, err := cli.RunCommandWithStdIn(
+	result, err := cli.RunCommandWithStdIn(
 		ctx,
 		"y\nTESTENV\n",
 		"init",
@@ -318,6 +318,8 @@ func Test_CLI_Init_CanUseTemplate(t *testing.T) {
 		"cosmos-dotnet-core-todo-app",
 	)
 	require.NoError(t, err)
+	require.Contains(t, result.Stdout, "WARNING: This template repository is archived")
+	require.FileExists(t, getTestEnvPath(dir, "TESTENV"))
 
 	// Functional tests run as subprocesses with piped stdin (non-TTY), so
 	// auto-directory creation does not activate. Files land in CWD directly.

--- a/cli/azd/test/functional/init_test.go
+++ b/cli/azd/test/functional/init_test.go
@@ -309,9 +309,10 @@ func Test_CLI_Init_CanUseTemplate(t *testing.T) {
 	cli.WorkingDirectory = dir
 	cli.Env = append(os.Environ(), "AZURE_LOCATION=eastus2")
 
+	// The template is archived, so accept the warning before providing the environment name.
 	_, err := cli.RunCommandWithStdIn(
 		ctx,
-		"TESTENV\n",
+		"y\nTESTENV\n",
 		"init",
 		"--template",
 		"cosmos-dotnet-core-todo-app",

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -41,9 +41,9 @@ Used by `azd init --template` when checking GitHub repository metadata before cl
 
 | Variable | Description |
 |---|---|
-| `GH_TOKEN` / `GITHUB_TOKEN` | Authenticate repository metadata requests to `github.com` |
+| `GH_TOKEN` / `GITHUB_TOKEN` | Authenticate repository metadata requests to `github.com` and GitHub Enterprise Cloud `*.ghe.com` hosts |
 | `GH_HOST` / `GITHUB_SERVER_URL` | Identify a GitHub Enterprise host for repository metadata checks |
-| `GH_ENTERPRISE_TOKEN` / `GITHUB_ENTERPRISE_TOKEN` | Authenticate repository metadata requests to the recognized GitHub Enterprise host |
+| `GH_ENTERPRISE_TOKEN` / `GITHUB_ENTERPRISE_TOKEN` | Authenticate repository metadata requests to a recognized GitHub Enterprise Server host |
 
 ## Build Configuration
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -35,6 +35,16 @@ Override the path to external tools that azd invokes:
 | `AZD_GH_TOOL_PATH` | Path to the GitHub CLI binary |
 | `AZD_PACK_TOOL_PATH` | Path to the Cloud Native Buildpacks (`pack`) binary |
 
+## GitHub Repository Access
+
+Used by `azd init --template` when checking GitHub repository metadata before cloning:
+
+| Variable | Description |
+|---|---|
+| `GH_TOKEN` / `GITHUB_TOKEN` | Authenticate repository metadata requests to `github.com` |
+| `GH_HOST` / `GITHUB_SERVER_URL` | Identify a GitHub Enterprise host for repository metadata checks |
+| `GH_ENTERPRISE_TOKEN` / `GITHUB_ENTERPRISE_TOKEN` | Authenticate repository metadata requests to the recognized GitHub Enterprise host |
+
 ## Build Configuration
 
 | Variable | Description |


### PR DESCRIPTION
## Summary

- query GitHub repository metadata before cloning an `azd init --template` repository
- warn when the selected repository is archived and require a default-No `[y/N]` confirmation
- display a distinct cancellation state instead of reporting a declined initialization as success
- stop safely in `--no-prompt` mode and clean up auto-created project directories when the user declines
- support authenticated metadata checks for GitHub.com and configured GitHub Enterprise hosts
- document the GitHub-compatible environment variables used by metadata requests

## User experience

```text
WARNING: This template repository is archived and no longer maintained.
It may not receive dependency updates, compatibility fixes, or security patches.

? Continue using this archived template? [y/N] No

CANCELLED: Initialization stopped.
```

A richer flow that recommends similar maintained templates is tracked separately in #9629. This PR intentionally starts with the simple warning and safe default-No confirmation.

Metadata checks use a bounded timeout. Request cancellation and timeout errors stop initialization and are recorded by command telemetry; other metadata lookup failures preserve the existing clone behavior.

## Validation

- `go test ./internal/repository ./cmd -run 'TestInitializerConfirmArchivedTemplate|TestInitArchivedTemplateDeclinedCleansCreatedDirectory'`
- `go test ./internal/repository`
- `go build ./...`
- `golangci-lint run ./internal/repository/... ./cmd/...`
- verified `--no-prompt` against `Azure-Samples/todo-csharp-sql-swa-func`; initialization stopped before cloning and left the working directory unchanged

Closes #9540
