### PR TITLE
Support hosted agent session idle timeout in azure.yaml

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/README.md
+++ b/cli/azd/extensions/azure.ai.agents/README.md
@@ -133,6 +133,38 @@ Details:
 > the other inline agent properties such as `codeConfiguration` and
 > `environmentVariables`.
 
+## Session idle timeout
+
+A hosted agent's runtime sessions are torn down by Foundry after a period of
+inactivity. The default is 900 seconds. Override it with
+`sessionConfiguration.idleTimeoutSeconds` on the `azure.ai.agent` service entry
+in `azure.yaml`:
+
+```yaml
+services:
+  my-agent:
+    host: azure.ai.agent
+    project: .
+    kind: hosted
+    name: my-agent
+    sessionConfiguration:
+      idleTimeoutSeconds: 300
+```
+
+`sessionConfiguration` applies to both deploy modes — container images and code
+deploys (`codeConfiguration`) alike. It is optional; when omitted, the setting
+is left out of the service request and Foundry applies its default (900
+seconds).
+
+Details:
+
+- `idleTimeoutSeconds` must be between **300 and 3600** seconds (inclusive).
+  Values outside that range are rejected at deploy time and by schema
+  validation.
+- In the deprecated on-disk `agent.yaml` shape the keys are snake_case
+  (`session_configuration.idle_timeout_seconds`). In `azure.yaml` they are
+  camelCase, like the other inline agent properties.
+
 ## Session carry-over across deploys
 
 When a hosted agent is redeployed, Foundry assigns the agent a **new version** and

--- a/cli/azd/extensions/azure.ai.agents/README.md
+++ b/cli/azd/extensions/azure.ai.agents/README.md
@@ -135,8 +135,8 @@ Details:
 
 ## Session idle timeout
 
-A hosted agent's runtime sessions are torn down by Foundry after a period of
-inactivity. The default is 900 seconds. Override it with
+A hosted agent's runtime session sandbox is suspended by Foundry after a period
+of inactivity. The default is 900 seconds. Override it with
 `sessionConfiguration.idleTimeoutSeconds` on the `azure.ai.agent` service entry
 in `azure.yaml`:
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
@@ -244,6 +244,16 @@ type ContainerConfigurationAPI struct {
 	Image string `json:"image"`
 }
 
+// SessionConfigurationAPI represents the session_configuration block in the API request.
+// It controls hosted-agent session runtime behavior; when omitted the service applies
+// its own defaults.
+type SessionConfigurationAPI struct {
+	// IdleTimeoutSeconds maps to session_configuration.idle_timeout_seconds. Valid
+	// range is 300–3600 (inclusive). When the field is unset the whole
+	// session_configuration block is omitted and the service default (900) applies.
+	IdleTimeoutSeconds int `json:"idle_timeout_seconds"`
+}
+
 // HostedAgentDefinition represents a hosted agent that can be either container-based
 // (with ContainerConfiguration) or code-based (with CodeConfiguration).
 // Both deploy modes now use "protocol_versions" in the serialized JSON.
