### PR TITLE
Teach preflight skill to validate changelog aliases

### DIFF
--- a/.github/skills/azd-preflight/SKILL.md
+++ b/.github/skills/azd-preflight/SKILL.md
@@ -2,14 +2,14 @@
 name: azd-preflight
 license: MIT
 metadata:
-  version: "1.0"
+  version: "1.2"
   # Bump major on breaking prompt/trigger changes; bump minor on new references or fix strategies.
 description: >-
   **WORKFLOW SKILL** — Runs `mage preflight` from `cli/azd/` and auto-fixes failures.
   Covers linting, formatting, copyright, spelling, build, and tests.
   Iterates fix-then-rerun cycles until all checks pass.
 
-  INVOKES: mage CLI, go CLI, golangci-lint, cspell, bash/sh, ask_user.
+  INVOKES: mage CLI, go CLI, golangci-lint, cspell, gh CLI, bash/sh, ask_user.
 
   USE FOR: azd preflight, run preflight, preflight checks, pre-commit checks, azd lint,
   azd build and test, validate azd changes, check azd code quality, mage preflight.
@@ -24,7 +24,7 @@ Runs the full azd preflight suite and auto-fixes failures.
 
 ## Overview
 
-The azd preflight suite (`mage preflight`) validates code quality across 8 checks before
+The azd preflight suite (`mage preflight`) validates code quality across 9 checks before
 changes are submitted. This skill runs the suite, parses failures, applies automated fixes,
 and re-runs until all checks pass — or escalates to the user when a fix requires human judgment.
 
@@ -36,6 +36,7 @@ and re-runs until all checks pass — or escalates to the user when a fix requir
 
 ## Exit Criteria
 
-- All 8 preflight checks pass (or user explicitly chose to skip specific checks)
+- All 9 preflight checks pass (or user explicitly chose to skip specific checks)
+- Every changed `CHANGELOG.md` passes its targeted spell check
 - All auto-applied fixes are saved to disk (not staged or committed — the user decides when to commit)
 - A clear summary of what passed, what was fixed, and what was skipped is displayed

--- a/.github/skills/azd-preflight/references/fix-strategies.md
+++ b/.github/skills/azd-preflight/references/fix-strategies.md
@@ -1,7 +1,7 @@
 # Fix Strategies
 
 Detailed fix procedures for each preflight check failure. Process checks in
-their original order (1-8) because earlier fixes can resolve later failures.
+their original order (1-9) because earlier fixes can resolve later failures.
 
 ## Formatting (`gofmt`) — Auto-fix
 
@@ -45,9 +45,9 @@ For each finding:
 
 If a lint finding is ambiguous or the fix would change behavior, ask the user via `ask_user`.
 
-## Spell Check (`cspell`) — Analyze and Fix
+## Go Spell Check (`cspell`) — Analyze and Fix
 
-Re-run cspell to get the specific unknown words:
+Re-run the Go source spell check to get the specific unknown words:
 
 ```bash
 cd cli/azd && cspell lint "**/*.go" --relative --config ./.vscode/cspell.yaml --no-progress 2>&1
@@ -58,6 +58,45 @@ For each unknown word:
 2. **If it's a legitimate technical term**: Add it to `cli/azd/.vscode/cspell.yaml` using a
    file-scoped `overrides` entry. Use the pattern from existing entries in that file.
 3. **If uncertain**: Ask the user via `ask_user` whether to fix the spelling or add to the dictionary.
+
+## Misc/Docs Spell Check (`cspell-misc`) — Analyze and Fix
+
+Re-run the repository-wide spell check from the repository root:
+
+```bash
+cspell lint "**/*" --relative --config ./.vscode/cspell.misc.yaml --no-progress 2>&1
+```
+
+For each unknown word:
+1. **If it's a typo**: Fix the spelling in the source file.
+2. **If it's a legitimate file-specific term**: Add it to a file-scoped `overrides` entry in
+   `.vscode/cspell.misc.yaml`. Use `.vscode/cspell.global.yaml` only for terms used broadly across
+   the repository.
+3. **If uncertain**: Ask the user via `ask_user` whether to fix the spelling or update a dictionary.
+
+## Changed CHANGELOG Spell Check — Analyze and Fix
+
+The normal misc/docs check excludes directories with their own cspell configuration, including
+`cli/`. For each changed changelog, walk from its directory toward the repository root and select
+the nearest `cspell.yaml` or `.vscode/cspell.yaml`. Fall back to
+`cli/azd/.vscode/cspell.yaml` when no nearer config exists. Run the targeted check from the
+repository root:
+
+```bash
+cspell lint "<changelog-path>" --relative --config "<cspell-config>" --no-progress 2>&1
+```
+
+For each unknown word:
+1. **If it's a typo or ordinary prose**: Fix the changelog entry.
+2. **If it is a GitHub username in a contributor attribution**:
+   - Verify the exact alias is the author of the changelog entry's linked PR. If the PR author is
+    unavailable, verify the account resolves with `gh api "users/<alias>" --silent`.
+   - Add the exact alias to `.vscode/cspell-github-user-aliases.txt`, preserving the file's
+    case-insensitive alphabetical order and avoiding duplicates.
+   - Do not add ordinary names, misspellings, or unverified handles to the alias dictionary.
+3. **If it's another legitimate changelog-specific term**: Add it to a `CHANGELOG.md`
+   file-scoped `overrides` entry in the resolved owning cspell config.
+4. **If uncertain**: Ask the user via `ask_user` whether to fix the spelling or update a dictionary.
 
 ## Build (`go build`) — Analyze and Fix
 

--- a/.github/skills/azd-preflight/references/output-and-errors.md
+++ b/.github/skills/azd-preflight/references/output-and-errors.md
@@ -5,16 +5,19 @@
 ### Success
 
 ```
