### PR TITLE
feat(extensions): publish PR bundles

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -7,6 +7,7 @@ on:
       - "!cli/azd/extensions/**"
       - ".github/workflows/cli-ci.yml"
       - "eng/scripts/Get-CoverageDiff*.ps1"
+      - "eng/scripts/Set-ExtensionVersionVariable*.ps1"
     branches: [main]
 
 # If two events are triggered within a short time in the same PR, cancel the run of the oldest event
@@ -52,14 +53,17 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Run Pester tests for coverage scripts
+      - name: Run Pester tests for engineering scripts
         shell: pwsh
         run: |
           # Pin Pester to a specific signed release for deterministic, supply-chain-safe installs.
           Install-Module -Name Pester -RequiredVersion 5.7.1 -Force -Scope CurrentUser
           Import-Module Pester -RequiredVersion 5.7.1
           $config = New-PesterConfiguration
-          $config.Run.Path = './eng/scripts/Get-CoverageDiff.Tests.ps1'
+          $config.Run.Path = @(
+            './eng/scripts/Get-CoverageDiff.Tests.ps1'
+            './eng/scripts/Set-ExtensionVersionVariable.Tests.ps1'
+          )
           $config.Run.Exit = $true
           $config.Output.Verbosity = 'Detailed'
           Invoke-Pester -Configuration $config

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/init_test.go
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/cmd/init_test.go
@@ -583,6 +583,8 @@ func TestCreateInternalExtensionScaffold(t *testing.T) {
 		filepath.Join(repoRoot, "eng", "pipelines", "release-ext-"+sanitizedId+".yml"),
 		"AzdExtensionId: azure.ai.example",
 		"SanitizedExtensionId: azure-ai-example",
+		"/eng/pipelines/templates/stages/publish-extension-pr.yml",
+		"/eng/scripts/Set-ExtensionVersionVariable.ps1",
 	)
 	assertFileContains(
 		t,

--- a/cli/azd/extensions/microsoft.azd.extensions/internal/resources/internal/go/pipelines/release-ext.yml.tmpl
+++ b/cli/azd/extensions/microsoft.azd.extensions/internal/resources/internal/go/pipelines/release-ext.yml.tmpl
@@ -7,9 +7,11 @@ trigger:
     include:
       - cli/azd/extensions/{{.Metadata.Id}}
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
 
 pr:
   paths:
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/{{.Metadata.Id}}
       - eng/pipelines/release-ext-{{.SanitizedId}}.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-agents.yml
+++ b/eng/pipelines/release-ext-azure-ai-agents.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/azure.ai.agents
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/azure.ai.agents
       - eng/pipelines/release-ext-azure-ai-agents.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-connections.yml
+++ b/eng/pipelines/release-ext-azure-ai-connections.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/azure.ai.connections
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/azure.ai.connections
       - eng/pipelines/release-ext-azure-ai-connections.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-finetune.yml
+++ b/eng/pipelines/release-ext-azure-ai-finetune.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/azure.ai.finetune
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/azure.ai.finetune
       - eng/pipelines/release-ext-azure-ai-finetune.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-inspector.yml
+++ b/eng/pipelines/release-ext-azure-ai-inspector.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/azure.ai.inspector
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/azure.ai.inspector
       - eng/pipelines/release-ext-azure-ai-inspector.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-models.yml
+++ b/eng/pipelines/release-ext-azure-ai-models.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/azure.ai.models
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/azure.ai.models
       - eng/pipelines/release-ext-azure-ai-models.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-projects.yml
+++ b/eng/pipelines/release-ext-azure-ai-projects.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/azure.ai.projects
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/azure.ai.projects
       - eng/pipelines/release-ext-azure-ai-projects.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-rle.yml
+++ b/eng/pipelines/release-ext-azure-ai-rle.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/azure.ai.rle
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/azure.ai.rle
       - eng/pipelines/release-ext-azure-ai-rle.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-routines.yml
+++ b/eng/pipelines/release-ext-azure-ai-routines.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/azure.ai.routines
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/azure.ai.routines
       - eng/pipelines/release-ext-azure-ai-routines.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-skills.yml
+++ b/eng/pipelines/release-ext-azure-ai-skills.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/azure.ai.skills
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/azure.ai.skills
       - eng/pipelines/release-ext-azure-ai-skills.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-toolboxes.yml
+++ b/eng/pipelines/release-ext-azure-ai-toolboxes.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/azure.ai.toolboxes
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/azure.ai.toolboxes
       - eng/pipelines/release-ext-azure-ai-toolboxes.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-ai-training.yml
+++ b/eng/pipelines/release-ext-azure-ai-training.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/azure.ai.training
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/azure.ai.training
       - eng/pipelines/release-ext-azure-ai-training.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-appservice.yml
+++ b/eng/pipelines/release-ext-azure-appservice.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/azure.appservice
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/azure.appservice
       - eng/pipelines/release-ext-azure-appservice.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-azure-coding-agent.yml
+++ b/eng/pipelines/release-ext-azure-coding-agent.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/azure.coding-agent
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/azure.coding-agent
       - eng/pipelines/release-ext-azure-coding-agent.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-microsoft-azd-ai-builder.yml
+++ b/eng/pipelines/release-ext-microsoft-azd-ai-builder.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/microsoft.azd.ai.builder
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/microsoft.azd.ai.builder
       - eng/pipelines/release-ext-microsoft-azd-ai-builder.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-microsoft-azd-concurx.yml
+++ b/eng/pipelines/release-ext-microsoft-azd-concurx.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/microsoft.azd.concurx
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/microsoft.azd.concurx
       - eng/pipelines/release-ext-microsoft-azd-concurx.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-microsoft-azd-demo.yml
+++ b/eng/pipelines/release-ext-microsoft-azd-demo.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/microsoft.azd.demo
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/microsoft.azd.demo
       - eng/pipelines/release-ext-microsoft-azd-demo.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/release-ext-microsoft-azd-extensions.yml
+++ b/eng/pipelines/release-ext-microsoft-azd-extensions.yml
@@ -7,6 +7,8 @@ trigger:
     include:
       - cli/azd/extensions/microsoft.azd.extensions
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - /eng/pipelines/templates/jobs/build-azd-extension.yml
       - /eng/pipelines/templates/jobs/cross-build-azd-extension.yml
       - /eng/pipelines/templates/variables/image.yml
@@ -17,6 +19,8 @@ pr:
       - cli/azd/extensions/microsoft.azd.extensions
       - eng/pipelines/release-ext-microsoft-azd-extensions.yml
       - /eng/pipelines/templates/stages/release-azd-extension.yml
+      - /eng/pipelines/templates/stages/publish-extension-pr.yml
+      - /eng/scripts/Set-ExtensionVersionVariable.ps1
       - eng/pipelines/templates/steps/publish-cli.yml
     exclude:
       - cli/azd/docs/**

--- a/eng/pipelines/templates/stages/publish-extension-pr.yml
+++ b/eng/pipelines/templates/stages/publish-extension-pr.yml
@@ -13,13 +13,7 @@ stages:
       and(
         succeeded(),
         ne(variables['Skip.Release'], 'true'),
-        or(
-          eq('PullRequest', variables['BuildReasonOverride']),
-          and(
-            eq('', variables['BuildReasonOverride']),
-            eq(variables['Build.Reason'], 'PullRequest')
-          )
-        )
+        eq(variables['Build.Reason'], 'PullRequest')
       )
 
     variables:

--- a/eng/pipelines/templates/stages/publish-extension-pr.yml
+++ b/eng/pipelines/templates/stages/publish-extension-pr.yml
@@ -1,0 +1,222 @@
+parameters:
+  - name: AzdExtensionId
+    type: string
+  - name: AzdExtensionDirectory
+    type: string
+  - name: SanitizedExtensionId
+    type: string
+
+stages:
+  - stage: PublishExtensionForPR
+    dependsOn: BuildAndTest
+    condition: >-
+      and(
+        succeeded(),
+        ne(variables['Skip.Release'], 'true'),
+        or(
+          eq('PullRequest', variables['BuildReasonOverride']),
+          and(
+            eq('', variables['BuildReasonOverride']),
+            eq(variables['Build.Reason'], 'PullRequest')
+          )
+        )
+      )
+
+    variables:
+      - template: /eng/pipelines/templates/variables/globals.yml
+      - template: /eng/pipelines/templates/variables/image.yml
+
+    jobs:
+      - job: Pack_Bundle_For_PR
+        pool:
+          name: $(LINUXPOOL)
+          image: $(LINUXVMIMAGE)
+          os: linux
+
+        steps:
+          - checkout: self
+
+          - template: /eng/pipelines/templates/steps/extension-set-metadata-variables.yml
+
+          - pwsh: |
+              $binPath = '${{ parameters.AzdExtensionDirectory }}/bin'
+              if (Test-Path -LiteralPath $binPath) {
+                Remove-Item -LiteralPath $binPath -Recurse -Force
+              }
+              New-Item -ItemType Directory -Path $binPath -Force | Out-Null
+            displayName: Prepare bundle input directory
+
+          - task: DownloadPipelineArtifact@2
+            displayName: Download Linux AMD64 artifact
+            inputs:
+              artifactName: ${{ parameters.SanitizedExtensionId }}-linux-amd64
+              targetPath: ${{ parameters.AzdExtensionDirectory }}/bin
+
+          - task: DownloadPipelineArtifact@2
+            displayName: Download Linux ARM64 artifact
+            inputs:
+              artifactName: ${{ parameters.SanitizedExtensionId }}-linux-arm64
+              targetPath: ${{ parameters.AzdExtensionDirectory }}/bin
+
+          - task: DownloadPipelineArtifact@2
+            displayName: Download macOS AMD64 artifact
+            inputs:
+              artifactName: ${{ parameters.SanitizedExtensionId }}-darwin-amd64
+              targetPath: ${{ parameters.AzdExtensionDirectory }}/bin
+
+          - task: DownloadPipelineArtifact@2
+            displayName: Download macOS ARM64 artifact
+            inputs:
+              artifactName: ${{ parameters.SanitizedExtensionId }}-darwin-arm64
+              targetPath: ${{ parameters.AzdExtensionDirectory }}/bin
+
+          - task: DownloadPipelineArtifact@2
+            displayName: Download Windows AMD64 artifact
+            inputs:
+              artifactName: ${{ parameters.SanitizedExtensionId }}-windows-amd64.exe
+              targetPath: ${{ parameters.AzdExtensionDirectory }}/bin
+
+          - task: DownloadPipelineArtifact@2
+            displayName: Download Windows ARM64 artifact
+            inputs:
+              artifactName: ${{ parameters.SanitizedExtensionId }}-windows-arm64.exe
+              targetPath: ${{ parameters.AzdExtensionDirectory }}/bin
+
+          - bash: |
+              set -euo pipefail
+              chmod +x \
+                "${{ parameters.SanitizedExtensionId }}-linux-amd64" \
+                "${{ parameters.SanitizedExtensionId }}-linux-arm64" \
+                "${{ parameters.SanitizedExtensionId }}-darwin-amd64" \
+                "${{ parameters.SanitizedExtensionId }}-darwin-arm64"
+            workingDirectory: ${{ parameters.AzdExtensionDirectory }}/bin
+            displayName: Restore executable permissions
+
+          - pwsh: |
+              $manifestPath = '${{ parameters.AzdExtensionDirectory }}/extension.yaml'
+              $content = Get-Content -LiteralPath $manifestPath -Raw
+              $pattern = '(?m)^version:\s*.*$'
+              $matches = [regex]::Matches($content, $pattern)
+              if ($matches.Count -ne 1) {
+                throw "Expected exactly one top-level version field in $manifestPath, found $($matches.Count)."
+              }
+
+              $updated = [regex]::Replace($content, $pattern, 'version: $(EXT_VERSION)')
+              Set-Content -LiteralPath $manifestPath -Value $updated -NoNewline
+            displayName: Set bundle manifest version
+
+          - bash: |
+              set -euo pipefail
+              curl -fsSL https://aka.ms/install-azd.sh | bash -s -- --verbose
+              azd version
+            displayName: Install azd
+
+          - bash: |
+              set -euo pipefail
+              azd ext install microsoft.azd.extensions --source azd
+            displayName: Install microsoft.azd.extensions
+
+          - bash: |
+              set -euo pipefail
+              azd x pack \
+                --bundle \
+                --output "$(Build.SourcesDirectory)/release/${{ parameters.SanitizedExtensionId }}.zip"
+            workingDirectory: ${{ parameters.AzdExtensionDirectory }}
+            displayName: Create extension bundle
+
+        templateContext:
+          outputs:
+            - output: pipelineArtifact
+              path: $(Build.SourcesDirectory)/release
+              artifact: pr-bundle
+              condition: succeeded()
+              displayName: Upload PR bundle artifact
+
+      - deployment: Publish_For_PR
+        dependsOn: Pack_Bundle_For_PR
+        environment: none
+
+        pool:
+          name: azsdk-pool
+          image: ubuntu-22.04
+          os: linux
+
+        templateContext:
+          type: releaseJob
+          isProduction: false
+          inputs:
+            - input: pipelineArtifact
+              artifactName: pr-bundle
+              targetPath: release
+
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - pwsh: |
+                    $prNumber = '$(System.PullRequest.PullRequestNumber)'
+                    if ($env:PRNUMBEROVERRIDE) {
+                      $prNumber = $env:PRNUMBEROVERRIDE
+                    }
+                    Write-Host "##vso[task.setvariable variable=PRNumber]$prNumber"
+                  displayName: Set PR number
+
+                - template: /eng/pipelines/templates/steps/publish-extension-storage.yml
+                  parameters:
+                    PublishUploadLocations: pr/$(PRNumber)/${{ parameters.SanitizedExtensionId }}
+
+      - job: Comment_On_PR
+        dependsOn: Publish_For_PR
+
+        pool:
+          name: $(LINUXPOOL)
+          image: $(LINUXVMIMAGE)
+          os: linux
+
+        steps:
+          - checkout: self
+
+          - pwsh: |
+              $prNumber = '$(System.PullRequest.PullRequestNumber)'
+              if ($env:PRNUMBEROVERRIDE) {
+                $prNumber = $env:PRNUMBEROVERRIDE
+              }
+              Write-Host "##vso[task.setvariable variable=PRNumber]$prNumber"
+            displayName: Set PR number
+
+          - template: /eng/pipelines/templates/steps/extension-set-metadata-variables.yml
+
+          - pwsh: |
+              $bundleUrl = "$(publish-storage-static-host)/azd/extensions/pr/$(PRNumber)/" +
+                "${{ parameters.SanitizedExtensionId }}/${{ parameters.SanitizedExtensionId }}.zip"
+              $content = @"
+              <!-- #comment-ext-pr-${{ parameters.SanitizedExtensionId }} -->
+              ### Test ``${{ parameters.AzdExtensionId }}`` PR build
+
+              > [!NOTE]
+              > This is an unsigned development build, not an official release. Install it only if you trust this PR.
+              > The artifact is temporary, and this URL may later point to a newer successful build from this PR.
+
+              Install the extension:
+
+              ``````sh
+              azd ext install "$bundleUrl"
+              ``````
+
+              - **Version:** ``$(EXT_VERSION)``
+              - **Merge commit:** ``$(Build.SourceVersion)``
+              "@
+
+              $file = New-TemporaryFile
+              Set-Content -LiteralPath $file -Value $content
+              Write-Host "##vso[task.setvariable variable=CommentBodyFile]$file"
+            displayName: Write PR comment
+
+          - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+
+          - template: /eng/pipelines/templates/steps/update-prcomment.yml
+            parameters:
+              PrNumber: $(PRNumber)
+              BodyFile: $(CommentBodyFile)
+              Tag: '<!-- #comment-ext-pr-${{ parameters.SanitizedExtensionId }} -->'
+              GitHubToken: $(GH_TOKEN)

--- a/eng/pipelines/templates/stages/publish-extension-pr.yml
+++ b/eng/pipelines/templates/stages/publish-extension-pr.yml
@@ -163,7 +163,7 @@ stages:
 
                 - template: /eng/pipelines/templates/steps/publish-extension-storage.yml
                   parameters:
-                    PublishUploadLocations: pr/$(PRNumber)/${{ parameters.SanitizedExtensionId }}
+                    PublishUploadLocations: pr/$(PRNumber)
 
       - job: Comment_On_PR
         dependsOn: Publish_For_PR
@@ -188,23 +188,22 @@ stages:
 
           - pwsh: |
               $bundleUrl = "$(publish-storage-static-host)/azd/extensions/pr/$(PRNumber)/" +
-                "${{ parameters.SanitizedExtensionId }}/${{ parameters.SanitizedExtensionId }}.zip"
+                "${{ parameters.SanitizedExtensionId }}.zip"
               $content = @"
               <!-- #comment-ext-pr-${{ parameters.SanitizedExtensionId }} -->
-              ### Test ``${{ parameters.AzdExtensionId }}`` PR build
+              ### ${{ parameters.AzdExtensionId }} PR build
 
               > [!NOTE]
-              > This is an unsigned development build, not an official release. Install it only if you trust this PR.
-              > The artifact is temporary, and this URL may later point to a newer successful build from this PR.
+              > This is an unsigned development build. Install it only if you trust this PR.
 
-              Install the extension:
+              **Install the extension:**
 
               ``````sh
               azd ext install "$bundleUrl"
               ``````
 
               - **Version:** ``$(EXT_VERSION)``
-              - **Merge commit:** ``$(Build.SourceVersion)``
+              - **Merge commit:** $(Build.SourceVersion)
               "@
 
               $file = New-TemporaryFile

--- a/eng/pipelines/templates/stages/release-azd-extension.yml
+++ b/eng/pipelines/templates/stages/release-azd-extension.yml
@@ -84,6 +84,13 @@ stages:
               SetExecutableBit: true
               AZURE_DEV_CI_OS: mac-arm64
 
+  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - template: /eng/pipelines/templates/stages/publish-extension-pr.yml
+      parameters:
+        AzdExtensionId: ${{ parameters.AzdExtensionId }}
+        AzdExtensionDirectory: ${{ parameters.AzdExtensionDirectory }}
+        SanitizedExtensionId: ${{ parameters.SanitizedExtensionId }}
+
   # Sign and release on manual builds (stable/dev/nightly release) and scheduled
   # builds (nightly) from internal. Nightly builds reuse the same sign + package +
   # publish path; publish-extension.yml branches its behavior on both the schedule

--- a/eng/pipelines/templates/steps/update-prcomment.yml
+++ b/eng/pipelines/templates/steps/update-prcomment.yml
@@ -21,6 +21,7 @@ steps:
       $PrNumber = "${{ parameters.PrNumber }}"
       $BodyFile = "${{ parameters.BodyFile }}"
       $Tag = "${{ parameters.Tag }}"
+      $commentsToErase = @()
 
       if ($Tag) {
           # Using --jq formats the JSON objects on separate lines which can be
@@ -32,6 +33,10 @@ steps:
               repos/$Repo/issues/$PrNumber/comments `
               --paginate `
               --jq '.[]'
+          if ($LASTEXITCODE) {
+              throw "Failed to list PR comments."
+          }
+
           $comments = @()
           foreach ($row in $commentsJsonRows) {
               $comments +=@( ConvertFrom-Json $row )
@@ -40,13 +45,20 @@ steps:
           Write-Host "Comments found: $($comments.Length)"
 
           $commentsToErase = $comments.Where({ $_.body.Contains($Tag) })
-          foreach ($comment in $commentsToErase) {
-              Write-Host "Deleting previous tagged comment $($comment.id)"
-              gh api --method DELETE "repos/$Repo/issues/comments/$($comment.id)"
-          }
       }
 
       Write-Host "Posting comment"
       gh pr comment $PRNumber --repo "$Repo" --body-file $BodyFile
+      if ($LASTEXITCODE) {
+          throw "Failed to post PR comment."
+      }
+
+      foreach ($comment in $commentsToErase) {
+          Write-Host "Deleting previous tagged comment $($comment.id)"
+          gh api --method DELETE "repos/$Repo/issues/comments/$($comment.id)"
+          if ($LASTEXITCODE) {
+              throw "Failed to delete previous PR comment $($comment.id)."
+          }
+      }
     env:
       GH_TOKEN: ${{ parameters.GitHubToken }}

--- a/eng/scripts/Set-ExtensionVersionVariable.Tests.ps1
+++ b/eng/scripts/Set-ExtensionVersionVariable.Tests.ps1
@@ -1,0 +1,110 @@
+Describe 'Set-ExtensionVersionVariable' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot 'Set-ExtensionVersionVariable.ps1'
+
+        function Set-TestVersion {
+            param([string] $Version)
+
+            Set-Content -Path (Join-Path $extensionDirectory 'version.txt') -Value $Version
+        }
+
+        function Invoke-VersionScript {
+            param(
+                [string] $BuildReason = 'Manual',
+                [string] $BuildReasonOverride = '',
+                [string] $BuildId = '1234',
+                [string] $PullRequestNumber = '',
+                [string] $PullRequestNumberOverride = '',
+                [string] $PublishToRegistry = 'stable'
+            )
+
+            & $scriptPath `
+                -ExtensionDirectory $extensionDirectory `
+                -BuildReason $BuildReason `
+                -BuildReasonOverride $BuildReasonOverride `
+                -BuildId $BuildId `
+                -PullRequestNumber $PullRequestNumber `
+                -PullRequestNumberOverride $PullRequestNumberOverride `
+                -PublishToRegistry $PublishToRegistry 6>&1 |
+                ForEach-Object { $_.ToString() }
+        }
+    }
+
+    BeforeEach {
+        $extensionDirectory = Join-Path $TestDrive 'extension'
+        New-Item -ItemType Directory -Path $extensionDirectory -Force | Out-Null
+    }
+
+    It 'adds PR identity to a stable version' {
+        Set-TestVersion '1.2.3'
+
+        $output = Invoke-VersionScript -BuildReason PullRequest -PullRequestNumber 9409
+
+        $output | Should -Contain 'Extension Version: 1.2.3-pr.9409.1234'
+    }
+
+    It 'extends an existing prerelease version with PR identity' {
+        Set-TestVersion '1.2.3-preview'
+
+        $output = Invoke-VersionScript -BuildReason PullRequest -PullRequestNumber 9409
+
+        $output | Should -Contain 'Extension Version: 1.2.3-preview.pr.9409.1234'
+    }
+
+    It 'uses the build reason and PR number overrides' {
+        Set-TestVersion '1.2.3'
+
+        $output = Invoke-VersionScript `
+            -BuildReason Manual `
+            -BuildReasonOverride PullRequest `
+            -PullRequestNumber 100 `
+            -PullRequestNumberOverride 9409
+
+        $output | Should -Contain 'Extension Version: 1.2.3-pr.9409.1234'
+    }
+
+    It 'rejects PR versioning without a PR number' {
+        Set-TestVersion '1.2.3'
+
+        { Invoke-VersionScript -BuildReason PullRequest } |
+            Should -Throw '*PullRequestNumber is required for PR versioning*'
+    }
+
+    It 'rejects PR versioning without a build ID' {
+        Set-TestVersion '1.2.3'
+
+        { Invoke-VersionScript -BuildReason PullRequest -PullRequestNumber 9409 -BuildId '' } |
+            Should -Throw '*BuildId is required for PR versioning*'
+    }
+
+    It 'leaves a non-PR release version unchanged' {
+        Set-TestVersion '1.2.3'
+
+        $output = Invoke-VersionScript
+
+        $output | Should -Contain 'Extension Version: 1.2.3'
+    }
+
+    It 'preserves scheduled nightly versioning' {
+        Set-TestVersion '1.2.3-preview'
+
+        $output = Invoke-VersionScript `
+            -BuildReason Schedule `
+            -BuildReasonOverride PullRequest `
+            -PullRequestNumber 9409
+
+        $output | Should -Contain 'Extension Version: 1.2.3-preview.nightly.1234'
+    }
+
+    It 'preserves manually selected nightly versioning' {
+        Set-TestVersion '1.2.3'
+
+        $output = Invoke-VersionScript `
+            -BuildReason Manual `
+            -BuildReasonOverride PullRequest `
+            -PullRequestNumber 9409 `
+            -PublishToRegistry nightly
+
+        $output | Should -Contain 'Extension Version: 1.2.3-nightly.1234'
+    }
+}

--- a/eng/scripts/Set-ExtensionVersionVariable.Tests.ps1
+++ b/eng/scripts/Set-ExtensionVersionVariable.Tests.ps1
@@ -11,7 +11,6 @@ Describe 'Set-ExtensionVersionVariable' {
         function Invoke-VersionScript {
             param(
                 [string] $BuildReason = 'Manual',
-                [string] $BuildReasonOverride = '',
                 [string] $BuildId = '1234',
                 [string] $PullRequestNumber = '',
                 [string] $PullRequestNumberOverride = '',
@@ -21,7 +20,6 @@ Describe 'Set-ExtensionVersionVariable' {
             & $scriptPath `
                 -ExtensionDirectory $extensionDirectory `
                 -BuildReason $BuildReason `
-                -BuildReasonOverride $BuildReasonOverride `
                 -BuildId $BuildId `
                 -PullRequestNumber $PullRequestNumber `
                 -PullRequestNumberOverride $PullRequestNumberOverride `
@@ -51,12 +49,11 @@ Describe 'Set-ExtensionVersionVariable' {
         $output | Should -Contain 'Extension Version: 1.2.3-preview.pr.9409.1234'
     }
 
-    It 'uses the build reason and PR number overrides' {
+    It 'uses the PR number override' {
         Set-TestVersion '1.2.3'
 
         $output = Invoke-VersionScript `
-            -BuildReason Manual `
-            -BuildReasonOverride PullRequest `
+            -BuildReason PullRequest `
             -PullRequestNumber 100 `
             -PullRequestNumberOverride 9409
 
@@ -90,7 +87,6 @@ Describe 'Set-ExtensionVersionVariable' {
 
         $output = Invoke-VersionScript `
             -BuildReason Schedule `
-            -BuildReasonOverride PullRequest `
             -PullRequestNumber 9409
 
         $output | Should -Contain 'Extension Version: 1.2.3-preview.nightly.1234'
@@ -101,7 +97,6 @@ Describe 'Set-ExtensionVersionVariable' {
 
         $output = Invoke-VersionScript `
             -BuildReason Manual `
-            -BuildReasonOverride PullRequest `
             -PullRequestNumber 9409 `
             -PublishToRegistry nightly
 

--- a/eng/scripts/Set-ExtensionVersionVariable.ps1
+++ b/eng/scripts/Set-ExtensionVersionVariable.ps1
@@ -2,17 +2,27 @@ param(
     [string] $ExtensionDirectory,
     # Defaults to the pipeline-provided values so the script is unit-testable.
     [string] $BuildReason = $env:BUILD_REASON,
+    [string] $BuildReasonOverride = $env:BUILDREASONOVERRIDE,
     [string] $BuildId = $env:BUILD_BUILDID,
+    [string] $PullRequestNumber = $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER,
+    [string] $PullRequestNumberOverride = $env:PRNUMBEROVERRIDE,
     [string] $PublishToRegistry = 'stable'
 )
 
 $extVersion = (Get-Content "$ExtensionDirectory/version.txt").Trim()
+$effectiveBuildReason = if ([string]::IsNullOrWhiteSpace($BuildReasonOverride)) {
+    $BuildReason
+}
+else {
+    $BuildReasonOverride
+}
 
 # On nightly (scheduled or manually selected) runs, append a semver-valid prerelease suffix so each
 # nightly sorts above the previous one (numeric build id) while still sorting
 # below the matching stable release for non-prerelease base versions. The build
 # id keeps all matrix jobs in a single run on the same version even if the run
-# crosses midnight, and guarantees a re-run produces a distinct version.
+# crosses midnight, and guarantees a re-run produces a distinct version. Nightly
+# selection takes precedence over build-reason overrides.
 if ($BuildReason -eq 'Schedule' -or $PublishToRegistry -eq 'nightly') {
     if ([string]::IsNullOrWhiteSpace($BuildId)) {
         throw "BuildId is required for nightly versioning but was empty (expected Build.BuildId)."
@@ -25,6 +35,28 @@ if ($BuildReason -eq 'Schedule' -or $PublishToRegistry -eq 'nightly') {
     else {
         # Stable base (e.g. 1.2.3): add the prerelease label.
         $extVersion = "$extVersion-nightly.$BuildId"
+    }
+}
+elseif ($effectiveBuildReason -eq 'PullRequest') {
+    $effectivePullRequestNumber = if ([string]::IsNullOrWhiteSpace($PullRequestNumberOverride)) {
+        $PullRequestNumber
+    }
+    else {
+        $PullRequestNumberOverride
+    }
+
+    if ([string]::IsNullOrWhiteSpace($effectivePullRequestNumber)) {
+        throw "PullRequestNumber is required for PR versioning but was empty."
+    }
+    if ([string]::IsNullOrWhiteSpace($BuildId)) {
+        throw "BuildId is required for PR versioning but was empty (expected Build.BuildId)."
+    }
+
+    if ($extVersion.Contains('-')) {
+        $extVersion = "$extVersion.pr.$effectivePullRequestNumber.$BuildId"
+    }
+    else {
+        $extVersion = "$extVersion-pr.$effectivePullRequestNumber.$BuildId"
     }
 }
 

--- a/eng/scripts/Set-ExtensionVersionVariable.ps1
+++ b/eng/scripts/Set-ExtensionVersionVariable.ps1
@@ -2,7 +2,6 @@ param(
     [string] $ExtensionDirectory,
     # Defaults to the pipeline-provided values so the script is unit-testable.
     [string] $BuildReason = $env:BUILD_REASON,
-    [string] $BuildReasonOverride = $env:BUILDREASONOVERRIDE,
     [string] $BuildId = $env:BUILD_BUILDID,
     [string] $PullRequestNumber = $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER,
     [string] $PullRequestNumberOverride = $env:PRNUMBEROVERRIDE,
@@ -10,19 +9,12 @@ param(
 )
 
 $extVersion = (Get-Content "$ExtensionDirectory/version.txt").Trim()
-$effectiveBuildReason = if ([string]::IsNullOrWhiteSpace($BuildReasonOverride)) {
-    $BuildReason
-}
-else {
-    $BuildReasonOverride
-}
 
 # On nightly (scheduled or manually selected) runs, append a semver-valid prerelease suffix so each
 # nightly sorts above the previous one (numeric build id) while still sorting
 # below the matching stable release for non-prerelease base versions. The build
 # id keeps all matrix jobs in a single run on the same version even if the run
-# crosses midnight, and guarantees a re-run produces a distinct version. Nightly
-# selection takes precedence over build-reason overrides.
+# crosses midnight, and guarantees a re-run produces a distinct version.
 if ($BuildReason -eq 'Schedule' -or $PublishToRegistry -eq 'nightly') {
     if ([string]::IsNullOrWhiteSpace($BuildId)) {
         throw "BuildId is required for nightly versioning but was empty (expected Build.BuildId)."
@@ -37,7 +29,7 @@ if ($BuildReason -eq 'Schedule' -or $PublishToRegistry -eq 'nightly') {
         $extVersion = "$extVersion-nightly.$BuildId"
     }
 }
-elseif ($effectiveBuildReason -eq 'PullRequest') {
+elseif ($BuildReason -eq 'PullRequest') {
     $effectivePullRequestNumber = if ([string]::IsNullOrWhiteSpace($PullRequestNumberOverride)) {
         $PullRequestNumber
     }


### PR DESCRIPTION
Fixes #9409

### Summary

This PR publishes an unsigned, self-contained bundle for each first-party extension PR pipeline and posts a direct install command on the pull request. It provides a safe way to share unmerged extension builds without manually transferring ZIP files or running a release pipeline that can create tags, GitHub releases, durable release artifacts, and registry updates.

PR publishing is separate from signing and official release publishing. Installing a bundle also leaves no temporary PR registry source on the tester's machine.

> [!IMPORTANT]
> This is currently gated on internal, which means the following extensions won't have the publish integration as they run in **azure-sdk/public**:
> 
> * azure.ai.agents
> * azure.ai.finetune
> * azure.coding-agents
> * microsoft.azd.ai.builder
> * microsoft.azd.concurx
> * microsoft.azd.demo
> * microsoft.azd.extensions

### Publishing and storage

The flow adapts the existing core CLI PR publishing pattern: prepare a pipeline artifact, upload it through a non-production 1ES deployment, then post tagged install instructions. Extensions add a packaging job because their six platform binaries must first be combined into one bundle.

- PR versions use `<version>-pr.<pr-number>.<build-id>`, or `<version>.pr.<pr-number>.<build-id>` when the base is already a prerelease.
- The pipeline packages the existing Linux, macOS, and Windows AMD64 and ARM64 artifacts with `azd x pack --bundle`.
- A non-production 1ES deployment uses the existing `Azure SDK Artifacts` service connection and `azcopy` authentication.
- Bundles are public block blobs in the `azuresdkartifacts` static website `$web` container at `azd/extensions/pr/<pr-number>/<sanitized-extension-id>.zip`.
- Each pipeline uploads one uniquely named bundle, allowing concurrent extension pipelines to share the PR folder without collisions.
- Upload uses `azcopy copy --overwrite=true`, replacing only that extension's previous bundle without deleting sibling blobs.
- Each tagged PR comment contains the unsigned-build warning, `azd ext install` command, version, and merge commit.
- The comment helper posts the replacement before deleting older tagged comments and fails closed on GitHub API errors.

Storage retention is managed outside this repository. The common `$web/azd/extensions/pr/` prefix allows EngSys to apply a lifecycle rule per blob, such as deletion after a configured number of days since its last modification. No PR-close cleanup job or lifecycle policy is added here.

This is the supported replacement needed before restricting off-main extension release publishing in #9408.

### Testing

- Ran 45 Pester tests covering stable, prerelease, override, error, and nightly versioning cases.
- Ran the generated internal extension pipeline scaffold test.
- Parsed the affected pipeline and workflow YAML and verified path filters across all 17 first-party extension pipelines.
- Exercised tagged-comment discovery and posting failure paths.
- Verified the generated comment Markdown and flattened bundle URL.
- Confirmed the internal Azure Pipelines run published bundles and posted extension-specific comments.
