### PR TITLE
fix(azure.ai.agents): classify activity deployment errors

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/exterrors/codes.go
@@ -175,6 +175,8 @@ const (
 	CodeContainerStartFailed          = "container_start_failed"
 	CodeContainerStartTimeout         = "container_start_timeout"
 	CodeAgentCreateFailed             = "agent_create_failed"
+	CodeMsaAppIDAlreadyInUse          = "msa_app_id_already_in_use"
+	CodeMultipleBotsForMsaAppID       = "multiple_bots_for_msa_app_id"
 )
 
 // Operation names for [ServiceFromAzure] errors.
@@ -185,6 +187,10 @@ const (
 	OpContainerPackage      = "container_package"
 	OpContainerPublish      = "container_publish"
 	OpCreateAgent           = "create_agent"
+	OpUpdateAgent           = "update_agent"
+	OpGetActivityBot        = "get_activity_bot"
+	OpEnsureActivityBot     = "ensure_activity_bot"
+	OpEnsureTeamsChannel    = "ensure_teams_channel"
 	OpDeleteAgent           = "delete_agent"
 	OpStartContainer        = "start_container"
 	OpGetContainerOperation = "get_container_operation"

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/botservice/botservice.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/botservice/botservice.go
@@ -198,6 +198,14 @@ type BotReference struct {
 	Name          string
 }
 
+// MultipleBotsForMsaAppIDError indicates that an agent identity cannot be
+// resolved to a unique Azure Bot.
+type MultipleBotsForMsaAppIDError struct{}
+
+func (e *MultipleBotsForMsaAppIDError) Error() string {
+	return "botservice: multiple Azure Bots are bound to the same MsaAppID"
+}
+
 // TeamsChannelError marks a failure while enabling or updating the Teams
 // channel, so callers can preserve that operation boundary in telemetry.
 type TeamsChannelError struct {
@@ -269,7 +277,7 @@ func (c *Client) FindByMsaAppID(ctx context.Context, msaAppID string) (*BotRefer
 		return nil, nil
 	}
 	if len(matches) > 1 {
-		return nil, fmt.Errorf("botservice: multiple Azure Bots are bound to MsaAppID %q", msaAppID)
+		return nil, &MultipleBotsForMsaAppIDError{}
 	}
 	return &matches[0], nil
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/botservice/botservice.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/botservice/botservice.go
@@ -198,6 +198,20 @@ type BotReference struct {
 	Name          string
 }
 
+// TeamsChannelError marks a failure while enabling or updating the Teams
+// channel, so callers can preserve that operation boundary in telemetry.
+type TeamsChannelError struct {
+	Err error
+}
+
+func (e *TeamsChannelError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *TeamsChannelError) Unwrap() error {
+	return e.Err
+}
+
 // GetBot returns the Bot at the exact resource group and name, or nil when it does not exist.
 func (c *Client) GetBot(ctx context.Context, resourceGroup, name string) (*armbotservice.Bot, error) {
 	response, err := c.bots.Get(ctx, resourceGroup, name, nil)
@@ -314,7 +328,9 @@ func (c *Client) ensureTeamsChannel(ctx context.Context, resourceGroup, botName 
 	if _, err := c.channels.Create(
 		ctx, resourceGroup, botName, armbotservice.ChannelNameMsTeamsChannel, channel, nil,
 	); err != nil {
-		return fmt.Errorf("botservice: enabling Microsoft Teams channel on bot %q: %w", botName, err)
+		return &TeamsChannelError{
+			Err: fmt.Errorf("botservice: enabling Microsoft Teams channel on bot %q: %w", botName, err),
+		}
 	}
 	return nil
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/botservice/botservice_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/botservice/botservice_test.go
@@ -231,3 +231,28 @@ func TestFindByMsaAppID(t *testing.T) {
 		t.Fatalf("FindByMsaAppID = %+v, want published-bot in m365-rg", got)
 	}
 }
+
+func TestFindByMsaAppIDReturnsTypedErrorForMultipleMatches(t *testing.T) {
+	t.Parallel()
+
+	matchingBot := func(name string) *armbotservice.Bot {
+		return &armbotservice.Bot{
+			ID:   new("/subscriptions/sub/resourceGroups/m365-rg/providers/Microsoft.BotService/botServices/" + name),
+			Name: new(name),
+			Properties: &armbotservice.BotProperties{
+				MsaAppID: new("client-id-123"),
+			},
+		}
+	}
+	c := &Client{
+		listBots: func(context.Context) ([]*armbotservice.Bot, error) {
+			return []*armbotservice.Bot{matchingBot("bot-one"), matchingBot("bot-two")}, nil
+		},
+	}
+
+	_, err := c.FindByMsaAppID(t.Context(), "client-id-123")
+	_, ok := errors.AsType[*MultipleBotsForMsaAppIDError](err)
+	if !ok {
+		t.Fatalf("FindByMsaAppID error = %T, want *MultipleBotsForMsaAppIDError", err)
+	}
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1466,16 +1466,8 @@ func (p *AgentServiceTargetProvider) Deploy(
 				}
 			}
 			if err != nil {
-				return nil, exterrors.Service(
-					exterrors.OpEnsureActivityBot,
-					exterrors.CodeMsaAppIDAlreadyInUse,
-					fmt.Sprintf("Azure Bot MsaAppID %q is already in use and no existing Bot could be reused", identity.ClientID),
-					"botservice",
-					"set a unique Bot name or remove the existing Azure Bot bound to this MsaAppID, then retry",
-				)
+				return nil, classifyActivityBotError(err, identity.ClientID)
 			}
-		} else {
-			return nil, classifyActivityBotError(err, identity.ClientID)
 		}
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1199,6 +1199,29 @@ func isMsaAppIDAlreadyInUseError(err error) bool {
 		strings.Contains(msg, "msaapp id is already in use")
 }
 
+func isMultipleBotsForMsaAppIDError(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "multiple azure bots are bound to msaappid")
+}
+
+func classifyActivityBotError(err error, msaAppID string) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := errors.AsType[*botservice.TeamsChannelError](err); ok {
+		return exterrors.ServiceFromAzure(err, exterrors.OpEnsureTeamsChannel)
+	}
+	if isMsaAppIDAlreadyInUseError(err) {
+		return exterrors.Service(
+			exterrors.OpEnsureActivityBot,
+			exterrors.CodeMsaAppIDAlreadyInUse,
+			fmt.Sprintf("Azure Bot MsaAppID %q is already in use", msaAppID),
+			"botservice",
+			"set a unique Bot name or remove the existing Azure Bot bound to this MsaAppID, then retry",
+		)
+	}
+	return exterrors.ServiceFromAzure(err, exterrors.OpEnsureActivityBot)
+}
+
 // Deploy performs the deployment operation for the agent service
 func (p *AgentServiceTargetProvider) Deploy(
 	ctx context.Context,
@@ -1370,7 +1393,7 @@ func (p *AgentServiceTargetProvider) Deploy(
 		activityBotResourceGroup = botResourceGroup
 		existingBot, err := client.GetBot(ctx, botResourceGroup, activityBotName)
 		if err != nil {
-			return nil, err
+			return nil, exterrors.ServiceFromAzure(err, exterrors.OpGetActivityBot)
 		}
 		var existingTags map[string]*string
 		if existingBot != nil {
@@ -1395,8 +1418,20 @@ func (p *AgentServiceTargetProvider) Deploy(
 			// Recovery path: BotService enforces MsaAppID uniqueness. If a different
 			// bot name is already bound to this identity, switch to that bot and retry.
 			if isMsaAppIDAlreadyInUseError(err) {
-				if boundBot, findErr := client.FindByMsaAppID(ctx, identity.ClientID); findErr == nil &&
-					boundBot != nil && strings.TrimSpace(boundBot.Name) != "" {
+				boundBot, findErr := client.FindByMsaAppID(ctx, identity.ClientID)
+				if findErr != nil {
+					if isMultipleBotsForMsaAppIDError(findErr) {
+						return nil, exterrors.Service(
+							exterrors.OpGetActivityBot,
+							exterrors.CodeMultipleBotsForMsaAppID,
+							findErr.Error(),
+							"botservice",
+							"keep only one Azure Bot bound to this MsaAppID, then retry",
+						)
+					}
+					return nil, exterrors.ServiceFromAzure(findErr, exterrors.OpGetActivityBot)
+				}
+				if boundBot != nil && strings.TrimSpace(boundBot.Name) != "" {
 					activityBotName = strings.TrimSpace(boundBot.Name)
 					if strings.TrimSpace(boundBot.ResourceGroup) != "" {
 						botResourceGroup = strings.TrimSpace(boundBot.ResourceGroup)
@@ -1413,7 +1448,7 @@ func (p *AgentServiceTargetProvider) Deploy(
 					ensureCfg.ResourceGroup = botResourceGroup
 					existingBot, getErr := client.GetBot(ctx, botResourceGroup, activityBotName)
 					if getErr != nil {
-						return nil, getErr
+						return nil, exterrors.ServiceFromAzure(getErr, exterrors.OpGetActivityBot)
 					}
 					var existingTags map[string]*string
 					if existingBot != nil {
@@ -1426,13 +1461,21 @@ func (p *AgentServiceTargetProvider) Deploy(
 					if retryErr := client.EnsureBot(ctx, ensureCfg); retryErr == nil {
 						err = nil
 					} else {
-						return nil, retryErr
+						return nil, classifyActivityBotError(retryErr, identity.ClientID)
 					}
 				}
 			}
 			if err != nil {
-				return nil, err
+				return nil, exterrors.Service(
+					exterrors.OpEnsureActivityBot,
+					exterrors.CodeMsaAppIDAlreadyInUse,
+					fmt.Sprintf("Azure Bot MsaAppID %q is already in use and no existing Bot could be reused", identity.ClientID),
+					"botservice",
+					"set a unique Bot name or remove the existing Azure Bot bound to this MsaAppID, then retry",
+				)
 			}
+		} else {
+			return nil, classifyActivityBotError(err, identity.ClientID)
 		}
 	}
 
@@ -1904,7 +1947,7 @@ func (p *AgentServiceTargetProvider) patchAgentEndpointFields(
 
 	_, err := agentClient.PatchAgent(ctx, agentName, patchRequest, agent_api.AgentEndpointAPIVersion)
 	if err != nil {
-		return exterrors.ServiceFromAzure(err, exterrors.OpCreateAgent)
+		return exterrors.ServiceFromAzure(err, exterrors.OpUpdateAgent)
 	}
 
 	fmt.Fprintf(os.Stderr, "Agent endpoint/card updated.\n")

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1137,6 +1137,9 @@ func (p *AgentServiceTargetProvider) resolveActivityBotName(
 	if botFinder != nil && strings.TrimSpace(agentIdentityClientID) != "" {
 		boundBot, err := botFinder.FindByMsaAppID(ctx, agentIdentityClientID)
 		if err != nil {
+			if _, ok := errors.AsType[*botservice.MultipleBotsForMsaAppIDError](err); ok {
+				return "", "", classifyActivityBotLookupError(err)
+			}
 			fmt.Fprintf(
 				os.Stderr,
 				"Unable to search for an Azure Bot already bound to the deployed agent identity: %v\n",
@@ -1199,10 +1202,6 @@ func isMsaAppIDAlreadyInUseError(err error) bool {
 		strings.Contains(msg, "msaapp id is already in use")
 }
 
-func isMultipleBotsForMsaAppIDError(err error) bool {
-	return err != nil && strings.Contains(strings.ToLower(err.Error()), "multiple azure bots are bound to msaappid")
-}
-
 func classifyActivityBotError(err error, msaAppID string) error {
 	if err == nil {
 		return nil
@@ -1221,6 +1220,19 @@ func classifyActivityBotError(err error, msaAppID string) error {
 		)
 	}
 	return exterrors.ServiceFromAzure(err, exterrors.OpEnsureActivityBot)
+}
+
+func classifyActivityBotLookupError(err error) error {
+	if _, ok := errors.AsType[*botservice.MultipleBotsForMsaAppIDError](err); ok {
+		return exterrors.Service(
+			exterrors.OpGetActivityBot,
+			exterrors.CodeMultipleBotsForMsaAppID,
+			err.Error(),
+			"",
+			"keep only one Azure Bot bound to this MsaAppID, then retry",
+		)
+	}
+	return exterrors.ServiceFromAzure(err, exterrors.OpGetActivityBot)
 }
 
 // Deploy performs the deployment operation for the agent service
@@ -1421,16 +1433,7 @@ func (p *AgentServiceTargetProvider) Deploy(
 			if isMsaAppIDAlreadyInUseError(err) {
 				boundBot, findErr := client.FindByMsaAppID(ctx, identity.ClientID)
 				if findErr != nil {
-					if isMultipleBotsForMsaAppIDError(findErr) {
-						return nil, exterrors.Service(
-							exterrors.OpGetActivityBot,
-							exterrors.CodeMultipleBotsForMsaAppID,
-							findErr.Error(),
-							"botservice",
-							"keep only one Azure Bot bound to this MsaAppID, then retry",
-						)
-					}
-					return nil, exterrors.ServiceFromAzure(findErr, exterrors.OpGetActivityBot)
+					return nil, classifyActivityBotLookupError(findErr)
 				}
 				if boundBot != nil && strings.TrimSpace(boundBot.Name) != "" {
 					activityBotName = strings.TrimSpace(boundBot.Name)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1216,7 +1216,8 @@ func classifyActivityBotError(err error, msaAppID string) error {
 			exterrors.CodeMsaAppIDAlreadyInUse,
 			fmt.Sprintf("Azure Bot MsaAppID %q is already in use", msaAppID),
 			"botservice",
-			"set a unique Bot name or remove the existing Azure Bot bound to this MsaAppID, then retry",
+			"configure the Activity Bot name to use the existing Azure Bot bound to this MsaAppID, "+
+				"or remove that Bot, then retry",
 		)
 	}
 	return exterrors.ServiceFromAzure(err, exterrors.OpEnsureActivityBot)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -166,6 +166,17 @@ func TestClassifyActivityBotErrorSeparatesTeamsChannelFailures(t *testing.T) {
 	require.Equal(t, "ensure_teams_channel.AuthorizationFailed", serviceErr.ErrorCode)
 }
 
+func TestClassifyActivityBotErrorPreservesBotServiceFailures(t *testing.T) {
+	t.Parallel()
+
+	responseErr := &azcore.ResponseError{ErrorCode: "InvalidBotConfiguration", StatusCode: 400}
+	err := classifyActivityBotError(responseErr, "client-id-1")
+
+	serviceErr, ok := errors.AsType[*azdext.ServiceError](err)
+	require.True(t, ok)
+	require.Equal(t, "ensure_activity_bot.InvalidBotConfiguration", serviceErr.ErrorCode)
+}
+
 func TestGetServiceKey_NormalizesToolboxNames(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -152,13 +152,24 @@ func TestClassifyActivityBotErrorUsesMsaAppIDConflictCode(t *testing.T) {
 	)
 }
 
-func TestIsMultipleBotsForMsaAppIDError(t *testing.T) {
+func TestResolveActivityBotNameReturnsMultipleBotClassification(t *testing.T) {
 	t.Parallel()
 
-	require.True(t, isMultipleBotsForMsaAppIDError(
-		errors.New("botservice: multiple Azure Bots are bound to MsaAppID \"client-id-1\""),
-	))
-	require.False(t, isMultipleBotsForMsaAppIDError(errors.New("botservice: listing bots failed")))
+	p := &AgentServiceTargetProvider{}
+	_, _, err := p.resolveActivityBotName(
+		t.Context(),
+		fakeActivityBotFinder{err: &botservice.MultipleBotsForMsaAppIDError{}},
+		"my-svc",
+		"agent-a",
+		"client-id-1",
+		"fallback-rg",
+		map[string]string{envkey.AgentBotName("my-svc"): "env-bot"},
+	)
+
+	serviceErr, ok := errors.AsType[*azdext.ServiceError](err)
+	require.True(t, ok)
+	require.Equal(t, "get_activity_bot.multiple_bots_for_msa_app_id", serviceErr.ErrorCode)
+	require.Empty(t, serviceErr.ServiceName)
 }
 
 func TestClassifyActivityBotErrorSeparatesTeamsChannelFailures(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -21,6 +21,7 @@ import (
 	"azureaiagent/internal/pkg/botservice"
 	"azureaiagent/internal/pkg/envkey"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -132,6 +133,37 @@ func TestAgentDeploymentFailedErrorUsesFallbackCode(t *testing.T) {
 		"run `azd ai agent show` to inspect the latest deployment status",
 		serviceErr.Suggestion,
 	)
+}
+
+func TestClassifyActivityBotErrorUsesMsaAppIDConflictCode(t *testing.T) {
+	t.Parallel()
+
+	err := classifyActivityBotError(errors.New("MsaAppId is already in use"), "client-id-1")
+
+	serviceErr, ok := errors.AsType[*azdext.ServiceError](err)
+	require.True(t, ok)
+	require.Equal(t, "ensure_activity_bot.msa_app_id_already_in_use", serviceErr.ErrorCode)
+	require.Equal(t, "botservice", serviceErr.ServiceName)
+}
+
+func TestIsMultipleBotsForMsaAppIDError(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isMultipleBotsForMsaAppIDError(
+		errors.New("botservice: multiple Azure Bots are bound to MsaAppID \"client-id-1\""),
+	))
+	require.False(t, isMultipleBotsForMsaAppIDError(errors.New("botservice: listing bots failed")))
+}
+
+func TestClassifyActivityBotErrorSeparatesTeamsChannelFailures(t *testing.T) {
+	t.Parallel()
+
+	responseErr := &azcore.ResponseError{ErrorCode: "AuthorizationFailed", StatusCode: 403}
+	err := classifyActivityBotError(&botservice.TeamsChannelError{Err: responseErr}, "client-id-1")
+
+	serviceErr, ok := errors.AsType[*azdext.ServiceError](err)
+	require.True(t, ok)
+	require.Equal(t, "ensure_teams_channel.AuthorizationFailed", serviceErr.ErrorCode)
 }
 
 func TestGetServiceKey_NormalizesToolboxNames(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -144,6 +144,12 @@ func TestClassifyActivityBotErrorUsesMsaAppIDConflictCode(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "ensure_activity_bot.msa_app_id_already_in_use", serviceErr.ErrorCode)
 	require.Equal(t, "botservice", serviceErr.ServiceName)
+	require.Equal(
+		t,
+		"configure the Activity Bot name to use the existing Azure Bot bound to this MsaAppID, "+
+			"or remove that Bot, then retry",
+		serviceErr.Suggestion,
+	)
 }
 
 func TestIsMultipleBotsForMsaAppIDError(t *testing.T) {


### PR DESCRIPTION
## Summary

Extends the structured error classification introduced in #9491 to the Activity Agent post-deployment flow without adding or renaming telemetry events.

- Classifies agent endpoint updates, Activity Bot lookup/provisioning, and Teams channel setup with operation-specific service error codes.
- Adds stable classifications for MsaAppID conflicts and ambiguous Bot bindings.
- Preserves the underlying Azure service status and error code when one is available.
- Adds regression coverage for the new Activity-specific classifications.

## Background

An Activity Agent deploy continues after the hosted agent version becomes active: azd patches the agent endpoint, resolves or creates an Azure Bot, binds it to the agent instance identity through `MsaAppID`, and enables the Microsoft Teams channel.

Failures in those steps were previously returned as generic wrapped errors, or endpoint PATCH failures were grouped under `create_agent`. This made it difficult to distinguish a Foundry deployment failure from an Azure Bot lookup, Bot provisioning, or Teams channel failure in the existing command telemetry.

## Changes

- Adds operation-specific error boundaries:
  - `update_agent`
  - `get_activity_bot`
  - `ensure_activity_bot`
  - `ensure_teams_channel`
- Adds stable local service codes:
  - `ensure_activity_bot.msa_app_id_already_in_use`
  - `get_activity_bot.multiple_bots_for_msa_app_id`
- Marks Teams channel failures with a typed wrapper so they remain distinguishable from Azure Bot create/update failures while preserving the underlying Azure response error.
- Classifies agent endpoint/card PATCH failures as `update_agent.<AzureErrorCode>` instead of `create_agent.<AzureErrorCode>`.
- Preserves the existing recovery behavior for MsaAppID conflicts: when azd finds and successfully reuses the already-bound Bot, deployment continues successfully and no failure classification is emitted.
- Ensures successful Activity Bot setup continues to deploy finalization and environment-variable registration.

## Telemetry impact

This PR uses the existing command event and structured extension-error transport. It does not introduce a new event name or telemetry field.

Expected error-code buckets include:

| Failure | Service error code |
| --- | --- |
| Agent endpoint/card PATCH | `update_agent.<AzureErrorCode>` |
| Azure Bot lookup | `get_activity_bot.<AzureErrorCode>` |
| Multiple Bots bound to one MsaAppID | `get_activity_bot.multiple_bots_for_msa_app_id` |
| Azure Bot create/update | `ensure_activity_bot.<AzureErrorCode>` |
| Unrecoverable MsaAppID conflict | `ensure_activity_bot.msa_app_id_already_in_use` |
| Teams channel create/update | `ensure_teams_channel.<AzureErrorCode>` |

All added codes are fixed, low-cardinality values and do not contain resource names, IDs, or other customer-provided values.

## Scope

This change is limited to the `azure.ai.agents` extension's Activity Agent deployment path. Existing hosted-agent deployment classifications such as `ImageError`, `CodeError`, and `ProvisioningError` are unchanged.

## Validation

- `go test ./...` from `cli/azd/extensions/azure.ai.agents`