@@ -255,6 +265,7 @@ type HostedAgentDefinition struct {
 	EnvironmentVariables   map[string]string          `json:"environment_variables,omitempty"`
 	ContainerConfiguration *ContainerConfigurationAPI `json:"container_configuration,omitempty"` // container deploy only
 	CodeConfiguration      *CodeConfigurationAPI      `json:"code_configuration,omitempty"`      // code deploy only
+	SessionConfiguration   *SessionConfigurationAPI   `json:"session_configuration,omitempty"`   // optional session tuning
 	Image                  string                     `json:"image,omitempty"`                   // deprecated: for backward compat deserialization only
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
@@ -363,7 +363,6 @@ func convertFloat64ToFloat32(f64 *float64) *float32 {
 	return &f32
 }
 
-// CreateHostedAgentAPIRequest creates a CreateAgentRequest for hosted agents
 // mapSessionConfiguration converts the author-facing session configuration into
 // the API shape, validating the idle-timeout bounds. It returns nil when the
 // author omitted session configuration so session_configuration is left out of
@@ -376,13 +375,16 @@ func mapSessionConfiguration(sc *SessionConfiguration) (*agent_api.SessionConfig
 	idle := *sc.IdleTimeoutSeconds
 	if idle < MinSessionIdleTimeoutSeconds || idle > MaxSessionIdleTimeoutSeconds {
 		return nil, fmt.Errorf(
-			"sessionConfiguration.idleTimeoutSeconds must be between %d and %d seconds, got %d",
+			"session idle timeout must be between %d and %d seconds, got %d "+
+				"('sessionConfiguration.idleTimeoutSeconds' in azure.yaml, "+
+				"'session_configuration.idle_timeout_seconds' in agent.yaml)",
 			MinSessionIdleTimeoutSeconds, MaxSessionIdleTimeoutSeconds, idle)
 	}
 
 	return &agent_api.SessionConfigurationAPI{IdleTimeoutSeconds: idle}, nil
 }
 
+// CreateHostedAgentAPIRequest creates a CreateAgentRequest for hosted agents
 func CreateHostedAgentAPIRequest(hostedAgent ContainerAgent, buildConfig *AgentBuildConfig) (*agent_api.CreateAgentRequest, error) {
 	imageURL := hostedAgent.Image
 	cpu := "1"      // Default CPU

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map.go
@@ -364,6 +364,25 @@ func convertFloat64ToFloat32(f64 *float64) *float32 {
 }
 
 // CreateHostedAgentAPIRequest creates a CreateAgentRequest for hosted agents
+// mapSessionConfiguration converts the author-facing session configuration into
+// the API shape, validating the idle-timeout bounds. It returns nil when the
+// author omitted session configuration so session_configuration is left out of
+// the request and the service applies its default.
+func mapSessionConfiguration(sc *SessionConfiguration) (*agent_api.SessionConfigurationAPI, error) {
+	if sc == nil || sc.IdleTimeoutSeconds == nil {
+		return nil, nil
+	}
+
+	idle := *sc.IdleTimeoutSeconds
+	if idle < MinSessionIdleTimeoutSeconds || idle > MaxSessionIdleTimeoutSeconds {
+		return nil, fmt.Errorf(
+			"sessionConfiguration.idleTimeoutSeconds must be between %d and %d seconds, got %d",
+			MinSessionIdleTimeoutSeconds, MaxSessionIdleTimeoutSeconds, idle)
+	}
+
+	return &agent_api.SessionConfigurationAPI{IdleTimeoutSeconds: idle}, nil
+}
+
 func CreateHostedAgentAPIRequest(hostedAgent ContainerAgent, buildConfig *AgentBuildConfig) (*agent_api.CreateAgentRequest, error) {
 	imageURL := hostedAgent.Image
 	cpu := "1"      // Default CPU
@@ -401,6 +420,13 @@ func CreateHostedAgentAPIRequest(hostedAgent ContainerAgent, buildConfig *AgentB
 		}
 	}
 
+	// Map optional session configuration (validated); nil when omitted so the
+	// service applies its default.
+	sessionConfig, err := mapSessionConfiguration(hostedAgent.SessionConfiguration)
+	if err != nil {
+		return nil, err
+	}
+
 	// Code deploy path
 	if hostedAgent.CodeConfiguration != nil {
 		cmdPrefix := RuntimeCmdPrefix(hostedAgent.CodeConfiguration.Runtime)
@@ -428,6 +454,7 @@ func CreateHostedAgentAPIRequest(hostedAgent ContainerAgent, buildConfig *AgentB
 				EntryPoint:           entryPoint,
 				DependencyResolution: depRes,
 			},
+			SessionConfiguration: sessionConfig,
 		}
 
 		return createAgentAPIRequest(hostedAgent.AgentDefinition, codeDef,
@@ -451,6 +478,7 @@ func CreateHostedAgentAPIRequest(hostedAgent ContainerAgent, buildConfig *AgentB
 		ContainerConfiguration: &agent_api.ContainerConfigurationAPI{
 			Image: imageURL,
 		},
+		SessionConfiguration: sessionConfig,
 	}
 
 	return createAgentAPIRequest(hostedAgent.AgentDefinition, imageDef,

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
@@ -1729,3 +1729,138 @@ func TestMapRaiConfig(t *testing.T) {
 		t.Errorf("mapRaiConfig(p1) = %+v, want RaiPolicyName=p1", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Session configuration (idle timeout) mapping
+// ---------------------------------------------------------------------------
+
+func TestCreateHostedAgentAPIRequest_ContainerSessionConfiguration(t *testing.T) {
+	t.Parallel()
+	agent := ContainerAgent{
+		AgentDefinition:      AgentDefinition{Kind: AgentKindHosted, Name: "session-container"},
+		SessionConfiguration: &SessionConfiguration{IdleTimeoutSeconds: new(600)},
+	}
+
+	req, err := CreateHostedAgentAPIRequest(agent, &AgentBuildConfig{ImageURL: "img:latest"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	imgDef := req.Definition.(agent_api.HostedAgentDefinition)
+	if imgDef.SessionConfiguration == nil {
+		t.Fatal("expected SessionConfiguration to be set")
+	}
+	if imgDef.SessionConfiguration.IdleTimeoutSeconds != 600 {
+		t.Errorf("IdleTimeoutSeconds = %d, want 600", imgDef.SessionConfiguration.IdleTimeoutSeconds)
+	}
+}
+
+func TestCreateAgentAPIRequest_CodeDeploySessionConfiguration(t *testing.T) {
+	t.Parallel()
+	agent := ContainerAgent{
+		AgentDefinition: AgentDefinition{Kind: AgentKindHosted, Name: "session-code"},
+		CodeConfiguration: &CodeConfiguration{
+			Runtime:    "python_3_12",
+			EntryPoint: "main.py",
+		},
+		SessionConfiguration: &SessionConfiguration{IdleTimeoutSeconds: new(1200)},
+	}
+
+	req, err := CreateHostedAgentAPIRequest(agent, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	codeDef := req.Definition.(agent_api.HostedAgentDefinition)
+	if codeDef.CodeConfiguration == nil {
+		t.Fatal("expected code deploy path")
+	}
+	if codeDef.SessionConfiguration == nil || codeDef.SessionConfiguration.IdleTimeoutSeconds != 1200 {
+		t.Errorf("SessionConfiguration = %+v, want IdleTimeoutSeconds=1200", codeDef.SessionConfiguration)
+	}
+}
+
+func TestCreateHostedAgentAPIRequest_SessionConfigurationOmitted(t *testing.T) {
+	t.Parallel()
+	// Neither the whole block nor the idle timeout is set: session_configuration
+	// must be omitted so the service applies its default.
+	cases := map[string]*SessionConfiguration{
+		"nil block":        nil,
+		"nil idle timeout": {IdleTimeoutSeconds: nil},
+	}
+	for name, sc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			agent := ContainerAgent{
+				AgentDefinition:      AgentDefinition{Kind: AgentKindHosted, Name: "no-session"},
+				SessionConfiguration: sc,
+			}
+
+			req, err := CreateHostedAgentAPIRequest(agent, &AgentBuildConfig{ImageURL: "img:latest"})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			imgDef := req.Definition.(agent_api.HostedAgentDefinition)
+			if imgDef.SessionConfiguration != nil {
+				t.Errorf("expected SessionConfiguration to be nil, got %+v", imgDef.SessionConfiguration)
+			}
+
+			data, err := json.Marshal(imgDef)
+			if err != nil {
+				t.Fatalf("marshal error: %v", err)
+			}
+			if strings.Contains(string(data), "session_configuration") {
+				t.Errorf("session_configuration should be omitted from JSON, got %s", data)
+			}
+		})
+	}
+}
+
+func TestCreateHostedAgentAPIRequest_SessionIdleTimeoutBoundaries(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		seconds int
+		wantErr bool
+	}{
+		{name: "min valid", seconds: MinSessionIdleTimeoutSeconds},
+		{name: "max valid", seconds: MaxSessionIdleTimeoutSeconds},
+		{name: "mid valid", seconds: 900},
+		{name: "below min", seconds: MinSessionIdleTimeoutSeconds - 1, wantErr: true},
+		{name: "above max", seconds: MaxSessionIdleTimeoutSeconds + 1, wantErr: true},
+		{name: "zero", seconds: 0, wantErr: true},
+		{name: "negative", seconds: -1, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			agent := ContainerAgent{
+				AgentDefinition: AgentDefinition{Kind: AgentKindHosted, Name: "boundary"},
+				SessionConfiguration: &SessionConfiguration{
+					IdleTimeoutSeconds: new(test.seconds),
+				},
+			}
+
+			req, err := CreateHostedAgentAPIRequest(agent, &AgentBuildConfig{ImageURL: "img:latest"})
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %d seconds, got none", test.seconds)
+				}
+				if !strings.Contains(err.Error(), "idleTimeoutSeconds") {
+					t.Errorf("error = %q, want it to mention idleTimeoutSeconds", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %d seconds: %v", test.seconds, err)
+			}
+
+			imgDef := req.Definition.(agent_api.HostedAgentDefinition)
+			if imgDef.SessionConfiguration == nil ||
+				imgDef.SessionConfiguration.IdleTimeoutSeconds != test.seconds {
+				t.Errorf("IdleTimeoutSeconds = %+v, want %d", imgDef.SessionConfiguration, test.seconds)
+			}
+		})
+	}
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/map_test.go
@@ -1753,6 +1753,16 @@ func TestCreateHostedAgentAPIRequest_ContainerSessionConfiguration(t *testing.T)
 	if imgDef.SessionConfiguration.IdleTimeoutSeconds != 600 {
 		t.Errorf("IdleTimeoutSeconds = %d, want 600", imgDef.SessionConfiguration.IdleTimeoutSeconds)
 	}
+
+	// Assert the wire payload so a wrong JSON tag can't slip through: the struct
+	// check above passes regardless of the tag, but the service reads the JSON.
+	data, err := json.Marshal(imgDef)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if !strings.Contains(string(data), `"session_configuration":{"idle_timeout_seconds":600}`) {
+		t.Errorf("wire payload missing session_configuration.idle_timeout_seconds, got %s", data)
+	}
 }
 
 func TestCreateAgentAPIRequest_CodeDeploySessionConfiguration(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
@@ -252,8 +252,8 @@ const (
 
 // SessionConfiguration configures the runtime session behavior of a hosted agent.
 type SessionConfiguration struct {
-	// IdleTimeoutSeconds is the number of seconds a session may stay idle before
-	// the service tears it down. Valid range is 300–3600 (inclusive). When nil,
+	// IdleTimeoutSeconds is the idle duration, in seconds, before a session's
+	// sandbox is suspended. Valid range is 300–3600 (inclusive). When nil,
 	// session_configuration is omitted from the request and the service default
 	// (900 seconds) applies.
 	IdleTimeoutSeconds *int `json:"idleTimeoutSeconds,omitempty" yaml:"idle_timeout_seconds,omitempty"`

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
@@ -240,6 +240,25 @@ type CodeConfiguration struct {
 // default as `azd ai agent init --dep-resolution`).
 const DefaultDependencyResolution = "remote_build"
 
+// Session idle-timeout bounds (in seconds) for a hosted agent, matching the
+// upstream HostedAgentDefinition.session_configuration.idle_timeout_seconds
+// contract. When omitted, the service applies its own default.
+const (
+	// MinSessionIdleTimeoutSeconds is the smallest accepted idle timeout.
+	MinSessionIdleTimeoutSeconds = 300
+	// MaxSessionIdleTimeoutSeconds is the largest accepted idle timeout.
+	MaxSessionIdleTimeoutSeconds = 3600
+)
+
+// SessionConfiguration configures the runtime session behavior of a hosted agent.
+type SessionConfiguration struct {
+	// IdleTimeoutSeconds is the number of seconds a session may stay idle before
+	// the service tears it down. Valid range is 300–3600 (inclusive). When nil,
+	// session_configuration is omitted from the request and the service default
+	// (900 seconds) applies.
+	IdleTimeoutSeconds *int `json:"idleTimeoutSeconds,omitempty" yaml:"idle_timeout_seconds,omitempty"`
+}
+
 // PolicyType identifies the kind of governance policy attached to a hosted agent.
 type PolicyType string
 
@@ -278,6 +297,7 @@ type ContainerAgent struct {
 	AgentCard            *AgentCard              `json:"agentCard,omitempty" yaml:"agent_card,omitempty"`
 	CodeConfiguration    *CodeConfiguration      `json:"codeConfiguration,omitempty" yaml:"code_configuration,omitempty"`
 	Policies             []Policy                `json:"policies,omitempty" yaml:"policies,omitempty"`
+	SessionConfiguration *SessionConfiguration   `json:"sessionConfiguration,omitempty" yaml:"session_configuration,omitempty"`
 }
 
 // AgentManifest The following represents a manifest that can be used to create agents dynamically.

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agent_definition.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agent_definition.go
@@ -134,6 +134,7 @@ type AgentDefinitionInline struct {
 	AgentCard            *agent_yaml.AgentCard             `json:"agentCard,omitempty"`
 	CodeConfiguration    *agent_yaml.CodeConfiguration     `json:"codeConfiguration,omitempty"`
 	Policies             []agent_yaml.Policy               `json:"policies,omitempty"`
+	SessionConfiguration *agent_yaml.SessionConfiguration  `json:"sessionConfiguration,omitempty"`
 
 	// Voice-agent fields (kind: prompt-voice). All omitempty so container/
 	// workflow entries are byte-for-byte unchanged.
@@ -175,12 +176,13 @@ func (d AgentDefinitionInline) toVoiceAgent() agent_yaml.VoiceAgent {
 // returned separately so the caller can place them on their respective homes.
 func agentDefinitionToInline(ca agent_yaml.ContainerAgent) (AgentDefinitionInline, *ContainerSettings, string) {
 	inline := AgentDefinitionInline{
-		AgentDefinition:   ca.AgentDefinition,
-		Protocols:         ca.Protocols,
-		AgentEndpoint:     ca.AgentEndpoint,
-		AgentCard:         ca.AgentCard,
-		CodeConfiguration: ca.CodeConfiguration,
-		Policies:          ca.Policies,
+		AgentDefinition:      ca.AgentDefinition,
+		Protocols:            ca.Protocols,
+		AgentEndpoint:        ca.AgentEndpoint,
+		AgentCard:            ca.AgentCard,
+		CodeConfiguration:    ca.CodeConfiguration,
+		Policies:             ca.Policies,
+		SessionConfiguration: ca.SessionConfiguration,
 	}
 
 	var container *ContainerSettings
@@ -222,6 +224,7 @@ func (d AgentDefinitionInline) toContainerAgent(
 		AgentCard:            d.AgentCard,
 		CodeConfiguration:    d.CodeConfiguration,
 		Policies:             d.Policies,
+		SessionConfiguration: d.SessionConfiguration,
 	}
 
 	if container != nil && container.Resources != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agent_definition_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agent_definition_test.go
@@ -94,6 +94,30 @@ func TestAgentDefinitionRoundTrip(t *testing.T) {
 	require.Equal(t, "1", cfg.Container.Resources.Cpu)
 }
 
+// TestAgentDefinitionRoundTrip_SessionConfiguration verifies the optional
+// sessionConfiguration.idleTimeoutSeconds survives the inline marshal/unmarshal.
+func TestAgentDefinitionRoundTrip_SessionConfiguration(t *testing.T) {
+	ca := sampleContainerAgent()
+	ca.SessionConfiguration = &agent_yaml.SessionConfiguration{IdleTimeoutSeconds: new(600)}
+
+	props, err := AgentDefinitionToServiceProperties(ca, nil)
+	require.NoError(t, err)
+
+	svc := &azdext.ServiceConfig{
+		Name:                 "basic-agent",
+		Host:                 "azure.ai.agent",
+		AdditionalProperties: props,
+		Environment:          AgentEnvironment(ca),
+	}
+
+	got, _, found, _, err := AgentDefinitionFromService(svc)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NotNil(t, got.SessionConfiguration)
+	require.NotNil(t, got.SessionConfiguration.IdleTimeoutSeconds)
+	require.Equal(t, 600, *got.SessionConfiguration.IdleTimeoutSeconds)
+}
+
 // TestAgentDefinitionFromService_LegacyConfigShape verifies that a definition
 // stored under the deprecated config-nested shape is detected as legacy.
 func TestAgentDefinitionFromService_LegacyConfigShape(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/doc_examples_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/doc_examples_test.go
@@ -792,6 +792,39 @@ func TestDocSchemaValidatesConstraints(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "session idle timeout min valid",
+			mutate: func(value *fixture) {
+				value.value["sessionConfiguration"] = map[string]any{"idleTimeoutSeconds": 300}
+			},
+		},
+		{
+			name: "session idle timeout max valid",
+			mutate: func(value *fixture) {
+				value.value["sessionConfiguration"] = map[string]any{"idleTimeoutSeconds": 3600}
+			},
+		},
+		{
+			name: "session idle timeout below min",
+			mutate: func(value *fixture) {
+				value.value["sessionConfiguration"] = map[string]any{"idleTimeoutSeconds": 299}
+			},
+			wantErr: true,
+		},
+		{
+			name: "session idle timeout above max",
+			mutate: func(value *fixture) {
+				value.value["sessionConfiguration"] = map[string]any{"idleTimeoutSeconds": 3601}
+			},
+			wantErr: true,
+		},
+		{
+			name: "session idle timeout unknown property",
+			mutate: func(value *fixture) {
+				value.value["sessionConfiguration"] = map[string]any{"idleTimeoutMinutes": 5}
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
@@ -131,6 +131,19 @@
                   }
                 }
               }
+            },
+            "sessionConfiguration": {
+              "type": "object",
+              "description": "Optional hosted-agent session runtime settings. When omitted, the service applies its defaults (idle timeout 900 seconds).",
+              "additionalProperties": false,
+              "properties": {
+                "idleTimeoutSeconds": {
+                  "type": "integer",
+                  "description": "Seconds a session may stay idle before the service tears it down. Range 300–3600 (inclusive). Defaults to 900 when omitted.",
+                  "minimum": 300,
+                  "maximum": 3600
+                }
+              }
             }
           }
         }

--- a/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
@@ -139,7 +139,7 @@
               "properties": {
                 "idleTimeoutSeconds": {
                   "type": "integer",
-                  "description": "Seconds a session may stay idle before the service tears it down. Range 300–3600 (inclusive). Defaults to 900 when omitted.",
+                  "description": "Idle duration in seconds before a session's sandbox is suspended. Range 300–3600 (inclusive). Defaults to 900 when omitted.",
                   "minimum": 300,
                   "maximum": 3600
                 }

--- a/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
@@ -107,6 +107,9 @@
     "codeConfiguration": {
       "$ref": "#/definitions/CodeConfiguration"
     },
+    "sessionConfiguration": {
+      "$ref": "#/definitions/SessionConfiguration"
+    },
     "policies": {
       "type": "array",
       "description": "Governance policies attached to the agent (e.g., Responsible AI).",
@@ -158,6 +161,19 @@
         "dependencyResolution": { "type": "string", "description": "Dependency resolution mode (e.g., 'bundled', 'remote_build')." }
       },
       "required": ["runtime", "entryPoint"],
+      "additionalProperties": false
+    },
+    "SessionConfiguration": {
+      "type": "object",
+      "description": "Optional hosted-agent session runtime settings. When omitted, the service applies its defaults (idle timeout 900 seconds).",
+      "properties": {
+        "idleTimeoutSeconds": {
+          "type": "integer",
+          "description": "Seconds a session may stay idle before the service tears it down. Range 300–3600 (inclusive). Defaults to 900 when omitted.",
+          "minimum": 300,
+          "maximum": 3600
+        }
+      },
       "additionalProperties": false
     },
     "Policy": {

--- a/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
@@ -169,7 +169,7 @@
       "properties": {
         "idleTimeoutSeconds": {
           "type": "integer",
-          "description": "Seconds a session may stay idle before the service tears it down. Range 300–3600 (inclusive). Defaults to 900 when omitted.",
+          "description": "Idle duration in seconds before a session's sandbox is suspended. Range 300–3600 (inclusive). Defaults to 900 when omitted.",
           "minimum": 300,
           "maximum": 3600
         }


### PR DESCRIPTION
## Summary

Adds support in the `azure.ai.agents` extension for configuring `HostedAgentDefinition.session_configuration.idle_timeout_seconds` from `azure.yaml`.

Users can now set the session idle timeout on a hosted agent service:

```yaml
services:
  my-agent:
    host: azure.ai.agent
    project: .
    kind: hosted
    name: my-agent
    sessionConfiguration:
      idleTimeoutSeconds: 300
```

The value is validated against the upstream contract (optional `int32`, range **300–3600** seconds inclusive) and mapped to `HostedAgentDefinition.session_configuration.idle_timeout_seconds`. When omitted, `session_configuration` is left out of the service request so the service applies its default (900 seconds).

Upstream API spec: Azure/azure-rest-api-specs#45103

## Changes

- **`agent_yaml/yaml.go`** — new `SessionConfiguration` type + field on `ContainerAgent`; `Min/MaxSessionIdleTimeoutSeconds` (300/3600) constants.
- **`agent_api/models.go`** — new `SessionConfigurationAPI` + `session_configuration` field (`omitempty`) on `HostedAgentDefinition`.
- **`agent_yaml/map.go`** — `mapSessionConfiguration` validates the range and is wired into **both** code and container deploy paths in `CreateHostedAgentAPIRequest`.
- **`project/agent_definition.go`** — `AgentDefinitionInline` field + round-trip wiring (`agentDefinitionToInline` / `toContainerAgent`).
- **`schemas/azure.ai.agent.json`** and **`schemas/Agent.json`** — new `sessionConfiguration.idleTimeoutSeconds` (integer, min 300, max 3600, `additionalProperties: false`).
- **`README.md`** — new "Session idle timeout" section.

## Behavior

- Works for both code-based and container-based hosted deployments.
- Omitting the setting preserves current behavior (no `session_configuration` in the request).
- camelCase in `azure.yaml` (`sessionConfiguration.idleTimeoutSeconds`); snake_case in the deprecated on-disk `agent.yaml` (`session_configuration.idle_timeout_seconds`), consistent with other properties.

## Tests

- Request mapping for container and code deploy paths.
- Omission (nil block + nil timeout) → `session_configuration` absent from JSON.
- Boundary values (300 / 3600 valid; 299 / 3601 / 0 / -1 rejected).
- Schema validation constraints, including `additionalProperties: false`.
- Inline azure.yaml round-trip.
- New README example validated by `TestDocExamplesAreValid`.

Full extension test suite, `gofmt`, and `golangci-lint` all pass.

Fixes #9602