-Preflight passed — all 8 checks clean.
+Preflight passed — all 9 checks clean.
 
   ✓ gofmt
   ✓ go fix
   ✓ copyright
   ✓ lint
   ✓ cspell
+  ✓ cspell-misc
   ✓ build
   ✓ test
   ✓ playback tests
+
+  − changed changelogs (none changed)
 ```
 
 ### Success After Fixes
@@ -27,9 +30,11 @@ Preflight passed after fixes.
   ✓ copyright (no issues)
   ✓ lint (fixed: 5 findings resolved)
   ✓ cspell (fixed: 1 word added to dictionary)
+  ✓ cspell-misc (no issues)
   ✓ build (no issues)
   ✓ test (no issues)
   ✓ playback tests (no issues)
+  ✓ changed changelogs (fixed: 1 verified GitHub alias added to dictionary)
 
 Files modified: {list of changed files}
 ```
@@ -37,16 +42,18 @@ Files modified: {list of changed files}
 ### Partial Success
 
 ```
-Preflight partially passed — {N} of 8 checks clean, {M} skipped.
+Preflight partially passed — {N} of 9 checks clean, {M} skipped.
 
   ✓ gofmt
   ✓ go fix
   ✓ copyright
   ✓ lint
   ✓ cspell
+  ✓ cspell-misc
   ✓ build
   ✗ test (skipped — user chose to skip after 3 attempts)
   ✓ playback tests
+  ✓ changed changelogs
 
 Skipped checks require manual intervention.
 ```
@@ -56,6 +63,7 @@ Skipped checks require manual intervention.
 - **mage not installed** → offer to install: `go install github.com/magefile/mage@latest`
 - **golangci-lint not installed** → offer: `go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.11.4`
 - **cspell not installed** → offer to install: `npm install -g cspell@8.13.1`
+- **gh not installed** → offer installation guidance from https://cli.github.com/
 - **bash/sh not found (Windows)** → suggest Git for Windows: https://git-scm.com/downloads/win
 - **Go version mismatch** → preflight sets `GOTOOLCHAIN` automatically; report version conflict if persists
 - **Preflight timeout** → unit tests can take 10+ min; use at least 15-min timeout

--- a/.github/skills/azd-preflight/references/preflight-checks.md
+++ b/.github/skills/azd-preflight/references/preflight-checks.md
@@ -1,6 +1,6 @@
 # Preflight Checks Reference
 
-The `mage preflight` command runs these 8 checks in order. Each check, its
+The `mage preflight` command runs these 9 checks in order. Each check, its
 purpose, and the automated fix strategy are listed below.
 
 ## 1. Formatting (`gofmt`)
@@ -33,7 +33,7 @@ issues include:
 - `unused` — remove dead code
 - `staticcheck` — fix static analysis warnings
 
-## 5. Spell Check (`cspell`)
+## 5. Go Spell Check (`cspell`)
 
 **Command**: `cspell lint "**/*.go" --relative --config ./.vscode/cspell.yaml --no-progress` (from `cli/azd/`)
 **Passes when**: No unknown words found.
