### PR TITLE
fix(ai-agents): propagate local agent exit failures

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
@@ -38,6 +38,7 @@ import (
 const (
 	agentInspectorExtensionID     = "azure.ai.inspector"
 	agentInspectorReadyPollPeriod = 250 * time.Millisecond
+	windowsControlCExitCode       = 0xC000013A
 	// defaultInspectorUIPort mirrors the default UI port of the
 	// azure.ai.inspector extension. The inspector extension remains the source
 	// of truth for the actual default: when --inspector-port is unset we do not
@@ -364,7 +365,7 @@ func runRun(ctx context.Context, flags *runFlags, noPrompt bool) error {
 
 	err = proc.Wait()
 	close(done)
-	wasCanceled := ctx.Err() != nil
+	wasCanceled := ctx.Err() != nil || isAgentProcessCanceled(err)
 	cancel()
 	<-nextDone
 
@@ -378,6 +379,22 @@ func runRun(ctx context.Context, flags *runFlags, noPrompt bool) error {
 		return fmt.Errorf("agent exited: %w", err)
 	}
 	return nil
+}
+
+func isAgentProcessCanceled(err error) bool {
+	exitErr, ok := errors.AsType[*exec.ExitError](err)
+	if !ok {
+		return false
+	}
+
+	if waitStatus, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+		switch waitStatus.Signal() {
+		case syscall.SIGINT, syscall.SIGTERM:
+			return true
+		}
+	}
+
+	return uint32(exitErr.ExitCode()) == windowsControlCExitCode //nolint:gosec // preserve the Windows exit code bit pattern
 }
 
 func handleInspectorAutoLaunch(

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/run.go
@@ -364,11 +364,12 @@ func runRun(ctx context.Context, flags *runFlags, noPrompt bool) error {
 
 	err = proc.Wait()
 	close(done)
+	wasCanceled := ctx.Err() != nil
 	cancel()
 	<-nextDone
 
 	// Suppress the noisy "signal: interrupt" error on Ctrl+C
-	if ctx.Err() != nil {
+	if wasCanceled {
 		fmt.Println("Agent stopped.")
 		return nil
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/run_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/run_test.go
@@ -529,6 +529,72 @@ func TestRunRun_PortCollisionDoesNotClearStoredSession(t *testing.T) {
 	}
 }
 
+func TestRunRun_ReturnsAgentProcessExitError(t *testing.T) {
+	projectDir := t.TempDir()
+	projectServer := &helpersProjectServer{
+		project: &azdext.ProjectConfig{
+			Name: "test-project",
+			Path: projectDir,
+			Services: map[string]*azdext.ServiceConfig{
+				"agent": {
+					Name:         "agent",
+					Host:         AiAgentHost,
+					RelativePath: ".",
+				},
+			},
+		},
+	}
+
+	grpcServer := grpc.NewServer()
+	azdext.RegisterProjectServiceServer(grpcServer, projectServer)
+	azdext.RegisterUserConfigServiceServer(grpcServer, newInvokeUserConfigServer())
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = grpcServer.Serve(listener) }()
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		_ = listener.Close()
+	})
+	t.Setenv("AZD_SERVER", listener.Addr().String())
+	t.Setenv("AZD_AGENT_RUN_TEST_EXIT_CODE", "17")
+
+	agentListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve agent port: %v", err)
+	}
+	agentPort := agentListener.Addr().(*net.TCPAddr).Port
+	if err := agentListener.Close(); err != nil {
+		t.Fatalf("release agent port: %v", err)
+	}
+
+	startCommand := fmt.Sprintf(`"%s" -test.run=^TestRunRunHelperProcess$`, os.Args[0])
+	err = runRun(t.Context(), &runFlags{
+		name:         "agent",
+		port:         agentPort,
+		startCommand: startCommand,
+		noClient:     true,
+	}, true)
+	if err == nil || !strings.Contains(err.Error(), "agent exited: exit status 17") {
+		t.Fatalf("runRun() error = %v, want agent exit status 17", err)
+	}
+}
+
+func TestRunRunHelperProcess(t *testing.T) {
+	exitCodeValue := os.Getenv("AZD_AGENT_RUN_TEST_EXIT_CODE")
+	if exitCodeValue == "" {
+		return
+	}
+
+	exitCode, err := strconv.Atoi(exitCodeValue)
+	if err != nil {
+		t.Fatalf("parse helper exit code: %v", err)
+	}
+	os.Exit(exitCode)
+}
+
 func TestWarnInspectorPortIssues(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/run_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/run_test.go
@@ -530,6 +530,21 @@ func TestRunRun_PortCollisionDoesNotClearStoredSession(t *testing.T) {
 }
 
 func TestRunRun_ReturnsAgentProcessExitError(t *testing.T) {
+	err := runRunWithHelperProcess(t, "exit", "17")
+	if err == nil || !strings.Contains(err.Error(), "agent exited: exit status 17") {
+		t.Fatalf("runRun() error = %v, want agent exit status 17", err)
+	}
+}
+
+func TestRunRun_TreatsInterruptExitAsCancellation(t *testing.T) {
+	if err := runRunWithHelperProcess(t, "interrupt", ""); err != nil {
+		t.Fatalf("runRun() error = %v, want nil for interrupt exit", err)
+	}
+}
+
+func runRunWithHelperProcess(t *testing.T, mode string, exitCode string) error {
+	t.Helper()
+
 	projectDir := t.TempDir()
 	projectServer := &helpersProjectServer{
 		project: &azdext.ProjectConfig{
@@ -559,7 +574,8 @@ func TestRunRun_ReturnsAgentProcessExitError(t *testing.T) {
 		_ = listener.Close()
 	})
 	t.Setenv("AZD_SERVER", listener.Addr().String())
-	t.Setenv("AZD_AGENT_RUN_TEST_EXIT_CODE", "17")
+	t.Setenv("AZD_AGENT_RUN_TEST_HELPER_MODE", mode)
+	t.Setenv("AZD_AGENT_RUN_TEST_EXIT_CODE", exitCode)
 
 	agentListener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -571,21 +587,42 @@ func TestRunRun_ReturnsAgentProcessExitError(t *testing.T) {
 	}
 
 	startCommand := fmt.Sprintf(`"%s" -test.run=^TestRunRunHelperProcess$`, os.Args[0])
-	err = runRun(t.Context(), &runFlags{
+	return runRun(t.Context(), &runFlags{
 		name:         "agent",
 		port:         agentPort,
 		startCommand: startCommand,
 		noClient:     true,
 	}, true)
-	if err == nil || !strings.Contains(err.Error(), "agent exited: exit status 17") {
-		t.Fatalf("runRun() error = %v, want agent exit status 17", err)
-	}
 }
 
 func TestRunRunHelperProcess(t *testing.T) {
+	mode := os.Getenv("AZD_AGENT_RUN_TEST_HELPER_MODE")
+	if mode == "" {
+		return
+	}
+
+	if mode == "interrupt" {
+		if runtime.GOOS == "windows" {
+			exitCode := uint32(windowsControlCExitCode)
+			os.Exit(int(exitCode)) //nolint:gosec // preserve the Windows exit code bit pattern
+		}
+
+		time.AfterFunc(5*time.Second, func() {
+			os.Exit(99)
+		})
+		proc, err := os.FindProcess(os.Getpid())
+		if err != nil {
+			t.Fatalf("find helper process: %v", err)
+		}
+		if err := proc.Signal(os.Interrupt); err != nil {
+			t.Fatalf("interrupt helper process: %v", err)
+		}
+		select {}
+	}
+
 	exitCodeValue := os.Getenv("AZD_AGENT_RUN_TEST_EXIT_CODE")
 	if exitCodeValue == "" {
-		return
+		t.Fatalf("missing helper exit code for mode %q", mode)
 	}
 
 	exitCode, err := strconv.Atoi(exitCodeValue)


### PR DESCRIPTION
## Summary

- preserve the run context's cancellation state before cleanup cancellation
- return non-zero local agent process exits instead of reporting `Agent stopped.` successfully
- add a cross-platform regression test that runs a child process exiting with status 17

## Validation

- `go test ./internal/cmd`
- `go vet ./internal/cmd`

Fixes #9599