### PR TITLE
fix: preserve hosted agent service errors across gRPC

### DIFF
--- a/cli/azd/.vscode/cspell.yaml
+++ b/cli/azd/.vscode/cspell.yaml
@@ -84,6 +84,7 @@ words:
   - protoreflect
   - SNAPPROCESS
   - structpb
+  - statuspb
   - subtest
   - subtests
   - syncmap

--- a/cli/azd/internal/grpcserver/errors.go
+++ b/cli/azd/internal/grpcserver/errors.go
@@ -78,7 +78,7 @@ func hostErrorStatus(
 	}
 
 	statusProto := proto.Clone(existingStatus.Proto()).(*statuspb.Status)
-	statusProto.Code = int32(code)
+	statusProto.Code = int32(code) //nolint:gosec // gRPC status codes use the defined int32 range
 	statusProto.Message = message
 	return status.FromProto(statusProto)
 }

--- a/cli/azd/internal/grpcserver/errors.go
+++ b/cli/azd/internal/grpcserver/errors.go
@@ -8,12 +8,15 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/azure/azure-dev/cli/azd/internal"
 	"github.com/azure/azure-dev/cli/azd/pkg/auth"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // mapHostError serializes a host-originated Go error into a gRPC status error for transport
@@ -36,27 +39,97 @@ func mapHostError(err error) error {
 
 	suggestionErr, hasSuggestion := errors.AsType[*internal.ErrorWithSuggestion](err)
 	isAuthErr := isAuthError(err)
-	if !hasSuggestion && !isAuthErr {
+	responseErr, hasResponseError := errors.AsType[*azcore.ResponseError](err)
+	existingStatus, hasExistingStatus := azdext.GRPCStatusFromError(err)
+	if !hasSuggestion && !isAuthErr && !hasResponseError {
 		return err
 	}
 
 	code := codes.Unknown
-	if st, ok := azdext.GRPCStatusFromError(err); ok {
-		code = st.Code()
+	if hasExistingStatus {
+		code = existingStatus.Code()
 	}
 	if isAuthErr {
 		code = codes.Unauthenticated
 	}
 
-	st := status.New(code, statusMessage(err, suggestionErr))
+	st := hostErrorStatus(existingStatus, hasExistingStatus, code, statusMessage(err, suggestionErr))
 	if isAuthErr {
 		st = withAuthErrorInfo(st, err)
 	}
 	if hasSuggestion {
 		st = withActionableErrorDetail(st, suggestionErr)
 	}
+	if hasResponseError && !hasServiceErrorDetail(st) {
+		st = withServiceErrorDetail(st, responseErr)
+	}
 
 	return st.Err()
+}
+
+func hostErrorStatus(
+	existingStatus *status.Status,
+	hasExistingStatus bool,
+	code codes.Code,
+	message string,
+) *status.Status {
+	if !hasExistingStatus {
+		return status.New(code, message)
+	}
+
+	statusProto := proto.Clone(existingStatus.Proto()).(*statuspb.Status)
+	statusProto.Code = int32(code)
+	statusProto.Message = message
+	return status.FromProto(statusProto)
+}
+
+func hasServiceErrorDetail(st *status.Status) bool {
+	if st == nil {
+		return false
+	}
+
+	for _, detail := range st.Details() {
+		if _, ok := detail.(*azdext.ServiceErrorDetail); ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func withServiceErrorDetail(st *status.Status, responseErr *azcore.ResponseError) *status.Status {
+	if st == nil || responseErr == nil {
+		return st
+	}
+
+	detail := &azdext.ServiceErrorDetail{
+		ErrorCode:   responseErr.ErrorCode,
+		StatusCode:  int32(responseErr.StatusCode), //nolint:gosec // HTTP status codes fit in int32
+		ServiceName: responseErrorServiceName(responseErr),
+	}
+	withDetails, detailErr := st.WithDetails(detail)
+	if detailErr != nil {
+		log.Printf("failed to attach service error detail to gRPC status: %v", detailErr)
+		return st
+	}
+
+	return withDetails
+}
+
+func responseErrorServiceName(responseErr *azcore.ResponseError) string {
+	if responseErr == nil || responseErr.RawResponse == nil || responseErr.RawResponse.Request == nil {
+		return ""
+	}
+
+	request := responseErr.RawResponse.Request
+	if request.Host != "" {
+		return request.Host
+	}
+	if request.URL != nil {
+		return request.URL.Hostname()
+	}
+
+	return ""
 }
 
 // statusMessage returns the user-facing message that should populate status.Message.

--- a/cli/azd/internal/grpcserver/server_test.go
+++ b/cli/azd/internal/grpcserver/server_test.go
@@ -11,8 +11,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -460,6 +463,175 @@ func Test_mapHostError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMapHostError_ResponseErrorPreservesServiceDetails(t *testing.T) {
+	t.Parallel()
+
+	responseErr := &azcore.ResponseError{
+		StatusCode: http.StatusTooManyRequests,
+		ErrorCode:  "TooManyRequests",
+		RawResponse: &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Request: &http.Request{
+				Host: "registry.azurecr.io",
+				URL:  &url.URL{Scheme: "https", Host: "registry.azurecr.io"},
+			},
+		},
+	}
+
+	mapped := mapHostError(responseErr)
+	st, ok := status.FromError(mapped)
+	require.True(t, ok)
+	require.Equal(t, codes.Unknown, st.Code())
+
+	detail := requireServiceErrorDetail(t, st)
+	require.Equal(t, "TooManyRequests", detail.GetErrorCode())
+	require.Equal(t, int32(http.StatusTooManyRequests), detail.GetStatusCode())
+	require.Equal(t, "registry.azurecr.io", detail.GetServiceName())
+}
+
+func TestMapHostError_ResponseErrorUsesURLHostname(t *testing.T) {
+	t.Parallel()
+
+	responseErr := &azcore.ResponseError{
+		StatusCode: http.StatusForbidden,
+		ErrorCode:  "AuthorizationFailed",
+		RawResponse: &http.Response{
+			StatusCode: http.StatusForbidden,
+			Request: &http.Request{
+				URL: &url.URL{
+					Scheme: "https",
+					Host:   "management.azure.com",
+					Path:   "/subscriptions/redacted",
+				},
+			},
+		},
+	}
+
+	st, ok := status.FromError(mapHostError(responseErr))
+	require.True(t, ok)
+
+	detail := requireServiceErrorDetail(t, st)
+	require.Equal(t, "management.azure.com", detail.GetServiceName())
+}
+
+func TestMapHostError_ResponseErrorPreservesExistingDetails(t *testing.T) {
+	t.Parallel()
+
+	responseErr := &azcore.ResponseError{
+		StatusCode: http.StatusForbidden,
+		ErrorCode:  "AuthorizationFailed",
+		RawResponse: &http.Response{
+			StatusCode: http.StatusForbidden,
+			Request: &http.Request{
+				Host: "management.azure.com",
+				URL:  &url.URL{Scheme: "https", Host: "management.azure.com"},
+			},
+		},
+	}
+	baseStatus, err := status.New(codes.Unavailable, "service unavailable").WithDetails(
+		&errdetails.ErrorInfo{Reason: "existing-detail"},
+	)
+	require.NoError(t, err)
+
+	wrapped := &internal.ErrorWithSuggestion{
+		Err:        &hostErrorChain{error: responseErr, status: baseStatus},
+		Message:    "request failed",
+		Suggestion: "try again later",
+	}
+
+	st, ok := status.FromError(mapHostError(wrapped))
+	require.True(t, ok)
+	require.Equal(t, codes.Unavailable, st.Code())
+	require.Equal(t, "request failed", st.Message())
+	require.Equal(t, "existing-detail", requireErrorInfo(t, st).GetReason())
+	require.Equal(t, "try again later", azdext.ActionableErrorDetailFromStatus(st).GetSuggestion())
+
+	detail := requireServiceErrorDetail(t, st)
+	require.Equal(t, "AuthorizationFailed", detail.GetErrorCode())
+	require.Equal(t, int32(http.StatusForbidden), detail.GetStatusCode())
+}
+
+func TestMapHostError_DoesNotDuplicateExistingServiceDetails(t *testing.T) {
+	t.Parallel()
+
+	baseStatus, err := status.New(codes.Unknown, "request failed").WithDetails(
+		&azdext.ServiceErrorDetail{
+			ErrorCode:   "AlreadyStructured",
+			StatusCode:  http.StatusBadGateway,
+			ServiceName: "management.azure.com",
+		},
+	)
+	require.NoError(t, err)
+
+	wrapped := &internal.ErrorWithSuggestion{
+		Err:        baseStatus.Err(),
+		Suggestion: "try again later",
+	}
+
+	st, ok := status.FromError(mapHostError(wrapped))
+	require.True(t, ok)
+	require.Len(t, serviceErrorDetails(st), 1)
+	require.Equal(t, "AlreadyStructured", requireServiceErrorDetail(t, st).GetErrorCode())
+}
+
+func TestMapHostError_ResponseErrorWithoutRawResponse(t *testing.T) {
+	t.Parallel()
+
+	responseErr := &azcore.ResponseError{
+		StatusCode: http.StatusBadGateway,
+		ErrorCode:  "BadGateway",
+	}
+
+	st, ok := status.FromError(mapHostError(responseErr))
+	require.True(t, ok)
+
+	detail := requireServiceErrorDetail(t, st)
+	require.Equal(t, "BadGateway", detail.GetErrorCode())
+	require.Equal(t, int32(http.StatusBadGateway), detail.GetStatusCode())
+	require.Empty(t, detail.GetServiceName())
+}
+
+type hostErrorChain struct {
+	error
+	status *status.Status
+}
+
+func (e *hostErrorChain) Unwrap() error {
+	return e.error
+}
+
+func (e *hostErrorChain) GRPCStatus() *status.Status {
+	return e.status
+}
+
+func serviceErrorDetails(st *status.Status) []*azdext.ServiceErrorDetail {
+	var result []*azdext.ServiceErrorDetail
+	for _, detail := range st.Details() {
+		if serviceDetail, ok := detail.(*azdext.ServiceErrorDetail); ok {
+			result = append(result, serviceDetail)
+		}
+	}
+	return result
+}
+
+func requireServiceErrorDetail(t *testing.T, st *status.Status) *azdext.ServiceErrorDetail {
+	t.Helper()
+	details := serviceErrorDetails(st)
+	require.Len(t, details, 1)
+	return details[0]
+}
+
+func requireErrorInfo(t *testing.T, st *status.Status) *errdetails.ErrorInfo {
+	t.Helper()
+	for _, detail := range st.Details() {
+		if info, ok := detail.(*errdetails.ErrorInfo); ok {
+			return info
+		}
+	}
+	require.FailNow(t, "expected ErrorInfo detail")
+	return nil
 }
 
 func requireAuthErrorInfo(t *testing.T, st *status.Status) *errdetails.ErrorInfo {


### PR DESCRIPTION
Closes: #9616 

## Summary

- Preserve `azcore.ResponseError` metadata when host errors cross the extension gRPC boundary.
- Reuse the existing `ServiceErrorDetail` to carry the provider error code, HTTP status, and request hostname.
- Keep existing gRPC status codes and details, including auth and actionable error details.

## Telemetry impact

This allows the existing `azure.ai.agents` error handling and telemetry classifier to emit the existing `ext.service.*` classification for structured Azure service errors instead of falling back to `ext.internal.container_*` when metadata was lost at the core boundary.

No new telemetry properties, protobuf fields, or `error.category` values are introduced. The existing fallback remains for generic Docker/Podman, local code/folder, and tool errors that do not carry an `azcore.ResponseError`.

## Compatibility

- Older extensions continue to receive the existing gRPC status message.
- Newer extensions receive the existing `ServiceErrorDetail` when the source error is an `azcore.ResponseError`.
- Existing `ServiceErrorDetail` instances are not duplicated.
- Response bodies, request paths, query strings, headers, and resource identifiers are not added to the structured detail.