@@ -41,7 +41,15 @@ issues include:
 using file-scoped `overrides` entries (not the global `words` list). For actual
 typos, fix the spelling in source code.
 
-## 6. Build (`go build`)
+## 6. Misc/Docs Spell Check (`cspell-misc`)
+
+**Command**: `cspell lint "**/*" --relative --config ./.vscode/cspell.misc.yaml --no-progress`
+(from the repository root)
+**Passes when**: No unknown words are found in miscellaneous and documentation files.
+**Auto-fix**: Fix typos. Add legitimate terms to file-scoped `overrides` entries in
+`.vscode/cspell.misc.yaml`.
+
+## 7. Build (`go build`)
 
 **Command**: `go build ./...` (from `cli/azd/`)
 **Passes when**: Compilation succeeds with zero errors.
@@ -51,14 +59,14 @@ typos, fix the spelling in source code.
 - Undefined symbols
 - Syntax errors
 
-## 7. Unit Tests (`go test -short`)
+## 8. Unit Tests (`go test -short`)
 
 **Command**: `go test ./... -short -cover -count=1` (from `cli/azd/`)
 **Passes when**: All tests pass.
 **Auto-fix**: Analyze test failures and fix the root cause in source code or
 tests. Do NOT skip or delete failing tests — fix them.
 
-## 8. Playback Tests (Functional)
+## 9. Playback Tests (Functional)
 
 **Command**: Discovers test recordings in `test/functional/testdata/recordings/`
 and runs matching functional tests with `AZURE_RECORD_MODE=playback`.
@@ -68,6 +76,21 @@ recording is stale, add the test name to `excludedPlaybackTests` in
 `cli/azd/magefile.go` with a reason string — but only as a last resort after
 confirming the recording genuinely needs re-recording.
 
+## Conditional: Changed CHANGELOG Spell Check
+
+**Command**: `cspell lint "<changelog-path>" --relative --config "<cspell-config>"
+--no-progress` (from the repository root)
+**Runs when**: One or more tracked or untracked `CHANGELOG.md` files have changed.
+**Passes when**: Every changed changelog has no unknown words.
+**Config resolution**: Starting in the changelog's directory, select the nearest `cspell.yaml`
+or `.vscode/cspell.yaml` while walking toward the repository root. Fall back to
+`cli/azd/.vscode/cspell.yaml` when no nearer config exists.
+**Auto-fix**: Fix typos. For contributor attributions, verify the GitHub username against the
+linked PR author or GitHub account, then add the exact alias to
+`.vscode/cspell-github-user-aliases.txt` in case-insensitive alphabetical order. Do not add
+unverified handles. Add other valid terms to a `CHANGELOG.md` file-scoped override in the
+resolved owning config.
+
 ## Prerequisites
 
 Before running preflight, these tools must be installed:
@@ -75,5 +98,6 @@ Before running preflight, these tools must be installed:
 - **Go** (version matching `cli/azd/go.mod`)
 - **golangci-lint**: `go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.11.4`
 - **cspell**: `npm install -g cspell@8.13.1`
+- **GitHub CLI (`gh`)**: install from https://cli.github.com/
 - **bash or sh**: On Windows, Git for Windows provides this
 - **mage**: `go install github.com/magefile/mage@latest`

--- a/.github/skills/azd-preflight/references/workflow.md
+++ b/.github/skills/azd-preflight/references/workflow.md
@@ -5,7 +5,7 @@
 1. Locate the repo root by checking for `cli/azd/magefile.go` relative to cwd.
    If cwd is already `cli/azd/` (contains `magefile.go`), use cwd directly.
    If cwd is the repo root, use `cli/azd/` as the working directory.
-2. Verify tools: `mage`, `go`, `golangci-lint`, `cspell`.
+2. Verify tools: `mage`, `go`, `golangci-lint`, `cspell`, `gh`.
 3. If any tool is missing, offer to install via `ask_user` (see preflight-checks.md § Prerequisites).
    If the user declines, stop.
 
@@ -25,6 +25,27 @@ Use an appropriate timeout (at least 15 minutes).
 
 Capture the full output including the summary table at the end.
 
