### PR TITLE
Configure Agency MCP tools

### DIFF
--- a/.vscode/cspell.misc.yaml
+++ b/.vscode/cspell.misc.yaml
@@ -156,3 +156,7 @@ overrides:
           - usgovcloudapi
           - vsrpc
           - whatif
+    - filename: ./agency.toml
+      words:
+          - mcps
+          - toolsets

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
 
 **Contributing to this repo?** See [AGENTS.md](AGENTS.md) for coding standards and [docs/](docs/README.md) for contributor documentation.
 
+**Microsoft contributor?** The repository's [`agency.toml`](agency.toml) configures [Agency](https://aka.ms/agency) with Azure DevOps and Kusto MCP tools.
+
 **Using `azd` with an AI coding assistant?** Check out the [docs](https://aka.ms/azd) and [templates](https://azure.github.io/awesome-azd/).
 
 ---

--- a/agency.toml
+++ b/agency.toml
@@ -1,0 +1,12 @@
+# aka.ms/agency/config
+# cspell:ignore mcps
+
+[mcps.builtins.ado]
+type = "ado"
+organization = "azure-sdk"
+toolsets = ["core", "repositories", "pipelines", "search"]
+
+[mcps.builtins.kusto]
+type = "kusto"
+service_uri = "https://ddazureclients.kusto.windows.net"
+database = "DevCli"

--- a/agency.toml
+++ b/agency.toml
@@ -1,5 +1,4 @@
 # aka.ms/agency/config
-# cspell:ignore mcps
 
 [mcps.builtins.ado]
 type = "ado"

--- a/cli/azd/AGENTS.md
+++ b/cli/azd/AGENTS.md
@@ -36,14 +36,22 @@ cli/azd/
 
 ## Agency and MCP Tools
 
-This repository includes an [`agency.toml`](../../agency.toml) configuration for [Agency](https://aka.ms/agency), Microsoft's internal AI engineering environment.
+For Microsoft contributors, this repository's [`agency.toml`](../../agency.toml) preconfigures [Agency](https://aka.ms/agency) with Azure DevOps MCP access for the `azure-sdk` organization and Kusto MCP access to the `DevCli` database. Prefer these tools for ADO operations and authorized telemetry investigations. Do not expose customer-identifying data in issues, pull requests, logs, or generated artifacts.
 
-It preconfigures:
+### Checking Azure DevOps Pipelines
 
-- **Azure DevOps MCP** for the `azure-sdk` organization.
-- **Kusto MCP** for the `DevCli` database on the shared telemetry cluster.
+All repository-owned azd pipelines are in the Azure DevOps `internal` project:
 
-Use the Azure DevOps MCP for ADO operations and the Kusto MCP for authorized telemetry investigations. Handle telemetry according to the repository's privacy and data-classification guidance, and do not expose customer-identifying data in issues, pull requests, logs, or generated artifacts.
+- [Core and repository pipelines](https://dev.azure.com/azure-sdk/internal/_build?definitionScope=%5Cazure-dev) are under `\azure-dev`.
+- [Extension pipelines](https://dev.azure.com/azure-sdk/internal/_build?definitionScope=%5Cazure-dev%5Cextensions) are under `\azure-dev\extensions`.
+
+When investigating a pipeline:
+
+- Start from the GitHub pull request check link when available. It identifies the exact Azure DevOps build and often the specific job.
+- Otherwise, locate the relevant pipeline in the folders above.
+- Correlate runs using the pull request number, commit SHA, and source branch.
+- Inspect the failed or running job logs first. Distinguish the root failure from secondary warnings, infrastructure noise, or downstream failures.
+- For releases, distinguish publishing from validation using the source branch and template parameters. For the core CLI pipeline, `DoPublish=true` identifies a publishing release run.
 
 ## Development
 

--- a/cli/azd/AGENTS.md
+++ b/cli/azd/AGENTS.md
@@ -34,6 +34,16 @@ cli/azd/
 
 **Tip**: Service registration in `cmd/container.go` shows all major components. To find where a feature is implemented, start with the command in `cmd/`, follow to the action, then trace service dependencies.
 
+## Agency and MCP Tools
+
+This repository includes an [`agency.toml`](../../agency.toml) configuration for [Agency](https://aka.ms/agency), Microsoft's internal AI engineering environment.
+
+It preconfigures:
+
+- **Azure DevOps MCP** for the `azure-sdk` organization.
+- **Kusto MCP** for the `DevCli` database on the shared telemetry cluster.
+
+Use the Azure DevOps MCP for ADO operations and the Kusto MCP for authorized telemetry investigations. Handle telemetry according to the repository's privacy and data-classification guidance, and do not expose customer-identifying data in issues, pull requests, logs, or generated artifacts.
 
 ## Development
 

--- a/cli/azd/AGENTS.md
+++ b/cli/azd/AGENTS.md
@@ -1,6 +1,6 @@
 # Azure Developer CLI (azd) - Agent Instructions
 
-<!-- cspell:ignore Errorf Chdir azapi gofmt golangci stdlib strconv Readdirnames -->
+<!-- cspell:ignore Errorf Chdir azapi gofmt golangci stdlib strconv Readdirnames preconfigures -->
 
 Instructions for AI coding agents working with the Azure Developer CLI.
 


### PR DESCRIPTION
### Summary

This PR adds repository-scoped [Agency](https://aka.ms/agency) configuration for Microsoft contributors. It preconfigures the Azure DevOps MCP for the `azure-sdk` organization and the Kusto MCP for the shared `DevCli` telemetry database.

### Access and data handling

- The configuration contains service scopes and endpoints, not credentials.
- Microsoft Entra authentication and existing Azure DevOps and Kusto permissions continue to control access.
- Contributor guidance directs agents to use the tools only for authorized work and to follow the repository's telemetry privacy and data-classification requirements.

### Testing

- Parsed `agency.toml` with Python's TOML parser.
- Confirmed the configured Azure DevOps MCP is scoped to the `azure-sdk` organization.
- Confirmed a read-only Kusto connectivity query succeeds against the `DevCli` database.
- Ran the repository spell checker and `git diff --check`.