+Inspect `git status --porcelain=v1 -z --untracked-files=all -- ':(glob)**/CHANGELOG.md'`.
+Parse the null-delimited records before collecting changelog paths:
+
+1. Skip records whose index or worktree status is `D`.
+2. For rename or copy records, use the first path field after the status as the destination and
+   consume the second path field as the source.
+3. For all other records, use the single path field.
+
+For each remaining changelog, resolve its owning cspell config by walking from the changelog's
+directory toward the repository root and selecting the nearest `cspell.yaml` or
+`.vscode/cspell.yaml`. Fall back to `cli/azd/.vscode/cspell.yaml` if no nearer config exists.
+Run this targeted check from the repository root:
+
+```bash
+cspell lint "<changelog-path>" --relative --config "<cspell-config>" --no-progress
+```
+
+Capture these results separately from the nine `mage preflight` checks. This conditional check is
+required because the repository-wide misc config excludes directories that have their own cspell
+configuration, including `cli/`.
+
 ### Step 3 — Parse Results
 
 The preflight output ends with a summary block listing each check as `✓` (pass) or `✗` (fail):
@@ -34,21 +55,25 @@ The preflight output ends with a summary block listing each check as `✓` (pass
   Preflight Summary
 ══════════════════════════
   ✓ gofmt        ✗ lint
-  ✓ cspell        ...
+  ✓ cspell       ✓ cspell-misc
+  ...
 ══════════════════════════
 ```
 
 Parse this summary to identify which checks passed (`✓`) and which failed (`✗`).
+Also parse the targeted changelog spell-check results when changed changelogs were found.
 
-**If all checks pass**: Report success and stop. No fixes needed.
+**If all checks pass** and every changed changelog is clean: Report success and stop. No fixes needed.
 
-**If any checks fail**: Proceed to Step 4 for each failing check, in order.
+**If any check fails**: Proceed to Step 4 for each failing check, in order.
 
 ### Step 4 — Fix Failures (Iterative)
 
 For each failing check, apply the fix strategy from the references. Process checks in
-their original order (1-8) because earlier fixes can resolve later failures (e.g., `gofmt`
+their original order (1-9) because earlier fixes can resolve later failures (e.g., `gofmt`
 fixes may resolve `lint` issues, `build` fixes resolve `test` failures).
+
+After the nine standard checks, fix any targeted changelog spelling failures.
 
 {{ references/fix-strategies.md }}
 
@@ -60,11 +85,13 @@ After applying all fixes, re-run the full preflight:
 cd cli/azd && mage preflight
 ```
 
-**If all checks pass**: Report success and stop.
+Re-run the targeted spell check for every changed changelog.
+
+**If all checks pass** and every changed changelog is clean: Report success and stop.
 
 **If failures remain**: Return to Step 4 for the remaining failures. This is an iterative
 loop — continue until either:
-- All 8 checks pass, OR
+- All 9 checks and every changed changelog pass, OR
 - 3 full cycles have been attempted without progress on a specific check
 
 ### Step 6 — Escalate if Stuck


### PR DESCRIPTION
## Why

The preflight skill did not model the repository's current nine-check suite, and its spelling guidance only covered Go files. Because the repository-wide misc cspell configuration excludes `cli/`, modified azd changelogs could bypass spell validation and new contributor aliases would not be added to the shared GitHub alias dictionary.

## What changed

- Document all nine checks currently run by `mage preflight`, including `cspell-misc`.
- Detect tracked and untracked `CHANGELOG.md` changes with null-delimited porcelain output, skip deletions, and lint rename destinations.
- Resolve each changelog's nearest owning `cspell.yaml` or `.vscode/cspell.yaml`, with the core azd config as fallback.
- Verify contributor aliases against the linked PR author or GitHub before adding them to `.vscode/cspell-github-user-aliases.txt`.
- Require GitHub CLI for alias verification and document its missing-tool guidance.
- Preserve case-insensitive alias ordering, avoid duplicates, and keep non-alias terms in file-scoped cspell overrides.

## Validation

Targeted cspell checks passed for both `cli/azd/CHANGELOG.md` with the core config and `cli/azd/extensions/azure.ai.agents/CHANGELOG.md` with its extension config.

`mage preflight` previously passed formatting, modernization, copyright, lint, both cspell checks, build, and unit tests. The existing `Test_CLI_Up_Down_ContainerFuncApp` playback test failed twice while Docker ran `npm ci` because `registry.npmjs.org` returned an SSL/TLS handshake failure. This failure is unrelated to the documentation-only changes.

Closes #9548