### PR TITLE
[TEMP - do not merge] eval extension review slice 2/2: command surface

### DIFF
--- a/cli/azd/extensions/azure.ai.evaluations/.gitignore
+++ b/cli/azd/extensions/azure.ai.evaluations/.gitignore
@@ -1,0 +1,5 @@
+# Test report written by ci-test.ps1 for the pipeline to publish.
+junitTestReport.xml
+
+# Debug log written when --debug or AZD_EXT_DEBUG is set.
+azd-ai-eval-*.log

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/agent_context_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/agent_context_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The generation spec names an instructions file relative to itself, not to the
+// working directory, so `generate --config <elsewhere>` reads the same file the
+// author sees next to the spec.
+func TestDeclaredInstructions_ResolvesRelativeToTheSpec(t *testing.T) {
+	dir := t.TempDir()
+	specDir := filepath.Join(dir, "evals")
+	require.NoError(t, os.MkdirAll(filepath.Join(specDir, "agent"), 0o750))
+
+	body := "Answer only from the product catalog."
+	require.NoError(t, os.WriteFile(
+		filepath.Join(specDir, "agent", "instructions.md"), []byte("  "+body+"\n"), 0o600))
+
+	got, err := declaredInstructions(
+		"./agent/instructions.md", filepath.Join(specDir, "generate.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, body, got, "the file's contents should be used, trimmed")
+}
+
+// A path can be declared before that file exists. Treating the gap as an error
+// would break the flow `init` itself scaffolds.
+func TestDeclaredInstructions_MissingFileIsNotAnError(t *testing.T) {
+	got, err := declaredInstructions(
+		"./agent/instructions.md", filepath.Join(t.TempDir(), "generate.yaml"))
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestDeclaredInstructions_UnsetIsEmpty(t *testing.T) {
+	got, err := declaredInstructions("", "generate.yaml")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// Only the newest version is read, and an agent with no published version must
+// not panic the caller.
+func TestAgentInstructions(t *testing.T) {
+	var agent eval_api.Agent
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "support",
+      "versions": { "latest": { "version": "2", "definition": {
+        "model": "gpt-5-mini",
+        "instructions": "  You are a support assistant.\n" } } }
+    }`), &agent))
+	assert.Equal(t, "You are a support assistant.", agent.Instructions())
+
+	var empty eval_api.Agent
+	require.NoError(t, json.Unmarshal([]byte(`{"name":"x","versions":{}}`), &empty))
+	assert.Empty(t, empty.Instructions(), "an agent with no published version has no instructions")
+
+	var nilAgent *eval_api.Agent
+	assert.Empty(t, nilAgent.Instructions())
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/apiversions.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/apiversions.go
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+// API versions used by the Foundry data plane.
+const (
+	// ProjectEndpointAPIVersion covers datasets, evaluators, and evaluator
+	// generation jobs on the project endpoint.
+	ProjectEndpointAPIVersion = "2025-11-15-preview"
+
+	// DataGenerationAPIVersion covers dataset generation jobs.
+	DataGenerationAPIVersion = "v1"
+
+	// OpenAI-compatible eval and run calls send no api-version, so there
+	// is deliberately no constant for them.
+)

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/asset_name_parity_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/asset_name_parity_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every verb that takes a <name> refuses an invalid one locally.
+//
+// The guard was written for the dataset verbs and never reached the evaluator
+// ones, so `azd ai eval dataset show "my set"` explained itself and
+// `azd ai eval evaluator show "my rubric"` returned the service's 400 wrapped
+// in four levels of JSON. Walking the tree rather than listing the verbs is
+// the point: a verb added later is covered without anyone remembering to.
+func TestEveryNamedAssetVerbRefusesAnInvalidName(t *testing.T) {
+	const badName = "has space"
+
+	var walk func(cmd *cobra.Command, path string)
+	checked := 0
+
+	walk = func(cmd *cobra.Command, path string) {
+		for _, sub := range cmd.Commands() {
+			walk(sub, strings.TrimSpace(path+" "+sub.Name()))
+		}
+		if cmd.RunE == nil || !strings.Contains(cmd.Use, "<name>") {
+			return
+		}
+
+		checked++
+		// The guard has to come first: it runs before the client is built, so
+		// a mistyped name costs neither a round trip nor an azd connection.
+		err := cmd.RunE(cmd, []string{badName})
+		require.Errorf(t, err, "%s accepted %q", path, badName)
+		assert.Containsf(t, err.Error(), "is invalid",
+			"%s refused %q, but not by naming the name", path, badName)
+	}
+
+	walk(newDatasetCommand(), "dataset")
+	walk(newEvaluatorCommand(), "evaluator")
+
+	assert.GreaterOrEqual(t, checked, 8,
+		"both command groups take a name on create, update, show, delete and versions list")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/build.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/build.go
@@ -1,0 +1,440 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/pkg/evalcore"
+	"azureaieval/internal/project"
+)
+
+// evaluatorSchemas indexes the published contract of every evaluator a group
+// can reference.
+//
+// Built-ins have to be asked for separately. An unfiltered list returns only
+// the project's own evaluators, so relying on it leaves every built-in without
+// a schema and falling back to legacyInputs — which happens to match
+// query/response and so looks right for the common evaluators while quietly
+// dropping the fields anything else needs.
+//
+// A failure is deliberately not fatal: without schemas the builder falls back
+// to the agent-target shape, which is what it always used to send.
+func (ec *evalContext) evaluatorSchemas(ctx context.Context) map[string]*eval_api.EvaluatorSummary {
+	if ec.schemas != nil {
+		return ec.schemas
+	}
+
+	index := map[string]*eval_api.EvaluatorSummary{}
+	complete := true
+	for _, filter := range []string{"", eval_api.EvaluatorTypeBuiltin} {
+		list, err := ec.evalClient.ListEvaluators(ctx, filter, ProjectEndpointAPIVersion)
+		if err != nil {
+			complete = false
+			continue
+		}
+		maps.Copy(index, list.ByName())
+	}
+	if len(index) == 0 {
+		return nil
+	}
+	// Only a complete read is worth keeping. Caching a half of it would leave
+	// every later eval validating against legacyInputs, which accepts fields
+	// the evaluator never declared.
+	if complete {
+		ec.schemas = index
+	}
+	return index
+}
+
+// sampleBindings are the fields an agent target produces at run time. Anything
+// an evaluator accepts that is not in this set has to come from a dataset
+// column instead.
+var sampleBindings = map[string]string{
+	"response":         "{{sample.output_items}}",
+	"tool_calls":       "{{sample.tool_calls}}",
+	"tool_definitions": "{{sample.tool_definitions}}",
+}
+
+// sampleBindingsFor returns the run-time bindings a target of this kind can
+// satisfy. An empty target kind means nothing is invoked, so nothing is bound.
+//
+// A model target gets none: a model answers as plain text and calls no tools,
+// so binding an agent's richer output would leave the evaluator waiting on
+// fields the run never produces.
+func sampleBindingsFor(targetType string) map[string]string {
+	if targetType == project.TargetTypeAgent {
+		return sampleBindings
+	}
+	return nil
+}
+
+// legacyInputs is the mapping used when the service publishes no schema for an
+// evaluator, which is the case for freshly uploaded custom evaluators. It
+// matches the agent-target shape.
+var legacyInputs = []string{"query", "response", "tool_calls", "tool_definitions"}
+
+// criterionPlan is the resolved binding for one evaluator.
+type criterionPlan struct {
+	dataMapping map[string]string
+	initParams  map[string]any
+	// itemFields are the fields sourced from dataset columns; they have to be
+	// declared in the item schema.
+	itemFields []string
+}
+
+// conversationField carries a whole conversation. The service rejects a
+// mapping that pairs it with the turn-level fields:
+//
+//	Evaluator 'builtin.task_completion' has both 'messages' and
+//	'query'/'response' in data_mapping. Use 'messages' for conversation-level
+//	evaluation or 'query'/'response' for turn-level evaluation, but not both.
+const conversationField = "messages"
+
+// turnFields are the per-turn counterparts to conversationField.
+var turnFields = []string{"query", "response"}
+
+// selectLevelFields resolves the conversation/turn exclusivity for evaluators
+// that accept both shapes, keeping whichever matches the evaluation level.
+// Required fields are never dropped, so a genuine conflict still surfaces as a
+// missing-field error rather than being silently reshaped.
+func selectLevelFields(accepted, required []string, level string) []string {
+	isRequired := make(map[string]bool, len(required))
+	for _, name := range required {
+		isRequired[name] = true
+	}
+
+	acceptsConversation := false
+	acceptsTurn := false
+	for _, field := range accepted {
+		if field == conversationField {
+			acceptsConversation = true
+		}
+		for _, turn := range turnFields {
+			if field == turn {
+				acceptsTurn = true
+			}
+		}
+	}
+	if !acceptsConversation || !acceptsTurn {
+		return accepted
+	}
+
+	drop := map[string]bool{}
+	if strings.EqualFold(level, project.EvaluationLevelConversation) {
+		for _, turn := range turnFields {
+			drop[turn] = true
+		}
+	} else {
+		drop[conversationField] = true
+	}
+
+	kept := make([]string, 0, len(accepted))
+	for _, field := range accepted {
+		if drop[field] && !isRequired[field] {
+			continue
+		}
+		kept = append(kept, field)
+	}
+	return kept
+}
+
+// planCriterion shapes one evaluator's bindings from its published contract.
+//
+// Evaluators do not share an input contract: builtin.similarity needs
+// ground_truth, builtin.retrieval needs context, and builtin.ifeval needs
+// instruction_id_list. Sending one fixed mapping to all of them earns a
+// service-side MissingRequiredDataMapping rejection, so the mapping is derived
+// per evaluator and anything unsatisfiable is reported before the request is
+// sent.
+func planCriterion(
+	ref evalcore.EvaluatorRef,
+	schema *eval_api.EvaluatorSummary,
+	targetBindings map[string]string,
+	datasetColumns map[string]bool,
+	level string,
+) (*criterionPlan, error) {
+	accepted := legacyInputs
+	var required []string
+	// A published schema is authoritative even when it is empty: an empty
+	// property set means the evaluator accepts nothing, which is different from
+	// publishing no schema at all.
+	if dataSchema := schema.DataSchema(); dataSchema != nil {
+		accepted = dataSchema.PropertyNames()
+		required = dataSchema.Required
+	}
+	accepted = selectLevelFields(accepted, required, level)
+
+	plan := &criterionPlan{
+		dataMapping: map[string]string{},
+		initParams:  map[string]any{},
+	}
+
+	for _, field := range accepted {
+		if binding, ok := targetBindings[field]; ok {
+			plan.dataMapping[field] = binding
+			continue
+		}
+		// Everything else comes from the dataset. When the columns are known,
+		// bind only the ones that exist so optional fields stay unbound rather
+		// than resolving to nothing at run time.
+		if datasetColumns != nil && !datasetColumns[field] {
+			continue
+		}
+		plan.dataMapping[field] = fmt.Sprintf("{{item.%s}}", field)
+		plan.itemFields = append(plan.itemFields, field)
+	}
+
+	// A declared mapping is the author saying the inference got it wrong, so it
+	// wins. Anything it binds to an item column is a column the schema has to
+	// declare, whether or not inference found it.
+	for field, binding := range ref.DataMapping {
+		plan.dataMapping[field] = binding
+		if column, ok := itemColumn(binding); ok && !contains(plan.itemFields, column) {
+			plan.itemFields = append(plan.itemFields, column)
+		}
+	}
+
+	var missing []string
+	for _, field := range required {
+		if _, ok := plan.dataMapping[field]; !ok {
+			missing = append(missing, field)
+		}
+	}
+	if len(missing) > 0 {
+		return nil, messages.EvaluatorNeedsFields(ref.Evaluator, missing)
+	}
+
+	if !schema.SupportsLevel(level) {
+		return nil, messages.EvaluatorLevelUnsupported(
+			ref.Evaluator, level, schema.SupportedEvaluationLevels)
+	}
+
+	initSchema := schema.InitSchema()
+	accepts := func(name string) bool {
+		// Only an absent schema falls back to the historical parameters;
+		// builtin.ifeval publishes an empty one and takes none.
+		if initSchema == nil {
+			return name == "deployment_name" || name == "threshold"
+		}
+		return initSchema.Accepts(name)
+	}
+
+	// Evaluators disagree on what the judge model is called: built-ins declare
+	// deployment_name, custom rubrics declare model. The declaration names one
+	// of them; bind whichever the evaluator actually accepts rather than
+	// forwarding a spelling it will reject.
+	for name, value := range ref.InitializationParameters {
+		if accepts(name) {
+			plan.initParams[name] = value
+			continue
+		}
+		if alias, ok := judgeModelAliases[name]; ok && accepts(alias) {
+			plan.initParams[alias] = value
+		}
+	}
+	if level != "" && accepts("evaluation_level") {
+		plan.initParams["evaluation_level"] = level
+	}
+
+	if initSchema != nil {
+		var missingInit []string
+		for _, name := range initSchema.Required {
+			if _, ok := plan.initParams[name]; !ok {
+				missingInit = append(missingInit, name)
+			}
+		}
+		if len(missingInit) > 0 {
+			return nil, messages.EvaluatorNeedsInitParams(ref.Evaluator, missingInit)
+		}
+	}
+
+	return plan, nil
+}
+
+// checkEvaluatorRequirements refuses a declaration the evaluators cannot
+// satisfy, before anything is published.
+//
+// The same checks happen while building the request, but that runs after the
+// datasets and evaluators have been pushed -- so a missing judge deployment
+// cost an immutable dataset version per attempt, and the version numbers climb
+// whether or not the eval was ever created. Only what the published contract
+// alone can settle is checked here: the data mapping needs the dataset's
+// columns, which is a separate question.
+func checkEvaluatorRequirements(
+	eval *project.Eval,
+	schemas map[string]*eval_api.EvaluatorSummary,
+) error {
+	level := resolveLevel(eval)
+	for _, ref := range eval.Evaluators {
+		schema := schemas[ref.Evaluator]
+		if schema == nil {
+			// Nothing published to check against. The service still gets the
+			// last word, which is what happened before this existed.
+			continue
+		}
+		if !schema.SupportsLevel(level) {
+			return messages.EvaluatorLevelUnsupported(
+				ref.Evaluator, level, schema.SupportedEvaluationLevels)
+		}
+
+		initSchema := schema.InitSchema()
+		if initSchema == nil {
+			continue
+		}
+		var missing []string
+		for _, name := range initSchema.Required {
+			if declaredInitParam(ref, name) {
+				continue
+			}
+			if name == "evaluation_level" && level != "" {
+				continue
+			}
+			missing = append(missing, name)
+		}
+		if len(missing) > 0 {
+			return messages.EvaluatorNeedsInitParams(ref.Evaluator, missing)
+		}
+	}
+	return nil
+}
+
+// declaredInitParam reports whether the reference supplies a parameter under
+// either spelling of the judge deployment.
+func declaredInitParam(ref evalcore.EvaluatorRef, name string) bool {
+	if _, ok := ref.InitializationParameters[name]; ok {
+		return true
+	}
+	if alias, ok := judgeModelAliases[name]; ok {
+		_, declared := ref.InitializationParameters[alias]
+		return declared
+	}
+	return false
+}
+
+// judgeModelAliases maps the two spellings of the judge deployment onto each
+// other, so one declaration works whichever the evaluator publishes.
+var judgeModelAliases = map[string]string{
+	"deployment_name": "model",
+	"model":           "deployment_name"}
+
+// itemColumn reads the dataset column out of an `{{item.<name>}}` binding.
+func itemColumn(binding string) (string, bool) {
+	const prefix, suffix = "{{item.", "}}"
+	if !strings.HasPrefix(binding, prefix) || !strings.HasSuffix(binding, suffix) {
+		return "", false
+	}
+	name := strings.TrimSuffix(strings.TrimPrefix(binding, prefix), suffix)
+	if name == "" {
+		return "", false
+	}
+	return name, true
+}
+
+func contains(values []string, want string) bool {
+	return slices.Contains(values, want)
+}
+
+// buildEvalRequest converts an eval declaration into the create
+// request. Each evaluator becomes a testing criterion bound to its own
+// contract, and the item schema declares every dataset column those bindings
+// reference.
+//
+// schemas may be nil or partial; an evaluator with no published contract falls
+// back to the agent-target shape. datasetColumns may be nil, meaning the
+// columns are unknown and every accepted field is assumed present.
+func buildEvalRequest(
+	group *project.Eval,
+	schemas map[string]*eval_api.EvaluatorSummary,
+	datasetColumns map[string]bool,
+) (*eval_api.CreateOpenAIEvalRequest, error) {
+	metadata := map[string]string{}
+	hasTarget := group.Target != nil && group.Target.Name != ""
+	targetType := ""
+	if hasTarget {
+		metadata[metaAgent] = group.Target.Name
+		targetType = group.Target.Type
+		if targetType == "" {
+			targetType = project.TargetTypeAgent
+		}
+	}
+	targetBindings := sampleBindingsFor(targetType)
+	metadata[metaEvalName] = group.Name
+	// The create request has no description field, so the group's own
+	// description rides in metadata rather than being dropped.
+	if group.Description != "" {
+		metadata[metaDescription] = group.Description
+	}
+
+	level := group.EvaluationLevel
+
+	req := &eval_api.CreateOpenAIEvalRequest{
+		Name:     group.Name,
+		Metadata: metadata,
+	}
+
+	itemFields := map[string]bool{}
+
+	for _, ref := range group.Evaluators {
+		schema := schemas[ref.Evaluator]
+		if schema == nil {
+			schema = &eval_api.EvaluatorSummary{Name: ref.Evaluator}
+		}
+
+		plan, err := planCriterion(ref, schema, targetBindings, datasetColumns, level)
+		if err != nil {
+			return nil, err
+		}
+
+		criterion := eval_api.TestingCriterion{
+			Type: "azure_ai_evaluator",
+			// Name labels the criterion in results and defaults to the
+			// evaluator without its builtin prefix; EvaluatorName keeps it.
+			Name:          ref.CriterionName(),
+			EvaluatorName: ref.Evaluator,
+			DataMapping:   plan.dataMapping,
+		}
+		if ref.Version != "" {
+			criterion.EvaluatorVersion = ref.Version
+		}
+		if len(plan.initParams) > 0 {
+			criterion.InitializationParameters = plan.initParams
+		}
+		for _, field := range plan.itemFields {
+			itemFields[field] = true
+		}
+
+		req.TestingCriteria = append(req.TestingCriteria, criterion)
+	}
+
+	req.DataSourceConfig = &eval_api.DataSourceConfig{
+		Type:                "custom",
+		IncludeSampleSchema: hasTarget,
+		ItemSchema:          itemSchema(itemFields),
+	}
+
+	return req, nil
+}
+
+// itemSchema declares the dataset columns the criteria bind to. It always
+// declares at least `query`, the column an agent target reads.
+func itemSchema(fields map[string]bool) map[string]any {
+	if len(fields) == 0 {
+		fields = map[string]bool{"query": true}
+	}
+	properties := map[string]any{}
+	for field := range fields {
+		properties[field] = map[string]any{"type": "string"}
+	}
+	return map[string]any{
+		"type":       "object",
+		"properties": properties,
+	}
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/build_live_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/build_live_test.go
@@ -1,0 +1,216 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build live
+
+// This file proves the request buildEvalRequest produces is accepted by
+// the real service. It lives in the cmd package on purpose: the tests under
+// tests/live can only hand-roll a request, which validates the API but not the
+// code that ships.
+//
+//	go test -tags live -v ./internal/cmd/ -run TestLiveBuild
+//
+// Required: AZURE_AI_EVAL_E2E_LIVE=1 and FOUNDRY_PROJECT_ENDPOINT.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/pkg/evalcore"
+	"azureaieval/internal/project"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/stretchr/testify/require"
+)
+
+// One credential for the whole package, because azidentity caches tokens per
+// instance. Building one per test made every test shell out to azd again, and
+// a refresh that overruns the SDK's ten-second budget for that subprocess
+// surfaces as "AzureDeveloperCLICredential: exit status 1" — which reads like
+// a broken login rather than a timeout, and lands on whichever test happened
+// to run after a slow one.
+var (
+	sharedCredOnce sync.Once
+	sharedCred     *azidentity.AzureDeveloperCLICredential
+	sharedCredErr  error
+)
+
+func liveCredential() (*azidentity.AzureDeveloperCLICredential, error) {
+	sharedCredOnce.Do(func() {
+		sharedCred, sharedCredErr = azidentity.NewAzureDeveloperCLICredential(
+			&azidentity.AzureDeveloperCLICredentialOptions{})
+	})
+	return sharedCred, sharedCredErr
+}
+
+// credentialFlake is what a token refresh that overran its budget looks like
+// by the time it reaches a test.
+const credentialFlake = "AzureDeveloperCLICredential: exit status 1"
+
+// retryingCredential retries a token request that failed for that reason.
+//
+// The refresh shells out to azd, and the SDK gives that subprocess ten
+// seconds. On a machine already running the rest of this suite it sometimes
+// does not finish in ten, and the failure lands on whichever test asked for a
+// token at the wrong moment — reproducibly at 10.1s, and never when that test
+// is run on its own. Retrying is right because nothing about the request was
+// wrong: the same call succeeds moments later.
+type retryingCredential struct {
+	inner azcore.TokenCredential
+}
+
+func (c retryingCredential) GetToken(
+	ctx context.Context,
+	opts policy.TokenRequestOptions,
+) (azcore.AccessToken, error) {
+	var token azcore.AccessToken
+	var err error
+	for attempt := range 4 {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return azcore.AccessToken{}, ctx.Err()
+			case <-time.After(time.Duration(attempt) * 2 * time.Second):
+			}
+		}
+		token, err = c.inner.GetToken(ctx, opts)
+		if err == nil || !strings.Contains(err.Error(), credentialFlake) {
+			return token, err
+		}
+	}
+	return token, err
+}
+
+func liveEvalClient(t *testing.T) (*eval_api.EvalClient, string) {
+	t.Helper()
+	if os.Getenv("AZURE_AI_EVAL_E2E_LIVE") != "1" {
+		t.Skip("set AZURE_AI_EVAL_E2E_LIVE=1 to run live tests")
+	}
+	endpoint := strings.TrimSuffix(os.Getenv("FOUNDRY_PROJECT_ENDPOINT"), "/")
+	if endpoint == "" {
+		t.Fatal("FOUNDRY_PROJECT_ENDPOINT is required")
+	}
+	cred, err := liveCredential()
+	require.NoError(t, err)
+
+	judge := os.Getenv("AZURE_AI_EVAL_MODEL")
+	if judge == "" {
+		judge = "gpt-4.1-nano"
+	}
+	return eval_api.NewEvalClient(endpoint, retryingCredential{inner: cred}), judge
+}
+
+// TestLiveBuildAcceptedForEveryBuiltin walks every built-in the project
+// exposes, builds a group with the shipping builder, and posts it.
+//
+// Each evaluator declares a different input contract, so this is the test that
+// would have caught the fixed data mapping: it previously produced a
+// MissingRequiredDataMapping rejection for builtin.ifeval and would do so
+// again for any evaluator whose contract the builder stops honouring.
+func TestLiveBuildAcceptedForEveryBuiltin(t *testing.T) {
+	client, judge := liveEvalClient(t)
+	ctx := context.Background()
+
+	listed, err := client.ListEvaluators(ctx, eval_api.EvaluatorTypeBuiltin, ProjectEndpointAPIVersion)
+	require.NoError(t, err)
+	require.NotEmpty(t, listed.Value)
+
+	// Deliberately the production lookup rather than the listing above. Taking
+	// the schemas straight from a filtered list is what let this test pass
+	// while the shipping path resolved none of them: it built the input the
+	// product was failing to build.
+	ec := &evalContext{evalClient: client}
+	schemas := ec.evaluatorSchemas(ctx)
+	require.NotEmpty(t, schemas)
+
+	for _, summary := range listed.Value {
+		summary := summary
+		t.Run(summary.Name, func(t *testing.T) {
+			require.NotNil(t, schemas[summary.Name],
+				"the shipping lookup did not resolve %s", summary.Name)
+			// Give the builder a dataset carrying every column the evaluator
+			// accepts, so a rejection means the request shape is wrong rather
+			// than the data being genuinely absent.
+			columns := map[string]bool{"query": true}
+			if ds := summary.DataSchema(); ds != nil {
+				for _, name := range ds.PropertyNames() {
+					columns[name] = true
+				}
+			}
+
+			level := ""
+			if len(summary.SupportedEvaluationLevels) > 0 {
+				level = summary.SupportedEvaluationLevels[0]
+			}
+
+			group := &project.Eval{
+				Name:    fmt.Sprintf("azd-live-%d", time.Now().UTC().UnixNano()),
+				Dataset: "inline",
+				Target:  &project.Target{Type: "agent", Name: "probe-agent"},
+				Evaluators: []evalcore.EvaluatorRef{{
+					Evaluator:                summary.Name,
+					InitializationParameters: map[string]any{"deployment_name": judge},
+				}},
+				EvaluationLevel: level,
+			}
+
+			req, err := buildEvalRequest(group, schemas, columns)
+			require.NoError(t, err, "the builder must satisfy every published contract")
+
+			created, err := client.CreateOpenAIEval(ctx, req)
+			require.NoError(t, err,
+				"the service rejected the request this extension builds for %s", summary.Name)
+			require.NotEmpty(t, created.ID)
+			t.Cleanup(func() {
+				_ = client.DeleteOpenAIEval(context.Background(), created.ID)
+			})
+			t.Logf("%s accepted as %s", summary.Name, created.ID)
+		})
+	}
+}
+
+// TestLiveBuildRejectsMissingColumnsLocally proves the pre-flight check fires
+// before the network call, so a user sees which column is missing instead of a
+// service error naming an internal field path.
+func TestLiveBuildRejectsMissingColumnsLocally(t *testing.T) {
+	client, judge := liveEvalClient(t)
+	ctx := context.Background()
+
+	listed, err := client.ListEvaluators(ctx, eval_api.EvaluatorTypeBuiltin, ProjectEndpointAPIVersion)
+	require.NoError(t, err)
+	schemas := listed.ByName()
+
+	target, ok := schemas["builtin.ifeval"]
+	if !ok {
+		t.Skip("builtin.ifeval is not available in this project")
+	}
+	require.NotNil(t, target.DataSchema())
+	require.NotEmpty(t, target.DataSchema().Required,
+		"this test relies on ifeval declaring required inputs")
+
+	group := &project.Eval{
+		Name:    "azd-live-negative",
+		Dataset: "inline",
+		Target:  &project.Target{Type: "agent", Name: "probe-agent"},
+		Evaluators: []evalcore.EvaluatorRef{{
+			Name:                     "builtin.ifeval",
+			InitializationParameters: map[string]any{"deployment_name": judge},
+		}},
+	}
+
+	// A dataset with only `query` cannot satisfy ifeval.
+	_, err = buildEvalRequest(group, schemas, map[string]bool{"query": true})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "instruction_id_list")
+	t.Logf("pre-flight error: %v", err)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/build_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/build_test.go
@@ -1,0 +1,320 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/pkg/evalcore"
+	"azureaieval/internal/project"
+
+	"github.com/stretchr/testify/require"
+)
+
+// schema builds an evaluator contract the way the service publishes one.
+func schema(name string, dataRequired, dataProps, initRequired, initProps []string, levels ...string) *eval_api.EvaluatorSummary {
+	toProps := func(names []string) map[string]any {
+		if names == nil {
+			return nil
+		}
+		out := map[string]any{}
+		for _, n := range names {
+			out[n] = map[string]any{"type": "string"}
+		}
+		return out
+	}
+	return &eval_api.EvaluatorSummary{
+		Name:                      name,
+		SupportedEvaluationLevels: levels,
+		Definition: &eval_api.EvaluatorContract{
+			DataSchema:     &eval_api.JSONSchema{Required: dataRequired, Properties: toProps(dataProps)},
+			InitParameters: &eval_api.JSONSchema{Required: initRequired, Properties: toProps(initProps)},
+		},
+	}
+}
+
+func groupWith(evaluators []evalcore.EvaluatorRef, level string) *project.Eval {
+	return &project.Eval{
+		Name:            "g",
+		Dataset:         "d",
+		Target:          &project.Target{Type: "agent", Name: "my-agent"},
+		Evaluators:      evaluators,
+		EvaluationLevel: level,
+	}
+}
+
+// withJudge declares the judge deployment where the service reads it from: an
+// evaluator's initialization parameters, not a setting on the eval. It merges,
+// so a parameter the reference already carries survives.
+func withJudge(model string, refs ...evalcore.EvaluatorRef) []evalcore.EvaluatorRef {
+	for i := range refs {
+		if refs[i].InitializationParameters == nil {
+			refs[i].InitializationParameters = map[string]any{}
+		}
+		refs[i].InitializationParameters["deployment_name"] = model
+	}
+	return refs
+}
+
+// An agent evaluator takes its response from the sample and its query from the
+// dataset.
+func TestBuildBindsAgentFieldsFromSample(t *testing.T) {
+	schemas := map[string]*eval_api.EvaluatorSummary{
+		"builtin.task_adherence": schema("builtin.task_adherence",
+			nil, []string{"query", "response", "tool_definitions", "messages"},
+			[]string{"deployment_name"}, []string{"deployment_name", "threshold", "evaluation_level"},
+			"turn"),
+	}
+	group := groupWith(
+		withJudge("gpt-4.1-nano", evalcore.EvaluatorRef{Evaluator: "builtin.task_adherence"}),
+		"",
+	)
+
+	req, err := buildEvalRequest(group, schemas, map[string]bool{"query": true})
+	require.NoError(t, err)
+	require.Len(t, req.TestingCriteria, 1)
+
+	mapping := req.TestingCriteria[0].DataMapping
+	require.Equal(t, "{{item.query}}", mapping["query"])
+	require.Equal(t, "{{sample.output_items}}", mapping["response"])
+	require.Equal(t, "{{sample.tool_definitions}}", mapping["tool_definitions"])
+	// `messages` is not a dataset column here, so it stays unbound.
+	require.NotContains(t, mapping, "messages")
+}
+
+// A required field the dataset does not carry is reported before the request
+// is sent, naming the field.
+func TestBuildRejectsUnsatisfiableEvaluator(t *testing.T) {
+	schemas := map[string]*eval_api.EvaluatorSummary{
+		"builtin.ifeval": schema("builtin.ifeval",
+			[]string{"response", "instruction_id_list", "instruction_kwargs"},
+			[]string{"response", "instruction_id_list", "instruction_kwargs"},
+			nil, nil, "turn"),
+	}
+	group := groupWith([]evalcore.EvaluatorRef{{Evaluator: "builtin.ifeval"}}, "")
+
+	_, err := buildEvalRequest(group, schemas, map[string]bool{"query": true})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "instruction_id_list")
+	require.Contains(t, err.Error(), "instruction_kwargs")
+}
+
+// The same evaluator succeeds once the dataset supplies the columns.
+func TestBuildAcceptsEvaluatorWhenDatasetSupplies(t *testing.T) {
+	schemas := map[string]*eval_api.EvaluatorSummary{
+		"builtin.ifeval": schema("builtin.ifeval",
+			[]string{"response", "instruction_id_list", "instruction_kwargs"},
+			[]string{"response", "instruction_id_list", "instruction_kwargs"},
+			nil, nil, "turn"),
+	}
+	group := groupWith([]evalcore.EvaluatorRef{{Evaluator: "builtin.ifeval"}}, "")
+
+	req, err := buildEvalRequest(group, schemas, map[string]bool{
+		"instruction_id_list": true,
+		"instruction_kwargs":  true,
+	})
+	require.NoError(t, err)
+
+	mapping := req.TestingCriteria[0].DataMapping
+	// response is satisfied by the agent target.
+	require.Equal(t, "{{sample.output_items}}", mapping["response"])
+	require.Equal(t, "{{item.instruction_id_list}}", mapping["instruction_id_list"])
+
+	// The item schema has to declare the columns the criteria reference.
+	props := req.DataSourceConfig.ItemSchema["properties"].(map[string]any)
+	require.Contains(t, props, "instruction_id_list")
+	require.Contains(t, props, "instruction_kwargs")
+}
+
+// Initialization parameters are filtered to what the evaluator accepts.
+// builtin.ifeval takes none, so nothing is sent even when a model is set.
+func TestBuildOmitsUnacceptedInitParameters(t *testing.T) {
+	threshold := 4.0
+	schemas := map[string]*eval_api.EvaluatorSummary{
+		"builtin.ifeval": schema("builtin.ifeval",
+			nil, []string{"response"}, nil, nil, "turn"),
+		"builtin.similarity": schema("builtin.similarity",
+			nil, []string{"query", "response", "ground_truth"},
+			[]string{"deployment_name"}, []string{"deployment_name", "threshold"}, "turn"),
+	}
+	group := groupWith(withJudge("gpt-4.1-nano",
+		evalcore.EvaluatorRef{Evaluator: "builtin.ifeval",
+			InitializationParameters: map[string]any{"threshold": threshold}},
+		evalcore.EvaluatorRef{Evaluator: "builtin.similarity",
+			InitializationParameters: map[string]any{"threshold": threshold}},
+	), "")
+
+	req, err := buildEvalRequest(group, schemas, map[string]bool{
+		"query": true, "ground_truth": true,
+	})
+	require.NoError(t, err)
+
+	// ifeval accepts no init parameters at all.
+	require.Empty(t, req.TestingCriteria[0].InitializationParameters)
+
+	// similarity accepts both, and never the `model` alias.
+	params := req.TestingCriteria[1].InitializationParameters
+	require.Equal(t, "gpt-4.1-nano", params["deployment_name"])
+	require.InDelta(t, 4.0, params["threshold"], 0.0001)
+	require.NotContains(t, params, "model")
+}
+
+// evaluation_level is an initialization parameter, not run metadata, and only
+// on evaluators that declare it.
+func TestBuildPassesEvaluationLevelAsInitParameter(t *testing.T) {
+	schemas := map[string]*eval_api.EvaluatorSummary{
+		"builtin.task_completion": schema("builtin.task_completion",
+			nil, []string{"query", "response"},
+			[]string{"deployment_name"}, []string{"deployment_name", "evaluation_level"},
+			"conversation", "turn"),
+		"builtin.similarity": schema("builtin.similarity",
+			nil, []string{"query", "response"},
+			[]string{"deployment_name"}, []string{"deployment_name", "threshold"}, "turn"),
+	}
+	group := groupWith(withJudge("m",
+		evalcore.EvaluatorRef{Evaluator: "builtin.task_completion"},
+		evalcore.EvaluatorRef{Evaluator: "builtin.similarity"},
+	), "turn")
+
+	req, err := buildEvalRequest(group, schemas, map[string]bool{"query": true})
+	require.NoError(t, err)
+
+	require.Equal(t, "turn", req.TestingCriteria[0].InitializationParameters["evaluation_level"])
+	require.NotContains(t, req.TestingCriteria[1].InitializationParameters, "evaluation_level")
+}
+
+// An evaluator that does not support the requested level is rejected with the
+// levels it does support.
+func TestBuildRejectsUnsupportedLevel(t *testing.T) {
+	schemas := map[string]*eval_api.EvaluatorSummary{
+		"builtin.similarity": schema("builtin.similarity",
+			nil, []string{"query", "response"},
+			[]string{"deployment_name"}, []string{"deployment_name"}, "turn"),
+	}
+	group := groupWith(withJudge("m", evalcore.EvaluatorRef{Evaluator: "builtin.similarity"}),
+		"conversation")
+
+	_, err := buildEvalRequest(group, schemas, map[string]bool{"query": true})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "conversation")
+	require.Contains(t, err.Error(), "turn")
+}
+
+// A required init parameter with no judge model configured is caught locally.
+func TestBuildRequiresJudgeModelWhenEvaluatorDoes(t *testing.T) {
+	schemas := map[string]*eval_api.EvaluatorSummary{
+		"builtin.similarity": schema("builtin.similarity",
+			nil, []string{"query", "response"},
+			[]string{"deployment_name"}, []string{"deployment_name"}, "turn"),
+	}
+	group := groupWith([]evalcore.EvaluatorRef{{Evaluator: "builtin.similarity"}}, "")
+
+	_, err := buildEvalRequest(group, schemas, map[string]bool{"query": true})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "deployment_name")
+}
+
+// An evaluator with no published contract keeps the historical agent-target
+// shape, so custom evaluators still deploy.
+func TestBuildFallsBackWithoutSchema(t *testing.T) {
+	group := groupWith(withJudge("m", evalcore.EvaluatorRef{Evaluator: "my-custom-evaluator"}), "")
+
+	req, err := buildEvalRequest(group, nil, nil)
+	require.NoError(t, err)
+
+	mapping := req.TestingCriteria[0].DataMapping
+	require.Equal(t, "{{item.query}}", mapping["query"])
+	require.Equal(t, "{{sample.output_items}}", mapping["response"])
+	require.Equal(t, "{{sample.tool_calls}}", mapping["tool_calls"])
+	require.Equal(t, "{{sample.tool_definitions}}", mapping["tool_definitions"])
+	require.Equal(t, "m", req.TestingCriteria[0].InitializationParameters["deployment_name"])
+}
+
+// `messages` and `query`/`response` are mutually exclusive; the evaluation
+// level picks which shape is bound. Sending both is rejected by the service.
+func TestBuildResolvesConversationTurnExclusivity(t *testing.T) {
+	schemas := map[string]*eval_api.EvaluatorSummary{
+		"builtin.task_completion": schema("builtin.task_completion",
+			nil, []string{"query", "response", "messages", "tool_definitions"},
+			[]string{"deployment_name"}, []string{"deployment_name", "evaluation_level"},
+			"conversation", "turn"),
+	}
+	columns := map[string]bool{"query": true, "messages": true, "response": true}
+
+	// Turn level keeps query/response and drops messages.
+	turn := groupWith(withJudge("m", evalcore.EvaluatorRef{Evaluator: "builtin.task_completion"}),
+		"turn")
+	req, err := buildEvalRequest(turn, schemas, columns)
+	require.NoError(t, err)
+	mapping := req.TestingCriteria[0].DataMapping
+	require.Contains(t, mapping, "query")
+	require.NotContains(t, mapping, "messages")
+
+	// Conversation level keeps messages and drops query/response.
+	conv := groupWith(withJudge("m", evalcore.EvaluatorRef{Evaluator: "builtin.task_completion"}),
+		"conversation")
+	req, err = buildEvalRequest(conv, schemas, columns)
+	require.NoError(t, err)
+	mapping = req.TestingCriteria[0].DataMapping
+	require.Contains(t, mapping, "messages")
+	require.NotContains(t, mapping, "query")
+	require.NotContains(t, mapping, "response")
+
+	// An unset level behaves as turn, matching the service default.
+	dflt := groupWith(withJudge("m", evalcore.EvaluatorRef{Evaluator: "builtin.task_completion"}), "")
+	req, err = buildEvalRequest(dflt, schemas, columns)
+	require.NoError(t, err)
+	require.NotContains(t, req.TestingCriteria[0].DataMapping, "messages")
+}
+
+// Evaluators disagree on what the judge model is called. Built-ins declare
+// deployment_name; a custom rubric declares model, and rejects the eval with
+// "requires model" if only deployment_name is sent. One declaration binds
+// whichever the evaluator actually accepts.
+func TestBuildBindsJudgeModelUnderTheDeclaredName(t *testing.T) {
+	schemas := map[string]*eval_api.EvaluatorSummary{
+		"builtin.similarity": schema("builtin.similarity",
+			nil, []string{"query", "response"},
+			[]string{"deployment_name"}, []string{"deployment_name"}, "turn"),
+		"my-rubric": schema("my-rubric",
+			nil, []string{"query", "response"},
+			[]string{"model"}, []string{"model"}, "turn"),
+	}
+	group := groupWith(withJudge("gpt-4.1-nano",
+		evalcore.EvaluatorRef{Evaluator: "builtin.similarity"},
+		evalcore.EvaluatorRef{Evaluator: "my-rubric"},
+	), "")
+
+	req, err := buildEvalRequest(group, schemas, map[string]bool{"query": true})
+	require.NoError(t, err)
+
+	builtin := req.TestingCriteria[0].InitializationParameters
+	require.Equal(t, "gpt-4.1-nano", builtin["deployment_name"])
+	require.NotContains(t, builtin, "model")
+
+	custom := req.TestingCriteria[1].InitializationParameters
+	require.Equal(t, "gpt-4.1-nano", custom["model"])
+	require.NotContains(t, custom, "deployment_name")
+}
+
+// Without an agent target the sample bindings are unavailable, so every field
+// has to come from the dataset and the sample schema is not requested.
+func TestBuildWithoutTargetSourcesEverythingFromDataset(t *testing.T) {
+	schemas := map[string]*eval_api.EvaluatorSummary{
+		"builtin.similarity": schema("builtin.similarity",
+			[]string{"query", "response", "ground_truth"},
+			[]string{"query", "response", "ground_truth"},
+			nil, nil, "turn"),
+	}
+	group := groupWith([]evalcore.EvaluatorRef{{Evaluator: "builtin.similarity"}}, "")
+	group.Target = nil
+
+	req, err := buildEvalRequest(group, schemas, map[string]bool{
+		"query": true, "response": true, "ground_truth": true,
+	})
+	require.NoError(t, err)
+	require.False(t, req.DataSourceConfig.IncludeSampleSchema)
+	require.Equal(t, "{{item.response}}", req.TestingCriteria[0].DataMapping["response"])
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/catalog.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/catalog.go
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/project"
+
+	"github.com/spf13/cobra"
+)
+
+// Generation writes the artifact and then names it in the configuration, so
+// what it produced is referenceable without a hand edit. Only the catalogs are
+// touched: which evals use the artifact is the author's decision, and `init` is
+// the command that makes it.
+
+// addDatasetToCatalog records a generated dataset in `datasets:`.
+func addDatasetToCatalog(cmd *cobra.Command, evalDir string, ref *project.ArtifactRef) error {
+	if ref == nil {
+		return nil
+	}
+	return updateCatalog(cmd, evalDir, "dataset", ref, func(cfg *project.EvalConfig) bool {
+		for i := range cfg.Datasets {
+			if cfg.Datasets[i].Name == ref.Name {
+				// Regeneration overwrites the file in place, so the entry only
+				// changes when the artifact moved.
+				if cfg.Datasets[i].Source == ref.Source {
+					return false
+				}
+				cfg.Datasets[i].Source = ref.Source
+				return true
+			}
+		}
+		cfg.Datasets = append(cfg.Datasets, project.DatasetDecl{
+			Name:   ref.Name,
+			Source: ref.Source,
+		})
+		return true
+	})
+}
+
+// addEvaluatorToCatalog records a generated evaluator in `evaluators:`.
+func addEvaluatorToCatalog(cmd *cobra.Command, evalDir string, ref *project.ArtifactRef) error {
+	if ref == nil {
+		return nil
+	}
+	return updateCatalog(cmd, evalDir, "evaluator", ref, func(cfg *project.EvalConfig) bool {
+		for i := range cfg.Evaluators {
+			if cfg.Evaluators[i].Name == ref.Name {
+				if cfg.Evaluators[i].Source == ref.Source {
+					return false
+				}
+				cfg.Evaluators[i].Source = ref.Source
+				return true
+			}
+		}
+		cfg.Evaluators = append(cfg.Evaluators, project.EvaluatorDecl{
+			Name:   ref.Name,
+			Source: ref.Source,
+		})
+		return true
+	})
+}
+
+// updateCatalog applies a change to the configuration and writes it back.
+//
+// A missing configuration is created holding only the catalog. `generate` runs
+// before `init` on the golden path, and a downloaded artifact nobody recorded
+// is the one state that goes stale. The file it creates has no evals and no
+// azure.yaml entry, so it stays inert until init wires one.
+func updateCatalog(
+	cmd *cobra.Command,
+	evalDir string,
+	kind string,
+	ref *project.ArtifactRef,
+	apply func(*project.EvalConfig) bool,
+) error {
+	// Held across the read and the write: two generates adding different
+	// entries would otherwise both read the same state, and the second write
+	// would drop the first one's entry while reporting success.
+	unlock, err := project.LockEvalConfig(cmd.Context(), evalDir)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	cfg, err := project.OpenEvalConfig(evalDir)
+	if err != nil {
+		return err
+	}
+	created := cfg == nil
+	if created {
+		cfg = &project.EvalConfig{}
+	}
+	if !apply(cfg) {
+		return nil
+	}
+
+	if err := project.SaveEvalConfig(evalDir, cfg); err != nil {
+		return err
+	}
+	if !isJSON(cmd) {
+		// Resolved, not the current name: SaveEvalConfig writes back over a
+		// legacy file when that is what the project has, and the line has to
+		// name the file it actually wrote.
+		resolved, err := project.ResolveEvalConfigPath(evalDir)
+		if err != nil {
+			return err
+		}
+		path := filepath.ToSlash(resolved)
+		if created {
+			fmt.Fprint(cmd.OutOrStdout(), messages.CreatedCatalogFile(path))
+		}
+		fmt.Fprint(cmd.OutOrStdout(),
+			messages.AddedToCatalog(kind, describeArtifact(ref), path))
+	}
+	return nil
+}
+
+// describeArtifact names what was recorded, with the published version when the
+// job reported one, so a reader can pin it without going to look.
+//
+// Single-quoted to match the spec's transcripts; the surrounding Done: lines
+// carry bare values, but a dataset name can hold a space and these cannot.
+func describeArtifact(ref *project.ArtifactRef) string {
+	return messages.ArtifactDescription(ref.Name, ref.Version)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/catalog_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/catalog_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"azureaieval/internal/project"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// catalogCommand builds a command whose output can be read back.
+func catalogCommand(t *testing.T, buf *bytes.Buffer) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "generate"}
+	cmd.Flags().StringP("output", "o", "", "")
+	cmd.SetOut(buf)
+	return cmd
+}
+
+// The spec's Scenario 2 transcript names what was recorded and the version it
+// was published at. "Added catalog entry" says neither, which leaves the reader
+// to infer both from the line above it.
+func TestCatalogLineNamesTheArtifactAndVersion(t *testing.T) {
+	dir := t.TempDir()
+	var buf bytes.Buffer
+
+	require.NoError(t, addDatasetToCatalog(catalogCommand(t, &buf), dir, &project.ArtifactRef{
+		Name:    "support-agent-regression",
+		Source:  "datasets/support-agent-regression.jsonl",
+		Version: "1",
+	}))
+
+	out := buf.String()
+	assert.Contains(t, out, `Added dataset 'support-agent-regression' (version 1) to`)
+	assert.Contains(t, out, "eval.yaml")
+}
+
+// The evaluator half of the same transcript.
+func TestCatalogLineForAnEvaluator(t *testing.T) {
+	dir := t.TempDir()
+	var buf bytes.Buffer
+
+	require.NoError(t, addEvaluatorToCatalog(catalogCommand(t, &buf), dir, &project.ArtifactRef{
+		Name:    "support-agent-quality",
+		Source:  "evaluators/support-agent-quality.json",
+		Version: "1",
+	}))
+
+	assert.Contains(t, buf.String(), `Added evaluator 'support-agent-quality' (version 1) to`)
+}
+
+// A job that reported no version still has to name what it recorded, rather
+// than printing an empty parenthesis or the word "latest" as if it were one.
+func TestCatalogLineWithoutAVersion(t *testing.T) {
+	for _, version := range []string{"", "latest"} {
+		dir := t.TempDir()
+		var buf bytes.Buffer
+
+		require.NoError(t, addDatasetToCatalog(catalogCommand(t, &buf), dir, &project.ArtifactRef{
+			Name: "golden", Source: "datasets/golden.jsonl", Version: version,
+		}))
+
+		out := buf.String()
+		assert.Contains(t, out, `Added dataset 'golden' to`)
+		assert.NotContains(t, out, "version", "version %q is not one to print", version)
+	}
+}
+
+// The first generate in a repository has no configuration to append to, so it
+// says the file was created as well as what went into it.
+func TestCatalogLineWhenTheFileIsCreated(t *testing.T) {
+	dir := t.TempDir()
+	var buf bytes.Buffer
+
+	require.NoError(t, addDatasetToCatalog(catalogCommand(t, &buf), dir, &project.ArtifactRef{
+		Name: "golden", Source: "datasets/golden.jsonl", Version: "1",
+	}))
+
+	out := buf.String()
+	assert.Contains(t, out, "Created")
+	assert.Contains(t, out, `Added dataset 'golden' (version 1) to`,
+		"creating the file still has to say what was put in it")
+
+	// The entry is really on disk, not just announced.
+	body, err := os.ReadFile(filepath.Join(dir, project.EvalConfigBase))
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "golden")
+}
+
+// Regenerating the same artifact to the same path changes nothing, so it must
+// not claim it did.
+func TestCatalogSaysNothingWhenNothingChanged(t *testing.T) {
+	dir := t.TempDir()
+	ref := &project.ArtifactRef{Name: "golden", Source: "datasets/golden.jsonl", Version: "1"}
+
+	var first bytes.Buffer
+	require.NoError(t, addDatasetToCatalog(catalogCommand(t, &first), dir, ref))
+	require.Contains(t, first.String(), "Added dataset")
+
+	var second bytes.Buffer
+	require.NoError(t, addDatasetToCatalog(catalogCommand(t, &second), dir, ref))
+	assert.Empty(t, second.String(), "an unchanged catalog is not an edit")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/context.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/context.go
@@ -1,0 +1,523 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"azureaieval/internal/foundry/projectctx"
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/dataset_api"
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/project"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+)
+
+// projectEndpointEnvKey is the azd environment key holding the Foundry project
+// endpoint the data-plane clients target.
+const projectEndpointEnvKey = "FOUNDRY_PROJECT_ENDPOINT"
+
+// evalContext carries everything the commands need to reach the data plane.
+type evalContext struct {
+	azdClient *azdext.AzdClient
+	endpoint  string
+	envName   string
+	cred      azcore.TokenCredential
+
+	evalClient    *eval_api.EvalClient
+	datasetClient *dataset_api.DatasetClient
+
+	// Held only once both listings succeed; a partial read is not reusable.
+	schemas map[string]*eval_api.EvaluatorSummary
+
+	// Resolved on first use. Which command deploys cannot change while one
+	// command runs, and asking azd costs a round trip.
+	deployCmd string
+}
+
+// newEvalContext resolves the project endpoint and builds the data-plane
+// clients. The resolution order is projectctx's, so that every Foundry
+// extension answers the same question the same way:
+//
+//  1. --project-endpoint
+//  2. the active azd environment (FOUNDRY_PROJECT_ENDPOINT, then AZURE_AI_PROJECT_ENDPOINT)
+//  3. global config: extensions.ai-agents.project.context.endpoint
+//  4. the host environment variables of the same two names
+//  5. otherwise an error naming how to set one
+func newEvalContext(ctx context.Context, endpointFlag string) (*evalContext, error) {
+	azdClient, err := azdext.NewAzdClient()
+	if err != nil {
+		return nil, messages.ConnectingToAzd(err)
+	}
+
+	ec := &evalContext{azdClient: azdClient}
+
+	// The environment name is resolved regardless of where the endpoint comes
+	// from: it is what the cached eval and run ids are read from and
+	// written to. Deriving it only when the endpoint came from azd meant
+	// --project-endpoint silently disabled that cache.
+	_, envName := lookupEndpointFromAzd(ctx, azdClient)
+	ec.envName = envName
+
+	resolved, err := projectctx.Resolve(ctx, projectctx.ResolveOpts{FlagValue: endpointFlag})
+	if err != nil {
+		// The caller only defers Close on a context it was handed, so every
+		// path that abandons this one has to close it here.
+		ec.Close()
+		return nil, err
+	}
+	ec.endpoint = strings.TrimSuffix(resolved.Endpoint, "/")
+	log.Printf("[endpoint] resolved from %s", resolved.Source)
+
+	cred, err := newAzdTokenCredential()
+	if err != nil {
+		ec.Close()
+		return nil, err
+	}
+	ec.cred = cred
+
+	ec.evalClient = eval_api.NewEvalClient(ec.endpoint, ec.cred)
+	ec.datasetClient = dataset_api.NewDatasetClient(ec.endpoint, ec.cred)
+
+	return ec, nil
+}
+
+// newAzdTokenCredential returns the azd credential already wrapped in its
+// retry. Handing back the wrapper rather than the raw credential is what keeps
+// the retry wired: an earlier version assigned the wrapper to the context and
+// then built both clients from the unwrapped one, so nothing retried.
+func newAzdTokenCredential() (azcore.TokenCredential, error) {
+	cred, err := azidentity.NewAzureDeveloperCLICredential(
+		&azidentity.AzureDeveloperCLICredentialOptions{},
+	)
+	if err != nil {
+		return nil, messages.CreatingCredential(err)
+	}
+	return azdTokenRetry{inner: cred}, nil
+}
+
+// azdTokenRetry retries a failed token request once. azidentity gives the azd
+// subprocess a fixed 10 second timeout and discards its stderr, so an azd that
+// overruns surfaces as "exit status 1" with no cause; the next call usually
+// finds a warm token. Without this a slow token turns into a failed command.
+type azdTokenRetry struct{ inner azcore.TokenCredential }
+
+func (c azdTokenRetry) GetToken(
+	ctx context.Context,
+	opts policy.TokenRequestOptions,
+) (azcore.AccessToken, error) {
+	tok, err := c.inner.GetToken(ctx, opts)
+	if err == nil || ctx.Err() != nil {
+		return tok, err
+	}
+	log.Printf("[auth] token request failed (%v); retrying once", err)
+	return c.inner.GetToken(ctx, opts)
+}
+
+// lookupEndpointFromAzd reads the endpoint from the active azd environment,
+// returning empty strings when azd has no current environment.
+// azdEnvironmentName is the environment this invocation acts on: the one
+// -e/--environment named, or azd's current one when it named none.
+//
+// Answered here because it was answered independently in five places and
+// -e was honoured by none of them. `azd ai eval create -e staging` read its
+// endpoint out of the default environment and wrote its eval id back there,
+// and `-e a-name-azd-rejects` was accepted in silence.
+//
+// Empty means there is no environment to act on, which is ordinary: the atomic
+// commands work standalone against the data plane.
+func azdEnvironmentName(ctx context.Context, azdClient *azdext.AzdClient) string {
+	if name := projectctx.SelectedEnvironment(ctx); name != "" {
+		return name
+	}
+	envResp, err := azdClient.Environment().GetCurrent(ctx, &azdext.EmptyRequest{})
+	if err != nil || envResp.GetEnvironment() == nil {
+		return ""
+	}
+	return envResp.Environment.Name
+}
+
+func lookupEndpointFromAzd(ctx context.Context, azdClient *azdext.AzdClient) (endpoint, envName string) {
+	envName = azdEnvironmentName(ctx, azdClient)
+	if envName == "" {
+		return "", ""
+	}
+	val, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+		EnvName: envName,
+		Key:     projectEndpointEnvKey,
+	})
+	if err != nil || val == nil || val.Value == "" {
+		return "", envName
+	}
+	return val.Value, envName
+}
+
+// errNoAzdEnvironment reports that there is no azd environment to persist into.
+//
+// The atomic commands are meant to work standalone against the data plane, so
+// running outside a project is ordinary rather than a problem worth reporting.
+// A write that fails for any other reason still is.
+var errNoAzdEnvironment = messages.ErrNoAzdEnvironment
+
+// remember persists a value that the extension can recover without, so a
+// failure to store it must not fail the work that produced it.
+//
+// Running outside a project is ordinary -- the atomic commands are meant to
+// work standalone against the data plane -- so having nowhere to write is not
+// worth a word. Anything else is: these keys are how a later deploy recognizes
+// what it already published, and losing one silently means the next `azd up`
+// creates a second immutable version of something it had already created.
+//
+// Written to stderr, not through log: the standard logger is pointed at
+// io.Discard unless --debug, so logging this would be the same silence with a
+// more reassuring name. stderr keeps `-o json` on stdout parseable. azd does
+// not surface an extension's stderr, so under `azd up` this reaches the debug
+// log and no further -- direct invocations are where it shows.
+func (ec *evalContext) remember(ctx context.Context, key, value string) {
+	err := ec.setEnvValue(ctx, key, value)
+	if err == nil || errors.Is(err, errNoAzdEnvironment) {
+		return
+	}
+	fmt.Fprint(os.Stderr, messages.Warning(err))
+	log.Printf("[env] could not record %s: %v", key, err)
+}
+
+// setEnvValue persists a value into the active azd environment. azd itself
+// writes none of these keys -- the extension owns them.
+func (ec *evalContext) setEnvValue(ctx context.Context, key, value string) error {
+	if ec.envName == "" {
+		envResp, err := ec.azdClient.Environment().GetCurrent(ctx, &azdext.EmptyRequest{})
+		if err != nil || envResp == nil || envResp.Environment == nil {
+			return messages.NoAzdEnvironmentToWrite(key)
+		}
+		ec.envName = envResp.Environment.Name
+	}
+	_, err := ec.azdClient.Environment().SetValue(ctx, &azdext.SetEnvRequest{
+		EnvName: ec.envName,
+		Key:     key,
+		Value:   value,
+	})
+	if err != nil {
+		return messages.WritingEnvValue(key, err)
+	}
+	return nil
+}
+
+// confirmedNoAzdEnvironment reports that azd answered, and the answer was that
+// there is no current environment.
+//
+// ec.envName being empty is not that answer. It is left empty by any failure to
+// reach azd as well as by there being no environment, so reading it as "there
+// is none" turns a transient gRPC hiccup into advice to create an environment
+// the user already has.
+//
+// The environment name is recovered here when there turns out to be one, so a
+// caller whose earlier lookup came up empty because of a hiccup can retry it.
+func (ec *evalContext) confirmedNoAzdEnvironment(ctx context.Context) bool {
+	if ec.envName != "" {
+		return false
+	}
+	if ec.azdClient == nil {
+		// No azd to ask: running standalone against the data plane, where
+		// there is genuinely nowhere to have recorded an id.
+		return true
+	}
+	envResp, err := ec.azdClient.Environment().GetCurrent(ctx, &azdext.EmptyRequest{})
+	if err != nil {
+		return isNoDefaultEnvironmentError(err)
+	}
+	if envResp == nil || envResp.Environment == nil || envResp.Environment.Name == "" {
+		return true
+	}
+	ec.envName = envResp.Environment.Name
+	return false
+}
+
+// isNoDefaultEnvironmentError picks azd's "there is no environment to record
+// anything in" out of every other reason the call could have failed.
+//
+// The distinction is the whole point: a transport failure must not be reported
+// as a missing environment, or a gRPC hiccup tells the user to create one they
+// already have.
+//
+// Written as the cascade's own rule minus the one case the two disagree on,
+// rather than as a second list of azd's sentinels. Keeping a second list is how
+// `no project exists` came to be handled in the cascade and missed here, which
+// told anyone running outside a project to publish an eval that already exists.
+func isNoDefaultEnvironmentError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return projectctx.HostedSourceAbsent(err) && !projectctx.DaemonUnreachable(err)
+}
+
+// getEnvValue reads a value from the active azd environment, returning empty
+// when it is unset.
+func (ec *evalContext) getEnvValue(ctx context.Context, key string) string {
+	if ec.envName == "" || ec.azdClient == nil {
+		return ""
+	}
+	val, err := ec.azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+		EnvName: ec.envName,
+		Key:     key,
+	})
+	if err != nil || val == nil {
+		return ""
+	}
+	return val.Value
+}
+
+// deployCommand names the command that publishes this project's evals.
+//
+// `azd up` provisions before it deploys, so it only works where there is
+// infrastructure to provision. Evals are data-plane only, so a project that
+// ships none fails compiling a missing infra/main.bicep and never reaches
+// them -- naming `azd up` there hands the reader a failure instead of a fix.
+func (ec *evalContext) deployCommand(ctx context.Context) string {
+	if ec.deployCmd != "" {
+		return ec.deployCmd
+	}
+
+	proj, err := ec.azdProject(ctx)
+	name := deployCommandName(proj)
+	if err != nil {
+		// A project we could not read is not a project without infrastructure.
+		// Answer for this call, but do not cache what a transport failure said:
+		// one hiccup would otherwise downgrade the advice for the whole process.
+		return name
+	}
+	ec.deployCmd = name
+	return name
+}
+
+// azdProject reads the project azd is running against. A nil project with no
+// error means azd answered and there is none; an error means it did not answer.
+func (ec *evalContext) azdProject(ctx context.Context) (*azdext.ProjectConfig, error) {
+	if ec.azdClient == nil {
+		return nil, nil
+	}
+	resp, err := ec.azdClient.Project().Get(ctx, &azdext.EmptyRequest{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.GetProject(), nil
+}
+
+// deployCommandName is projectCanProvision phrased as the command to run.
+//
+// Without infrastructure the answer is this extension's own command rather than
+// `azd deploy`. Deploy refuses with "infrastructure has not been provisioned"
+// in an environment that has never provisioned one, which is exactly the
+// scratch project `azd init --minimal` produces and an eval gets scaffolded
+// into. `azd ai eval create` reconciles the same configuration needing nothing
+// but an endpoint.
+func deployCommandName(proj *azdext.ProjectConfig) string {
+	if projectCanProvision(proj) {
+		return azdUpCommand
+	}
+	return "azd ai eval create"
+}
+
+// azdUpCommand provisions before it deploys. It is named rather than repeated
+// because callers have to be able to tell it apart from this extension's own
+// commands -- it takes none of their flags.
+const azdUpCommand = "azd up"
+
+// appInsightsEnvKey is where a connected Application Insights resource lands in
+// the azd environment. azd's own provisioning writes it, and the agents
+// extension reads the same key to pass tracing configuration to a running
+// agent, so its presence is the project's answer to "are traces being
+// collected?".
+const appInsightsEnvKey = "APPLICATIONINSIGHTS_CONNECTION_STRING"
+
+// defaultGenerationSource picks what `dataset generate` sends when --from was
+// not given, from the Application Insights connection string the project has
+// (or has not) been given.
+//
+// Traces are the better dataset when they exist, being real conversations
+// rather than synthesized ones, so they win whenever the project is wired to
+// collect them. Outside a project, or in one with no Application Insights,
+// there are no traces to ask for and the agent's own definition is all that is
+// left.
+func defaultGenerationSource(appInsightsConnection string) []string {
+	if appInsightsConnection != "" {
+		return []string{project.GenerateFromTraces}
+	}
+	return []string{project.GenerateFromAgent}
+}
+
+func (ec *evalContext) Close() {
+	if ec.azdClient != nil {
+		ec.azdClient.Close()
+	}
+}
+
+// projectARMIDEnvKey holds the project's ARM resource ID, which is what the
+// Foundry portal addresses a project by. azd provisioning writes it, and the
+// agents extension reads the same key to build the same links.
+const projectARMIDEnvKey = "AZURE_AI_PROJECT_ID"
+
+// portalPrefix builds the Foundry portal prefix for this project, or nil when
+// the project cannot be addressed.
+//
+// Best effort by design: a portal link is a convenience on top of a command
+// that already did its work, so a missing or unparseable resource ID drops the
+// line rather than failing the command that earned it.
+func (ec *evalContext) portalPrefix(ctx context.Context) *eval_api.PortalPrefix {
+	armID := ec.getEnvValue(ctx, projectARMIDEnvKey)
+	if armID == "" {
+		return nil
+	}
+	prefix, err := eval_api.NewPortalPrefix(armID)
+	if err != nil {
+		log.Printf("[portal] %s is not a project resource ID: %v", projectARMIDEnvKey, err)
+		return nil
+	}
+	return prefix
+}
+
+// withPortalLink stamps a run with its portal URL, so the terminal and `-o json`
+// answer with the same link from one place.
+func (ec *evalContext) withPortalLink(
+	ctx context.Context,
+	evalID string,
+	run *eval_api.OpenAIEvalRun,
+) *eval_api.OpenAIEvalRun {
+	if run == nil || evalID == "" || run.ID == "" {
+		return run
+	}
+	if prefix := ec.portalPrefix(ctx); prefix != nil {
+		run.PortalURL = prefix.EvalRunURL(evalID, run.ID)
+	}
+	return run
+}
+
+// azd environment keys written by this extension.
+const (
+	envKeyEvalID            = "EVAL_ID"
+	envKeyEvalRunID         = "EVAL_RUN_ID"
+	envKeyDatasetVersion    = "EVAL_DATASET_VERSION"
+	envKeyFingerprintPrefix = "EVAL_FINGERPRINT_"
+	// envKeyEvalPath records where `init` put the configuration, so the
+	// commands that read it afterwards do not each need --path repeated.
+	envKeyEvalPath = "EVAL_CONFIG_PATH"
+)
+
+// evalDirCascade is the one rule for where the configuration lives:
+//
+//  1. --path
+//  2. the path `init` recorded in the azd environment
+//  3. ./evals
+//
+// The middle level is what stops `--path` from having to be repeated on every
+// later command. Without it, `init --path ./quality` wrote a configuration that
+// `run` then looked for under ./evals and reported as missing -- while
+// azure.yaml's $ref pointed at it correctly the whole time.
+//
+// This is the whole rule, and every command that reads the configuration goes
+// through it. Stating it here and applying it on only some paths is how
+// `create` came to report the configuration missing and `generate` came to
+// write a second one under ./evals, both in a project where init had recorded
+// where it put the first.
+//
+// recorded tells absence apart from failure, and the two get different
+// answers. A project with no azd environment has genuinely recorded nothing,
+// so ./evals is right. An azd that could not be asked has said nothing at all,
+// and defaulting on that would write the second configuration all over again --
+// this time for a reason nobody could reproduce.
+func evalDirCascade(flagValue string, recorded func() (string, error)) (string, error) {
+	if flagValue != "" {
+		return flagValue, nil
+	}
+	path, err := recorded()
+	if err != nil {
+		return "", err
+	}
+	if path != "" {
+		return path, nil
+	}
+	return project.DefaultEvalDir, nil
+}
+
+// evalDir is the cascade for a command that already holds an azd connection.
+func (ec *evalContext) evalDir(ctx context.Context, flagValue string) (string, error) {
+	return evalDirCascade(flagValue, func() (string, error) {
+		if ec.envName == "" || ec.azdClient == nil {
+			return "", nil
+		}
+		return readRecordedEvalPath(ctx, ec.azdClient, ec.envName)
+	})
+}
+
+// resolveEvalDir is the cascade for a command that has not built an
+// evalContext yet.
+//
+// `create`, `generate` and `init` all have to find the configuration before
+// they resolve a Foundry endpoint, so that a project with no configuration is
+// told to run `init` rather than told to set an endpoint. The extra azd
+// connection is local and short-lived, and is what buys that ordering.
+func resolveEvalDir(ctx context.Context, flagValue string) (string, error) {
+	return evalDirCascade(flagValue, func() (string, error) {
+		azdClient, err := azdext.NewAzdClient()
+		if err != nil {
+			// Nothing to ask. This extension is spawned by azd, so the case
+			// that reaches here is a test or a direct invocation, neither of
+			// which has an environment holding a recorded path.
+			return "", nil
+		}
+		defer azdClient.Close()
+
+		if name := projectctx.SelectedEnvironment(ctx); name != "" {
+			return readRecordedEvalPath(ctx, azdClient, name)
+		}
+
+		env, err := azdClient.Environment().GetCurrent(ctx, &azdext.EmptyRequest{})
+		if err != nil {
+			// The same rule the endpoint cascade uses: azd saying "there is no
+			// project or environment" is an answer, and anything else is not.
+			if isNoDefaultEnvironmentError(err) {
+				return "", nil
+			}
+			return "", err
+		}
+		if env.GetEnvironment() == nil {
+			return "", nil
+		}
+		return readRecordedEvalPath(ctx, azdClient, env.GetEnvironment().GetName())
+	})
+}
+
+// readRecordedEvalPath reads back what recordEvalPath wrote, distinguishing a
+// key that was never set from a read that failed.
+func readRecordedEvalPath(
+	ctx context.Context,
+	client *azdext.AzdClient,
+	envName string,
+) (string, error) {
+	val, err := client.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+		EnvName: envName,
+		Key:     envKeyEvalPath,
+	})
+	if err != nil {
+		// An unset key is an answer; init records the path best effort and
+		// succeeds without an azd environment to record it in.
+		if isNoDefaultEnvironmentError(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	if val == nil {
+		return "", nil
+	}
+	return val.Value, nil
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/context_retry_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/context_retry_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingCred fails its first failUntil calls, then succeeds.
+type countingCred struct {
+	calls    int
+	failFor  int
+	lastOpts policy.TokenRequestOptions
+}
+
+func (c *countingCred) GetToken(
+	_ context.Context, opts policy.TokenRequestOptions,
+) (azcore.AccessToken, error) {
+	c.calls++
+	c.lastOpts = opts
+	if c.calls <= c.failFor {
+		return azcore.AccessToken{}, errors.New("AzureDeveloperCLICredential: exit status 1")
+	}
+	return azcore.AccessToken{Token: "token"}, nil
+}
+
+// The tests below construct azdTokenRetry directly, so they all pass even if
+// nothing wires it in. This one guards the wiring: an earlier version assigned
+// the wrapper to the context and built both clients from the raw credential,
+// which made the retry dead code.
+func TestNewAzdTokenCredentialReturnsTheRetryingCredential(t *testing.T) {
+	cred, err := newAzdTokenCredential()
+	require.NoError(t, err)
+	_, wrapped := cred.(azdTokenRetry)
+	assert.True(t, wrapped, "clients must be built from the retrying credential, not the raw one")
+}
+
+// The failure this retries carries no cause: azidentity kills the azd
+// subprocess at a fixed 10s and discards its stderr. Retrying is the only way
+// to tell a slow token from a broken login.
+func TestAzdTokenRetryRecoversFromOneFailure(t *testing.T) {
+	inner := &countingCred{failFor: 1}
+
+	tok, err := azdTokenRetry{inner: inner}.GetToken(
+		t.Context(), policy.TokenRequestOptions{Scopes: []string{"scope"}})
+
+	require.NoError(t, err, "a token that succeeds on the second attempt must not fail the command")
+	assert.Equal(t, "token", tok.Token)
+	assert.Equal(t, 2, inner.calls, "exactly one retry")
+	assert.Equal(t, []string{"scope"}, inner.lastOpts.Scopes, "the retry keeps the caller's scopes")
+}
+
+func TestAzdTokenRetryDoesNotRetryASuccess(t *testing.T) {
+	inner := &countingCred{}
+	_, err := azdTokenRetry{inner: inner}.GetToken(t.Context(), policy.TokenRequestOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, inner.calls, "a working token costs one call")
+}
+
+// Retrying must not paper over a genuine failure, and must stop at one.
+func TestAzdTokenRetryGivesUpAfterTheSecondFailure(t *testing.T) {
+	inner := &countingCred{failFor: 99}
+	_, err := azdTokenRetry{inner: inner}.GetToken(t.Context(), policy.TokenRequestOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exit status 1", "the original cause survives")
+	assert.Equal(t, 2, inner.calls, "no more than one retry")
+}
+
+// A cancelled context is the user pressing Ctrl+C or a deadline expiring;
+// retrying there would just fail again more slowly.
+func TestAzdTokenRetryDoesNotRetryACancelledContext(t *testing.T) {
+	inner := &countingCred{failFor: 99}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := azdTokenRetry{inner: inner}.GetToken(ctx, policy.TokenRequestOptions{})
+	require.Error(t, err)
+	assert.Equal(t, 1, inner.calls, "a cancelled context is not retried")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/dataset.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/dataset.go
@@ -1,0 +1,439 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/dataset_api"
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/spf13/cobra"
+)
+
+// firstDatasetVersions are the versions a dataset's first publish can carry,
+// probed when the version listing has not caught up yet.
+//
+// The service assigns nothing; the client picks. This CLI's first publish is
+// NextVersion(""), so probing a hardcoded "1" never found a dataset this CLI
+// had just created -- which is the one case the probe exists for. "1" is still
+// probed because a generation job, the SDK or the portal can register one.
+var firstDatasetVersions = []string{dataset_api.NextVersion(""), "1"}
+
+func newDatasetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dataset",
+		Short: "Manage evaluation datasets.",
+	}
+	cmd.AddCommand(
+		newDatasetCreateCommand(),
+		newDatasetUpdateCommand(),
+		newDatasetListCommand(),
+		newDatasetShowCommand(),
+		newDatasetDeleteCommand(),
+		newDatasetVersionsCommand(),
+	)
+	return cmd
+}
+
+// newDatasetCreateCommand builds `dataset create <name>`, which registers a
+// dataset that does not exist yet.
+func newDatasetCreateCommand() *cobra.Command {
+	return newDatasetWriteCommand("create", "Register a dataset, publishing its first version.")
+}
+
+// newDatasetUpdateCommand builds `dataset update <name>`, which publishes a
+// further version of one that does.
+func newDatasetUpdateCommand() *cobra.Command {
+	return newDatasetWriteCommand("update", "Publish a new version of a dataset.")
+}
+
+// datasetPresence answers whether the dataset is already registered, and
+// whether a "no" can be trusted.
+//
+// The version listing lags a publish, so a create followed straight by an
+// update was told the dataset it had just made does not exist. A point read of
+// the versions a first publish can carry usually settles that, catching up
+// sooner than the listing.
+//
+// Absence is only certain when the listing itself answered 404. An empty 200
+// does not prove it: an unknown dataset and a listing that has not caught up
+// are indistinguishable.
+//
+// A read that failed for any other reason proves nothing at all, and is
+// returned. Treating a 403 or a timeout as "not there" let `create` go on to
+// publish a further version of a dataset that already existed -- the one thing
+// separating create from update, decided by an error nobody looked at.
+func datasetPresence(
+	ctx context.Context,
+	client *dataset_api.DatasetClient,
+	name string,
+) (exists, absenceCertain bool, err error) {
+	existing, listErr := client.ListDatasetVersions(ctx, name, ProjectEndpointAPIVersion)
+	if listErr != nil && !dataset_api.IsNotFound(listErr) {
+		return false, false, messages.CheckingDataset(name, listErr)
+	}
+	if listErr == nil && existing != nil && len(existing.Value) > 0 {
+		return true, false, nil
+	}
+
+	for _, v := range firstDatasetVersions {
+		_, getErr := client.GetDataset(ctx, name, v, ProjectEndpointAPIVersion)
+		if getErr == nil {
+			return true, false, nil
+		}
+		if !dataset_api.IsNotFound(getErr) {
+			return false, false, messages.CheckingDataset(name, getErr)
+		}
+	}
+	return false, dataset_api.IsNotFound(listErr), nil
+}
+
+// newDatasetWriteCommand builds create and update. Both run the same upload,
+// and the existence check is the only thing that separates them: a version is
+// brought into being by startPendingUpload, which neither knows nor cares
+// whether the name was already in use.
+func newDatasetWriteCommand(verb, short string) *cobra.Command {
+	var (
+		fromFile    string
+		version     string
+		endpointFlg string
+	)
+
+	cmd := &cobra.Command{
+		Use:   verb + " <name>",
+		Short: short,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if !validAssetName(name) {
+				return messages.InvalidDatasetName(name)
+			}
+			if fromFile == "" {
+				return requireFlag("from-file")
+			}
+
+			localSource, err := datasetUploadSource(fromFile)
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			exists, absenceCertain, err := datasetPresence(ctx, ec.datasetClient, name)
+			if err != nil {
+				return err
+			}
+			if err := checkAssetExistence(
+				verb, "dataset", name, exists, absenceCertain,
+			); err != nil {
+				return err
+			}
+
+			ds, err := ec.datasetClient.UploadNextVersion(
+				ctx, name, version, localSource, ProjectEndpointAPIVersion,
+			)
+			if err != nil {
+				return messages.RegisteringDataset(name, err)
+			}
+
+			if err := ec.setEnvValue(ctx, envKeyDatasetVersion, ds.Version); err != nil {
+				// Persisting is a convenience, so this never fails the command.
+				// It goes to stdout because azd does not surface an extension's
+				// stderr, and is skipped outside a project, where having nowhere
+				// to persist is expected rather than notable.
+				if !errors.Is(err, errNoAzdEnvironment) && !isJSON(cmd) {
+					fmt.Fprint(cmd.OutOrStdout(), messages.Warning(err))
+				}
+			}
+
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), ds)
+			}
+			fmt.Fprint(cmd.OutOrStdout(), messages.DatasetRegistered(ds.Name, ds.Version))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&fromFile, "from-file", "",
+		"Path to a .jsonl file, or a directory containing one.")
+	// Only on update. create publishes a first version, and the upload derives
+	// the next version from whatever this holds, so `create --version 4.0`
+	// would publish 5.0 -- and leave the existence probe, which looks for the
+	// versions a first publish can carry, unable to find what it wrote.
+	if verb == "update" {
+		cmd.Flags().StringVar(&version, "version", "",
+			"Current version to increment from. Omit to increment from the latest registered version.")
+	}
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// datasetUploadSource resolves what was named into the path the upload reads.
+//
+// A named file is returned as itself. Returning its directory would upload
+// whichever .jsonl sorts first, so pointing --from-file at one dataset in a
+// folder holding several would register a different one under that name — and
+// the fingerprint would describe the file that was named, so the two would
+// agree forever afterwards.
+//
+// A directory is resolved to the single .jsonl inside it, which is what the
+// flag offers. Several is not that, and picking one would be a guess.
+func datasetUploadSource(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", messages.ReadingFromFile(path, err)
+	}
+	if !info.IsDir() {
+		if !strings.EqualFold(filepath.Ext(path), ".jsonl") {
+			return "", messages.FromFileMustBeJSONL(path)
+		}
+		return path, nil
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return "", messages.ReadingFromFile(path, err)
+	}
+	var found []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.EqualFold(filepath.Ext(e.Name()), ".jsonl") {
+			found = append(found, e.Name())
+		}
+	}
+	switch len(found) {
+	case 0:
+		return "", messages.FromFileDirectoryHasNoJSONL(path)
+	case 1:
+		return filepath.Join(path, found[0]), nil
+	default:
+		return "", messages.FromFileDirectoryIsAmbiguous(path, found)
+	}
+}
+
+func newDatasetListCommand() *cobra.Command {
+	var endpointFlg string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List the project's datasets.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			list, err := ec.datasetClient.ListDatasets(ctx, ProjectEndpointAPIVersion)
+			if err != nil {
+				return messages.ListingDatasets(err)
+			}
+			return renderDatasets(cmd, list, messages.NoDatasets())
+		},
+	}
+
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// newDatasetVersionsCommand groups the version listing, so that `list` means
+// the assets rather than the history of one of them.
+func newDatasetVersionsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "versions",
+		Short: "Inspect the versions of one dataset.",
+	}
+	cmd.AddCommand(newDatasetVersionsListCommand())
+	return cmd
+}
+
+func newDatasetVersionsListCommand() *cobra.Command {
+	var endpointFlg string
+
+	cmd := &cobra.Command{
+		Use:   "list <name>",
+		Short: "List the versions of a dataset.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if !validAssetName(name) {
+				return messages.InvalidDatasetName(name)
+			}
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			list, err := ec.datasetClient.ListDatasetVersions(ctx, name, ProjectEndpointAPIVersion)
+			if err != nil {
+				return messages.ListingDatasetVersions(name, err)
+			}
+			// An unknown name lists nothing and succeeds; it is not an error.
+			// `-o json` callers range over the array, and `dataset delete` is
+			// checked for idempotence by listing what is left. The empty sentence
+			// names the dataset, though: the project may hold plenty of others, so
+			// "No datasets found." would be answering a different question.
+			return renderDatasets(cmd, list, messages.NoDatasetVersions(name))
+		},
+	}
+
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+func renderDatasets(cmd *cobra.Command, list *dataset_api.DatasetList, whenEmpty string) error {
+	// JSON is decided before emptiness: a caller piping this into a parser needs
+	// an empty array, not the sentence a human would read.
+	if list == nil {
+		list = &dataset_api.DatasetList{}
+	}
+	if isJSON(cmd) {
+		return emitJSONList(cmd.OutOrStdout(), list.Value)
+	}
+	rows := make([][]string, 0, len(list.Value))
+	for _, d := range list.Value {
+		rows = append(rows, []string{d.Name, d.Version, d.Type})
+	}
+	if len(rows) == 0 {
+		fmt.Fprint(cmd.OutOrStdout(), messages.NoDatasets())
+		return nil
+	}
+	// TYPE, not FORMAT: the service populates type (`uri_file`) and leaves
+	// format empty, so the column was blank on every row.
+	return emitTable(cmd.OutOrStdout(), []string{"NAME", "VERSION", "TYPE"}, rows)
+}
+
+func newDatasetShowCommand() *cobra.Command {
+	var (
+		version     string
+		endpointFlg string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "show <name>",
+		Short: "Show a dataset version.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if !validAssetName(name) {
+				return messages.InvalidDatasetName(name)
+			}
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			if version == "" {
+				list, err := ec.datasetClient.ListDatasetVersions(ctx, name, ProjectEndpointAPIVersion)
+				if err != nil {
+					return messages.ResolvingLatestDatasetVersion(name, err)
+				}
+				if len(list.Value) == 0 {
+					// The service answers an unknown name with an empty list
+					// rather than a 404, and a dataset cannot exist with no
+					// versions, so this is what "no such dataset" looks like.
+					return messages.DatasetNotFound(name)
+				}
+				version = dataset_api.LatestVersion(list.Value)
+			}
+
+			ds, err := ec.datasetClient.GetDataset(ctx, name, version, ProjectEndpointAPIVersion)
+			if err != nil {
+				if eval_api.IsNotFound(err) {
+					return messages.DatasetVersionNotFoundWithHint(name, version)
+				}
+				return messages.ReadingDatasetVersion(name, version, err)
+			}
+
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), ds)
+			}
+			if err := emitDetail(cmd.OutOrStdout(), []field{
+				{"Name", ds.Name},
+				{"Version", ds.Version},
+				{"Type", ds.Type},
+				{"URI", ds.ResolvedBlobURI()},
+			}); err != nil {
+				return err
+			}
+			if prefix := ec.portalPrefix(ctx); prefix != nil {
+				writePortalLink(cmd.OutOrStdout(), prefix.DatasetURL(ds.Name, ds.Version))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&version, "version", "", "Version to show. Omit for the latest.")
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+func newDatasetDeleteCommand() *cobra.Command {
+	var (
+		version     string
+		endpointFlg string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "delete <name>",
+		Short: "Delete a dataset version.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if !validAssetName(name) {
+				return messages.InvalidDatasetName(name)
+			}
+			if version == "" {
+				return requireFlag("version")
+			}
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			if err := ec.datasetClient.DeleteDatasetVersion(
+				ctx, name, version, ProjectEndpointAPIVersion,
+			); err != nil {
+				if eval_api.IsNotFound(err) {
+					return messages.DatasetVersionNotFound(name, version)
+				}
+				return messages.DeletingDatasetVersion(name, version, err)
+			}
+
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), map[string]string{
+					"name": name, "version": version, "status": "deleted",
+				})
+			}
+			fmt.Fprint(cmd.OutOrStdout(), messages.DatasetDeleted(name, version))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&version, "version", "", "Version to delete.")
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/dataset_presence_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/dataset_presence_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"azureaieval/internal/pkg/dataset_api"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// presenceServer stands up a fake project endpoint and records every path the
+// presence probe asks for, so a test can assert what was tried as well as what
+// was concluded.
+type presenceServer struct {
+	mu    sync.Mutex
+	paths []string
+}
+
+// requested returns the paths seen so far, in order.
+func (s *presenceServer) requested() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.paths...)
+}
+
+// newPresenceClient wires a DatasetClient to a server that answers the version
+// listing with listStatus/listBody, and answers a point read of a dataset
+// version with whatever found reports for that version.
+//
+// Retries are off: a test that means "the service said 404" should cost one
+// request, not a backoff schedule.
+func newPresenceClient(
+	t *testing.T,
+	listStatus int,
+	listBody string,
+	found map[string]bool,
+) (*dataset_api.DatasetClient, *presenceServer) {
+	t.Helper()
+
+	rec := &presenceServer{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.mu.Lock()
+		rec.paths = append(rec.paths, r.URL.Path)
+		rec.mu.Unlock()
+
+		// Assertions inside a handler run on the server's goroutine, where a
+		// Fatalf would leave the client hanging on a response never written.
+		assert.Equal(t, http.MethodGet, r.Method)
+
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/versions"):
+			w.WriteHeader(listStatus)
+			_, _ = w.Write([]byte(listBody))
+		default:
+			version := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+			if found[version] {
+				w.WriteHeader(http.StatusOK)
+				// A fixed body: datasetPresence reads only whether the point
+				// read succeeded, and echoing the request path back would make
+				// this a taint sink for no benefit.
+				_, _ = w.Write([]byte(`{"name":"ds"}`))
+				return
+			}
+			http.Error(w, `{"error":{"code":"NotFound"}}`, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := dataset_api.NewDatasetClientFromPipeline(
+		srv.URL, runtime.NewPipeline("test", "v1", runtime.PipelineOptions{}, nil))
+	return client, rec
+}
+
+// TestPresenceTrustsANonEmptyVersionListing is the ordinary case: the listing
+// answered, so no point read is needed.
+func TestPresenceTrustsANonEmptyVersionListing(t *testing.T) {
+	client, rec := newPresenceClient(t,
+		http.StatusOK, `{"value":[{"name":"ds","version":"1.0"}]}`, nil)
+
+	exists, absenceCertain, err := datasetPresence(t.Context(), client, "ds")
+	require.NoError(t, err)
+
+	require.True(t, exists)
+	require.False(t, absenceCertain)
+	require.Equal(t, []string{"/datasets/ds/versions"}, rec.requested(),
+		"a listing that answered should settle it without a point read")
+}
+
+// TestPresenceProbesPastAListingThatHasNotCaughtUp covers the bug the probe
+// exists for: a create publishes 1.0, the listing still reports nothing, and
+// the update that follows must not be told the dataset is missing.
+func TestPresenceProbesPastAListingThatHasNotCaughtUp(t *testing.T) {
+	client, rec := newPresenceClient(t,
+		http.StatusOK, `{"value":[]}`, map[string]bool{"1.0": true})
+
+	exists, absenceCertain, err := datasetPresence(t.Context(), client, "ds")
+	require.NoError(t, err)
+
+	require.True(t, exists, "the point read found the version the listing had not")
+	require.False(t, absenceCertain)
+	require.Equal(t, []string{"/datasets/ds/versions", "/datasets/ds/versions/1.0"},
+		rec.requested())
+	require.NoError(t, checkAssetExistence("update", "dataset", "ds", exists, absenceCertain))
+	require.Error(t, checkAssetExistence("create", "dataset", "ds", exists, absenceCertain),
+		"create must still refuse a name the probe found")
+}
+
+// TestPresenceProbesTheVersionSomethingElseRegistered covers a dataset created
+// by the portal, the SDK or a generation job, which numbers its first version
+// "1" rather than the "1.0" this CLI publishes.
+func TestPresenceProbesTheVersionSomethingElseRegistered(t *testing.T) {
+	client, rec := newPresenceClient(t,
+		http.StatusOK, `{"value":[]}`, map[string]bool{"1": true})
+
+	exists, absenceCertain, err := datasetPresence(t.Context(), client, "ds")
+	require.NoError(t, err)
+
+	require.True(t, exists)
+	require.False(t, absenceCertain)
+	require.Equal(t,
+		[]string{"/datasets/ds/versions", "/datasets/ds/versions/1.0", "/datasets/ds/versions/1"},
+		rec.requested(),
+		"both first-publish versions should be probed before giving up")
+}
+
+// TestPresenceWillNotCallAnEmptyListingProofOfAbsence is the guard that keeps
+// `update` working against a service whose listing lags. An empty 200 is not a
+// 404, so the gate must let the update through rather than refuse it.
+func TestPresenceWillNotCallAnEmptyListingProofOfAbsence(t *testing.T) {
+	client, _ := newPresenceClient(t, http.StatusOK, `{"value":[]}`, nil)
+
+	exists, absenceCertain, err := datasetPresence(t.Context(), client, "ds")
+	require.NoError(t, err)
+
+	require.False(t, exists)
+	require.False(t, absenceCertain,
+		"an empty listing does not distinguish an unknown dataset from a stale one")
+	require.NoError(t, checkAssetExistence("update", "dataset", "ds", exists, absenceCertain),
+		"update must proceed when absence is unproven")
+}
+
+// TestPresenceTreatsA404ListingAsProofOfAbsence is the other half: a service
+// that actually said "no such dataset" should stop an update before it uploads.
+func TestPresenceTreatsA404ListingAsProofOfAbsence(t *testing.T) {
+	client, _ := newPresenceClient(t,
+		http.StatusNotFound, `{"error":{"code":"NotFound"}}`, nil)
+
+	exists, absenceCertain, err := datasetPresence(t.Context(), client, "ds")
+	require.NoError(t, err)
+
+	require.False(t, exists)
+	require.True(t, absenceCertain)
+
+	gateErr := checkAssetExistence("update", "dataset", "ds", exists, absenceCertain)
+	require.Error(t, gateErr)
+	require.Contains(t, gateErr.Error(), `dataset "ds" does not exist`)
+	require.NoError(t, checkAssetExistence("create", "dataset", "ds", exists, absenceCertain),
+		"create is exactly what a proven-absent name should allow")
+}
+
+// A read that failed proves nothing. Answering "not there" let `create` publish
+// a further version of a dataset that already existed -- the one thing
+// separating create from update, decided by an error nobody looked at.
+func TestPresenceReportsAListingThatFailedRatherThanGuessing(t *testing.T) {
+	for _, status := range []int{
+		http.StatusForbidden,
+		http.StatusUnauthorized,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			client, _ := newPresenceClient(t, status, `{"error":{"code":"Nope"}}`, nil)
+
+			exists, absenceCertain, err := datasetPresence(t.Context(), client, "ds")
+
+			require.Error(t, err, "a failed listing is not an answer about existence")
+			require.False(t, exists)
+			require.False(t, absenceCertain)
+			require.Contains(t, err.Error(), "ds")
+		})
+	}
+}
+
+// The same rule on the point read: only a 404 means "not this version".
+func TestPresenceReportsAPointReadThatFailedRatherThanGuessing(t *testing.T) {
+	rec := &presenceServer{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.mu.Lock()
+		rec.paths = append(rec.paths, r.URL.Path)
+		rec.mu.Unlock()
+
+		if strings.HasSuffix(r.URL.Path, "/versions") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"value":[]}`))
+			return
+		}
+		http.Error(w, `{"error":{"code":"Forbidden"}}`, http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := dataset_api.NewDatasetClientFromPipeline(
+		srv.URL, runtime.NewPipeline("test", "v1", runtime.PipelineOptions{}, nil))
+
+	exists, absenceCertain, err := datasetPresence(t.Context(), client, "ds")
+
+	require.Error(t, err)
+	require.False(t, exists)
+	require.False(t, absenceCertain)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/dataset_rows_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/dataset_rows_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadJSONLBytes(t *testing.T) {
+	content := []byte(
+		"{\"query\":\"a\"}\n" +
+			"\n" + // blank lines are skipped, not treated as rows
+			"{\"query\":\"b\"}\n" +
+			"  {\"query\":\"c\"}  \n")
+
+	all, err := readJSONLBytes(content, 0)
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+	assert.Equal(t, "a", all[0]["query"])
+	assert.Equal(t, "c", all[2]["query"], "surrounding whitespace is not part of the row")
+}
+
+// The limit is what makes --max-samples mean the same thing for a published
+// dataset as for a local file.
+func TestReadJSONLBytes_StopsAtTheLimit(t *testing.T) {
+	content := []byte("{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n")
+
+	two, err := readJSONLBytes(content, 2)
+	require.NoError(t, err)
+	require.Len(t, two, 2)
+	assert.EqualValues(t, 1, two[0]["n"])
+	assert.EqualValues(t, 2, two[1]["n"])
+
+	// A limit larger than the file is not an error.
+	more, err := readJSONLBytes(content, 99)
+	require.NoError(t, err)
+	assert.Len(t, more, 3)
+}
+
+func TestReadJSONLBytes_ReportsTheOffendingLine(t *testing.T) {
+	_, err := readJSONLBytes([]byte("{\"n\":1}\nnot json\n"), 0)
+	require.ErrorContains(t, err, "line 2")
+}
+
+func TestReadJSONLBytes_EmptyIsNotAnError(t *testing.T) {
+	items, err := readJSONLBytes([]byte("\n\n"), 0)
+	require.NoError(t, err)
+	assert.Empty(t, items, "the caller decides whether no rows is a problem")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/dataset_source_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/dataset_source_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A named file has to be uploaded as itself.
+//
+// This resolver used to return the file's DIRECTORY, and the upload then took
+// whichever .jsonl sorted first. Pointing --from-file at one dataset in a
+// folder holding several therefore registered a different one under that name,
+// and because the fingerprint described the file that was named, the two agreed
+// with each other forever afterwards. The sibling dataset extension was fixed;
+// this copy was not, so the same command uploaded different bytes depending on
+// which namespace the user typed.
+func TestDatasetUploadSourceReadsTheFileThatWasNamed(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "a-sorts-first.jsonl")
+	wanted := filepath.Join(dir, "b-is-the-one-named.jsonl")
+	require.NoError(t, os.WriteFile(first, []byte(`{"query":"a"}`), 0o600))
+	require.NoError(t, os.WriteFile(wanted, []byte(`{"query":"b"}`), 0o600))
+
+	got, err := datasetUploadSource(wanted)
+
+	require.NoError(t, err)
+	assert.Equal(t, wanted, got, "the file that was named, not the one that sorts first")
+}
+
+// A directory is offered by the flag, so one .jsonl inside it resolves.
+func TestDatasetUploadSourceResolvesADirectoryHoldingOne(t *testing.T) {
+	dir := t.TempDir()
+	only := filepath.Join(dir, "only.jsonl")
+	require.NoError(t, os.WriteFile(only, []byte(`{"query":"a"}`), 0o600))
+
+	got, err := datasetUploadSource(dir)
+
+	require.NoError(t, err)
+	assert.Equal(t, only, got)
+}
+
+// Several is not "a directory containing one", and picking would be a guess.
+func TestDatasetUploadSourceRefusesAnAmbiguousDirectory(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.jsonl"), []byte(`{}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.jsonl"), []byte(`{}`), 0o600))
+
+	_, err := datasetUploadSource(dir)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "a.jsonl")
+	assert.Contains(t, err.Error(), "b.jsonl", "naming them is what makes the refusal actionable")
+}
+
+func TestDatasetUploadSourceRefusesADirectoryWithNoJSONL(t *testing.T) {
+	_, err := datasetUploadSource(t.TempDir())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no .jsonl file")
+}
+
+// The service refuses a bad name with a 400 wrapping four levels of JSON, so
+// the guard exists to say it plainly. The sibling extension had it; this copy,
+// which serves the same commands under `azd ai eval dataset`, did not.
+func TestValidAssetNameMatchesTheSibling(t *testing.T) {
+	for _, ok := range []string{"golden", "a_b-c", "A1"} {
+		assert.Truef(t, validAssetName(ok), "%q is a name the service accepts", ok)
+	}
+	for _, bad := range []string{"", "has space", "slash/name", "dots.here", "uni\u00e9"} {
+		assert.Falsef(t, validAssetName(bad), "%q must be refused before the round trip", bad)
+	}
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/dataset_version_live_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/dataset_version_live_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build live
+
+// A version is what an eval binds to, so publishing must always add one and
+// never change one that exists. Evaluators needed a guard for that; this is
+// the same question asked of datasets, against the real service.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"azureaieval/internal/pkg/dataset_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// liveDatasetClient builds a dataset client against the live project.
+func liveDatasetClient(t *testing.T) *dataset_api.DatasetClient {
+	t.Helper()
+	if os.Getenv("AZURE_AI_EVAL_E2E_LIVE") != "1" {
+		t.Skip("set AZURE_AI_EVAL_E2E_LIVE=1 to run live tests")
+	}
+	endpoint := os.Getenv("FOUNDRY_PROJECT_ENDPOINT")
+	require.NotEmpty(t, endpoint, "FOUNDRY_PROJECT_ENDPOINT is required")
+
+	cred, err := liveCredential()
+	require.NoError(t, err)
+	return dataset_api.NewDatasetClient(endpoint, retryingCredential{inner: cred})
+}
+
+// writeRows puts a one-row JSONL file in its own directory, which is what the
+// upload path reads from.
+func writeRows(t *testing.T, answer string) string {
+	t.Helper()
+	dir := t.TempDir()
+	row := fmt.Sprintf(`{"query":"q","response":%q}`+"\n", answer)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "rows.jsonl"), []byte(row), 0o600))
+	return dir
+}
+
+// TestLiveDatasetVersionIsNeverOverwritten publishes at a version that already
+// exists and requires the service to refuse.
+//
+// The reconciler relies on exactly this: when an author pins `version:` and
+// the local content has changed, it publishes at that version and treats a
+// conflict as the signal to stop. If the service accepted the write instead,
+// the pinned version would silently change under every eval bound to it, and
+// `azd up` would report success.
+func TestLiveDatasetVersionIsNeverOverwritten(t *testing.T) {
+	client := liveDatasetClient(t)
+	ctx := context.Background()
+
+	name := fmt.Sprintf("azdlive_ds_immutable_%d", time.Now().UnixNano())
+
+	first, err := client.UploadVersion(
+		ctx, name, "1", writeRows(t, "original"), ProjectEndpointAPIVersion)
+	require.NoError(t, err)
+	require.Equal(t, "1", first.Version)
+	t.Cleanup(func() {
+		_ = client.DeleteDatasetVersion(
+			context.Background(), name, "1", ProjectEndpointAPIVersion)
+	})
+
+	_, err = client.UploadVersion(
+		ctx, name, "1", writeRows(t, "replacement"), ProjectEndpointAPIVersion)
+	require.Error(t, err,
+		"publishing over an existing dataset version must be refused, not accepted")
+	assert.True(t, dataset_api.IsVersionConflict(err),
+		"the refusal must be a conflict the reconciler can recognize; got: %v", err)
+}
+
+// TestLiveDatasetUpdateAddsAVersion is the other half: the ordinary path must
+// keep adding versions rather than reusing the newest.
+func TestLiveDatasetUpdateAddsAVersion(t *testing.T) {
+	client := liveDatasetClient(t)
+	ctx := context.Background()
+
+	name := fmt.Sprintf("azdlive_ds_next_%d", time.Now().UnixNano())
+
+	first, err := client.UploadNextVersion(
+		ctx, name, "", writeRows(t, "one"), ProjectEndpointAPIVersion)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = client.DeleteDatasetVersion(
+			context.Background(), name, first.Version, ProjectEndpointAPIVersion)
+	})
+
+	// Immediate, because the version listing lags a publish and this is the
+	// window where a second upload could be told the dataset is new and
+	// restart at the version the first one just took.
+	second, err := client.UploadNextVersion(
+		ctx, name, "", writeRows(t, "two"), ProjectEndpointAPIVersion)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = client.DeleteDatasetVersion(
+			context.Background(), name, second.Version, ProjectEndpointAPIVersion)
+	})
+
+	assert.NotEqual(t, first.Version, second.Version,
+		"a second upload must add a version rather than reuse the first")
+
+	// Both readable, and the first still holding what it was published with.
+	original, err := client.GetDataset(ctx, name, first.Version, ProjectEndpointAPIVersion)
+	require.NoError(t, err)
+	assert.NotEmpty(t, original.Version)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/dataset_version_probe_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/dataset_version_probe_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/pkg/dataset_api"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The existence probe exists for one case: `create` then immediately `update`,
+// where the version listing has not caught up. It probed a hardcoded "1" while
+// this CLI's first publish is NextVersion(""), which is "1.0" -- so for the
+// case it was written for it read a version that never existed and the fallback
+// was inert. Deriving it keeps the two in step if the base ever moves.
+func TestFirstDatasetVersionsCoverWhatThisCLIPublishes(t *testing.T) {
+	assert.Contains(t, firstDatasetVersions, dataset_api.NextVersion(""),
+		"the probe has to look for the version a create actually writes")
+	assert.Contains(t, firstDatasetVersions, "1",
+		"a generation job, the SDK or the portal can register a plain 1")
+}
+
+// The probe still cannot prove absence -- it only ever proves existence, and a
+// dataset whose early versions were deleted has none of them left to find. So
+// an absence the service never confirmed has to publish rather than refuse,
+// otherwise the caller is sent to `create`, which fails in turn once the
+// listing catches up and reports the name already taken.
+func TestCheckAssetExistenceLetsAnUnprovableAbsenceThrough(t *testing.T) {
+	assert.NoError(t, checkAssetExistence("update", "dataset", "x", false, false))
+
+	err := checkAssetExistence("update", "dataset", "x", false, true)
+	assert.Error(t, err, "a 404 is the service saying the name is unknown, which still refuses")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/debug.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/debug.go
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	azcorelog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
+	"github.com/spf13/pflag"
+)
+
+// setupDebugLogging silences the standard logger unless debug mode is on.
+//
+// The data-plane clients trace every request through log.Printf, which Go
+// writes to stderr by default. Without this the CLI interleaves raw HTTP traces
+// with its own output on every command.
+//
+// The returned function puts the logger back and closes the file. Callers run
+// for the length of the process and let the OS close it, so it is returned for
+// tests and for any caller that wants to stop logging early.
+func setupDebugLogging(flags *pflag.FlagSet) func() {
+	if !isDebug(flags) {
+		log.SetOutput(io.Discard)
+		azcorelog.SetListener(nil)
+		return func() {}
+	}
+
+	// Written outside the working directory: that is the user's repository, the
+	// scaffolded .gitignore does not cover this name, and a routine `git add -A`
+	// committed one.
+	//
+	// The name is picked by CreateTemp rather than built from the date alone.
+	// The temp directory is shared on Linux, and at a predictable path another
+	// user can leave a file of their own -- readable, to collect HTTP traces
+	// that carry request headers, or a symbolic link, to have them written to a
+	// file of their choosing. CreateTemp finds an unused name and creates it
+	// 0600 in one step, so neither is reachable. The date stays in the name
+	// because it is what makes a directory of these readable, and the full path
+	// is echoed below.
+	logFile, err := os.CreateTemp("", fmt.Sprintf("azd-ai-eval-%s-*.log", time.Now().Format("2006-01-02")))
+
+	var w io.Writer
+	var closeFile func()
+	if err != nil {
+		w = os.Stderr
+		closeFile = func() {}
+	} else {
+		w = logFile
+		closeFile = func() { _ = logFile.Close() }
+		// A log nobody can find is not a log. Debugging was asked for
+		// explicitly, so naming the file costs nothing.
+		fmt.Fprintf(os.Stderr, "Debug log: %s\n", filepath.ToSlash(logFile.Name()))
+	}
+
+	log.SetOutput(w)
+	azcorelog.SetListener(func(event azcorelog.Event, msg string) {
+		fmt.Fprintf(w, "[%s] %s: %s\n", time.Now().Format(time.RFC3339), event, msg)
+	})
+
+	return func() {
+		log.SetOutput(io.Discard)
+		azcorelog.SetListener(nil)
+		closeFile()
+	}
+}
+
+// isDebug reports whether --debug or AZD_EXT_DEBUG is set.
+func isDebug(flags *pflag.FlagSet) bool {
+	if debugFlag, err := flags.GetBool("debug"); err == nil && debugFlag {
+		return true
+	}
+	debug, _ := strconv.ParseBool(os.Getenv("AZD_EXT_DEBUG"))
+	return debug
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/description_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/description_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/pkg/evalcore"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The create request has no description field, so a documented description
+// would otherwise be parsed and dropped.
+func TestBuildCarriesGroupDescriptionInMetadata(t *testing.T) {
+	schemas := map[string]*eval_api.EvaluatorSummary{
+		"builtin.similarity": schema("builtin.similarity",
+			nil, []string{"query", "response"},
+			[]string{"deployment_name"}, []string{"deployment_name"}, "turn"),
+	}
+	group := groupWith(withJudge("m", evalcore.EvaluatorRef{Evaluator: "builtin.similarity"}), "")
+	group.Description = "Quality gate for the support agent"
+
+	req, err := buildEvalRequest(group, schemas, map[string]bool{"query": true})
+	require.NoError(t, err)
+	require.Equal(t, "Quality gate for the support agent", req.Metadata["azd_description"])
+}
+
+// An absent description adds no metadata key rather than an empty one.
+func TestBuildOmitsEmptyDescription(t *testing.T) {
+	schemas := map[string]*eval_api.EvaluatorSummary{
+		"builtin.similarity": schema("builtin.similarity",
+			nil, []string{"query", "response"},
+			[]string{"deployment_name"}, []string{"deployment_name"}, "turn"),
+	}
+	group := groupWith(withJudge("m", evalcore.EvaluatorRef{Evaluator: "builtin.similarity"}), "")
+
+	req, err := buildEvalRequest(group, schemas, map[string]bool{"query": true})
+	require.NoError(t, err)
+	require.NotContains(t, req.Metadata, "azd_description")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/detail_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/detail_test.go
@@ -1,0 +1,244 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The spec's output conventions split the two shapes: a list view is uppercase
+// headers over a rule, a detail view is Title Case key/value. `show` returns
+// one thing, so it is a detail view -- and all three used to disagree, two
+// emitting raw JSON whatever was asked for and one printing a one-row table.
+//
+// Checked by reading the source rather than running the command, because these
+// commands need a service; a shape regression should not wait for a live run.
+func TestShowCommandsUseDetailViews(t *testing.T) {
+	// Command → the file and function that renders it.
+	renderers := map[string]string{
+		"dataset show":   "dataset.go",
+		"evaluator show": "evaluator.go",
+		"show":           "eval_group.go",
+	}
+
+	for path, file := range renderers {
+		t.Run(path, func(t *testing.T) {
+			require.NotNil(t, find(t, path), "the command has to exist to have a shape")
+
+			body, err := os.ReadFile(filepath.Join(".", file))
+			require.NoError(t, err)
+			assert.Containsf(t, string(body), "emitDetail",
+				"%s returns one thing, so %s renders it as a detail view", path, file)
+		})
+	}
+}
+
+// Every command returning data supports -o json, which is what makes the
+// detail view a presentation choice rather than a loss of information.
+func TestShowCommandsStillAnswerInJSON(t *testing.T) {
+	for _, path := range []string{"dataset show", "evaluator show", "show"} {
+		cmd := find(t, path)
+		// -o comes from the SDK root, so a command must not shadow it.
+		assert.Nilf(t, cmd.LocalFlags().Lookup("output"),
+			"%s must inherit -o rather than declaring its own", path)
+	}
+}
+
+// A detail view is two columns with Title Case keys, per the spec's output
+// conventions. It is what `show` prints; `-o json` is the machine-readable
+// alternative, not the only form.
+func TestEmitDetail(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, emitDetail(&buf, []field{
+		{"Name", "support-quality"},
+		{"Version", "3"},
+		{"Type", "rubric"},
+	}))
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 3)
+	for i, want := range []string{"Name", "Version", "Type"} {
+		assert.Truef(t, strings.HasPrefix(lines[i], want),
+			"line %d should start with the key %q, got %q", i, want, lines[i])
+	}
+	assert.Contains(t, lines[0], "support-quality")
+}
+
+// A blank value says only that the writer did not know which fields this kind
+// has, so it is dropped rather than printed as an empty column.
+func TestEmitDetail_DropsEmptyValues(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, emitDetail(&buf, []field{
+		{"Name", "support-quality"},
+		{"Description", ""},
+		{"Type", "rubric"},
+	}))
+
+	assert.NotContains(t, buf.String(), "Description")
+	assert.Len(t, strings.Split(strings.TrimRight(buf.String(), "\n"), "\n"), 2)
+}
+
+// `evaluator show` used to emit raw JSON whatever was asked for, which left it
+// the one `show` with no detail view and nowhere to put a portal link.
+func TestRenderEvaluator(t *testing.T) {
+	var buf bytes.Buffer
+	ec := &evalContext{}
+
+	require.NoError(t, ec.renderEvaluator(context.Background(), &buf, &eval_api.EvaluatorSummary{
+		Name:                      "support-quality",
+		Version:                   "3",
+		EvaluatorType:             "rubric",
+		Description:               "Grades politeness and accuracy.",
+		Categories:                []string{"quality", "custom"},
+		SupportedEvaluationLevels: []string{"turn", "conversation"},
+	}))
+
+	out := buf.String()
+	for _, want := range []string{
+		"Name", "support-quality",
+		"Version", "3",
+		"Type", "rubric",
+		"Description", "Grades politeness and accuracy.",
+		"Categories", "quality, custom",
+		"Evaluation Levels", "turn, conversation",
+	} {
+		assert.Contains(t, out, want)
+	}
+
+	// The schemas live in -o json: printed here they would bury the few lines a
+	// reader came for.
+	assert.NotContains(t, out, "data_schema")
+	assert.NotContains(t, out, "init_parameters")
+}
+
+// Both spellings of the type field are read, because the listing says
+// evaluator_type and other payloads say type.
+func TestRenderEvaluator_ReadsEitherTypeSpelling(t *testing.T) {
+	for _, e := range []*eval_api.EvaluatorSummary{
+		{Name: "x", EvaluatorType: "rubric"},
+		{Name: "x", TypeAlias: "rubric"},
+	} {
+		var buf bytes.Buffer
+		ec := &evalContext{}
+		require.NoError(t, ec.renderEvaluator(context.Background(), &buf, e))
+		assert.Contains(t, buf.String(), "rubric")
+	}
+}
+
+// Without an azd environment there is no project to address, so the view ends
+// at its last field rather than at an empty label.
+func TestRenderEvaluator_NoPortalLinkWithoutAProject(t *testing.T) {
+	var buf bytes.Buffer
+	ec := &evalContext{}
+
+	require.NoError(t, ec.renderEvaluator(context.Background(), &buf,
+		&eval_api.EvaluatorSummary{Name: "support-quality", Version: "3"}))
+
+	assert.NotContains(t, buf.String(), "Portal:")
+}
+
+// The spec gives evaluator URLs their own shape, distinct from datasets and
+// runs, so a link built from the wrong one resolves to nothing.
+func TestPortalEvaluatorURLShape(t *testing.T) {
+	prefix, err := eval_api.NewPortalPrefix(
+		"/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg/" +
+			"providers/Microsoft.CognitiveServices/accounts/acct/projects/proj")
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasSuffix(
+		prefix.EvaluatorURL("support-quality", "3"),
+		"/build/evaluations/catalog/support-quality/3"))
+}
+
+// The pass mark is what Scenario 4 changes between versions, so a version
+// listing that omits it cannot answer the question it is read for.
+func TestEvaluatorPassThreshold(t *testing.T) {
+	threshold := func(v float64) *eval_api.EvaluatorContract {
+		return &eval_api.EvaluatorContract{PassThreshold: &v}
+	}
+
+	cases := []struct {
+		name string
+		in   *eval_api.EvaluatorSummary
+		want string
+	}{
+		{"absent evaluator", nil, ""},
+		{"no definition", &eval_api.EvaluatorSummary{}, ""},
+		{
+			"definition without a threshold",
+			&eval_api.EvaluatorSummary{Definition: &eval_api.EvaluatorContract{}},
+			"",
+		},
+		{
+			"a threshold of zero is a real threshold, not an absent one",
+			&eval_api.EvaluatorSummary{Definition: threshold(0)},
+			"0.00",
+		},
+		{
+			"two decimals, because 0.7 and 0.75 pass different samples",
+			&eval_api.EvaluatorSummary{Definition: threshold(0.75)},
+			"0.75",
+		},
+		{
+			"a trailing zero is kept so the column stays aligned",
+			&eval_api.EvaluatorSummary{Definition: threshold(0.8)},
+			"0.80",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, evaluatorPassThreshold(tc.in))
+		})
+	}
+}
+
+func TestRenderEvaluatorVersionsShowsTheThreshold(t *testing.T) {
+	raised, held := 0.80, 0.70
+	var buf bytes.Buffer
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+
+	require.NoError(t, renderEvaluatorVersions(cmd, &eval_api.EvaluatorListResponse{
+		Value: []eval_api.EvaluatorSummary{
+			{
+				Version:     "3",
+				CreatedAt:   "2026-08-03T11:22:04Z",
+				Description: "Raised threshold, split cites_policy",
+				Definition:  &eval_api.EvaluatorContract{PassThreshold: &raised},
+			},
+			{
+				Version:     "2",
+				CreatedAt:   "2026-08-01T14:07:33Z",
+				Description: "Tightened offers_next_step criteria",
+				Definition:  &eval_api.EvaluatorContract{PassThreshold: &held},
+			},
+		},
+	}))
+
+	out := buf.String()
+	for _, want := range []string{
+		"VERSION", "CREATED AT", "PASS THRESHOLD", "DESCRIPTION",
+		"0.80", "0.70",
+		"Raised threshold, split cites_policy",
+	} {
+		assert.Contains(t, out, want)
+	}
+
+	// Name and type are constant down the listing, so printing them would cost
+	// width and say nothing.
+	assert.NotContains(t, out, "NAME")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/envkeys_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/envkeys_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Ids are per declaration. A shared key works only while a config has one
+// group: with two, the second deploy finds the first's id cached, confirms it
+// exists, and hands it back for the wrong group — so group A silently scores
+// group B's criteria.
+func TestIDKey_IsPerName(t *testing.T) {
+	a := idKey("eval", "quality-a")
+	b := idKey("eval", "quality-b")
+
+	assert.NotEqual(t, a, b, "two groups must not share an id key")
+	assert.Contains(t, a, "QUALITY_A")
+	assert.True(t, len(a) > 3 && a[len(a)-3:] == "_ID")
+}
+
+// Names that are not valid env identifiers still have to produce distinct,
+// stable keys.
+//
+// The readable half of the key cannot tell "my group" from "my-group" — both
+// sanitize to MY_GROUP. Letting them share a key is the collision the test
+// above describes: the second declaration finds the first's id cached and
+// scores the wrong group.
+func TestIDKey_NormalizesNames(t *testing.T) {
+	assert.NotEqual(t, idKey("eval", "my group"), idKey("eval", "my-group"),
+		"names that sanitize alike are still different names")
+	assert.NotEqual(t, idKey("eval", "a"), idKey("dataset", "a"),
+		"the kind keeps different resources apart")
+
+	assert.Equal(t, idKey("eval", "my group"), idKey("eval", "my group"),
+		"the same name must key the same way on every deploy")
+}
+
+// The id and version keys for the same declaration must not collide.
+func TestIDKey_DoesNotCollideWithVersionKey(t *testing.T) {
+	assert.NotEqual(t, idKey("dataset", "golden"), versionKey("dataset", "golden"))
+}
+
+// The shared EVAL_ID entry is written by every deploy, so it cannot say which
+// declaration it belongs to. Reading it for a config that names a single eval
+// let a file whose one entry had been replaced run the previous eval's criteria
+// over the new one's rows, reported as success. An eval's id is read from the
+// entry recorded under its own name and nowhere else.
+func TestEvalIDIsReadFromTheEvalsOwnEntry(t *testing.T) {
+	assert.NotEqual(t, envKeyEvalID, idKey("eval", "quality"))
+	assert.NotEqual(t, idKey("eval", "quality"), idKey("eval", "nightly"),
+		"two declarations cannot share an entry")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/envwarn_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/envwarn_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The atomic commands are meant to work standalone against the data plane, so
+// running outside a project is ordinary. Warning about nowhere to persist would
+// be noise on every standalone invocation.
+func TestNoAzdEnvironmentIsRecognizable(t *testing.T) {
+	err := fmt.Errorf("%w to write %s into", errNoAzdEnvironment, "EVAL_RUN_ID")
+
+	require.ErrorIs(t, err, errNoAzdEnvironment,
+		"callers rely on telling this apart from a failed write")
+	require.Contains(t, err.Error(), "EVAL_RUN_ID",
+		"the key is still named when the message is shown")
+}
+
+// A write that fails for any other reason stays reportable.
+func TestOtherEnvironmentFailuresStayReportable(t *testing.T) {
+	err := fmt.Errorf("writing %s to the azd environment: %w", "EVAL_RUN_ID", errors.New("rpc failed"))
+
+	require.NotErrorIs(t, err, errNoAzdEnvironment)
+	require.Contains(t, err.Error(), "rpc failed")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/eval_choice.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/eval_choice.go
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"azureaieval/internal/messages"
+	"azureaieval/internal/project"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/spf13/cobra"
+)
+
+// chooseEvalIn is chooseEval for the run commands, which hold a directory
+// rather than a loaded configuration. A configuration that will not open is
+// left to the command that opens it properly, so the error stays the same one.
+func chooseEvalIn(cmd *cobra.Command, evalDir, named string) string {
+	if named != "" || noPrompt(cmd) {
+		return named
+	}
+	cfg, err := project.OpenEvalConfig(evalDir)
+	if err != nil {
+		return named
+	}
+	return chooseEval(cmd, cfg, named)
+}
+
+// chooseEval settles which eval a command means when the caller named none.
+//
+// Refusing is right under --no-prompt, where there is nobody to ask. Standing
+// at a terminal it is not: the command holds the whole candidate list, and the
+// documented scenarios declare a second eval, so every bare `run start` after
+// that would fail permanently.
+//
+// Returning the name empty leaves the existing error to the caller, which is
+// what happens whenever the prompt cannot run.
+func chooseEval(cmd *cobra.Command, cfg *project.EvalConfig, named string) string {
+	if named != "" || cfg == nil || len(cfg.Evals) < 2 || noPrompt(cmd) {
+		return named
+	}
+
+	azdClient, err := azdext.NewAzdClient()
+	if err != nil {
+		return named
+	}
+	defer azdClient.Close()
+
+	names := cfg.EvalNames()
+	choices := make([]*azdext.SelectChoice, 0, len(names))
+	for i := range names {
+		choices = append(choices, &azdext.SelectChoice{Label: names[i], Value: names[i]})
+	}
+
+	resp, err := azdClient.Prompt().Select(commandContext(cmd), &azdext.SelectRequest{
+		Options: &azdext.SelectOptions{
+			Message: messages.SelectEvalPrompt(),
+			Choices: choices,
+		},
+	})
+	if err != nil {
+		return named
+	}
+	// Value is optional on the wire, so an unset one arrives as 0 from
+	// GetValue -- indistinguishable from the first choice. Reading it as a
+	// selection would start a billed run against an eval nobody picked.
+	if resp == nil || resp.Value == nil {
+		return named
+	}
+	index := int(resp.GetValue())
+	if index < 0 || index >= len(names) {
+		return named
+	}
+	return names[index]
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/eval_choice_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/eval_choice_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/project"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// configWith builds a configuration declaring the named evals.
+func configWith(names ...string) *project.EvalConfig {
+	cfg := &project.EvalConfig{}
+	for _, n := range names {
+		cfg.Evals = append(cfg.Evals, project.Eval{Name: n})
+	}
+	return cfg
+}
+
+// chooseEval only asks when asking can settle something. Every case below
+// resolves without a prompt, so none of them reaches the azd client.
+func TestChooseEvalOnlyAsksWhenThereIsAChoice(t *testing.T) {
+	t.Run("a name given is never second-guessed", func(t *testing.T) {
+		got := chooseEval(newEvalCreateCommand(), configWith("a", "b"), "b")
+		assert.Equal(t, "b", got)
+	})
+
+	t.Run("one declared eval needs no question", func(t *testing.T) {
+		got := chooseEval(newEvalCreateCommand(), configWith("only"), "")
+		assert.Empty(t, got, "the caller resolves the single eval, so nothing is chosen here")
+	})
+
+	t.Run("no configuration is left to the caller", func(t *testing.T) {
+		assert.Empty(t, chooseEval(newEvalCreateCommand(), nil, ""))
+	})
+
+	t.Run("--no-prompt keeps the error", func(t *testing.T) {
+		cmd := newEvalCreateCommand()
+		cmd.Flags().Bool("no-prompt", true, "")
+
+		got := chooseEval(cmd, configWith("a", "b"), "")
+
+		assert.Empty(t, got,
+			"there is nobody to ask, so the command must still refuse rather than guess")
+	})
+}
+
+// Returning the name unchanged is what leaves the existing error in place, and
+// that error is the one users praised: it counts the evals and names them all.
+func TestSeveralEvalsErrorStillNamesEveryCandidate(t *testing.T) {
+	cfg := configWith("obs-trace-eval", "obs-eval")
+	cmd := newEvalCreateCommand()
+	// Without this the picker reaches azdext.NewAzdClient and attempts a real
+	// RPC, which passes only because resolving an empty address fails fast.
+	// This test is about the message, not about network behaviour.
+	cmd.Flags().Bool("no-prompt", true, "")
+
+	_, err := cfg.Eval(chooseEval(cmd, cfg, ""))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "obs-trace-eval")
+	assert.Contains(t, err.Error(), "obs-eval")
+	assert.Contains(t, err.Error(), "--eval")
+}
+
+// A directory with no configuration must not turn into a prompt, and must not
+// swallow the error the command that opens it properly will raise.
+func TestChooseEvalInLeavesAnAbsentConfigAlone(t *testing.T) {
+	assert.Empty(t, chooseEvalIn(newEvalCreateCommand(), t.TempDir(), ""))
+	assert.Equal(t, "named", chooseEvalIn(newEvalCreateCommand(), t.TempDir(), "named"))
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/eval_group.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/eval_group.go
@@ -1,0 +1,344 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/project"
+
+	"github.com/spf13/cobra"
+)
+
+// Creation normally belongs to `azd up`, which owns reconciliation. `create`
+// is the same path for a single eval outside a project, and takes the
+// configuration rather than a wall of flags so there is never a second
+// definition to maintain.
+
+// newEvalCreateCommand creates one declared eval without deploying the rest.
+func newEvalCreateCommand() *cobra.Command {
+	var (
+		fromFile    string
+		evalDir     string
+		endpointFlg string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create [name]",
+		Short: "Create one eval declared in the configuration.",
+		Long: "Create one eval declared in the configuration.\n\n" +
+			"`azd up` reconciles every eval in the file. This creates a single one, " +
+			"for a project that is not deployed as a whole — or, with --from-file, " +
+			"for no project at all.\n\n" +
+			"The name is optional while the configuration declares exactly one eval.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			path := fromFile
+			if path == "" {
+				dir, err := resolveEvalDir(ctx, evalDir)
+				if err != nil {
+					return err
+				}
+				if path, err = project.ResolveEvalConfigPath(dir); err != nil {
+					return err
+				}
+			}
+			cfg, err := project.LoadEvalConfig(path)
+			if err != nil {
+				return err
+			}
+			if err := cfg.Validate(); err != nil {
+				return err
+			}
+
+			eval, err := cfg.Eval(chooseEval(cmd, cfg, firstArg(args)))
+			if err != nil {
+				return err
+			}
+
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			// Local sources resolve against the file, not the working directory,
+			// so the columns are read from where the declaration points.
+			baseDir := filepath.Dir(path)
+			datasetPath := ""
+			if decl, ok := cfg.DatasetDeclaration(eval.Dataset); ok {
+				datasetPath = project.ResolveSource(baseDir, decl.Source)
+			}
+
+			reconciler := &evalReconciler{ec: ec}
+			out := cmd.OutOrStdout()
+
+			// Before anything is pushed. Publishing is not free -- a dataset
+			// version is immutable and the number climbs on every attempt -- so
+			// a declaration the evaluators cannot satisfy is refused first.
+			if err := checkEvaluatorRequirements(eval, ec.evaluatorSchemas(ctx)); err != nil {
+				return err
+			}
+			// Reported per artifact, because "publishes nothing when nothing
+			// changed" is the contract a reader is checking here and a single
+			// closing line cannot show it. Silent under -o json.
+			say := func(kind, name, version string, changed bool) {
+				if isJSON(cmd) {
+					return
+				}
+				if changed {
+					fmt.Fprintln(out, messages.PublishedVersion(kind, name, version))
+				} else {
+					fmt.Fprintln(out, messages.UnchangedAtVersion(kind, name, version))
+				}
+			}
+
+			// The eval names its dataset and evaluators, and the service resolves
+			// those names when the eval is created, so they have to be published
+			// first. `azd up` reconciles the whole file; this reconciles only what
+			// this eval refers to, which is also what makes a rubric edit reach
+			// the service without a full deploy.
+			if decl, ok := cfg.DatasetDeclaration(eval.Dataset); ok {
+				version, changed, err := reconciler.EnsureDataset(ctx, *decl, datasetPath)
+				if err != nil {
+					return messages.DatasetProblem(decl.Name, err)
+				}
+				say("dataset", decl.Name, version, changed)
+			}
+			for _, ref := range eval.Evaluators {
+				decl, ok := cfg.EvaluatorDeclaration(ref.Evaluator)
+				// A built-in, or one already registered, has nothing local to publish.
+				if !ok || decl.Source == "" {
+					continue
+				}
+				local := project.ResolveSource(baseDir, decl.Source)
+				version, changed, err := reconciler.EnsureEvaluator(ctx, *decl, local)
+				if err != nil {
+					return messages.EvaluatorProblem(decl.Name, err)
+				}
+				say("evaluator", decl.Name, version, changed)
+			}
+
+			id, created, err := reconciler.EnsureEval(ctx, *eval, datasetPath)
+			if err != nil {
+				return err
+			}
+
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), map[string]string{
+					"id": id, "name": eval.Name,
+				})
+			}
+			if created {
+				fmt.Fprint(out, messages.EvalCreated(eval.Name, id))
+			} else {
+				fmt.Fprint(out, messages.EvalUnchanged(eval.Name, id))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&fromFile, "from-file", "",
+		"Read the configuration from this path instead of the eval directory.")
+	cmd.Flags().StringVar(&evalDir, "path", "",
+		"Directory holding the evaluation configuration. Defaults to the directory "+
+			"`init` scaffolded, otherwise ./evals.")
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+func newEvalListCommand() *cobra.Command {
+	var (
+		limit       int
+		endpointFlg string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List the project's evals.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			list, err := ec.evalClient.ListOpenAIEvals(ctx, limit)
+			if err != nil {
+				return messages.ListingEvals(err)
+			}
+
+			if isJSON(cmd) {
+				return emitJSONList(cmd.OutOrStdout(), list.Data)
+			}
+			if len(list.Data) == 0 {
+				fmt.Fprint(cmd.OutOrStdout(), messages.NoEvals())
+				return nil
+			}
+			rows := make([][]string, 0, len(list.Data))
+			for _, e := range list.Data {
+				rows = append(rows, []string{e.ID, e.Name})
+			}
+			return emitTable(cmd.OutOrStdout(), []string{"EVAL ID", "NAME"}, rows)
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 0, "Cap the number of evals returned.")
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+func newEvalShowCommand() *cobra.Command {
+	var endpointFlg string
+
+	cmd := &cobra.Command{
+		Use:   "show <eval>",
+		Short: "Show an eval definition.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			evalID := args[0]
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			group, err := ec.evalClient.GetOpenAIEval(ctx, evalID)
+			if err != nil && eval_api.IsNotFound(err) {
+				// The argument reads as an id. `list` reports names, and this
+				// refused the very name it points the reader at, so a name is
+				// resolved before giving up.
+				if resolved := ec.evalIDNamed(ctx, evalID); resolved != "" {
+					group, err = ec.evalClient.GetOpenAIEval(ctx, resolved)
+				}
+			}
+			if err != nil {
+				if eval_api.IsNotFound(err) {
+					return messages.EvalNotFound(evalID)
+				}
+				return messages.ReadingEval(evalID, err)
+			}
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), group)
+			}
+			detail := []field{
+				{"Id", group.ID},
+				{"Name", group.Name},
+				// CreatedAt is `any` because the service sends epoch seconds here
+				// and RFC3339 elsewhere; fmt.Sprint on the former prints a float
+				// in scientific notation.
+				{"Created", timestampString(group.CreatedAt)},
+				{"Created By", group.CreatedBy},
+			}
+			// Without this the command answers "does this id exist", which is
+			// not what a definition is, nor what its own help promises.
+			if graders := evalGraders(group); graders != "" {
+				detail = append(detail, field{"Evaluators", graders})
+			}
+			return emitDetail(cmd.OutOrStdout(), detail)
+		},
+	}
+
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// evalGraders lists the evaluators the eval grades with, preferring the
+// reference a caller would recognize over the criterion label.
+//
+// data_source_config is deliberately not shown beside it: every eval this
+// extension creates carries type "custom", which describes the item schema
+// rather than where the rows come from, so a "Source" row would read as an
+// answer while always saying the same thing.
+func evalGraders(group *eval_api.OpenAIEval) string {
+	if group == nil {
+		return ""
+	}
+	names := make([]string, 0, len(group.TestingCriteria))
+	for _, c := range group.TestingCriteria {
+		name := c.EvaluatorName
+		if name == "" {
+			name = c.Name
+		}
+		if name == "" {
+			continue
+		}
+		if c.EvaluatorVersion != "" {
+			name += " (" + c.EvaluatorVersion + ")"
+		}
+		names = append(names, name)
+	}
+	return strings.Join(names, ", ")
+}
+
+func newEvalDeleteCommand() *cobra.Command {
+	var endpointFlg string
+
+	cmd := &cobra.Command{
+		Use:   "delete <eval>",
+		Short: "Delete an eval and everything under it.",
+		Long: "Delete an eval and everything under it.\n\n" +
+			"An eval owns its runs, so deleting one discards their results too.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			evalID := args[0]
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			err = ec.evalClient.DeleteOpenAIEval(ctx, evalID)
+			if err != nil && eval_api.IsNotFound(err) {
+				// `list` reports names, so a name is what a reader has to hand.
+				// An eval is immutable, though, so editing a declaration leaves
+				// another under the same name, and this deletes the runs under
+				// whichever it picks: with more than one it asks rather than guesses.
+				ids, listErr := ec.evalIDsNamed(ctx, evalID)
+				if listErr != nil {
+					// Reporting the eval gone on a listing we could not
+					// read would be a delete silently doing nothing.
+					return listErr
+				}
+				switch len(ids) {
+				case 0:
+				case 1:
+					evalID = ids[0]
+					err = ec.evalClient.DeleteOpenAIEval(ctx, evalID)
+				default:
+					return messages.AmbiguousEvalName(evalID, ids)
+				}
+			}
+			if err != nil {
+				if eval_api.IsNotFound(err) {
+					return messages.EvalGone(evalID)
+				}
+				return messages.DeletingEval(evalID, err)
+			}
+
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), map[string]string{
+					"id": evalID, "status": "deleted",
+				})
+			}
+			fmt.Fprint(cmd.OutOrStdout(), messages.EvalDeleted(evalID))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/eval_id_key_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/eval_id_key_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// EVAL_ID is written by every deploy, so nothing tells a value meant for this
+// declaration from one left behind by the eval it replaced.
+//
+// Reading it as a fallback meant a file whose one entry had been swapped ran
+// the previous eval's criteria over the new one's rows and reported success,
+// and `run cancel` with no arguments cancelled a run of the eval the file no
+// longer described -- a destructive verb on a resource picked by accident.
+//
+// This is the only enforcement of that. The reasoning lives in a comment on
+// the reconciler and in another on `resolveEvalID`, and a comment cannot fail.
+func TestRecordedEvalIDIgnoresTheSharedKey(t *testing.T) {
+	env := &testEnvServer{values: map[string]string{
+		envKeyEvalID: "evalgroup_the_one_this_replaced",
+	}}
+	ec := &evalContext{azdClient: newTestAzdClient(t, env), envName: "test"}
+
+	assert.Empty(t, ec.recordedEvalID(context.Background(), "nightly"),
+		"a shared key cannot say which declaration it belongs to")
+
+	// The entry recorded under the eval's own name does answer, which is what
+	// makes the miss above a deliberate refusal rather than a broken read.
+	env.values[idKey("eval", "nightly")] = "evalgroup_nightly"
+	require.Equal(t, "evalgroup_nightly", ec.recordedEvalID(context.Background(), "nightly"))
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/eval_show_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/eval_show_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// `show` is documented as showing an eval definition, and answered with the id,
+// the name and who created it -- true of any eval, and none of the definition.
+// The graders are the part of the definition the service does return.
+func TestShowSurfacesWhatTheEvalGrades(t *testing.T) {
+	group := &eval_api.OpenAIEval{
+		ID:   "eval_1",
+		Name: "support-trace-eval",
+		TestingCriteria: []eval_api.TestingCriterion{
+			{Name: "task_adherence", EvaluatorName: "builtin.task_adherence"},
+			{Name: "quality", EvaluatorName: "support-quality", EvaluatorVersion: "2"},
+		},
+	}
+
+	assert.Equal(t, "builtin.task_adherence, support-quality (2)", evalGraders(group))
+}
+
+// The criterion label is what the service echoes when no evaluator reference
+// was recorded, so it is better than printing nothing.
+func TestShowFallsBackToTheCriterionLabel(t *testing.T) {
+	group := &eval_api.OpenAIEval{
+		TestingCriteria: []eval_api.TestingCriterion{{Name: "custom-grader"}},
+	}
+
+	assert.Equal(t, "custom-grader", evalGraders(group))
+}
+
+// An older eval, or one the service answers without a definition, still shows
+// its identity rather than blank rows.
+func TestShowOmitsWhatTheServiceDidNotSend(t *testing.T) {
+	assert.Empty(t, evalGraders(&eval_api.OpenAIEval{ID: "eval_1"}))
+	assert.Empty(t, evalGraders(nil))
+
+	// A criterion carrying no name at all contributes nothing rather than an
+	// empty entry with a stray separator.
+	assert.Empty(t, evalGraders(&eval_api.OpenAIEval{
+		TestingCriteria: []eval_api.TestingCriterion{{Type: "azure_ai_evaluator"}},
+	}))
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evaldir_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evaldir_test.go
@@ -1,0 +1,341 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"azureaieval/internal/project"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Where the configuration lives is settled by one cascade -- --path, then the
+// path `init` recorded in the azd environment, then ./evals -- and these tests
+// pin it.
+//
+// `init --path ./quality` wrote a configuration that `run` then looked for
+// under ./evals and reported as missing, while azure.yaml's $ref pointed at it
+// correctly the whole time. The path init used is remembered so the flag does
+// not have to be repeated on every later command.
+//
+// That fix reached `run` and stopped there. In a project scaffolded outside
+// ./evals, `create` went on reporting the configuration missing and `generate`
+// went on submitting a billed job and writing a *second* configuration under
+// ./evals that nothing else read. So these tests are written over every
+// command, not over the one that was wrong at the time.
+
+func TestEvalDirCascade(t *testing.T) {
+	// No azd environment: there is nothing to read, so only flag and default apply.
+	ec := &evalContext{}
+
+	dir, err := ec.evalDir(context.Background(), "")
+	require.NoError(t, err)
+	assert.Equal(t, project.DefaultEvalDir, dir, "nothing given anywhere is ./evals")
+
+	dir, err = ec.evalDir(context.Background(), "quality")
+	require.NoError(t, err)
+	assert.Equal(t, "quality", dir, "--path wins")
+}
+
+func TestEvalDirCascadeAnswersInOrder(t *testing.T) {
+	cases := []struct {
+		name     string
+		flag     string
+		recorded string
+		want     string
+	}{
+		{
+			name:     "the flag wins",
+			flag:     "./given",
+			recorded: "./recorded",
+			want:     "./given",
+		},
+		{
+			name:     "the flag wins even over nothing recorded",
+			flag:     "./given",
+			recorded: "",
+			want:     "./given",
+		},
+		{
+			name:     "what init recorded is used when no flag was given",
+			flag:     "",
+			recorded: "./quality",
+			want:     "./quality",
+		},
+		{
+			name:     "the default is the last resort",
+			flag:     "",
+			recorded: "",
+			want:     project.DefaultEvalDir,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := evalDirCascade(tc.flag, func() (string, error) {
+				return tc.recorded, nil
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// A read that failed is not a project that recorded nothing. Defaulting on it
+// is how `generate` would write a second configuration under ./evals for a
+// reason nobody could reproduce, so the failure has to come back out.
+func TestEvalDirCascadeDoesNotDefaultOnAFailedRead(t *testing.T) {
+	boom := errors.New("the environment could not be read")
+
+	got, err := evalDirCascade("", func() (string, error) { return "", boom })
+
+	require.ErrorIs(t, err, boom)
+	assert.Empty(t, got, "a failed read must not answer with the default")
+}
+
+// A --path that was given is the answer on its own, so a broken azd cannot
+// stop a caller who already said where to look.
+func TestEvalDirCascadeIgnoresAFailedReadWhenPathWasGiven(t *testing.T) {
+	got, err := evalDirCascade("./given", func() (string, error) {
+		return "", errors.New("the environment could not be read")
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "./given", got)
+}
+
+// Each read is a round trip, and a --path that was given makes it unnecessary.
+func TestEvalDirCascadeAsksForTheRecordedPathOnce(t *testing.T) {
+	var asked int
+	got, err := evalDirCascade("", func() (string, error) {
+		asked++
+		return "", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, project.DefaultEvalDir, got)
+	assert.Equal(t, 1, asked, "the recorded path should be read exactly once")
+
+	asked = 0
+	_, err = evalDirCascade("./given", func() (string, error) {
+		asked++
+		return "", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, asked, "a --path that was given should not cost a round trip")
+}
+
+// --path defaults to empty, not to ./evals, so "not given" stays
+// distinguishable from "given the default". A non-empty default shadows the
+// path init recorded, because level 1 only yields on an empty value -- so the
+// command has opted out of the cascade without saying so.
+//
+// This was asserted for `run start` alone, which is exactly how `create`,
+// `generate` and `init` came to be filling the default in. It is written over
+// the whole tree now.
+func TestPathFlagsLeaveRoomForTheRecordedPath(t *testing.T) {
+	var checked int
+	walk(t, NewRootCommand(), nil, func(name string, cmd *cobra.Command) {
+		f := cmd.Flags().Lookup("path")
+		if f == nil {
+			return
+		}
+		checked++
+		assert.Empty(t, f.DefValue,
+			"`azd ai eval %s --path` defaults to %q, so the path `init` recorded can "+
+				"never be reached: level 1 of the cascade only yields on an empty value",
+			name, f.DefValue)
+	})
+
+	// If --path is ever renamed, the loop above passes by visiting nothing.
+	assert.GreaterOrEqual(t, checked, 3,
+		"expected --path on at least init, generate and eval create; found %d", checked)
+}
+
+// Every command that reads the configuration has to be able to say where it is,
+// or a project scaffolded with --path is unreachable from that command.
+//
+// `create` was missing from this list, and was one of the two commands that
+// could not find a configuration outside ./evals.
+func TestCommandsReadingTheConfigTakePath(t *testing.T) {
+	for _, path := range []string{"run start", "init", "generate", "create"} {
+		cmd := find(t, path)
+		assert.NotNilf(t, cmd.Flags().Lookup("path"),
+			"%s reads the configuration, so it must accept --path", path)
+	}
+}
+
+// Guards against the tree walk above passing because the flag was renamed.
+func TestPathFlagIsStillCalledPath(t *testing.T) {
+	var names []string
+	walk(t, NewRootCommand(), nil, func(name string, cmd *cobra.Command) {
+		cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
+			if f.Name == "path" {
+				names = append(names, name)
+			}
+		})
+	})
+
+	for _, want := range []string{"init", "generate", "create", "run start"} {
+		assert.Contains(t, names, want)
+	}
+}
+
+// The recorded key is what `init` writes and what the other commands read; a
+// rename on one side alone silently stops the hand-off working.
+func TestEvalPathEnvKey(t *testing.T) {
+	assert.Equal(t, "EVAL_CONFIG_PATH", envKeyEvalPath)
+}
+
+// `init` prints the commands to run next, and the claim those lines make is
+// that they run as printed. A scaffold written somewhere other than ./evals is
+// only reachable by a command that names it, because EVAL_CONFIG_PATH is
+// recorded best effort and `init` succeeds without an azd environment to record
+// it in.
+func TestNextStepsRunAsPrinted(t *testing.T) {
+	cases := []struct {
+		name      string
+		evalDir   string
+		deployCmd string
+		wantPath  bool
+	}{
+		{
+			name:      "a scaffold outside ./evals names itself",
+			evalDir:   "./quality",
+			deployCmd: "azd ai eval create",
+			wantPath:  true,
+		},
+		{
+			name:      "the default directory needs no flag",
+			evalDir:   project.DefaultEvalDir,
+			deployCmd: "azd ai eval create",
+			wantPath:  false,
+		},
+		{
+			name:      "an unrecorded directory needs no flag",
+			evalDir:   "",
+			deployCmd: "azd ai eval create",
+			wantPath:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := scaffold{eval: &project.Eval{Name: "an-eval"}, evalDir: tc.evalDir}
+			for _, step := range s.nextSteps(tc.deployCmd) {
+				assert.Equal(t, tc.wantPath, strings.Contains(step, "--path "),
+					"step %q", step)
+			}
+		})
+	}
+}
+
+// `azd up` provisions and then deploys, reading azure.yaml -- which already
+// $refs the configuration wherever it was written. It takes none of this
+// extension's flags, so handing it --path prints a step that fails.
+func TestNextStepsNeverFlagAzdUp(t *testing.T) {
+	s := scaffold{eval: &project.Eval{Name: "an-eval"}, evalDir: "./quality"}
+
+	steps := s.nextSteps(azdUpCommand)
+	assert.Contains(t, steps, azdUpCommand,
+		"`azd up` should be suggested exactly as it is run")
+	for _, step := range steps {
+		if strings.HasPrefix(step, azdUpCommand) {
+			assert.NotContains(t, step, "--path", "step %q", step)
+		}
+	}
+}
+
+// A generated next step already carried --target and --generation-model for the
+// same reason. --path joins them.
+func TestGenerateStepNamesTheScaffoldedDirectory(t *testing.T) {
+	s := scaffold{
+		eval:            &project.Eval{Name: "an-eval"},
+		evalDir:         "./quality",
+		target:          "support-agent",
+		judgeModel:      "gpt-4.1-nano",
+		rubricName:      "support-agent-quality",
+		datasetName:     "support-agent-dataset",
+		generateDataset: true,
+		generateRubric:  true,
+	}
+
+	steps := s.nextSteps("azd ai eval create")
+	if assert.Len(t, steps, 1) {
+		for _, want := range []string{
+			"--target support-agent",
+			"--generation-model gpt-4.1-nano",
+			"--path ./quality",
+		} {
+			assert.Contains(t, steps[0], want)
+		}
+	}
+}
+
+// A directory with a space in it printed `--path ./team evals`, which resolves
+// ./team and reports the configuration missing -- the printed step failing in
+// the one case it was added for. Found by running it, not by reading it.
+func TestNextStepQuotesADirectoryThatNeedsIt(t *testing.T) {
+	cases := []struct {
+		name    string
+		evalDir string
+		want    string
+	}{
+		{
+			name:    "a space",
+			evalDir: "./team evals",
+			want:    `--path "./team evals"`,
+		},
+		{
+			name:    "a windows path with a space",
+			evalDir: `C:\Users\Me\My Evals`,
+			want:    `--path "C:\Users\Me\My Evals"`,
+		},
+		{
+			name:    "a plain relative path is left alone",
+			evalDir: "./quality",
+			want:    "--path ./quality",
+		},
+		{
+			name:    "a plain windows path is left alone",
+			evalDir: `C:\Users\Me\quality`,
+			want:    `--path C:\Users\Me\quality`,
+		},
+		{
+			name:    "a character the shell would expand",
+			evalDir: "./eval$dir",
+			want:    `--path "./eval$dir"`,
+		},
+		{
+			name:    "a character that would end the command",
+			evalDir: "./a;rm -rf b",
+			want:    `--path "./a;rm -rf b"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := scaffold{eval: &project.Eval{Name: "an-eval"}, evalDir: tc.evalDir}
+			steps := s.nextSteps("azd ai eval create")
+			require.NotEmpty(t, steps)
+			for _, step := range steps {
+				assert.Contains(t, step, tc.want, "step %q", step)
+			}
+		})
+	}
+}
+
+// Backslashes must survive: doubling them is right for bash and wrong for the
+// two shells most likely to be reading a path that looks like this.
+func TestQuoteForShellLeavesBackslashesAlone(t *testing.T) {
+	assert.Equal(t, `"C:\Users\Me\My Evals"`, quoteForShell(`C:\Users\Me\My Evals`))
+	assert.Equal(t, `C:\Users\Me\Evals`, quoteForShell(`C:\Users\Me\Evals`))
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evalref.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evalref.go
@@ -1,0 +1,196 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"sort"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/project"
+)
+
+// evalRef is what `--eval` resolved to: the service id, plus the declaration
+// behind it when there was one.
+//
+// Commands need both. The id is what every route under {eval_id} takes, and the
+// declaration is what says which dataset and target a new run should use.
+type evalRef struct {
+	ID         string
+	Eval       *project.Eval
+	Config     *project.EvalConfig
+	ConfigPath string
+}
+
+// Declared reports whether the reference came from the configuration.
+func (r evalRef) Declared() bool { return r.Eval != nil }
+
+// resolveEvalRef turns `--eval` into an id.
+//
+// One flag takes a name or an id, matching `azd ai training job show`, whose
+// --name is documented as "Job name/ID". Name is tried first, in three cases:
+// a name in evals: with a recorded id resolves to it; a name in evals: with
+// none fails fast naming `azd up` rather than returning a service 404; and
+// anything else is sent as an id.
+//
+// Ids matter because an eval created by `azd ai eval create` has no evals:
+// entry, and because the environment records one id per name, so editing a
+// declaration leaves every run of the previous eval reachable only by id.
+func (ec *evalContext) resolveEvalRef(
+	ctx context.Context,
+	evalDir, nameOrID string,
+) (evalRef, error) {
+	configPath, err := project.ResolveEvalConfigPath(evalDir)
+	if err != nil {
+		return evalRef{}, err
+	}
+	cfg, err := project.OpenEvalConfig(evalDir)
+	if err != nil {
+		return evalRef{}, err
+	}
+
+	if cfg != nil {
+		if err := cfg.ValidateForLookup(); err != nil {
+			return evalRef{}, err
+		}
+		eval, err := cfg.Eval(nameOrID)
+		switch {
+		case err == nil:
+			id := ec.recordedEvalID(ctx, eval.Name)
+			if id == "" {
+				// Nothing recorded is not the same as nothing published. The
+				// id is kept in the azd environment, so a run against
+				// --project-endpoint with no project, or a `create` that ran
+				// before the environment existed, leaves a published eval
+				// with no note of it. The service lists evals by name, so
+				// ask it before deciding this was never deployed.
+				//
+				// Refused rather than guessed when a name carries several, as
+				// `eval delete` already does. Newest-wins is fine for showing
+				// something, but this id also reaches `run start`, and grading
+				// against the wrong definition produces results that look
+				// right and answer a different question.
+				ids, err := ec.evalIDsNamed(ctx, eval.Name)
+				if err != nil {
+					// A listing that failed is not a listing that came
+					// back empty. Falling through to "not deployed"
+					// sends the reader to republish an eval that
+					// already exists -- which is what a listing failing
+					// under concurrent `run start` actually produced.
+					return evalRef{}, err
+				}
+				if len(ids) > 1 {
+					return evalRef{}, messages.AmbiguousEvalName(eval.Name, ids)
+				}
+				if len(ids) == 1 {
+					id = ids[0]
+				}
+			}
+			if id == "" {
+				// With no environment there was nowhere an id could have been
+				// recorded, so telling the reader to deploy again would not
+				// help. Only said when azd confirmed there is none.
+				if ec.confirmedNoAzdEnvironment(ctx) {
+					return evalRef{}, messages.NoEnvironmentToRememberEval(eval.Name)
+				}
+				// That call recovers the environment name when the first
+				// lookup missed it -- a transient failure in newEvalContext
+				// leaves it empty, and recordedEvalID answers "" without
+				// asking when it is. Now that there is a name, ask properly
+				// before reporting a deployed eval as missing.
+				if id = ec.recordedEvalID(ctx, eval.Name); id == "" {
+					return evalRef{}, messages.EvalNotDeployedYet(
+						eval.Name, ec.deployCommand(ctx))
+				}
+			}
+			return evalRef{ID: id, Eval: eval, Config: cfg, ConfigPath: configPath}, nil
+		case nameOrID == "":
+			// No name to fall back on, so the configuration's own complaint —
+			// none declared, or several to choose between — is the answer.
+			return evalRef{}, err
+		}
+	}
+
+	if nameOrID == "" {
+		return evalRef{}, messages.NoEvalNamedOrDeclared(configPath)
+	}
+	// Not a declared name, so it is an id.
+	return evalRef{ID: nameOrID}, nil
+}
+
+// recordedEvalID reads the id `azd up` stored for a declared eval.
+//
+// Only the entry recorded under this eval's own name. EVAL_ID is written by
+// every deploy as well as being settable by hand, so nothing tells a value that
+// was meant for this declaration from one left behind by the eval it replaced.
+// Reading it for a config that names a single eval meant a file whose one entry
+// had been swapped for a different one ran the previous eval's criteria over
+// the new one's rows, reported as success. A miss falls through to the service
+// listing by name, which answers the question the id was standing in for.
+func (ec *evalContext) recordedEvalID(ctx context.Context, evalName string) string {
+	return ec.getEnvValue(ctx, idKey("eval", evalName))
+}
+
+// evalIDNamed finds the id of the eval the service lists under this name.
+//
+// Evals are addressed by id, but every listing reports a name, so a name is
+// what a reader has to hand. Returns empty when nothing matches, leaving the
+// caller's not-found reporting alone.
+//
+// The newest match wins when a name is carried by several. An eval is
+// immutable, so editing a declaration creates another one under the same name,
+// and the newest is the one the configuration currently describes.
+//
+// A listing that failed answers empty here, unlike in resolveEvalRef: both
+// callers reach this only after the service already returned 404 for the id
+// they were given, and that refusal is what they report.
+func (ec *evalContext) evalIDNamed(ctx context.Context, name string) string {
+	ids, err := ec.evalIDsNamed(ctx, name)
+	if err != nil || len(ids) == 0 {
+		return ""
+	}
+	return ids[0]
+}
+
+// evalIDsNamed finds every eval the service lists under this name, newest
+// first, so a caller that must not guess can see the ambiguity.
+//
+// The order is established here rather than taken from the service, which does
+// not promise one. timestampString normalizes both shapes the service uses for
+// created_at to RFC3339 UTC, and those sort chronologically as text. An eval
+// whose timestamp is missing or unparseable sorts last rather than winning by
+// accident.
+func (ec *evalContext) evalIDsNamed(ctx context.Context, name string) ([]string, error) {
+	list, err := ec.evalClient.ListOpenAIEvals(ctx, 0)
+	if err != nil {
+		return nil, messages.ListingEvals(err)
+	}
+	if list == nil {
+		return nil, nil
+	}
+	return idsNamedIn(list, name), nil
+}
+
+// idsNamedIn picks the evals carrying this name, newest first.
+//
+// timestampString normalizes both shapes the service uses for created_at to
+// RFC3339 UTC, and those sort chronologically as text. An eval whose timestamp
+// is missing or unparseable sorts last rather than winning by accident.
+func idsNamedIn(list *eval_api.OpenAIEvalList, name string) []string {
+	var matches []eval_api.OpenAIEval
+	for _, e := range list.Data {
+		if e.Name == name {
+			matches = append(matches, e)
+		}
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		return timestampString(matches[i].CreatedAt) > timestampString(matches[j].CreatedAt)
+	})
+	ids := make([]string, 0, len(matches))
+	for _, m := range matches {
+		ids = append(ids, m.ID)
+	}
+	return ids
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evalref_drift_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evalref_drift_test.go
@@ -1,0 +1,329 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"azureaieval/internal/pkg/dataset_api"
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// reconcilerListingVersions builds a reconciler whose dataset client answers a
+// version listing with these versions.
+func reconcilerListingVersions(t *testing.T, versions ...string) *evalReconciler {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		values := make([]map[string]any, 0, len(versions))
+		for _, v := range versions {
+			values = append(values, map[string]any{"name": "golden", "version": v})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// assert, not require: this runs on the server's goroutine, and FailNow
+		// there aborts mid-response and fails whichever test is running instead.
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"value": values}))
+	}))
+	t.Cleanup(srv.Close)
+
+	pipeline := runtime.NewPipeline("test", "v1", runtime.PipelineOptions{},
+		&policy.ClientOptions{Retry: policy.RetryOptions{MaxRetries: -1}})
+	return &evalReconciler{ec: &evalContext{
+		datasetClient: dataset_api.NewDatasetClientFromPipeline(srv.URL, pipeline),
+	}}
+}
+
+// A version published outside the repo would otherwise be overwritten by the
+// next deploy. The evaluator side of this is guarded; the dataset side is the
+// same risk against content nobody has a copy of.
+func TestCheckDatasetDriftRefusesANewerPublishedVersion(t *testing.T) {
+	r := reconcilerListingVersions(t, "1.0", "2.0", "3.0")
+
+	err := r.checkDatasetDrift(context.Background(), "golden", "2.0")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "3.0", "the version that is actually there")
+	assert.Contains(t, err.Error(), "2.0", "and the one this repo last deployed")
+	assert.Contains(t, err.Error(), "outside this configuration")
+	assert.Contains(t, err.Error(), "version: 3.0", "the fix is a pin the user can paste")
+}
+
+// Matching versions are the ordinary case and must stay silent, or every
+// deploy would report drift.
+func TestCheckDatasetDriftAcceptsAMatch(t *testing.T) {
+	r := reconcilerListingVersions(t, "1.0", "2.0")
+	require.NoError(t, r.checkDatasetDrift(context.Background(), "golden", "2.0"))
+}
+
+// The listing is eventually consistent and answers with nothing for a second
+// or two after a publish. Reading that as "the project is behind" would report
+// drift on a dataset this repo had just deployed.
+func TestCheckDatasetDriftIgnoresAnEmptyListing(t *testing.T) {
+	r := reconcilerListingVersions(t)
+	require.NoError(t, r.checkDatasetDrift(context.Background(), "golden", "2.0"))
+	latest, err := r.latestDatasetVersion(context.Background(), "golden")
+	require.NoError(t, err)
+	assert.Empty(t, latest)
+}
+
+// Only a newer version is someone else's work. An older one means this repo is
+// ahead, which the deploy is about to fix anyway.
+func TestCheckDatasetDriftIgnoresAnOlderVersion(t *testing.T) {
+	r := reconcilerListingVersions(t, "1.0")
+	require.NoError(t, r.checkDatasetDrift(context.Background(), "golden", "2.0"),
+		"a project behind this repo is not drift")
+}
+
+// A listing that failed is not evidence there was no newer version. The drift
+// check exists to catch someone else's publish, so it fails closed: tolerating
+// the error let a 403 or a timeout skip the guard silently.
+func TestLatestDatasetVersionSurfacesAFailedListing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	pipeline := runtime.NewPipeline("test", "v1", runtime.PipelineOptions{},
+		&policy.ClientOptions{Retry: policy.RetryOptions{MaxRetries: -1}})
+	r := &evalReconciler{ec: &evalContext{
+		datasetClient: dataset_api.NewDatasetClientFromPipeline(srv.URL, pipeline),
+	}}
+
+	_, err := r.latestDatasetVersion(context.Background(), "golden")
+	require.Error(t, err, "a listing we could not read is not proof there was no newer version")
+	require.Error(t, r.checkDatasetDrift(context.Background(), "golden", "2.0"),
+		"the drift guard fails closed rather than skipping silently")
+}
+
+// writeEvalYAML puts a configuration in a temp dir and returns the dir.
+func writeEvalYAML(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	evals := filepath.Join(dir, "evals")
+	require.NoError(t, os.MkdirAll(evals, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(evals, "eval.yaml"), []byte(body), 0o600))
+	return evals
+}
+
+// evalContextListingEvals builds a context whose service lists exactly these
+// evals. resolveEvalRef asks the service by name when no id was recorded, so a
+// context without a client cannot exercise it.
+func evalContextListingEvals(t *testing.T, envName, body string) *evalContext {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	pipeline := runtime.NewPipeline("test", "v1", runtime.PipelineOptions{},
+		&policy.ClientOptions{Retry: policy.RetryOptions{MaxRetries: -1}})
+	return &evalContext{
+		envName:    envName,
+		evalClient: eval_api.NewEvalClientFromPipeline(srv.URL, pipeline),
+	}
+}
+
+// evalContextRefusingToListEvals builds a context whose service will not answer
+// the listing at all, which is a different thing from listing nothing.
+func evalContextRefusingToListEvals(t *testing.T, envName string, status int) *evalContext {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(`{"error":{"code":"TooManyRequests"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	pipeline := runtime.NewPipeline("test", "v1", runtime.PipelineOptions{},
+		&policy.ClientOptions{Retry: policy.RetryOptions{MaxRetries: -1}})
+	return &evalContext{
+		envName:    envName,
+		evalClient: eval_api.NewEvalClientFromPipeline(srv.URL, pipeline),
+	}
+}
+
+// A listing that failed is not a listing that came back empty. Both leave no
+// id, and only one of them means the eval was never deployed.
+//
+// This is not hypothetical: four concurrent `run start` calls against a live
+// project produced exactly one of these, and the reader was told a deployed
+// eval did not exist and to run `azd up` -- which would publish a second copy
+// of something already there.
+func TestResolveEvalRefReportsARefusedListingRatherThanCallingItUndeployed(t *testing.T) {
+	dir := writeEvalYAML(t, `
+datasets:
+  - name: golden
+evals:
+  - name: support-quality
+    dataset: golden
+    evaluators:
+      - evaluator: builtin.relevance
+`)
+	ec := evalContextRefusingToListEvals(t, "dev", http.StatusTooManyRequests)
+
+	_, err := ec.resolveEvalRef(context.Background(), dir, "support-quality")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listing evals",
+		"the failure that actually happened is the one reported")
+	assert.NotContains(t, err.Error(), "azd up",
+		"deploying again does not fix a listing the service refused")
+}
+
+// A declared eval that was never deployed has no id to address, and the
+// service would answer 404 for a name it never saw. Naming the command that
+// deploys is the difference between a dead end and a next step.
+func TestResolveEvalRefFailsFastOnAnUndeployedDeclaration(t *testing.T) {
+	dir := writeEvalYAML(t, `
+datasets:
+  - name: golden
+evals:
+  - name: support-quality
+    dataset: golden
+    evaluators:
+      - evaluator: builtin.relevance
+`)
+	// An environment exists; the id was simply never recorded in it. Without
+	// this the case under test is "nowhere to record", which is a different
+	// answer. The service lists nothing, which is what never deployed looks
+	// like from the outside.
+	ec := evalContextListingEvals(t, "dev", `{"data":[]}`)
+
+	_, err := ec.resolveEvalRef(context.Background(), dir, "support-quality")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "support-quality")
+	// No azd project stands behind this context, so there is no infrastructure
+	// to provision and neither `azd up` nor `azd deploy` would run here.
+	assert.Contains(t, err.Error(), "azd ai eval create",
+		"the error has to say what would fix it")
+}
+
+// The id lives in the azd environment, so `--project-endpoint` against a
+// directory that never had one has a published eval and no note of it. Failing
+// there would make the declaration unusable outside a project, though the
+// service can be asked for the same name.
+func TestResolveEvalRefFindsAPublishedEvalByName(t *testing.T) {
+	dir := writeEvalYAML(t, `
+datasets:
+  - name: golden
+evals:
+  - name: support-quality
+    dataset: golden
+    evaluators:
+      - evaluator: builtin.relevance
+`)
+	ec := evalContextListingEvals(t, "",
+		`{"data":[{"id":"eval_published","name":"support-quality"}]}`)
+
+	ref, err := ec.resolveEvalRef(context.Background(), dir, "support-quality")
+
+	require.NoError(t, err)
+	assert.Equal(t, "eval_published", ref.ID,
+		"the service knows the id this environment never recorded")
+	assert.True(t, ref.Declared(), "and it is still the declaration that was matched")
+}
+
+// With no azd environment at all there is nowhere the id could have been
+// recorded, so `create` may well have published this eval and had nowhere to
+// note it. Sending the reader to `azd up` lands them in the same place.
+func TestResolveEvalRefNamesTheMissingEnvironment(t *testing.T) {
+	dir := writeEvalYAML(t, `
+datasets:
+  - name: golden
+evals:
+  - name: support-quality
+    dataset: golden
+    evaluators:
+      - evaluator: builtin.relevance
+`)
+	ec := evalContextListingEvals(t, "", `{"data":[]}`)
+
+	_, err := ec.resolveEvalRef(context.Background(), dir, "support-quality")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "azd env new",
+		"the fix is an environment, not another deploy")
+	assert.NotContains(t, err.Error(), "azd up",
+		"deploying again would record the id in the same nowhere")
+}
+
+// An eval made by `azd ai eval create` has no evals: entry, so anything that
+// is not a declared name is sent on as an id rather than refused.
+func TestResolveEvalRefTreatsAnUnknownNameAsAnID(t *testing.T) {
+	dir := writeEvalYAML(t, `
+datasets:
+  - name: golden
+evals:
+  - name: support-quality
+    dataset: golden
+    evaluators:
+      - evaluator: builtin.relevance
+`)
+	ec := &evalContext{}
+
+	ref, err := ec.resolveEvalRef(context.Background(), dir, "eval_68a1f2c3")
+
+	require.NoError(t, err)
+	assert.Equal(t, "eval_68a1f2c3", ref.ID)
+	assert.False(t, ref.Declared(), "an id carries no declaration to run from")
+	assert.Nil(t, ref.Eval)
+}
+
+// With no configuration and no name there is nothing to resolve, and the
+// message has to say where a declaration would have been looked for.
+func TestResolveEvalRefWithoutAConfigurationOrAName(t *testing.T) {
+	ec := &evalContext{}
+
+	_, err := ec.resolveEvalRef(context.Background(), t.TempDir(), "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--eval")
+	assert.Contains(t, err.Error(), "eval.yaml")
+}
+
+// Outside a project an id is still enough to address every route under it.
+func TestResolveEvalRefAcceptsAnIDWithoutAConfiguration(t *testing.T) {
+	ec := &evalContext{}
+
+	ref, err := ec.resolveEvalRef(context.Background(), t.TempDir(), "eval_68a1f2c3")
+
+	require.NoError(t, err)
+	assert.Equal(t, "eval_68a1f2c3", ref.ID)
+	assert.False(t, ref.Declared())
+}
+
+// Naming nothing where several evals are declared is ambiguous, and the
+// configuration's own complaint is the useful one.
+func TestResolveEvalRefReportsAmbiguity(t *testing.T) {
+	dir := writeEvalYAML(t, `
+datasets:
+  - name: golden
+evals:
+  - name: first
+    dataset: golden
+    evaluators:
+      - evaluator: builtin.relevance
+  - name: second
+    dataset: golden
+    evaluators:
+      - evaluator: builtin.coherence
+`)
+	ec := &evalContext{}
+
+	_, err := ec.resolveEvalRef(context.Background(), dir, "")
+	require.Error(t, err)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evalref_order_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evalref_order_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// `delete` refuses a name carried by several evals and lists the ids, so the
+// order those ids come back in is part of a message a reader acts on. The
+// service does not promise an order, and this used to hand back whatever the
+// listing happened to contain while the comment above it claimed newest-first.
+func TestEvalIDsNamedSortsNewestFirst(t *testing.T) {
+	list := &eval_api.OpenAIEvalList{Data: []eval_api.OpenAIEval{
+		{ID: "eval_oldest", Name: "shared", CreatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "eval_newest", Name: "shared", CreatedAt: "2026-08-01T00:00:00Z"},
+		{ID: "eval_middle", Name: "shared", CreatedAt: "2026-04-01T00:00:00Z"},
+		{ID: "eval_other", Name: "different", CreatedAt: "2026-09-01T00:00:00Z"},
+	}}
+
+	got := idsNamedIn(list, "shared")
+
+	assert.Equal(t, []string{"eval_newest", "eval_middle", "eval_oldest"}, got)
+}
+
+// The service spells created_at as epoch seconds on some routes and RFC3339 on
+// others, so both have to order the same way.
+func TestEvalIDsNamedSortsAcrossTimestampShapes(t *testing.T) {
+	list := &eval_api.OpenAIEvalList{Data: []eval_api.OpenAIEval{
+		{ID: "eval_old", Name: "shared", CreatedAt: float64(1767225600)}, // 2026-01-01
+		{ID: "eval_new", Name: "shared", CreatedAt: "2026-08-01T00:00:00Z"},
+	}}
+
+	assert.Equal(t, []string{"eval_new", "eval_old"}, idsNamedIn(list, "shared"))
+}
+
+// An eval the service described without a usable timestamp must not win by
+// accident; it sorts last and the ones that can be ordered still are.
+func TestEvalIDsNamedPutsUndatedLast(t *testing.T) {
+	list := &eval_api.OpenAIEvalList{Data: []eval_api.OpenAIEval{
+		{ID: "eval_undated", Name: "shared"},
+		{ID: "eval_dated", Name: "shared", CreatedAt: "2026-01-01T00:00:00Z"},
+	}}
+
+	assert.Equal(t, []string{"eval_dated", "eval_undated"}, idsNamedIn(list, "shared"))
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evaluator.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evaluator.go
@@ -1,0 +1,515 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/project"
+
+	"github.com/spf13/cobra"
+)
+
+func newEvaluatorCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "evaluator",
+		Short: "Manage custom evaluators.",
+	}
+	cmd.AddCommand(
+		newEvaluatorCreateCommand(),
+		newEvaluatorUpdateCommand(),
+		newEvaluatorListCommand(),
+		newEvaluatorShowCommand(),
+		newEvaluatorDeleteCommand(),
+		newEvaluatorVersionsCommand(),
+	)
+	return cmd
+}
+
+// newEvaluatorCreateCommand builds `evaluator create <name>`, which registers
+// an evaluator that does not exist yet.
+func newEvaluatorCreateCommand() *cobra.Command {
+	return newEvaluatorWriteCommand("create", "Register an evaluator, publishing its first version.")
+}
+
+// newEvaluatorUpdateCommand builds `evaluator update <name>`, which publishes a
+// further version of one that does.
+func newEvaluatorUpdateCommand() *cobra.Command {
+	return newEvaluatorWriteCommand("update", "Publish a new version of an evaluator.")
+}
+
+// newEvaluatorWriteCommand builds create and update, which send the same
+// request and differ only in which starting state they accept. The service has
+// one route for both and assigns the version either way, so the existence check
+// is ours: without it, `create` on a name already in use would silently publish
+// a further version of someone else's evaluator.
+func newEvaluatorWriteCommand(verb, short string) *cobra.Command {
+	var (
+		fromFile    string
+		endpointFlg string
+	)
+
+	cmd := &cobra.Command{
+		Use:   verb + " <name>",
+		Short: short,
+		Long: short + "\n\n" +
+			"An evaluator is a rubric: a JSON file of weighted scoring dimensions.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if !validAssetName(name) {
+				return messages.InvalidEvaluatorName(name)
+			}
+			if fromFile == "" {
+				return requireFlag("from-file")
+			}
+
+			raw, err := project.ReadFileNoBOM(fromFile)
+			if err != nil {
+				return messages.ReadingEvaluator(fromFile, err)
+			}
+
+			body, err := normalizeRubricBody(name, raw)
+			if err != nil {
+				return messages.EvaluatorProblem(fromFile, err)
+			}
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			// Asked of the direct read, not the version listing. The listing
+			// lags a publish by up to a second and a half, so an update
+			// issued straight after a create would be told the evaluator it
+			// just made does not exist.
+			existing, readErr := ec.evalClient.GetEvaluatorRaw(
+				ctx, name, "", ProjectEndpointAPIVersion,
+			)
+			if readErr != nil && !eval_api.IsNotFound(readErr) {
+				return messages.CheckingEvaluatorExists(name, readErr)
+			}
+			// A non-404 already returned above, so reaching here means the read
+			// either found the evaluator or the service said it is unknown.
+			if err := checkAssetExistence(verb, "evaluator", name, readErr == nil, true); err != nil {
+				return err
+			}
+
+			// What that read saw is what keeps the publish from being
+			// answered with the same version and replacing it.
+			if readErr != nil {
+				existing = nil
+			}
+
+			created, err := ec.evalClient.CreateEvaluatorVersion(
+				ctx, name, body, existing, ProjectEndpointAPIVersion,
+			)
+			if err != nil {
+				return messages.RegisteringEvaluator(name, err)
+			}
+
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), created)
+			}
+			fmt.Fprint(cmd.OutOrStdout(),
+				messages.EvaluatorRegistered(created.Name, created.Version))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "Path to the evaluator JSON file.")
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// checkAssetExistence enforces the one difference between create and update.
+//
+// absenceCertain separates "the service says this name is unknown" from "nothing
+// came back", and only the former refuses an update. A caller reading an
+// eventually consistent version listing cannot prove absence, so an update
+// issued moments after a create would otherwise be refused for a dataset that
+// plainly exists -- and sent to `create`, which fails in turn once the listing
+// catches up. Callers that read a point endpoint can prove it and pass true.
+func checkAssetExistence(verb, kind, name string, exists, absenceCertain bool) error {
+	switch {
+	case verb == "create" && exists:
+		return messages.AssetAlreadyExists(kind, name)
+	case verb == "update" && !exists && absenceCertain:
+		return messages.AssetDoesNotExist(kind, name)
+	}
+	return nil
+}
+
+// rubricDefinitionType is the discriminator the service uses to deserialize a
+// rubric definition.
+const rubricDefinitionType = "rubric"
+
+// ensureDefinitionType adds the type discriminator when a definition omits it.
+//
+// Without it the service cannot tell which definition kind it is holding and
+// rejects the whole request with "The request field is required", which points
+// at the wrong field entirely. Generated rubrics carry the type; hand-authored
+// ones written to the shape the spec documents — a bare list of weighted
+// dimensions — do not.
+func ensureDefinitionType(definition json.RawMessage) (json.RawMessage, error) {
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(definition, &doc); err != nil {
+		return nil, messages.DefinitionNotJSONObject(err)
+	}
+	if _, ok := doc["type"]; ok {
+		return definition, nil
+	}
+	doc["type"] = json.RawMessage(fmt.Sprintf("%q", rubricDefinitionType))
+	return json.Marshal(doc)
+}
+
+// normalizeRubricBody accepts either a bare definition ({type, dimensions}) or
+// a full evaluator document ({name, definition}) and returns the request body.
+func normalizeRubricBody(name string, raw []byte) (json.RawMessage, error) {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return nil, messages.NotValidJSON(err)
+	}
+
+	if definition, hasDefinition := probe["definition"]; hasDefinition {
+		// Already a full document; make sure the name matches the argument.
+		typed, err := ensureDefinitionType(definition)
+		if err != nil {
+			return nil, err
+		}
+		probe["definition"] = typed
+		probe["name"] = json.RawMessage(fmt.Sprintf("%q", name))
+		out, err := json.Marshal(probe)
+		if err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+
+	if _, hasDimensions := probe["dimensions"]; !hasDimensions {
+		return nil, messages.RubricMissingDimensions()
+	}
+
+	typed, err := ensureDefinitionType(raw)
+	if err != nil {
+		return nil, err
+	}
+	doc := map[string]any{
+		"name":       name,
+		"definition": typed,
+	}
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func newEvaluatorListCommand() *cobra.Command {
+	var (
+		builtin     bool
+		endpointFlg string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List the project's evaluators, or the built-in ones.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			// The service filters by type, and asking for nothing returns only
+			// the project's own evaluators.
+			filter := ""
+			if builtin {
+				filter = eval_api.EvaluatorTypeBuiltin
+			}
+			list, err := ec.evalClient.ListEvaluators(ctx, filter, ProjectEndpointAPIVersion)
+			if err != nil {
+				return messages.ListingEvaluators(err)
+			}
+			return renderEvaluators(cmd, list)
+		},
+	}
+
+	cmd.Flags().BoolVar(&builtin, "builtin", false,
+		"List the built-in evaluators instead of the project's own.")
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// newEvaluatorVersionsCommand groups the version listing, so that `list` means
+// the same thing for evaluators as it does for datasets: the assets, not their
+// history.
+func newEvaluatorVersionsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "versions",
+		Short: "Inspect the versions of one evaluator.",
+	}
+	cmd.AddCommand(newEvaluatorVersionsListCommand())
+	return cmd
+}
+
+func newEvaluatorVersionsListCommand() *cobra.Command {
+	var endpointFlg string
+
+	cmd := &cobra.Command{
+		Use:   "list <name>",
+		Short: "List the versions of an evaluator.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if !validAssetName(name) {
+				return messages.InvalidEvaluatorName(name)
+			}
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			list, err := ec.evalClient.ListEvaluatorVersions(ctx, name, ProjectEndpointAPIVersion)
+			if err != nil {
+				// A name nobody published is the ordinary way to get here, and
+				// it does not need the whole 404 body to explain it.
+				if eval_api.IsNotFound(err) {
+					return messages.EvaluatorNotFound(name)
+				}
+				return messages.ListingEvaluatorVersions(name, err)
+			}
+			return renderEvaluatorVersions(cmd, list)
+		},
+	}
+
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+func renderEvaluators(cmd *cobra.Command, list *eval_api.EvaluatorListResponse) error {
+	if isJSON(cmd) {
+		return emitJSONList(cmd.OutOrStdout(), list.Value)
+	}
+	if len(list.Value) == 0 {
+		fmt.Fprint(cmd.OutOrStdout(), messages.NoEvaluators())
+		return nil
+	}
+	rows := make([][]string, 0, len(list.Value))
+	for _, e := range list.Value {
+		rows = append(rows, []string{e.Name, e.Version, e.Type()})
+	}
+	return emitTable(cmd.OutOrStdout(), []string{"NAME", "VERSION", "TYPE"}, rows)
+}
+
+// evaluatorPassThreshold renders the rubric's pass mark for a table cell,
+// empty when the evaluator does not carry one.
+//
+// Two decimals because the scale is normalized 0.0-1.0, where the difference
+// between 0.7 and 0.75 is a real change in what passes.
+func evaluatorPassThreshold(e *eval_api.EvaluatorSummary) string {
+	if e == nil || e.Definition == nil || e.Definition.PassThreshold == nil {
+		return ""
+	}
+	return strconv.FormatFloat(*e.Definition.PassThreshold, 'f', 2, 64)
+}
+
+// renderEvaluatorVersions lists one evaluator's history.
+//
+// Name and type are the same on every row here, so they say nothing. What the
+// scenario reads a version list for is how the rubric changed, which is the
+// date, the pass mark and the description the author left.
+func renderEvaluatorVersions(cmd *cobra.Command, list *eval_api.EvaluatorListResponse) error {
+	if isJSON(cmd) {
+		return emitJSONList(cmd.OutOrStdout(), list.Value)
+	}
+	if len(list.Value) == 0 {
+		fmt.Fprint(cmd.OutOrStdout(), messages.NoEvaluators())
+		return nil
+	}
+	rows := make([][]string, 0, len(list.Value))
+	for _, e := range list.Value {
+		rows = append(rows, []string{
+			e.Version,
+			timestampString(e.CreatedAt),
+			evaluatorPassThreshold(&e),
+			e.Description,
+		})
+	}
+	return emitTable(cmd.OutOrStdout(),
+		[]string{"VERSION", "CREATED AT", "PASS THRESHOLD", "DESCRIPTION"}, rows)
+}
+
+func newEvaluatorShowCommand() *cobra.Command {
+	var (
+		version     string
+		outFile     string
+		endpointFlg string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "show <name>",
+		Short: "Show an evaluator definition.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if !validAssetName(name) {
+				return messages.InvalidEvaluatorName(name)
+			}
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			raw, err := ec.evalClient.GetEvaluatorRaw(ctx, name, version, ProjectEndpointAPIVersion)
+			if err != nil {
+				if eval_api.IsNotFound(err) {
+					return messages.EvaluatorNotFound(name)
+				}
+				return messages.ReadingEvaluator(name, err)
+			}
+
+			// --output-file writes the service's document verbatim, because
+			// reconciliation points here to adopt a remote change over the local
+			// definition: anything this view dropped would be lost on adoption.
+			if outFile != "" {
+				body := raw
+				var pretty any
+				if err := json.Unmarshal(raw, &pretty); err == nil {
+					if indented, err := json.MarshalIndent(pretty, "", "  "); err == nil {
+						body = append(indented, '\n')
+					}
+				}
+				if err := writeFileAtomic(outFile, body); err != nil {
+					return err
+				}
+				if !isJSON(cmd) {
+					fmt.Fprint(cmd.OutOrStdout(), messages.WroteArtifact(outFile))
+				}
+				return nil
+			}
+
+			// -o json answers with the service's document untouched, because a
+			// caller asking for JSON wants the evaluator, not this view of it.
+			if isJSON(cmd) {
+				var pretty any
+				if err := json.Unmarshal(raw, &pretty); err != nil {
+					fmt.Fprintln(cmd.OutOrStdout(), string(raw))
+					return nil
+				}
+				return emitJSON(cmd.OutOrStdout(), pretty)
+			}
+
+			var summary eval_api.EvaluatorSummary
+			if err := json.Unmarshal(raw, &summary); err != nil {
+				// An evaluator shaped in a way this view cannot read is still
+				// worth showing; falling back beats refusing to print it.
+				fmt.Fprintln(cmd.OutOrStdout(), string(raw))
+				return nil
+			}
+			return ec.renderEvaluator(ctx, cmd.OutOrStdout(), &summary)
+		},
+	}
+
+	cmd.Flags().StringVar(&version, "version", "", "Version to show. Omit for the latest.")
+	cmd.Flags().StringVar(&outFile, "output-file", "",
+		"Write the evaluator document to this path instead of stdout.")
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// renderEvaluator prints the detail view for one evaluator, closing with its
+// portal link.
+//
+// The columns an evaluator is identified by, then what it grades and where it
+// can run. The full definition is in `-o json`; a schema printed here would
+// bury the four lines a reader came for.
+func (ec *evalContext) renderEvaluator(
+	ctx context.Context,
+	out io.Writer,
+	e *eval_api.EvaluatorSummary,
+) error {
+	if err := emitDetail(out, []field{
+		{"Name", e.Name},
+		{"Version", e.Version},
+		{"Type", e.Type()},
+		{"Pass Threshold", evaluatorPassThreshold(e)},
+		{"Description", e.Description},
+		{"Categories", strings.Join(e.Categories, ", ")},
+		{"Evaluation Levels", strings.Join(e.SupportedEvaluationLevels, ", ")},
+	}); err != nil {
+		return err
+	}
+	if prefix := ec.portalPrefix(ctx); prefix != nil && e.Name != "" {
+		writePortalLink(out, prefix.EvaluatorURL(e.Name, e.Version))
+	}
+	return nil
+}
+
+func newEvaluatorDeleteCommand() *cobra.Command {
+	var (
+		version     string
+		endpointFlg string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "delete <name>",
+		Short: "Delete an evaluator version.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			if !validAssetName(name) {
+				return messages.InvalidEvaluatorName(name)
+			}
+			if version == "" {
+				return requireFlag("version")
+			}
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			if err := ec.evalClient.DeleteEvaluatorVersion(
+				ctx, name, version, ProjectEndpointAPIVersion,
+			); err != nil {
+				if eval_api.IsNotFound(err) {
+					return messages.EvaluatorVersionNotFound(name, version)
+				}
+				return messages.DeletingEvaluatorVersion(name, version, err)
+			}
+
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), map[string]string{
+					"name": name, "version": version, "status": "deleted",
+				})
+			}
+			fmt.Fprint(cmd.OutOrStdout(), messages.EvaluatorDeleted(name, version))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&version, "version", "", "Version to delete.")
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evaluator_flag_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evaluator_flag_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// `--evaluator a,b` used to be accepted whole, writing one evaluator literally
+// named "a,b" into the config. init exited 0 and the failure surfaced two
+// commands later at create, naming a value passed to a different command.
+func TestEvaluatorFlagSplitsOnCommas(t *testing.T) {
+	cmd := newInitCommand()
+	require.NoError(t, cmd.Flags().Parse([]string{
+		"--evaluator", "builtin.task_adherence,builtin.relevance",
+	}))
+
+	got, err := cmd.Flags().GetStringSlice("evaluator")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"builtin.task_adherence", "builtin.relevance"}, got,
+		"a comma separates references; it is never part of an evaluator name")
+}
+
+// The sibling repeatable flag already split on commas, and two flags documented
+// the same way behaving differently is visible only to someone who knows pflag.
+func TestRepeatableFlagsAgreeOnCommas(t *testing.T) {
+	typeOf := func(cmd *pflag.FlagSet, name string) string {
+		f := cmd.Lookup(name)
+		require.NotNilf(t, f, "%s is not registered", name)
+		return f.Value.Type()
+	}
+
+	assert.Equal(t, "stringSlice", typeOf(newInitCommand().Flags(), "evaluator"))
+	assert.Equal(t, typeOf(newGenerateCommand().Flags(), "from"),
+		typeOf(newInitCommand().Flags(), "evaluator"),
+		"both are repeatable reference lists, so they must split alike")
+}
+
+// Repeating the flag still works, because a comma list is an addition rather
+// than a replacement.
+func TestEvaluatorFlagStillRepeats(t *testing.T) {
+	cmd := newInitCommand()
+	require.NoError(t, cmd.Flags().Parse([]string{
+		"--evaluator", "builtin.task_adherence", "--evaluator", "builtin.relevance",
+	}))
+
+	got, err := cmd.Flags().GetStringSlice("evaluator")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"builtin.task_adherence", "builtin.relevance"}, got)
+}
+
+// A stray comma leaves an empty reference, which would otherwise be written to
+// the config and looked up as "".
+func TestEvaluatorRefsRejectWhatCannotNameAnEvaluator(t *testing.T) {
+	require.NoError(t, validateEvaluatorRefs([]string{"builtin.relevance", "my-rubric"}))
+
+	err := validateEvaluatorRefs([]string{"builtin.relevance", ""})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--evaluator")
+
+	err = validateEvaluatorRefs([]string{"two words"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "two words")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evaluator_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evaluator_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The service needs a type discriminator to deserialize a definition. Without
+// it the whole request is rejected with "The request field is required", which
+// names the wrong field, so a hand-authored rubric failed to upload.
+func TestNormalizeRubricBodyAddsDefinitionType(t *testing.T) {
+	raw := []byte(`{"dimensions":[{"id":"accuracy","description":"Correct.","weight":5}]}`)
+
+	body, err := normalizeRubricBody("support-quality", raw)
+	require.NoError(t, err)
+
+	var doc struct {
+		Name       string `json:"name"`
+		Definition struct {
+			Type       string `json:"type"`
+			Dimensions []struct {
+				ID     string `json:"id"`
+				Weight int    `json:"weight"`
+			} `json:"dimensions"`
+		} `json:"definition"`
+	}
+	require.NoError(t, json.Unmarshal(body, &doc))
+	require.Equal(t, "support-quality", doc.Name)
+	require.Equal(t, "rubric", doc.Definition.Type)
+	require.Len(t, doc.Definition.Dimensions, 1)
+	require.Equal(t, 5, doc.Definition.Dimensions[0].Weight)
+}
+
+// A definition that already declares its type keeps it, so a generated rubric
+// round-trips unchanged.
+func TestNormalizeRubricBodyKeepsExistingType(t *testing.T) {
+	raw := []byte(`{"type":"custom_kind","dimensions":[{"id":"a","weight":1}]}`)
+
+	body, err := normalizeRubricBody("x", raw)
+	require.NoError(t, err)
+
+	var doc struct {
+		Definition struct {
+			Type string `json:"type"`
+		} `json:"definition"`
+	}
+	require.NoError(t, json.Unmarshal(body, &doc))
+	require.Equal(t, "custom_kind", doc.Definition.Type)
+}
+
+// A full document is normalized the same way, and the name follows the flag.
+func TestNormalizeRubricBodyHandlesFullDocument(t *testing.T) {
+	raw := []byte(`{"name":"stale","definition":{"dimensions":[{"id":"a","weight":1}]}}`)
+
+	body, err := normalizeRubricBody("actual-name", raw)
+	require.NoError(t, err)
+
+	var doc struct {
+		Name       string `json:"name"`
+		Definition struct {
+			Type string `json:"type"`
+		} `json:"definition"`
+	}
+	require.NoError(t, json.Unmarshal(body, &doc))
+	require.Equal(t, "actual-name", doc.Name)
+	require.Equal(t, "rubric", doc.Definition.Type)
+}
+
+func TestNormalizeRubricBodyRejectsNonRubric(t *testing.T) {
+	_, err := normalizeRubricBody("x", []byte(`{"something":1}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dimensions")
+
+	_, err = normalizeRubricBody("x", []byte(`not json`))
+	require.Error(t, err)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evaluator_version_live_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/evaluator_version_live_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build live
+
+// Evaluator versions are the unit an eval binds to, and the service assigns
+// them. This proves the extension never hands back a version it has quietly
+// overwritten.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLiveEvaluatorUpdateAlwaysPublishesANewVersion covers the shape of a
+// first authoring session: create a rubric, look at it, change one weight,
+// update.
+//
+// For a few seconds after a publish the service can answer the next one with
+// the version it just assigned, writing over it rather than adding one.
+// Nothing observable marks the end of that race — the version listing lags a
+// publish as well, answering 404 immediately after a create — so the guard
+// is the document the caller already read: it says which version exists and
+// when it was written.
+//
+// Without it, `evaluator update` run straight after `evaluator create` reports
+// success, leaves a single version holding the second rubric, and every eval
+// bound to the first scores against a rubric nobody chose.
+func TestLiveEvaluatorUpdateAlwaysPublishesANewVersion(t *testing.T) {
+	client, _ := liveEvalClient(t)
+	ctx := context.Background()
+
+	name := fmt.Sprintf("azdlive-version-%d", time.Now().UnixNano())
+
+	rubric := func(weight int) json.RawMessage {
+		body, err := normalizeRubricBody(name, []byte(fmt.Sprintf(
+			`{"dimensions":[{"id":"tone","weight":%d,"description":"polite"}]}`, weight)))
+		require.NoError(t, err)
+		return body
+	}
+
+	first, err := client.CreateEvaluatorVersion(ctx, name, rubric(1), nil, ProjectEndpointAPIVersion)
+	require.NoError(t, err)
+	require.NotEmpty(t, first.Version)
+	t.Cleanup(func() {
+		for _, v := range []string{first.Version, "1", "2"} {
+			_ = client.DeleteEvaluatorVersion(
+				context.Background(), name, v, ProjectEndpointAPIVersion)
+		}
+	})
+
+	// Deliberately immediate, and passing what the caller holds rather than
+	// re-reading: this is the window the guard exists for, and a test that
+	// waited first would pass with the guard removed.
+	previous, err := json.Marshal(first)
+	require.NoError(t, err)
+
+	started := time.Now()
+	second, err := client.CreateEvaluatorVersion(
+		ctx, name, rubric(2), previous, ProjectEndpointAPIVersion)
+	require.NoError(t, err)
+	require.NotEqual(t, first.Version, second.Version,
+		"an update issued inside the race must still publish a new version")
+	t.Logf("the second version was assigned after %s", time.Since(started).Round(time.Millisecond))
+
+	// The new version holds the new rubric, and both versions are readable.
+	// The earlier one is not asserted on: if the service does collide, the
+	// attempt that collided has already written the new definition over it,
+	// and no amount of care on this side can undo that.
+	require.Equal(t, 2, liveRubricWeight(t, client, name, second.Version))
+	require.NotZero(t, liveRubricWeight(t, client, name, first.Version),
+		"version %s must remain readable", first.Version)
+}
+
+// liveRubricWeight reads back the one weight the fixture rubric carries.
+//
+// Read as JSON rather than matched as a substring: the service reformats what
+// it stores, so `"weight":1` goes in and `"weight": 1` comes back, and a
+// substring assertion would fail for a reason that has nothing to do with what
+// is being tested.
+func liveRubricWeight(
+	t *testing.T,
+	client *eval_api.EvalClient,
+	name, version string,
+) int {
+	t.Helper()
+
+	raw, err := client.GetEvaluatorRaw(
+		context.Background(), name, version, ProjectEndpointAPIVersion)
+	require.NoError(t, err)
+
+	var doc struct {
+		Definition struct {
+			Dimensions []struct {
+				ID     string `json:"id"`
+				Weight int    `json:"weight"`
+			} `json:"dimensions"`
+		} `json:"definition"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	require.Len(t, doc.Definition.Dimensions, 1)
+	return doc.Definition.Dimensions[0].Weight
+}
+
+// TestLiveFirstPublishReturnsVersionOne is the other half: the guard must not
+// change what a first publish answers.
+func TestLiveFirstPublishReturnsVersionOne(t *testing.T) {
+	client, _ := liveEvalClient(t)
+	ctx := context.Background()
+
+	name := fmt.Sprintf("azdlive-firstpub-%d", time.Now().UnixNano())
+	body, err := normalizeRubricBody(name, []byte(
+		`{"dimensions":[{"id":"tone","weight":1,"description":"polite"}]}`))
+	require.NoError(t, err)
+
+	created, err := client.CreateEvaluatorVersion(ctx, name, body, nil, ProjectEndpointAPIVersion)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = client.DeleteEvaluatorVersion(
+			context.Background(), name, created.Version, ProjectEndpointAPIVersion)
+	})
+
+	require.Equal(t, "1", created.Version,
+		"a name the project has never seen must publish as version 1")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating.go
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/spf13/cobra"
+)
+
+// Gating is opt-in. A completed run with failing samples exits 0 without
+// --fail-on: failing samples are the expected output of a working evaluation,
+// not a tool error, and `run start` is used constantly in the inner loop. A
+// default that returned non-zero on any failure would break a build the first
+// time a noisy grader disagreed.
+//
+// The separate exit code matters more than the flag. It lets a pipeline tell
+// "the evaluation regressed" from "the evaluation could not run", which are
+// different failures with different owners.
+
+// exitCodeGateBreached is returned when a run completed but missed its
+// threshold.
+const exitCodeGateBreached = 2
+
+// gate is a parsed --fail-on threshold.
+type gate struct {
+	set        bool
+	anyFailure bool
+	passRate   float64
+}
+
+// parseGate reads the --fail-on value. An empty value means no gating.
+func parseGate(spec string) (gate, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return gate{}, nil
+	}
+	if spec == "any-failure" {
+		return gate{set: true, anyFailure: true}, nil
+	}
+
+	rate, ok := strings.CutPrefix(spec, "pass-rate=")
+	if !ok {
+		return gate{}, messages.FailOnInvalid(spec)
+	}
+	value, err := strconv.ParseFloat(rate, 64)
+	if err != nil {
+		return gate{}, messages.FailOnRateNotNumber(rate)
+	}
+	// NaN parses, then passes both range checks, and then loses every
+	// comparison it is put in -- so a pipeline that asked to be gated would
+	// never be, and nothing would say so.
+	if math.IsNaN(value) {
+		return gate{}, messages.FailOnRateNotNumber(rate)
+	}
+	if value < 0 || value > 1 {
+		return gate{}, messages.FailOnRateOutOfRange(value)
+	}
+	return gate{set: true, passRate: value}, nil
+}
+
+// breach reports why the run missed the threshold, or empty when it met it.
+//
+// Errored and skipped rows count against the pass rate, and they can: the
+// service puts them inside `total`, verified live on a run that reported
+// total=3 passed=2 errored=1. Were they outside it, a run with two passes and
+// one error would report total=2 and score a perfect rate, which is precisely
+// the broken evaluation a gate exists to catch.
+//
+// A run that scored nothing at all breaches every threshold rather than
+// dividing by zero — "no rows passed" is the honest reading of an empty result.
+func (g gate) breach(counts *eval_api.EvalRunResultCounts) string {
+	if !g.set {
+		return ""
+	}
+	if counts == nil {
+		return messages.GateNoResultCounts()
+	}
+	// Checked before any-failure as well as before the rate: a run that graded
+	// nothing has not passed, and reading zero unpassed rows as success let an
+	// empty run clear the gate that exists to catch exactly that.
+	if counts.Total == 0 {
+		return messages.GateNoRowsScored()
+	}
+	if g.anyFailure {
+		unpassed := counts.Total - counts.Passed
+		if unpassed > 0 {
+			return messages.GateSamplesDidNotPass(unpassed, counts.Total)
+		}
+		return ""
+	}
+	actual := float64(counts.Passed) / float64(counts.Total)
+	if actual < g.passRate {
+		return messages.GatePassRateBelow(actual, g.passRate)
+	}
+	return ""
+}
+
+// gateBreachMessage is what a breached gate prints, kept separate from the
+// exit so the wording can be tested: it is the block the spec's CI scenario
+// shows, and a pipeline's logs are where it is read.
+func gateBreachMessage(reason string) string {
+	return messages.GateBreached(reason)
+}
+
+// applyGate ends the process with exit code 2 when the run missed its
+// threshold.
+//
+// It exits here rather than returning an error because the extension SDK's
+// Run collapses every error to exit 1, and the whole point of the flag is a
+// code a pipeline can tell apart from an operational failure.
+func applyGate(cmd *cobra.Command, g gate, run *eval_api.OpenAIEvalRun) {
+	if run == nil {
+		return
+	}
+	reason := g.breach(run.ResultCounts)
+	if reason == "" {
+		return
+	}
+	fmt.Fprint(os.Stderr, gateBreachMessage(reason))
+	os.Exit(exitCodeGateBreached)
+}
+
+func addFailOnFlag(cmd *cobra.Command, target *string) {
+	// States the observed code rather than the one this process exits with: azd
+	// collapses an extension's exit code, and a pipeline author who reads 2 here
+	// writes a condition that never fires.
+	cmd.Flags().StringVar(target, "fail-on", "",
+		"Fail when the run misses this threshold: any-failure, or pass-rate=<0..1>. "+
+			"Exits 1.")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_budget_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_budget_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"azureaieval/internal/messages"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A run that outlives the wait leaves --fail-on with nothing to judge. Exiting
+// 0 there tells a pipeline the gate passed, which is the silent drop --no-wait
+// is refused for, reached by running long instead. The message has to say the
+// gate did not run, not merely that the wait stopped.
+func TestGateOutlivedTheWaitSaysTheGateNeverRan(t *testing.T) {
+	err := messages.GateOutlivedTheWait("run_abc", 2*time.Hour)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "run_abc")
+	assert.Contains(t, err.Error(), "2h0m0s", "the message has to say how long it waited")
+	assert.Contains(t, err.Error(), "--fail-on",
+		"a reader has to know which flag went unanswered")
+	assert.Contains(t, err.Error(), "run show",
+		"and how to get the verdict they asked for")
+}
+
+// The check above only proves the message is right, not that anything calls it.
+// Driving the branch itself needs a run that outlives a two-hour const budget
+// and a signed-in client, so this reads the source instead.
+//
+// Worth the ugliness here: the failure mode is a gate that passes silently, so
+// a regression looks exactly like success and no other test would notice. Same
+// reasoning as the linker-path check in internal/version.
+func TestWaitBudgetBranchStillConsultsTheGate(t *testing.T) {
+	body, err := os.ReadFile("run.go")
+	require.NoError(t, err)
+
+	src := string(body)
+	start := strings.Index(src, "errors.Is(err, errWaitBudgetSpent)")
+	require.NotEqual(t, -1, start, "the wait-budget branch has moved or gone")
+
+	branch := src[start:]
+	if end := strings.Index(branch, "\n\t\t\tif err != nil {"); end != -1 {
+		branch = branch[:end]
+	}
+
+	assert.Contains(t, branch, "threshold.set",
+		"the branch has to ask whether a gate was set before reporting success")
+	assert.Contains(t, branch, "GateOutlivedTheWait",
+		"and refuse rather than exit 0 when one was")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_conformance_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_conformance_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The spec's CI scenario prints this block verbatim, and a pipeline's log is
+// where it is read. Both lines are asserted whole: the marker is what tells a
+// reader this is a gate rather than a crash, and the ERROR: line is what the
+// azd style guide reserves for a terminal failure.
+func TestGateBreachMessageMatchesTheScenario(t *testing.T) {
+	msg := gateBreachMessage("pass rate 76.0% is below the required 80.0%")
+
+	assert.Equal(t,
+		"(x) Failed: Evaluation gate: pass rate 76.0% is below the required 80.0%\n\n"+
+			"ERROR: evaluation quality gate not met.\n",
+		msg)
+}
+
+// Exit 2 is the whole point of --fail-on: a pipeline has to tell "the
+// evaluation regressed" apart from "the tool could not run", which is exit 1.
+func TestGateBreachUsesItsOwnExitCode(t *testing.T) {
+	assert.Equal(t, 2, exitCodeGateBreached,
+		"the spec's exit table gives 2 to a breached threshold")
+}
+
+// The spec's exit table: a completed run is 0 whatever it scored, and a run
+// that errored rather than completed is an operational failure.
+func TestRunCompletedSeparatesRegressionFromFailureToRun(t *testing.T) {
+	for _, status := range []string{"completed", "Completed", ""} {
+		assert.NoErrorf(t, runCompleted(&eval_api.OpenAIEvalRun{ID: "r", Status: status}),
+			"%q is a run that produced results, so its score decides the outcome", status)
+	}
+
+	for _, status := range []string{"failed", "errored", "canceled"} {
+		err := runCompleted(&eval_api.OpenAIEvalRun{ID: "r1", Status: status})
+		require.Errorf(t, err, "%q never produced results, so it did not regress", status)
+		assert.Contains(t, err.Error(), status)
+		assert.Contains(t, err.Error(), "r1")
+	}
+}
+
+// pass-rate is passed/total, and the service puts errored and skipped rows
+// inside total. Were they outside it, a run with two passes and one error
+// would score a perfect rate -- exactly the broken evaluation a gate exists to
+// catch.
+func TestPassRateCountsErroredAndSkippedAgainstTheThreshold(t *testing.T) {
+	g, err := parseGate("pass-rate=0.8")
+	require.NoError(t, err)
+
+	// 2 passed of 3 total, the third errored: 66.7%, below 80%.
+	breach := g.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 2, Errored: 1})
+	require.NotEmpty(t, breach, "an errored row is not a pass")
+	assert.Contains(t, breach, "66.7%")
+
+	assert.Empty(t, g.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 3}))
+}
+
+// any-failure is the same concern as the rate above asked as a yes or no, and
+// it was the untested half: the gate counts everything that is not a pass, so
+// replacing that with the Failed count alone let a run whose rows errored
+// report success, and no test noticed.
+func TestAnyFailureCountsErroredAndSkippedAsUnpassed(t *testing.T) {
+	g, err := parseGate("any-failure")
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, g.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 2, Errored: 1}),
+		"a row that errored did not pass")
+	assert.NotEmpty(t, g.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 2, Skipped: 1}),
+		"a row that was skipped did not pass either")
+	assert.NotEmpty(t, g.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 2, Failed: 1}))
+
+	assert.Empty(t, g.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 3}),
+		"every row passed, so there is nothing to report")
+}
+
+// A run that scored nothing breaches every threshold rather than dividing by
+// zero. "No rows passed" is the honest reading of an empty result.
+func TestEmptyRunBreachesEveryThreshold(t *testing.T) {
+	g, err := parseGate("pass-rate=0.1")
+	require.NoError(t, err)
+
+	breach := g.breach(&eval_api.EvalRunResultCounts{})
+
+	assert.NotEmpty(t, breach)
+	assert.NotContains(t, breach, "NaN", "dividing by zero must not reach the message")
+}
+
+// --fail-on belongs to the commands that wait for a terminal state, so a
+// pipeline that started a run asynchronously can still gate where it reattaches.
+func TestFailOnSitsOnTheWaitingCommands(t *testing.T) {
+	for _, path := range []string{"run start", "run show"} {
+		assert.NotNilf(t, find(t, path).Flags().Lookup("fail-on"),
+			"%s waits for a terminal state, so it can gate on one", path)
+	}
+
+	usage := find(t, "run start").Flags().Lookup("fail-on").Usage
+	for _, form := range []string{"any-failure", "pass-rate"} {
+		assert.Containsf(t, usage, form, "--fail-on accepts %q, so its help has to say so", form)
+	}
+	assert.Contains(t, strings.ToLower(usage), "1",
+		"the help has to name the exit code a caller observes, which is the only reason to use the flag")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_nowait_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_nowait_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// `--no-wait --fail-on ...` reads as "start it and tell me if it regressed".
+// It cannot be: --no-wait returns before there is a result, so the gate was
+// dropped and the command exited 0 however the run turned out. A pipeline
+// written that way believes it is gated and is not, which is worse than not
+// gating at all.
+//
+// Refused up front, before any network work.
+func TestFailOnWithNoWaitIsRefused(t *testing.T) {
+	for _, gate := range []string{"any-failure", "pass-rate=0.8"} {
+		root := NewRootCommand()
+		var out bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&out)
+		root.SetArgs([]string{"run", "start", "--no-wait", "--fail-on", gate})
+
+		err := root.ExecuteContext(context.Background())
+
+		require.Errorf(t, err, "--no-wait with --fail-on %s must not be accepted", gate)
+		assert.Contains(t, err.Error(), "--fail-on")
+		assert.Contains(t, err.Error(), "--no-wait")
+		assert.Containsf(t, err.Error(), "run show",
+			"the refusal has to name the way to gate a run started with --no-wait")
+	}
+}
+
+// The gate on its own still parses and still reaches the run, so the refusal
+// above is about the combination and not about --fail-on.
+func TestFailOnAloneIsStillAccepted(t *testing.T) {
+	root := NewRootCommand()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"run", "start", "--fail-on", "pass-rate=0.8"})
+
+	err := root.ExecuteContext(context.Background())
+
+	if err != nil {
+		assert.NotContains(t, err.Error(), "--no-wait",
+			"a gate without --no-wait must not be refused for needing the wait")
+	}
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_silent_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_silent_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A gate is the whole reason a pipeline runs this command, so the ways it can
+// silently stop gating matter more than the ways it can fire.
+
+// NaN parses, clears both range checks, and then loses every comparison it is
+// put in. A pipeline written this way believes it is gated and is not.
+func TestFailOnRejectsAThresholdThatCanNeverFire(t *testing.T) {
+	for _, spec := range []string{"pass-rate=NaN", "pass-rate=nan", "pass-rate=-nan"} {
+		_, err := parseGate(spec)
+		require.Errorf(t, err, "%s would disable the gate while looking like one", spec)
+	}
+
+	// The range check already covers infinities; this pins that it still does.
+	for _, spec := range []string{"pass-rate=Inf", "pass-rate=-Inf", "pass-rate=1.5", "pass-rate=-0.1"} {
+		_, err := parseGate(spec)
+		require.Errorf(t, err, "%s is not a pass rate", spec)
+	}
+
+	g, err := parseGate("pass-rate=0.8")
+	require.NoError(t, err)
+	assert.True(t, g.set)
+	assert.InDelta(t, 0.8, g.passRate, 1e-9)
+}
+
+// A run that graded nothing has not passed. The pass-rate gate always said so;
+// any-failure computed Total-Passed, which is zero for an empty run, and let it
+// through -- the one shape a gate exists to catch.
+func TestEveryGateBreachesOnARunThatScoredNothing(t *testing.T) {
+	empty := &eval_api.EvalRunResultCounts{Total: 0}
+
+	anyFailure, err := parseGate("any-failure")
+	require.NoError(t, err)
+	assert.NotEmpty(t, anyFailure.breach(empty),
+		"an empty run must not clear an any-failure gate")
+
+	rate, err := parseGate("pass-rate=0.8")
+	require.NoError(t, err)
+	assert.NotEmpty(t, rate.breach(empty))
+
+	// A gate that was never asked for stays silent whatever the counts.
+	assert.Empty(t, gate{}.breach(empty))
+}
+
+// The ordinary cases still behave, so the empty-run guard did not swallow them.
+func TestGatesStillJudgeRunsThatScoredSomething(t *testing.T) {
+	anyFailure, err := parseGate("any-failure")
+	require.NoError(t, err)
+
+	assert.Empty(t, anyFailure.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 3}),
+		"every row passed, so there is nothing to report")
+	assert.NotEmpty(t, anyFailure.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 2}),
+		"one row did not pass")
+
+	rate, err := parseGate("pass-rate=0.8")
+	require.NoError(t, err)
+	assert.Empty(t, rate.breach(&eval_api.EvalRunResultCounts{Total: 10, Passed: 9}))
+	assert.NotEmpty(t, rate.breach(&eval_api.EvalRunResultCounts{Total: 10, Passed: 7}))
+
+	// Counts the service never sent are not a pass.
+	assert.NotEmpty(t, rate.breach(nil))
+}
+
+// The spec puts --fail-on on the commands that wait. A run still in progress
+// has partial counts, so gating it can fail a run that would have passed --
+// and silently skipping the gate would leave a pipeline believing it is
+// protected when it is not.
+func TestOnlyATerminalRunCanBeGated(t *testing.T) {
+	// Read from the polling vocabulary instead of a second copy of it. Spelling
+	// the list out here is what hid "error" being gateable: the test agreed with
+	// the bug.
+	for status := range terminalRunStates {
+		assert.Truef(t, runIsTerminal(&eval_api.OpenAIEvalRun{Status: status}),
+			"the poller stops on %q, so its counts are final", status)
+	}
+	assert.True(t, runIsTerminal(&eval_api.OpenAIEvalRun{Status: ""}),
+		"a run the service reported no status for is gated on the counts it gave")
+
+	for _, status := range []string{"in_progress", "queued", "running"} {
+		assert.Falsef(t, runIsTerminal(&eval_api.OpenAIEvalRun{Status: status}),
+			"%q is still moving, so its counts are partial", status)
+	}
+
+	assert.False(t, runIsTerminal(nil), "no run is not a finished run")
+
+	err := messages.GateNeedsATerminalRun("evalrun_1", "in_progress")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--wait", "the way out has to be named")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGate(t *testing.T) {
+	t.Run("empty means no gating", func(t *testing.T) {
+		g, err := parseGate("")
+		require.NoError(t, err)
+		require.False(t, g.set)
+		require.Empty(t, g.breach(&eval_api.EvalRunResultCounts{Total: 3}),
+			"an unset gate must never breach")
+	})
+
+	t.Run("any-failure", func(t *testing.T) {
+		g, err := parseGate("any-failure")
+		require.NoError(t, err)
+		require.True(t, g.anyFailure)
+	})
+
+	t.Run("pass-rate", func(t *testing.T) {
+		g, err := parseGate("pass-rate=0.8")
+		require.NoError(t, err)
+		require.InDelta(t, 0.8, g.passRate, 1e-9)
+	})
+
+	for _, bad := range []string{"passrate=0.8", "pass-rate=abc", "pass-rate=1.5", "pass-rate=-1", "sometimes"} {
+		t.Run("refuses "+bad, func(t *testing.T) {
+			_, err := parseGate(bad)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestGateBreach(t *testing.T) {
+	anyFailure, err := parseGate("any-failure")
+	require.NoError(t, err)
+	eighty, err := parseGate("pass-rate=0.8")
+	require.NoError(t, err)
+
+	t.Run("any-failure passes only when every row passed", func(t *testing.T) {
+		require.Empty(t, anyFailure.breach(&eval_api.EvalRunResultCounts{Total: 2, Passed: 2}))
+		require.NotEmpty(t, anyFailure.breach(&eval_api.EvalRunResultCounts{Total: 2, Passed: 1, Failed: 1}))
+	})
+
+	// Errored rows are inside the total, verified live, so they count against
+	// the threshold the same way a failing row does.
+	t.Run("errored rows count against the rate", func(t *testing.T) {
+		counts := &eval_api.EvalRunResultCounts{Total: 10, Passed: 8, Errored: 2}
+		require.Empty(t, eighty.breach(counts), "0.8 exactly meets a 0.8 threshold")
+
+		counts = &eval_api.EvalRunResultCounts{Total: 10, Passed: 7, Errored: 3}
+		require.NotEmpty(t, eighty.breach(counts))
+	})
+
+	// The wording is pinned because the hero scenario shows it verbatim.
+	t.Run("reads as a percentage", func(t *testing.T) {
+		counts := &eval_api.EvalRunResultCounts{Total: 1000, Passed: 764}
+		require.Equal(t,
+			"pass rate 76.4% is below the required 80.0%",
+			eighty.breach(counts))
+	})
+
+	// A run that scored nothing has no defensible pass rate, and treating it as
+	// 100% would let a broken evaluation hold a gate open.
+	t.Run("a run that scored nothing breaches", func(t *testing.T) {
+		require.NotEmpty(t, eighty.breach(&eval_api.EvalRunResultCounts{Total: 0}))
+		require.NotEmpty(t, eighty.breach(nil))
+	})
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate.go
@@ -1,0 +1,494 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/project"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+)
+
+// generatePollBudget replaces the inherited 2s x 300 (10 minute) client budget.
+// The generation job is not gateway-capped; the old limit simply gave up while
+// the service was still working, forcing a second command.
+var generatePollBudget = eval_api.PollerOptions{
+	Interval:    5 * time.Second,
+	MaxAttempts: 720, // one hour
+}
+
+// generationPlan is everything one generation job needs, after the flags, the
+// generation spec, and the eval's own target have been reconciled.
+type generationPlan struct {
+	// Name of the artifact being generated — the positional argument.
+	Name string
+	// Agent whose context seeds generation. May be empty, in which case
+	// generation runs from the instruction alone.
+	Agent string
+	// Model deployment the generation job runs against.
+	Model string
+	// Instruction describing what the agent does and what to test.
+	Instruction string
+	// BaseDir is the directory OutputDir resolves against.
+	BaseDir string
+	// OutputDir is where the artifact is written.
+	OutputDir string
+	// SampleSize applies to dataset generation only.
+	SampleSize int
+	// From is what --from named: which of the service's sources to send. Empty
+	// sends whatever the plan has to offer.
+	From []string
+	// TraceDays seeds generation from that many days of recent traces.
+	TraceDays int
+	// Kind is which artifact this plan produces, so one runner can submit both.
+	Kind generateKind
+}
+
+// generateKind names the two generation resources, which share no collection.
+type generateKind string
+
+const (
+	generateKindDataset   generateKind = "dataset"
+	generateKindEvaluator generateKind = "evaluator"
+)
+
+// traceOptions converts the plan's trace window into the generation client's
+// day count. Traces seed generation only; they are never a run's data source.
+func (p generationPlan) traceOptions() *eval_api.TraceOptions {
+	if p.TraceDays <= 0 {
+		return nil
+	}
+	return &eval_api.TraceOptions{Days: p.TraceDays}
+}
+
+// resolveInstruction returns the generation instruction, reading it from a
+// file when one is named.
+//
+// A useful instruction describes the agent and what to test, which is often
+// more than fits comfortably on a command line, so it can live in a file that
+// is reviewable alongside the rest of the config.
+func resolveInstruction(inline, path string) (string, error) {
+	if path == "" {
+		return inline, nil
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", messages.ReadingInstructionFile(path, err)
+	}
+	text := strings.TrimSpace(string(raw))
+	if text == "" {
+		return "", messages.InstructionFileEmpty(path)
+	}
+	return text, nil
+}
+
+// declaredInstructions reads the file named by a generation entry's
+// `instructions`, relative to the spec that declared it.
+//
+// A missing file is not an error. The path can be written before the file
+// exists, so treating its absence as a failure would break the flow `init`
+// scaffolds.
+func declaredInstructions(named, configPath string) (string, error) {
+	if named == "" {
+		return "", nil
+	}
+
+	path := named
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(filepath.Dir(configPath), filepath.FromSlash(named))
+	}
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", messages.ReadingInstructions(named, err)
+	}
+	return strings.TrimSpace(string(raw)), nil
+}
+
+// resolveGenerationInstruction decides what generation is seeded from.
+//
+// The service accepts an agent source that is meant to pull the agent's own
+// instructions, but it fails for every agent, so the agent's context is read
+// here instead. In precedence order: what the caller passed, the instructions
+// the project already holds, then the agent's published ones.
+//
+// The project comes before the service because a local read cannot fail
+// slowly, and because instructions that have been optimized but not yet
+// deployed are the ones the author means — generating against what is still
+// published would test the version they are replacing.
+//
+// The last step is what makes `generate` work with no authored input at all,
+// which is the flow `init` sets up.
+func (ec *evalContext) resolveGenerationInstruction(
+	ctx context.Context,
+	explicit, agentName string,
+	out io.Writer,
+	quiet bool,
+) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+
+	if agentName == "" {
+		return "", nil
+	}
+
+	local, path, err := ec.agentInstructionsFromProject(ctx, agentName)
+	if err != nil {
+		return "", err
+	}
+	if local != "" {
+		if !quiet {
+			fmt.Fprint(out, messages.SeedingFromFile(filepath.ToSlash(path)))
+		}
+		return local, nil
+	}
+
+	agent, err := ec.evalClient.GetAgent(ctx, agentName, ProjectEndpointAPIVersion)
+	if err != nil {
+		// Reported without stopping, because the model can still be supplied by
+		// --generation-model and the caller has its own checks for what is left
+		// missing. Making an absent agent fatal here reads well for a typo but
+		// takes away the only path to "nothing supplied a model", which is the
+		// case the flag validation exists for.
+		if !quiet {
+			fmt.Fprint(out, messages.WarningAgentUnreadable(agentName, err))
+		}
+		return "", nil
+	}
+	instructions := agent.Instructions()
+	if instructions != "" && !quiet {
+		fmt.Fprint(out, messages.SeedingFromAgent(agentName))
+	}
+	return instructions, nil
+}
+
+// agentInstructionsFromProject reads the agent's instructions out of the azd
+// project, coming back empty when there is no project to read.
+//
+// Running outside a project is ordinary — the atomic commands work standalone
+// against the data plane — so not finding one is not an error. An ambiguous
+// target inside one is, because it would otherwise pick an agent at random.
+func (ec *evalContext) agentInstructionsFromProject(
+	ctx context.Context,
+	agentName string,
+) (instruction string, path string, err error) {
+	if ec.azdClient == nil {
+		return "", "", nil
+	}
+	resp, err := ec.azdClient.Project().Get(ctx, &azdext.EmptyRequest{})
+	if err != nil || resp.GetProject() == nil {
+		return "", "", nil
+	}
+	return project.AgentInstructionsFromProject(resp.GetProject(), agentName)
+}
+
+// generateRubric submits the evaluator generation job and saves the rubric.
+func (ec *evalContext) generateRubric(
+	ctx context.Context,
+	plan generationPlan,
+	out io.Writer,
+	noWait bool,
+	// jobID receives the submitted job's id, for the same reason as above.
+	jobID *string,
+) (*project.ArtifactRef, error) {
+	fmt.Fprint(out, messages.GeneratingRubric(plan.Name))
+
+	sources, unbuildable := eval_api.BuildGenerationSources(
+		plan.From, plan.Agent, "", plan.Instruction, plan.traceOptions(),
+	)
+	if err := refuseUnusableSources(sources, unbuildable); err != nil {
+		return nil, err
+	}
+	req := eval_api.NewEvaluatorGenerationJobRequest(plan.Name, plan.Model, sources)
+
+	job, err := ec.evalClient.CreateEvaluatorGenerationJob(ctx, req, ProjectEndpointAPIVersion)
+	if err != nil {
+		return nil, messages.SubmittingRubricJob(err)
+	}
+	if jobID != nil {
+		*jobID = job.ID
+	}
+	if noWait {
+		reportSubmitted(out, "evaluator", job.ID)
+		return nil, nil
+	}
+
+	completed, err := ec.pollGeneration(ctx, job.ID, ProjectEndpointAPIVersion,
+		ec.evalClient.GetEvaluatorGenerationJob)
+	if err != nil {
+		return nil, messages.RubricGeneration(err)
+	}
+
+	path := project.ArtifactPath(plan.BaseDir, plan.OutputDir, plan.Name, ".json")
+	if err := writeRubric(path, completed.Result); err != nil {
+		return nil, err
+	}
+	fmt.Fprint(out, messages.WroteArtifact(path))
+
+	_, version := completed.ResolvedNameVersion()
+	return &project.ArtifactRef{
+		Name:    plan.Name,
+		Source:  relativeSource(plan.BaseDir, path),
+		Version: version,
+	}, nil
+}
+
+// refuseUnbuildableSources reports a --from the plan could not honour.
+//
+// Submitting anyway would run a billed job seeded from less than was asked for
+// and return a plausible-looking artifact, which is the worst outcome: the
+// caller has no way to tell it apart from one built the way they intended.
+// refuseUnusableSources rejects a generation the service could only refuse.
+//
+// Unbuildable kinds each get their own reason. Beyond those, a request with no
+// sources at all is refused here rather than sent: a kind can be selected
+// without being asked for and without anything to build it from, which added to
+// neither list, so an empty request went out and came back as a 400 wrapping
+// thirty lines of JSON around one sentence.
+func refuseUnusableSources(sources []eval_api.GenerationSource, kinds []string) error {
+	if err := refuseUnbuildableSources(kinds); err != nil {
+		return err
+	}
+	if len(sources) == 0 {
+		return messages.NothingToGenerateFrom()
+	}
+	return nil
+}
+
+func refuseUnbuildableSources(kinds []string) error {
+	if len(kinds) == 0 {
+		return nil
+	}
+	reasons := map[string]string{
+		"prompt": messages.FromPromptNeedsInstruction(),
+		"agent":  messages.FromAgentNeedsTarget(),
+		"file":   messages.FromFileNotASource(),
+	}
+	reasonsForKinds := make([]string, 0, len(kinds))
+	for _, k := range kinds {
+		if reason, ok := reasons[k]; ok {
+			reasonsForKinds = append(reasonsForKinds, reason)
+			continue
+		}
+		reasonsForKinds = append(reasonsForKinds, messages.FromNotBuildable(k))
+	}
+	return messages.UnbuildableSources(reasonsForKinds)
+}
+
+// reportSubmitted says what was started and how to get back to it.
+//
+// The job id goes into the command rather than being left as a placeholder:
+// --no-wait exists so the caller can walk away, and the line they walk away
+// with has to be the one they can paste when they come back. The group is named
+// too, because the two job types share no collection.
+func reportSubmitted(out io.Writer, group, jobID string) {
+	fmt.Fprint(out, messages.JobSubmitted(jobID))
+	fmt.Fprint(out, messages.ReattachToJob(group, jobID))
+}
+
+// generateDataset submits the data generation job and downloads the result.
+func (ec *evalContext) generateDataset(
+	ctx context.Context,
+	plan generationPlan,
+	out io.Writer,
+	noWait bool,
+	// jobID receives the submitted job's id. Under --no-wait nothing is
+	// downloaded and there is no artifact to return, so this is the only thing
+	// the caller can report or reattach to.
+	jobID *string,
+) (*project.ArtifactRef, error) {
+	fmt.Fprint(out, messages.GeneratingDataset(plan.Name, plan.SampleSize))
+
+	sources, unbuildable := eval_api.BuildGenerationSources(
+		plan.From, plan.Agent, "", plan.Instruction, plan.traceOptions(),
+	)
+	if err := refuseUnusableSources(sources, unbuildable); err != nil {
+		return nil, err
+	}
+	req := eval_api.NewDataGenerationJobRequest(plan.Name, plan.Model, plan.SampleSize, sources)
+
+	job, err := ec.evalClient.CreateDataGenerationJob(ctx, req, DataGenerationAPIVersion)
+	if err != nil {
+		return nil, messages.SubmittingDataJob(err)
+	}
+	if jobID != nil {
+		*jobID = job.ID
+	}
+	if noWait {
+		reportSubmitted(out, "dataset", job.ID)
+		return nil, nil
+	}
+
+	completed, err := ec.pollGeneration(ctx, job.ID, DataGenerationAPIVersion,
+		ec.evalClient.GetDataGenerationJob)
+	if err != nil && isAgentSeededGenerationFailure(err) {
+		// Agent-seeded generation fails server-side for every agent, while the
+		// same request carrying only the prompt succeeds. Failing the whole
+		// command would block the documented flow on a defect the user cannot
+		// do anything about, so retry without the agent and say so.
+		promptOnly := eval_api.WithoutAgentSource(sources)
+		if eval_api.HasPromptSource(promptOnly) {
+			fmt.Fprint(out, messages.WarningAgentSeedFailedRetrying(plan.Agent))
+
+			req = eval_api.NewDataGenerationJobRequest(
+				plan.Name, plan.Model, plan.SampleSize, promptOnly)
+			job, err = ec.evalClient.CreateDataGenerationJob(ctx, req, DataGenerationAPIVersion)
+			if err != nil {
+				return nil, messages.SubmittingDataJob(err)
+			}
+			// The retry is a second billed job, so the id the caller reports
+			// has to move with it. Leaving it on the abandoned first job points
+			// every resume and every `job show` at the wrong one.
+			if jobID != nil {
+				*jobID = job.ID
+			}
+			completed, err = ec.pollGeneration(ctx, job.ID, DataGenerationAPIVersion,
+				ec.evalClient.GetDataGenerationJob)
+		}
+	}
+	if err != nil {
+		return nil, messages.DataGeneration(explainDataGenerationFailure(err, plan.Agent))
+	}
+
+	name, version := completed.ResolvedNameVersion()
+	if name == "" {
+		return nil, messages.DataJobReturnedNoDataset()
+	}
+
+	// Confirm the version exists before reading it, so a missing dataset is
+	// reported as such rather than as a download failure.
+	if _, err := ec.datasetClient.GetDataset(
+		ctx, name, version, ProjectEndpointAPIVersion,
+	); err != nil {
+		return nil, messages.ReadingGeneratedDataset(name, err)
+	}
+	content, err := ec.datasetClient.DownloadDatasetContent(ctx, name, version, ProjectEndpointAPIVersion)
+	if err != nil {
+		return nil, messages.DownloadingGeneratedDataset(name, err)
+	}
+
+	path := project.ArtifactPath(plan.BaseDir, plan.OutputDir, plan.Name, ".jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return nil, messages.Creating(filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		return nil, messages.Writing(path, err)
+	}
+	fmt.Fprint(out, messages.WroteArtifact(path))
+
+	// The job registered the version and this file is a copy of it, so the
+	// state a deploy would have left behind is recorded now. Without it the
+	// next `azd up` finds no fingerprint for this dataset, reads the file as
+	// new, and publishes a second version identical to the one just generated.
+	ec.recordDeployedDataset(ctx, plan.Name, path, version)
+
+	return &project.ArtifactRef{
+		Name:    plan.Name,
+		Source:  relativeSource(plan.BaseDir, path),
+		Version: version,
+	}, nil
+}
+
+// isAgentSeededGenerationFailure recognizes the service-side failure that hits
+// every agent, so it can be retried without the agent rather than surfaced.
+func isAgentSeededGenerationFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := err.Error()
+	return strings.Contains(text, "DataGenerationJobSystemError") ||
+		strings.Contains(text, "Something went wrong during data generation")
+}
+
+// explainDataGenerationFailure adds context to the service's opaque system
+// error.
+//
+// Seeding generation from an agent currently fails server-side with
+// DataGenerationJobSystemError for every agent, within seconds, while the same
+// request without the agent source runs normally. The raw message says only
+// that something went wrong and to try again, which sends users into a retry
+// loop against a deterministic failure.
+func explainDataGenerationFailure(err error, agentName string) error {
+	if err == nil || agentName == "" {
+		return err
+	}
+	// The poller surfaces the service's message; the code is not always in it.
+	text := err.Error()
+	if !strings.Contains(text, "DataGenerationJobSystemError") &&
+		!strings.Contains(text, "Something went wrong during data generation") {
+		return err
+	}
+	return messages.AgentSeededGenerationFailing(err, agentName)
+}
+
+// pollGeneration waits for a generation job using the raised budget.
+func (ec *evalContext) pollGeneration(
+	ctx context.Context,
+	operationID, apiVersion string,
+	get eval_api.GetJobFunc,
+) (*eval_api.GenerationJob, error) {
+	poller := eval_api.NewPoller(operationID, apiVersion, get)
+	poller.Options = generatePollBudget
+	return poller.Poll(ctx)
+}
+
+// writeRubric persists the rubric so the developer can edit weights and
+// descriptions and publish a new version.
+//
+// The definition is written through as it arrived rather than re-marshalled
+// from a struct. Re-marshalling keeps only the fields the struct models, and
+// dropped pass_threshold: the file then differed from the version that had just
+// been published, so the next deploy republished it, silently without a
+// threshold. Anything the service adds later would have been lost the same way.
+func writeRubric(path string, result json.RawMessage) error {
+	if len(result) == 0 {
+		return messages.RubricJobReturnedNoResult()
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return messages.Creating(filepath.Dir(path), err)
+	}
+
+	var envelope struct {
+		Definition json.RawMessage `json:"definition"`
+	}
+	if err := json.Unmarshal(result, &envelope); err == nil && len(envelope.Definition) > 0 {
+		var probe struct {
+			Dimensions []json.RawMessage `json:"dimensions"`
+		}
+		if json.Unmarshal(envelope.Definition, &probe) == nil && len(probe.Dimensions) > 0 {
+			var pretty bytes.Buffer
+			if err := json.Indent(&pretty, envelope.Definition, "", "  "); err != nil {
+				return messages.Serializing(path, err)
+			}
+			return os.WriteFile(path, pretty.Bytes(), 0o600)
+		}
+	}
+
+	// Fall back to the raw payload rather than losing the result.
+	return os.WriteFile(path, result, 0o600)
+}
+
+// relativeSource expresses an artifact path relative to the deployment spec.
+func relativeSource(baseDir, path string) string {
+	rel, err := filepath.Rel(baseDir, path)
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	return "./" + filepath.ToSlash(rel)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_commands.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_commands.go
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/project"
+
+	"github.com/spf13/cobra"
+)
+
+// Generation is split per artifact because the service splits it: datasets and
+// evaluators are separate long-running resources. One composite verb leaves
+// partial failure undefined, cannot regenerate one artifact after the other has
+// been hand-edited, and gives --no-wait nothing to reattach to.
+//
+// Neither command edits azure.yaml. Both add a catalog entry to azure.eval.yaml for
+// what they produced, so the artifact is referenceable without a hand edit.
+
+// generateFlags are the settings both generate commands share.
+//
+// There is no generation spec file. Every setting is a flag, because the
+// artifact is checked in and a regeneration usually wants different settings
+// anyway; what that costs is provenance, which is Open Question 8.
+type generateFlags struct {
+	path            string
+	target          string
+	instruction     string
+	instructionFile string
+	model           string
+	outputDir       string
+	noWait          bool
+	force           bool
+	endpoint        string
+}
+
+func addGenerateFlags(cmd *cobra.Command, f *generateFlags) {
+	cmd.Flags().StringVar(&f.path, "path", "",
+		"Directory holding the evaluation configuration. Defaults to the directory "+
+			"`init` scaffolded, otherwise ./evals.")
+	cmd.Flags().StringVar(&f.target, "target", "", "Agent whose context seeds generation.")
+	cmd.Flags().StringVar(&f.instruction, "agent-instruction", "",
+		"What the agent does and what to test.")
+	cmd.Flags().StringVar(&f.instructionFile, "agent-instruction-file", "",
+		"Read the agent instruction from this file. Mutually exclusive with --agent-instruction.")
+	cmd.MarkFlagsMutuallyExclusive("agent-instruction", "agent-instruction-file")
+	cmd.Flags().StringVar(&f.model, "generation-model", "",
+		"Model deployment that generates the artifact.")
+	cmd.Flags().StringVar(&f.outputDir, "output-dir", "",
+		"Directory the generated artifact is written to.")
+	cmd.Flags().BoolVar(&f.noWait, "no-wait", false,
+		"Submit the job and return its id without polling.")
+	cmd.Flags().BoolVar(&f.force, "force", false,
+		"Overwrite an artifact file that already exists.")
+	cmd.Flags().StringVar(&f.endpoint, "project-endpoint", "", "Foundry project endpoint.")
+}
+
+// resolvePlan settles every input that does not need the network.
+//
+// Doing it before the client is built means a missing model or an out-of-range
+// sample count is refused without an authentication round trip. The instruction
+// file is read here rather than later so that an input the caller named and got
+// wrong is reported ahead of one they simply left out.
+func resolvePlan(f *generateFlags, name string, defaultOutputDir string) (generationPlan, error) {
+	instruction, err := resolveInstruction(f.instruction, f.instructionFile)
+	if err != nil {
+		return generationPlan{}, err
+	}
+
+	plan := generationPlan{
+		Name:        name,
+		Agent:       firstNonEmpty(f.target, declaredTarget(f.path)),
+		Model:       f.model,
+		Instruction: instruction,
+		BaseDir:     f.path,
+		OutputDir:   firstNonEmpty(f.outputDir, "./"+defaultOutputDir),
+	}
+	if plan.Model == "" && plan.Agent == "" {
+		return plan, messages.GenerationModelRequired()
+	}
+	return plan, nil
+}
+
+// prepareGeneration builds the client and settles the two inputs that need it:
+// the agent's published instructions, and its deployment when the caller named
+// no model of its own. Only the service can supply either.
+func prepareGeneration(
+	cmd *cobra.Command,
+	f *generateFlags,
+	plan generationPlan,
+) (*evalContext, generationPlan, error) {
+	ctx := cmd.Context()
+	ec, err := newEvalContext(ctx, f.endpoint)
+	if err != nil {
+		return nil, plan, err
+	}
+
+	plan.Instruction, err = ec.resolveGenerationInstruction(
+		ctx, plan.Instruction, plan.Agent, cmd.OutOrStdout(), isJSON(cmd),
+	)
+	if err != nil {
+		ec.Close()
+		return nil, plan, err
+	}
+
+	if plan.Model == "" {
+		plan.Model = ec.agentDeployment(ctx, plan.Agent, cmd.OutOrStdout(), isJSON(cmd))
+	}
+	if plan.Model == "" {
+		ec.Close()
+		return nil, plan, messages.GenerationModelRequired()
+	}
+	return ec, plan, nil
+}
+
+// agentDeployment reads the deployment the target agent answers with.
+//
+// Best effort, but not silent: a misspelled --target and an agent with no
+// published version both end in "pass --generation-model", which names neither.
+// The warning is what tells those two apart.
+func (ec *evalContext) agentDeployment(
+	ctx context.Context,
+	agentName string,
+	out io.Writer,
+	quiet bool,
+) string {
+	if agentName == "" {
+		return ""
+	}
+	agent, err := ec.evalClient.GetAgent(ctx, agentName, ProjectEndpointAPIVersion)
+	if err != nil {
+		if !quiet {
+			fmt.Fprint(out, messages.CouldNotReadAgentForModel(agentName, err))
+		}
+		return ""
+	}
+	return agent.Model()
+}
+
+// declaredTarget reads the agent from the evaluation configuration, which is
+// where the target is already declared, so `generate` does not need it
+// repeated. Best effort: generation runs from the instruction alone when there
+// is no configuration to read, which is the case in a bare directory.
+func declaredTarget(evalDir string) string {
+	cfg, err := project.OpenEvalConfig(evalDir)
+	if err != nil || cfg == nil {
+		return ""
+	}
+	for _, eval := range cfg.Evals {
+		if eval.Target != nil && eval.Target.Name != "" {
+			return eval.Target.Name
+		}
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// refuseExistingArtifact stops a generation that would overwrite a checked-in
+// file, because the job is billed and the diff is what the author reviews.
+func refuseExistingArtifact(path string, force bool) error {
+	if force {
+		return nil
+	}
+	if _, err := os.Stat(path); err == nil {
+		return messages.ArtifactExists(filepath.ToSlash(path))
+	}
+	return nil
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_composite.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_composite.go
@@ -1,0 +1,395 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/project"
+
+	"github.com/spf13/cobra"
+)
+
+// One verb with a selector, per the spec.
+//
+// The two artifacts are separate long-running service resources, but a
+// developer starting out wants both and should not have to know that. Omitting
+// both flags generates both; passing one narrows generation to it, which is
+// also how you regenerate one after the other has been hand-edited.
+//
+// The jobs are submitted together because neither is an input to the other.
+// Their output is buffered and replayed in a fixed order rather than written as
+// it arrives: two generations reporting progress into the same terminal
+// interleave into nonsense. The catalog is written after both have finished,
+// on this goroutine, because both entries land in the same file.
+
+func newGenerateCommand() *cobra.Command {
+	var (
+		flags         generateFlags
+		maxSamples    int
+		from          []string
+		traceDays     int
+		wantDataset   bool
+		wantEvaluator bool
+		datasetName   string
+		evaluatorName string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "generate",
+		Short: "Generate a dataset and a rubric evaluator, and download them.",
+		Long: "Generate a dataset and a rubric evaluator, and download them.\n\n" +
+			"Both are produced unless --dataset or --evaluator narrows it to one. " +
+			"Neither is an input to the other, so the jobs run together and each " +
+			"reports its own outcome; the command fails if either did.\n\n" +
+			"--from selects one or more of the sources the service generates the " +
+			"dataset from, and is repeatable.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dataset, evaluator := selectedArtifacts(wantDataset, wantEvaluator)
+
+			// Checked before any network work, so a flag that cannot apply
+			// costs nothing to find out about. Changed() rather than the value,
+			// so a zero the caller actually typed is still caught and an
+			// untouched default is not.
+			if err := refuseInapplicableFlags(cmd, dataset, evaluator); err != nil {
+				return err
+			}
+			if traceDays < 0 {
+				return messages.NegativeTraceDays(traceDays)
+			}
+			if flags.noWait && cmd.Flags().Changed("output-dir") {
+				return messages.OutputDirNeedsTheWait()
+			}
+
+			if dataset {
+				for _, src := range from {
+					if err := project.ValidateGenerateSource(src); err != nil {
+						return err
+					}
+				}
+				if err := project.ValidateSampleSize(maxSamples); err != nil {
+					return err
+				}
+			}
+
+			// Settled before anything reads or writes the configuration, so the
+			// catalog entry lands next to the eval `init` scaffolded rather than
+			// in a second configuration under ./evals that nothing else reads.
+			resolvedPath, err := resolveEvalDir(cmd.Context(), flags.path)
+			if err != nil {
+				return err
+			}
+			flags.path = resolvedPath
+
+			target := firstNonEmpty(flags.target, declaredTarget(flags.path))
+			plans, err := buildGeneratePlans(generateRequest{
+				flags:         &flags,
+				target:        target,
+				dataset:       dataset,
+				evaluator:     evaluator,
+				datasetName:   datasetName,
+				evaluatorName: evaluatorName,
+				maxSamples:    maxSamples,
+				from:          from,
+				traceDays:     traceDays,
+			})
+			if err != nil {
+				return err
+			}
+
+			ec, resolved, err := prepareGeneration(cmd, &flags, plans[0])
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			// prepareGeneration settles the inputs only the service can supply.
+			// They are the same for both artifacts, so they are read once.
+			for i := range plans {
+				plans[i].Instruction = resolved.Instruction
+				plans[i].Model = resolved.Model
+			}
+			if dataset && len(plans[0].From) == 0 {
+				plans[0].From = defaultGenerationSource(
+					ec.getEnvValue(cmd.Context(), appInsightsEnvKey),
+				)
+			}
+
+			return ec.runGenerations(cmd, plans, flags)
+		},
+	}
+
+	cmd.Flags().BoolVar(&wantDataset, "dataset", false,
+		"Generate only the dataset. Omit both flags to generate both.")
+	cmd.Flags().BoolVar(&wantEvaluator, "evaluator", false,
+		"Generate only the evaluator. Omit both flags to generate both.")
+	cmd.Flags().StringVar(&datasetName, "dataset-name", "",
+		"Name for the generated dataset. Defaults to <target>-dataset.")
+	cmd.Flags().StringVar(&evaluatorName, "evaluator-name", "",
+		"Name for the generated evaluator. Defaults to <target>-evaluator.")
+	cmd.Flags().IntVar(&maxSamples, "max-samples", 0,
+		fmt.Sprintf("Rows to synthesize (%d-%d). Defaults to %d. Dataset only.",
+			project.MinSampleSize, project.MaxSampleSize, project.DefaultSampleSize))
+	cmd.Flags().StringSliceVar(&from, "from", nil,
+		fmt.Sprintf("Where the dataset's rows come from: %s. Repeatable, and the "+
+			"service accepts more than one. Defaults to %s when the project has "+
+			"Application Insights connected, otherwise %s. Dataset only.",
+			strings.Join(project.GenerateSources, ", "),
+			project.GenerateFromTraces, project.GenerateFromAgent))
+	cmd.Flags().IntVar(&traceDays, "trace-days", 0,
+		"Days of traces to seed the evaluator's rubric. 0 disables.")
+	addGenerateFlags(cmd, &flags)
+	return cmd
+}
+
+// selectedArtifacts reads the pair of narrowing flags. Neither set means both,
+// which is the zero-to-first-eval path the composite exists for.
+func selectedArtifacts(dataset, evaluator bool) (bool, bool) {
+	if !dataset && !evaluator {
+		return true, true
+	}
+	return dataset, evaluator
+}
+
+type generateRequest struct {
+	flags         *generateFlags
+	target        string
+	dataset       bool
+	evaluator     bool
+	datasetName   string
+	evaluatorName string
+	maxSamples    int
+	from          []string
+	traceDays     int
+}
+
+// artifactScopedFlags are the flags buildGeneratePlans reads only while
+// building one kind of artifact. Given for the other kind they were accepted
+// and dropped, so `--dataset --trace-days 7` produced a dataset and said
+// nothing about the seven days.
+var artifactScopedFlags = []struct {
+	name     string
+	forEval  bool // read under req.evaluator rather than req.dataset
+	otherFor string
+}{
+	{name: "from", otherFor: "--evaluator"},
+	{name: "max-samples", otherFor: "--evaluator"},
+	{name: "dataset-name", otherFor: "--evaluator"},
+	{name: "trace-days", forEval: true, otherFor: "--dataset"},
+	{name: "evaluator-name", forEval: true, otherFor: "--dataset"},
+}
+
+func refuseInapplicableFlags(cmd *cobra.Command, dataset, evaluator bool) error {
+	for _, f := range artifactScopedFlags {
+		applies := dataset
+		if f.forEval {
+			applies = evaluator
+		}
+		if !applies && cmd.Flags().Changed(f.name) {
+			return messages.FlagDoesNotApply(f.name, f.otherFor)
+		}
+	}
+	return nil
+}
+
+// buildGeneratePlans settles everything that does not need the network, for
+// each artifact asked for. Ordered dataset first, which is the order their
+// progress is replayed in.
+func buildGeneratePlans(req generateRequest) ([]generationPlan, error) {
+	plans := make([]generationPlan, 0, 2)
+
+	if req.dataset {
+		name, err := generatedName(req.datasetName, req.target, "dataset")
+		if err != nil {
+			return nil, err
+		}
+		plan, err := resolvePlan(req.flags, name, project.DefaultDatasetsDir)
+		if err != nil {
+			return nil, err
+		}
+		plan.Kind = generateKindDataset
+		plan.From = req.from
+		plan.SampleSize = req.maxSamples
+		if plan.SampleSize == 0 {
+			plan.SampleSize = project.DefaultSampleSize
+		}
+		if err := refuseExistingArtifact(
+			project.ArtifactPath(plan.BaseDir, plan.OutputDir, name, ".jsonl"),
+			req.flags.force,
+		); err != nil {
+			return nil, err
+		}
+		plans = append(plans, plan)
+	}
+
+	if req.evaluator {
+		name, err := generatedName(req.evaluatorName, req.target, "evaluator")
+		if err != nil {
+			return nil, err
+		}
+		plan, err := resolvePlan(req.flags, name, project.DefaultEvaluatorsDir)
+		if err != nil {
+			return nil, err
+		}
+		plan.Kind = generateKindEvaluator
+		plan.TraceDays = req.traceDays
+		if err := refuseExistingArtifact(
+			project.ArtifactPath(plan.BaseDir, plan.OutputDir, name, ".json"),
+			req.flags.force,
+		); err != nil {
+			return nil, err
+		}
+		plans = append(plans, plan)
+	}
+
+	return plans, nil
+}
+
+// generatedName is the explicit name, or one derived from the target.
+//
+// The name becomes a filename as well as a service asset name, so it is
+// checked here: `--dataset-name ../../x` would otherwise write outside the
+// directory the caller pointed generation at, and `--force` would overwrite
+// whatever is there.
+func generatedName(explicit, target, suffix string) (string, error) {
+	name := explicit
+	if name == "" {
+		if target == "" {
+			return "", messages.GeneratedNameNeedsATarget(suffix)
+		}
+		name = target + "-" + suffix
+	}
+	if !nameIsAPathComponent(name) {
+		return "", messages.GeneratedNameNotAFileName(suffix, name)
+	}
+	return name, nil
+}
+
+// nameIsAPathComponent reports whether a name stays where it is put.
+//
+// Only the filesystem's objections are checked. The service enforces its own
+// character set, and duplicating it here would refuse names it accepts.
+func nameIsAPathComponent(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	// A leading dash writes a file whose name reads as a flag to whatever the
+	// caller pipes the path into, which is the filesystem's objection rather
+	// than the service's.
+	if strings.HasPrefix(name, "-") {
+		return false
+	}
+	if strings.ContainsAny(name, `/\:`) || filepath.IsAbs(name) {
+		return false
+	}
+	return true
+}
+
+type generationOutcome struct {
+	plan   generationPlan
+	ref    *project.ArtifactRef
+	jobID  string
+	output bytes.Buffer
+	err    error
+}
+
+// runGenerations submits every plan at once and settles them together.
+func (ec *evalContext) runGenerations(
+	cmd *cobra.Command,
+	plans []generationPlan,
+	flags generateFlags,
+) error {
+	outcomes := make([]generationOutcome, len(plans))
+	var wg sync.WaitGroup
+
+	// The announcements go out before the goroutines start, so a long
+	// generation is not silent while it runs. Only the per-job progress is
+	// buffered, which is what would interleave.
+	out := cmd.OutOrStdout()
+	if !isJSON(cmd) {
+		for i := range plans {
+			fmt.Fprint(out, messages.GenerationStarting(string(plans[i].Kind), plans[i].Name))
+		}
+	}
+
+	for i := range plans {
+		outcomes[i].plan = plans[i]
+		wg.Add(1)
+		go func(o *generationOutcome) {
+			defer wg.Done()
+			switch o.plan.Kind {
+			case generateKindDataset:
+				o.ref, o.err = ec.generateDataset(
+					cmd.Context(), o.plan, &o.output, flags.noWait, &o.jobID)
+			default:
+				o.ref, o.err = ec.generateRubric(
+					cmd.Context(), o.plan, &o.output, flags.noWait, &o.jobID)
+			}
+		}(&outcomes[i])
+	}
+	wg.Wait()
+
+	// A failed write must not cost the caller the catalog entries for work the
+	// service already billed them for, so it is carried rather than returned.
+	var failures []error
+	if !isJSON(cmd) {
+		for i := range outcomes {
+			if _, err := out.Write(outcomes[i].output.Bytes()); err != nil {
+				failures = append(failures, err)
+				break
+			}
+		}
+	}
+
+	// Catalog entries land in one file, so they are written here rather than
+	// from the goroutines that produced them.
+	for i := range outcomes {
+		o := &outcomes[i]
+		if o.err != nil {
+			failures = append(failures, messages.GenerationFailed(string(o.plan.Kind), o.err))
+			continue
+		}
+		var err error
+		switch o.plan.Kind {
+		case generateKindDataset:
+			err = addDatasetToCatalog(cmd, flags.path, o.ref)
+		default:
+			err = addEvaluatorToCatalog(cmd, flags.path, o.ref)
+		}
+		if err != nil {
+			failures = append(failures, err)
+		}
+	}
+
+	if len(failures) > 0 {
+		return messages.SomeGenerationsFailed(failures)
+	}
+
+	// One document, keyed by artifact: two bare objects on stdout is not
+	// something a caller can parse. Under --no-wait there is no artifact yet,
+	// so the job id is what the caller gets and what they reattach with.
+	if isJSON(cmd) {
+		produced := map[string]any{}
+		for i := range outcomes {
+			o := &outcomes[i]
+			if o.ref != nil {
+				produced[string(o.plan.Kind)] = o.ref
+				continue
+			}
+			if o.jobID != "" {
+				produced[string(o.plan.Kind)] = map[string]string{"job_id": o.jobID}
+				continue
+			}
+			produced[string(o.plan.Kind)] = nil
+		}
+		return emitJSON(out, produced)
+	}
+	return nil
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_composite_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_composite_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Omitting both flags is the zero-to-first-eval path the composite exists for,
+// so it has to mean both rather than nothing.
+func TestSelectedArtifacts(t *testing.T) {
+	cases := []struct {
+		name                       string
+		dataset, evaluator         bool
+		wantDataset, wantEvaluator bool
+	}{
+		{"neither means both", false, false, true, true},
+		{"--dataset narrows", true, false, true, false},
+		{"--evaluator narrows", false, true, false, true},
+		{"both means both", true, true, true, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotDataset, gotEvaluator := selectedArtifacts(c.dataset, c.evaluator)
+
+			assert.Equal(t, c.wantDataset, gotDataset, "dataset")
+			assert.Equal(t, c.wantEvaluator, gotEvaluator, "evaluator")
+		})
+	}
+}
+
+// The spec's defaults. Deriving from the target is what lets `generate` take no
+// positional argument at all.
+func TestGeneratedName_DerivesFromTheTarget(t *testing.T) {
+	name, err := generatedName("", "support-agent", "dataset")
+	require.NoError(t, err)
+	assert.Equal(t, "support-agent-dataset", name)
+
+	name, err = generatedName("", "support-agent", "evaluator")
+	require.NoError(t, err)
+	assert.Equal(t, "support-agent-evaluator", name)
+}
+
+func TestGeneratedName_ExplicitWins(t *testing.T) {
+	name, err := generatedName("golden", "support-agent", "dataset")
+
+	require.NoError(t, err)
+	assert.Equal(t, "golden", name)
+}
+
+// With neither there is nothing to name the artifact after, and the refusal has
+// to name both flags that would answer it.
+func TestGeneratedName_NeedsSomethingToNameItAfter(t *testing.T) {
+	_, err := generatedName("", "", "dataset")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--dataset-name")
+	assert.Contains(t, err.Error(), "--target")
+}
+
+// A composite that submits two jobs has to build a plan for each.
+func TestBuildGeneratePlans_BuildsBothPlans(t *testing.T) {
+	plans, err := buildGeneratePlans(generateRequest{
+		flags:     &generateFlags{path: t.TempDir(), target: "support-agent"},
+		target:    "support-agent",
+		dataset:   true,
+		evaluator: true,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, plans, 2)
+	assert.Equal(t, generateKindDataset, plans[0].Kind,
+		"dataset first, which is the order its progress is replayed in")
+	assert.Equal(t, generateKindEvaluator, plans[1].Kind)
+	assert.Equal(t, "support-agent-dataset", plans[0].Name)
+	assert.Equal(t, "support-agent-evaluator", plans[1].Name)
+}
+
+// Narrowing builds one plan, so nothing is submitted for the other.
+func TestBuildGeneratePlans_NarrowedToOne(t *testing.T) {
+	plans, err := buildGeneratePlans(generateRequest{
+		flags:   &generateFlags{path: t.TempDir(), target: "support-agent"},
+		target:  "support-agent",
+		dataset: true,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, plans, 1)
+	assert.Equal(t, generateKindDataset, plans[0].Kind)
+}
+
+// The name becomes a filename, so one carrying a separator would write outside
+// the directory generation was pointed at, and --force would overwrite it.
+func TestGeneratedName_RefusesANameThatWouldLeaveTheDirectory(t *testing.T) {
+	escapes := []string{
+		"../outside",
+		"..\\outside",
+		"sub/dir",
+		"sub\\dir",
+		"..",
+		".",
+		"C:\\Windows\\System32\\drivers\\etc\\hosts",
+		"/etc/passwd",
+	}
+
+	for _, name := range escapes {
+		t.Run(name, func(t *testing.T) {
+			_, err := generatedName(name, "support-agent", "dataset")
+
+			require.Errorf(t, err, "%q must not be accepted as a file name", name)
+			assert.Contains(t, err.Error(), "file name")
+		})
+	}
+}
+
+// The service decides its own character set. Refusing everything it might
+// accept would block names that work.
+func TestGeneratedName_AllowsOrdinaryNames(t *testing.T) {
+	for _, name := range []string{
+		"golden",
+		"support-agent-dataset",
+		"support_agent.v2",
+		"caf\u00e9-dataset",
+		"dataset 2",
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := generatedName(name, "support-agent", "dataset")
+
+			require.NoError(t, err)
+			assert.Equal(t, name, got)
+		})
+	}
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_flag_guards_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_flag_guards_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runGenerate(t *testing.T, args ...string) error {
+	t.Helper()
+	root := NewRootCommand()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs(append([]string{"generate"}, args...))
+	return root.ExecuteContext(context.Background())
+}
+
+// Each of these is read while building one kind of artifact and ignored while
+// building the other, so given for the wrong one they were accepted and
+// dropped -- `--evaluator --max-samples 50` produced a rubric and said nothing
+// about the 50, and `--dataset --trace-days 7` a dataset and nothing about the
+// seven days.
+func TestFlagsThatCannotApplyAreRefused(t *testing.T) {
+	cases := []struct {
+		flag     string
+		narrowed string
+		args     []string
+	}{
+		{"--from", "--evaluator",
+			[]string{"--evaluator", "--evaluator-name", "ev", "--from", "prompt"}},
+		{"--max-samples", "--evaluator",
+			[]string{"--evaluator", "--evaluator-name", "ev", "--max-samples", "50"}},
+		{"--dataset-name", "--evaluator",
+			[]string{"--evaluator", "--evaluator-name", "ev", "--dataset-name", "ds"}},
+		{"--trace-days", "--dataset",
+			[]string{"--dataset", "--dataset-name", "ds", "--trace-days", "7"}},
+		{"--evaluator-name", "--dataset",
+			[]string{"--dataset", "--dataset-name", "ds", "--evaluator-name", "ev"}},
+	}
+
+	for _, c := range cases {
+		err := runGenerate(t, c.args...)
+
+		require.Errorf(t, err, "%s cannot apply under %s", c.flag, c.narrowed)
+		assert.Contains(t, err.Error(), c.flag)
+		assert.Containsf(t, err.Error(), c.narrowed,
+			"the refusal has to name the flag that made %s inapplicable", c.flag)
+	}
+}
+
+// Generating both is the default, and every one of those flags applies then.
+// Without this the guard above could be satisfied by refusing them always.
+func TestNoFlagIsRefusedWhenBothArtifactsAreGenerated(t *testing.T) {
+	err := runGenerate(t,
+		"--dataset-name", "ds", "--evaluator-name", "ev",
+		"--from", "prompt", "--max-samples", "50", "--trace-days", "7")
+
+	if err != nil {
+		assert.NotContains(t, err.Error(), "has no effect on what",
+			"generating both artifacts makes every one of these flags applicable")
+	}
+}
+
+// And each flag is still accepted for the artifact it does affect.
+func TestEachFlagIsAcceptedForItsOwnArtifact(t *testing.T) {
+	forDataset := runGenerate(t,
+		"--dataset", "--dataset-name", "ds", "--from", "prompt", "--max-samples", "50")
+	if forDataset != nil {
+		assert.NotContains(t, forDataset.Error(), "has no effect on what")
+	}
+
+	forEvaluator := runGenerate(t,
+		"--evaluator", "--evaluator-name", "ev", "--trace-days", "7")
+	if forEvaluator != nil {
+		assert.NotContains(t, forEvaluator.Error(), "has no effect on what")
+	}
+}
+
+// Zero already means "seed the rubric from no traces", so a negative window has
+// nothing left to mean. It was accepted and read as zero, quietly producing a
+// rubric with none of the trace seeding that was asked for.
+func TestNegativeTraceDaysIsRefused(t *testing.T) {
+	err := runGenerate(t, "--evaluator", "--evaluator-name", "ev", "--trace-days", "-5")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--trace-days")
+	assert.Contains(t, err.Error(), "-5", "the value that was rejected")
+}
+
+// Zero is a real answer and has to keep working.
+func TestZeroTraceDaysIsAccepted(t *testing.T) {
+	err := runGenerate(t, "--evaluator", "--evaluator-name", "ev", "--trace-days", "0")
+
+	if err != nil {
+		assert.NotContains(t, err.Error(), "--trace-days",
+			"0 is how a caller says to read no traces")
+	}
+}
+
+// --no-wait returns as soon as the job is submitted, so there is no artifact to
+// place. Accepting both left the caller waiting for a file never coming.
+func TestOutputDirWithNoWaitIsRefused(t *testing.T) {
+	err := runGenerate(t,
+		"--dataset", "--dataset-name", "ds", "--no-wait", "--output-dir", t.TempDir())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--output-dir")
+	assert.Contains(t, err.Error(), "--no-wait")
+	assert.Contains(t, err.Error(), "job show",
+		"the refusal has to name how to collect the artifact later")
+}
+
+// An output directory without --no-wait is what the flag is for.
+func TestOutputDirAloneIsStillAccepted(t *testing.T) {
+	err := runGenerate(t, "--dataset", "--dataset-name", "ds", "--output-dir", t.TempDir())
+
+	if err != nil {
+		assert.NotContains(t, err.Error(), "nothing to write to",
+			"an output directory without --no-wait must not be refused")
+	}
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_plan_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_plan_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"azureaieval/internal/pkg/evalcore"
+	"azureaieval/internal/project"
+
+	"github.com/stretchr/testify/require"
+)
+
+// `generate` decides what to submit before it touches the network, so the plan
+// it builds — which agent, what model, where the artifact lands — is checkable
+// without paying for a generation job. These are the parts that cannot be
+// observed afterwards: once the job is submitted, a wrong default is
+// indistinguishable from an intended one.
+
+// evalsDir returns flags pointing at an empty eval directory.
+func evalsDir(t *testing.T) *generateFlags {
+	t.Helper()
+	return &generateFlags{path: t.TempDir()}
+}
+
+// withEvals writes a configuration into the flags' directory.
+func withEvals(t *testing.T, f *generateFlags, evals ...project.Eval) {
+	t.Helper()
+	require.NoError(t, project.SaveEvalConfig(f.path, &project.EvalConfig{Evals: evals}))
+}
+
+// Generation settings are flags only: there is no generate.yaml, because the
+// artifact is checked in and regeneration usually wants different settings.
+func TestResolvePlan_FromFlagsAlone(t *testing.T) {
+	f := evalsDir(t)
+	f.target = "shop-agent"
+	f.model = "gpt-4o-mini"
+
+	plan, err := resolvePlan(f, "shop-golden", project.DefaultDatasetsDir)
+	require.NoError(t, err)
+
+	require.Equal(t, "shop-golden", plan.Name)
+	require.Equal(t, "shop-agent", plan.Agent)
+	require.Equal(t, "gpt-4o-mini", plan.Model)
+	require.Equal(t, "./"+project.DefaultDatasetsDir, plan.OutputDir)
+	require.Equal(t, f.path, plan.BaseDir)
+}
+
+// Each generate has its own default output directory, so a rubric never lands
+// in the datasets folder.
+func TestResolvePlan_OutputDirDefaultsPerArtifact(t *testing.T) {
+	f := evalsDir(t)
+	f.target = "shop-agent"
+	f.model = "gpt-4o-mini"
+
+	ds, err := resolvePlan(f, "d", project.DefaultDatasetsDir)
+	require.NoError(t, err)
+	require.Equal(t, "./"+project.DefaultDatasetsDir, ds.OutputDir)
+
+	ev, err := resolvePlan(f, "r", project.DefaultEvaluatorsDir)
+	require.NoError(t, err)
+	require.Equal(t, "./"+project.DefaultEvaluatorsDir, ev.OutputDir)
+
+	f.outputDir = "./from-flag"
+	override, err := resolvePlan(f, "d", project.DefaultDatasetsDir)
+	require.NoError(t, err)
+	require.Equal(t, "./from-flag", override.OutputDir)
+}
+
+// A named target carries a deployment, and the spec makes it the default, so
+// the plan settles without one and lets prepareGeneration read it. Refusing
+// here would ask the caller for something the project already knows.
+func TestResolvePlan_DefersToTheAgentForTheModel(t *testing.T) {
+	f := evalsDir(t)
+	f.target = "shop-agent"
+
+	plan, err := resolvePlan(f, "d", project.DefaultDatasetsDir)
+	require.NoError(t, err)
+	require.Empty(t, plan.Model, "the deployment is read from the agent, not guessed here")
+	require.Equal(t, "shop-agent", plan.Agent)
+}
+
+// With no target either there is nothing to read a deployment from, so the
+// refusal happens before authentication and names the flag that supplies one.
+func TestResolvePlan_RequiresAGenerationModelWithNoAgent(t *testing.T) {
+	f := evalsDir(t)
+
+	_, err := resolvePlan(f, "d", project.DefaultDatasetsDir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--generation-model")
+}
+
+// An input the caller named and got wrong is reported ahead of one they simply
+// left out. Both checks are local, so the only thing deciding which the user
+// sees is the order they run in — and a missing instruction file is a typo the
+// caller can act on, while the model has a documented default path.
+func TestResolvePlan_ReportsABadExplicitInputFirst(t *testing.T) {
+	f := evalsDir(t)
+	f.target = "shop-agent"
+	f.instructionFile = filepath.Join(t.TempDir(), "absent.md")
+
+	_, err := resolvePlan(f, "d", project.DefaultDatasetsDir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--agent-instruction-file",
+		"the flag the caller got wrong must win over the one they omitted")
+}
+
+// The target is already declared on an eval, so `generate` does not need it
+// repeated on every invocation.
+func TestResolvePlan_FallsBackToTheDeclaredTarget(t *testing.T) {
+	f := evalsDir(t)
+	f.model = "gpt-4o"
+	withEvals(t, f, project.Eval{
+		Name:       "support-agent-eval",
+		Evaluators: evalcore.EvaluatorList{{Evaluator: "builtin.relevance"}},
+		Target:     &project.Target{Type: project.TargetTypeAgent, Name: "support-agent"},
+	})
+
+	plan, err := resolvePlan(f, "d", project.DefaultDatasetsDir)
+	require.NoError(t, err)
+	require.Equal(t, "support-agent", plan.Agent,
+		"the declared target is the agent to generate from")
+
+	// An explicit flag still wins, which is what makes a one-off run possible
+	// without editing a file that is checked in.
+	f.target = "from-flag"
+	plan, err = resolvePlan(f, "d", project.DefaultDatasetsDir)
+	require.NoError(t, err)
+	require.Equal(t, "from-flag", plan.Agent)
+}
+
+// With no configuration at all, generation runs from the instruction alone.
+// This is the golden path: both generates precede init.
+func TestResolvePlan_NoConfigurationYet(t *testing.T) {
+	f := evalsDir(t)
+	f.model = "gpt-4o"
+	f.instruction = "test refunds and returns"
+
+	plan, err := resolvePlan(f, "d", project.DefaultDatasetsDir)
+	require.NoError(t, err)
+	require.Empty(t, plan.Agent)
+	require.Equal(t, "test refunds and returns", plan.Instruction)
+}
+
+// The bounds are the service's, and the boundaries themselves have to be
+// accepted: a check that rejected 15 or 1000 would be indistinguishable from
+// one that is simply too strict.
+func TestGenerateSampleSizeBounds(t *testing.T) {
+	for _, tc := range []struct {
+		size    int
+		allowed bool
+	}{
+		{project.MinSampleSize - 1, false},
+		{project.MinSampleSize, true},
+		{project.DefaultSampleSize, true},
+		{project.MaxSampleSize, true},
+		{project.MaxSampleSize + 1, false},
+	} {
+		err := project.ValidateSampleSize(tc.size)
+		if tc.allowed {
+			require.NoErrorf(t, err, "%d is inside the service's range", tc.size)
+			continue
+		}
+		require.Errorf(t, err, "%d is outside the service's range", tc.size)
+		require.Contains(t, err.Error(), "must be between")
+	}
+}
+
+func TestResolveInstruction(t *testing.T) {
+	dir := t.TempDir()
+	filled := filepath.Join(dir, "instruction.md")
+	require.NoError(t, os.WriteFile(filled, []byte("  test refunds and returns\n\n"), 0o600))
+	blank := filepath.Join(dir, "blank.md")
+	require.NoError(t, os.WriteFile(blank, []byte("   \n"), 0o600))
+
+	t.Run("inline is returned as given", func(t *testing.T) {
+		got, err := resolveInstruction("inline text", "")
+		require.NoError(t, err)
+		require.Equal(t, "inline text", got)
+	})
+
+	t.Run("a file is read and trimmed", func(t *testing.T) {
+		got, err := resolveInstruction("", filled)
+		require.NoError(t, err)
+		require.Equal(t, "test refunds and returns", got)
+	})
+
+	// A whitespace-only file would otherwise generate from nothing, which
+	// produces a rubric with no relation to the agent.
+	t.Run("an empty file is refused", func(t *testing.T) {
+		_, err := resolveInstruction("", blank)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "is empty")
+	})
+
+	t.Run("a missing file names the flag", func(t *testing.T) {
+		_, err := resolveInstruction("", filepath.Join(dir, "absent.md"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "--agent-instruction-file")
+	})
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_rubric_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_rubric_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The generated rubric is the file the next deploy compares against, so a field
+// dropped on the way to disk republishes the evaluator without it. pass_threshold
+// is what decides pass or fail, so losing it changes grading silently.
+func TestWriteRubricKeepsTheWholeDefinition(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rubric.json")
+
+	result := json.RawMessage(`{
+      "name": "support-agent-quality",
+      "version": "1",
+      "definition": {
+        "type": "rubric",
+        "pass_threshold": 0.5,
+        "dimensions": [{"id": "accuracy", "description": "Correct.", "weight": 9}],
+        "something_the_service_added_later": true
+      }
+    }`)
+
+	require.NoError(t, writeRubric(path, result))
+
+	var got map[string]any
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(body, &got))
+
+	assert.Equal(t, 0.5, got["pass_threshold"],
+		"the threshold decides pass or fail, so losing it changes grading")
+	assert.Equal(t, true, got["something_the_service_added_later"],
+		"the definition is written through, so a new field is not lost either")
+	assert.Equal(t, "rubric", got["type"])
+	assert.Len(t, got["dimensions"], 1)
+	assert.NotContains(t, got, "name", "only the definition is written, not the envelope")
+}
+
+// A payload that is not a rubric is kept verbatim rather than discarded.
+func TestWriteRubricFallsBackToTheRawPayload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rubric.json")
+	require.NoError(t, writeRubric(path, json.RawMessage(`{"unexpected":"shape"}`)))
+
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"unexpected":"shape"}`, string(body))
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_sources_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_sources_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The spec's default: traces when the project has Application Insights
+// connected, otherwise the agent. The connection string is how a project says
+// it collects traces at all, so asking for traces without one would submit a
+// billed job against nothing.
+func TestDefaultGenerationSource(t *testing.T) {
+	assert.Equal(t, []string{"traces"},
+		defaultGenerationSource("InstrumentationKey=00000000-0000-0000-0000-000000000000"),
+		"a project collecting traces should be generated from them")
+
+	assert.Equal(t, []string{"agent"}, defaultGenerationSource(""),
+		"with nowhere for traces to have been collected, the agent is all there is")
+}
+
+// --from is a request, and one the plan cannot honour has to stop the command
+// rather than quietly submit a job seeded from less than was asked for.
+func TestRefuseUnbuildableSources(t *testing.T) {
+	assert.NoError(t, refuseUnbuildableSources(nil))
+	assert.NoError(t, refuseUnbuildableSources([]string{}))
+
+	tests := []struct {
+		kind string
+		says string
+	}{
+		{"prompt", "--agent-instruction"},
+		{"agent", "--target"},
+		{"file", "azd ai eval dataset create"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			err := refuseUnbuildableSources([]string{tt.kind})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.says,
+				"the error has to name the way out, not just the problem")
+		})
+	}
+}
+
+// Two unhonoured sources are two things the caller has to fix, so both are
+// reported at once rather than one per attempt.
+func TestRefuseUnbuildableSources_ReportsAllOfThemAtOnce(t *testing.T) {
+	err := refuseUnbuildableSources([]string{"prompt", "agent"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--agent-instruction")
+	assert.Contains(t, err.Error(), "--target")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/generate_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The service's system error says only that something went wrong and to try
+// again, but agent-seeded generation fails deterministically, so a bare retry
+// suggestion sends users into a loop.
+func TestExplainDataGenerationFailureAddsAgentContext(t *testing.T) {
+	err := errors.New(
+		`job failed with status "failed": Something went wrong during data generation. Please try again.`)
+
+	explained := explainDataGenerationFailure(err, "my-agent")
+	require.Error(t, explained)
+	require.Contains(t, explained.Error(), "my-agent")
+	require.Contains(t, explained.Error(), "--dataset")
+	require.ErrorIs(t, explained, err, "the original error must stay in the chain")
+}
+
+// The code spelling is matched as well, in case the poller starts surfacing it.
+func TestExplainDataGenerationFailureMatchesErrorCode(t *testing.T) {
+	err := fmt.Errorf("job failed: DataGenerationJobSystemError")
+	explained := explainDataGenerationFailure(err, "my-agent")
+	require.Contains(t, explained.Error(), "Workarounds")
+}
+
+// Unrelated failures are passed through untouched, and so is a job that had no
+// agent source to blame.
+func TestExplainDataGenerationFailureLeavesOthersAlone(t *testing.T) {
+	other := errors.New("submitting the data generation job: 403 Forbidden")
+	require.Equal(t, other, explainDataGenerationFailure(other, "my-agent"))
+
+	systemErr := errors.New("Something went wrong during data generation")
+	require.Equal(t, systemErr, explainDataGenerationFailure(systemErr, ""))
+
+	require.NoError(t, explainDataGenerationFailure(nil, "my-agent"))
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/helpers_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/helpers_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"azureaieval/internal/project"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// digestIDKey is what makes a rename find the eval it already deployed: the id
+// is recorded against the eval's substance, so a declaration whose name
+// changed still resolves. That only works while the key derives from the
+// digest the same way it did last deploy — change the format and every
+// deployed eval silently loses its recorded id and gets recreated.
+func TestDigestIDKey(t *testing.T) {
+	const digest = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	key := digestIDKey(digest)
+
+	assert.Equal(t, "EVAL_SUBSTANCE_0123456789ABCDEF_ID", key)
+	for _, r := range key {
+		assert.Truef(t,
+			(r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_',
+			"%q is not allowed in an environment key", r)
+	}
+}
+
+// Same substance, same key — that is the whole mechanism.
+func TestDigestIDKey_IsStableForTheSameSubstance(t *testing.T) {
+	group := project.Eval{
+		Name:    "support",
+		Dataset: "support-regression",
+		Target:  &project.Target{Name: "support-agent"},
+	}
+
+	first, err := project.FingerprintGroup(group)
+	require.NoError(t, err)
+
+	renamed := group
+	renamed.Name = "support-renamed"
+	renamed.Description = "reworded"
+	second, err := project.FingerprintGroup(renamed)
+	require.NoError(t, err)
+
+	assert.Equal(t, digestIDKey(first), digestIDKey(second),
+		"a rename must land on the key the first deploy wrote")
+}
+
+// Different substance, different key, so a genuinely new eval does not adopt
+// an unrelated one's id.
+func TestDigestIDKey_DiffersWhenTheSubstanceDoes(t *testing.T) {
+	a, err := project.FingerprintGroup(project.Eval{Name: "x", Dataset: "one"})
+	require.NoError(t, err)
+	b, err := project.FingerprintGroup(project.Eval{Name: "x", Dataset: "two"})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, digestIDKey(a), digestIDKey(b))
+}
+
+// The version recorded for an artifact comes out of what the service returned,
+// falling back to what the caller already knew.
+func TestVersionFromRaw(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		fallback string
+		want     string
+	}{
+		{"version in the body wins", `{"version":"7"}`, "3", "7"},
+		{"empty version falls back", `{"version":""}`, "3", "3"},
+		{"absent version falls back", `{"name":"x"}`, "3", "3"},
+		{"unparseable body falls back", `not json`, "3", "3"},
+		{"empty body falls back", ``, "3", "3"},
+		{"no fallback either", `{}`, "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, versionFromRaw([]byte(tt.raw), tt.fallback))
+		})
+	}
+}
+
+// A criterion binds to a dataset column through `{{item.<name>}}`. Reading the
+// name wrong is how a run is submitted against a column the dataset does not
+// have, which the service rejects without saying which one.
+func TestItemColumn(t *testing.T) {
+	bound := map[string]string{
+		"{{item.query}}":        "query",
+		"{{item.ground_truth}}": "ground_truth",
+		"{{item.a.b}}":          "a.b",
+	}
+	for binding, want := range bound {
+		got, ok := itemColumn(binding)
+		assert.Truef(t, ok, "%q is a binding", binding)
+		assert.Equal(t, want, got)
+	}
+
+	notBound := []string{
+		"",
+		"query",
+		"{{item.}}",
+		"{{ item.query }}",
+		"{{item.query",
+		"item.query}}",
+		"{{response.output}}",
+	}
+	for _, binding := range notBound {
+		got, ok := itemColumn(binding)
+		assert.Falsef(t, ok, "%q is not an item binding", binding)
+		assert.Empty(t, got)
+	}
+}
+
+// An eval is named after what it evaluates and what it reads, so two evals over
+// the same agent from different sources do not collide.
+func TestDefaultEvalName(t *testing.T) {
+	assert.Equal(t, "support-agent-trace-eval",
+		defaultEvalName("support-agent", initSourceTraces))
+	assert.Equal(t, "support-agent-eval",
+		defaultEvalName("support-agent", "dataset"))
+	assert.Equal(t, "support-agent-eval",
+		defaultEvalName("support-agent", ""))
+
+	assert.NotEqual(t,
+		defaultEvalName("support-agent", initSourceTraces),
+		defaultEvalName("support-agent", "dataset"),
+		"the source is in the name so the two do not collide")
+}
+
+// The reattach line printed by --no-wait has to name the group the job
+// actually belongs to; the two job types share no collection, so the wrong
+// group is a command that returns "not found".
+func TestJobLookupErrorNamesTheGroup(t *testing.T) {
+	for _, kind := range []jobKind{datasetJobs, evaluatorJobs} {
+		err := jobLookupError("reading", kind, "job_1", assert.AnError)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "job_1")
+		assert.Truef(t, strings.Contains(err.Error(), kind.name),
+			"the error must name the %q group so the retry goes to the right one", kind.name)
+	}
+}
+
+// A failed delete used to report that a read failed, which sends the reader
+// looking for a read that never happened.
+func TestJobLookupErrorNamesWhatWasAttempted(t *testing.T) {
+	deleteErr := jobLookupError("deleting", datasetJobs, "job_1", assert.AnError)
+	require.Error(t, deleteErr)
+	assert.Contains(t, deleteErr.Error(), "deleting")
+	assert.NotContains(t, deleteErr.Error(), "reading")
+
+	cancelErr := jobLookupError("cancelling", datasetJobs, "job_1", assert.AnError)
+	require.Error(t, cancelErr)
+	assert.Contains(t, cancelErr.Error(), "cancelling")
+
+	// A genuine 404 still points at the sibling group whatever the verb was.
+	notFound := jobLookupError("deleting", datasetJobs, "job_1",
+		&azcore.ResponseError{StatusCode: http.StatusNotFound})
+	require.Error(t, notFound)
+	assert.Contains(t, notFound.Error(), jobKindEvaluator)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init.go
@@ -1,0 +1,821 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/evalcore"
+	"azureaieval/internal/project"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// Data sources `init` can point an eval at.
+const (
+	initSourceDataset = "dataset"
+	initSourceTraces  = "traces"
+)
+
+// newInitCommand scaffolds the eval configuration. It makes no service calls at
+// all, so it works offline and unauthenticated.
+//
+// It only ever adds. A name already declared is refused rather than
+// overwritten, because the settings a reader tunes by hand — thresholds, judge
+// model, data mapping — live nowhere but that entry and `init` cannot
+// reproduce them. Editing an eval is a file edit.
+func newInitCommand() *cobra.Command {
+	var (
+		evalName   string
+		target     string
+		source     string
+		dataset    string
+		maxTraces  int
+		evaluators []string
+		judgeModel string
+		path       string
+		force      bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Scaffold evaluation config for an agent. Makes no service calls.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+
+			switch source {
+			case "", initSourceDataset, initSourceTraces:
+			default:
+				return messages.SourceNotADataSource(
+					source, initSourceDataset, initSourceTraces)
+			}
+			if source == initSourceTraces && dataset != "" {
+				return messages.TracesTakesNoDataset()
+			}
+			if cmd.Flags().Changed("max-traces") && source != initSourceTraces {
+				return messages.MaxTracesNeedsTraceSource()
+			}
+			if maxTraces < 0 {
+				return messages.MaxTracesMustBePositive()
+			}
+			// Checked with the other flag-only rules, before anything is asked
+			// or read: a reference that cannot name an evaluator is otherwise
+			// written by a command that exits 0, and only fails two commands
+			// later. Answering two prompts first to be told a flag was wrong is
+			// the same defect one step removed.
+			if err := validateEvaluatorRefs(evaluators); err != nil {
+				return err
+			}
+			// Asked twice -- once to pick the default source, once to say so --
+			// and each call opens an azd connection. The answer cannot change
+			// mid-command, and a run that never asks never connects.
+			tracesWired := sync.OnceValue(func() bool {
+				return tracesConnected(commandContext(cmd))
+			})
+			if source == "" {
+				// The same signal `generate --from` defaults on, read from the azd
+				// environment rather than the service, so init still makes no
+				// service calls. Traces are real conversations; a project wired to
+				// collect them should not have to ask for them by flag.
+				if tracesWired() {
+					source = initSourceTraces
+				} else {
+					source = initSourceDataset
+				}
+			}
+			// The same cascade every other command reads the configuration
+			// through. init merges into the configuration it finds, so a second
+			// `init` in a project scaffolded at ./quality has to find that one --
+			// otherwise it writes a second configuration under ./evals and
+			// declares a second service pointing at it.
+			path, err := resolveEvalDir(cmd.Context(), path)
+			if err != nil {
+				return err
+			}
+
+			// Asked before anything is written: the project is the one thing
+			// init cannot supply for itself, and failing after creating
+			// directories leaves a half-scaffolded tree behind.
+			azdProject, err := readAzdProject(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			// The target is what the whole scaffold is named and shaped around,
+			// so it is settled before anything derived from it.
+			if target == "" {
+				target, err = resolveAgentTarget(cmd, azdProject)
+				if err != nil {
+					return err
+				}
+			}
+			if evalName == "" {
+				evalName = defaultEvalName(target, source)
+			}
+			if judgeModel == "" {
+				judgeModel, err = resolveJudgeModel(cmd, azdProject)
+				if err != nil {
+					return err
+				}
+			}
+
+			configPath, err := project.ResolveEvalConfigPath(path)
+			if err != nil {
+				return err
+			}
+			// Captured before the write: init merges into an existing config, so
+			// reporting it as created would claim a file it only added to.
+			_, configExistedErr := os.Stat(configPath)
+			configExisted := configExistedErr == nil
+			cfg, err := project.OpenEvalConfig(path)
+			if err != nil {
+				return err
+			}
+			if cfg == nil {
+				cfg = &project.EvalConfig{}
+			}
+			// Checked before the prompt as well as after it, so a name that is
+			// already taken is reported without asking a question first.
+			if cfg.HasEval(evalName) && !force {
+				return messages.EvalAlreadyDeclared(
+					evalName, filepath.ToSlash(configPath))
+			}
+
+			// Asked, not detected: an eval grades on a set, so there is no
+			// "the only one" to settle on, and which criteria define quality
+			// is the substantive decision in the configuration.
+			//
+			// Deliberately outside the lock below. This is an unbounded human
+			// pause, and a lock held across it would either block a concurrent
+			// `generate` for as long as someone leaves the terminal, or -- once
+			// that side gave up waiting -- protect nothing at all. The listing
+			// it offers is only a menu; the authoritative read is taken after.
+			evaluatorsWereChosen := len(evaluators) > 0
+			if len(evaluators) == 0 {
+				var asked bool
+				evaluators, asked, err = resolveEvaluators(
+					cmd, cfg, target+"-quality", source == initSourceTraces)
+				if err != nil {
+					return err
+				}
+				evaluatorsWereChosen = asked
+			}
+
+			// The read-modify-write starts here, and nothing inside it waits on
+			// a person. The configuration is read again because the copy above
+			// was taken before the prompt, and a `generate` may well have
+			// finished writing to it since.
+			unlockConfig, err := project.LockEvalConfig(cmd.Context(), path)
+			if err != nil {
+				return err
+			}
+			defer unlockConfig()
+
+			cfg, err = project.OpenEvalConfig(path)
+			if err != nil {
+				return err
+			}
+			if cfg == nil {
+				cfg = &project.EvalConfig{}
+			}
+			if cfg.HasEval(evalName) {
+				if !force {
+					return messages.EvalAlreadyDeclared(
+						evalName, filepath.ToSlash(configPath))
+				}
+				cfg.RemoveEval(evalName)
+			}
+
+			if err := os.MkdirAll(filepath.Join(path, project.DefaultDatasetsDir), 0o750); err != nil {
+				return messages.CreatingDatasetsDir(err)
+			}
+			if err := os.MkdirAll(filepath.Join(path, project.DefaultEvaluatorsDir), 0o750); err != nil {
+				return messages.CreatingEvaluatorsDir(err)
+			}
+
+			plan := planScaffold(scaffoldInput{
+				evalName:   evalName,
+				target:     target,
+				source:     source,
+				dataset:    dataset,
+				maxTraces:  maxTraces,
+				evaluators: evaluators,
+				judgeModel: judgeModel,
+				rubricName: target + "-quality",
+				evalDir:    path,
+				cfg:        cfg,
+			})
+
+			if err := project.SaveEvalConfig(path, cfg); err != nil {
+				return err
+			}
+
+			// Scaffolding a config azd cannot see is half a step: the eval
+			// service has to be referenced from the root config before any of
+			// `azd up`, `azd deploy` or `azd ai eval run` will act on it.
+			serviceName := target + "-evals"
+			rootWiring, err := ensureRootEvalService(cmd.Context(), serviceName, target, configPath)
+			if err != nil {
+				return err
+			}
+
+			recordEvalPath(cmd.Context(), path)
+
+			if isJSON(cmd) {
+				return emitJSON(out, map[string]any{
+					"eval":          evalName,
+					"evalConfig":    configPath,
+					"service":       serviceName,
+					"datasetsDir":   filepath.Join(path, project.DefaultDatasetsDir),
+					"evaluatorsDir": filepath.Join(path, project.DefaultEvaluatorsDir),
+					"rootConfig":    rootWiring,
+					"target":        target,
+					"source":        source,
+					"judgeModel":    judgeModel,
+					"evaluators":    plan.evaluatorNames(),
+				})
+			}
+
+			fmt.Fprint(out, messages.DetectedTarget(target))
+			if source == initSourceTraces {
+				// Claiming the connection is only honest when it was found. init
+				// makes no service calls, so it cannot verify one it did not see.
+				fmt.Fprint(out, messages.UsingTraceSource(tracesWired()))
+			}
+			// Only what was settled without asking: a reader who just picked
+			// from a list does not need it read back to them.
+			if names := plan.evaluatorNames(); len(names) > 0 && !evaluatorsWereChosen {
+				fmt.Fprint(out, messages.GradingWith(names))
+			}
+			if judgeModel != "" {
+				fmt.Fprint(out, messages.JudgeModelDeployment(judgeModel))
+			}
+
+			fmt.Fprint(out, messages.ScaffoldHeading(configExisted))
+			fmt.Fprint(out, messages.ScaffoldConfigLine(filepath.ToSlash(configPath), configExisted))
+			switch rootWiring {
+			case wiringAdded:
+				fmt.Fprint(out, messages.AddedServiceLine(rootConfigName, serviceName))
+			case wiringPresent:
+				fmt.Fprint(out, messages.AlreadyDeclaresServiceLine(rootConfigName, serviceName))
+			}
+
+			// Only what was actually scheduled is offered. Suggesting
+			// `dataset generate` for a dataset the caller supplied sends them
+			// to submit a billed job for an artifact they already have.
+			next := plan.nextSteps(deployCommandName(azdProject))
+			fmt.Fprint(out, messages.FirstNextStep(next[0]))
+			for _, step := range next[1:] {
+				fmt.Fprint(out, messages.FurtherNextStep(step))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&evalName, "name", "",
+		"Name of the eval. Defaults to <target>-eval, or <target>-trace-eval under --source traces.")
+	cmd.Flags().StringVar(&target, "target", "",
+		"Name of the agent to evaluate. Detected when the project has one agent; prompts when it has several.")
+	cmd.Flags().StringVar(&source, "source", "",
+		"Where rows come from: dataset or traces. Defaults to traces when the azd "+
+			"environment records an Application Insights connection, otherwise dataset.")
+	cmd.Flags().StringVar(&dataset, "dataset", "",
+		"Path to a local .jsonl, or the name of a registered dataset.")
+	cmd.Flags().IntVar(&maxTraces, "max-traces", project.DefaultScaffoldMaxTraces,
+		"Cap on traces read by a --source traces eval. Delete max_traces from the "+
+			"file to take the service default instead.")
+	cmd.Flags().StringSliceVar(&evaluators, "evaluator", nil,
+		"Evaluator reference, repeatable and comma-separated. Use builtin.<name> for a "+
+			"built-in. Passing this replaces the defaults, so it also opts out of rubric generation.")
+	cmd.Flags().StringVar(&judgeModel, "judge-model", "",
+		"Model deployment the graders judge with. Detected from the project when omitted.")
+	cmd.Flags().StringVar(&path, "path", "",
+		"Directory to write the configuration into. Used verbatim, never re-rooted. "+
+			"Defaults to the directory an earlier `init` scaffolded, otherwise ./evals.")
+	cmd.Flags().BoolVar(&force, "force", false,
+		"Replace an eval of the same name instead of failing.")
+	return cmd
+}
+
+// defaultEvalName names an eval after what it evaluates and what it reads.
+func defaultEvalName(target, source string) string {
+	if source == initSourceTraces {
+		return target + "-trace-eval"
+	}
+	return target + "-eval"
+}
+
+// scaffoldInput is everything planScaffold needs, gathered so the signature
+// does not grow a seventh positional string.
+type scaffoldInput struct {
+	evalName   string
+	target     string
+	source     string
+	dataset    string
+	maxTraces  int
+	evaluators []string
+	judgeModel string
+	rubricName string
+	evalDir    string
+	cfg        *project.EvalConfig
+}
+
+// scaffold is what `init` added, and what it should suggest doing next.
+type scaffold struct {
+	eval        *project.Eval
+	datasetName string
+	rubricName  string
+	target      string
+	judgeModel  string
+	// evalDir is where the configuration was written, so the next steps can
+	// name it when it is not the default.
+	evalDir         string
+	generateDataset bool
+	generateRubric  bool
+}
+
+// planScaffold appends one eval to the configuration, adding any catalog
+// entries it needs.
+//
+// The default evaluator set is a built-in plus a generated rubric: the built-in
+// alone would be generic, and the rubric is what makes the baseline about this
+// agent. Passing --evaluator replaces both, which is how a caller opts out of
+// rubric generation.
+func planScaffold(in scaffoldInput) scaffold {
+	cfg := in.cfg
+	out := scaffold{
+		rubricName: in.rubricName,
+		target:     in.target,
+		judgeModel: in.judgeModel,
+		evalDir:    in.evalDir,
+	}
+
+	eval := project.Eval{
+		Name:            in.evalName,
+		Description:     fmt.Sprintf("Basic quality evaluation for %s", in.target),
+		EvaluationLevel: project.EvaluationLevelTurn,
+		Target: &project.Target{
+			Type: project.TargetTypeAgent,
+			Name: in.target,
+		},
+	}
+
+	if in.source == initSourceTraces {
+		// A trace-backed eval filters by agent rather than invoking one: the
+		// conversations already happened.
+		eval.Target = nil
+		eval.Source = &project.SourceDecl{
+			Type:      project.SourceTypeTraces,
+			AgentName: in.target,
+			MaxTraces: in.maxTraces,
+		}
+	} else {
+		datasetName := in.evalName
+		datasetSource := ""
+		out.generateDataset = true
+		if in.dataset != "" {
+			out.generateDataset = false
+			if looksLikeLocalDataset(in.dataset) {
+				// --dataset is given relative to where the user is standing,
+				// but source: resolves relative to the config, so the path has
+				// to be rebased or the deploy looks for it inside evals/.
+				datasetSource = relativeToConfig(in.dataset, in.evalDir)
+				datasetName = strings.TrimSuffix(
+					filepath.Base(in.dataset), filepath.Ext(in.dataset))
+			} else {
+				// A bare name references an already-registered dataset.
+				datasetName = in.dataset
+			}
+		} else {
+			datasetSource = fmt.Sprintf("./%s/%s.jsonl", project.DefaultDatasetsDir, datasetName)
+		}
+		eval.Dataset = datasetName
+		out.datasetName = datasetName
+		addDatasetDecl(cfg, project.DatasetDecl{Name: datasetName, Source: datasetSource})
+	}
+
+	// Every evaluator carries the judge deployment, because that is where the
+	// service reads it from: judging built-ins declare it as required, so an
+	// eval that leaves it off is rejected before it runs. The binding step
+	// drops it again for a rule-based evaluator that declares no judge.
+	initParams := map[string]any{}
+	if in.judgeModel != "" {
+		initParams["model"] = in.judgeModel
+	}
+	withModel := func(ref evalcore.EvaluatorRef) evalcore.EvaluatorRef {
+		if len(initParams) == 0 {
+			return ref
+		}
+		params := make(map[string]any, len(initParams))
+		maps.Copy(params, initParams)
+		ref.InitializationParameters = params
+		return ref
+	}
+
+	refs := evalcore.EvaluatorList{}
+	if len(in.evaluators) == 0 {
+		refs = append(refs,
+			withModel(evalcore.EvaluatorRef{
+				Evaluator: evalcore.BuiltinPrefix + "task_adherence",
+			}))
+		if in.source != initSourceTraces {
+			refs = append(refs, withModel(evalcore.EvaluatorRef{Evaluator: in.rubricName}))
+			addEvaluatorDecl(cfg, project.EvaluatorDecl{
+				Name:   in.rubricName,
+				Source: fmt.Sprintf("./%s/%s.json", project.DefaultEvaluatorsDir, in.rubricName),
+			})
+			out.generateRubric = true
+		}
+	} else {
+		for _, e := range in.evaluators {
+			ref := evalcore.EvaluatorRef{Evaluator: e}
+			refs = append(refs, withModel(ref))
+			if ref.IsBuiltin() {
+				continue
+			}
+			addEvaluatorDecl(cfg, project.EvaluatorDecl{
+				Name:   e,
+				Source: fmt.Sprintf("./%s/%s.json", project.DefaultEvaluatorsDir, e),
+			})
+			// Chosen, not defaulted, but it is still the rubric init offers to
+			// write, so it still has to be generated. Without this the config
+			// declares a file that nothing produces and `create` fails looking
+			// for it.
+			if e == in.rubricName {
+				out.generateRubric = true
+			}
+		}
+	}
+	eval.Evaluators = refs
+
+	cfg.Evals = append(cfg.Evals, eval)
+	out.eval = &cfg.Evals[len(cfg.Evals)-1]
+	return out
+}
+
+// addDatasetDecl adds a catalog entry unless the name is already declared.
+func addDatasetDecl(cfg *project.EvalConfig, decl project.DatasetDecl) {
+	if decl.Name == "" {
+		return
+	}
+	// A source-less entry is still declared: it names a dataset already
+	// registered on the project. Skipping it left the eval referencing a
+	// dataset absent from the catalog, which its own validation rejects.
+	if _, ok := cfg.DatasetDeclaration(decl.Name); ok {
+		return
+	}
+	cfg.Datasets = append(cfg.Datasets, decl)
+}
+
+// addEvaluatorDecl adds a catalog entry unless the name is already declared.
+func addEvaluatorDecl(cfg *project.EvalConfig, decl project.EvaluatorDecl) {
+	if _, ok := cfg.EvaluatorDeclaration(decl.Name); ok {
+		return
+	}
+	cfg.Evaluators = append(cfg.Evaluators, decl)
+}
+
+// evaluatorNames lists the evaluators the eval will run, in declaration order.
+func (s scaffold) evaluatorNames() []string {
+	names := make([]string, 0, len(s.eval.Evaluators))
+	for _, ref := range s.eval.Evaluators {
+		names = append(names, ref.Evaluator)
+	}
+	return names
+}
+
+// nextSteps are the commands to run after `init`, and only the ones that have
+// something to do.
+//
+// A caller who supplied both a dataset and their evaluators has nothing left to
+// generate, and pointing them at a generation command would submit a billed job
+// for an artifact they already have.
+//
+// Every generate step carries --target and --generation-model, which `generate`
+// requires and does not detect. Omitting them printed a next step that failed
+// twice before it ran, each failure naming one more flag.
+func (s scaffold) nextSteps(deployCmd string) []string {
+	var steps []string
+	switch {
+	case s.generateDataset && s.generateRubric:
+		// One command produces both, which is the whole point of the composite.
+		steps = append(steps, s.generateCommand(""))
+	case s.generateDataset:
+		steps = append(steps, s.generateCommand("--dataset --dataset-name "+s.datasetName))
+	case s.generateRubric:
+		steps = append(steps, s.generateCommand("--evaluator --evaluator-name "+s.rubricName))
+	}
+	if len(steps) == 0 {
+		// `azd up` reads azure.yaml, which already $refs the configuration
+		// wherever it was written, so it is the one step --path must not join.
+		deploy := deployCmd
+		if deploy != azdUpCommand {
+			deploy = s.withPath(deploy)
+		}
+		steps = append(steps, deploy, s.withPath("azd ai eval run start"))
+	}
+	return steps
+}
+
+// withPath appends --path to a step that needs it to run where init wrote.
+//
+// The recorded EVAL_CONFIG_PATH would usually supply this on its own, but
+// recording it is best effort -- it needs an azd environment, and `init` works
+// without one. Naming the directory makes the printed step run as printed
+// either way, which is the claim these lines make.
+func (s scaffold) withPath(step string) string {
+	if s.evalDir == "" || s.evalDir == project.DefaultEvalDir {
+		return step
+	}
+	return step + " --path " + quoteForShell(s.evalDir)
+}
+
+// quoteForShell wraps a value a shell would otherwise read as more than one
+// argument.
+//
+// `--path "./team evals"` is the difference between a printed step that runs
+// and one that resolves ./team and reports the configuration missing. That is
+// the case worth getting right, and double quotes are what cmd, PowerShell,
+// bash and zsh all read the same way for a path containing spaces.
+//
+// A path containing $ or a backtick has no portable answer: double quotes stop
+// neither from expanding in bash, zsh or PowerShell, and single quotes -- which
+// would -- are literal only on the POSIX shells. Such a path is wrapped anyway,
+// because one argument that may expand still beats two that certainly break,
+// and this line is printed for a person to read rather than executed here.
+//
+// Backslashes are left alone: C:\Users\Me\My Evals has to come back out as
+// itself, and doubling them would be right for bash and wrong for the two
+// shells most likely to be reading a path that looks like that.
+func quoteForShell(v string) string {
+	if v == "" {
+		return `""`
+	}
+	if !strings.ContainsAny(v, " \t\n\"'`$&|;<>()*?[]#~!") {
+		return v
+	}
+	return `"` + strings.ReplaceAll(v, `"`, `\"`) + `"`
+}
+
+// generateCommand builds a `generate` invocation that runs as printed.
+func (s scaffold) generateCommand(what string) string {
+	cmd := "azd ai eval generate"
+	if what != "" {
+		cmd += " " + what
+	}
+	if s.target != "" {
+		cmd += " --target " + s.target
+	}
+	if s.judgeModel != "" {
+		cmd += " --generation-model " + s.judgeModel
+	}
+	return s.withPath(cmd)
+}
+
+// relativeToConfig rewrites a path given relative to the working directory so
+// it resolves from the directory holding the eval config.
+func relativeToConfig(path, evalDir string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	absOut, err := filepath.Abs(evalDir)
+	if err != nil {
+		return path
+	}
+
+	rel, err := filepath.Rel(absOut, absPath)
+	if err != nil {
+		return path
+	}
+
+	rel = filepath.ToSlash(rel)
+	if !strings.HasPrefix(rel, ".") {
+		rel = "./" + rel
+	}
+	return rel
+}
+
+// rootConfigName is azd's project file, which the eval service is declared in.
+const rootConfigName = "azure.yaml"
+
+// aiProjectHost is the Foundry project service other extensions declare. The
+// eval service uses it for ordering when the repo has one.
+const aiProjectHost = "azure.ai.project"
+
+// How the root config ended up referencing the eval service.
+const (
+	wiringAdded   = "added"   // the service was added to the project
+	wiringPresent = "present" // an eval service was already declared
+)
+
+// readAzdProject returns the project, without changing it.
+func readAzdProject(ctx context.Context) (*azdext.ProjectConfig, error) {
+	azdClient, err := azdext.NewAzdClient()
+	if err != nil {
+		return nil, messages.NoAzdProject()
+	}
+	defer azdClient.Close()
+
+	resp, err := azdClient.Project().Get(ctx, &azdext.EmptyRequest{})
+	if err != nil || resp.GetProject() == nil {
+		return nil, messages.NoAzdProject()
+	}
+	return resp.GetProject(), nil
+}
+
+// azdDefaultInfraDir is where azd looks for infrastructure when the project
+// does not name a directory itself.
+const azdDefaultInfraDir = "infra"
+
+// projectCanProvision reports whether `azd provision` has anything to compile.
+//
+// This mirrors the provider sniff in azd's detectProviderFromFiles: the
+// provider is inferred from the files in the infra directory, and a missing
+// directory leaves it unspecified, which falls back to Bicep and fails on the
+// absent infra/main.bicep -- verified against azd 1.30.0, where `azd up` on an
+// eval-only project exits 1 and `azd deploy` does not run either.
+//
+// It is deliberately only that sniff. azd's real decision, ProjectInfrastructure,
+// is also satisfied by infra layers, a .NET Aspire AppHost, and a `resources:`
+// block in azure.yaml, none of which look at this directory. Each makes this
+// answer false where `azd up` would have worked, so the cost of being wrong is
+// naming our own command in a project that could also have provisioned -- which
+// still publishes the eval.
+func projectCanProvision(proj *azdext.ProjectConfig) bool {
+	if proj == nil {
+		return false
+	}
+
+	dir := proj.GetInfra().GetPath()
+	if dir == "" {
+		dir = azdDefaultInfraDir
+	}
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(proj.GetPath(), dir)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		switch filepath.Ext(e.Name()) {
+		case ".bicep", ".bicepparam", ".tf", ".tfvars":
+			return true
+		}
+	}
+	return false
+}
+
+// aiModelHost is the model-deployment service the sibling Foundry extensions
+// declare, which is where a judge deployment can be read without a service
+// call.
+const aiModelHost = "azure.ai.model"
+
+// detectModelDeployment finds the deployment the graders judge with, from what
+// the project already declares.
+//
+// `init` makes no service calls, so detection is limited to the project file.
+// Coming back empty leaves it to resolveJudgeModel, which reads the Foundry
+// project's deployments: and then asks or names --judge-model.
+func detectModelDeployment(proj *azdext.ProjectConfig) string {
+	for name, svc := range proj.GetServices() {
+		if svc.GetHost() != aiModelHost {
+			continue
+		}
+		if props := svc.GetAdditionalProperties().AsMap(); props != nil {
+			for _, key := range []string{"deployment", "deploymentName", "name", "model"} {
+				if v, ok := props[key].(string); ok && v != "" {
+					return v
+				}
+			}
+		}
+		return name
+	}
+	return ""
+}
+
+// recordEvalPath remembers where the configuration was written, so the commands
+// that read it afterwards do not need --path repeated.
+//
+// Best effort: `init` works outside an azd environment, and a path that could
+// not be recorded only costs the caller a flag later. It is never a reason to
+// fail a scaffold that already succeeded.
+func recordEvalPath(ctx context.Context, path string) {
+	if path == "" || path == project.DefaultEvalDir {
+		return
+	}
+	azdClient, err := azdext.NewAzdClient()
+	if err != nil {
+		return
+	}
+	defer azdClient.Close()
+
+	envName := azdEnvironmentName(ctx, azdClient)
+	if envName == "" {
+		return
+	}
+	_, _ = azdClient.Environment().SetValue(ctx, &azdext.SetEnvRequest{
+		EnvName: envName,
+		Key:     envKeyEvalPath,
+		Value:   filepath.ToSlash(path),
+	})
+}
+
+// ensureRootEvalService declares the eval service in azd's project file.
+//
+// azd acts on nothing until the service exists, so the reference is made rather
+// than described. It goes through azd's own Project().AddService, the same call
+// the agents extension uses, so azd owns the edit and the project file keeps
+// whatever shape azd gives it.
+func ensureRootEvalService(
+	ctx context.Context,
+	serviceName, target, configPath string,
+) (string, error) {
+	azdClient, err := azdext.NewAzdClient()
+	if err != nil {
+		return "", messages.ConnectingToAzd(err)
+	}
+	defer azdClient.Close()
+
+	resp, err := azdClient.Project().Get(ctx, &azdext.EmptyRequest{})
+	if err != nil || resp.GetProject() == nil {
+		return "", messages.NoAzdProject()
+	}
+
+	// A service already pointing at this configuration is left alone:
+	// re-adding it would deploy the same evals twice.
+	if svc, ok := resp.GetProject().GetServices()[serviceName]; ok && svc.GetHost() == project.EvalHost {
+		return wiringPresent, nil
+	}
+
+	props, err := structpb.NewStruct(map[string]any{
+		"$ref": "./" + filepath.ToSlash(configPath),
+	})
+	if err != nil {
+		return "", messages.BuildingServiceEntry(err)
+	}
+
+	_, err = azdClient.Project().AddService(ctx, &azdext.AddServiceRequest{
+		Service: &azdext.ServiceConfig{
+			Name:                 serviceName,
+			Host:                 project.EvalHost,
+			Uses:                 evalServiceUses(resp.GetProject(), target),
+			AdditionalProperties: props,
+		},
+	})
+	if err != nil {
+		return "", messages.AddingServiceTo(rootConfigName, err)
+	}
+	return wiringAdded, nil
+}
+
+// evalServiceUses orders the eval after the things it reads.
+//
+// It is conditional for the same reason the agents extension makes it
+// conditional: naming a service the project does not declare is a broken
+// reference, and an eval config can perfectly well sit in a repo that reaches
+// an existing Foundry project by endpoint and an agent deployed elsewhere.
+//
+// Catalog entries need no ordering of their own — datasets, evaluators and
+// evals are reconciled in a fixed order inside one deploy, forced by the
+// contract rather than chosen.
+func evalServiceUses(proj *azdext.ProjectConfig, target string) []string {
+	var uses []string
+	for name, svc := range proj.GetServices() {
+		if svc.GetHost() == aiProjectHost {
+			uses = append(uses, name)
+			break
+		}
+	}
+	if _, ok := proj.GetServices()[target]; ok {
+		uses = append(uses, target)
+	}
+	return uses
+}
+
+// looksLikeLocalDataset distinguishes a path from a registered dataset name.
+func looksLikeLocalDataset(v string) bool {
+	if strings.ContainsAny(v, `/\`) {
+		return true
+	}
+	return strings.EqualFold(filepath.Ext(v), ".jsonl")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_evaluators.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_evaluators.go
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/evalcore"
+	"azureaieval/internal/project"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+)
+
+// defaultEvaluators is what `init` proposes: one built-in that judges whether
+// the agent did what was asked, plus a rubric generated from the agent's own
+// instructions, which is what makes the criteria specific to this agent.
+//
+// The rubric is not offered for a trace-backed eval, which has no target to
+// read instructions from.
+func defaultEvaluators(rubricName string, traceBacked bool) []string {
+	refs := []string{evalcore.BuiltinPrefix + "task_adherence"}
+	if !traceBacked {
+		refs = append(refs, rubricName)
+	}
+	return refs
+}
+
+// evaluatorChoices are the references `init` can offer.
+//
+// `init` makes no service calls, so the service's full built-in catalogue is
+// not knowable here; offering a hardcoded copy of it would drift. What is
+// knowable is the pair init proposes and whatever this configuration already
+// declares. Anything else is reachable with --evaluator.
+func evaluatorChoices(cfg *project.EvalConfig, rubricName string, traceBacked bool) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(ref string) {
+		if ref == "" || seen[ref] {
+			return
+		}
+		seen[ref] = true
+		out = append(out, ref)
+	}
+
+	for _, ref := range defaultEvaluators(rubricName, traceBacked) {
+		add(ref)
+	}
+	if cfg != nil {
+		for _, decl := range cfg.Evaluators {
+			add(decl.Name)
+		}
+	}
+	return out
+}
+
+// resolveEvaluators settles what the eval grades on.
+//
+// Unlike the target and the judge model, there is no "the only one" here: an
+// eval grades on a SET, and which criteria define quality for this agent is the
+// substantive decision in the whole configuration. So this asks rather than
+// detects, with the defaults preselected. Under --no-prompt the preselection
+// stands, which is what keeps CI and the init -> generate flow working.
+//
+// The second return says whether the reader chose. Only a set decided FOR them
+// is worth reporting back; echoing a selection they just made is noise.
+func resolveEvaluators(
+	cmd *cobra.Command,
+	cfg *project.EvalConfig,
+	rubricName string,
+	traceBacked bool,
+) ([]string, bool, error) {
+	defaults := defaultEvaluators(rubricName, traceBacked)
+	if noPrompt(cmd) {
+		return defaults, false, nil
+	}
+	chosen, err := promptEvaluators(cmd, evaluatorChoices(cfg, rubricName, traceBacked), defaults)
+	if err != nil {
+		return nil, false, err
+	}
+	return chosen, true, nil
+}
+
+// promptEvaluators asks which references to grade with, defaults ticked.
+func promptEvaluators(cmd *cobra.Command, choices, preselected []string) ([]string, error) {
+	azdClient, err := azdext.NewAzdClient()
+	if err != nil {
+		return nil, messages.ConnectingToAzd(err)
+	}
+	defer azdClient.Close()
+
+	ticked := map[string]bool{}
+	for _, p := range preselected {
+		ticked[p] = true
+	}
+	opts := make([]*azdext.MultiSelectChoice, 0, len(choices))
+	for i := range choices {
+		opts = append(opts, &azdext.MultiSelectChoice{
+			Label:    choices[i],
+			Value:    choices[i],
+			Selected: ticked[choices[i]],
+		})
+	}
+
+	resp, err := azdClient.Prompt().MultiSelect(commandContext(cmd), &azdext.MultiSelectRequest{
+		Options: &azdext.MultiSelectOptions{
+			Message: messages.SelectEvaluatorsPrompt(),
+			Choices: opts,
+		},
+	})
+	if err != nil {
+		return nil, messages.SelectingEvaluators(err)
+	}
+
+	chosen := make([]string, 0, len(resp.GetValues()))
+	for _, v := range resp.GetValues() {
+		// A blank choice would otherwise be written to the config as an
+		// evaluator named "", and looked up as one two commands later.
+		if v.GetValue() == "" {
+			continue
+		}
+		chosen = append(chosen, v.GetValue())
+	}
+	if len(chosen) == 0 {
+		// An eval that grades on nothing is rejected by the service, and the
+		// refusal names none of this.
+		return nil, messages.NoEvaluatorsChosen()
+	}
+	return chosen, nil
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_evaluators_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_evaluators_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/pkg/evalcore"
+	"azureaieval/internal/project"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// What an eval grades on is a SET, so there is no "the only one" to detect the
+// way there is for the target and the judge model. Which criteria define
+// quality is the substantive decision in the configuration, so init asks.
+//
+// The defaults are what it proposes, and they are what --no-prompt takes.
+func TestDefaultEvaluatorsProposeABuiltinAndTheRubric(t *testing.T) {
+	assert.Equal(t,
+		[]string{evalcore.BuiltinPrefix + "task_adherence", "support-agent-quality"},
+		defaultEvaluators("support-agent-quality", false))
+}
+
+// A trace-backed eval has no target whose instructions a rubric is written
+// from, so proposing one would plan a file nothing can generate.
+func TestDefaultEvaluatorsSkipTheRubricForTraces(t *testing.T) {
+	assert.Equal(t,
+		[]string{evalcore.BuiltinPrefix + "task_adherence"},
+		defaultEvaluators("support-agent-quality", true))
+}
+
+// The prompt offers what is knowable without a service call -- init makes none
+// -- which is the pair it proposes plus whatever the catalog already declares.
+func TestEvaluatorChoicesOfferTheCatalogToo(t *testing.T) {
+	cfg := &project.EvalConfig{Evaluators: []project.EvaluatorDecl{
+		{Name: "support-agent-quality"}, // already proposed, must not double up
+		{Name: "tone-check"},
+	}}
+
+	got := evaluatorChoices(cfg, "support-agent-quality", false)
+
+	assert.Equal(t, []string{
+		evalcore.BuiltinPrefix + "task_adherence",
+		"support-agent-quality",
+		"tone-check",
+	}, got)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_model.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_model.go
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"azureaieval/internal/messages"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/spf13/cobra"
+)
+
+// judgeModelEnvKey is the key `azd ai agent init` writes the bound deployment
+// to, and the only place it appears when the project was created beforehand.
+const judgeModelEnvKey = "AZURE_AI_MODEL_DEPLOYMENT_NAME"
+
+// modelDeployments names every model deployment the project declares, sorted so
+// a prompt and an error list the same way twice.
+//
+// They live under the Foundry project service's deployments:, which is where
+// the sibling extensions put them, so reading them is a file read rather than a
+// service call. An entry given as a $ref is skipped rather than followed:
+// resolving includes is the project extension's job, and a scaffold that cannot
+// see a deployment falls back to naming --judge-model, which is a worse message
+// but never a wrong one.
+func modelDeployments(proj *azdext.ProjectConfig) []string {
+	seen := map[string]bool{}
+	var names []string
+
+	for _, svc := range proj.GetServices() {
+		if svc.GetHost() != aiProjectHost {
+			continue
+		}
+		props := svc.GetAdditionalProperties()
+		if props == nil || len(props.GetFields()) == 0 {
+			props = svc.GetConfig()
+		}
+		if props == nil {
+			continue
+		}
+		declared, ok := props.AsMap()["deployments"].([]any)
+		if !ok {
+			continue
+		}
+		for _, entry := range declared {
+			fields, ok := entry.(map[string]any)
+			if !ok {
+				continue
+			}
+			name, ok := fields["name"].(string)
+			if !ok || name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+
+	sort.Strings(names)
+	return names
+}
+
+// resolveJudgeModel settles the deployment the graders judge with.
+//
+// The judging built-ins declare the deployment as required, so an eval written
+// without one is rejected by the service long after the command that wrote it.
+// That is why coming back empty is a failure here rather than something left
+// for later: `init` would otherwise exit 0 having written a configuration that
+// cannot be deployed.
+func resolveJudgeModel(cmd *cobra.Command, proj *azdext.ProjectConfig) (string, error) {
+	if model := detectModelDeployment(proj); model != "" {
+		return model, nil
+	}
+
+	deployments := modelDeployments(proj)
+	switch len(deployments) {
+	case 0:
+		// Binding to an existing Foundry project writes `deployments: []` into
+		// azure.yaml, so the deployment `azd ai agent init` chose survives only
+		// in the azd environment. Reading it there is the difference between a
+		// configured project working and erroring.
+		if model := modelDeploymentFromAzdEnv(commandContext(cmd)); model != "" {
+			return model, nil
+		}
+		return "", messages.JudgeModelRequired()
+	case 1:
+		return deployments[0], nil
+	}
+
+	if noPrompt(cmd) {
+		return "", messages.AmbiguousJudgeModel(deployments)
+	}
+	return promptJudgeModel(cmd, deployments)
+}
+
+// tracesConnected reports whether the azd environment records an Application
+// Insights connection, which is what `generate --from` already defaults on.
+//
+// A local read, so `init` keeps its promise to make no service calls. Absence
+// is ordinary: init runs outside an azd project too.
+func tracesConnected(ctx context.Context) bool {
+	return azdEnvValue(ctx, appInsightsEnvKey) != ""
+}
+
+// modelDeploymentFromAzdEnv reads the deployment `azd ai agent init` recorded
+// in the active azd environment. Absence is ordinary: `init` runs outside an
+// azd project too, and the caller falls back to naming --judge-model.
+func modelDeploymentFromAzdEnv(ctx context.Context) string {
+	return azdEnvValue(ctx, judgeModelEnvKey)
+}
+
+// azdEnvValue reads one key from the azd environment this invocation acts on,
+// answering empty whenever there is no daemon, no environment, or no such key.
+func azdEnvValue(ctx context.Context, key string) string {
+	azdClient, err := azdext.NewAzdClient()
+	if err != nil {
+		return ""
+	}
+	defer azdClient.Close()
+
+	envName := azdEnvironmentName(ctx, azdClient)
+	if envName == "" {
+		return ""
+	}
+	val, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+		EnvName: envName,
+		Key:     key,
+	})
+	if err != nil {
+		return ""
+	}
+	return val.GetValue()
+}
+
+// validateEvaluatorRefs rejects references that cannot name an evaluator.
+//
+// This needs no service call, so it keeps `init`'s promise to make none. The
+// alternative is a config that scaffolds cleanly and fails at `create`, naming
+// a value the user passed to a different command.
+func validateEvaluatorRefs(refs []string) error {
+	for _, ref := range refs {
+		if strings.TrimSpace(ref) == "" {
+			return messages.EvaluatorRefEmpty()
+		}
+		if strings.ContainsAny(ref, " \t") {
+			return messages.EvaluatorRefMalformed(ref)
+		}
+	}
+	return nil
+}
+
+// promptJudgeModel asks which of the project's deployments to judge with.
+func promptJudgeModel(cmd *cobra.Command, deployments []string) (string, error) {
+	azdClient, err := azdext.NewAzdClient()
+	if err != nil {
+		return "", messages.ConnectingToAzd(err)
+	}
+	defer azdClient.Close()
+
+	choices := make([]*azdext.SelectChoice, 0, len(deployments))
+	for i := range deployments {
+		choices = append(choices, &azdext.SelectChoice{
+			Label: deployments[i], Value: deployments[i],
+		})
+	}
+
+	resp, err := azdClient.Prompt().Select(commandContext(cmd), &azdext.SelectRequest{
+		Options: &azdext.SelectOptions{
+			Message: messages.SelectJudgeModelPrompt(),
+			Choices: choices,
+		},
+	})
+	if err != nil {
+		return "", messages.SelectingJudgeModel(err)
+	}
+	// Value is optional on the wire, so an unset one arrives as 0 from
+	// GetValue and would read as the first deployment rather than as no answer.
+	if resp == nil || resp.Value == nil {
+		return "", messages.AmbiguousJudgeModel(deployments)
+	}
+	index := int(resp.GetValue())
+	if index < 0 || index >= len(deployments) {
+		return "", messages.AmbiguousJudgeModel(deployments)
+	}
+	return deployments[index], nil
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_model_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_model_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// projectWithDeployments builds a project whose Foundry project service
+// declares the given deployments, which is the shape azd hands the extension
+// for a `deployments:` list in azure.yaml.
+func projectWithDeployments(t *testing.T, names ...string) *azdext.ProjectConfig {
+	t.Helper()
+	declared := make([]any, 0, len(names))
+	for _, n := range names {
+		declared = append(declared, map[string]any{
+			"name":  n,
+			"model": map[string]any{"name": n, "format": "OpenAI", "version": "1"},
+		})
+	}
+	proj := projectWith()
+	proj.Services["ai-project"] = &azdext.ServiceConfig{
+		Name: "ai-project",
+		Host: aiProjectHost,
+		AdditionalProperties: mustStruct(t, map[string]any{
+			"deployments": declared,
+		}),
+	}
+	return proj
+}
+
+// The deployments live under the Foundry project service, which is where the
+// sibling extensions put them. Reading them is a file read, so `init` keeps
+// making no service calls.
+func TestModelDeployments_ReadFromTheProjectService(t *testing.T) {
+	assert.Empty(t, modelDeployments(projectWith("api", "web")),
+		"a project with no Foundry project service declares no deployments")
+
+	assert.Equal(t, []string{"gpt-4.1-nano", "gpt-4o-mini"},
+		modelDeployments(projectWithDeployments(t, "gpt-4o-mini", "gpt-4.1-nano")),
+		"sorted, so a prompt and an error list them the same way twice")
+}
+
+// A single declared deployment is the one to judge with, so the common project
+// needs no flag at all.
+func TestResolveJudgeModel_DetectsTheOnlyDeployment(t *testing.T) {
+	model, err := resolveJudgeModel(newInitCommand(),
+		projectWithDeployments(t, "gpt-4.1-nano"))
+
+	require.NoError(t, err)
+	assert.Equal(t, "gpt-4.1-nano", model)
+}
+
+// The judging built-ins declare the deployment as required, so a project that
+// declares none has to say which to use. Failing here is the point: `init` used
+// to exit 0 having written a configuration the service later rejects.
+func TestResolveJudgeModel_NoDeploymentsNamesTheFlag(t *testing.T) {
+	_, err := resolveJudgeModel(newInitCommand(), projectWith("api", "web"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--judge-model")
+}
+
+// With several there is nothing to detect. Under --no-prompt the flag is the
+// only way to say which, so the error names it and lists the candidates.
+func TestResolveJudgeModel_AmbiguousUnderNoPrompt(t *testing.T) {
+	cmd := newInitCommand()
+	// --no-prompt is inherited from the root in the real tree, so the test has
+	// to supply it the way the root does.
+	cmd.Flags().Bool("no-prompt", true, "")
+
+	_, err := resolveJudgeModel(cmd, projectWithDeployments(t, "gpt-4.1-nano", "gpt-4o-mini"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--judge-model")
+	assert.Contains(t, err.Error(), "gpt-4.1-nano")
+	assert.Contains(t, err.Error(), "gpt-4o-mini")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_rubric_choice_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_rubric_choice_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/pkg/evalcore"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Now that init asks rather than defaults, the rubric arrives as an explicit
+// choice instead of through the empty-evaluators branch. It still has to be
+// generated: the configuration declares a file, and if nothing produces it,
+// `create` fails looking for it -- which is finding 0b, reintroduced by the
+// prompt if the chosen path did not set this.
+func TestScaffoldGeneratesARubricThatWasChosenRatherThanDefaulted(t *testing.T) {
+	plan, cfg := scaffoldFor(t, scaffoldInput{
+		evalName: "support-agent-eval",
+		target:   "support-agent",
+		dataset:  "golden",
+		evaluators: []string{
+			evalcore.BuiltinPrefix + "task_adherence",
+			"support-agent-quality",
+		},
+	})
+
+	assert.True(t, plan.generateRubric,
+		"a chosen rubric still has to be generated, or its file never exists")
+
+	require.Len(t, cfg.Evaluators, 1, "only the rubric is a catalog entry; the builtin is not")
+	assert.Equal(t, "support-agent-quality", cfg.Evaluators[0].Name)
+}
+
+// A built-in is resolved by the service and has no local file, so choosing only
+// built-ins must not plan a generation.
+func TestScaffoldGeneratesNoRubricForBuiltinsAlone(t *testing.T) {
+	plan, cfg := scaffoldFor(t, scaffoldInput{
+		evalName:   "support-agent-eval",
+		target:     "support-agent",
+		dataset:    "golden",
+		evaluators: []string{evalcore.BuiltinPrefix + "task_adherence"},
+	})
+
+	assert.False(t, plan.generateRubric)
+	assert.Empty(t, cfg.Evaluators)
+}
+
+// An evaluator the author already has on disk is not the rubric init offers, so
+// it is declared without planning a generation over it.
+func TestScaffoldDoesNotGenerateAnUnrelatedEvaluator(t *testing.T) {
+	plan, cfg := scaffoldFor(t, scaffoldInput{
+		evalName:   "support-agent-eval",
+		target:     "support-agent",
+		dataset:    "golden",
+		evaluators: []string{"tone-check"},
+	})
+
+	assert.False(t, plan.generateRubric,
+		"only the rubric init offers to write is one it knows how to generate")
+	require.Len(t, cfg.Evaluators, 1)
+	assert.Equal(t, "tone-check", cfg.Evaluators[0].Name)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_target.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_target.go
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"sort"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/project"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/spf13/cobra"
+)
+
+// agentServices names every agent the project declares, sorted so a prompt and
+// an error list the same way twice.
+func agentServices(proj *azdext.ProjectConfig) []string {
+	var names []string
+	for name, svc := range proj.GetServices() {
+		if svc.GetHost() == project.AgentHost {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// resolveAgentTarget settles which agent the scaffold is written for.
+//
+// The spec makes --target default to the project's only agent, so requiring it
+// would put a flag in front of the one command a developer runs first. With
+// several agents there is nothing to detect, so it asks; under --no-prompt it
+// names the flag rather than guessing which agent someone meant.
+//
+// It does not announce what it found: init prints that for every target, so
+// that an explicit --target and a detected one read the same.
+func resolveAgentTarget(cmd *cobra.Command, proj *azdext.ProjectConfig) (string, error) {
+	agents := agentServices(proj)
+	switch len(agents) {
+	case 0:
+		return "", messages.NoAgentToEvaluate()
+	case 1:
+		return agents[0], nil
+	}
+
+	if noPrompt(cmd) {
+		return "", messages.AmbiguousAgentTarget(agents)
+	}
+	return promptAgentTarget(cmd, agents)
+}
+
+// promptAgentTarget asks which of the project's agents to evaluate.
+func promptAgentTarget(cmd *cobra.Command, agents []string) (string, error) {
+	azdClient, err := azdext.NewAzdClient()
+	if err != nil {
+		return "", messages.ConnectingToAzd(err)
+	}
+	defer azdClient.Close()
+
+	choices := make([]*azdext.SelectChoice, 0, len(agents))
+	for i := range agents {
+		choices = append(choices, &azdext.SelectChoice{Label: agents[i], Value: agents[i]})
+	}
+
+	resp, err := azdClient.Prompt().Select(commandContext(cmd), &azdext.SelectRequest{
+		Options: &azdext.SelectOptions{
+			Message: messages.SelectAgentPrompt(),
+			Choices: choices,
+		},
+	})
+	if err != nil {
+		return "", messages.SelectingAgent(err)
+	}
+	// Value is optional on the wire, so an unset one arrives as 0 from
+	// GetValue and would read as the first agent rather than as no answer.
+	if resp == nil || resp.Value == nil {
+		return "", messages.AmbiguousAgentTarget(agents)
+	}
+	index := int(resp.GetValue())
+	if index < 0 || index >= len(agents) {
+		return "", messages.AmbiguousAgentTarget(agents)
+	}
+	return agents[index], nil
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_target_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_target_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/project"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// projectWithHosts builds a project whose services carry hosts, which is what
+// agent detection keys on. The sibling projectWith helper sets names only.
+func projectWithHosts(services map[string]string) *azdext.ProjectConfig {
+	svcs := map[string]*azdext.ServiceConfig{}
+	for name, host := range services {
+		svcs[name] = &azdext.ServiceConfig{Name: name, Host: host}
+	}
+	return &azdext.ProjectConfig{Services: svcs}
+}
+
+// The spec's first hero command is `azd ai eval init --source traces`, with no
+// target. Requiring the flag put it in front of the one command a developer
+// runs first.
+func TestAgentServices_FindsTheOnlyAgent(t *testing.T) {
+	proj := projectWithHosts(map[string]string{
+		"ai-project":    "azure.ai.project",
+		"support-agent": project.AgentHost,
+	})
+
+	agents := agentServices(proj)
+
+	require.Len(t, agents, 1)
+	assert.Equal(t, "support-agent", agents[0])
+}
+
+// Sorted, so a prompt and an error list them the same way twice.
+func TestAgentServices_AreSorted(t *testing.T) {
+	proj := projectWithHosts(map[string]string{
+		"zebra-agent":   project.AgentHost,
+		"alpha-agent":   project.AgentHost,
+		"ai-project":    "azure.ai.project",
+		"support-agent": project.AgentHost,
+	})
+
+	assert.Equal(t, []string{"alpha-agent", "support-agent", "zebra-agent"}, agentServices(proj))
+}
+
+func TestAgentServices_NoneWhenTheProjectHasNoAgent(t *testing.T) {
+	proj := projectWithHosts(map[string]string{"ai-project": "azure.ai.project"})
+
+	assert.Empty(t, agentServices(proj))
+}
+
+// A project with no agent cannot be scaffolded, and the error has to say that
+// rather than name a flag the developer has nothing to put in.
+func TestResolveAgentTarget_NoAgent(t *testing.T) {
+	cmd := newInitCommand()
+
+	_, err := resolveAgentTarget(cmd, projectWithHosts(map[string]string{
+		"ai-project": "azure.ai.project",
+	}))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no agent service")
+}
+
+// With several agents there is nothing to detect. Under --no-prompt the flag is
+// the only way to say which, so the error names it and lists the candidates.
+func TestResolveAgentTarget_AmbiguousUnderNoPrompt(t *testing.T) {
+	cmd := newInitCommand()
+	// --no-prompt is inherited from the root in the real tree, so the test has
+	// to supply it the way the root does.
+	cmd.Flags().Bool("no-prompt", true, "")
+
+	_, err := resolveAgentTarget(cmd, projectWithHosts(map[string]string{
+		"one-agent": project.AgentHost,
+		"two-agent": project.AgentHost,
+	}))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--target")
+	assert.Contains(t, err.Error(), "one-agent")
+	assert.Contains(t, err.Error(), "two-agent")
+}
+
+func TestResolveAgentTarget_DetectsTheSoleAgent(t *testing.T) {
+	cmd := newInitCommand()
+
+	target, err := resolveAgentTarget(cmd, projectWithHosts(map[string]string{
+		"ai-project":    "azure.ai.project",
+		"support-agent": project.AgentHost,
+	}))
+
+	require.NoError(t, err)
+	assert.Equal(t, "support-agent", target)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_test.go
@@ -1,0 +1,452 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"azureaieval/internal/project"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+)
+
+// projectCanProvision decides which deploy command `init` names, so it has to
+// agree with what azd actually does rather than with what the layout suggests.
+// azd infers the provider from the files in the infra directory; an empty or
+// missing directory leaves it unspecified, falls back to Bicep, and fails on
+// the absent infra/main.bicep.
+func TestProjectCanProvision(t *testing.T) {
+	write := func(t *testing.T, dir string, names ...string) string {
+		t.Helper()
+		root := t.TempDir()
+		if dir != "" {
+			require.NoError(t, os.MkdirAll(filepath.Join(root, dir), 0o750))
+		}
+		for _, n := range names {
+			require.NoError(t,
+				os.WriteFile(filepath.Join(root, dir, n), []byte("// x"), 0o600))
+		}
+		return root
+	}
+
+	t.Run("no infra directory", func(t *testing.T) {
+		root := write(t, "")
+		require.False(t, projectCanProvision(&azdext.ProjectConfig{Path: root}),
+			"this is the eval-only project, where `azd up` exits 1")
+	})
+
+	t.Run("infra directory with bicep", func(t *testing.T) {
+		root := write(t, "infra", "main.bicep")
+		require.True(t, projectCanProvision(&azdext.ProjectConfig{Path: root}))
+	})
+
+	t.Run("infra directory with terraform", func(t *testing.T) {
+		root := write(t, "infra", "main.tf")
+		require.True(t, projectCanProvision(&azdext.ProjectConfig{Path: root}))
+	})
+
+	// An empty directory is the case a plain os.Stat would get wrong: the
+	// directory exists, and azd still has nothing to compile.
+	t.Run("empty infra directory", func(t *testing.T) {
+		root := write(t, "infra")
+		require.False(t, projectCanProvision(&azdext.ProjectConfig{Path: root}))
+	})
+
+	// Nothing recurses: azd reads one directory and skips subdirectories.
+	t.Run("bicep only in a subdirectory", func(t *testing.T) {
+		root := write(t, filepath.Join("infra", "modules"), "db.bicep")
+		require.False(t, projectCanProvision(&azdext.ProjectConfig{Path: root}))
+	})
+
+	t.Run("project names its own infra directory", func(t *testing.T) {
+		root := write(t, "deploy", "main.bicep")
+		require.True(t, projectCanProvision(&azdext.ProjectConfig{
+			Path:  root,
+			Infra: &azdext.InfraOptions{Path: "deploy"},
+		}), "the declared path is read, not the default one")
+		require.False(t, projectCanProvision(&azdext.ProjectConfig{Path: root}),
+			"and the default is empty here")
+	})
+
+	t.Run("no project", func(t *testing.T) {
+		require.False(t, projectCanProvision(nil),
+			"an unreadable project cannot be claimed to provision")
+	})
+}
+
+// scaffoldFor runs planScaffold against a fresh configuration, which is what
+// `init` does on a project that has never been initialized.
+func scaffoldFor(t *testing.T, in scaffoldInput) (scaffold, *project.EvalConfig) {
+	t.Helper()
+	if in.cfg == nil {
+		in.cfg = &project.EvalConfig{}
+	}
+	if in.evalDir == "" {
+		in.evalDir = project.DefaultEvalDir
+	}
+	if in.rubricName == "" {
+		in.rubricName = in.target + "-quality"
+	}
+	return planScaffold(in), in.cfg
+}
+
+// The scaffold must round-trip and validate, otherwise `azd up` fails on a
+// config the tool itself produced.
+func TestScaffold_RoundTripsAndValidates(t *testing.T) {
+	dir := t.TempDir()
+	_, cfg := scaffoldFor(t, scaffoldInput{
+		evalName:   "support-agent-smoke",
+		target:     "support-agent",
+		judgeModel: "gpt-4.1-nano",
+		evalDir:    dir,
+	})
+
+	require.NoError(t, project.SaveEvalConfig(dir, cfg))
+	loaded, err := project.OpenEvalConfig(dir)
+	require.NoError(t, err)
+	require.NoError(t, loaded.Validate(), "the generated scaffold must be valid")
+
+	eval, err := loaded.Eval("support-agent-smoke")
+	require.NoError(t, err)
+	require.Equal(t, project.TargetTypeAgent, eval.Target.Type)
+	require.Equal(t, "support-agent", eval.Target.Name)
+	require.Equal(t, project.EvaluationLevelTurn, eval.EvaluationLevel)
+}
+
+// Re-running init appends rather than replacing, so one file ends up holding
+// every eval for the target.
+func TestScaffold_AppendsToAnExistingConfiguration(t *testing.T) {
+	dir := t.TempDir()
+	_, cfg := scaffoldFor(t, scaffoldInput{
+		evalName: "first", target: "support-agent", judgeModel: "m", evalDir: dir,
+	})
+	_, cfg = scaffoldFor(t, scaffoldInput{
+		evalName: "second", target: "support-agent", judgeModel: "m", evalDir: dir, cfg: cfg,
+	})
+
+	require.Equal(t, []string{"first", "second"}, cfg.EvalNames())
+	require.NoError(t, project.SaveEvalConfig(dir, cfg))
+	loaded, err := project.OpenEvalConfig(dir)
+	require.NoError(t, err)
+	require.NoError(t, loaded.Validate())
+}
+
+// A trace-backed eval invokes nothing, so agent_name filters instead of
+// targeting, and a scaffolded cap keeps the first run bounded rather than
+// taking the service's default of 1000.
+func TestScaffold_TraceSourceHasNoTarget(t *testing.T) {
+	plan, _ := scaffoldFor(t, scaffoldInput{
+		evalName:  "support-agent-trace-eval",
+		target:    "support-agent",
+		source:    initSourceTraces,
+		maxTraces: project.DefaultScaffoldMaxTraces,
+	})
+
+	require.Nil(t, plan.eval.Target)
+	require.NotNil(t, plan.eval.Source)
+	require.Equal(t, project.SourceTypeTraces, plan.eval.Source.Type)
+	require.Equal(t, "support-agent", plan.eval.Source.AgentName)
+	require.Equal(t, 20, plan.eval.Source.MaxTraces)
+}
+
+// Omitting the cap leaves the key out, which is how the service default is
+// taken — writing a zero would send one.
+func TestScaffold_TraceCapIsOmittedWhenZero(t *testing.T) {
+	plan, _ := scaffoldFor(t, scaffoldInput{
+		evalName: "t", target: "a", source: initSourceTraces,
+	})
+	require.Zero(t, plan.eval.Source.MaxTraces)
+
+	body, err := yaml.Marshal(plan.eval)
+	require.NoError(t, err)
+	require.NotContains(t, string(body), "max_traces")
+}
+
+// The default set is a built-in plus a generated rubric: the built-in alone
+// would be generic, and the rubric is what makes the baseline about this agent.
+func TestScaffold_DefaultEvaluators(t *testing.T) {
+	plan, _ := scaffoldFor(t, scaffoldInput{
+		evalName: "support-agent-smoke", target: "support-agent", judgeModel: "gpt-5.6-luna",
+	})
+
+	require.Equal(t,
+		[]string{"builtin.task_adherence", "support-agent-quality"},
+		plan.evaluatorNames())
+
+	// Every evaluator carries the judge deployment, because the judging
+	// built-ins declare it and an eval that leaves it off is rejected.
+	for _, ref := range plan.eval.Evaluators {
+		require.Equal(t, "gpt-5.6-luna", ref.InitializationParameters["model"],
+			"%s must name a judge deployment", ref.Evaluator)
+	}
+}
+
+// Passing --evaluator replaces the defaults, which is how a caller opts out of
+// rubric generation.
+func TestScaffold_ExplicitEvaluatorsOptOutOfGeneration(t *testing.T) {
+	plan, _ := scaffoldFor(t, scaffoldInput{
+		evalName:   "smoke",
+		target:     "support-agent",
+		evaluators: []string{"builtin.task_adherence"},
+		judgeModel: "m",
+	})
+
+	require.Equal(t, []string{"builtin.task_adherence"}, plan.evaluatorNames())
+	require.False(t, plan.generateRubric, "no rubric is generated when evaluators are given")
+}
+
+// `init` closes by naming what to run next, and only what has something to do.
+// Pointing a caller who supplied their own artifacts at a generation command
+// would submit a billed job for something they already have.
+func TestScaffold_NextStepsOfferOnlyWhatIsScheduled(t *testing.T) {
+	t.Run("nothing supplied", func(t *testing.T) {
+		plan, _ := scaffoldFor(t, scaffoldInput{
+			evalName: "support-agent-smoke", target: "support-agent", judgeModel: "m",
+		})
+		// One command produces both, so there is one step, not two.
+		require.Equal(t,
+			[]string{"azd ai eval generate --target support-agent --generation-model m"},
+			plan.nextSteps("azd ai eval create"))
+	})
+
+	t.Run("dataset supplied", func(t *testing.T) {
+		plan, _ := scaffoldFor(t, scaffoldInput{
+			evalName: "smoke", target: "support-agent", dataset: "prod-golden", judgeModel: "m",
+		})
+		require.Equal(t,
+			[]string{"azd ai eval generate --evaluator --evaluator-name support-agent-quality " +
+				"--target support-agent --generation-model m"},
+			plan.nextSteps("azd ai eval create"))
+	})
+
+	t.Run("everything supplied", func(t *testing.T) {
+		plan, _ := scaffoldFor(t, scaffoldInput{
+			evalName:   "smoke",
+			target:     "support-agent",
+			dataset:    "prod-golden",
+			evaluators: []string{"builtin.task_adherence"},
+			judgeModel: "m",
+		})
+		// Verified against azd 1.30.0. `azd up` on a project with no infra/
+		// exits 1 compiling a missing infra/main.bicep, and `azd deploy` exits
+		// 1 with "infrastructure has not been provisioned" in an environment
+		// that never provisioned one. `azd ai eval create` needs neither.
+		require.Equal(t, []string{"azd ai eval create", "azd ai eval run start"},
+			plan.nextSteps("azd ai eval create"),
+			"the deploy step is the one the project can actually run")
+		require.Equal(t, []string{"azd up", "azd ai eval run start"},
+			plan.nextSteps("azd up"),
+			"where the project does provision, one command covers both")
+	})
+}
+
+// Which command deploys is decided in one place, so every message that names
+// one agrees. The detection itself is covered by TestProjectCanProvision.
+func TestDeployCommandName(t *testing.T) {
+	root := t.TempDir()
+	require.Equal(t, "azd ai eval create", deployCommandName(&azdext.ProjectConfig{Path: root}),
+		"nothing to provision, so neither `azd up` nor `azd deploy` would run here")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "infra"), 0o750))
+	require.NoError(t,
+		os.WriteFile(filepath.Join(root, "infra", "main.bicep"), []byte("// x"), 0o600))
+	require.Equal(t, "azd up", deployCommandName(&azdext.ProjectConfig{Path: root}))
+
+	require.Equal(t, "azd ai eval create", deployCommandName(nil),
+		"a project we cannot read is not one we can claim provisions")
+}
+
+// The literals above are only as good as the surface they name. This resolves
+// every step against the real command tree, so a step naming a command that has
+// been renamed or removed fails here rather than in a user's terminal — which
+// is how `azd ai eval dataset generate` survived being deleted.
+func TestScaffold_NextStepsNameCommandsThatExist(t *testing.T) {
+	inputs := []scaffoldInput{
+		{evalName: "smoke", target: "support-agent", judgeModel: "m"},
+		{evalName: "smoke", target: "support-agent", dataset: "prod-golden", judgeModel: "m"},
+		// Reaches the deploy branch, so the command it names is resolved too.
+		{evalName: "smoke", target: "support-agent", dataset: "prod-golden",
+			evaluators: []string{"builtin.task_adherence"}, judgeModel: "m"},
+	}
+
+	for _, in := range inputs {
+		plan, _ := scaffoldFor(t, in)
+		for _, step := range plan.nextSteps("azd ai eval create") {
+			// Steps that drive azd itself -- `azd up`, `azd deploy` -- are not
+			// this extension's commands and resolve against a different tree.
+			if !strings.HasPrefix(step, "azd ai eval ") {
+				continue
+			}
+			words := strings.Fields(strings.TrimPrefix(step, "azd ai eval "))
+			if len(words) == 0 {
+				continue
+			}
+			// Stop at the first flag: what follows is arguments, not commands.
+			var path []string
+			for _, w := range words {
+				if strings.HasPrefix(w, "-") {
+					break
+				}
+				path = append(path, w)
+			}
+
+			cmd, rest, err := NewRootCommand().Find(path)
+			require.NoErrorf(t, err, "%q names no command", step)
+			require.Emptyf(t, rest, "%q left %v unresolved, so it is not a command", step, rest)
+			require.Equalf(t, path[len(path)-1], strings.Fields(cmd.Use)[0],
+				"%q resolved to %q, not the command it names", step, cmd.Use)
+		}
+	}
+}
+
+// The Next: line is what a new user runs immediately after init, and it used to
+// fail twice before it worked: `generate` requires --target and
+// --generation-model, detects neither, and reports them one per invocation.
+// Both values were on screen when init printed the hint.
+func TestScaffold_NextStepsCarryWhatGenerateRequires(t *testing.T) {
+	for _, in := range []scaffoldInput{
+		{evalName: "smoke", target: "support-agent", judgeModel: "gpt-4o-mini"},
+		{evalName: "smoke", target: "support-agent", dataset: "prod-golden", judgeModel: "gpt-4o-mini"},
+	} {
+		plan, _ := scaffoldFor(t, in)
+		seen := 0
+		for _, step := range plan.nextSteps("azd ai eval create") {
+			if !strings.HasPrefix(step, "azd ai eval generate") {
+				continue
+			}
+			seen++
+			require.Containsf(t, step, "--target support-agent",
+				"%q omits the target init had just detected", step)
+			require.Containsf(t, step, "--generation-model gpt-4o-mini",
+				"%q omits the model init had just resolved", step)
+		}
+		require.NotZerof(t, seen,
+			"no generate step was produced, so this asserted nothing: %+v", in)
+	}
+}
+
+// Built-ins are referenced but never declared, so the scaffold must not give
+// one a catalog entry to publish.
+func TestScaffold_BuiltinEvaluatorsGetNoCatalogEntry(t *testing.T) {
+	dir := t.TempDir()
+	plan, cfg := scaffoldFor(t, scaffoldInput{
+		evalName:   "smoke",
+		target:     "support-agent",
+		evaluators: []string{"builtin.task_adherence", "my-custom"},
+		judgeModel: "m",
+		evalDir:    dir,
+	})
+
+	require.Len(t, plan.eval.Evaluators, 2)
+	require.True(t, plan.eval.Evaluators[0].IsBuiltin())
+	require.False(t, plan.eval.Evaluators[1].IsBuiltin())
+
+	require.Len(t, cfg.Evaluators, 1, "only the custom evaluator is declared")
+	require.Equal(t, "my-custom", cfg.Evaluators[0].Name)
+	require.Len(t, cfg.CustomEvaluators(), 1,
+		"only the custom evaluator is this config's to publish")
+
+	require.NoError(t, project.SaveEvalConfig(dir, cfg))
+	loaded, err := project.OpenEvalConfig(dir)
+	require.NoError(t, err)
+	require.NoError(t, loaded.Validate())
+}
+
+// A bare name means an already-registered dataset; a path means a local file.
+// Either way the dataset was supplied, so nothing is scheduled to generate it —
+// only a missing --dataset produces a generation step.
+func TestScaffold_DatasetReferenceForms(t *testing.T) {
+	t.Run("local path becomes a source", func(t *testing.T) {
+		// --dataset is relative to the working directory, but source: is
+		// resolved relative to the eval config, so it has to be rebased.
+		plan, cfg := scaffoldFor(t, scaffoldInput{
+			evalName: "smoke", target: "a", dataset: "./tests/golden.jsonl", evalDir: "evals",
+		})
+		decl, ok := cfg.DatasetDeclaration("golden")
+		require.True(t, ok)
+		require.Equal(t, "../tests/golden.jsonl", decl.Source,
+			"a dataset outside the eval dir must be reached with ..")
+		require.Equal(t, "golden", plan.eval.Dataset)
+		require.False(t, plan.generateDataset,
+			"a supplied dataset must not be scheduled for generation")
+	})
+
+	t.Run("bare name references a registered dataset", func(t *testing.T) {
+		plan, cfg := scaffoldFor(t, scaffoldInput{
+			evalName: "smoke", target: "a", dataset: "prod-sample",
+		})
+		decl, ok := cfg.DatasetDeclaration("prod-sample")
+		require.True(t, ok)
+		require.Empty(t, decl.Source, "a registered dataset must not get a local source")
+		require.Equal(t, "prod-sample", plan.eval.Dataset)
+		require.False(t, plan.generateDataset)
+	})
+
+	t.Run("no dataset flag scaffolds a local path and a generation step", func(t *testing.T) {
+		plan, cfg := scaffoldFor(t, scaffoldInput{
+			evalName: "support-agent-smoke", target: "support-agent",
+		})
+		require.Equal(t, "support-agent-smoke", plan.eval.Dataset,
+			"the dataset is named after the eval")
+		decl, ok := cfg.DatasetDeclaration("support-agent-smoke")
+		require.True(t, ok)
+		require.Contains(t, decl.Source, "support-agent-smoke.jsonl")
+		require.True(t, plan.generateDataset)
+	})
+}
+
+func TestLooksLikeLocalDataset(t *testing.T) {
+	require.True(t, looksLikeLocalDataset("./data/golden.jsonl"))
+	require.True(t, looksLikeLocalDataset("golden.jsonl"))
+	require.True(t, looksLikeLocalDataset(`data\golden.jsonl`))
+	require.False(t, looksLikeLocalDataset("prod-sample"))
+}
+
+// Paths are used verbatim relative to the working directory; the doubling bug
+// in the agent-scoped command must not reappear.
+func TestSaveEvalConfig_UsesPathVerbatim(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "evals")
+
+	require.NoError(t, project.SaveEvalConfig(nested, &project.EvalConfig{}))
+	_, err := os.Stat(project.EvalConfigPath(nested))
+	require.NoError(t, err, "the file must land exactly at the requested path")
+
+	doubled := filepath.Join(dir, "evals", "evals")
+	_, err = os.Stat(doubled)
+	require.Error(t, err, "the path must not be re-rooted under itself")
+}
+
+// normalizeRubricBody accepts a bare definition or a full document.
+func TestNormalizeRubricBody(t *testing.T) {
+	t.Run("bare definition is wrapped", func(t *testing.T) {
+		body, err := normalizeRubricBody("quality",
+			[]byte(`{"type":"rubric","dimensions":[{"id":"q","weight":10}]}`))
+		require.NoError(t, err)
+		require.Contains(t, string(body), `"name":"quality"`)
+		require.Contains(t, string(body), `"definition"`)
+	})
+
+	t.Run("full document keeps its definition and takes the flag name", func(t *testing.T) {
+		body, err := normalizeRubricBody("renamed",
+			[]byte(`{"name":"old","definition":{"type":"rubric","dimensions":[]}}`))
+		require.NoError(t, err)
+		require.Contains(t, string(body), `"name":"renamed"`)
+	})
+
+	t.Run("rejects a document with neither", func(t *testing.T) {
+		_, err := normalizeRubricBody("x", []byte(`{"unrelated":true}`))
+		require.ErrorContains(t, err, "dimensions")
+	})
+
+	t.Run("rejects invalid JSON", func(t *testing.T) {
+		_, err := normalizeRubricBody("x", []byte(`not json`))
+		require.ErrorContains(t, err, "not valid JSON")
+	})
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_wiring_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/init_wiring_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func projectWith(names ...string) *azdext.ProjectConfig {
+	proj := &azdext.ProjectConfig{Services: map[string]*azdext.ServiceConfig{}}
+	for _, n := range names {
+		proj.Services[n] = &azdext.ServiceConfig{Name: n}
+	}
+	return proj
+}
+
+// The eval service is ordered after everything it reads, but only names
+// services the project actually declares. Naming one it does not have is a
+// broken reference, and an eval config can sit in a repo that reaches an
+// existing Foundry project by endpoint and an agent deployed elsewhere.
+func TestEvalServiceUses_OnlyWhatTheProjectDeclares(t *testing.T) {
+	assert.Nil(t, evalServiceUses(projectWith("api", "web"), "support-agent"),
+		"neither the project service nor the agent is declared, so there is nothing to order after")
+
+	withProject := projectWith("api", "support-agent")
+	withProject.Services["ai-project"] = &azdext.ServiceConfig{
+		Name: "ai-project", Host: aiProjectHost,
+	}
+	assert.Equal(t, []string{"ai-project", "support-agent"},
+		evalServiceUses(withProject, "support-agent"),
+		"the eval runs after the project it evaluates against and the agent it evaluates")
+
+	assert.Equal(t, []string{"support-agent"},
+		evalServiceUses(projectWith("support-agent"), "support-agent"),
+		"an agent alone is still worth ordering after")
+}
+
+// `init` detects the judge deployment from the project, because it makes no
+// service calls and this is the only place it can read one.
+func TestDetectModelDeployment(t *testing.T) {
+	assert.Empty(t, detectModelDeployment(projectWith("api", "web")))
+
+	proj := projectWith("api")
+	proj.Services["chat"] = &azdext.ServiceConfig{Name: "chat", Host: aiModelHost}
+	assert.Equal(t, "chat", detectModelDeployment(proj),
+		"the service name is the deployment name when nothing more specific is declared")
+
+	named := projectWith()
+	named.Services["chat"] = &azdext.ServiceConfig{
+		Name: "chat",
+		Host: aiModelHost,
+		AdditionalProperties: mustStruct(t, map[string]any{
+			"deployment": "gpt-5.6-luna",
+		}),
+	}
+	assert.Equal(t, "gpt-5.6-luna", detectModelDeployment(named))
+}
+
+func mustStruct(t *testing.T, m map[string]any) *structpb.Struct {
+	t.Helper()
+	s, err := structpb.NewStruct(m)
+	require.NoError(t, err)
+	return s
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/instruction_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/instruction_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A useful generation instruction is often longer than fits on a command
+// line, so it can come from a file instead.
+func TestResolveInstructionReadsFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "instruction.md")
+	require.NoError(t, os.WriteFile(path,
+		[]byte("  A customer support agent answering billing questions.\n\n"), 0o600))
+
+	got, err := resolveInstruction("", path)
+	require.NoError(t, err)
+	require.Equal(t, "A customer support agent answering billing questions.", got,
+		"surrounding whitespace should be trimmed")
+}
+
+func TestResolveInstructionPrefersInlineWhenNoFile(t *testing.T) {
+	got, err := resolveInstruction("inline text", "")
+	require.NoError(t, err)
+	require.Equal(t, "inline text", got)
+
+	got, err = resolveInstruction("", "")
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+// An unreadable or empty file is reported rather than silently generating from
+// no instruction at all.
+func TestResolveInstructionRejectsUnusableFile(t *testing.T) {
+	_, err := resolveInstruction("", filepath.Join(t.TempDir(), "absent.md"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "agent-instruction-file")
+
+	empty := filepath.Join(t.TempDir(), "empty.md")
+	require.NoError(t, os.WriteFile(empty, []byte("   \n"), 0o600))
+	_, err = resolveInstruction("", empty)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/job.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/job.go
@@ -1,0 +1,322 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/spf13/cobra"
+)
+
+// Generation runs as two independent long-running resources — one for datasets,
+// one for evaluators — sharing no collection. A job group therefore nests under
+// the resource that produced it: a top-level `job show <id>` would have to guess
+// the endpoint from an id prefix that is not a documented contract.
+
+const (
+	jobKindDataset   = "dataset"
+	jobKindEvaluator = "evaluator"
+)
+
+// jobKind binds a group to one generation resource, so every command under it
+// calls one endpoint rather than trying both and reporting whichever answered.
+type jobKind struct {
+	name   string
+	list   func(context.Context, *evalContext) ([]eval_api.GenerationJob, error)
+	get    func(context.Context, *evalContext, string) (*eval_api.GenerationJob, error)
+	cancel func(context.Context, *evalContext, string) (*eval_api.GenerationJob, error)
+	remove func(context.Context, *evalContext, string) error
+}
+
+// Data generation is the one collection on its own API version, so the job
+// commands have to ask for it the same way generate does. Evaluator generation
+// is on the project endpoint version, which is why only these four differ.
+var datasetJobs = jobKind{
+	name: jobKindDataset,
+	list: func(ctx context.Context, ec *evalContext) ([]eval_api.GenerationJob, error) {
+		out, err := ec.evalClient.ListDataGenerationJobs(ctx, DataGenerationAPIVersion)
+		if err != nil {
+			return nil, err
+		}
+		return out.Data, nil
+	},
+	get: func(ctx context.Context, ec *evalContext, id string) (*eval_api.GenerationJob, error) {
+		return ec.evalClient.GetDataGenerationJob(ctx, id, DataGenerationAPIVersion)
+	},
+	cancel: func(ctx context.Context, ec *evalContext, id string) (*eval_api.GenerationJob, error) {
+		return ec.evalClient.CancelDataGenerationJob(ctx, id, DataGenerationAPIVersion)
+	},
+	remove: func(ctx context.Context, ec *evalContext, id string) error {
+		return ec.evalClient.DeleteDataGenerationJob(ctx, id, DataGenerationAPIVersion)
+	},
+}
+
+var evaluatorJobs = jobKind{
+	name: jobKindEvaluator,
+	list: func(ctx context.Context, ec *evalContext) ([]eval_api.GenerationJob, error) {
+		out, err := ec.evalClient.ListEvaluatorGenerationJobs(ctx, ProjectEndpointAPIVersion)
+		if err != nil {
+			return nil, err
+		}
+		return out.Data, nil
+	},
+	get: func(ctx context.Context, ec *evalContext, id string) (*eval_api.GenerationJob, error) {
+		return ec.evalClient.GetEvaluatorGenerationJob(ctx, id, ProjectEndpointAPIVersion)
+	},
+	cancel: func(ctx context.Context, ec *evalContext, id string) (*eval_api.GenerationJob, error) {
+		return ec.evalClient.CancelEvaluatorGenerationJob(ctx, id, ProjectEndpointAPIVersion)
+	},
+	remove: func(ctx context.Context, ec *evalContext, id string) error {
+		return ec.evalClient.DeleteEvaluatorGenerationJob(ctx, id, ProjectEndpointAPIVersion)
+	},
+}
+
+// jobSelector binds a command to one of the two generation collections.
+//
+// Required here, unlike on `generate`: an id alone does not say which
+// collection to call, and the two share an id shape, so guessing would mean
+// trying both and reporting whichever answered.
+type jobSelector struct {
+	dataset   bool
+	evaluator bool
+}
+
+func (s *jobSelector) bind(cmd *cobra.Command) {
+	// "Required." leads, because the same two flag names are optional filters
+	// one command over on `generate`, and the help is the only thing that says
+	// which meaning applies here.
+	cmd.Flags().BoolVar(&s.dataset, "dataset", false,
+		"Required (or --evaluator). Act on dataset generation jobs.")
+	cmd.Flags().BoolVar(&s.evaluator, "evaluator", false,
+		"Required (or --dataset). Act on evaluator generation jobs.")
+	cmd.MarkFlagsMutuallyExclusive("dataset", "evaluator")
+	cmd.MarkFlagsOneRequired("dataset", "evaluator")
+}
+
+// kind resolves the selector. Total rather than defaulting: cobra enforces
+// that one flag is set, and if that enforcement is ever dropped a silent
+// default would query the wrong collection and report "not found".
+func (s *jobSelector) kind() (jobKind, error) {
+	switch {
+	case s.dataset && !s.evaluator:
+		return datasetJobs, nil
+	case s.evaluator && !s.dataset:
+		return evaluatorJobs, nil
+	default:
+		return jobKind{}, messages.JobKindRequired()
+	}
+}
+
+func newJobCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "job",
+		Short: "Inspect, cancel and delete generation jobs.",
+		Long: "Inspect, cancel and delete generation jobs.\n\n" +
+			"This is the resume path for `generate`: a job started with --no-wait, " +
+			"or one whose client was interrupted, is reattached to here rather than " +
+			"restarted.\n\n" +
+			"Pass --dataset or --evaluator to say which generation to act on. " +
+			"The two are separate service collections, so it is required.",
+	}
+	cmd.AddCommand(
+		newJobListCommand(),
+		newJobShowCommand(),
+		newJobCancelCommand(),
+		newJobDeleteCommand(),
+	)
+	return cmd
+}
+
+func newJobListCommand() *cobra.Command {
+	var endpointFlg string
+	sel := &jobSelector{}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List the project's generation jobs.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			kind, err := sel.kind()
+			if err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			jobs, err := kind.list(ctx, ec)
+			if err != nil {
+				return messages.ListingJobs(kind.name, err)
+			}
+
+			if isJSON(cmd) {
+				return emitJSONList(cmd.OutOrStdout(), jobs)
+			}
+			if len(jobs) == 0 {
+				fmt.Fprint(cmd.OutOrStdout(), messages.NoJobs(kind.name))
+				return nil
+			}
+			table := make([][]string, 0, len(jobs))
+			for _, j := range jobs {
+				table = append(table, []string{j.ID, j.Status})
+			}
+			return emitTable(cmd.OutOrStdout(), []string{"JOB ID", "STATUS"}, table)
+		},
+	}
+
+	sel.bind(cmd)
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+func newJobShowCommand() *cobra.Command {
+	var endpointFlg string
+	sel := &jobSelector{}
+
+	cmd := &cobra.Command{
+		Use:   "show <job-id>",
+		Short: "Show a generation job.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			jobID := args[0]
+			kind, err := sel.kind()
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			job, err := kind.get(ctx, ec, jobID)
+			if err != nil {
+				return jobLookupError("reading", kind, jobID, err)
+			}
+
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), job)
+			}
+			fmt.Fprint(cmd.OutOrStdout(), messages.JobLine(job.ID, job.Status))
+			if job.Error != nil && job.Error.Message != "" {
+				fmt.Fprint(cmd.OutOrStdout(), messages.JobErrorLine(job.Error.Message))
+			}
+			return nil
+		},
+	}
+
+	sel.bind(cmd)
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+func newJobCancelCommand() *cobra.Command {
+	var endpointFlg string
+	sel := &jobSelector{}
+
+	cmd := &cobra.Command{
+		Use:   "cancel <job-id>",
+		Short: "Cancel an in-flight generation job.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			jobID := args[0]
+			kind, err := sel.kind()
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			canceled, err := kind.cancel(ctx, ec, jobID)
+			if err != nil {
+				return jobLookupError("cancelling", kind, jobID, err)
+			}
+
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), canceled)
+			}
+			fmt.Fprint(cmd.OutOrStdout(),
+				messages.JobCancelled(kind.name, jobID, canceled.Status))
+			return nil
+		},
+	}
+
+	sel.bind(cmd)
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+func newJobDeleteCommand() *cobra.Command {
+	var endpointFlg string
+	sel := &jobSelector{}
+
+	cmd := &cobra.Command{
+		Use:   "delete <job-id>",
+		Short: "Delete a generation job record.",
+		Long: "Delete a generation job record.\n\n" +
+			"The artifact the job produced is already registered as its own version " +
+			"and is not affected.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			jobID := args[0]
+			kind, err := sel.kind()
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			if err := kind.remove(ctx, ec, jobID); err != nil {
+				return jobLookupError("deleting", kind, jobID, err)
+			}
+
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), map[string]string{
+					"id": jobID, "kind": kind.name, "status": "deleted",
+				})
+			}
+			fmt.Fprint(cmd.OutOrStdout(), messages.JobDeleted(kind.name, jobID))
+			return nil
+		},
+	}
+
+	sel.bind(cmd)
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// jobLookupError names the sibling group, because the two job types share an id
+// shape and reaching for the wrong one is the likely mistake.
+//
+// action is what the caller was doing, so a failed delete does not report that
+// a read failed.
+func jobLookupError(action string, kind jobKind, jobID string, err error) error {
+	if eval_api.IsNotFound(err) {
+		other := jobKindEvaluator
+		if kind.name == jobKindEvaluator {
+			other = jobKindDataset
+		}
+		return messages.JobNotFound(kind.name, jobID, other)
+	}
+	return messages.JobActionFailed(action, kind.name, jobID, err)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/jsonl_validation_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/jsonl_validation_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeJSONL(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "d.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
+}
+
+// The service accepts whatever bytes it is given, so a malformed row becomes a
+// published version with an eval bound to it, and only fails much later
+// on a row nobody has looked at. A live deploy published `{not json at all}`
+// as version 1.0 before this existed.
+func TestValidateJSONL_RejectsAMalformedRowByLine(t *testing.T) {
+	err := validateJSONL(writeJSONL(t, "{\"query\":\"fine\"}\n{not json at all}\n"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "line 2")
+	assert.Contains(t, err.Error(), "one JSON object")
+}
+
+func TestValidateJSONL_AcceptsWellFormedRows(t *testing.T) {
+	assert.NoError(t, validateJSONL(writeJSONL(t,
+		"{\"query\":\"a\"}\n{\"query\":\"b\"}\n")))
+}
+
+// Trailing and interior blank lines are formatting, not rows.
+func TestValidateJSONL_IgnoresBlankLines(t *testing.T) {
+	assert.NoError(t, validateJSONL(writeJSONL(t,
+		"{\"query\":\"a\"}\n\n{\"query\":\"b\"}\n\n")))
+}
+
+// A file with nothing in it publishes a version that can never score anything.
+func TestValidateJSONL_RejectsAFileWithNoRows(t *testing.T) {
+	err := validateJSONL(writeJSONL(t, "\n\n"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no rows")
+}
+
+// A JSON array is the shape people reach for when they mean JSONL.
+func TestValidateJSONL_RejectsAJSONArray(t *testing.T) {
+	err := validateJSONL(writeJSONL(t, "[{\"query\":\"a\"},{\"query\":\"b\"}]\n"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "line 1")
+}
+
+// An empty object parses but evaluates to nothing.
+func TestValidateJSONL_RejectsAnEmptyObject(t *testing.T) {
+	err := validateJSONL(writeJSONL(t, "{\"query\":\"a\"}\n{}\n"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "line 2")
+	assert.Contains(t, err.Error(), "empty object")
+}
+
+// A conversation-level row holds a whole transcript and runs past bufio's
+// default 64KB line limit, which would otherwise be reported as invalid JSON.
+func TestValidateJSONL_AcceptsAVeryLongRow(t *testing.T) {
+	long := make([]byte, 200*1024)
+	for i := range long {
+		long[i] = 'x'
+	}
+	assert.NoError(t, validateJSONL(writeJSONL(t,
+		"{\"query\":\""+string(long)+"\"}\n")))
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/legacy_trace_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/legacy_trace_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/project"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A run reattached by id repeats the data source the last one sent, so an eval
+// whose last run predates the preview shape would keep sending the old one for
+// good. The old shape carried no agent version, which is the whole reason to
+// move off it.
+func TestPinReusedTraceWindow_MovesTheLegacyShapeOn(t *testing.T) {
+	ds := pinReusedTraceWindow(&eval_api.EvalRunDataSource{
+		Type:          eval_api.EvalRunDataSourceTypeTraces,
+		AgentName:     "support-agent",
+		LookbackHours: 24,
+		MaxTraces:     500,
+	})
+
+	require.NotNil(t, ds.TraceSource)
+	assert.Equal(t, eval_api.EvalRunDataSourceTypeTracePreview, ds.Type)
+	assert.Equal(t, "agent_filter", ds.TraceSource.Type)
+	assert.Equal(t, "support-agent", ds.TraceSource.AgentName)
+	assert.Equal(t, 500, ds.TraceSource.MaxTraces)
+	assert.InDelta(t, time.Now().Add(-24*time.Hour).Unix(), ds.TraceSource.StartTime, 60)
+	// Nothing was pinned before, so nothing is pinned now: the upgrade must not
+	// invent a version the previous runs were never graded against.
+	assert.Empty(t, ds.TraceSource.AgentVersion)
+}
+
+// A window with a start and no end means "up to now", so replaying it a week
+// later grades a week more than the run it was copied from, and the run after
+// that more again. Both ends are written down, whatever shape the window
+// arrived in, so the span cannot grow with each reattach.
+func TestPinReusedTraceWindow_ClosesAWindowSoItCannotWiden(t *testing.T) {
+	cases := []struct {
+		name string
+		ds   *eval_api.EvalRunDataSource
+	}{
+		{
+			"a legacy source",
+			&eval_api.EvalRunDataSource{
+				Type:          eval_api.EvalRunDataSourceTypeTraces,
+				AgentName:     "support-agent",
+				LookbackHours: 24,
+			},
+		},
+		{
+			// The shape this extension writes today. Pinning only the legacy
+			// one left the current one growing in exactly the way the legacy
+			// handling exists to prevent.
+			"a source this extension wrote",
+			&eval_api.EvalRunDataSource{
+				Type: eval_api.EvalRunDataSourceTypeTracePreview,
+				TraceSource: &eval_api.TraceSourceFilter{
+					Type:      "agent_filter",
+					AgentName: "support-agent",
+					StartTime: time.Now().Add(-24 * time.Hour).Unix(),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := pinReusedTraceWindow(tc.ds)
+
+			require.NotNil(t, ds.TraceSource)
+			assert.InDelta(t, time.Now().Unix(), ds.TraceSource.EndTime, 60)
+			assert.InDelta(t, int64(24*3600), ds.TraceSource.EndTime-ds.TraceSource.StartTime, 60)
+
+			// An already-closed window is repeated rather than re-pinned, so
+			// the span cannot creep run after run. Asserted by identity: two
+			// calls a microsecond apart write the same second, so comparing
+			// the values would pass with the guard deleted.
+			assert.Same(t, ds, pinReusedTraceWindow(ds))
+		})
+	}
+}
+
+// The old shape had no start bound, so a run that set no lookback was graded
+// over whatever the service chose. Carrying it forward with no start would
+// widen it to all of history instead.
+func TestPinReusedTraceWindow_KeepsTheWindowALegacyRunRanUnder(t *testing.T) {
+	ds := pinReusedTraceWindow(&eval_api.EvalRunDataSource{
+		Type:      eval_api.EvalRunDataSourceTypeTraces,
+		AgentName: "support-agent",
+	})
+
+	require.NotNil(t, ds.TraceSource)
+	assert.Equal(t, int64(24*7*3600), ds.TraceSource.EndTime-ds.TraceSource.StartTime)
+}
+
+// The recorded values come from an older build, from before the bounds existed.
+// A lookback past the bound reaches back further than a window may cover, and a
+// negative cap is no cap at all: left as zero it is dropped from the request,
+// which means the service's own default of a thousand traces -- a bigger and
+// costlier run than the one being repeated.
+func TestPinReusedTraceWindow_ClampsWhatAnOlderBuildRecorded(t *testing.T) {
+	ds := pinReusedTraceWindow(&eval_api.EvalRunDataSource{
+		Type:          eval_api.EvalRunDataSourceTypeTraces,
+		AgentName:     "support-agent",
+		LookbackHours: project.MaxLookbackHours + 1,
+		MaxTraces:     -5,
+	})
+
+	require.NotNil(t, ds.TraceSource)
+	assert.Greater(t, ds.TraceSource.EndTime, ds.TraceSource.StartTime)
+	assert.Equal(t, int64(24*7*3600), ds.TraceSource.EndTime-ds.TraceSource.StartTime)
+	assert.Equal(t, project.DefaultScaffoldMaxTraces, ds.TraceSource.MaxTraces,
+		"a bounded cap, rather than none at all")
+}
+
+// An end bound anchors the window it closes, rather than being read alongside a
+// start measured from now: a run that ended a month ago covered the week before
+// that, not the week before today.
+func TestPinReusedTraceWindow_MeasuresBackFromTheEnd(t *testing.T) {
+	end := time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC)
+
+	ds := pinReusedTraceWindow(&eval_api.EvalRunDataSource{
+		Type:          eval_api.EvalRunDataSourceTypeTraces,
+		AgentName:     "support-agent",
+		LookbackHours: 24,
+		EndTime:       end.Unix(),
+	})
+
+	require.NotNil(t, ds.TraceSource)
+	assert.Equal(t, end.Unix(), ds.TraceSource.EndTime)
+	assert.Equal(t, end.Add(-24*time.Hour).Unix(), ds.TraceSource.StartTime)
+}
+
+// Anything that is not an open trace window is repeated exactly, so a source
+// this extension has never heard of is not quietly replaced with one it made up.
+func TestPinReusedTraceWindow_LeavesEverythingElseAlone(t *testing.T) {
+	assert.Nil(t, pinReusedTraceWindow(nil))
+
+	closed := &eval_api.EvalRunDataSource{
+		Type: eval_api.EvalRunDataSourceTypeTracePreview,
+		TraceSource: &eval_api.TraceSourceFilter{
+			Type: "agent_filter", AgentName: "a", StartTime: 7, EndTime: 8,
+		},
+	}
+	assert.Same(t, closed, pinReusedTraceWindow(closed))
+
+	jsonl := &eval_api.EvalRunDataSource{Type: eval_api.EvalRunDataSourceTypeJSONL}
+	assert.Same(t, jsonl, pinReusedTraceWindow(jsonl))
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/listen.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/listen.go
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+
+	"azureaieval/internal/project"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/spf13/cobra"
+)
+
+// newListenCommand registers the service-target provider with azd. It is hidden
+// and invoked by azd itself, not by users.
+func newListenCommand() *cobra.Command {
+	return azdext.NewListenCommand(configureExtensionHost)
+}
+
+// configureExtensionHost wires the azure.ai.eval service target so `azd up` and
+// `azd deploy` reach this extension. The provider name must match the manifest.
+func configureExtensionHost(host *azdext.ExtensionHost) {
+	azdClient := host.Client()
+
+	host.WithServiceTarget(project.EvalHost, func() azdext.ServiceTargetProvider {
+		return project.NewEvalServiceTargetProvider(
+			azdClient,
+			func(ctx context.Context) (project.Reconciler, error) {
+				return newEvalReconciler(ctx)
+			},
+		)
+	})
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/main_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/main_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/fatih/color"
+)
+
+// TestMain pins colour off for the whole package.
+//
+// fatih/color decides once, at init, from whether the process's stdout is a
+// terminal -- not from the writer a renderer was handed. `go test` pipes
+// stdout, so a test asserting on plain text passes under `go test` and fails
+// when the compiled test binary is run from a terminal. Pinning it here makes
+// the expected output the same either way, rather than leaving every assertion
+// on a rendered line to depend on how the suite was started.
+func TestMain(m *testing.M) {
+	color.NoColor = true
+	os.Exit(m.Run())
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/manifest_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/manifest_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+)
+
+// extensionManifest is the subset of extension.yaml this test asserts on.
+type extensionManifest struct {
+	ID           string   `yaml:"id"`
+	Version      string   `yaml:"version"`
+	Capabilities []string `yaml:"capabilities"`
+	Providers    []struct {
+		Name string `yaml:"name"`
+		Type string `yaml:"type"`
+	} `yaml:"providers"`
+}
+
+func loadManifest(t *testing.T) extensionManifest {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "extension.yaml"))
+	require.NoError(t, err, "reading extension.yaml")
+
+	var manifest extensionManifest
+	require.NoError(t, yaml.Unmarshal(raw, &manifest))
+	return manifest
+}
+
+// A declared capability azd cannot reach is worse than an undeclared one: azd
+// invokes `metadata` to discover the command tree, and it was declared without
+// the command being registered, so discovery failed with "unknown command".
+func TestDeclaredCapabilitiesAreImplemented(t *testing.T) {
+	manifest := loadManifest(t)
+	root := NewRootCommand()
+
+	hasCommand := func(name string) bool {
+		for _, sub := range root.Commands() {
+			if sub.Name() == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, capability := range manifest.Capabilities {
+		switch capability {
+		case "metadata":
+			require.True(t, hasCommand("metadata"),
+				"the metadata capability requires a metadata command")
+		case "service-target-provider":
+			require.True(t, hasCommand("listen"),
+				"a service-target provider is registered through the listen command")
+			require.NotEmpty(t, manifest.Providers,
+				"the manifest must name the provider it registers")
+		case "custom-commands":
+			require.NotEmpty(t, root.Commands())
+		case "lifecycle-events":
+			// The SDK only starts the event manager when handlers are
+			// registered, so declaring this without any is an unused
+			// permission. Nothing here registers handlers today.
+			t.Fatalf("lifecycle-events is declared but no event handlers are registered")
+		}
+	}
+}
+
+// The provider name in the manifest is what azd matches a service's `host`
+// against, so a mismatch silently means the provider is never invoked.
+func TestManifestProviderMatchesHostConstant(t *testing.T) {
+	manifest := loadManifest(t)
+	require.NotEmpty(t, manifest.Providers)
+
+	names := make([]string, 0, len(manifest.Providers))
+	for _, p := range manifest.Providers {
+		names = append(names, p.Name)
+	}
+	require.Contains(t, names, "azure.ai.eval",
+		"the manifest must declare the host the provider registers for")
+}
+
+// extension.yaml carries a note asking that version.txt be kept in sync. The
+// build stamps the binary from version.txt while the registry reads
+// extension.yaml, so a drift ships a binary that misreports its own version.
+func TestManifestVersionMatchesVersionFile(t *testing.T) {
+	manifest := loadManifest(t)
+
+	raw, err := os.ReadFile(filepath.Join("..", "..", "version.txt"))
+	require.NoError(t, err, "reading version.txt")
+
+	require.Equal(t,
+		strings.TrimSpace(string(raw)),
+		strings.TrimSpace(manifest.Version),
+		"version.txt and extension.yaml must agree")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/mutable_metadata_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/mutable_metadata_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/project"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordedUpdate is the body of an update the reconciler pushed, or nil when it
+// pushed nothing.
+type recordedUpdate struct {
+	body *eval_api.UpdateOpenAIEvalRequest
+}
+
+// reconcilerHoldingEval builds a reconciler whose service holds this eval, and
+// records any update pushed to it.
+func reconcilerHoldingEval(
+	t *testing.T,
+	held eval_api.OpenAIEval,
+) (*evalReconciler, *recordedUpdate) {
+	t.Helper()
+	seen := &recordedUpdate{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// assert, not require: this runs on the server's goroutine, and FailNow
+		// there aborts mid-response and fails whichever test is running instead.
+		if r.Method == http.MethodPost {
+			raw, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+			var body eval_api.UpdateOpenAIEvalRequest
+			assert.NoError(t, json.Unmarshal(raw, &body))
+			seen.body = &body
+		}
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(held))
+	}))
+	t.Cleanup(srv.Close)
+
+	pipeline := runtime.NewPipeline("test", "v1", runtime.PipelineOptions{},
+		&policy.ClientOptions{Retry: policy.RetryOptions{MaxRetries: -1}})
+	return &evalReconciler{ec: &evalContext{
+		evalClient: eval_api.NewEvalClientFromPipeline(srv.URL, pipeline),
+	}}, seen
+}
+
+// A description is excluded from the fingerprint so that editing it does not
+// fork the run history. Excluding it from the digest is not the same as
+// ignoring it: the edit still has to reach the service, and this reuse path is
+// the only place it can.
+func TestPushMutableSendsAnEditedDescription(t *testing.T) {
+	r, seen := reconcilerHoldingEval(t, eval_api.OpenAIEval{
+		ID:       "eval-1",
+		Name:     "support-gate",
+		Metadata: map[string]string{metaEvalName: "support-gate", metaDescription: "old wording"},
+	})
+
+	r.pushMutable(context.Background(), "eval-1", project.Eval{
+		Name:        "support-gate",
+		Description: "new wording",
+	}, &eval_api.OpenAIEval{
+		ID:       "eval-1",
+		Name:     "support-gate",
+		Metadata: map[string]string{metaEvalName: "support-gate", metaDescription: "old wording"},
+	})
+
+	require.NotNil(t, seen.body, "an edited description must be pushed")
+	assert.Equal(t, "new wording", seen.body.Metadata[metaDescription])
+	assert.Equal(t, "support-gate", seen.body.Name, "the name rides along unchanged")
+}
+
+// A rename is applied in place rather than forking the history.
+func TestPushMutableSendsARename(t *testing.T) {
+	held := eval_api.OpenAIEval{ID: "eval-1", Name: "old-name"}
+	r, seen := reconcilerHoldingEval(t, held)
+
+	r.pushMutable(context.Background(), "eval-1",
+		project.Eval{Name: "new-name"}, &held)
+
+	require.NotNil(t, seen.body)
+	assert.Equal(t, "new-name", seen.body.Name)
+}
+
+// Every deploy walks this path, so an unchanged declaration must stay silent.
+// Pushing regardless would write to the service on every `azd up`.
+func TestPushMutableIsSilentWhenNothingChanged(t *testing.T) {
+	held := eval_api.OpenAIEval{
+		ID:       "eval-1",
+		Name:     "support-gate",
+		Metadata: map[string]string{metaEvalName: "support-gate", metaDescription: "wording"},
+	}
+	r, seen := reconcilerHoldingEval(t, held)
+
+	r.pushMutable(context.Background(), "eval-1", project.Eval{
+		Name:        "support-gate",
+		Description: "wording",
+	}, &held)
+
+	assert.Nil(t, seen.body, "an unchanged eval must not be written to")
+}
+
+// Deleting the line from the config is an edit like any other.
+func TestPushMutableClearsARemovedDescription(t *testing.T) {
+	held := eval_api.OpenAIEval{
+		ID:       "eval-1",
+		Name:     "support-gate",
+		Metadata: map[string]string{metaDescription: "wording that was deleted"},
+	}
+	r, seen := reconcilerHoldingEval(t, held)
+
+	r.pushMutable(context.Background(), "eval-1",
+		project.Eval{Name: "support-gate"}, &held)
+
+	require.NotNil(t, seen.body)
+	assert.NotContains(t, seen.body.Metadata, metaDescription)
+}
+
+// The update replaces metadata rather than merging it, so anything the service
+// or another writer put there has to be carried across or it is dropped.
+func TestWithDescriptionKeepsMetadataItDoesNotOwn(t *testing.T) {
+	held := map[string]string{
+		metaEvalName:    "support-gate",
+		metaAgent:       "support-agent",
+		"service_added": "keep me",
+	}
+
+	merged := withDescription(held, "new wording")
+
+	assert.Equal(t, "new wording", merged[metaDescription])
+	assert.Equal(t, "keep me", merged["service_added"])
+	assert.Equal(t, "support-agent", merged[metaAgent])
+	assert.NotContains(t, held, metaDescription, "the held map must not be mutated")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/names.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/names.go
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import "regexp"
+
+// assetNamePattern is what the service accepts for a dataset name. Its own
+// refusal is a 400 carrying four levels of nested JSON, and the sentence that
+// matters is at the bottom of it.
+//
+// This extension carries its own copy of the dataset commands, so it needs its
+// own copy of the guard: without it the same mistyped name is refused clearly
+// by `azd ai dataset` and obscurely by `azd ai eval dataset`.
+var assetNamePattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+const assetNameMaxLength = 255
+
+// validAssetName reports whether the service will accept this name, so a
+// mistyped one is refused before a round trip rather than after.
+func validAssetName(name string) bool {
+	if name == "" || len(name) > assetNameMaxLength {
+		return false
+	}
+	return assetNamePattern.MatchString(name)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/no_environment_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/no_environment_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// azd reports "there is no environment" as an ERROR, not as an empty answer:
+//
+//	if defaultEnvironment == "" {
+//	    return nil, environment.ErrDefaultEnvironmentNotFound
+//	}
+//
+// So a check that treats every error as "could not ask" can never conclude
+// there is no environment, and the diagnostic that names `azd env new` is
+// unreachable -- which is what the first version of this did. Equally, treating
+// every error as "no environment" would tell someone whose azd hiccupped to
+// create an environment they already have.
+//
+// The only caller reads these off a gRPC call, so every error carries a status.
+// These are the shapes that reach it.
+func TestNoDefaultEnvironmentIsToldApartFromAFailureToAsk(t *testing.T) {
+	// The text of azd's environment.ErrDefaultEnvironmentNotFound.
+	const azdText = "default environment not found"
+
+	assert.True(t,
+		isNoDefaultEnvironmentError(status.Error(codes.Unknown, azdText)),
+		"the sentinel, as azd wraps it in a gRPC status")
+	assert.True(t,
+		isNoDefaultEnvironmentError(fmt.Errorf("getting environment: %w",
+			status.Error(codes.Unknown, azdText))),
+		"and wrapped again by a caller")
+	// Outside a project there is nowhere an id could have been recorded, which
+	// is the same answer for this caller. Missing it told anyone running
+	// standalone to publish an eval that may already exist.
+	assert.True(t,
+		isNoDefaultEnvironmentError(status.Error(codes.Unknown,
+			"no project exists; to create a new project, run `azd init`")),
+		"outside a project there is no environment either")
+
+	assert.False(t,
+		isNoDefaultEnvironmentError(status.Error(codes.Unavailable, "connection refused")),
+		"azd being unreachable is not an answer about environments")
+	assert.False(t,
+		isNoDefaultEnvironmentError(status.Error(codes.DeadlineExceeded, "context deadline exceeded")),
+		"nor is a timeout")
+	assert.False(t,
+		isNoDefaultEnvironmentError(status.Error(codes.Unknown, "loading project state: permission denied")),
+		"nor is a daemon that broke while looking")
+	assert.False(t, isNoDefaultEnvironmentError(nil), "nor is success")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/output.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/output.go
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/project"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+const outputJSON = "json"
+
+// writePortalLink closes a detail view with the asset's portal URL.
+//
+// Last line and cyan, matching the sibling extensions, and silent when there is
+// no URL — the link is a convenience on top of work already done, so its
+// absence must not look like a failure.
+func writePortalLink(w io.Writer, url string) {
+	if url == "" {
+		return
+	}
+	fmt.Fprint(w, messages.PortalLink(color.CyanString(url)))
+}
+
+// runLink is the one link a run has.
+//
+// The service sends report_url and the extension builds its own portal URL, and
+// the two resolve to the same page. Printing both put two labels on one
+// destination with no rule a reader could infer, so the service's value wins and
+// ours is the fallback that keeps the link from going missing. Callers format
+// it themselves, because the three views that show it are laid out differently.
+func runLink(reportURL, portalURL string) string {
+	if reportURL != "" {
+		return reportURL
+	}
+	return portalURL
+}
+
+// outputFormat reads the inherited -o/--output flag.
+func outputFormat(cmd *cobra.Command) string {
+	if cmd == nil {
+		return ""
+	}
+	v, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(v)
+}
+
+// isJSON reports whether the command should emit machine-readable output.
+func isJSON(cmd *cobra.Command) bool {
+	return outputFormat(cmd) == outputJSON
+}
+
+// noPrompt reports whether the caller asked for no interaction.
+//
+// JSON output counts: a prompt written into a document nobody is reading is a
+// hang, not a question.
+func noPrompt(cmd *cobra.Command) bool {
+	if isJSON(cmd) {
+		return true
+	}
+	value, err := cmd.Flags().GetBool("no-prompt")
+	return err == nil && value
+}
+
+// commandContext is cmd.Context() with cobra's pre-Execute nil made safe.
+// gRPC dereferences the context it is handed, so a nil one is a panic rather
+// than a failed call.
+func commandContext(cmd *cobra.Command) context.Context {
+	if ctx := cmd.Context(); ctx != nil {
+		return ctx
+	}
+	return context.Background()
+}
+
+// emitJSON writes v as indented JSON.
+func emitJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// emitJSONList writes items as a JSON array.
+//
+// List commands emit a bare array rather than the envelope the service replied
+// with. The envelopes disagree with each other — the OpenAI-shaped APIs wrap
+// results in `data`, the ARM-shaped ones in `value` — so passing them through
+// would make a caller's parsing depend on which service happens to back a given
+// command. They also carry paging fields that this extension does not follow,
+// which would suggest there is more to fetch when there is not.
+//
+// A nil slice encodes as `null`, so it is normalized to an empty array: a
+// caller iterating the result should see no elements, not a type error.
+func emitJSONList[T any](w io.Writer, items []T) error {
+	if items == nil {
+		items = []T{}
+	}
+	return emitJSON(w, items)
+}
+
+// emitTable writes a list view: uppercase headers over a rule, tab-aligned.
+//
+// The rule is what separates the header from the data at a glance, and it is
+// what `azure.ai.skills` prints, so a reader moving between the Foundry
+// extensions sees one table.
+func emitTable(w io.Writer, headers []string, rows [][]string) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	if _, err := fmt.Fprintln(tw, strings.Join(headers, "\t")); err != nil {
+		return err
+	}
+	rule := make([]string, len(headers))
+	for i, h := range headers {
+		rule[i] = strings.Repeat("-", len(h))
+	}
+	if _, err := fmt.Fprintln(tw, strings.Join(rule, "\t")); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if _, err := fmt.Fprintln(tw, strings.Join(row, "\t")); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+// field is one row of a detail view.
+type field struct {
+	Key   string // Title Case, per the azd style guide
+	Value string
+}
+
+// emitDetail writes a two-column key/value view, the shape `show` uses.
+//
+// Empty values are dropped rather than printed blank: a detail view is read to
+// learn what a thing is, and a column of empty keys says only that the writer
+// did not know which fields this kind has.
+func emitDetail(w io.Writer, fields []field) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	for _, f := range fields {
+		if f.Value == "" {
+			continue
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\n", f.Key, f.Value); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+// requireFlag returns an error naming a flag the command needs and has no way
+// to settle for itself.
+func requireFlag(name string) error {
+	return messages.FlagRequired(name)
+}
+
+// writeFileAtomic replaces a file's contents in one step.
+//
+// The caller is usually overwriting a definition the developer already has and
+// wants to keep working with, so a half-written file is worse than no write at
+// all: os.WriteFile truncates first, and a failure after that leaves the good
+// local copy destroyed.
+//
+// Every error names the path the caller passed. The temporary file is this
+// function's business and appears nowhere the caller asked for.
+func writeFileAtomic(path string, body []byte) error {
+	// Refuse anything that is not a regular file: pointed at a directory, the
+	// replacement below would report a confusing rename failure instead.
+	switch info, err := os.Stat(path); {
+	case err == nil && !info.Mode().IsRegular():
+		return messages.NotARegularFile(path)
+	case err != nil && !errors.Is(err, os.ErrNotExist):
+		return messages.Creating(path, err)
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".azd-eval-*")
+	if err != nil {
+		return messages.CannotWriteInDirectory(dir, err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(body); err != nil {
+		_ = tmp.Close()
+		return messages.Creating(path, err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return messages.Creating(path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return messages.Creating(path, err)
+	}
+	if err := project.ReplaceFile(tmpName, path); err != nil {
+		return messages.Creating(path, err)
+	}
+	return nil
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/output_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/output_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The list commands are backed by two different services whose envelopes
+// disagree — `data` on one side, `value` on the other. Emitting whichever one
+// came back would make a caller's parsing depend on that accident, so every
+// list emits a bare array instead.
+func TestEmitJSONList_EmitsAnArrayNotAnEnvelope(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, emitJSONList(&buf, []string{"a", "b"}))
+	assert.Equal(t, "[\n  \"a\",\n  \"b\"\n]\n", buf.String())
+}
+
+// A nil slice marshals to `null`, which a caller iterating the output cannot
+// range over. An empty listing has to come back as an empty array.
+func TestEmitJSONList_NilBecomesEmptyArray(t *testing.T) {
+	var buf bytes.Buffer
+	var none []string
+	require.NoError(t, emitJSONList(&buf, none))
+	assert.Equal(t, "[]\n", buf.String())
+}
+
+// `evaluator show --output-file` is pointed at a definition the developer is
+// still working with, so a write that cannot complete must leave the old one
+// intact rather than truncate it.
+func TestWriteFileAtomic(t *testing.T) {
+	t.Run("replaces an existing file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "evaluator.json")
+		require.NoError(t, os.WriteFile(path, []byte("old"), 0o600))
+		require.NoError(t, writeFileAtomic(path, []byte("new")))
+
+		body, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, "new", string(body))
+	})
+
+	t.Run("creates a file that was not there", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "evaluator.json")
+		require.NoError(t, writeFileAtomic(path, []byte("new")))
+
+		body, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, "new", string(body))
+	})
+
+	t.Run("a directory is refused, not removed", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "evaluator.json")
+		require.NoError(t, os.Mkdir(path, 0o750))
+
+		require.Error(t, writeFileAtomic(path, []byte("new")))
+
+		info, err := os.Stat(path)
+		require.NoError(t, err, "the directory must survive")
+		assert.True(t, info.IsDir())
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Len(t, entries, 1, "no temporary file may be left behind")
+	})
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/portal_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/portal_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The portal link is the last line of a detail view, and it is the one thing a
+// user clicks to see the run they just waited for.
+func TestWritePortalLink(t *testing.T) {
+	var buf bytes.Buffer
+	writePortalLink(&buf, "https://ai.azure.com/nextgen/r/x,y,,z,p/build/evaluations/e/run/r")
+
+	out := buf.String()
+	assert.Contains(t, out, "Portal: ")
+	assert.Contains(t, out, "/build/evaluations/e/run/r")
+	assert.True(t, strings.HasSuffix(out, "\n"), "it closes the view, so it ends the line")
+}
+
+// Resolution is best effort: the link is a convenience on top of work already
+// done, so having none must print nothing rather than an empty label that
+// reads like a failure.
+func TestWritePortalLink_SilentWithoutAURL(t *testing.T) {
+	var buf bytes.Buffer
+	writePortalLink(&buf, "")
+
+	assert.Empty(t, buf.String())
+}
+
+// Colour is pinned off for the rest of the package, which leaves nothing
+// exercising the branch that actually runs in a terminal. The escape codes have
+// to wrap the URL and nothing else: one leaking into the label, or past the
+// newline, follows the link into whatever a reader pastes it in.
+func TestWritePortalLink_WrapsOnlyTheURL(t *testing.T) {
+	restore := color.NoColor
+	color.NoColor = false
+	t.Cleanup(func() { color.NoColor = restore })
+
+	var buf bytes.Buffer
+	writePortalLink(&buf, "https://ai.azure.com/x")
+
+	assert.Equal(t, "Portal: \x1b[36mhttps://ai.azure.com/x\x1b[0m\n", buf.String())
+}
+
+// `-o json` carries the same link the terminal prints, so a pipeline reading
+// JSON is not the one consumer that cannot find the run in the portal.
+func TestRunPortalURLTravelsInJSON(t *testing.T) {
+	run := &eval_api.OpenAIEvalRun{
+		ID:        "evalrun_1",
+		Status:    "completed",
+		PortalURL: "https://ai.azure.com/nextgen/r/x,y,,z,p/build/evaluations/eval_1/run/evalrun_1",
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, emitJSON(&buf, run))
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	assert.Equal(t, run.PortalURL, decoded["portal_url"],
+		"the key is portal_url, which is what the spec tells consumers to read")
+}
+
+// A run with no portal link must not carry an empty key, or a consumer cannot
+// tell "no link" from "link is the empty string".
+func TestRunWithoutPortalURLOmitsTheKey(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, emitJSON(&buf, &eval_api.OpenAIEvalRun{ID: "evalrun_1"}))
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	assert.NotContains(t, decoded, "portal_url")
+}
+
+// The portal URL is built from the eval and run ids, which is what makes the
+// link land on the run rather than the eval's list of them.
+func TestPortalRunURLShape(t *testing.T) {
+	prefix, err := eval_api.NewPortalPrefix(
+		"/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/rg/" +
+			"providers/Microsoft.CognitiveServices/accounts/acct/projects/proj")
+	require.NoError(t, err)
+
+	assert.True(t, strings.HasSuffix(
+		prefix.EvalRunURL("eval_1", "evalrun_9"),
+		"/build/evaluations/eval_1/run/evalrun_9"))
+}
+
+// A run has one destination. The service's report_url and the portal URL the
+// extension builds resolve to the same page, and printing both put two labels
+// on it with no rule a reader could infer.
+func TestRenderRunPrintsOneLink(t *testing.T) {
+	run := &eval_api.OpenAIEvalRun{
+		ID:        "evalrun_1",
+		Status:    "completed",
+		ReportURL: "https://service.example/report/1",
+		PortalURL: "https://ai.azure.com/nextgen/r/x,y,,z,p/build/evaluations/e/run/r",
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, renderRun(&buf, run, nil))
+
+	out := buf.String()
+	assert.Contains(t, out, "Report: https://service.example/report/1",
+		"the service's url wins where it sent one")
+	assert.NotContains(t, out, "Portal: ",
+		"the second label named the same destination")
+	assert.NotContains(t, out, run.PortalURL)
+}
+
+// Ours is the fallback, so a service that sends no report_url does not leave
+// the reader with no way to open the run.
+func TestRenderRunFallsBackToTheBuiltLink(t *testing.T) {
+	run := &eval_api.OpenAIEvalRun{
+		ID:        "evalrun_1",
+		Status:    "completed",
+		PortalURL: "https://ai.azure.com/nextgen/r/x,y,,z,p/build/evaluations/e/run/r",
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, renderRun(&buf, run, nil))
+
+	assert.Contains(t, buf.String(), "Report: "+run.PortalURL)
+}
+
+// A run with neither prints no link rather than an empty label.
+func TestRenderRunOmitsAnAbsentLink(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, renderRun(&buf, &eval_api.OpenAIEvalRun{
+		ID: "evalrun_1", Status: "completed",
+	}, nil))
+
+	assert.NotContains(t, buf.String(), "Report:")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/preflight_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/preflight_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/pkg/evalcore"
+	"azureaieval/internal/project"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func relevanceSchema(required ...string) map[string]*eval_api.EvaluatorSummary {
+	return map[string]*eval_api.EvaluatorSummary{
+		"builtin.relevance": {
+			Name:                      "builtin.relevance",
+			SupportedEvaluationLevels: []string{"turn"},
+			Definition: &eval_api.EvaluatorContract{
+				InitParameters: &eval_api.JSONSchema{Required: required},
+			},
+		},
+	}
+}
+
+func evalRequiring(params map[string]any) *project.Eval {
+	return &project.Eval{
+		Name:            "quality",
+		Dataset:         "golden",
+		EvaluationLevel: "turn",
+		Evaluators: evalcore.EvaluatorList{{
+			Evaluator:                "builtin.relevance",
+			InitializationParameters: params,
+		}},
+	}
+}
+
+// The same requirement was checked while building the request, which runs after
+// the datasets and evaluators have been pushed. A missing judge deployment
+// therefore cost an immutable dataset version per attempt, and the version
+// number climbs whether or not the eval is ever created.
+func TestCreateRefusesAMissingJudgeBeforePublishing(t *testing.T) {
+	err := checkEvaluatorRequirements(evalRequiring(nil), relevanceSchema("deployment_name"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deployment_name")
+	assert.Contains(t, err.Error(), "builtin.relevance")
+}
+
+// Either spelling of the judge deployment satisfies it, the same way the
+// request builder binds whichever the evaluator publishes.
+func TestEitherJudgeSpellingSatisfiesTheRequirement(t *testing.T) {
+	for _, declared := range []string{"deployment_name", "model"} {
+		err := checkEvaluatorRequirements(
+			evalRequiring(map[string]any{declared: "o4-mini"}),
+			relevanceSchema("deployment_name"))
+
+		assert.NoErrorf(t, err, "%q is the same parameter under the other name", declared)
+	}
+}
+
+// evaluation_level is supplied from the eval's own declaration rather than
+// written under initialization_parameters, so requiring it must not refuse a
+// configuration that sets the level.
+func TestRequiredEvaluationLevelComesFromTheDeclaration(t *testing.T) {
+	err := checkEvaluatorRequirements(
+		evalRequiring(map[string]any{"deployment_name": "o4-mini"}),
+		relevanceSchema("deployment_name", "evaluation_level"))
+
+	assert.NoError(t, err)
+}
+
+// An evaluator the listing did not describe leaves the service with the last
+// word, which is what happened before this check existed.
+func TestAnUnknownEvaluatorIsLeftToTheService(t *testing.T) {
+	err := checkEvaluatorRequirements(evalRequiring(nil),
+		map[string]*eval_api.EvaluatorSummary{})
+
+	assert.NoError(t, err, "nothing published to check against")
+}
+
+// A level the evaluator does not support is the other thing settled by the
+// contract alone, so it is worth catching before a publish too.
+func TestAnUnsupportedLevelIsRefusedBeforePublishing(t *testing.T) {
+	schemas := relevanceSchema("deployment_name")
+	schemas["builtin.relevance"].SupportedEvaluationLevels = []string{"conversation"}
+
+	err := checkEvaluatorRequirements(
+		evalRequiring(map[string]any{"deployment_name": "o4-mini"}), schemas)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "turn")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/providers_manifest_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/providers_manifest_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigureExtensionHostMatchesManifest verifies that the providers this
+// extension registers match those declared in its extension.yaml.
+func TestConfigureExtensionHostMatchesManifest(t *testing.T) {
+	manifestPath := filepath.Join("..", "..", "extension.yaml")
+	require.NoError(t, azdext.VerifyProvidersMatchManifest(configureExtensionHost, manifestPath))
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/reconciler.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/reconciler.go
@@ -1,0 +1,723 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"log"
+	"maps"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/dataset_api"
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/project"
+)
+
+// evalReconciler applies the eval configuration to the data plane. It is the
+// deploy half of the provider; the provider owns ordering, this owns the calls.
+type evalReconciler struct {
+	ec *evalContext
+}
+
+var _ project.Reconciler = (*evalReconciler)(nil)
+
+func newEvalReconciler(ctx context.Context) (project.Reconciler, error) {
+	ec, err := newEvalContext(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	return &evalReconciler{ec: ec}, nil
+}
+
+// EnsureDataset registers a new version only when the local content changed.
+//
+// The dataset API exposes no content hash, so comparing against the service
+// would mean downloading the blob on every deploy. Instead the local file is
+// hashed and the digest kept in the azd environment.
+func (r *evalReconciler) EnsureDataset(
+	ctx context.Context,
+	decl project.DatasetDecl,
+	localPath string,
+) (string, bool, error) {
+	// No local source means the dataset is already registered; just confirm it.
+	if localPath == "" {
+		version := decl.Version
+		if version == "" {
+			list, err := r.ec.datasetClient.ListDatasetVersions(
+				ctx, decl.Name, ProjectEndpointAPIVersion,
+			)
+			if err != nil {
+				return "", false, messages.DatasetNotLocalNorFound(decl.Name, err)
+			}
+			if len(list.Value) == 0 {
+				return "", false, messages.DatasetNotLocalNorRegistered(decl.Name)
+			}
+			version = dataset_api.LatestVersion(list.Value)
+		} else if _, err := r.ec.datasetClient.GetDataset(
+			ctx, decl.Name, version, ProjectEndpointAPIVersion,
+		); err != nil {
+			return "", false, messages.DatasetVersionNotFoundWithHint(decl.Name, version)
+		}
+
+		// Recorded so a run reads the version reconciliation settled on. Without
+		// this a pin is honoured at deploy and then ignored at run time, which
+		// scores different rows than the ones the author asked for.
+		r.ec.remember(ctx, versionKey("dataset", decl.Name), version)
+		return version, false, nil
+	}
+
+	if _, err := os.Stat(localPath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", false, messages.DatasetNotGeneratedYet(decl.Name, localPath)
+		}
+		return "", false, messages.DatasetSource(localPath, err)
+	}
+
+	// A malformed row is only noticed once the service tries to evaluate it,
+	// by which point a version has been published and the eval points at
+	// it. Reading the file here costs nothing and names the offending line.
+	if err := validateJSONL(localPath); err != nil {
+		return "", false, messages.DatasetProblem(decl.Name, err)
+	}
+
+	digest, err := project.Fingerprint(localPath)
+	if err != nil {
+		return "", false, err
+	}
+
+	key := project.FingerprintKey("dataset", decl.Name)
+	if prior := r.ec.getEnvValue(ctx, key); prior == digest {
+		// Unchanged since the last deploy; reuse the recorded version, but only
+		// after confirming nobody published a newer one outside the repo. An
+		// explicit `version:` is the author saying which version they want, so
+		// it settles the question and the check does not apply.
+		if version := r.ec.getEnvValue(ctx, versionKey("dataset", decl.Name)); version != "" {
+			if decl.Version != "" {
+				// A pin settles which version to use, not whether it is still
+				// there. Skipping the service entirely let a deleted version
+				// report as unchanged while the eval pointed at nothing. Only a
+				// confirmed 404 refuses: anything else leaves the pin alone
+				// rather than failing a deploy on a transient read.
+				if _, err := r.ec.datasetClient.GetDataset(
+					ctx, decl.Name, decl.Version, ProjectEndpointAPIVersion,
+				); err != nil && dataset_api.IsNotFound(err) {
+					return "", false, messages.DatasetVersionNotFoundWithHint(decl.Name, decl.Version)
+				}
+				return decl.Version, false, nil
+			}
+			if err := r.checkDatasetDrift(ctx, decl.Name, version); err != nil {
+				return "", false, err
+			}
+			return version, false, nil
+		}
+	}
+
+	// Uploaded by the path the author declared. Collapsing a file to its
+	// directory would upload whichever .jsonl sorts first, while the
+	// fingerprint below still describes the declared one.
+	dir := localPath
+
+	// A declared version is the version to publish, not one to count from.
+	// Reaching here means the content differs from what that version holds, so
+	// republishing over it would change a version the author pinned.
+	if decl.Version != "" {
+		ds, err := r.ec.datasetClient.UploadVersion(
+			ctx, decl.Name, decl.Version, dir, ProjectEndpointAPIVersion,
+		)
+		if err != nil {
+			if dataset_api.IsVersionConflict(err) {
+				return "", false, messages.DatasetVersionConflict(decl.Name, decl.Version)
+			}
+			return "", false, err
+		}
+		r.ec.remember(ctx, key, digest)
+		r.ec.remember(ctx, versionKey("dataset", decl.Name), ds.Version)
+		return ds.Version, true, nil
+	}
+
+	// UploadNextVersion discovers the currently registered version when none is
+	// declared, so the upload does not restart at 1.0 and collide.
+	ds, err := r.ec.datasetClient.UploadNextVersion(
+		ctx, decl.Name, decl.Version, dir, ProjectEndpointAPIVersion,
+	)
+	if err != nil {
+		return "", false, err
+	}
+
+	r.ec.remember(ctx, key, digest)
+	r.ec.remember(ctx, versionKey("dataset", decl.Name), ds.Version)
+	r.ec.remember(ctx, envKeyDatasetVersion, ds.Version)
+
+	return ds.Version, true, nil
+}
+
+// validateJSONL checks that every row is a JSON object before the file is
+// published.
+//
+// The service accepts the upload whatever the bytes are, so a typo becomes a
+// registered version, an eval bound to it, and a run that fails on a row
+// nobody has looked at. Blank lines are skipped: they are not rows.
+func validateJSONL(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return messages.ReadingPath(path, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	// A row carrying a whole conversation runs well past the 64KB default.
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+
+	rows := 0
+	for line := 1; scanner.Scan(); line++ {
+		text := strings.TrimSpace(scanner.Text())
+		if text == "" {
+			continue
+		}
+		var row map[string]any
+		if err := json.Unmarshal([]byte(text), &row); err != nil {
+			return messages.JSONLRowInvalid(path, line, err)
+		}
+		if len(row) == 0 {
+			return messages.JSONLRowEmpty(path, line)
+		}
+		rows++
+	}
+	if err := scanner.Err(); err != nil {
+		return messages.ReadingPath(path, err)
+	}
+	if rows == 0 {
+		return messages.JSONLNoRows(path)
+	}
+	return nil
+}
+
+func (r *evalReconciler) checkDatasetDrift(
+	ctx context.Context,
+	name, recorded string,
+) error {
+	latest, err := r.latestDatasetVersion(ctx, name)
+	if err != nil {
+		// The whole point of this check is to catch a version published behind
+		// our back. A listing we could not read is not evidence there was none.
+		return err
+	}
+	if latest == "" || latest == recorded {
+		return nil
+	}
+	if !dataset_api.VersionGreater(latest, recorded) {
+		return nil
+	}
+	return messages.DatasetDrifted(name, latest, recorded)
+}
+
+// latestDatasetVersion reports the newest registered version. A dataset the
+// service does not know, and a listing that has not caught up, both report an
+// empty version and no error; anything else is returned.
+func (r *evalReconciler) latestDatasetVersion(ctx context.Context, name string) (string, error) {
+	list, err := r.ec.datasetClient.ListDatasetVersions(ctx, name, ProjectEndpointAPIVersion)
+	if err != nil {
+		if dataset_api.IsNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	if list == nil || len(list.Value) == 0 {
+		return "", nil
+	}
+	return dataset_api.LatestVersion(list.Value), nil
+}
+
+// EnsureEvaluator publishes a new version when the local definition differs
+// from what the service holds.
+//
+// The two kinds of evaluator are told apart by the source's extension: `.py`
+// is code, anything else is a rubric. They also detect change differently. A
+// rubric definition comes back inline, so it is compared directly; a code
+// definition's source is not read back in a form worth comparing, so a
+// fingerprint of the script is kept in the azd environment, the same way
+// datasets work.
+func (r *evalReconciler) EnsureEvaluator(
+	ctx context.Context,
+	decl project.EvaluatorDecl,
+	localPath string,
+) (string, bool, error) {
+	if localPath == "" {
+		raw, err := r.ec.evalClient.GetEvaluatorRaw(
+			ctx, decl.Name, decl.Version, ProjectEndpointAPIVersion,
+		)
+		if err != nil {
+			return "", false, messages.EvaluatorNotLocalNorFound(decl.Name, err)
+		}
+		return versionFromRaw(raw, decl.Version), false, nil
+	}
+
+	if _, err := os.Stat(localPath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", false, messages.EvaluatorNotGeneratedYet(decl.Name, localPath)
+		}
+		return "", false, messages.EvaluatorSource(localPath, err)
+	}
+
+	raw, err := project.ReadFileNoBOM(localPath)
+	if err != nil {
+		return "", false, messages.EvaluatorSource(localPath, err)
+	}
+
+	body, err := normalizeRubricBody(decl.Name, raw)
+	if err != nil {
+		return "", false, messages.EvaluatorProblem(decl.Name, err)
+	}
+
+	// The author's own file decides whether there is anything to publish.
+	// Comparing against the service cannot: it enriches a definition with
+	// fields nobody authored, so sameDefinition only looks for authored keys on
+	// the service and a key the author *deleted* — a pass_threshold, say — is
+	// still there to be found, and the deletion never publishes.
+	digest, err := project.Fingerprint(localPath)
+	if err != nil {
+		return "", false, messages.EvaluatorSource(localPath, err)
+	}
+	digestKey := project.FingerprintKey("evaluator", decl.Name)
+	prior := r.ec.getEnvValue(ctx, digestKey)
+	authorEdited := prior != "" && prior != digest
+
+	// Compare against the definition already on the service.
+	var known json.RawMessage
+	if existing, err := r.ec.evalClient.GetEvaluatorRaw(
+		ctx, decl.Name, "", ProjectEndpointAPIVersion,
+	); err == nil {
+		remote := versionFromRaw(existing, "")
+		if !authorEdited && sameDefinition(existing, body) {
+			// Nothing to publish, but the version is still worth recording:
+			// it is what a later deploy compares against to notice that
+			// someone moved the evaluator on from here.
+			if remote != "" {
+				r.ec.remember(ctx, versionKey("evaluator", decl.Name), remote)
+			}
+			r.ec.remember(ctx, digestKey, digest)
+			return versionFromRaw(existing, decl.Version), false, nil
+		}
+
+		// The definitions differ, which means either the local file changed
+		// or someone published a version outside the repo. The version
+		// recorded at the last deploy is what tells them apart, and
+		// publishing over the second case would bury an intentional change
+		// under one nobody asked for.
+		if recorded := r.ec.getEnvValue(ctx, versionKey("evaluator", decl.Name)); recorded != "" {
+			if err := checkEvaluatorDrift(decl.Name, recorded, remote); err != nil {
+				return "", false, err
+			}
+		}
+
+		// What that read saw is what keeps the publish from being answered
+		// with it again.
+		known = existing
+	}
+
+	created, err := r.ec.evalClient.CreateEvaluatorVersion(
+		ctx, decl.Name, body, known, ProjectEndpointAPIVersion,
+	)
+	if err != nil {
+		return "", false, err
+	}
+	r.awaitEvaluatorReadable(ctx, decl.Name, created.Version)
+	r.ec.remember(ctx, versionKey("evaluator", decl.Name), created.Version)
+	r.ec.remember(ctx, digestKey, digest)
+	return created.Version, true, nil
+}
+
+// checkEvaluatorDrift fails when the service holds a newer version than the
+// one recorded at the last deploy.
+//
+// It is asked only when the local definition and the remote one disagree,
+// which on its own says nothing about who moved: the author may have edited
+// the file, or someone may have published a version from outside the repo.
+// The recorded version settles it, and the difference matters because
+// publishing is how this reconciler resolves a disagreement — doing that over
+// a version somebody deliberately published would bury their change under one
+// nobody asked for, with `azd up` reporting success.
+//
+// The remote version is passed in rather than listed, because the version
+// listing lags a publish and would report an evaluator as un-drifted for the
+// first seconds of its newest version's life.
+func checkEvaluatorDrift(name, recorded, remote string) error {
+	recordedNumber, err := strconv.Atoi(recorded)
+	if err != nil {
+		return nil
+	}
+	remoteNumber, err := strconv.Atoi(remote)
+	if err != nil || remoteNumber <= recordedNumber {
+		return nil
+	}
+	return messages.EvaluatorDrifted(name, remote, recorded)
+}
+
+// evaluatorPropagation bounds the wait for a freshly published evaluator to
+// become usable.
+//
+// A create returns before the version is resolvable everywhere, and the very
+// next step of a deploy is EnsureEval, which names the evaluator in a testing
+// criterion. Creating the eval inside that window fails with "The evaluator X
+// was not found" — a confusing error, because the evaluator was published
+// seconds earlier and is plainly there by the time anyone looks. The observed
+// gap is under a second, so the poll is frequent and the cap is generous
+// enough to absorb a slow day without stalling a deploy on an evaluator that
+// is genuinely missing.
+const (
+	evaluatorPropagationTimeout  = 30 * time.Second
+	evaluatorPropagationInterval = 250 * time.Millisecond
+)
+
+// awaitEvaluatorReadable polls until a published version is resolvable, or the
+// cap passes.
+//
+// Two reads have to agree, because they are not backed by the same view. The
+// direct read goes consistent almost immediately; the version listing lags it
+// by seconds, the same way the dataset listing does. A live publish was
+// observed reading back at 03:06:58 and still failing eval creation at
+// 03:06:59, so waiting on the direct read alone leaves exactly the race this
+// exists to close. The listing is the slower of the two and therefore the one
+// worth waiting on.
+//
+// A timeout is not an error. The wait is a courtesy that makes the common case
+// reliable; if it never succeeds, the create that follows will report the real
+// problem with far more context than a wait that gave up could.
+func (r *evalReconciler) awaitEvaluatorReadable(ctx context.Context, name, version string) {
+	if version == "" {
+		return
+	}
+	deadline := time.Now().Add(evaluatorPropagationTimeout)
+	for {
+		if r.evaluatorVersionResolvable(ctx, name, version) {
+			return
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(evaluatorPropagationInterval):
+		}
+	}
+}
+
+// evaluatorVersionResolvable reports whether a version can be both read
+// directly and found in the listing.
+func (r *evalReconciler) evaluatorVersionResolvable(
+	ctx context.Context,
+	name, version string,
+) bool {
+	if _, err := r.ec.evalClient.GetEvaluatorRaw(
+		ctx, name, version, ProjectEndpointAPIVersion,
+	); err != nil {
+		return false
+	}
+
+	list, err := r.ec.evalClient.ListEvaluatorVersions(
+		ctx, name, ProjectEndpointAPIVersion,
+	)
+	if err != nil || list == nil {
+		return false
+	}
+	for _, entry := range list.Value {
+		if entry.Version == version {
+			return true
+		}
+	}
+	return false
+}
+
+// EnsureEval creates the eval when it has never been deployed, or when its own
+// declaration changed. Evals are immutable, so a declaration change means a new
+// eval and a new id.
+//
+// What an eval's references *resolve to* is deliberately not a reason to
+// recreate it: an evaluator tracking latest that publishes a new version leaves
+// every eval that runs it alone, which is what keeps a rubric edit comparable
+// against the runs taken before it.
+func (r *evalReconciler) EnsureEval(
+	ctx context.Context,
+	group project.Eval,
+	datasetPath string,
+) (string, bool, error) {
+	if group.ID != "" {
+		return group.ID, false, nil
+	}
+
+	// Evals are immutable, so a change to the eval's own substance — evaluators,
+	// dataset, source, target, level — needs a new eval. Name and description are
+	// excluded from the digest and pushed in place instead.
+	recreate := false
+	digest, err := project.FingerprintGroup(group)
+	if err != nil {
+		return "", false, err
+	}
+	key := project.FingerprintKey("eval", group.Name)
+	if prior := r.ec.getEnvValue(ctx, key); prior != "" && prior != digest {
+		recreate = true
+	}
+
+	// Building the request is also what checks the declaration against the
+	// dataset's columns, so it happens before the reuse decision: a dataset can
+	// lose a column an evaluator needs without the eval's own declaration
+	// changing, and reusing the eval would let that reach a run unreported.
+	req, err := buildEvalRequest(
+		&group,
+		r.ec.evaluatorSchemas(ctx),
+		datasetColumnsFromPath(datasetPath),
+	)
+	if err != nil {
+		return "", false, err
+	}
+
+	cached := r.ec.getEnvValue(ctx, idKey("eval", group.Name))
+	if cached == "" && !recreate {
+		// Nothing recorded under this name, but the substance may already be
+		// deployed under the name it had before. The environment records the id
+		// against the digest as well, which is what recognizes a rename rather
+		// than reading it as a delete plus an add.
+		adopted, err := r.adoptRenamed(ctx, group, digest)
+		if err != nil {
+			return "", false, err
+		}
+		if adopted != "" {
+			cached = adopted
+		}
+	}
+	if cached != "" && !recreate {
+		remote, err := r.ec.evalClient.GetOpenAIEval(ctx, cached)
+		if err != nil && !eval_api.IsNotFound(err) {
+			// A read that failed is not an eval that is gone. Falling through
+			// on a 429, a 503 or an expired token would create a second eval
+			// and overwrite the recorded id, forking for good the run history
+			// this lookup exists to keep.
+			return "", false, err
+		}
+		if err == nil {
+			// Reusing the eval is not the same as leaving it alone: name and
+			// description are excluded from the digest because they must not
+			// split a history, which makes this the only place an edit to
+			// either of them can reach the service.
+			r.pushMutable(ctx, cached, group, remote)
+
+			// Record the digest on reuse as well, otherwise an eval deployed
+			// before fingerprinting existed never establishes a baseline and
+			// later edits go undetected.
+			r.ec.remember(ctx, key, digest)
+			r.ec.remember(ctx, idKey("eval", group.Name), cached)
+			r.ec.remember(ctx, digestIDKey(digest), cached)
+			r.ec.remember(ctx, envKeyEvalID, cached)
+			return cached, false, nil
+		}
+	}
+
+	created, err := r.ec.evalClient.CreateOpenAIEval(ctx, req)
+	if err != nil {
+		return "", false, err
+	}
+	r.ec.remember(ctx, key, digest)
+	r.ec.remember(ctx, idKey("eval", group.Name), created.ID)
+	r.ec.remember(ctx, digestIDKey(digest), created.ID)
+	// EVAL_ID stays the last-deployed eval. Nothing reads it to decide which
+	// eval a command means, because every deploy writes it and it cannot say
+	// which declaration it belongs to; it is here for anything outside this
+	// extension that wants the id of what was just deployed.
+	r.ec.remember(ctx, envKeyEvalID, created.ID)
+	return created.ID, true, nil
+}
+
+// adoptRenamed reclaims the eval this declaration used to be called, so a
+// rename keeps the id and every run under it rather than forking the history.
+//
+// The name is what UpdateEvalParametersBody reaches, so the new one is pushed
+// to the service.
+func (r *evalReconciler) adoptRenamed(
+	ctx context.Context,
+	group project.Eval,
+	digest string,
+) (string, error) {
+	id := r.ec.getEnvValue(ctx, digestIDKey(digest))
+	if id == "" {
+		return "", nil
+	}
+	remote, err := r.ec.evalClient.GetOpenAIEval(ctx, id)
+	if err != nil {
+		if eval_api.IsNotFound(err) {
+			// The eval it used to be called is genuinely gone, so there is
+			// nothing to adopt and the caller creates one.
+			return "", nil
+		}
+		return "", err
+	}
+	r.pushMutable(ctx, id, group, remote)
+	return id, nil
+}
+
+// pushMutable sends the half of a declaration the service treats as mutable.
+//
+// Substance never travels this way — an edit that touches it is a new eval.
+// Name and description are left out of the fingerprint precisely because they
+// cost nothing to change and must not split a run history, so they are
+// reconciled here rather than ignored, and the eval keeps its id and every run
+// under it.
+//
+// A failure is not fatal. The eval is still the right one and the declaration
+// still resolves; it just reads under its old wording in the portal until the
+// next deploy.
+func (r *evalReconciler) pushMutable(
+	ctx context.Context,
+	id string,
+	group project.Eval,
+	remote *eval_api.OpenAIEval,
+) {
+	if remote == nil {
+		return
+	}
+	desired := withDescription(remote.Metadata, group.Description)
+	if remote.Name == group.Name && maps.Equal(remote.Metadata, desired) {
+		return
+	}
+	if _, err := r.ec.evalClient.UpdateOpenAIEval(ctx, id, &eval_api.UpdateOpenAIEvalRequest{
+		Name:     group.Name,
+		Metadata: desired,
+	}); err != nil {
+		// Deliberately not fatal: a name or description that did not travel
+		// leaves the eval usable, and failing the deploy over it would be
+		// worse. It still has to be findable, so --debug can see it.
+		log.Printf("[reconcile] updating eval %s name/description: %v", id, err)
+	}
+}
+
+// withDescription applies the declaration's description to the metadata the
+// service already holds, leaving every other key alone — including any the
+// service added itself, which a replacing update would otherwise drop.
+func withDescription(held map[string]string, description string) map[string]string {
+	merged := make(map[string]string, len(held)+1)
+	maps.Copy(merged, held)
+	if description == "" {
+		delete(merged, metaDescription)
+	} else {
+		merged[metaDescription] = description
+	}
+	return merged
+}
+
+// sameDefinition reports whether the locally authored definition already
+// matches what the service holds.
+//
+// Only the keys the candidate declares are compared. The service enriches a
+// definition when it is created — a rubric of nothing but `type` and
+// `dimensions` comes back carrying data_schema, init_parameters and metrics it
+// was never given — so comparing whole documents never matches and every
+// deploy publishes a redundant version.
+func sameDefinition(existing, candidate []byte) bool {
+	extract := func(raw []byte) map[string]json.RawMessage {
+		var doc map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil
+		}
+		def, ok := doc["definition"]
+		if !ok {
+			return nil
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(def, &fields); err != nil {
+			return nil
+		}
+		return fields
+	}
+
+	onService, authored := extract(existing), extract(candidate)
+	if onService == nil || authored == nil {
+		return false
+	}
+
+	for key, want := range authored {
+		got, ok := onService[key]
+		if !ok || !equalJSON(got, want) {
+			return false
+		}
+	}
+	return true
+}
+
+// equalJSON compares two JSON values structurally, so key order and
+// whitespace do not register as a change.
+func equalJSON(a, b json.RawMessage) bool {
+	var left, right any
+	if err := json.Unmarshal(a, &left); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(b, &right); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(left, right)
+}
+
+func versionFromRaw(raw []byte, fallback string) string {
+	var doc struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(raw, &doc); err == nil && doc.Version != "" {
+		return doc.Version
+	}
+	return fallback
+}
+
+// versionKey holds the version resolved for an artifact at the last deploy.
+func versionKey(kind, name string) string {
+	return project.FingerprintKey(kind, name) + "_VERSION"
+}
+
+// recordDeployedDataset records the state a deploy would have left behind for a
+// dataset that the service has already registered and that already has a local
+// copy.
+//
+// `azd up` decides whether to publish by comparing the local file against a
+// fingerprint held in the environment. A generated dataset arrives with no such
+// fingerprint, so without this the first deploy after `generate` reads the file
+// as new and publishes a second version identical to the one the job just
+// registered. Only a local edit should produce version 2.
+//
+// Best effort: failing to record costs a redundant version, not correctness.
+func (ec *evalContext) recordDeployedDataset(
+	ctx context.Context,
+	name, localPath, version string,
+) {
+	digest, err := project.Fingerprint(localPath)
+	if err != nil {
+		return
+	}
+	ec.remember(ctx, project.FingerprintKey("dataset", name), digest)
+	if version != "" {
+		ec.remember(ctx, versionKey("dataset", name), version)
+	}
+}
+
+// idKey names the env entry holding a resolved id.
+//
+// Ids are per declaration. A single shared key works only while a config has
+// one group: with two, the second deploy finds the first's id cached, confirms
+// it exists, and hands it back for the wrong group.
+func idKey(kind, name string) string {
+	return project.FingerprintKey(kind, name) + "_ID"
+}
+
+// digestIDKey records an eval's id against its substance, which is what lets a
+// renamed declaration find the eval it already deployed. Keyed by a prefix of
+// the digest, because the whole hash makes an unreadable environment variable.
+func digestIDKey(digest string) string {
+	return "EVAL_SUBSTANCE_" + strings.ToUpper(digest[:16]) + "_ID"
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/reconciler_drift_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/reconciler_drift_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Drift is only interesting when the two definitions already disagree, and
+// then only when the disagreement came from the project rather than from the
+// author. These are the four ways that question can be answered.
+func TestCheckEvaluatorDrift(t *testing.T) {
+	// The author edited the file. The project is where the last deploy left
+	// it, so publishing is exactly right and must not be blocked.
+	require.NoError(t, checkEvaluatorDrift("support-quality", "3", "3"))
+
+	// Someone published outside the repo. Publishing over it would leave
+	// their change behind with `azd up` reporting success.
+	err := checkEvaluatorDrift("support-quality", "3", "4")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "support-quality")
+	assert.Contains(t, err.Error(), "version 4")
+	assert.Contains(t, err.Error(), "3 was recorded")
+	assert.Contains(t, err.Error(), "outside this configuration",
+		"the message has to say what moved, not just that something did")
+
+	// A version that went backwards is not drift: a newer version was
+	// deleted, and republishing is how the repo takes the name back.
+	require.NoError(t, checkEvaluatorDrift("support-quality", "4", "3"))
+
+	// Versions this extension did not number cannot be compared, and refusing
+	// a deploy over a numbering convention it does not own would be worse
+	// than not checking.
+	require.NoError(t, checkEvaluatorDrift("support-quality", "", "4"))
+	require.NoError(t, checkEvaluatorDrift("support-quality", "3", "preview"))
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/reconciler_env_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/reconciler_env_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"azureaieval/internal/pkg/dataset_api"
+	"azureaieval/internal/project"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// testEnvServer is an azd environment held in memory, so reconciliation paths
+// that only run once something was recorded at the last deploy are reachable
+// from a test. Without it, getEnvValue answers "" for everything and those
+// branches never execute.
+type testEnvServer struct {
+	azdext.UnimplementedEnvironmentServiceServer
+	values map[string]string
+}
+
+func (s *testEnvServer) GetValue(
+	_ context.Context, req *azdext.GetEnvRequest,
+) (*azdext.KeyValueResponse, error) {
+	return &azdext.KeyValueResponse{Value: s.values[req.Key]}, nil
+}
+
+func (s *testEnvServer) SetValue(
+	_ context.Context, req *azdext.SetEnvRequest,
+) (*azdext.EmptyResponse, error) {
+	if s.values == nil {
+		s.values = map[string]string{}
+	}
+	s.values[req.Key] = req.Value
+	return &azdext.EmptyResponse{}, nil
+}
+
+// newTestAzdClient serves the environment over gRPC the way azd itself does,
+// rather than faking the accessor, so the client code under test is the real one.
+func newTestAzdClient(t *testing.T, env *testEnvServer) *azdext.AzdClient {
+	t.Helper()
+
+	server := grpc.NewServer()
+	azdext.RegisterEnvironmentServiceServer(server, env)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() {
+		server.Stop()
+		_ = listener.Close()
+	})
+
+	client, err := azdext.NewAzdClient(azdext.WithAddress(listener.Addr().String()))
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	return client
+}
+
+// pinnedDatasetReconciler builds a reconciler whose environment already holds
+// what a previous deploy recorded for a dataset, and whose service answers a
+// version read with the given status.
+func pinnedDatasetReconciler(
+	t *testing.T, name, version string, versionStatus int,
+) (*evalReconciler, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, name+".jsonl")
+	require.NoError(t, os.WriteFile(localPath, []byte("{\"query\":\"hi\"}\n"), 0o600))
+
+	digest, err := project.Fingerprint(localPath)
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/versions/") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if versionStatus != http.StatusOK {
+			w.WriteHeader(versionStatus)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// assert, not require: this runs on the server's goroutine, and FailNow
+		// there aborts mid-response and fails whichever test is running instead.
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"name": name, "version": version,
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	env := &testEnvServer{values: map[string]string{
+		project.FingerprintKey("dataset", name): digest,
+		versionKey("dataset", name):             version,
+	}}
+
+	pipeline := runtime.NewPipeline("test", "v1", runtime.PipelineOptions{},
+		&policy.ClientOptions{Retry: policy.RetryOptions{MaxRetries: -1}})
+
+	return &evalReconciler{ec: &evalContext{
+		azdClient:     newTestAzdClient(t, env),
+		envName:       "test",
+		datasetClient: dataset_api.NewDatasetClientFromPipeline(srv.URL, pipeline),
+	}}, localPath
+}
+
+// A pin settles which version to use, not whether it is still there. Reusing it
+// unread let a deleted version report as unchanged while the eval pointed at
+// nothing, which is what `create` did straight after `dataset delete`.
+func TestEnsureDatasetRefusesAPinnedVersionTheServiceNoLongerHas(t *testing.T) {
+	r, localPath := pinnedDatasetReconciler(t, "golden", "1.0", http.StatusNotFound)
+
+	_, _, err := r.EnsureDataset(
+		context.Background(),
+		project.DatasetDecl{Name: "golden", Version: "1.0"},
+		localPath,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "1.0", "the version that is missing")
+	assert.Contains(t, err.Error(), "versions list", "and the command that shows what is there")
+}
+
+// The ordinary case: the pin is still registered, so reconciliation reuses it
+// and reports no change.
+func TestEnsureDatasetReusesAPinnedVersionThatStillExists(t *testing.T) {
+	r, localPath := pinnedDatasetReconciler(t, "golden", "1.0", http.StatusOK)
+
+	version, changed, err := r.EnsureDataset(
+		context.Background(),
+		project.DatasetDecl{Name: "golden", Version: "1.0"},
+		localPath,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", version)
+	assert.False(t, changed, "an unchanged file at a pinned version publishes nothing")
+}
+
+// A read that failed is not a read that came back empty. Failing the deploy on
+// a 403 or a timeout would turn a transient service problem into a broken
+// pipeline for a pin that is very probably fine.
+func TestEnsureDatasetKeepsAPinnedVersionWhenTheReadFails(t *testing.T) {
+	r, localPath := pinnedDatasetReconciler(t, "golden", "1.0", http.StatusForbidden)
+
+	version, changed, err := r.EnsureDataset(
+		context.Background(),
+		project.DatasetDecl{Name: "golden", Version: "1.0"},
+		localPath,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", version)
+	assert.False(t, changed)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/reconciler_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/reconciler_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The service enriches a definition when it stores it: a rubric of nothing but
+// type and dimensions comes back carrying data_schema, init_parameters and
+// metrics. Comparing whole documents therefore never matched, and every deploy
+// published a redundant version.
+func TestSameDefinitionIgnoresServerAddedFields(t *testing.T) {
+	authored := []byte(`{
+		"name": "r",
+		"definition": {
+			"type": "rubric",
+			"dimensions": [{"id":"accuracy","description":"Correct.","weight":5}]
+		}
+	}`)
+
+	onService := []byte(`{
+		"name": "r",
+		"version": "2",
+		"created_at": "2026-07-28T00:00:00Z",
+		"definition": {
+			"type": "rubric",
+			"dimensions": [{"id":"accuracy","description":"Correct.","weight":5}],
+			"data_schema": {"type":"object","properties":{"query":{"type":"string"}}},
+			"init_parameters": {"required":["model"],"properties":{"model":{"type":"string"}}},
+			"metrics": {"score":{"type":"number"}}
+		}
+	}`)
+
+	require.True(t, sameDefinition(onService, authored),
+		"server-added fields must not count as a change")
+}
+
+// A real edit still registers.
+func TestSameDefinitionDetectsAuthoredChange(t *testing.T) {
+	authored := []byte(`{"definition":{"type":"rubric","dimensions":[{"id":"a","weight":7}]}}`)
+	onService := []byte(`{"definition":{"type":"rubric","dimensions":[{"id":"a","weight":5}],"metrics":{}}}`)
+
+	require.False(t, sameDefinition(onService, authored))
+}
+
+// Key order and whitespace are not changes.
+func TestSameDefinitionIsStructural(t *testing.T) {
+	authored := []byte(`{"definition":{"type":"rubric","dimensions":[{"id":"a","weight":5}]}}`)
+	onService := []byte("{\"definition\":{\n  \"dimensions\": [ {\"weight\":5,\"id\":\"a\"} ],\n  \"type\":\"rubric\"\n}}")
+
+	require.True(t, sameDefinition(onService, authored))
+}
+
+func TestSameDefinitionRejectsMalformed(t *testing.T) {
+	good := []byte(`{"definition":{"type":"rubric"}}`)
+	require.False(t, sameDefinition([]byte(`not json`), good))
+	require.False(t, sameDefinition(good, []byte(`not json`)))
+	require.False(t, sameDefinition([]byte(`{"no":"definition"}`), good))
+}
+
+// What sameDefinition cannot see, and why EnsureEvaluator digests the author's
+// file instead of relying on it.
+//
+// The comparison walks the authored keys and looks for each on the service. A
+// key the author *deleted* is not among them, so its survival on the service
+// goes unnoticed and the definitions are called equal. Deleting a
+// pass_threshold — the spec's own Scenario 4 edit, in reverse — would publish
+// nothing and leave the old threshold grading every run.
+func TestSameDefinitionCannotSeeARemovedField(t *testing.T) {
+	authored := []byte(`{"definition":{"type":"rubric","dimensions":[{"id":"a","weight":5}]}}`)
+	onService := []byte(
+		`{"definition":{"type":"rubric","pass_threshold":0.7,` +
+			`"dimensions":[{"id":"a","weight":5}]}}`)
+
+	require.True(t, sameDefinition(onService, authored),
+		"this is the blind spot the digest exists to cover, not a property to rely on")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/resolution_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/resolution_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/project"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Precedence decides behaviour without announcing it, so a wrong answer here
+// is silent. options.max_samples was parsed and dropped once already, which is
+// what these lock down.
+func TestResolveMaxSamples_Precedence(t *testing.T) {
+	withOptions := &project.Eval{MaxSamples: 25}
+
+	assert.Equal(t, 5, resolveMaxSamples(5, withOptions), "the flag wins over the config")
+	assert.Equal(t, 25, resolveMaxSamples(0, withOptions), "the config is used when no flag is given")
+	assert.Equal(t, 0, resolveMaxSamples(0, &project.Eval{}), "neither means no cap")
+	assert.Equal(t, 0, resolveMaxSamples(0, nil))
+	assert.Equal(t, 7, resolveMaxSamples(7, nil), "a flag stands on its own")
+
+	// Zero in config is absent, not a cap of zero: a cap of zero would send
+	// nothing at all.
+	assert.Equal(t, 0, resolveMaxSamples(0, &project.Eval{MaxSamples: 0}))
+}
+
+// The level is the eval's alone. A per-run override would put two incomparable
+// result sets under one eval's history, and would bypass the
+// supported_evaluation_levels check `azd up` does against the declared level.
+func TestResolveLevel_ComesFromTheEval(t *testing.T) {
+	declared := &project.Eval{
+		EvaluationLevel: project.EvaluationLevelConversation,
+	}
+
+	assert.Equal(t, project.EvaluationLevelConversation, resolveLevel(declared))
+	assert.Empty(t, resolveLevel(&project.Eval{}), "unset defers to the service default")
+	assert.Empty(t, resolveLevel(nil))
+}
+
+// A group's target decides which run-time fields its criteria can bind. Getting
+// this wrong passes validation and then errors on every row.
+func TestSampleBindingsFor_UnknownTargetBindsNothing(t *testing.T) {
+	assert.Nil(t, sampleBindingsFor("prompt"),
+		"an unrecognized target must bind nothing rather than guess at agent fields")
+}
+
+// The level filter is what keeps a conversation evaluator from being sent turn
+// fields and the reverse. Both directions matter.
+func TestSelectLevelFields_KeepsOnlyTheLevelsShape(t *testing.T) {
+	accepted := []string{"query", "response", "messages", "tool_definitions"}
+
+	conv := selectLevelFields(accepted, nil, project.EvaluationLevelConversation)
+	assert.Contains(t, conv, "messages")
+	assert.NotContains(t, conv, "query")
+	assert.NotContains(t, conv, "response")
+	assert.Contains(t, conv, "tool_definitions", "fields outside the split are untouched")
+
+	turn := selectLevelFields(accepted, nil, project.EvaluationLevelTurn)
+	assert.Contains(t, turn, "query")
+	assert.Contains(t, turn, "response")
+	assert.NotContains(t, turn, "messages")
+
+	// An evaluator offering only one shape is left alone, whatever the level.
+	only := []string{"query", "response"}
+	assert.Equal(t, only, selectLevelFields(only, nil, project.EvaluationLevelConversation))
+
+	// A required field is never dropped: a genuine conflict has to surface as a
+	// missing-field error rather than being reshaped away.
+	kept := selectLevelFields(accepted, []string{"query"}, project.EvaluationLevelConversation)
+	assert.Contains(t, kept, "query", "a required field survives the level filter")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/reuse_ownership_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/reuse_ownership_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// What the previous run sent is history. A caller that logs it, or emits it
+// under -o json, has to see what was recorded rather than what this run decided
+// to send instead.
+func TestPinReusedTraceWindow_DoesNotTouchWhatItWasGiven(t *testing.T) {
+	recorded := &eval_api.EvalRunDataSource{
+		Type: eval_api.EvalRunDataSourceTypeTracePreview,
+		TraceSource: &eval_api.TraceSourceFilter{
+			Type:      "agent_filter",
+			AgentName: "support-agent",
+			StartTime: time.Now().Add(-24 * time.Hour).Unix(),
+		},
+	}
+	before := *recorded.TraceSource
+
+	pinned := pinReusedTraceWindow(recorded)
+
+	require.NotSame(t, recorded, pinned)
+	assert.Equal(t, before, *recorded.TraceSource, "the recorded source is unchanged")
+	assert.NotZero(t, pinned.TraceSource.EndTime)
+}
+
+// A window with no start says "everything", which is what it said when it was
+// recorded. Closing it would freeze a declaration that never asked to be
+// bounded, and each reattach would then grade a staler span than the last.
+func TestPinReusedTraceWindow_LeavesAnUnboundedWindowUnbounded(t *testing.T) {
+	open := &eval_api.EvalRunDataSource{
+		Type: eval_api.EvalRunDataSourceTypeTracePreview,
+		TraceSource: &eval_api.TraceSourceFilter{
+			Type: "agent_filter", AgentName: "support-agent",
+		},
+	}
+
+	assert.Same(t, open, pinReusedTraceWindow(open))
+	assert.Zero(t, open.TraceSource.EndTime)
+	assert.Zero(t, open.TraceSource.StartTime)
+}
+
+// A recorded end early enough to put the start at or before the epoch would
+// send a bound the wire drops, or a negative one, which is what a declaration
+// is refused for. The length of the window is kept and reached back from now.
+func TestPinReusedTraceWindow_KeepsAReattachedStartOutOfThePreEpoch(t *testing.T) {
+	ds := pinReusedTraceWindow(&eval_api.EvalRunDataSource{
+		Type:          eval_api.EvalRunDataSourceTypeTraces,
+		AgentName:     "support-agent",
+		LookbackHours: 24,
+		EndTime:       3600,
+	})
+
+	require.NotNil(t, ds.TraceSource)
+	assert.Positive(t, ds.TraceSource.StartTime)
+	assert.Equal(t, int64(24*3600), ds.TraceSource.EndTime-ds.TraceSource.StartTime)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/root.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/root.go
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"azureaieval/internal/foundry/projectctx"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// NewRootCommand builds the `azd ai eval` command tree.
+func NewRootCommand() *cobra.Command {
+	rootCmd, extCtx := azdext.NewExtensionRootCommand(azdext.ExtensionCommandOptions{
+		Name: "eval",
+		Use:  "eval <command> [options]",
+		Short: fmt.Sprintf(
+			"Define and run Foundry evaluations from your terminal. %s",
+			color.YellowString("(Beta)"),
+		),
+	})
+	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
+	// The data-plane clients trace requests through the standard logger, which
+	// Go writes to stderr, so it has to be silenced unless debug was asked for.
+	//
+	// The SDK's own hook is chained rather than replaced, and cobra ignores
+	// PersistentPreRun entirely once PersistentPreRunE is set. The SDK sets
+	// cobra.EnableTraverseRunHooks, so this still runs alongside subcommand
+	// hooks. The cleanup func is discarded on purpose: log writes are
+	// unbuffered and the OS closes the file at exit.
+	sdkPreRun := rootCmd.PersistentPreRunE
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if sdkPreRun != nil {
+			if err := sdkPreRun(cmd, args); err != nil {
+				return err
+			}
+		}
+		// -e/--environment is parsed by the SDK into extCtx and then has to be
+		// acted on. Discarding extCtx left the flag accepted and ignored:
+		// `azd ai eval create -e staging` read the endpoint out of the default
+		// environment and wrote its eval id back there, and even a name azd
+		// itself rejects was accepted in silence. Set here rather than at each
+		// reader, so there is one answer to which environment this invocation
+		// is about.
+		cmd.SetContext(projectctx.WithSelectedEnvironment(cmd.Context(), extCtx.Environment))
+		if err := projectctx.VerifySelectedEnvironment(cmd.Context()); err != nil {
+			return err
+		}
+		setupDebugLogging(cmd.Flags())
+		return nil
+	}
+
+	rootCmd.AddCommand(
+		newInitCommand(),
+		newDatasetCommand(),
+		newRunCommand(),
+		newEvaluatorCommand(),
+		newGenerateCommand(),
+		newJobCommand(),
+		newEvalCreateCommand(),
+		newEvalListCommand(),
+		newEvalShowCommand(),
+		newEvalDeleteCommand(),
+		newListenCommand(),
+	)
+
+	// The manifest declares the `metadata` capability, which azd uses to
+	// discover this extension's command tree. Without the command registered,
+	// that discovery fails with "unknown command".
+	rootCmd.AddCommand(azdext.NewMetadataCommand("1.0", "azure.ai.evaluations", func() *cobra.Command {
+		return rootCmd
+	}))
+
+	return rootCmd
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run.go
@@ -1,0 +1,1156 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/dataset_api"
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/project"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// Terminal run states reported by the service.
+var terminalRunStates = map[string]bool{
+	"completed": true,
+	"failed":    true,
+	"canceled":  true,
+	"cancelled": true,
+	"error":     true,
+}
+
+// runCompleted turns a run that did not complete into an error, so that a
+// caller who waited for it exits non-zero.
+//
+// The results have already been printed by the time this is asked, which is
+// the point: a run that errored has a reason worth reading, and reporting it
+// and then exiting 0 tells a pipeline the evaluation passed. It is checked
+// before the gate because the gate's exit code means "the evaluation
+// regressed", and a run that never produced results has not regressed — it did
+// not run. Distinguishing those two is what the separate code is for.
+func runCompleted(run *eval_api.OpenAIEvalRun) error {
+	if run == nil {
+		return nil
+	}
+	switch strings.ToLower(run.Status) {
+	case "completed", "":
+		return nil
+	}
+	return messages.RunFinishedWithStatus(run.ID, run.Status)
+}
+
+// runIsTerminal reports whether the run has stopped moving.
+//
+// A gate read from a run still in progress is read from partial counts: it can
+// fail a run that would have passed, and it can pass one that has not finished
+// failing.
+//
+// Derived from the polling vocabulary rather than repeating it: a state the
+// poller stops waiting on is a state whose counts are final, and keeping two
+// lists let "error" fall out of this one -- which told anyone gating an errored
+// run to pass --wait, on a run that had already stopped. The empty status is
+// the one deliberate difference: polling keeps waiting on a run the service has
+// not described yet, while a gate reads the counts it was handed.
+func runIsTerminal(run *eval_api.OpenAIEvalRun) bool {
+	if run == nil {
+		return false
+	}
+	status := strings.ToLower(run.Status)
+	return status == "" || terminalRunStates[status]
+}
+
+// newRunCommand builds the run group.
+//
+// `run` is a group, not an executable verb: once `run output` exists, a bare
+// `run` would make `azd ai eval run list` read as "run the thing called list".
+func newRunCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Start and inspect evaluation runs.",
+	}
+	addRunSubcommands(cmd)
+	cmd.AddCommand(buildRunCommand(
+		"start", "Start a run of an eval that has been deployed."))
+	return cmd
+}
+
+// buildRunCommand builds `run start`.
+func buildRunCommand(use, short string) *cobra.Command {
+	var (
+		groupName   string
+		datasetName string
+		runName     string
+		maxSamples  int
+		wait        bool
+		failOn      string
+		endpointFlg string
+		evalPath    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			out := cmd.OutOrStdout()
+
+			// Parsed before any network work, so a malformed threshold costs
+			// nothing to find out about.
+			threshold, err := parseGate(failOn)
+			if err != nil {
+				return err
+			}
+			// A gate is a verdict on a result. Returning before there is one
+			// used to drop the gate silently, so `--no-wait --fail-on ...`
+			// exited 0 however the run turned out -- a pipeline that believes
+			// it is gated and is not.
+			if !wait && threshold.set {
+				return messages.GateNeedsTheWait()
+			}
+			// resolveMaxSamples reads anything not above zero as "no cap", so a
+			// negative one sent the whole dataset to a billed run.
+			if maxSamples < 0 {
+				return messages.NegativeMaxSamplesFlag(maxSamples)
+			}
+
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			// One flag takes a name or an id. A declared name also brings the
+			// declaration, which is what says where rows come from; a bare id
+			// has none, so the pairing comes from the eval's previous run.
+			evalDir, err := ec.evalDir(ctx, evalPath)
+			if err != nil {
+				return err
+			}
+			ref, err := ec.resolveEvalRef(ctx, evalDir, chooseEvalIn(cmd, evalDir, groupName))
+			if err != nil {
+				return err
+			}
+			evalID := ref.ID
+			group := ref.Eval
+			configPath := ref.ConfigPath
+
+			if datasetName != "" {
+				if !ref.Declared() {
+					return messages.DatasetOverrideNeedsDeclaredEval()
+				}
+				if _, ok := ref.Config.DatasetDeclaration(datasetName); !ok {
+					return messages.DatasetNotInCatalog(
+						datasetName, filepath.ToSlash(configPath))
+				}
+				// The eval keeps its own declaration; only this run reads elsewhere.
+				overridden := *group
+				overridden.Dataset = datasetName
+				overridden.Source = nil
+				group = &overridden
+			}
+
+			if ref.Declared() {
+				if err := ec.checkDatasetRegistered(ctx, ref.Config, group, configPath); err != nil {
+					return err
+				}
+			}
+
+			var dataSource *eval_api.EvalRunDataSource
+			switch {
+			case group == nil:
+				dataSource, err = ec.reuseDataSourceFromLastRun(ctx, evalID)
+			default:
+				dataSource, err = ec.buildRunDataSource(
+					ctx, group, configPath, resolveMaxSamples(maxSamples, group))
+			}
+			if err != nil {
+				return err
+			}
+
+			if runName == "" {
+				base := "eval"
+				if group != nil {
+					base = group.Name
+				}
+				runName = fmt.Sprintf("%s-%s", base, time.Now().UTC().Format("20060102-150405"))
+			}
+
+			metadata := map[string]string{}
+			if lvl := resolveLevel(group); lvl != "" {
+				metadata["evaluation_level"] = lvl
+			}
+			// The eval carries its name in its own metadata, but a run is read
+			// on its own, and an id is not what the author called it.
+			if group != nil && group.Name != "" {
+				metadata[metaEvalName] = group.Name
+			}
+			// Recorded per run, not read from the configuration at list time:
+			// comparing two runs is the point of that listing, and the dataset
+			// under an eval can change between them. A source-backed run scored
+			// no dataset, so it records none.
+			if group != nil && group.Dataset != "" && group.Source == nil {
+				metadata[metaDataset] = group.Dataset
+				if v := ec.getEnvValue(ctx, versionKey("dataset", group.Dataset)); v != "" {
+					metadata[metaDatasetVersion] = v
+				}
+			}
+
+			run, err := ec.evalClient.CreateOpenAIEvalRun(ctx, evalID, &eval_api.CreateOpenAIEvalRunRequest{
+				Name:       runName,
+				DataSource: dataSource,
+				Metadata:   metadata,
+			})
+			if err != nil {
+				return messages.StartingRun(err)
+			}
+
+			// Remembered per group as well as globally: a single shared key
+			// belongs to whichever group ran last, so another group asking for
+			// "the last run" would be handed one that is not its own.
+			ec.remember(ctx, idKey("evalrun", evalID), run.ID)
+			if err := ec.setEnvValue(ctx, envKeyEvalRunID, run.ID); err != nil {
+				// Persisting the run id is a convenience for later commands.
+				// Reported on stdout because azd does not surface an
+				// extension's stderr, and skipped outside a project.
+				if !errors.Is(err, errNoAzdEnvironment) && !isJSON(cmd) {
+					fmt.Fprint(out, messages.Warning(err))
+				}
+			}
+
+			if !wait {
+				if isJSON(cmd) {
+					return emitJSON(out, startedRun(run, evalID, group))
+				}
+				fmt.Fprint(out, messages.RunStarted(run.ID, run.Status))
+				fmt.Fprint(out, messages.ReattachToRun(run.ID, evalID))
+				return nil
+			}
+
+			final, err := ec.pollRun(ctx, evalID, run.ID, out, isJSON(cmd))
+			if errors.Is(err, errWaitBudgetSpent) {
+				// A gate asked for a verdict that never arrived. Exiting 0 here
+				// would tell a pipeline the gate passed, which is the silent
+				// drop --no-wait is refused for, reached by running long.
+				if threshold.set {
+					return messages.GateOutlivedTheWait(run.ID, waitBudget)
+				}
+				// The run did not fail, the wait ran out. Same contract as
+				// --no-wait: exit 0 and say how to pick it back up.
+				if isJSON(cmd) {
+					return emitJSON(out, startedRun(run, evalID, group))
+				}
+				fmt.Fprint(out, messages.WaitBudgetSpent(run.ID, waitBudget))
+				fmt.Fprint(out, messages.ReattachToRun(run.ID, evalID))
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			final = ec.withPortalLink(ctx, evalID, final)
+
+			if isJSON(cmd) {
+				if err := emitJSON(out, final); err != nil {
+					return err
+				}
+			} else if err := renderRun(out, final, ec.runMeans(ctx, evalID, final)); err != nil {
+				return err
+			}
+
+			// Last, so that the results are reported whether or not the gate
+			// holds: a pipeline that only learns it failed is worse off than
+			// one that can see by how much.
+			if err := runCompleted(final); err != nil {
+				return err
+			}
+			applyGate(cmd, threshold, final)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&groupName, "eval", "",
+		"Name of the eval to run, or its id. Defaults to the only one declared.")
+	cmd.Flags().StringVar(&datasetName, "dataset", "",
+		"Catalog dataset to read instead of the one the eval declares. "+
+			"Must satisfy the eval's column schema.")
+	cmd.Flags().StringVar(&runName, "name", "", "Name for this run. Defaults to the eval name plus a timestamp.")
+	cmd.Flags().IntVar(&maxSamples, "max-samples", 0,
+		"Cap the rows sent from the dataset.")
+	cmd.Flags().BoolVar(&wait, "wait", true, "Block until the run reaches a terminal state.")
+	addFailOnFlag(cmd, &failOn)
+	// The spec documents --no-wait, and cobra does not derive it from a bool.
+	var noWait bool
+	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Submit the run and return immediately.")
+	cmd.PreRun = func(*cobra.Command, []string) {
+		if noWait {
+			wait = false
+		}
+	}
+	cmd.MarkFlagsMutuallyExclusive("wait", "no-wait")
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	addEvalPathFlag(cmd, &evalPath)
+
+	return cmd
+}
+
+// checkDatasetRegistered fails when the group's local dataset has edits that
+// were never deployed.
+//
+// A run sends a local dataset inline, so without this the run would evaluate
+// content that no registered version corresponds to: the results are attributed
+// to the eval but cannot be traced back to a dataset version, which
+// makes them impossible to reproduce or compare.
+//
+// The check only applies once a deploy has recorded a fingerprint. Before that
+// there is nothing to have drifted from, and running is how a group first comes
+// into existence.
+func (ec *evalContext) checkDatasetRegistered(
+	ctx context.Context,
+	cfg *project.EvalConfig,
+	group *project.Eval,
+	configPath string,
+) error {
+	localPath := localDatasetPath(configPath, group)
+	if localPath == "" {
+		return nil
+	}
+
+	decl, ok := cfg.DatasetDeclaration(group.Dataset)
+	if !ok {
+		return nil
+	}
+
+	recorded := ec.getEnvValue(ctx, project.FingerprintKey("dataset", decl.Name))
+	if recorded == "" {
+		return nil
+	}
+
+	digest, err := project.Fingerprint(localPath)
+	if err != nil {
+		// Reading the file is the run's problem to report, not this check's.
+		return nil
+	}
+	if digest == recorded {
+		return nil
+	}
+
+	return messages.DatasetHasUnregisteredEdits(decl.Name, ec.deployCommand(ctx))
+}
+
+// reuseDataSourceFromLastRun rebuilds a run's data source from the group's most
+// recent run.
+//
+// `--eval-id` deliberately ignores the config, but a run still needs a target
+// and a dataset, and an eval carries neither: the group holds only its
+// testing criteria, and the dataset travels on the run. The previous run is the
+// only place that pairing survives, so re-running a group means repeating what
+// it last ran.
+func (ec *evalContext) reuseDataSourceFromLastRun(
+	ctx context.Context,
+	evalID string,
+) (*eval_api.EvalRunDataSource, error) {
+	list, err := ec.evalClient.ListOpenAIEvalRuns(ctx, evalID, 1)
+	if err != nil {
+		if eval_api.IsNotFound(err) {
+			// The eval itself is missing, which is worth saying plainly rather
+			// than as forty lines of the 404 that discovered it.
+			return nil, messages.EvalNotFound(evalID)
+		}
+		return nil, messages.ReadingPreviousRuns(evalID, err)
+	}
+	if list == nil || len(list.Data) == 0 || list.Data[0].DataSource == nil {
+		return nil, messages.EvalHasNoPreviousRun(evalID)
+	}
+	return pinReusedTraceWindow(list.Data[0].DataSource), nil
+}
+
+// legacyTraceLookbackHours is the window a legacy source with no lookback ran
+// under: the service's own default of seven days.
+//
+// Recorded here because the old data source had no start bound of its own --
+// it carried agent_name, lookback_hours, end_time and max_traces, and nothing
+// else -- so a run that set no lookback was graded over whatever the service
+// chose. Carrying such a run forward with no start at all would widen it to all
+// of history instead.
+const legacyTraceLookbackHours = 24 * 7
+
+// pinReusedTraceWindow closes the window a reattached run repeats.
+//
+// A run reached by id repeats whatever data source the last one sent, and a
+// trace window with a start and no end means "up to now". Replaying it a week
+// later grades a week more than the run it was copied from, and the run after
+// that more again, so the span grows without limit and nothing says so.
+//
+// A window with no start at all is repeated as it stands: it says "everything",
+// which is what it said when it was recorded, and closing it would freeze a
+// declaration that never asked to be bounded. So is a window that already has
+// an end, which cannot widen and is not this function's to move.
+//
+// It is graded over the span it covers rather than the span it covered: the
+// declaration is where a window that should move with each run comes from, and
+// a run reached by id has no declaration to read. Freezing it once is the
+// closest a shape with no lookback can come to one.
+//
+// Pinning the end at now also excludes traces the service has not finished
+// ingesting, which an open end would have picked up on the next run.
+//
+// The argument is never modified: what the previous run sent is history, and a
+// caller that logs or emits it should see what was recorded.
+func pinReusedTraceWindow(ds *eval_api.EvalRunDataSource) *eval_api.EvalRunDataSource {
+	switch {
+	case ds == nil:
+		return ds
+	case ds.Type == eval_api.EvalRunDataSourceTypeTraces:
+		return upgradeLegacyTraceSource(ds)
+	case ds.Type == eval_api.EvalRunDataSourceTypeTracePreview:
+		if ds.TraceSource == nil || ds.TraceSource.EndTime != 0 || ds.TraceSource.StartTime == 0 {
+			return ds
+		}
+		pinned := *ds
+		filter := *ds.TraceSource
+		filter.EndTime = time.Now().Unix()
+		pinned.TraceSource = &filter
+		return &pinned
+	default:
+		return ds
+	}
+}
+
+// upgradeLegacyTraceSource carries a run recorded under the old trace shape
+// onto the one that keeps what it is given.
+//
+// Without it, an eval whose last run predates the change would keep sending the
+// version-blind source for good, and nothing would say so.
+func upgradeLegacyTraceSource(ds *eval_api.EvalRunDataSource) *eval_api.EvalRunDataSource {
+	// Without an agent the preview shape carries no filter at all, and
+	// omitempty drops it: the reattached run would read every agent's spans,
+	// a broader and costlier query than the one it is repeating. Repeating
+	// what was recorded is the lesser wrong.
+	if ds.AgentName == "" {
+		return ds
+	}
+	end := time.Now()
+	if ds.EndTime > 0 {
+		end = time.Unix(ds.EndTime, 0)
+		// A recorded end in the future would close the window after the last
+		// trace that exists, which reads nothing past now and says nothing.
+		if end.After(time.Now()) {
+			end = time.Now()
+		}
+	}
+	// The recorded values are whatever an older build sent, from before the
+	// bounds existed, so they are clamped rather than trusted: a lookback beyond
+	// what a window may cover reaches back further than any trace was recorded,
+	// and the reattached run reads nothing.
+	hours := ds.LookbackHours
+	if hours <= 0 || hours > project.MaxLookbackHours {
+		hours = legacyTraceLookbackHours
+	}
+	start := end.Add(-time.Duration(hours) * time.Hour)
+	// A recorded end early enough to put the start at or before the epoch would
+	// send a bound the wire drops, or a negative one -- the same silence a
+	// declaration is refused for. Reaching back from now instead keeps the
+	// length of the window the run asked for.
+	if start.Unix() <= 0 {
+		end = time.Now()
+		start = end.Add(-time.Duration(hours) * time.Hour)
+	}
+	// Only reachable on a machine whose clock is set before about 1980, where
+	// even now minus the longest window a declaration may name lands in the
+	// pre-epoch. Dropping the bound says "everything", which is at least what
+	// the legacy shape said when it carried no start.
+	if start.Unix() <= 0 {
+		start = time.Time{}
+	}
+	// A negative cap is no cap at all, and leaving it off means the service's
+	// own default of a thousand traces -- a bigger, costlier run than the one
+	// being repeated. The cap `init` writes is bounded and can be raised in the
+	// declaration, which is the only place a considered value can come from.
+	maxTraces := ds.MaxTraces
+	if maxTraces < 0 {
+		maxTraces = project.DefaultScaffoldMaxTraces
+	}
+	// The old shape carried no version, so this pins nothing that was not
+	// pinned before; it stops the service choosing differently run to run only
+	// once the declaration names one.
+	return eval_api.NewTracePreviewDataSource(ds.AgentName, "", start, end, maxTraces)
+}
+
+// runnableEval refuses a declaration this run could not carry out.
+//
+// The rules live with the check the configuration runs, so the two cannot come
+// to different conclusions about the same eval. Only the wrapper differs: the
+// configuration has an index to name and a run does not.
+func runnableEval(group *project.Eval) error {
+	if err := project.ValidateRunnable(group); err != nil {
+		return messages.InEval(group.Name, err)
+	}
+	return nil
+}
+
+// buildRunDataSource binds the eval's rows to the run.
+//
+// Three shapes, in the order the configuration decides them. A `source:` block
+// hands the gathering to the service and sends nothing local. Otherwise the
+// rows come from a dataset, and `target:` says what to invoke for each one --
+// including nothing at all, when the rows already hold both sides.
+//
+// This is where a declaration is refused, not merely where it is read. Resolving
+// an eval by name does not validate what it says about itself, and a run reached
+// by id has no declaration to validate, so every contradiction the configuration
+// names has to be answered here as well. Settling one by evaluation order sends
+// a request that succeeds and grades something the file did not ask for.
+func (ec *evalContext) buildRunDataSource(
+	ctx context.Context,
+	group *project.Eval,
+	configPath string,
+	maxSamples int,
+) (*eval_api.EvalRunDataSource, error) {
+	if group == nil {
+		return nil, messages.NoEvalToRun()
+	}
+	if err := runnableEval(group); err != nil {
+		return nil, err
+	}
+	if group.Dataset != "" && configPath != "" && !datasetIsDeclared(configPath, group) {
+		return nil, messages.InEval(group.Name, messages.DatasetNotDeclared(group.Dataset))
+	}
+
+	if group.Source != nil {
+		switch group.Source.Type {
+		case project.SourceTypeTraces:
+			return tracesDataSource(group)
+		default:
+			return responsesDataSource(group)
+		}
+	}
+
+	var ds *eval_api.EvalRunDataSource
+	switch {
+	case group.Target == nil || group.Target.Name == "":
+		// Nothing to invoke: the dataset is scored as it stands.
+		ds = eval_api.NewDatasetOnlyDataSource()
+	case group.Target.Type == project.TargetTypeModel:
+		ds = eval_api.NewModelTargetDataSource(group.Target.Name)
+	default:
+		ds = eval_api.NewAgentTargetDataSource(group.Target.Name, nil)
+	}
+
+	if group.Dataset == "" {
+		return nil, messages.EvalHasNoDataset(group.Name)
+	}
+
+	// A local source is read from disk; anything else is already registered and
+	// has to be fetched. Either way the rows are sent inline, because a run's
+	// file_id means an uploaded file and a dataset name is not one: sending the
+	// name is rejected with "invalid data source file ids".
+	localPath := localDatasetPath(configPath, group)
+	if localPath == "" {
+		items, err := ec.readRegisteredDataset(ctx, group.Dataset, maxSamples)
+		if err != nil {
+			return nil, err
+		}
+		ds.SetFileContent(items)
+		return ds, nil
+	}
+
+	items, err := readJSONL(localPath, maxSamples)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, messages.DatasetFileEmpty(localPath)
+	}
+	ds.SetFileContent(items)
+	return ds, nil
+}
+
+// tracesDataSource evaluates conversations the agent already had.
+//
+// The service reads them from Application Insights, so the agent has to be
+// emitting gen_ai.input.messages / gen_ai.output.messages for anything to be
+// found. `agent_name` filters the traces; it is not a target, because a trace
+// run invokes nothing.
+func tracesDataSource(group *project.Eval) (*eval_api.EvalRunDataSource, error) {
+	// runnableEval has already refused an empty one; read rather than assumed,
+	// because the agent name is what the whole request is about.
+	agent := project.TraceAgentName(group.Source, group.Target)
+	if agent == "" {
+		return nil, messages.InEval(group.Name, messages.TraceSourceNeedsAnAgent())
+	}
+
+	start, end, err := traceWindow(group.Name, group.Source)
+	if err != nil {
+		return nil, err
+	}
+	return eval_api.NewTracePreviewDataSource(
+		agent,
+		group.Source.AgentVersion,
+		start,
+		end,
+		group.Source.MaxTraces,
+	), nil
+}
+
+// traceWindow resolves the bounds of the span a trace run reads.
+//
+// The rules live in the project package, with the check the configuration runs,
+// so a source is judged the same way whichever door the eval came through.
+func traceWindow(evalName string, source *project.SourceDecl) (start, end time.Time, err error) {
+	start, end, err = project.ValidateSource(source)
+	if err != nil {
+		return time.Time{}, time.Time{}, messages.InEval(evalName, err)
+	}
+	return start, end, nil
+}
+
+// responsesDataSource evaluates responses the project already stored.
+func responsesDataSource(group *project.Eval) (*eval_api.EvalRunDataSource, error) {
+	if len(group.Source.ResponseIDs) == 0 {
+		return nil, messages.InEval(group.Name, messages.ResponsesSourceNeedsResponseIDs())
+	}
+	return eval_api.NewResponsesDataSource(group.Source.ResponseIDs, group.Source.MaxTurns), nil
+}
+
+// readRegisteredDataset fetches a published dataset's rows, optionally keeping
+// only the first n.
+//
+// The rows have to be fetched because a run cannot reference a dataset by
+// name: `file_id` means an uploaded file, and passing a dataset name there is
+// rejected. Fetching also makes --max-samples mean the same thing whether the
+// dataset is local or published, which a file reference could not — that
+// source carries no row limit.
+func (ec *evalContext) readRegisteredDataset(
+	ctx context.Context,
+	name string,
+	maxSamples int,
+) ([]map[string]any, error) {
+	version := ec.getEnvValue(ctx, versionKey("dataset", name))
+	if version == "" {
+		versions, err := ec.datasetClient.ListDatasetVersions(ctx, name, ProjectEndpointAPIVersion)
+		if err != nil {
+			return nil, messages.ReadingDataset(name, err)
+		}
+		if versions != nil {
+			version = dataset_api.LatestVersion(versions.Value)
+		}
+	}
+	if version == "" {
+		return nil, messages.DatasetHasNoVersionsToRead(name)
+	}
+
+	content, err := ec.datasetClient.DownloadDatasetContent(
+		ctx, name, version, ProjectEndpointAPIVersion)
+	if err != nil {
+		return nil, messages.ReadingDatasetVersion(name, version, err)
+	}
+
+	items, err := readJSONLBytes(content, maxSamples)
+	if err != nil {
+		return nil, messages.ReadingDatasetVersion(name, version, err)
+	}
+	if len(items) == 0 {
+		return nil, messages.DatasetVersionEmpty(name, version)
+	}
+	return items, nil
+}
+
+// datasetColumnsFromPath reads one row to learn the dataset's shape. An empty
+// path, or an unreadable file, yields nil.
+func datasetColumnsFromPath(localPath string) map[string]bool {
+	if localPath == "" {
+		return nil
+	}
+	// One row is enough to learn the shape.
+	items, err := readJSONL(localPath, 1)
+	if err != nil || len(items) == 0 {
+		return nil
+	}
+	columns := make(map[string]bool, len(items[0]))
+	for name := range items[0] {
+		columns[name] = true
+	}
+	return columns
+}
+
+// localDatasetPath resolves the dataset's local source relative to the config
+// file, returning empty when the dataset is registered rather than local.
+func localDatasetPath(configPath string, group *project.Eval) string {
+	cfg, err := project.LoadEvalConfig(configPath)
+	if err != nil || group == nil {
+		return ""
+	}
+	decl, ok := cfg.DatasetDeclaration(group.Dataset)
+	if !ok || decl.Source == "" {
+		return ""
+	}
+	if filepath.IsAbs(decl.Source) {
+		return decl.Source
+	}
+	return filepath.Join(filepath.Dir(configPath), decl.Source)
+}
+
+// datasetIsDeclared says whether the configuration's catalog holds the dataset
+// this eval names.
+//
+// Without it a mistyped name falls through to a registry read and comes back as
+// a 404 for a dataset nobody ever registered, which sends the reader to the
+// service rather than to the line they mistyped. Answered yes when there is no
+// configuration to ask: an eval reached by id has no catalog.
+func datasetIsDeclared(configPath string, group *project.Eval) bool {
+	cfg, err := project.LoadEvalConfig(configPath)
+	if err != nil || cfg == nil {
+		return true
+	}
+	_, ok := cfg.DatasetDeclaration(group.Dataset)
+	return ok
+}
+
+// readJSONL reads newline-delimited JSON, optionally truncating to limit rows.
+func readJSONL(path string, limit int) ([]map[string]any, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, messages.ReadingDataset(path, err)
+	}
+	defer f.Close()
+
+	items, err := scanJSONL(f, limit)
+	if err != nil {
+		return nil, messages.ReadingDataset(path, err)
+	}
+	return items, nil
+}
+
+// readJSONLBytes parses JSONL already in memory, which is how a registered
+// dataset arrives.
+func readJSONLBytes(content []byte, limit int) ([]map[string]any, error) {
+	return scanJSONL(bytes.NewReader(content), limit)
+}
+
+// scanJSONL reads rows until the limit is reached, so a subset costs only the
+// rows it needs to parse.
+func scanJSONL(r io.Reader, limit int) ([]map[string]any, error) {
+	var items []map[string]any
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	line := 0
+	for scanner.Scan() {
+		line++
+		text := strings.TrimSpace(scanner.Text())
+		if text == "" {
+			continue
+		}
+		var row map[string]any
+		if err := json.Unmarshal([]byte(text), &row); err != nil {
+			return nil, messages.JSONLLineInvalid(line, err)
+		}
+		items = append(items, row)
+		if limit > 0 && len(items) >= limit {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+// resolveLevel prefers the flag, then the eval's own declaration.
+// resolveLevel is the eval's declared scoring granularity.
+//
+// There is no per-run override: the level decides the row mapping, so two
+// levels under one eval would put incomparable result sets in the same history,
+// and it would bypass the supported_evaluation_levels check `azd up` does
+// against the declared level. A second level is a second eval.
+func resolveLevel(group *project.Eval) string {
+	if group != nil {
+		return group.EvaluationLevel
+	}
+	return ""
+}
+
+// resolveMaxSamples prefers the flag, then the eval's own declaration, matching
+// how the evaluation level resolves.
+//
+// Without this, max_samples parsed and did nothing: an eval that caps its
+// sample count in config would send the whole dataset, and only a flag on every
+// invocation would honour the cap.
+func resolveMaxSamples(flag int, group *project.Eval) int {
+	if flag > 0 {
+		return flag
+	}
+	if group != nil && group.MaxSamples > 0 {
+		return group.MaxSamples
+	}
+	return 0
+}
+
+// errWaitBudgetSpent says the run outlived the wait, not that anything failed.
+//
+// It is handled where --no-wait is: the run is still going server-side, so the
+// caller is handed the same reattach line and the same exit code.
+var errWaitBudgetSpent = errors.New("wait budget spent")
+
+// waitBudget bounds a foreground wait.
+//
+// Not a policy about how long an evaluation may take -- it is a guard against
+// waiting on a run that will never reach a terminal state. Runs are scored
+// sequentially at roughly 40s a sample, so this clears a few hundred samples
+// before it ever fires.
+const waitBudget = 2 * time.Hour
+
+// pollRun waits for the run to reach a terminal state, reporting status changes.
+func (ec *evalContext) pollRun(
+	ctx context.Context,
+	evalID, runID string,
+	out interface{ Write([]byte) (int, error) },
+	jsonMode bool,
+) (*eval_api.OpenAIEvalRun, error) {
+	const interval = 5 * time.Second
+	lastStatus := ""
+	deadline := time.Now().Add(waitBudget)
+
+	for {
+		run, err := ec.evalClient.GetOpenAIEvalRun(ctx, evalID, runID)
+		if err != nil {
+			return nil, messages.PollingRun(runID, err)
+		}
+		if run.Status != lastStatus {
+			lastStatus = run.Status
+			if !jsonMode {
+				fmt.Fprint(out, messages.RunStatusLine(run.Status))
+			}
+		}
+		if terminalRunStates[strings.ToLower(run.Status)] {
+			return run, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, errWaitBudgetSpent
+		}
+		select {
+		case <-ctx.Done():
+			// Name what is still running, or the run is lost to whoever
+			// interrupted the wait.
+			return nil, messages.WaitInterrupted(runID, ctx.Err())
+		case <-time.After(interval):
+		}
+	}
+}
+
+// startedRunHandoff is what `run start --no-wait -o json` returns.
+//
+// It is a handoff rather than a dump of the service object. The pipeline that
+// started the run has to come back for it later, and doing that needs exactly
+// three things: the run, the eval it belongs to, and a name a human can read
+// in the log that reports it. The service object carries none of the third and
+// buries the first two under the data source, the metadata and every field the
+// API happens to return, so a script reading it would depend on a shape this
+// extension does not control.
+type startedRunHandoff struct {
+	RunID    string `json:"run_id"`
+	EvalID   string `json:"eval_id"`
+	EvalName string `json:"eval_name,omitempty"`
+	// Which rows the run scored. A pipeline that records only a pass rate
+	// cannot say later what the rate was measured against.
+	Dataset        string `json:"dataset,omitempty"`
+	DatasetVersion string `json:"dataset_version,omitempty"`
+	Status         string `json:"status,omitempty"`
+	CreatedAt      string `json:"created_at,omitempty"`
+}
+
+// startedRun builds the handoff.
+func startedRun(
+	run *eval_api.OpenAIEvalRun,
+	evalID string,
+	group *project.Eval,
+) startedRunHandoff {
+	handoff := startedRunHandoff{
+		RunID:     run.ID,
+		EvalID:    evalID,
+		Status:    run.Status,
+		CreatedAt: timestampString(run.CreatedAt),
+	}
+	// Read back from the run rather than the configuration, so the handoff
+	// names what this run scored and not what the file says today. The create
+	// response does not always echo metadata, so the declaration is the
+	// fallback for the name.
+	handoff.Dataset = run.Metadata[metaDataset]
+	handoff.DatasetVersion = run.Metadata[metaDatasetVersion]
+	// Absent with --eval-id, where there is no config to take a name from.
+	if group != nil {
+		handoff.EvalName = group.Name
+		if handoff.Dataset == "" {
+			handoff.Dataset = group.Dataset
+		}
+	}
+	return handoff
+}
+
+// timestampString renders a service timestamp as RFC 3339.
+//
+// The field arrives as epoch seconds on a run and as a formatted string
+// elsewhere, so passing it through would hand a script a value whose type
+// depends on which route produced it.
+func timestampString(value any) string {
+	switch t := value.(type) {
+	case nil:
+		return ""
+	case string:
+		// Normalized, not passed through: the service returns sub-second
+		// precision and an offset here and epoch seconds elsewhere, so two
+		// listings would otherwise spell the same instant differently.
+		if parsed, err := time.Parse(time.RFC3339, t); err == nil {
+			return parsed.UTC().Format(time.RFC3339)
+		}
+		return t
+	case float64:
+		return time.Unix(int64(t), 0).UTC().Format(time.RFC3339)
+	case int64:
+		return time.Unix(t, 0).UTC().Format(time.RFC3339)
+	case json.Number:
+		if seconds, err := t.Int64(); err == nil {
+			return time.Unix(seconds, 0).UTC().Format(time.RFC3339)
+		}
+		return t.String()
+	default:
+		return fmt.Sprint(value)
+	}
+}
+
+// runMeans reads the run's rows to average each evaluator's score.
+//
+// Best effort: the summary is worth printing without the column, and a run
+// that scored nothing has no rows to read.
+func (ec *evalContext) runMeans(
+	ctx context.Context,
+	evalID string,
+	run *eval_api.OpenAIEvalRun,
+) map[string]float64 {
+	if run == nil || run.ResultCounts == nil || run.ResultCounts.Total == 0 {
+		return nil
+	}
+	items, err := ec.evalClient.ListOutputItems(ctx, evalID, run.ID, 0)
+	if err != nil || items == nil {
+		return nil
+	}
+	return criteriaMeans(items.Data)
+}
+
+// timestampTime reads a service timestamp, which arrives as epoch seconds on a
+// run and as a formatted string elsewhere.
+func timestampTime(value any) time.Time {
+	switch t := value.(type) {
+	case float64:
+		return time.Unix(int64(t), 0).UTC()
+	case int64:
+		return time.Unix(t, 0).UTC()
+	case string:
+		if parsed, err := time.Parse(time.RFC3339, t); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+// renderRun prints what a person needs after waiting for a run.
+//
+// means carries each criterion's average score, which the run summary does not
+// return; it is nil when the rows were not fetched, and the column is dropped.
+func renderRun(
+	out interface{ Write([]byte) (int, error) },
+	run *eval_api.OpenAIEvalRun,
+	means map[string]float64,
+) error {
+	fmt.Fprintln(out)
+	renderRunHeader(out, run)
+
+	// A run that failed carries why, and it is usually the only actionable
+	// thing in the response — dropping it leaves the caller with just the word
+	// "failed".
+	if why := run.Failure(); why != "" {
+		fmt.Fprintf(out, "\n%s\n", why)
+	}
+
+	renderCriteriaTable(out, run.PerTestingCriteria, means)
+
+	// Counted over samples, not over verdicts: a sample that failed two
+	// evaluators is one sample to go and look at, and reporting it as two
+	// overstates how much is wrong.
+	if c := run.ResultCounts; c != nil && c.Total > 0 {
+		fmt.Fprint(out, messages.OverallPassRate(formatRate(c.Passed, c.Total), c.Passed, c.Total))
+		if c.Errored > 0 {
+			fmt.Fprint(out, messages.SamplesErrored(c.Errored))
+		}
+		if c.Failed > 0 {
+			fmt.Fprint(out, messages.ViewFailingSamples())
+		}
+	}
+
+	if url := runLink(run.ReportURL, run.PortalURL); url != "" {
+		fmt.Fprint(out, messages.ReportLink(color.CyanString(url)))
+	}
+	return nil
+}
+
+// renderRunHeader prints the run's identity above the per-evaluator table.
+//
+// The eval is named from the metadata the extension wrote at create time,
+// because the run carries only an id and the id is not what anyone declared.
+func renderRunHeader(out interface{ Write([]byte) (int, error) }, run *eval_api.OpenAIEvalRun) {
+	fmt.Fprintf(out, "%-10s %s\n", "Run", run.ID)
+	if name := run.Metadata[metaEvalName]; name != "" {
+		fmt.Fprintf(out, "%-10s %s\n", "Eval", name)
+	} else if run.EvalID != "" {
+		fmt.Fprintf(out, "%-10s %s\n", "Eval", run.EvalID)
+	}
+	if ds := runDatasetLine(run.Metadata); ds != "" {
+		fmt.Fprintf(out, "%-10s %s\n", "Dataset", ds)
+	}
+	fmt.Fprintf(out, "%-10s %s\n", "Status", run.Status)
+	if c := run.ResultCounts; c != nil && c.Total > 0 {
+		fmt.Fprintf(out, "%-10s %d\n", "Samples", c.Total)
+	}
+	if d := runDuration(run); d != "" {
+		fmt.Fprintf(out, "%-10s %s\n", "Duration", d)
+	}
+}
+
+// runDuration reports how long the run took, or "" when either end is missing.
+func runDuration(run *eval_api.OpenAIEvalRun) string {
+	start, end := timestampTime(run.CreatedAt), timestampTime(run.ModifiedAt)
+	if start.IsZero() || end.IsZero() || !end.After(start) {
+		return ""
+	}
+	d := end.Sub(start).Round(time.Second)
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	return fmt.Sprintf("%dm%02ds", int(d.Minutes()), int(d.Seconds())%60)
+}
+
+// renderCriteriaTable prints one row per evaluator.
+//
+// Sorted by name so two runs of the same eval read the same way; the service
+// returns the criteria in whatever order it evaluated them.
+func renderCriteriaTable(
+	out interface{ Write([]byte) (int, error) },
+	results []eval_api.EvalRunCriteriaResult,
+	means map[string]float64,
+) {
+	if len(results) == 0 {
+		return
+	}
+
+	sorted := append([]eval_api.EvalRunCriteriaResult(nil), results...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].TestingCriteria < sorted[j].TestingCriteria
+	})
+
+	width := len("EVALUATOR")
+	for _, r := range sorted {
+		if n := len(r.TestingCriteria); n > width {
+			width = n
+		}
+	}
+
+	fmt.Fprintf(out, "\n%-*s  %4s  %4s  %9s", width, "EVALUATOR", "PASS", "FAIL", "PASS RATE")
+	fmt.Fprintf(out, "%s\n", meanHeader(means))
+	fmt.Fprintf(out, "%s  %s  %s  %s%s\n",
+		strings.Repeat("-", width), "----", "----", "---------", meanRule(means))
+
+	for _, r := range sorted {
+		scored := r.Passed + r.Failed
+		fmt.Fprintf(out, "%-*s  %4d  %4d  %9s",
+			width, r.TestingCriteria, r.Passed, r.Failed, formatRate(r.Passed, scored))
+		if means != nil {
+			if mean, ok := means[r.TestingCriteria]; ok {
+				fmt.Fprintf(out, "  %10.1f", mean)
+			} else {
+				fmt.Fprintf(out, "  %10s", "-")
+			}
+		}
+		fmt.Fprintln(out)
+		// Errors are not failures — the evaluator never reached a verdict —
+		// so they are named rather than folded into the fail column, where
+		// they would look like a quality problem.
+		if r.Errored > 0 {
+			fmt.Fprintf(out, "%-*s  %s\n", width, "", errorNote(r.Errored))
+		}
+	}
+}
+
+// meanHeader and meanRule add the score column only when there are scores.
+func meanHeader(means map[string]float64) string {
+	if means == nil {
+		return ""
+	}
+	return fmt.Sprintf("  %10s", "MEAN SCORE")
+}
+
+func meanRule(means map[string]float64) string {
+	if means == nil {
+		return ""
+	}
+	return "  " + strings.Repeat("-", 10)
+}
+
+// criteriaMeans averages each evaluator's score over the rows it scored.
+//
+// The run summary reports pass and fail counts but no score, so a table that
+// shows how close a passing evaluator came to failing has to read the rows.
+// Errored and unscored rows are left out rather than counted as zero, which
+// would drag the average toward a number no evaluator produced.
+func criteriaMeans(items []eval_api.OutputItem) map[string]float64 {
+	sums := map[string]float64{}
+	counts := map[string]int{}
+	for _, item := range items {
+		for _, r := range item.Results {
+			if !r.Score.Defined() {
+				continue
+			}
+			name := r.Name
+			if name == "" {
+				name = r.Metric
+			}
+			sums[name] += float64(r.Score)
+			counts[name]++
+		}
+	}
+	if len(counts) == 0 {
+		return nil
+	}
+	means := make(map[string]float64, len(counts))
+	for name, n := range counts {
+		means[name] = sums[name] / float64(n)
+	}
+	return means
+}
+
+// errorNote describes rows an evaluator could not score.
+func errorNote(errored int) string {
+	return messages.ErroredNotScored(errored)
+}
+
+// formatRate renders a share as a percentage, and a rate over nothing as a
+// dash: 0.0%% would read as a total failure rather than as no data.
+func formatRate(part, whole int) string {
+	if whole <= 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%.1f%%", float64(part)/float64(whole)*100)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_dataset_column_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_dataset_column_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Scenario 3 reads a trend off two rows of `run list`, and the dataset column
+// is what makes the comparison honest: two rates over different rows are not
+// the same claim.
+func TestRunDataset_NameAndVersion(t *testing.T) {
+	got := runDataset(map[string]string{
+		metaDataset:        "support-agent-regression",
+		metaDatasetVersion: "1",
+	})
+
+	assert.Equal(t, "support-agent-regression (v1)", got)
+}
+
+// A dataset recorded before it was published has a name but no version yet.
+func TestRunDataset_NameWithoutVersion(t *testing.T) {
+	got := runDataset(map[string]string{metaDataset: "support-golden"})
+
+	assert.Equal(t, "support-golden", got)
+}
+
+// Runs started before the extension recorded this show nothing. Falling back to
+// the configuration would print today's dataset against a run that scored a
+// different one, which is exactly the drift the column exists to reveal.
+func TestRunDataset_UnrecordedShowsNothing(t *testing.T) {
+	assert.Empty(t, runDataset(nil))
+	assert.Empty(t, runDataset(map[string]string{"evaluation_level": "turn"}))
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_datasource_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_datasource_test.go
@@ -1,0 +1,454 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/project"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeDataset drops a JSONL file beside a config that registers it, and
+// returns the config path. An eval's dataset: is a catalog name, not a path, so
+// the declaration is what makes the rows reachable.
+func writeDataset(t *testing.T, rows string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "datasets"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "datasets", "d.jsonl"), []byte(rows), 0o600))
+	configPath := filepath.Join(dir, "eval.yaml")
+	config := "datasets:\n  - name: d\n    source: ./datasets/d.jsonl\n"
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o600))
+	return configPath
+}
+
+const oneRow = `{"query":"q","ground_truth":"a"}` + "\n"
+
+// A trace-backed eval is the first hero scenario, and it is the one shape that
+// carries no dataset at all: the service gathers the rows itself. It used to be
+// refused for "not naming a target agent", which is the whole point of it.
+func TestBuildRunDataSource_Traces(t *testing.T) {
+	ec := &evalContext{}
+	group := &project.Eval{
+		Name: "trace-eval",
+		Source: &project.SourceDecl{
+			Type:          project.SourceTypeTraces,
+			AgentName:     "support-agent",
+			LookbackHours: 24,
+			MaxTraces:     500,
+		},
+	}
+
+	ds, err := ec.buildRunDataSource(context.Background(), group, "", 0)
+
+	require.NoError(t, err)
+	// The legacy azure_ai_traces shape discarded agent_version and start_time
+	// without saying so, and re-imposed its own lookback.
+	assert.Equal(t, eval_api.EvalRunDataSourceTypeTracePreview, ds.Type)
+	require.NotNil(t, ds.TraceSource)
+	assert.Equal(t, "agent_filter", ds.TraceSource.Type)
+	assert.Equal(t, "support-agent", ds.TraceSource.AgentName)
+	assert.Equal(t, 500, ds.TraceSource.MaxTraces)
+	// lookback_hours is still honoured, as the window's start bound. Asserted
+	// as a distance from now, because a merely non-zero start is also what a
+	// lookback that reached forwards would produce.
+	assert.InDelta(t, time.Now().Add(-24*time.Hour).Unix(), ds.TraceSource.StartTime, 60)
+	assert.Zero(t, ds.TraceSource.EndTime, "an open end means up to now")
+	// Nothing is invoked and nothing local is sent.
+	assert.Nil(t, ds.Target)
+	assert.Nil(t, ds.Source)
+}
+
+// Pinning the version is the whole reason the preview shape is used: without
+// it a redeployed agent is graded on whichever version the service picked.
+func TestBuildRunDataSource_TracesPinsTheAgentVersion(t *testing.T) {
+	ec := &evalContext{}
+	group := &project.Eval{
+		Name: "trace-eval",
+		Source: &project.SourceDecl{
+			Type:         project.SourceTypeTraces,
+			AgentName:    "support-agent",
+			AgentVersion: "2",
+		},
+	}
+
+	ds, err := ec.buildRunDataSource(context.Background(), group, "", 0)
+
+	require.NoError(t, err)
+	require.NotNil(t, ds.TraceSource)
+	assert.Equal(t, "2", ds.TraceSource.AgentVersion)
+}
+
+// An explicit window travels intact, in seconds and in UTC. The epochs are
+// spelled out because a drift into local time, or into milliseconds, would
+// still produce a window the service accepts and grades the wrong span of.
+func TestBuildRunDataSource_TracesCarriesAnExplicitWindow(t *testing.T) {
+	ec := &evalContext{}
+	group := &project.Eval{
+		Name: "trace-eval",
+		Source: &project.SourceDecl{
+			Type:      project.SourceTypeTraces,
+			AgentName: "support-agent",
+			StartTime: "2026-08-01T00:00:00Z",
+			EndTime:   "2026-08-02T00:00:00Z",
+		},
+	}
+
+	ds, err := ec.buildRunDataSource(context.Background(), group, "", 0)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(1785542400), ds.TraceSource.StartTime)
+	assert.Equal(t, int64(1785628800), ds.TraceSource.EndTime)
+}
+
+// Every input the configuration refuses has to be refused here too. The two
+// used to be separate checks and had drifted on six inputs, each accepted by
+// one door and refused by the other, so which rules applied depended on how the
+// eval was reached.
+func TestBuildRunDataSource_TracesRefusesEverySourceTheConfigWould(t *testing.T) {
+	ec := &evalContext{}
+	build := func(source *project.SourceDecl) error {
+		source.Type = project.SourceTypeTraces
+		source.AgentName = "a"
+		_, err := ec.buildRunDataSource(context.Background(),
+			&project.Eval{Name: "trace-eval", Source: source}, "", 0)
+		return err
+	}
+
+	cases := []struct {
+		name    string
+		source  project.SourceDecl
+		wantErr string
+	}{
+		{"start that is not a time", project.SourceDecl{StartTime: "yesterday"}, "not a time"},
+		{"start at year one", project.SourceDecl{StartTime: "0001-01-01T00:00:00Z"}, "traces were recorded at"},
+		{"start at the unix epoch", project.SourceDecl{StartTime: "1970-01-01T00:00:00Z"}, "traces were recorded at"},
+		{"negative lookback", project.SourceDecl{LookbackHours: -24}, "cannot be negative"},
+		{"lookback past the bound", project.SourceDecl{LookbackHours: project.MaxLookbackHours + 1}, "beyond the"},
+		{"negative cap", project.SourceDecl{MaxTraces: -5}, "source.max_traces"},
+		{
+			"window declared twice over",
+			project.SourceDecl{StartTime: "2026-08-01T00:00:00Z", LookbackHours: 24},
+			"keep one",
+		},
+		{
+			"end before start",
+			project.SourceDecl{StartTime: "2026-08-02T00:00:00Z", EndTime: "2026-08-01T00:00:00Z"},
+			"holds no traces",
+		},
+		// Not a window rule. The run door used to accept and ignore these
+		// while the config refused them.
+		{"a turn cap traces do not read", project.SourceDecl{MaxTurns: 3}, "does not read"},
+		{
+			"response ids traces do not read",
+			project.SourceDecl{ResponseIDs: []string{"resp_1"}},
+			"does not read",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := build(&tc.source)
+			require.Error(t, err)
+			// The eval is named, not the agent: the reader has to know which
+			// entry to edit, and a file can declare several evals over one agent.
+			assert.Contains(t, err.Error(), `eval "trace-eval"`)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// The responses door runs the same check. It reads no window, so a window on it
+// bounds nothing and only looks as though it does.
+func TestBuildRunDataSource_ResponsesRefusesFieldsItDoesNotRead(t *testing.T) {
+	ec := &evalContext{}
+
+	_, err := ec.buildRunDataSource(context.Background(), &project.Eval{
+		Name: "responses-eval",
+		Source: &project.SourceDecl{
+			Type:        project.SourceTypeResponses,
+			ResponseIDs: []string{"resp_1"},
+			// Present, so the missing-ids guard does not answer first.
+			LookbackHours: 24,
+		},
+	}, "", 0)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `eval "responses-eval"`)
+	assert.Contains(t, err.Error(), "lookback_hours")
+	assert.Contains(t, err.Error(), "does not read")
+}
+
+// agent_name under source: is a filter, but an eval that names a target and
+// leaves the filter off still means "this agent's traces".
+func TestBuildRunDataSource_TracesFallsBackToTargetName(t *testing.T) {
+	ec := &evalContext{}
+
+	for _, target := range []*project.Target{
+		{Type: project.TargetTypeAgent, Name: "support-agent"},
+		// `target.type` is optional, and config validation accepts the
+		// fallback on the name alone, so whatever it accepts a run has to be
+		// able to send. The dataset branch reads an untyped target as an agent
+		// too; requiring the type here made a config that deployed cleanly fail
+		// every run.
+		{Name: "support-agent"},
+	} {
+		group := &project.Eval{
+			Name:   "trace-eval",
+			Source: &project.SourceDecl{Type: project.SourceTypeTraces},
+			Target: target,
+		}
+
+		ds, err := ec.buildRunDataSource(context.Background(), group, "", 0)
+
+		require.NoError(t, err)
+		require.NotNil(t, ds.TraceSource)
+		assert.Equal(t, "support-agent", ds.TraceSource.AgentName)
+	}
+}
+
+// A model target names a deployment, not an agent. Filtering spans by a
+// deployment name matches nothing, so the run would come back empty with no
+// reason given; saying so is more use.
+func TestBuildRunDataSource_TracesWillNotReadAModelTarget(t *testing.T) {
+	ec := &evalContext{}
+	group := &project.Eval{
+		Name:   "trace-eval",
+		Source: &project.SourceDecl{Type: project.SourceTypeTraces},
+		Target: &project.Target{Type: project.TargetTypeModel, Name: "gpt-4o-mini"},
+	}
+
+	_, err := ec.buildRunDataSource(context.Background(), group, "", 0)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent_name")
+}
+
+// With neither, the run cannot say whose conversations to read, and saying so
+// is more use than letting the service return nothing.
+func TestBuildRunDataSource_TracesWithoutAnAgentIsRefused(t *testing.T) {
+	ec := &evalContext{}
+	group := &project.Eval{
+		Name:   "trace-eval",
+		Source: &project.SourceDecl{Type: project.SourceTypeTraces},
+	}
+
+	_, err := ec.buildRunDataSource(context.Background(), group, "", 0)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "source.agent_name")
+}
+
+// Stored responses travel as rows carrying ids, with a data_mapping telling the
+// service which field holds one.
+func TestBuildRunDataSource_Responses(t *testing.T) {
+	ec := &evalContext{}
+	group := &project.Eval{
+		Name: "replay",
+		Source: &project.SourceDecl{
+			Type:        project.SourceTypeResponses,
+			ResponseIDs: []string{"resp_1", "resp_2"},
+			MaxTurns:    3,
+		},
+	}
+
+	ds, err := ec.buildRunDataSource(context.Background(), group, "", 0)
+
+	require.NoError(t, err)
+	assert.Equal(t, eval_api.EvalRunDataSourceTypeResponses, ds.Type)
+	require.NotNil(t, ds.ItemGenerationParams)
+	assert.Equal(t, 3, ds.ItemGenerationParams.MaxNumTurns)
+	assert.Equal(t,
+		map[string]string{"response_id": "{{item.response_id}}"},
+		ds.ItemGenerationParams.DataMapping)
+	require.NotNil(t, ds.ItemGenerationParams.Source)
+	assert.Len(t, ds.ItemGenerationParams.Source.Content, 2)
+}
+
+func TestBuildRunDataSource_ResponsesWithoutIDsIsRefused(t *testing.T) {
+	ec := &evalContext{}
+	group := &project.Eval{
+		Name:   "replay",
+		Source: &project.SourceDecl{Type: project.SourceTypeResponses},
+	}
+
+	_, err := ec.buildRunDataSource(context.Background(), group, "", 0)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "source.response_ids")
+}
+
+// No target means the rows already hold both sides of the exchange, so the run
+// scores them as they stand rather than invoking anything.
+func TestBuildRunDataSource_NoTargetScoresTheDatasetAsItStands(t *testing.T) {
+	ec := &evalContext{}
+	configPath := writeDataset(t, oneRow)
+	group := &project.Eval{Name: "recorded", Dataset: "d"}
+
+	ds, err := ec.buildRunDataSource(context.Background(), group, configPath, 0)
+
+	require.NoError(t, err)
+	assert.Equal(t, eval_api.EvalRunDataSourceTypeJSONL, ds.Type)
+	assert.Nil(t, ds.Target)
+	require.NotNil(t, ds.Source)
+	assert.Len(t, ds.Source.Content, 1)
+}
+
+// A model target was accepted by config validation and then sent as
+// azure_ai_agent, so the run failed against a resource that does not exist.
+func TestBuildRunDataSource_ModelTargetIsSentAsAModel(t *testing.T) {
+	ec := &evalContext{}
+	configPath := writeDataset(t, oneRow)
+	group := &project.Eval{
+		Name:    "model-eval",
+		Dataset: "d",
+		Target:  &project.Target{Type: project.TargetTypeModel, Name: "gpt-4o-mini"},
+	}
+
+	ds, err := ec.buildRunDataSource(context.Background(), group, configPath, 0)
+
+	require.NoError(t, err)
+	require.NotNil(t, ds.Target)
+	assert.Equal(t, "azure_ai_model", ds.Target.Type)
+	assert.Equal(t, "gpt-4o-mini", ds.Target.Model)
+	assert.Empty(t, ds.Target.Name, "a model target is addressed by deployment, not by agent name")
+}
+
+func TestBuildRunDataSource_AgentTarget(t *testing.T) {
+	ec := &evalContext{}
+	configPath := writeDataset(t, oneRow)
+	group := &project.Eval{
+		Name:    "agent-eval",
+		Dataset: "d",
+		Target:  &project.Target{Type: project.TargetTypeAgent, Name: "support-agent"},
+	}
+
+	ds, err := ec.buildRunDataSource(context.Background(), group, configPath, 0)
+
+	require.NoError(t, err)
+	assert.Equal(t, eval_api.EvalRunDataSourceTypeAgentTarget, ds.Type)
+	require.NotNil(t, ds.Target)
+	assert.Equal(t, "azure_ai_agent", ds.Target.Type)
+	assert.Equal(t, "support-agent", ds.Target.Name)
+}
+
+// An eval with neither a dataset nor a source: has no rows from anywhere, and
+// the error has to name both ways out rather than only the dataset.
+func TestBuildRunDataSource_NoRowsFromAnywhere(t *testing.T) {
+	ec := &evalContext{}
+
+	_, err := ec.buildRunDataSource(context.Background(), &project.Eval{Name: "empty"}, "", 0)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dataset:")
+	assert.Contains(t, err.Error(), "source:")
+}
+
+// A misspelled source.type used to fall through to the dataset path, which
+// scored the wrong rows and then blamed the eval for declaring no source.
+//
+// The run door is the first refusal for a declared eval as well as for one
+// reached by id: resolving an eval by name checks only the name.
+func TestBuildRunDataSource_UnknownSourceTypeIsRefused(t *testing.T) {
+	ec := &evalContext{}
+	group := &project.Eval{
+		Name:   "typo",
+		Source: &project.SourceDecl{Type: "trace"},
+	}
+
+	_, err := ec.buildRunDataSource(context.Background(), group, "", 0)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `source.type "trace" is not supported`)
+	assert.NotContains(t, err.Error(), "references no dataset",
+		"a declared source must not be reported as no source at all")
+}
+
+// The run door refuses every contradiction the configuration names. Resolving
+// an eval by name does not check what it says about itself, and a run reached
+// by id has no declaration to check, so settling one of these by evaluation
+// order sends a request that succeeds and grades something else.
+func TestBuildRunDataSource_RefusesADeclarationNoRunCouldCarryOut(t *testing.T) {
+	ec := &evalContext{}
+
+	cases := []struct {
+		name    string
+		eval    project.Eval
+		wantErr string
+	}{
+		{
+			"rows from two places",
+			project.Eval{
+				Dataset: "d",
+				Source:  &project.SourceDecl{Type: project.SourceTypeTraces, AgentName: "a"},
+			},
+			"declare one",
+		},
+		{
+			// Read as "no cap", so the whole dataset went to a run billed per
+			// row when the file asked for fewer rows than that.
+			"a negative cap",
+			project.Eval{Dataset: "d", MaxSamples: -1},
+			"max_samples cannot be negative",
+		},
+		{
+			// Scored as though nothing were invoked, which is a different
+			// evaluation from the one that was written down.
+			"a target naming nothing",
+			project.Eval{Dataset: "d", Target: &project.Target{Type: project.TargetTypeAgent}},
+			"target.name is required",
+		},
+		{
+			"a target nothing can invoke",
+			project.Eval{Dataset: "d", Target: &project.Target{Type: "prompt", Name: "x"}},
+			"is not supported",
+		},
+		{
+			"a source that does not say what it reads",
+			project.Eval{Source: &project.SourceDecl{}},
+			"source.type is required",
+		},
+		{
+			"a responses source listing nothing",
+			project.Eval{Source: &project.SourceDecl{Type: project.SourceTypeResponses}},
+			"source.response_ids is required",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.eval.Name = "e"
+			_, err := ec.buildRunDataSource(context.Background(), &tc.eval, "", 0)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), `eval "e"`)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// --max-samples has to mean the same thing wherever the rows come from.
+func TestBuildRunDataSource_MaxSamplesCapsLocalRows(t *testing.T) {
+	ec := &evalContext{}
+	configPath := writeDataset(t, oneRow+oneRow+oneRow)
+	group := &project.Eval{
+		Name:    "capped",
+		Dataset: "d",
+		Target:  &project.Target{Type: project.TargetTypeAgent, Name: "a"},
+	}
+
+	ds, err := ec.buildRunDataSource(context.Background(), group, configPath, 2)
+
+	require.NoError(t, err)
+	require.NotNil(t, ds.Source)
+	assert.Len(t, ds.Source.Content, 2)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_handoff_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_handoff_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/project"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A pipeline that starts a run with --no-wait has to come back for it. What it
+// needs to do that is a fixed shape this extension controls, not whatever the
+// API happened to return.
+func TestStartedRunIsTheHandoffAPipelineNeeds(t *testing.T) {
+	run := &eval_api.OpenAIEvalRun{
+		ID:        "evalrun_01JQZX",
+		EvalID:    "eval_ignored",
+		Status:    "queued",
+		CreatedAt: "2026-07-31T21:04:11Z",
+		Metadata:  map[string]string{"azd_eval": "support-agent-smoke"},
+		DataSource: &eval_api.EvalRunDataSource{
+			Type: eval_api.EvalRunDataSourceTypeTraces,
+		},
+	}
+
+	raw, err := json.Marshal(startedRun(run, "eval_01JQZW", &project.Eval{Name: "support-agent-smoke"}))
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(raw, &out))
+
+	assert.Equal(t, "evalrun_01JQZX", out["run_id"])
+	assert.Equal(t, "support-agent-smoke", out["eval_name"])
+	assert.Equal(t, "queued", out["status"])
+	assert.Equal(t, "2026-07-31T21:04:11Z", out["created_at"])
+
+	// The eval the run was started against, which is the one the command
+	// resolved rather than whatever the run echoed back.
+	assert.Equal(t, "eval_01JQZW", out["eval_id"])
+
+	// Nothing the extension does not promise. A pipeline that could read the
+	// data source here would come to depend on it.
+	for _, leaked := range []string{"data_source", "metadata", "id", "report_url"} {
+		assert.NotContains(t, out, leaked,
+			"the handoff must not leak %q from the service object", leaked)
+	}
+}
+
+// A script logging created_at should not have to know which route produced
+// the run: the service sends epoch seconds here and a formatted string
+// elsewhere, so the handoff settles on one.
+func TestStartedRunNormalizesTheTimestamp(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{"epoch seconds", float64(1785801525), "2026-08-03T23:58:45Z"},
+		{"already formatted", "2026-07-31T21:04:11Z", "2026-07-31T21:04:11Z"},
+		{"absent", nil, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handoff := startedRun(
+				&eval_api.OpenAIEvalRun{ID: "evalrun_1", CreatedAt: tc.value}, "eval_1", nil)
+			assert.Equal(t, tc.want, handoff.CreatedAt)
+		})
+	}
+}
+
+// An empty one is omitted rather than reported as "", which a script would
+// otherwise print as the eval's name.
+func TestStartedRunOmitsTheNameItDoesNotHave(t *testing.T) {
+	raw, err := json.Marshal(startedRun(
+		&eval_api.OpenAIEvalRun{ID: "evalrun_1", Status: "queued"}, "eval_1", nil))
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.NotContains(t, out, "eval_name")
+	assert.Equal(t, "eval_1", out["eval_id"])
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_list_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_list_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Scenario 3 answers "did my change help?" by reading two rows of `run list`,
+// which only works if a row carries when it ran and how it scored. The columns
+// were RUN ID / NAME / STATUS / RESULTS, so the question the scenario exists to
+// answer could not be.
+func TestRunListColumnsMatchTheScenario(t *testing.T) {
+	counts := &eval_api.EvalRunResultCounts{Total: 15, Passed: 14, Failed: 1}
+
+	assert.Equal(t, "15", sampleCount(counts),
+		"a rate over 15 samples and one over 200 are not the same claim")
+	assert.Equal(t, "93.3%", runPassRate(counts),
+		"the scenario compares 80.0% against 93.3%, so the row has to carry the rate")
+}
+
+// The rate is the gate's arithmetic: passed over total, with errored and
+// skipped inside the total. A row a reader gates on must not disagree with the
+// gate that acts on it.
+func TestRunListPassRateAgreesWithTheGate(t *testing.T) {
+	counts := &eval_api.EvalRunResultCounts{Total: 3, Passed: 2, Errored: 1}
+
+	assert.Equal(t, "66.7%", runPassRate(counts),
+		"an errored row is not a pass, here or in the gate")
+
+	g, err := parseGate("pass-rate=0.8")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, g.breach(counts),
+		"the same counts that read 66.7% must breach an 80% threshold")
+}
+
+// A run that has not scored yet has no rate to show. An empty cell says that;
+// "0.0%" would say the run failed.
+func TestRunListOmitsARateItCannotCompute(t *testing.T) {
+	assert.Empty(t, runPassRate(nil))
+	assert.Empty(t, runPassRate(&eval_api.EvalRunResultCounts{}))
+	assert.Empty(t, sampleCount(nil))
+}
+
+// Timestamps are RFC3339 in UTC, whichever shape the service sent. The service
+// answers with epoch seconds on some routes and a string on others, and a list
+// that renders both would not sort.
+func TestRunListTimestampsAreRFC3339UTC(t *testing.T) {
+	assert.Equal(t, "2026-08-01T09:15:22Z", timestampString(float64(1785575722)))
+	assert.Equal(t, "2026-08-01T09:15:22Z", timestampString(int64(1785575722)))
+	assert.Equal(t, "2026-08-01T09:15:22Z", timestampString("2026-08-01T09:15:22Z"))
+	assert.Empty(t, timestampString(nil))
+}
+
+// The table shows one rate per run because a column per evaluator stops being
+// readable as soon as two runs score different evaluators. That makes `-o json`
+// the only place a per-evaluator breakdown can be read, and the service does
+// return it on the list route, so the runs go out unprojected.
+//
+// This pins the field name and that it survives marshalling. It does not catch
+// someone replacing the emitted type with a projection, which is the way this
+// would actually be lost -- that needs the command harness the reconciler tests
+// now have.
+func TestRunListJSONCarriesThePerEvaluatorBreakdown(t *testing.T) {
+	var buf bytes.Buffer
+	runs := []eval_api.OpenAIEvalRun{{
+		ID: "evalrun_1",
+		PerTestingCriteria: []eval_api.EvalRunCriteriaResult{
+			{TestingCriteria: "task_adherence", Passed: 14, Failed: 1},
+		},
+	}}
+
+	require.NoError(t, emitJSONList(&buf, runs))
+
+	assert.Contains(t, buf.String(), `"per_testing_criteria_results"`,
+		"the only place a script can read a per-evaluator result")
+	assert.Contains(t, buf.String(), "task_adherence")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_ops.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_ops.go
@@ -1,0 +1,402 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// addRunSubcommands attaches the atomic run operations.
+//
+// `azd ai eval run` is a group rather than a verb; these are the operations it
+// groups, each reachable without the config file.
+func addRunSubcommands(cmd *cobra.Command) {
+	cmd.AddCommand(
+		newRunListCommand(),
+		newRunShowCommand(),
+		newRunCancelCommand(),
+		newRunDeleteCommand(),
+		newRunOutputCommand(),
+	)
+}
+
+func newRunListCommand() *cobra.Command {
+	var (
+		endpointFlg string
+		groupName   string
+		limit       int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List runs for an eval.",
+		Long: "List runs for an eval.\n\n" +
+			"The table carries one pass rate per run. A per-evaluator breakdown " +
+			"cannot fit a column each and stay readable when runs score different " +
+			"evaluators, so `-o json` carries it instead, under " +
+			"`per_testing_criteria_results` on every run.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			evalID, err := resolveEvalID(cmd, ec, groupName)
+			if err != nil {
+				return err
+			}
+
+			list, err := ec.evalClient.ListOpenAIEvalRuns(ctx, evalID, limit)
+			if err != nil {
+				if eval_api.IsNotFound(err) {
+					return messages.EvalNotDeployed(evalID, ec.deployCommand(ctx))
+				}
+				return messages.ListingRuns(evalID, err)
+			}
+			if isJSON(cmd) {
+				// Emitted whole, unlike `run start`, which hands back a small
+				// handoff. The table cannot show a per-evaluator breakdown, so
+				// this is the only place a script can read one; narrowing these
+				// to the table's columns would drop it silently.
+				var runs []eval_api.OpenAIEvalRun
+				if list != nil {
+					runs = list.Data
+				}
+				return emitJSONList(cmd.OutOrStdout(), runs)
+			}
+			if list == nil || len(list.Data) == 0 {
+				fmt.Fprint(cmd.OutOrStdout(), messages.EvalHasNoRunsLine(evalID))
+				return nil
+			}
+
+			rows := make([][]string, 0, len(list.Data))
+			for _, run := range list.Data {
+				rows = append(rows, []string{
+					run.ID,
+					runDataset(run.Metadata),
+					timestampString(run.CreatedAt),
+					run.Status,
+					sampleCount(run.ResultCounts),
+					runPassRate(run.ResultCounts),
+				})
+			}
+			return emitTable(cmd.OutOrStdout(),
+				[]string{"RUN", "DATASET", "STARTED", "STATUS", "SAMPLES", "PASS RATE"}, rows)
+		},
+	}
+	addEvalFlag(cmd, &groupName)
+	// Registered wherever a declared name is resolved, so a configuration
+	// outside ./evals can be addressed by every command, not just `run start`.
+	addEvalPathFlag(cmd, new(string))
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"Return at most this many runs. Omit for the service default.")
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+func newRunShowCommand() *cobra.Command {
+	var (
+		endpointFlg string
+		groupName   string
+		wait        bool
+		failOn      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "show [run]",
+		Short: "Show a single run.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			threshold, err := parseGate(failOn)
+			if err != nil {
+				return err
+			}
+
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			evalID, err := resolveEvalID(cmd, ec, groupName)
+			if err != nil {
+				return err
+			}
+
+			runID := firstArg(args)
+			run, err := ec.latestOrNamedRun(cmd, evalID, runID, runID != "")
+			if err != nil {
+				return err
+			}
+			run = ec.withPortalLink(ctx, evalID, run)
+
+			// Reattaching to a run started asynchronously: the pipeline that
+			// gates on it is often not the one that started it.
+			//
+			// Only a caller that waited is told a bad status through the exit
+			// code. Without --wait this is an inspection command: it was asked
+			// what happened, and answering that is a success whatever the
+			// answer.
+			gateOnStatus := wait
+			if wait {
+				run, err = ec.pollRun(ctx, evalID, run.ID, cmd.OutOrStdout(), isJSON(cmd))
+				if err != nil {
+					return err
+				}
+			}
+
+			// The spec puts --fail-on on the commands that wait. Gating a run
+			// that is still moving would read partial counts; ignoring the flag
+			// would leave a pipeline believing it is gated when it is not.
+			if threshold.set && !runIsTerminal(run) {
+				return messages.GateNeedsATerminalRun(run.ID, run.Status)
+			}
+
+			if isJSON(cmd) {
+				if err := emitJSON(cmd.OutOrStdout(), run); err != nil {
+					return err
+				}
+				if gateOnStatus {
+					if err := runCompleted(run); err != nil {
+						return err
+					}
+				}
+				applyGate(cmd, threshold, run)
+				return nil
+			}
+
+			out := cmd.OutOrStdout()
+			fmt.Fprint(out, messages.RunHeading(run.ID))
+			fmt.Fprint(out, messages.RunNameLine(run.Name))
+			fmt.Fprint(out, messages.RunStatusDetail(run.Status))
+			if counts := summarizeCounts(run.ResultCounts); counts != "" {
+				fmt.Fprint(out, messages.RunResultsLine(counts))
+			}
+			if url := runLink(run.ReportURL, run.PortalURL); url != "" {
+				fmt.Fprint(out, messages.RunReportLine(color.CyanString(url)))
+			}
+			if gateOnStatus {
+				if err := runCompleted(run); err != nil {
+					return err
+				}
+			}
+			applyGate(cmd, threshold, run)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&wait, "wait", false,
+		"Block until the run reaches a terminal state before reporting.")
+	addFailOnFlag(cmd, &failOn)
+	addEvalFlag(cmd, &groupName)
+	// Registered wherever a declared name is resolved, so a configuration
+	// outside ./evals can be addressed by every command, not just `run start`.
+	addEvalPathFlag(cmd, new(string))
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// firstArg returns the positional argument, or empty when none was given.
+func firstArg(args []string) string {
+	if len(args) > 0 {
+		return args[0]
+	}
+	return ""
+}
+
+func newRunCancelCommand() *cobra.Command {
+	var (
+		endpointFlg string
+		groupName   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "cancel [run]",
+		Short: "Cancel an in-flight run.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			evalID, err := resolveEvalID(cmd, ec, groupName)
+			if err != nil {
+				return err
+			}
+
+			runID := firstArg(args)
+			target, err := ec.latestOrNamedRun(cmd, evalID, runID, runID != "")
+			if err != nil {
+				return err
+			}
+			// Cancelling a run that already finished is a no-op worth naming,
+			// since the service reports success either way. Lowercased to match
+			// the polling path: the service's casing is not guaranteed.
+			if terminalRunStates[strings.ToLower(target.Status)] {
+				return messages.RunAlreadyFinished(target.ID, target.Status)
+			}
+
+			canceled, err := ec.evalClient.CancelOpenAIEvalRun(ctx, evalID, target.ID)
+			if err != nil {
+				return messages.CancellingRun(target.ID, err)
+			}
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), canceled)
+			}
+			status := canceled.Status
+			if status == "" {
+				status = "cancelling"
+			}
+			fmt.Fprint(cmd.OutOrStdout(), messages.RunIsNow(target.ID, status))
+			return nil
+		},
+	}
+	addEvalFlag(cmd, &groupName)
+	// Registered wherever a declared name is resolved, so a configuration
+	// outside ./evals can be addressed by every command, not just `run start`.
+	addEvalPathFlag(cmd, new(string))
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// newRunDeleteCommand removes a run.
+//
+// Runs accumulate — every `run start` adds one — and a run that evaluated the
+// wrong dataset or target is noise in every later listing. The run is required
+// rather than defaulted to the most recent, because deleting is not undoable
+// and "the latest one" is a poor thing to guess at.
+func newRunDeleteCommand() *cobra.Command {
+	var (
+		endpointFlg string
+		groupName   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "delete <run>",
+		Short: "Delete a run.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			runID := args[0]
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			evalID, err := resolveEvalID(cmd, ec, groupName)
+			if err != nil {
+				return err
+			}
+
+			if err := ec.evalClient.DeleteOpenAIEvalRun(ctx, evalID, runID); err != nil {
+				if eval_api.IsNotFound(err) {
+					return messages.RunNotFound(runID, evalID)
+				}
+				return messages.DeletingRun(runID, err)
+			}
+
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), map[string]string{
+					"id": runID, "eval_id": evalID, "status": "deleted",
+				})
+			}
+			fmt.Fprint(cmd.OutOrStdout(), messages.RunDeleted(runID))
+			return nil
+		},
+	}
+	addEvalFlag(cmd, &groupName)
+	// Registered wherever a declared name is resolved, so a configuration
+	// outside ./evals can be addressed by every command, not just `run start`.
+	addEvalPathFlag(cmd, new(string))
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+func summarizeCounts(counts *eval_api.EvalRunResultCounts) string {
+	if counts == nil {
+		return ""
+	}
+	return messages.CountsSummary(counts.Passed, counts.Failed, counts.Errored)
+}
+
+// metaDataset and metaDatasetVersion record which rows a run scored. The run's
+// own data source cannot answer it: the rows travel inline, so the name that
+// selected them is not in the request the service keeps.
+const (
+	metaDataset        = "azd_dataset"
+	metaDatasetVersion = "azd_dataset_version"
+	// metaEvalName is the eval's declared name, recorded on the run because a
+	// run is read on its own and an id is not what the author called it.
+	metaEvalName = "azd_eval"
+	// metaAgent is the agent an eval targets.
+	metaAgent = "azd_agent"
+	// metaDescription carries an eval's description: the create request has no
+	// field of its own for it.
+	metaDescription = "azd_description"
+)
+
+// runDataset renders the dataset a run scored, versioned when a version was
+// recorded with it.
+//
+// A run started before this was recorded shows nothing rather than the name in
+// the configuration today, which is the one thing the column exists to detect
+// having changed.
+func runDataset(metadata map[string]string) string {
+	name := metadata[metaDataset]
+	if name == "" {
+		return ""
+	}
+	if version := metadata[metaDatasetVersion]; version != "" {
+		return fmt.Sprintf("%s (v%s)", name, version)
+	}
+	return name
+}
+
+// runDatasetLine is the same fact spelled for a detail view, where there is
+// room for the whole word.
+func runDatasetLine(metadata map[string]string) string {
+	name := metadata[metaDataset]
+	if name == "" {
+		return ""
+	}
+	if version := metadata[metaDatasetVersion]; version != "" {
+		return fmt.Sprintf("%s (version %s)", name, version)
+	}
+	return name
+}
+
+// sampleCount is how many rows the run scored, which is what makes two rows of
+// `run list` comparable: a rate over 15 samples and one over 200 are not the
+// same claim.
+func sampleCount(counts *eval_api.EvalRunResultCounts) string {
+	if counts == nil {
+		return ""
+	}
+	return strconv.Itoa(counts.Total)
+}
+
+// runPassRate is the same passed/total the gate uses, so a row a reader gates
+// on cannot disagree with the gate.
+func runPassRate(counts *eval_api.EvalRunResultCounts) string {
+	if counts == nil || counts.Total == 0 {
+		return ""
+	}
+	return formatRate(counts.Passed, counts.Total)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_ops_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_ops_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSummarizeCounts(t *testing.T) {
+	require.Equal(t, "", summarizeCounts(nil))
+	require.Equal(t, "3 passed, 1 failed, 0 errored",
+		summarizeCounts(&eval_api.EvalRunResultCounts{Total: 4, Passed: 3, Failed: 1}))
+}
+
+// Cancelling a finished run is rejected locally. The service reports success
+// either way, so without this the CLI would claim it cancelled a run that had
+// already completed.
+func TestTerminalRunStatesCoverServiceVocabulary(t *testing.T) {
+	for _, status := range []string{"completed", "failed", "canceled", "cancelled", "error"} {
+		require.True(t, terminalRunStates[status], "%q should be terminal", status)
+	}
+	for _, status := range []string{"in_progress", "queued", "running", ""} {
+		require.False(t, terminalRunStates[status], "%q should not be terminal", status)
+	}
+}
+
+// The atomic run operations have to be reachable as subcommands; the spec
+// requires start, list, show and cancel to exist alongside the composite.
+func TestRunCommandExposesAtomicSubcommands(t *testing.T) {
+	cmd := newRunCommand()
+
+	found := map[string]bool{}
+	for _, sub := range cmd.Commands() {
+		found[sub.Name()] = true
+	}
+	for _, name := range []string{"start", "list", "show", "cancel"} {
+		require.True(t, found[name], "run should expose the %q subcommand", name)
+	}
+}
+
+// `run start` is the atomic form of the composite and must accept the same
+// flags, otherwise the two forms diverge.
+func TestRunStartMirrorsCompositeFlags(t *testing.T) {
+	composite := newRunCommand()
+
+	var start *cobra.Command
+	for _, sub := range composite.Commands() {
+		if sub.Name() == "start" {
+			start = sub
+		}
+	}
+	require.NotNil(t, start)
+
+	for _, flag := range []string{"eval", "dataset", "name", "max-samples", "wait", "no-wait"} {
+		require.NotNil(t, start.Flags().Lookup(flag), "run start should accept --%s", flag)
+	}
+
+	// The level decides the row mapping, so a per-run override would put two
+	// incomparable result sets under one eval. A second level is a second eval.
+	require.Nil(t, start.Flags().Lookup("level"), "run start must not offer --level")
+}
+
+// Every command that acts on an eval says which one the same way. One flag
+// takes a name from the configuration or a raw service id: an eval created
+// outside a project has no declaration to name, and a second --eval-id beside
+// it was accepted and silently ignored.
+func TestEvalCommandsTakeOneEvalFlag(t *testing.T) {
+	subs := map[string]*cobra.Command{}
+	for _, sub := range newRunCommand().Commands() {
+		subs["run "+sub.Name()] = sub
+		if sub.Name() == "output" {
+			for _, leaf := range sub.Commands() {
+				subs["run output "+leaf.Name()] = leaf
+			}
+		}
+	}
+
+	for _, name := range []string{
+		"run list", "run show", "run cancel",
+		"run output list", "run output show", "run output export",
+	} {
+		cmd := subs[name]
+		require.NotNil(t, cmd, "%s should exist", name)
+		require.NotNil(t, cmd.Flags().Lookup("eval"), "%s should accept --eval", name)
+		require.Nil(t, cmd.Flags().Lookup("eval-id"),
+			"%s must not keep --eval-id beside --eval", name)
+	}
+}
+
+// --no-wait is documented in the spec, and cobra does not derive it from the
+// --wait bool. It belongs to `run start`: `run` itself is a group.
+func TestRunCommandAcceptsNoWait(t *testing.T) {
+	var start *cobra.Command
+	for _, sub := range newRunCommand().Commands() {
+		if sub.Name() == "start" {
+			start = sub
+		}
+	}
+	require.NotNil(t, start)
+	require.NotNil(t, start.Flags().Lookup("no-wait"), "run start should accept --no-wait")
+	require.NotNil(t, start.Flags().Lookup("wait"), "run start should keep --wait")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_output.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_output.go
@@ -1,0 +1,658 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// newRunOutputCommand groups the per-sample views of a run.
+//
+// `run show` is the summary - how many passed. These are the rows: which ones
+// failed, and why.
+func newRunOutputCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "output",
+		Short: "Inspect the per-sample results of a run.",
+	}
+	cmd.AddCommand(
+		newRunOutputListCommand(),
+		newRunOutputShowCommand(),
+		newRunOutputExportCommand(),
+	)
+	return cmd
+}
+
+func newRunOutputListCommand() *cobra.Command {
+	var (
+		failedOnly  bool
+		outFile     string
+		endpointFlg string
+		groupName   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list [run]",
+		Short: "List the per-sample results of a run.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			evalID, err := resolveEvalID(cmd, ec, groupName)
+			if err != nil {
+				return err
+			}
+
+			runID := firstArg(args)
+			run, err := ec.latestOrNamedRun(cmd, evalID, runID, runID != "")
+			if err != nil {
+				return err
+			}
+
+			// The run carries totals and a per-criterion breakdown. The output
+			// items are the rows themselves, which is what "which one failed,
+			// and why" needs. A run that never produced any still renders its
+			// totals rather than failing.
+			items, err := ec.evalClient.ListOutputItems(ctx, evalID, run.ID, 0)
+			if err != nil {
+				return messages.ReadingRunResults(run.ID, err)
+			}
+			rows := items.Data
+			if failedOnly {
+				kept := make([]eval_api.OutputItem, 0, len(rows))
+				for _, it := range rows {
+					if it.Failed() {
+						kept = append(kept, it)
+					}
+				}
+				rows = kept
+			}
+
+			// A bare array, as every other list emits. Wrapping the rows beside
+			// the run made `-o json` the one listing a script could not iterate,
+			// and it failed silently: the loop walked the two keys instead. The
+			// run itself is what `run show` answers.
+			if outFile != "" {
+				f, err := os.Create(outFile)
+				if err != nil {
+					return messages.Creating(outFile, err)
+				}
+				if err := emitJSON(f, rows); err != nil {
+					_ = f.Close()
+					return err
+				}
+				// The last write is flushed by Close, so discarding its error
+				// reports success over a file that stops mid-row.
+				if err := f.Close(); err != nil {
+					return messages.Writing(outFile, err)
+				}
+				return nil
+			}
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), rows)
+			}
+			return renderResults(cmd.OutOrStdout(), run, rows, failedOnly)
+		},
+	}
+
+	cmd.Flags().BoolVar(&failedOnly, "failed-only", false, "Show only the rows that failed.")
+	cmd.Flags().StringVar(&outFile, "output-file", "", "Write JSON results to this path.")
+	addEvalFlag(cmd, &groupName)
+	// Registered wherever a declared name is resolved, so a configuration
+	// outside ./evals can be addressed by every command, not just `run start`.
+	addEvalPathFlag(cmd, new(string))
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// newRunOutputShowCommand reads one evaluated row by its id.
+//
+// The listing truncates the input and the reason to keep a table readable, so
+// this is how the whole of either is seen.
+func newRunOutputShowCommand() *cobra.Command {
+	var (
+		runID       string
+		endpointFlg string
+		groupName   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "show <output-item>",
+		Short: "Show a single evaluated row.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			itemID := args[0]
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			evalID, err := resolveEvalID(cmd, ec, groupName)
+			if err != nil {
+				return err
+			}
+
+			run, err := ec.latestOrNamedRun(cmd, evalID, runID, runID != "")
+			if err != nil {
+				return err
+			}
+
+			item, err := ec.evalClient.GetOutputItem(ctx, evalID, run.ID, itemID)
+			if err != nil {
+				if eval_api.IsNotFound(err) {
+					return messages.OutputItemNotFound(itemID, run.ID)
+				}
+				return messages.ReadingOutputItem(itemID, err)
+			}
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), item)
+			}
+			return renderOutputItem(cmd.OutOrStdout(), item)
+		},
+	}
+
+	cmd.Flags().StringVar(&runID, "run", "", "Run the item belongs to. Defaults to the most recent run.")
+	addEvalFlag(cmd, &groupName)
+	// Registered wherever a declared name is resolved, so a configuration
+	// outside ./evals can be addressed by every command, not just `run start`.
+	addEvalPathFlag(cmd, new(string))
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// writeExport renders a run in the requested export format.
+//
+// Separate from the command so the file path can close explicitly and report
+// the failure. A deferred Close cannot reach an unnamed return, so discarding
+// it exits 0 over an export that stops mid-row.
+func writeExport(w io.Writer, format string, run *eval_api.OpenAIEvalRun) error {
+	switch format {
+	case formatCSV:
+		return writeResultsCSV(w, run)
+	case formatJSON:
+		return emitJSON(w, run)
+	case formatJSONL:
+		return writeResultsJSONL(w, run)
+	default:
+		return messages.ExportFormatUnsupported(
+			format, formatCSV, formatJSON, formatJSONL)
+	}
+}
+
+func newRunOutputExportCommand() *cobra.Command {
+	var (
+		format      string
+		outFile     string
+		endpointFlg string
+		groupName   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "export [run]",
+		Short: "Export run results as CSV, JSON or JSONL.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format = strings.ToLower(format)
+			// Checked against the same set the writer switches on: this guard
+			// used to name only json and csv, so --format jsonl was refused by a
+			// CLI whose own help offered it.
+			switch format {
+			case formatCSV, formatJSON, formatJSONL:
+			default:
+				return messages.ExportFormatUnsupported(
+					format, formatCSV, formatJSON, formatJSONL)
+			}
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			evalID, err := resolveEvalID(cmd, ec, groupName)
+			if err != nil {
+				return err
+			}
+
+			runID := firstArg(args)
+			run, err := ec.latestOrNamedRun(cmd, evalID, runID, runID != "")
+			if err != nil {
+				return err
+			}
+
+			if outFile == "" {
+				return writeExport(cmd.OutOrStdout(), format, run)
+			}
+
+			f, createErr := os.Create(outFile)
+			if createErr != nil {
+				return messages.Creating(outFile, createErr)
+			}
+			writeErr := writeExport(f, format, run)
+			// The last write is flushed by Close, so discarding its error
+			// reports success over a file that stops mid-row.
+			closeErr := f.Close()
+			if writeErr != nil {
+				return writeErr
+			}
+			if closeErr != nil {
+				return messages.Writing(outFile, closeErr)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&format, "format", formatCSV,
+		fmt.Sprintf("Output format: %s, %s or %s.", formatCSV, formatJSON, formatJSONL))
+	cmd.Flags().StringVar(&outFile, "output-file", "", "Write to this path instead of stdout.")
+	addEvalFlag(cmd, &groupName)
+	// Registered wherever a declared name is resolved, so a configuration
+	// outside ./evals can be addressed by every command, not just `run start`.
+	addEvalPathFlag(cmd, new(string))
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// resolveEvalID resolves the eval a run command is about, from --eval or from
+// the declaration the configuration holds.
+//
+// --eval accepts a name or a raw id on the one flag: an eval created outside a
+// project has no declaration to name, and the environment records one id per
+// name, so editing a declaration leaves every run of the previous eval
+// reachable only by id.
+//
+// It takes no positional argument, deliberately. The positional on `run show`,
+// `run cancel` and `run output *` is a *run* id, and a signature that accepted
+// either would let one be resolved as the other -- a destructive verb aimed at
+// a resource picked by accident.
+//
+// It reads no EVAL_ID either. Every deploy writes that key, so nothing tells a
+// value meant for this declaration from one left behind by the eval it
+// replaced; `run cancel` used to cancel a run of an eval the file no longer
+// described. The declaration is asked instead, which is how `run start`
+// decides it, so the two doors cannot pick different evals.
+func resolveEvalID(cmd *cobra.Command, ec *evalContext, groupName string) (string, error) {
+	evalDir, err := ec.evalDir(cmd.Context(), evalPathFlag(cmd))
+	if err != nil {
+		return "", err
+	}
+	// The same prompt `run start` gets. Without it a project declaring two
+	// evals could start a run by answering a question, and then not list,
+	// show or cancel it without repeating the answer as a flag.
+	ref, err := ec.resolveEvalRef(cmd.Context(), evalDir, chooseEvalIn(cmd, evalDir, groupName))
+	if err != nil {
+		return "", err
+	}
+	return ref.ID, nil
+}
+
+// addEvalFlag registers the flag that says which eval a command acts on. It
+// takes a name from the configuration or a raw service id, which is why there
+// is no second --eval-id beside it.
+func addEvalFlag(cmd *cobra.Command, target *string) {
+	cmd.Flags().StringVar(target, "eval", "",
+		"Name of the eval declared in the configuration, or its id.")
+}
+
+// addEvalPathFlag registers --path on a command that reads the configuration.
+//
+// It defaults to empty rather than to ./evals so that "not given" stays
+// distinguishable from "given the default", which is what lets the path `init`
+// recorded take effect in between.
+func addEvalPathFlag(cmd *cobra.Command, target *string) {
+	// No backticks: pflag reads a word in back quotes as the value placeholder,
+	// so `init` rendered the flag as "--path init" instead of "--path string".
+	cmd.Flags().StringVar(target, "path", "",
+		"Directory holding azure.eval.yaml. Defaults to the path init used, then ./evals.")
+}
+
+// evalPathFlag reads --path from whichever command is resolving a declared
+// name, so every one of them can be told where the configuration is.
+//
+// Read off the command rather than threaded through seven call sites. Without
+// it only `run start` offered the flag, so a configuration outside ./evals
+// could be run and then not listed, shown or cancelled -- the fallback that
+// covers the difference is a path recorded in the azd environment, which a
+// --project-endpoint caller does not have.
+func evalPathFlag(cmd *cobra.Command) string {
+	if f := cmd.Flags().Lookup("path"); f != nil {
+		return f.Value.String()
+	}
+	return ""
+}
+
+// latestOrNamedRun returns the named run, or the most recent one for the eval.
+//
+// explicit says whether the caller named the run rather than leaving it to
+// default. A remembered run that no longer resolves is worth falling through
+// on; one that was asked for by name is not.
+//
+// The remembered id is preferred over the service's listing, and deliberately.
+// Listing looks like the fix for two concurrent starts leaving this key holding
+// whichever wrote last, but ListOpenAIEvalRuns sends no order parameter, so
+// "the first row" is not promised to be the newest; and `run cancel` defaults
+// through here, so guessing would cancel a run this environment never started.
+// The remembered id is at least scoped to the environment that made it.
+func (ec *evalContext) latestOrNamedRun(
+	cmd *cobra.Command,
+	evalID, runID string,
+	explicit bool,
+) (*eval_api.OpenAIEvalRun, error) {
+	ctx := cmd.Context()
+
+	// The remembered run is per group. A single shared one belongs to whichever
+	// group ran last, and asking another group for it returns 404 rather than
+	// that group's own latest run.
+	if runID == "" {
+		runID = ec.getEnvValue(ctx, idKey("evalrun", evalID))
+	}
+	if runID != "" {
+		run, err := ec.evalClient.GetOpenAIEvalRun(ctx, evalID, runID)
+		if err == nil {
+			return run, nil
+		}
+		if explicit {
+			return nil, messages.ReadingRun(runID, err)
+		}
+	}
+
+	list, err := ec.evalClient.ListOpenAIEvalRuns(ctx, evalID, 1)
+	if err != nil {
+		if eval_api.IsNotFound(err) {
+			return nil, messages.EvalNotDeployed(evalID, ec.deployCommand(ctx))
+		}
+		return nil, messages.ListingRuns(evalID, err)
+	}
+	if list == nil || len(list.Data) == 0 {
+		return nil, messages.EvalHasNoRuns(evalID)
+	}
+	return &list.Data[0], nil
+}
+
+// renderOutputItem is the detail view for one evaluated row.
+//
+// This was the one `show` that emitted raw JSON whatever was asked for, which
+// made the command a person reaches for after a failing listing the hardest one
+// to read. The listing truncates the reason to a cell; this is where the whole
+// of it lives, so the reasons are printed in full rather than wrapped or cut.
+//
+// Results are grouped by evaluator: a rubric reports one result per dimension,
+// all carrying the evaluator's name, and printing them flat would read as
+// several evaluators that happen to share a name.
+func renderOutputItem(w io.Writer, item *eval_api.OutputItem) error {
+	if item == nil {
+		return messages.OutputItemEmpty()
+	}
+	if err := emitDetail(w, []field{
+		{"Item", item.ID},
+		{"Run", item.RunID},
+		{"Status", item.Status},
+	}); err != nil {
+		return err
+	}
+
+	order := make([]string, 0, len(item.Results))
+	byName := make(map[string][]eval_api.OutputResult, len(item.Results))
+	for _, r := range item.Results {
+		if _, seen := byName[r.Name]; !seen {
+			order = append(order, r.Name)
+		}
+		byName[r.Name] = append(byName[r.Name], r)
+	}
+
+	for _, name := range order {
+		results := byName[name]
+		fmt.Fprintln(w)
+
+		// The service repeats the evaluator's name in `metric` for a
+		// single-score evaluator, so a group is only worth nesting when its
+		// results name dimensions of their own.
+		if len(results) == 1 && (results[0].Metric == "" || results[0].Metric == name) {
+			r := results[0]
+			fmt.Fprint(w, messages.OutputItemVerdict(
+				name, formatScore(r.Score), verdictWord(r)))
+			if r.Reason != "" {
+				fmt.Fprint(w, messages.OutputItemReason(r.Reason))
+			}
+			continue
+		}
+
+		fmt.Fprint(w, messages.OutputItemEvaluator(name))
+		for _, r := range results {
+			label := r.Metric
+			if label == "" {
+				label = r.Name
+			}
+			fmt.Fprint(w, messages.OutputItemMetric(
+				label, formatScore(r.Score), verdictWord(r)))
+			if r.Reason != "" {
+				fmt.Fprint(w, messages.OutputItemReason(r.Reason))
+			}
+		}
+	}
+	return nil
+}
+
+// verdictWord spells a boolean the way the rest of the output does.
+func verdictWord(r eval_api.OutputResult) string {
+	if !r.Judged() {
+		// The evaluator returned no verdict, which is not the same as returning
+		// a failing one -- it says nothing about the sample.
+		return "no verdict"
+	}
+	if r.DidPass() {
+		return "pass"
+	}
+	return "fail"
+}
+
+// formatScore prints a judge's score at the two decimals the scale carries.
+// formatScore shows a score, or a dash where there is none. An evaluator that
+// errored on a row still sends a result, and its score decodes to NaN; printing
+// that verbatim put "NaN" in the SCORE column.
+func formatScore(score eval_api.LenientFloat) string {
+	if !score.Defined() {
+		return "-"
+	}
+	return strconv.FormatFloat(float64(score), 'f', 2, 64)
+}
+
+// meanScoreOf averages a sample's scores so the list can tell a bare pass from
+// a strong one. Pass/fail alone sent anyone asking "how well?" to the portal.
+//
+// Rows an evaluator errored on are left out rather than counted, the same rule
+// criteriaMeans applies to the summary: averaging a NaN in makes the whole
+// sample read NaN, and counting it as zero drags the mean toward a number no
+// evaluator produced.
+func meanScoreOf(results []eval_api.OutputResult) string {
+	total := 0.0
+	scored := 0
+	for _, r := range results {
+		if !r.Score.Defined() {
+			continue
+		}
+		total += float64(r.Score)
+		scored++
+	}
+	if scored == 0 {
+		return "-"
+	}
+	return strconv.FormatFloat(total/float64(scored), 'f', 2, 64)
+}
+
+func renderResults(
+	w io.Writer,
+	run *eval_api.OpenAIEvalRun,
+	items []eval_api.OutputItem,
+	failedOnly bool,
+) error {
+	fmt.Fprint(w, messages.RunStatusHeading(run.ID, run.Status))
+
+	if c := run.ResultCounts; c != nil {
+		fmt.Fprint(w, messages.ResultTotals(c.Passed, c.Failed, c.Errored))
+	}
+
+	if len(run.PerTestingCriteria) > 0 {
+		rows := make([][]string, 0, len(run.PerTestingCriteria))
+		for _, cr := range run.PerTestingCriteria {
+			if failedOnly && cr.Failed == 0 {
+				continue
+			}
+			rows = append(rows, []string{
+				cr.TestingCriteria,
+				strconv.Itoa(cr.Passed),
+				strconv.Itoa(cr.Failed),
+			})
+		}
+		if len(rows) > 0 {
+			if err := emitTable(w, []string{"CRITERION", "PASSED", "FAILED"}, rows); err != nil {
+				return err
+			}
+		}
+	}
+
+	// The rows are the point of `results show`: totals say how many failed,
+	// these say which and why.
+	if len(items) == 0 {
+		if failedOnly {
+			fmt.Fprint(w, messages.NoFailingRows())
+		} else {
+			fmt.Fprint(w, messages.NoRowsScored())
+		}
+	} else {
+		fmt.Fprintln(w)
+		rows := make([][]string, 0, len(items))
+		for i, it := range items {
+			// One row per evaluated sample, not per verdict: a sample that
+			// failed three evaluators is one sample to go and look at, and
+			// listing it three times buries how much is actually wrong.
+			var failed []string
+			reason := ""
+			for _, r := range it.Results {
+				if r.DidPass() {
+					continue
+				}
+				failed = append(failed, r.Name)
+				if reason == "" {
+					reason = r.Reason
+				}
+			}
+			if failedOnly && len(failed) == 0 {
+				continue
+			}
+			verdicts := strings.Join(failed, ", ")
+			if verdicts == "" {
+				verdicts = "-"
+			}
+			rows = append(rows, []string{
+				it.ID,
+				strconv.Itoa(i + 1),
+				meanScoreOf(it.Results),
+				truncate(verdicts, 40),
+				truncate(reason, 44),
+			})
+		}
+		// Only the first failure's reason fits a cell; `run output show` has
+		// the rest.
+		if err := emitTable(w,
+			[]string{"ITEM", "SAMPLE", "SCORE", "FAILED EVALUATORS", "REASON"},
+			rows); err != nil {
+			return err
+		}
+		if n := len(rows); failedOnly && n > 0 {
+			fmt.Fprint(w, messages.SamplesFailedAtLeastOne(n))
+		}
+	}
+
+	if url := runLink(run.ReportURL, run.PortalURL); url != "" {
+		fmt.Fprint(w, messages.ReportLinkAfterRows(color.CyanString(url)))
+	}
+	return nil
+}
+
+// truncate keeps a table readable when a reason runs to a paragraph. The full
+// text is always in `-o json`.
+func truncate(s string, n int) string {
+	s = strings.ReplaceAll(strings.ReplaceAll(s, "\n", " "), "\r", "")
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}
+
+func writeResultsCSV(w io.Writer, run *eval_api.OpenAIEvalRun) error {
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+
+	// Named as the service names it, and as the jsonl export already did, so a
+	// pipeline reading both formats needs one spelling rather than two.
+	if err := cw.Write([]string{"run_id", "status", "testing_criteria", "passed", "failed"}); err != nil {
+		return err
+	}
+	if len(run.PerTestingCriteria) == 0 {
+		return cw.Write([]string{run.ID, run.Status, "", "", ""})
+	}
+	for _, cr := range run.PerTestingCriteria {
+		if err := cw.Write([]string{
+			run.ID, run.Status, cr.TestingCriteria,
+			strconv.Itoa(cr.Passed), strconv.Itoa(cr.Failed),
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Export formats. csv is the default because the results are a table and a
+// build artifact is normally read by a spreadsheet or a diff.
+const (
+	formatCSV   = "csv"
+	formatJSON  = "json"
+	formatJSONL = "jsonl"
+)
+
+// writeResultsJSONL emits one criterion per line, which is what a downstream
+// job can stream without holding the whole run in memory.
+func writeResultsJSONL(w io.Writer, run *eval_api.OpenAIEvalRun) error {
+	enc := json.NewEncoder(w)
+	if len(run.PerTestingCriteria) == 0 {
+		return enc.Encode(map[string]any{"run_id": run.ID, "status": run.Status})
+	}
+	for _, cr := range run.PerTestingCriteria {
+		if err := enc.Encode(map[string]any{
+			"run_id":           run.ID,
+			"status":           run.Status,
+			"testing_criteria": cr.TestingCriteria,
+			"passed":           cr.Passed,
+			"failed":           cr.Failed,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_output_write_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_output_write_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// twoCriteriaRun is a finished run with the shape export has to preserve: one
+// row per testing criterion, all carrying the run they belong to.
+func twoCriteriaRun() *eval_api.OpenAIEvalRun {
+	return &eval_api.OpenAIEvalRun{
+		ID:     "evalrun_abc",
+		Status: "completed",
+		PerTestingCriteria: []eval_api.EvalRunCriteriaResult{
+			{TestingCriteria: "task_adherence", Passed: 8, Failed: 2},
+			{TestingCriteria: "coherence", Passed: 10, Failed: 0},
+		},
+	}
+}
+
+// An export is read by a spreadsheet or a diff, so the header is part of the
+// contract: renaming a column silently breaks whatever consumes it.
+func TestWriteResultsCSV(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeResultsCSV(&buf, twoCriteriaRun()))
+
+	rows, err := csv.NewReader(&buf).ReadAll()
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"run_id", "status", "testing_criteria", "passed", "failed"}, rows[0])
+	assert.Equal(t, []string{"evalrun_abc", "completed", "task_adherence", "8", "2"}, rows[1])
+	assert.Equal(t, []string{"evalrun_abc", "completed", "coherence", "10", "0"}, rows[2])
+	assert.Len(t, rows, 3, "one header and one row per criterion")
+}
+
+// A run that graded nothing still has to produce a file with a header, because
+// a consumer that gets zero bytes cannot tell an empty run from a failed
+// export.
+func TestWriteResultsCSV_RunWithNoCriteria(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeResultsCSV(&buf, &eval_api.OpenAIEvalRun{
+		ID: "evalrun_empty", Status: "failed",
+	}))
+
+	rows, err := csv.NewReader(&buf).ReadAll()
+	require.NoError(t, err)
+
+	require.Len(t, rows, 2)
+	assert.Equal(t, []string{"run_id", "status", "testing_criteria", "passed", "failed"}, rows[0])
+	assert.Equal(t, []string{"evalrun_empty", "failed", "", "", ""}, rows[1])
+}
+
+// A criterion name is service-supplied, so it can hold anything. The writer
+// has to quote rather than corrupt the row.
+func TestWriteResultsCSV_QuotesASeparatorInTheData(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeResultsCSV(&buf, &eval_api.OpenAIEvalRun{
+		ID:     "evalrun_abc",
+		Status: "completed",
+		PerTestingCriteria: []eval_api.EvalRunCriteriaResult{
+			{TestingCriteria: `groundedness, strict`, Passed: 1, Failed: 0},
+		},
+	}))
+
+	rows, err := csv.NewReader(&buf).ReadAll()
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "groundedness, strict", rows[1][2],
+		"a comma in a criterion name must survive the round trip")
+}
+
+// One criterion per line is what lets a downstream job stream results without
+// holding the whole run.
+func TestWriteResultsJSONL(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeResultsJSONL(&buf, twoCriteriaRun()))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2, "one line per criterion")
+
+	var first map[string]any
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
+	assert.Equal(t, "evalrun_abc", first["run_id"])
+	assert.Equal(t, "completed", first["status"])
+	assert.Equal(t, "task_adherence", first["testing_criteria"])
+	assert.EqualValues(t, 8, first["passed"])
+	assert.EqualValues(t, 2, first["failed"])
+
+	var second map[string]any
+	require.NoError(t, json.Unmarshal([]byte(lines[1]), &second))
+	assert.Equal(t, "coherence", second["testing_criteria"])
+}
+
+// Every line has to parse on its own; that is the whole point of the format.
+func TestWriteResultsJSONL_EachLineParsesAlone(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeResultsJSONL(&buf, twoCriteriaRun()))
+
+	for line := range strings.SplitSeq(strings.TrimSpace(buf.String()), "\n") {
+		var row map[string]any
+		assert.NoErrorf(t, json.Unmarshal([]byte(line), &row), "line is not self-contained: %s", line)
+	}
+}
+
+func TestWriteResultsJSONL_RunWithNoCriteria(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeResultsJSONL(&buf, &eval_api.OpenAIEvalRun{
+		ID: "evalrun_empty", Status: "failed",
+	}))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 1)
+
+	var row map[string]any
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &row))
+	assert.Equal(t, "evalrun_empty", row["run_id"])
+	assert.Equal(t, "failed", row["status"])
+	assert.NotContains(t, row, "testing_criteria",
+		"a run that graded nothing must not claim a criterion")
+}
+
+// The three export formats are a documented set. A fourth spelling, or a
+// missing one, is a promise broken on either side.
+func TestExportFormatsAreTheDocumentedSet(t *testing.T) {
+	assert.Equal(t, "csv", formatCSV)
+	assert.Equal(t, "json", formatJSON)
+	assert.Equal(t, "jsonl", formatJSONL)
+
+	usage := find(t, "run output export").Flags().Lookup("format")
+	require.NotNil(t, usage)
+	assert.Equal(t, formatCSV, usage.DefValue,
+		"results are a table, so the default artifact is the one a spreadsheet opens")
+
+	for _, f := range []string{formatCSV, formatJSON, formatJSONL} {
+		assert.Containsf(t, usage.Usage, f, "--format accepts %q, so its help has to say so", f)
+	}
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_render_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_render_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scoredRun is a run the way the service returns one, with rows attached.
+func scoredRows() []eval_api.OutputItem {
+	return []eval_api.OutputItem{
+		{
+			ID: "oi_1",
+			Results: []eval_api.OutputResult{
+				{Name: "relevance", Passed: new(true), Score: 5},
+				{Name: "coherence", Passed: new(true), Score: 4},
+			},
+		},
+		{
+			ID: "oi_2",
+			Results: []eval_api.OutputResult{
+				{Name: "relevance", Passed: new(false), Score: 1, Reason: "Answered a different question."},
+				{Name: "coherence", Passed: new(false), Score: 2, Reason: "Rambled."},
+			},
+		},
+	}
+}
+
+// One evaluated sample is one row. Listing a sample once per evaluator makes a
+// run with three evaluators look three times as broken as it is, and
+// --failed-only exists to answer "which samples do I go and look at".
+func TestRenderResultsIsOneRowPerSample(t *testing.T) {
+	var out bytes.Buffer
+	run := &eval_api.OpenAIEvalRun{ID: "evalrun_1", Status: "completed"}
+	require.NoError(t, renderResults(&out, run, scoredRows(), false))
+
+	text := out.String()
+	assert.Equal(t, 1, strings.Count(text, "oi_2"),
+		"a sample that failed two evaluators must still be one row:\n%s", text)
+
+	for _, header := range []string{"ITEM", "SAMPLE", "FAILED EVALUATORS", "REASON"} {
+		assert.Containsf(t, text, header, "the listing lost its %s column", header)
+	}
+}
+
+// The failing row has to name every evaluator that failed it, because that is
+// what says whether the sample is broken or one evaluator is.
+func TestRenderResultsNamesEveryFailedEvaluator(t *testing.T) {
+	var out bytes.Buffer
+	run := &eval_api.OpenAIEvalRun{ID: "evalrun_1", Status: "completed"}
+	require.NoError(t, renderResults(&out, run, scoredRows(), true))
+
+	text := out.String()
+	assert.Contains(t, text, "relevance, coherence")
+	assert.Contains(t, text, "Answered a different question.",
+		"the first failure's reason is what the row is looked at for")
+	assert.NotContains(t, text, "oi_1", "--failed-only must drop the passing sample")
+	assert.Contains(t, text, "1 sample(s) failed at least one evaluator.")
+}
+
+// The run summary carries pass and fail counts but no score, so the mean has
+// to be averaged over the rows an evaluator actually scored.
+func TestCriteriaMeans(t *testing.T) {
+	means := criteriaMeans(scoredRows())
+	assert.InDelta(t, 3.0, means["relevance"], 0.001)
+	assert.InDelta(t, 3.0, means["coherence"], 0.001)
+
+	assert.Nil(t, criteriaMeans(nil), "no rows means no column, not a column of zeroes")
+}
+
+// An unscored row is not a zero. Counting it as one drags the average toward a
+// number no evaluator produced.
+func TestCriteriaMeansIgnoresUnscoredRows(t *testing.T) {
+	rows := []eval_api.OutputItem{
+		{Results: []eval_api.OutputResult{{Name: "relevance", Score: 4, Passed: new(true)}}},
+		{Results: []eval_api.OutputResult{{Name: "relevance"}}},
+	}
+	// The zero value of a score is undefined, not 0.0.
+	rows[1].Results[0].Score = eval_api.LenientFloat(0)
+
+	means := criteriaMeans(rows)
+	require.Contains(t, means, "relevance")
+	assert.InDelta(t, 2.0, means["relevance"], 0.001,
+		"a defined zero counts; this pins the arithmetic so the undefined case is visible")
+}
+
+// The header the spec documents, and the identity a person needs to know which
+// run they are looking at.
+func TestRenderRunHeaderNamesTheEval(t *testing.T) {
+	run := &eval_api.OpenAIEvalRun{
+		ID:           "evalrun_9",
+		EvalID:       "eval_9",
+		Status:       "completed",
+		Metadata:     map[string]string{"azd_eval": "support-agent-smoke"},
+		ResultCounts: &eval_api.EvalRunResultCounts{Total: 15, Passed: 12, Failed: 3},
+		CreatedAt:    float64(1785801525),
+		ModifiedAt:   float64(1785802119),
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, renderRun(&out, run, map[string]float64{"relevance": 4.1}))
+	text := out.String()
+
+	assert.Contains(t, text, "Run        evalrun_9")
+	assert.Contains(t, text, "Eval       support-agent-smoke",
+		"the declared name is what the author recognizes, not the service id")
+	assert.Contains(t, text, "Status     completed")
+	assert.Contains(t, text, "Samples    15")
+	assert.Contains(t, text, "Duration   9m54s")
+}
+
+// Without the metadata the extension writes at create time there is no
+// declared name, so the id is the honest answer rather than a blank.
+func TestRenderRunHeaderFallsBackToTheEvalID(t *testing.T) {
+	var out bytes.Buffer
+	run := &eval_api.OpenAIEvalRun{ID: "evalrun_9", EvalID: "eval_9", Status: "queued"}
+	require.NoError(t, renderRun(&out, run, nil))
+	assert.Contains(t, out.String(), "Eval       eval_9")
+}
+
+// The score column is dropped rather than filled with dashes when the rows
+// were never read, so the table does not imply the run produced no scores.
+func TestRenderRunOmitsTheScoreColumnWithoutMeans(t *testing.T) {
+	run := &eval_api.OpenAIEvalRun{
+		ID: "evalrun_9", Status: "completed",
+		PerTestingCriteria: []eval_api.EvalRunCriteriaResult{{TestingCriteria: "relevance", Passed: 2}},
+	}
+
+	var without bytes.Buffer
+	require.NoError(t, renderRun(&without, run, nil))
+	assert.NotContains(t, without.String(), "MEAN SCORE")
+
+	var with bytes.Buffer
+	require.NoError(t, renderRun(&with, run, map[string]float64{"relevance": 4.15}))
+	assert.Contains(t, with.String(), "MEAN SCORE")
+	assert.Contains(t, with.String(), "4.2", "the mean is shown to one decimal")
+}
+
+// `run output show` is what a person opens after a failing listing, so it has
+// to be readable. It used to emit raw JSON whatever was asked for.
+func TestRenderOutputItemIsNotJSON(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, renderOutputItem(&out, &eval_api.OutputItem{
+		ID:     "oi_01JQZY7K3R",
+		RunID:  "evalrun_1",
+		Status: "fail",
+		Results: []eval_api.OutputResult{{
+			Name:   "builtin.task_adherence",
+			Score:  0.35,
+			Passed: new(false),
+			Reason: "Task abandoned after the first clarifying question.",
+		}},
+	}))
+
+	text := out.String()
+	assert.NotContains(t, text, `"results"`, "the detail view must not be JSON")
+	for _, want := range []string{
+		"Item", "oi_01JQZY7K3R",
+		"Status", "fail",
+		"builtin.task_adherence", "0.35",
+		"Task abandoned after the first clarifying question.",
+	} {
+		assert.Contains(t, text, want)
+	}
+}
+
+// The listing truncates the reason to a cell, so this view exists to carry the
+// whole of it. Cutting it here would leave it readable nowhere.
+func TestRenderOutputItemKeepsTheWholeReason(t *testing.T) {
+	reason := strings.Repeat("a reason that runs well past any column width. ", 8)
+
+	var out bytes.Buffer
+	require.NoError(t, renderOutputItem(&out, &eval_api.OutputItem{
+		ID:      "oi_1",
+		Status:  "fail",
+		Results: []eval_api.OutputResult{{Name: "relevance", Passed: new(false), Reason: reason}},
+	}))
+
+	assert.Contains(t, out.String(), reason)
+}
+
+// A rubric reports one result per dimension, all carrying the evaluator's
+// name. Printed flat they read as several evaluators that share a name.
+func TestRenderOutputItemGroupsARubricsDimensions(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, renderOutputItem(&out, &eval_api.OutputItem{
+		ID:     "oi_1",
+		Status: "fail",
+		Results: []eval_api.OutputResult{
+			{Name: "support-agent-quality", Metric: "resolves_issue", Score: 1, Passed: new(false)},
+			{Name: "support-agent-quality", Metric: "cites_policy", Score: 5, Passed: new(true)},
+			{Name: "builtin.task_adherence", Score: 0.35, Passed: new(false)},
+		},
+	}))
+
+	text := out.String()
+	assert.Equal(t, 1, strings.Count(text, "support-agent-quality"),
+		"the evaluator is named once, above its dimensions:\n%s", text)
+	for _, want := range []string{"resolves_issue", "cites_policy", "builtin.task_adherence"} {
+		assert.Contains(t, text, want)
+	}
+}
+
+// The service echoes the evaluator's name in `metric` for a single-score
+// evaluator. Nesting that reads as a dimension that happens to share its
+// evaluator's name.
+func TestRenderOutputItemDoesNotNestASelfNamedMetric(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, renderOutputItem(&out, &eval_api.OutputItem{
+		ID:     "oi_1",
+		Status: "completed",
+		Results: []eval_api.OutputResult{
+			{Name: "task_adherence", Metric: "task_adherence", Score: 1, Passed: new(true)},
+		},
+	}))
+
+	assert.Equal(t, 1, strings.Count(out.String(), "task_adherence"),
+		"the evaluator must be named once:\n%s", out.String())
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_status_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_status_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The exit code is the whole contract with a pipeline, and there are three
+// answers it has to be able to give: the evaluation ran and passed, it ran and
+// regressed, or it could not run. The gate owns the middle one; this owns the
+// last.
+//
+// Reporting a run that errored and then exiting 0 tells the pipeline the
+// evaluation passed, which is the one answer that is never true.
+func TestRunCompleted(t *testing.T) {
+	require.NoError(t, runCompleted(nil),
+		"nothing was waited for, so there is nothing to report")
+	require.NoError(t, runCompleted(&eval_api.OpenAIEvalRun{ID: "r1", Status: "completed"}))
+	require.NoError(t, runCompleted(&eval_api.OpenAIEvalRun{ID: "r1", Status: "Completed"}),
+		"the service is not consistent about case")
+	require.NoError(t, runCompleted(&eval_api.OpenAIEvalRun{ID: "r1"}),
+		"a status the service did not send is not a failure to report")
+
+	for _, status := range []string{"failed", "error", "canceled", "cancelled"} {
+		err := runCompleted(&eval_api.OpenAIEvalRun{ID: "run_abc", Status: status})
+		require.Error(t, err, "status %q must not exit 0", status)
+		assert.Contains(t, err.Error(), "run_abc")
+		assert.Contains(t, err.Error(), status,
+			"the message has to name the status, which is what the caller acts on")
+	}
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_summary_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_summary_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// finishedRun is a run the way the service returns one: counts over samples,
+// and a result per testing criterion.
+func finishedRun() *eval_api.OpenAIEvalRun {
+	return &eval_api.OpenAIEvalRun{
+		ID:     "evalrun_abc123",
+		Status: "completed",
+		ResultCounts: &eval_api.EvalRunResultCounts{
+			Total: 10, Passed: 7, Failed: 3,
+		},
+		PerTestingCriteria: []eval_api.EvalRunCriteriaResult{
+			{TestingCriteria: "relevance", Passed: 9, Failed: 1},
+			{TestingCriteria: "coherence", Passed: 7, Failed: 3},
+		},
+	}
+}
+
+// The whole point of waiting for a run is the verdict per evaluator. Printing
+// only the status meant the answer to the question the command was asked took
+// a second command to see.
+func TestRenderRunReportsEveryEvaluator(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, renderRun(&out, finishedRun(), nil))
+	text := out.String()
+
+	assert.Contains(t, text, "evalrun_abc123")
+	assert.Contains(t, text, "completed")
+
+	for _, criterion := range []string{"relevance", "coherence"} {
+		assert.Contains(t, text, criterion,
+			"every evaluator the run scored must appear")
+	}
+	assert.Contains(t, text, "90.0%", "relevance passed 9 of 10")
+	assert.Contains(t, text, "70.0%", "coherence passed 7 of 10")
+	assert.Contains(t, text, "7/10", "the sample counts must be shown, not just the rate")
+}
+
+// Two runs of the same eval have to read the same way. The service returns the
+// criteria in whatever order it evaluated them, which is not stable.
+func TestRenderRunOrdersEvaluatorsByName(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, renderRun(&out, finishedRun(), nil))
+
+	text := out.String()
+	assert.Less(t, strings.Index(text, "coherence"), strings.Index(text, "relevance"),
+		"evaluators must be listed in a stable order")
+}
+
+// An errored row is not a failing row: the evaluator never reached a verdict.
+// Folding the two together would report a service problem as a quality problem.
+func TestRenderRunSeparatesErrorsFromFailures(t *testing.T) {
+	run := finishedRun()
+	run.ResultCounts = &eval_api.EvalRunResultCounts{Total: 10, Passed: 7, Failed: 1, Errored: 2}
+	run.PerTestingCriteria = []eval_api.EvalRunCriteriaResult{
+		{TestingCriteria: "relevance", Passed: 7, Failed: 1, Errored: 2},
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, renderRun(&out, run, nil))
+	text := out.String()
+
+	assert.Contains(t, text, "2 errored")
+	assert.Contains(t, text, "87.5%",
+		"the pass rate is over what was scored, not over what was attempted")
+	assert.Contains(t, text, "errored and were not scored")
+}
+
+// A rate over nothing is not zero. Printing 0.0% for a criterion that scored
+// no rows reads as a total failure rather than as no data.
+func TestFormatRateHasNoOpinionAboutNothing(t *testing.T) {
+	assert.Equal(t, "-", formatRate(0, 0))
+	assert.Equal(t, "0.0%", formatRate(0, 4))
+	assert.Equal(t, "100.0%", formatRate(4, 4))
+	assert.Equal(t, "33.3%", formatRate(1, 3))
+}
+
+// The next thing anyone does after seeing failures is look at them, so the
+// command that shows them is named — and it has to be a command that exists.
+func TestRenderRunPointsAtTheFailingSamples(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, renderRun(&out, finishedRun(), nil))
+	assert.Contains(t, out.String(), "azd ai eval run output list --failed-only")
+
+	clean := finishedRun()
+	clean.ResultCounts = &eval_api.EvalRunResultCounts{Total: 10, Passed: 10}
+	clean.PerTestingCriteria = []eval_api.EvalRunCriteriaResult{
+		{TestingCriteria: "relevance", Passed: 10},
+	}
+	var cleanOut bytes.Buffer
+	require.NoError(t, renderRun(&cleanOut, clean, nil))
+	assert.NotContains(t, cleanOut.String(), "--failed-only",
+		"a run with nothing to look at must not send anyone looking")
+}
+
+// A run that never produced counts still has to render. The service returns
+// none for a run that failed before scoring, and a nil dereference there would
+// replace the failure message with a panic.
+func TestRenderRunSurvivesAnEmptyResult(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, renderRun(&out, &eval_api.OpenAIEvalRun{ID: "evalrun_x", Status: "failed"}, nil))
+	assert.Contains(t, out.String(), "evalrun_x")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/schemas_live_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/schemas_live_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build live
+
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/pkg/evalcore"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLiveEvaluatorSchemasIncludesBuiltins covers the function that supplies
+// the schemas, rather than the builder that consumes them.
+//
+// The builder was already tested against every built-in, but the test fetched
+// them itself with the Builtin filter. Production did not: it listed
+// unfiltered, which returns only the project's own evaluators, so every
+// built-in reached the builder with no schema at all. The builder was correct
+// and the criteria were still wrong, and no test could see it because each one
+// constructed the input production was failing to construct.
+func TestLiveEvaluatorSchemasIncludesBuiltins(t *testing.T) {
+	client, _ := liveEvalClient(t)
+	ctx := context.Background()
+
+	// The listing production used to rely on, to show what it omits.
+	unfiltered, err := client.ListEvaluators(ctx, "", ProjectEndpointAPIVersion)
+	require.NoError(t, err)
+	builtinsInUnfiltered := 0
+	for _, e := range unfiltered.Value {
+		if eval_api.IsBuiltinEvaluator(e.Name) {
+			builtinsInUnfiltered++
+		}
+	}
+
+	ec := &evalContext{evalClient: client}
+	schemas := ec.evaluatorSchemas(ctx)
+	require.NotEmpty(t, schemas, "no evaluator schemas were resolved at all")
+
+	builtins := 0
+	for name, summary := range schemas {
+		if !eval_api.IsBuiltinEvaluator(name) {
+			continue
+		}
+		builtins++
+		assert.NotNil(t, summary.DataSchema(),
+			"%s resolved without the contract the criteria are shaped from", name)
+	}
+
+	require.NotZero(t, builtins,
+		"built-ins must be resolvable; the unfiltered listing returns %d of them, "+
+			"so they have to be asked for by type", builtinsInUnfiltered)
+}
+
+// The fields an evaluator declares are the ones its criterion has to bind, so
+// a conversation-level evaluator must resolve to its conversation field.
+func TestLiveConversationEvaluatorBindsMessages(t *testing.T) {
+	client, judge := liveEvalClient(t)
+	ctx := context.Background()
+
+	ec := &evalContext{evalClient: client}
+	schemas := ec.evaluatorSchemas(ctx)
+	require.NotEmpty(t, schemas)
+
+	var name string
+	for n, summary := range schemas {
+		if eval_api.IsBuiltinEvaluator(n) && summary.SupportsLevel("conversation") {
+			if ds := summary.DataSchema(); ds != nil && ds.Accepts(conversationField) {
+				name = n
+				break
+			}
+		}
+	}
+	if name == "" {
+		t.Skip("no built-in advertises a conversation contract on this project")
+	}
+
+	plan, err := planCriterion(
+		evalcore.EvaluatorRef{
+			Name:                     name,
+			InitializationParameters: map[string]any{"deployment_name": judge},
+		},
+		schemas[name],
+		nil, // no target: the dataset holds both sides of the exchange
+		map[string]bool{conversationField: true},
+		"conversation",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "{{item."+conversationField+"}}", plan.dataMapping[conversationField],
+		"%s must bind its conversation field", name)
+	assert.NotEmpty(t, plan.dataMapping, "an empty mapping scores nothing")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/score_display_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/score_display_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"math"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An evaluator that errored on a row still sends a result, and its score
+// decodes to NaN. criteriaMeans has always skipped those -- its comment says
+// counting them as zero "would drag the average toward a number no evaluator
+// produced" -- but the per-sample column averaged them in, so one errored
+// evaluator made the whole sample read NaN.
+func TestASampleScoreLeavesOutWhatWasNotScored(t *testing.T) {
+	undefined := eval_api.LenientFloat(math.NaN())
+
+	cases := []struct {
+		name    string
+		results []eval_api.OutputResult
+		want    string
+	}{
+		{
+			name:    "no results at all",
+			results: nil,
+			want:    "-",
+		},
+		{
+			name: "every evaluator scored",
+			results: []eval_api.OutputResult{
+				{Score: 1.0}, {Score: 0.5},
+			},
+			want: "0.75",
+		},
+		{
+			name: "one evaluator errored",
+			results: []eval_api.OutputResult{
+				{Score: 4.0}, {Score: undefined},
+			},
+			want: "4.00",
+		},
+		{
+			name: "nothing was scored",
+			results: []eval_api.OutputResult{
+				{Score: undefined}, {Score: undefined},
+			},
+			want: "-",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, meanScoreOf(tc.results))
+		})
+	}
+}
+
+// The same rule for a single score: a dash says "not scored", where NaN says
+// nothing a reader can use.
+func TestAScoreThatIsNotANumberShowsAsAbsent(t *testing.T) {
+	assert.Equal(t, "-", formatScore(eval_api.LenientFloat(math.NaN())))
+	assert.Equal(t, "-", formatScore(eval_api.LenientFloat(math.Inf(1))))
+	assert.Equal(t, "0.75", formatScore(eval_api.LenientFloat(0.75)))
+	assert.Equal(t, "0.00", formatScore(eval_api.LenientFloat(0)),
+		"a real zero is a score and must still be shown")
+}
+
+// The gate compares exact values while the message rounds, so a rate just under
+// the threshold could be reported as below itself. The spec's hero scenario
+// shows one decimal, so that is kept for every case where the two differ.
+func TestAGateBreachNeverReportsARateAsBelowItself(t *testing.T) {
+	gate, err := parseGate("pass-rate=0.8")
+	require.NoError(t, err)
+
+	breach := gate.breach(&eval_api.EvalRunResultCounts{Total: 10000, Passed: 7996})
+	require.NotEmpty(t, breach, "7996/10000 is under 0.8 and must breach")
+	assert.NotContains(t, breach, "80.0% is below the required 80.0%",
+		"a line saying a rate is below itself tells a reader nothing")
+	assert.Contains(t, breach, "79.96%")
+
+	// The wording the spec shows is unchanged wherever rounding does not collide.
+	assert.Equal(t,
+		"pass rate 76.4% is below the required 80.0%",
+		gate.breach(&eval_api.EvalRunResultCounts{Total: 1000, Passed: 764}))
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/surface_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/surface_test.go
@@ -1,0 +1,617 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"azureaieval/internal/project"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The command surface is a contract with the spec and with the sibling Foundry
+// extensions, and it is the part of this tool users type from memory. Nothing
+// was checking it: the flag that writes results to a file was `--out-file`
+// while the spec, Scenario 4, and `azd ai skill download` all say
+// `--output-file`, and it took reading the two documents side by side to see.
+//
+// These tests walk the built tree, so a command or flag that is renamed,
+// dropped, or quietly added has to be acknowledged here.
+
+// walk visits every command in the tree, skipping the ones azd contributes.
+func walk(t *testing.T, cmd *cobra.Command, path []string, visit func(string, *cobra.Command)) {
+	t.Helper()
+	for _, child := range cmd.Commands() {
+		name := strings.Fields(child.Use)[0]
+		switch name {
+		case "help", "completion", "listen", "metadata":
+			continue
+		}
+		full := append(append([]string{}, path...), name)
+		visit(strings.Join(full, " "), child)
+		walk(t, child, full, visit)
+	}
+}
+
+// commandTree is every command the extension exposes, and is the surface the
+// spec's command table describes.
+func TestCommandTreeMatchesTheSpec(t *testing.T) {
+	want := []string{
+		"dataset",
+		"dataset create",
+		"dataset delete",
+		"dataset list",
+		"dataset show",
+		"dataset update",
+		"dataset versions",
+		"dataset versions list",
+		"create",
+		"delete",
+		"evaluator",
+		"evaluator create",
+		"evaluator delete",
+		"evaluator list",
+		"evaluator show",
+		"evaluator update",
+		"evaluator versions",
+		"evaluator versions list",
+		// One generate for both artifacts, and one job group for both
+		// collections, selected by --dataset / --evaluator.
+		"generate",
+		"job",
+		"job cancel",
+		"job delete",
+		"job list",
+		"job show",
+		"init",
+		"list",
+		"run",
+		"run cancel",
+		"run delete",
+		"run list",
+		"run output",
+		"run output export",
+		"run output list",
+		"run output show",
+		"run show",
+		"run start",
+		"show",
+	}
+
+	var got []string
+	walk(t, NewRootCommand(), nil, func(path string, _ *cobra.Command) {
+		got = append(got, path)
+	})
+
+	assert.ElementsMatch(t, want, got,
+		"the command tree changed; update the spec's command table with it")
+}
+
+// Flag names are shared vocabulary across the Foundry extensions. A command
+// that invents its own spelling for something the others already name is the
+// kind of difference nobody notices until a user types the one they learned
+// somewhere else.
+func TestFlagVocabularyIsShared(t *testing.T) {
+	// Meaning → the one spelling for it, from the spec's vocabulary table.
+	// A command that means one of these must use exactly this name, and the
+	// near-misses are listed so a rename back is caught rather than accepted.
+	forbidden := map[string]string{
+		"--out-file":     "--output-file",
+		"--out-dir":      "--output-dir",
+		"--file":         "--from-file",
+		"--rubric":       "--from-file",
+		"--from-traces":  "deferred to M2",
+		"--response-id":  "deferred to M2",
+		"--no-target":    "deferred to M2",
+		"--out":          "--output-file",
+		"--dir":          "--output-dir",
+		"--baseline":     "deferred to M2",
+		"--cron":         "deferred to M2",
+		"--folder":       "deferred to M2",
+		"--init-params":  "deferred to M2",
+		"--data-schema":  "deferred to M2",
+		"--metrics":      "deferred to M2",
+		"--trace-window": "deferred to M2",
+		"--max-turns":    "deferred to M2",
+	}
+
+	walk(t, NewRootCommand(), nil, func(path string, cmd *cobra.Command) {
+		cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
+			if want, bad := forbidden["--"+f.Name]; bad {
+				t.Errorf("%s declares --%s; use %s", path, f.Name, want)
+			}
+		})
+	})
+}
+
+// M1 promises `-o json` and `--no-prompt` throughout. Both come from the azd
+// extension SDK's root command, so every command inherits them — until one
+// declares its own flag by the same name, which silently shadows the global
+// and leaves that one command unable to answer in JSON or to run unattended.
+func TestNoCommandShadowsAGlobalFlag(t *testing.T) {
+	global := []string{"output", "no-prompt", "environment", "cwd", "debug"}
+
+	walk(t, NewRootCommand(), nil, func(path string, cmd *cobra.Command) {
+		for _, name := range global {
+			assert.Nilf(t, cmd.LocalFlags().Lookup(name),
+				"%s declares its own --%s, which shadows the global one", path, name)
+		}
+	})
+}
+
+// The two commands that write a file have to agree on what that flag is
+// called, and it has to be the name the sibling extensions use.
+func TestOutputFileFlagIsSpelledTheSharedWay(t *testing.T) {
+	for _, path := range []string{"run output list", "run output export"} {
+		cmd := find(t, path)
+		require.NotNil(t, cmd.Flags().Lookup("output-file"),
+			"%s must write to --output-file, the name `azd ai skill download` uses", path)
+		assert.Nil(t, cmd.Flags().Lookup("out-file"),
+			"%s must not keep the old spelling alongside the shared one", path)
+	}
+}
+
+// `init` is the one command with a documented flag table, so it is pinned
+// whole: an extra flag there is a promise the spec does not make, and a
+// missing one is a promise it does.
+func TestInitFlagsMatchTheSpec(t *testing.T) {
+	cmd := find(t, "init")
+
+	var got []string
+	cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
+		if f.Name != "help" {
+			got = append(got, "--"+f.Name)
+		}
+	})
+
+	assert.ElementsMatch(t, []string{
+		"--name", "--target", "--source", "--dataset", "--max-traces",
+		"--evaluator", "--judge-model", "--path", "--force",
+	}, got, "init's flags are a table in the spec; change both together")
+}
+
+// `init` makes no service calls, so it must not offer the flag that says where
+// to make them.
+func TestInitTakesNoProjectEndpoint(t *testing.T) {
+	assert.Nil(t, find(t, "init").Flags().Lookup("project-endpoint"),
+		"init is offline; a project endpoint would imply otherwise")
+}
+
+// Every command that does reach the service accepts it, because the shared
+// Foundry resolver is how a project is named without an azd environment.
+// --eval takes "the name of the eval declared in the configuration", which
+// means the command has to be able to find that configuration. The only other
+// way it can is a path `init` recorded in the azd environment, which a
+// --project-endpoint caller does not have -- so a configuration outside ./evals
+// could be started and then not listed, shown or cancelled.
+func TestEveryCommandTakingAnEvalNameCanBeToldWhereTheConfigIs(t *testing.T) {
+	var checked int
+	walk(t, NewRootCommand(), nil, func(path string, cmd *cobra.Command) {
+		if cmd.Flags().Lookup("eval") == nil {
+			return
+		}
+		checked++
+		assert.NotNilf(t, cmd.Flags().Lookup("path"),
+			"%s resolves a declared eval name, so it must accept --path", path)
+	})
+	assert.NotZero(t, checked, "no command took --eval, so this checked nothing")
+}
+
+func TestServiceCommandsTakeProjectEndpoint(t *testing.T) {
+	groups := map[string]bool{
+		"dataset": true, "evaluator": true, "run": true,
+		"job": true, "run output": true,
+	}
+
+	walk(t, NewRootCommand(), nil, func(path string, cmd *cobra.Command) {
+		if cmd.RunE == nil || path == "init" {
+			return
+		}
+		if groups[path] {
+			return
+		}
+		assert.NotNil(t, cmd.Flags().Lookup("project-endpoint"),
+			"%s reaches the service, so it must accept --project-endpoint", path)
+	})
+}
+
+// The spec says --from "selects one or more of the four sources", so it has to
+// be repeatable. Declared as a plain string it would still accept every
+// documented single-source invocation and silently keep only the last of a
+// repeated one, which is the kind of difference no example in the spec shows.
+func TestGenerateFromTakesMoreThanOneSource(t *testing.T) {
+	flag := find(t, "generate").Flags().Lookup("from")
+	require.NotNil(t, flag, "generate must offer --from")
+
+	assert.Equal(t, "stringSlice", flag.Value.Type(),
+		"--from selects one or more sources, so it cannot be a single string")
+}
+
+// `--from` names sources; the set it accepts is the set the service has a path
+// for, and the help has to list exactly that set.
+func TestGenerateFromListsEverySource(t *testing.T) {
+	usage := find(t, "generate").Flags().Lookup("from").Usage
+
+	for _, source := range project.GenerateSources {
+		assert.Containsf(t, usage, source,
+			"--from accepts %q, so its help has to say so", source)
+	}
+}
+
+// One command now generates both artifacts, but --from and --max-samples shape
+// the dataset only. The help has to say so, or they read as applying to the
+// rubric as well.
+func TestGenerateSaysWhichFlagsAreDatasetOnly(t *testing.T) {
+	flags := find(t, "generate").Flags()
+
+	for _, name := range []string{"from", "max-samples"} {
+		flag := flags.Lookup(name)
+		require.NotNilf(t, flag, "generate must offer --%s", name)
+		assert.Containsf(t, flag.Usage, "Dataset only",
+			"--%s shapes the dataset only, so its help has to say so", name)
+	}
+}
+
+// The selector narrows generation; omitting both is the zero-to-first-eval
+// path, so neither flag may be required.
+func TestGenerateSelectorIsOptional(t *testing.T) {
+	cmd := find(t, "generate")
+
+	for _, name := range []string{"dataset", "evaluator"} {
+		flag := cmd.Flags().Lookup(name)
+		require.NotNilf(t, flag, "generate must offer --%s", name)
+		assert.Equal(t, "false", flag.DefValue,
+			"--%s is off by default, which is what generates both", name)
+	}
+}
+
+// The spec's run table says which commands carry which flag. Where it says
+// "every", that is checkable; where it names two commands, a third carrying the
+// flag is a promise the spec does not make and a missing one is a promise it
+// does.
+//
+// This pins placement, not the whole flag list: unlike init's, the run table is
+// headed "Flag | Commands | Default" and documents defaults rather than
+// enumerating every flag.
+func TestRunFlagsSitWhereTheSpecSaysTheyDo(t *testing.T) {
+	// Flag → exactly the run commands that may declare it. nil means every
+	// run command that does something.
+	placement := map[string][]string{
+		"eval":    nil,
+		"dataset": {"run start"},
+		"fail-on": {"run start", "run show"},
+		"wait":    {"run start", "run show"},
+		"format":  {"run output export"},
+	}
+
+	// Every run command that actually runs, which is what "every run command"
+	// means — the bare groups take no flags.
+	var runCommands []string
+	walk(t, NewRootCommand(), nil, func(path string, cmd *cobra.Command) {
+		if strings.HasPrefix(path, "run") && cmd.RunE != nil {
+			runCommands = append(runCommands, path)
+		}
+	})
+	require.NotEmpty(t, runCommands)
+
+	for flag, allowed := range placement {
+		if allowed == nil {
+			allowed = runCommands
+		}
+		for _, path := range runCommands {
+			has := find(t, path).Flags().Lookup(flag) != nil
+			want := slices.Contains(allowed, path)
+
+			switch {
+			case want && !has:
+				t.Errorf("%s must accept --%s; the spec's run table says so", path, flag)
+			case !want && has:
+				t.Errorf("%s declares --%s, which the spec gives only to %s",
+					path, flag, strings.Join(allowed, ", "))
+			}
+		}
+	}
+}
+
+// `--eval` is how a run command finds the eval, and the spec gives it to every
+// one of them. Losing it from a single command makes that command unusable in a
+// project with more than one eval.
+func TestEveryRunCommandTakesEval(t *testing.T) {
+	walk(t, NewRootCommand(), nil, func(path string, cmd *cobra.Command) {
+		if !strings.HasPrefix(path, "run") || cmd.RunE == nil {
+			return
+		}
+		assert.NotNilf(t, cmd.Flags().Lookup("eval"),
+			"%s must accept --eval, which the spec gives to every run command", path)
+	})
+}
+
+// The tagged suites drive the binary by writing flags as strings, so a flag
+// that is renamed or removed still compiles there and only fails when someone
+// has the credentials to run them.
+//
+// That is not hypothetical. Removing `--eval-id` and the generation spec file
+// left 28 uses of `--eval-id` and two `--config` tests behind in tests/cli,
+// every one of which would have failed at the first live run — under `live` and
+// `hero` tags that `go test ./...` never builds. This checks them from the
+// default suite, where a rename is caught by the person doing the renaming.
+func TestTaggedSuitesNameFlagsThatExist(t *testing.T) {
+	// Every flag any command declares, plus the globals azd contributes.
+	known := map[string]bool{
+		"output": true, "no-prompt": true, "environment": true,
+		"cwd": true, "debug": true, "help": true,
+	}
+	walk(t, NewRootCommand(), nil, func(_ string, cmd *cobra.Command) {
+		cmd.Flags().VisitAll(func(f *pflag.Flag) { known[f.Name] = true })
+	})
+
+	// Only string literals, which is how a test spells a flag it passes to the
+	// binary. Prose in a comment is not a flag.
+	literal := regexp.MustCompile(`"--([a-z][a-z0-9-]*)"`)
+
+	err := filepath.WalkDir("../../tests", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		body, err := os.ReadFile(path) //nolint:gosec // walking this package's own source
+		if err != nil {
+			return err
+		}
+		for i, line := range strings.Split(string(body), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+			for _, m := range literal.FindAllStringSubmatch(line, -1) {
+				assert.Truef(t, known[m[1]],
+					"%s:%d passes --%s, which no command declares", path, i+1, m[1])
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// A suggestion that names a flag has to name one the suggested command takes.
+//
+// `run start --no-wait` closed with "Reattach with: azd ai eval run show <id>
+// --eval-id <eval>" for the whole life of the branch that removed --eval-id.
+// The command resolved, so the suggestion check passed; the flag did not exist,
+// so the one line a user is told to paste was the one guaranteed to fail.
+func TestSuggestedFlagsExist(t *testing.T) {
+	// `azd ai eval <command path> ... --flag`, with the flag anywhere after it.
+	suggestion := regexp.MustCompile(`azd ai eval ((?:[a-z][a-z0-9-]*\s+)+)([^"'\n]*)`)
+	flagName := regexp.MustCompile(`--([a-z][a-z0-9-]*)`)
+
+	err := filepath.WalkDir("../..", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		body, err := os.ReadFile(path) //nolint:gosec // walking this package's own source
+		if err != nil {
+			return err
+		}
+		for i, line := range strings.Split(string(body), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+			for _, m := range suggestion.FindAllStringSubmatch(line, -1) {
+				flags := flagName.FindAllStringSubmatch(m[2], -1)
+				if len(flags) == 0 {
+					continue
+				}
+				// Longest command prefix that resolves; the rest is arguments.
+				words := strings.Fields(m[1])
+				for len(words) > 0 {
+					if resolved, _, e := NewRootCommand().Find(words); e == nil &&
+						strings.Fields(resolved.Use)[0] == words[len(words)-1] {
+						break
+					}
+					words = words[:len(words)-1]
+				}
+				if len(words) == 0 {
+					continue // the command itself is checked above
+				}
+				cmd, _, _ := NewRootCommand().Find(words)
+				for _, f := range flags {
+					assert.NotNilf(t, cmd.Flags().Lookup(f[1]),
+						"%s:%d suggests `azd ai eval %s --%s`, which that command does not accept",
+						path, i+1, strings.Join(words, " "), f[1])
+				}
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// siblingNamespaces are the other Foundry extensions this one points users at.
+// Listed rather than wildcarded so a typo in a namespace still fails.
+var siblingNamespaces = map[string]bool{
+	"project": true, // `azd ai project set` owns the shared endpoint context
+	"dataset": true, // where the dataset commands go once they move
+	"agent":   true,
+}
+
+// find resolves a command path, failing the test when it does not exist.
+func find(t *testing.T, path string) *cobra.Command {
+	t.Helper()
+	cmd, _, err := NewRootCommand().Find(strings.Fields(path))
+	require.NoError(t, err, "no such command: %s", path)
+	require.Equal(t, strings.Fields(path)[len(strings.Fields(path))-1],
+		strings.Fields(cmd.Use)[0], "resolved the wrong command for %s", path)
+	return cmd
+}
+
+// Messages that tell a user what to run next have to name a command that
+// exists.
+//
+// Rebuilding the surface left `run start --no-wait` closing with "Check
+// progress with: azd ai eval results show", a command that had been renamed
+// out of existence — so the one instruction printed at the moment a user needs
+// it was the one thing guaranteed to fail. Nothing catches that: the string
+// compiles, the command that prints it succeeds, and only someone following
+// the advice finds out.
+// This extension's namespace is `ai.eval`, so every command it can suggest
+// begins `azd ai eval`. Anchoring on that prefix is what caught the renamed
+// command above — and anchoring only on it is what let three suggestions
+// through pointing at `azd ai dataset`, a namespace no installed extension
+// serves. So the prefix checked is `azd ai`, and anything under it that is not
+// this extension's own is a command nobody can run.
+func TestSuggestedCommandsExist(t *testing.T) {
+	root := "../.."
+	pattern := regexp.MustCompile("azd ai ([a-z][a-z0-9-]*(?: [a-z][a-z0-9-]*)*)")
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		body, err := os.ReadFile(path) //nolint:gosec // walking this package's own source
+		if err != nil {
+			return err
+		}
+
+		for line := range strings.SplitSeq(string(body), "\n") {
+			// Comments explain the surface; only what reaches a terminal has
+			// to resolve.
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+			for _, m := range pattern.FindAllStringSubmatch(line, -1) {
+				words := strings.Fields(m[1])
+				if len(words) == 0 {
+					continue
+				}
+
+				// A suggestion under a sibling's namespace is that extension's
+				// contract and cannot be resolved from here. Only the ones this
+				// extension actually points at are allowed, so a typo still
+				// fails rather than passing as "probably somebody else's".
+				if siblingNamespaces[words[0]] {
+					continue
+				}
+
+				// `ai.eval` is this extension's namespace, so it is the only
+				// other thing under `azd ai` that can resolve.
+				if words[0] != "eval" {
+					t.Errorf("%s suggests `azd ai %s`, which is neither this "+
+						"extension's namespace nor a sibling it knows about", path, m[1])
+					continue
+				}
+				words = words[1:]
+
+				// Trim trailing prose: "run start" is a command, "run start
+				// and summarize" is a sentence that begins with one.
+				for len(words) > 0 {
+					if _, _, err := NewRootCommand().Find(words); err == nil {
+						resolved, _, _ := NewRootCommand().Find(words)
+						if strings.Fields(resolved.Use)[0] == words[len(words)-1] {
+							break
+						}
+					}
+					words = words[:len(words)-1]
+				}
+				assert.NotEmpty(t, words,
+					"%s suggests `azd ai %s`, which is not a command", path, m[1])
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// Every flag a message names has to exist on some command.
+//
+// TestSuggestedFlagsExist only looks inside a quoted `azd ai eval ...` command,
+// so a message that names a flag on its own escapes it. One did:
+// DatasetHasUnregisteredEdits told the reader to pass `--eval-id <id>`, a flag
+// removed long before, and the check above saw no command to attach it to.
+func TestBareFlagsInMessagesExist(t *testing.T) {
+	flagRef := regexp.MustCompile(`--([a-z][a-z0-9-]{1,})`)
+
+	known := map[string]bool{}
+	root := NewRootCommand()
+	root.PersistentFlags().VisitAll(func(f *pflag.Flag) { known[f.Name] = true })
+	walk(t, root, nil, func(_ string, c *cobra.Command) {
+		c.Flags().VisitAll(func(f *pflag.Flag) { known[f.Name] = true })
+	})
+	// azd's own, which messages legitimately name.
+	for _, global := range []string{"cwd", "debug", "environment", "no-prompt", "output", "help"} {
+		known[global] = true
+	}
+
+	body, err := os.ReadFile(filepath.Join("..", "messages", "messages.go"))
+	require.NoError(t, err)
+
+	for i, line := range strings.Split(string(body), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		for _, m := range flagRef.FindAllStringSubmatch(line, -1) {
+			assert.Truef(t, known[m[1]],
+				"messages.go:%d names --%s, which no command accepts", i+1, m[1])
+		}
+	}
+}
+
+// A command suggested with an argument has to be suggested with the argument
+// filled in.
+//
+// `--no-wait` exists so the caller can walk away, and the line they walk away
+// with is the one they paste when they come back. Printing
+// `azd ai eval job show <job-id>` reads like a command and is not one: it
+// resolves, so the check above passes, and it fails the moment anyone uses it.
+func TestSuggestedCommandsCarryNoPlaceholders(t *testing.T) {
+	placeholder := regexp.MustCompile(`azd ai eval [^"'\n]*<[a-z-]+>`)
+
+	err := filepath.WalkDir("../..", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		body, err := os.ReadFile(path) //nolint:gosec // walking this package's own source
+		if err != nil {
+			return err
+		}
+		for i, line := range strings.Split(string(body), "\n") {
+			trimmed := strings.TrimSpace(line)
+			// A `Use:` string and the help text around it are where a
+			// placeholder belongs: cobra prints it as the signature.
+			if strings.HasPrefix(trimmed, "//") ||
+				strings.HasPrefix(trimmed, "Use:") ||
+				strings.HasPrefix(trimmed, "Short:") ||
+				strings.HasPrefix(trimmed, "Long:") {
+				continue
+			}
+			if m := placeholder.FindString(line); m != "" {
+				t.Errorf("%s:%d suggests %q; substitute the value instead",
+					path, i+1, m)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/table_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/table_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A list view is uppercase headers over a rule, per the spec's output
+// conventions and the sibling extension it cites. The rule is what separates
+// the header from the data at a glance, and every `list` command was printing
+// the header straight onto the first row.
+func TestEmitTableWritesTheRule(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, emitTable(&buf,
+		[]string{"NAME", "VERSION"},
+		[][]string{{"support-regression", "3"}, {"nightly", "1"}}))
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 4, "a header, its rule, and one line per row")
+
+	assert.Contains(t, lines[0], "NAME")
+	assert.Contains(t, lines[0], "VERSION")
+
+	// Dashes as wide as the header they sit under, which is what makes the
+	// rule line up once tabwriter has padded the columns.
+	assert.Contains(t, lines[1], strings.Repeat("-", len("NAME")))
+	assert.Contains(t, lines[1], strings.Repeat("-", len("VERSION")))
+	assert.Empty(t, strings.Trim(lines[1], "- "),
+		"the rule carries nothing but dashes and padding")
+
+	assert.Contains(t, lines[2], "support-regression")
+	assert.Contains(t, lines[3], "nightly")
+}
+
+// The columns line up: the rule is padded to the same widths as the header, so
+// a wide value in the first row does not leave the rule short.
+func TestEmitTableRuleAlignsWithTheHeader(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, emitTable(&buf,
+		[]string{"NAME", "STATUS"},
+		[][]string{{"a-very-much-longer-value-than-the-header", "completed"}}))
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 3)
+
+	// tabwriter pads every line in a column to the same width, so the header
+	// and its rule start their second column at the same offset.
+	assert.Equal(t,
+		strings.Index(lines[0], "STATUS"),
+		strings.Index(lines[1], "------"),
+		"the rule has to sit under the header it belongs to")
+}
+
+// A listing with nothing in it still prints the header and rule: a caller
+// seeing no output cannot tell an empty list from a command that failed to
+// render.
+func TestEmitTableWithNoRows(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, emitTable(&buf, []string{"NAME", "VERSION"}, nil))
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	assert.Len(t, lines, 2)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/main.go
+++ b/cli/azd/extensions/azure.ai.evaluations/main.go
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"azureaieval/internal/cmd"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+)
+
+func main() {
+	azdext.Run(cmd.NewRootCommand())
+}

--- a/cli/azd/extensions/azure.ai.evaluations/tests/cli/dataset_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/tests/cli/dataset_test.go
@@ -1,0 +1,252 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build live
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type datasetSummary struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Format  string `json:"format"`
+}
+
+const datasetRows = `{"query":"How do I reset my password?"}
+{"query":"What is the refund window?"}
+`
+
+// registeredDataset is a dataset with more than one version, which is what
+// makes --version on show and --name on list worth asserting.
+type registeredDataset struct {
+	Name string
+	// Versions are read back from each registration rather than assumed to
+	// start at 1: the server assigns them, and a test that hardcoded the
+	// numbering would be asserting its own guess.
+	Versions []string
+}
+
+var (
+	readOnlyDatasetOnce sync.Once
+	readOnlyDataset     *registeredDataset
+)
+
+// sharedDataset is registered once for the tests that only read it. Each
+// registration uploads a blob, so redoing it per test buys nothing.
+func sharedDataset(t *testing.T) *registeredDataset {
+	t.Helper()
+	readOnlyDatasetOnce.Do(func() {
+		readOnlyDataset = registerDataset(t, 2)
+	})
+	require.NotNil(t, readOnlyDataset, "the shared dataset could not be registered")
+	return readOnlyDataset
+}
+
+// registerDataset publishes a dataset and removes every version it created.
+func registerDataset(t *testing.T, versions int) *registeredDataset {
+	t.Helper()
+	require.Positive(t, versions)
+
+	path := filepath.Join(t.TempDir(), "golden.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte(datasetRows), 0o600))
+
+	ds := &registeredDataset{Name: uniqueName("azdcli_ds")}
+	for i := range versions {
+		// The first publish is a create; every later one is an update, which is
+		// the only difference between them.
+		verb := "update"
+		if i == 0 {
+			verb = "create"
+		}
+		r := requireSuccess(t, run(t, "dataset", verb,
+			ds.Name, "--from-file", path, "-o", "json"))
+
+		var created datasetSummary
+		r.JSON(t, &created)
+		require.NotEmpty(t, created.Version, "the service assigns the version")
+		ds.Versions = append(ds.Versions, created.Version)
+
+		version := created.Version
+		deferTeardown(func() {
+			runQuietly("dataset", "delete", ds.Name, "--version", version)
+		})
+	}
+	require.Len(t, ds.Versions, versions)
+	require.NotEqual(t, ds.Versions[0], ds.Versions[len(ds.Versions)-1],
+		"updating must advance the version rather than overwrite")
+	return ds
+}
+
+func TestCLIDatasetList(t *testing.T) {
+	ds := sharedDataset(t)
+
+	t.Run("table", func(t *testing.T) {
+		r := requireSuccess(t, run(t, "dataset", "versions", "list", ds.Name))
+		// TYPE, not FORMAT. The service populates `type` (`uri_file`) and leaves
+		// `format` empty, so the column this once pinned was blank on every row.
+		for _, header := range []string{"NAME", "VERSION", "TYPE"} {
+			require.Containsf(t, r.Stdout, header, "the listing lost its %s column", header)
+		}
+		require.Contains(t, r.Stdout, ds.Name)
+	})
+
+	// `versions list` is what makes the listing usable once a project holds more
+	// than a screenful: it narrows to one dataset's versions.
+	t.Run("versions list scopes to one dataset's versions", func(t *testing.T) {
+		r := requireSuccess(t, run(t, "dataset", "versions", "list", ds.Name, "-o", "json"))
+		var listed []datasetSummary
+		r.JSON(t, &listed)
+		require.NotEmpty(t, listed)
+
+		seen := map[string]bool{}
+		for _, v := range listed {
+			require.Equalf(t, ds.Name, v.Name,
+				"the listing must return only that dataset's versions; got %q", v.Name)
+			seen[v.Version] = true
+		}
+		for _, want := range ds.Versions {
+			require.Truef(t, seen[want], "version %s is missing from the listing", want)
+		}
+	})
+
+	// Unscoped, the listing is every dataset rather than every version, so the
+	// one just registered has to be in it.
+	t.Run("unscoped lists the project's datasets", func(t *testing.T) {
+		r := requireSuccess(t, run(t, "dataset", "list", "-o", "json"))
+		var all []datasetSummary
+		r.JSON(t, &all)
+		require.NotEmpty(t, all)
+
+		found := false
+		for _, d := range all {
+			if d.Name == ds.Name {
+				found = true
+			}
+		}
+		require.True(t, found, "a registered dataset must appear in the unscoped listing")
+	})
+
+	t.Run("an unknown name lists nothing rather than failing", func(t *testing.T) {
+		r := requireSuccess(t, run(t, "dataset", "versions", "list",
+			"azdcli-no-such-dataset", "-o", "json"))
+		var listed []datasetSummary
+		r.JSON(t, &listed)
+		require.Empty(t, listed)
+	})
+}
+
+func TestCLIDatasetShow(t *testing.T) {
+	ds := sharedDataset(t)
+	latest := ds.Versions[len(ds.Versions)-1]
+
+	// Omitting the version means the latest, which is the only sensible
+	// default for a name that gains a version on every registration.
+	t.Run("defaults to the latest version", func(t *testing.T) {
+		r := requireSuccess(t, run(t, "dataset", "show", ds.Name, "-o", "json"))
+		var shown datasetSummary
+		r.JSON(t, &shown)
+		require.Equal(t, ds.Name, shown.Name)
+		require.Equal(t, latest, shown.Version)
+	})
+
+	t.Run("version pins an earlier one", func(t *testing.T) {
+		r := requireSuccess(t, run(t, "dataset", "show",
+			ds.Name, "--version", ds.Versions[0], "-o", "json"))
+		var shown datasetSummary
+		r.JSON(t, &shown)
+		require.Equal(t, ds.Versions[0], shown.Version)
+		require.NotEqual(t, latest, shown.Version)
+	})
+
+	t.Run("table", func(t *testing.T) {
+		r := requireSuccess(t, run(t, "dataset", "show", ds.Name))
+		// `show` reads one dataset, so it renders a detail view keyed by label
+		// rather than a one-row table with a header. The labels are what is
+		// under test; the column-header form belongs to `dataset list`.
+		for _, label := range []string{"Name", "Version", "URI"} {
+			require.Containsf(t, r.Stdout, label, "the detail view lost its %s line", label)
+		}
+		require.Contains(t, r.Stdout, ds.Name)
+	})
+
+	t.Run("the name is required", func(t *testing.T) {
+		r := requireFailure(t, run(t, "dataset", "show"))
+		require.Contains(t, r.Combined(), "accepts 1 arg")
+	})
+
+	t.Run("an unknown dataset is brief", func(t *testing.T) {
+		r := requireFailure(t, run(t, "dataset", "show", "azdcli-no-such-dataset"))
+		require.Less(t, len(r.Combined()), 600,
+			"a not-found must stay short, not dump the service body:\n%s", r.Combined())
+		require.Contains(t, r.Combined(), "azdcli-no-such-dataset")
+	})
+
+	t.Run("an unknown version of a real dataset is refused", func(t *testing.T) {
+		r := requireFailure(t, run(t, "dataset", "show",
+			ds.Name, "--version", "9999"))
+		require.Contains(t, r.Combined(), "9999")
+		require.Less(t, len(r.Combined()), 600, r.Combined())
+	})
+}
+
+func TestCLIDatasetDelete(t *testing.T) {
+	t.Run("the name and version are both required", func(t *testing.T) {
+		require.Contains(t,
+			requireFailure(t, run(t, "dataset", "delete", "--version", "1")).Combined(),
+			"accepts 1 arg")
+		require.Contains(t,
+			requireFailure(t, run(t, "dataset", "delete", "whatever")).Combined(),
+			"--version is required")
+	})
+
+	// Deleting something that was never registered succeeds. The service
+	// treats DELETE as idempotent and answers 204 whatever the name, so the
+	// command reports a removal it did not perform — and the not-found branch
+	// in `dataset delete` cannot be reached this way. Asserted rather than
+	// wished away, because a caller scripting against the exit code is
+	// entitled to know it means "gone", not "was there and is now gone".
+	t.Run("deleting an unregistered dataset is idempotent, not an error", func(t *testing.T) {
+		r := requireSuccess(t, run(t, "dataset", "delete",
+			"azdcli-no-such-dataset", "--version", "1"))
+		require.Contains(t, r.Stdout, "Deleted dataset")
+
+		listed := requireSuccess(t, run(t, "dataset", "versions", "list",
+			"azdcli-no-such-dataset", "-o", "json"))
+		var remaining []datasetSummary
+		listed.JSON(t, &remaining)
+		require.Empty(t, remaining, "nothing was there to delete in the first place")
+	})
+
+	// A successful delete answers 204 No Content, so asserting the exit code
+	// is what catches a client that reads an empty body as a failure and
+	// reports a removal it just performed as an error.
+	t.Run("one version is removed and the other survives", func(t *testing.T) {
+		ds := registerDataset(t, 2)
+		gone, kept := ds.Versions[0], ds.Versions[1]
+
+		r := requireSuccess(t, run(t, "dataset", "delete",
+			ds.Name, "--version", gone))
+		require.Contains(t, r.Stdout, "Deleted dataset")
+		require.Contains(t, r.Stdout, ds.Name)
+
+		listed := requireSuccess(t, run(t, "dataset", "versions", "list",
+			ds.Name, "-o", "json"))
+		var remaining []datasetSummary
+		listed.JSON(t, &remaining)
+
+		versions := map[string]bool{}
+		for _, v := range remaining {
+			versions[v.Version] = true
+		}
+		require.False(t, versions[gone], "the deleted version must leave the listing")
+		require.True(t, versions[kept], "deleting one version must not remove the others")
+	})
+}

--- a/cli/azd/extensions/azure.ai.evaluations/tests/cli/evaluator_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/tests/cli/evaluator_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build live
+
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCLIEvaluatorListBuiltin is the cheapest proof the binary can reach the
+// service on its own: no azd project, no config, just a flag.
+func TestCLIEvaluatorListBuiltin(t *testing.T) {
+	r := requireSuccess(t, run(t, "evaluator", "list", "--builtin", "-o", "json"))
+
+	var builtins []struct {
+		Name          string `json:"name"`
+		EvaluatorType string `json:"evaluator_type"`
+	}
+	r.JSON(t, &builtins)
+	require.NotEmpty(t, builtins, "the project must expose built-in evaluators")
+
+	for _, b := range builtins {
+		require.True(t, strings.HasPrefix(b.Name, "builtin."),
+			"--builtin must return only built-ins, got %q", b.Name)
+	}
+
+	// The default rendering is a table, not JSON. A script reading stdout
+	// without -o json would otherwise silently parse a header row.
+	table := requireSuccess(t, run(t, "evaluator", "list", "--builtin"))
+	require.Contains(t, table.Stdout, "NAME")
+	require.Contains(t, table.Stdout, "VERSION")
+}
+
+// TestCLIJSONListsAreBareArrays pins the envelope.
+//
+// The service wraps listings in {"value":[...]} or {"data":[...]} depending on
+// the route. Leaking either would make every consumer special-case the
+// command it came from, so the CLI unwraps them, and this is what says so.
+func TestCLIJSONListsAreBareArrays(t *testing.T) {
+	for _, args := range [][]string{
+		{"evaluator", "list", "--builtin", "-o", "json"},
+		{"dataset", "list", "-o", "json"},
+	} {
+		t.Run(strings.Join(args[:2], " "), func(t *testing.T) {
+			r := requireSuccess(t, run(t, args...))
+			trimmed := strings.TrimSpace(r.Stdout)
+			require.True(t, strings.HasPrefix(trimmed, "["),
+				"a list must be a bare array, not an envelope; got:\n%s", firstLine(trimmed))
+
+			var out []any
+			r.JSON(t, &out)
+		})
+	}
+}
+
+// TestCLIUnknownEvaluatorIsBrief covers the failure a user hits by typo.
+//
+// The service answers with a long JSON body. Printing it verbatim buries the
+// one useful sentence, so the CLI shortens it, and a regression here is the
+// kind that only shows up in someone's terminal.
+func TestCLIUnknownEvaluatorIsBrief(t *testing.T) {
+	r := requireFailure(t, run(t, "evaluator", "show", "azdcli-does-not-exist-9999"))
+	require.Less(t, len(r.Combined()), 600,
+		"a not-found must stay short, not dump the service body:\n%s", r.Combined())
+}
+
+// TestCLIInitNeedsAnAzdProject covers the whole of what `init` can be asked
+// through this harness.
+//
+// init resolves the project over azd's gRPC channel, so it only works when azd
+// is hosting the extension. Running the binary directly there is no host, and
+// that is exactly the case a user hits by running the command outside a
+// project — so what is asserted is the refusal: it must name `azd init` rather
+// than surface a transport error. The scaffolding itself is covered by the
+// unit tests, which can supply a fake azd client.
+func TestCLIInitNeedsAnAzdProject(t *testing.T) {
+	dir := t.TempDir()
+
+	r := requireFailure(t, runIn(t, dir, "init",
+		"--target", "probe-agent",
+		"--judge-model", "gpt-4o-mini",
+		"--no-prompt"))
+
+	require.NotContains(t, r.Combined(), "unknown flag",
+		"the probe must use init's real flags, or it asserts nothing about projects")
+	require.Contains(t, r.Combined(), "azd init",
+		"the refusal must name the command that makes a project")
+	require.NotContains(t, strings.ToLower(r.Combined()), "grpc",
+		"a missing project must not surface as a transport error")
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Empty(t, entries,
+		"a refused init must leave nothing behind")
+}
+
+// TestCLINoPromptFailsInsteadOfHanging is what makes the CLI usable in CI: a
+// missing required value must end the process, not wait on a terminal nobody
+// is watching.
+func TestCLINoPromptFailsInsteadOfHanging(t *testing.T) {
+	dir := t.TempDir()
+	r := requireFailure(t, runIn(t, dir, "init", "--no-prompt"))
+	require.NotEmpty(t, strings.TrimSpace(r.Combined()),
+		"--no-prompt must say what it could not resolve")
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/cli/azd/extensions/azure.ai.evaluations/tests/cli/fixture_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/tests/cli/fixture_test.go
@@ -1,0 +1,415 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build live
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+)
+
+// The command tests need an eval that has already been run, and building one
+// through the CLI is not possible: there is no command that creates an eval
+// from flags, only `run start`, which needs a config file and a deployed
+// target. So the fixture is built with the client and every assertion is made
+// against the binary. What is under test is the command surface; the eval is
+// scenery.
+//
+// It is built once for the whole package because two completed runs cost
+// minutes, and torn down in TestMain rather than t.Cleanup so that whichever
+// test happened to trigger the build does not take the fixture away from the
+// rest.
+//
+// It evaluates an agent with a built-in evaluator, because that is all M1 can
+// run: a deterministic code grader over a target-less dataset would score the
+// rows predictably, but code evaluators and no-target runs are both M2. The
+// cost is that pass and fail are decided by a judge, so no test may assert how
+// many rows failed — only that filtering by verdict is self-consistent.
+
+const fixtureAPIVersion = "2025-11-15-preview"
+
+const defaultFixtureModel = "gpt-4o-mini"
+
+// fixtureQueries are answered by the agent under evaluation. They are ordinary
+// support questions: the fixture proves the command surface, not the agent.
+var fixtureQueries = []string{
+	"How do I reset my password?",
+	"How do I change my billing address?",
+	"What are your support hours?",
+}
+
+// evalFixture is one eval with two completed runs.
+type evalFixture struct {
+	EvaluatorName string
+	EvalID        string
+
+	// The agent the runs evaluate, so that a test needing a further run does
+	// not have to resolve one again.
+	AgentName string
+
+	// Two runs of the same eval, so that listing, limiting and defaulting to
+	// the most recent all have something to distinguish.
+	FirstRunID  string
+	SecondRunID string
+}
+
+var (
+	fixtureOnce sync.Once
+	fixture     *evalFixture
+	fixtureErr  error
+
+	// teardown runs after the last test, in reverse order.
+	teardownMu sync.Mutex
+	teardown   []func()
+)
+
+func deferTeardown(fn func()) {
+	teardownMu.Lock()
+	defer teardownMu.Unlock()
+	teardown = append(teardown, fn)
+}
+
+func runTeardown() {
+	teardownMu.Lock()
+	defer teardownMu.Unlock()
+	for i := len(teardown) - 1; i >= 0; i-- {
+		teardown[i]()
+	}
+	teardown = nil
+}
+
+// runQuietly invokes the binary without a *testing.T.
+//
+// Teardown runs after the last test has reported, and logging or asserting
+// against a finished test panics, so nothing here may touch one.
+func runQuietly(args ...string) {
+	full := append(append([]string{}, args...), "--project-endpoint", endpoint)
+	_ = exec.Command(binaryPath, full...).Run()
+}
+
+var (
+	credOnce sync.Once
+	cred     *azidentity.AzureDeveloperCLICredential
+	credErr  error
+)
+
+// liveClient builds the client the fixture is assembled with. One credential
+// for the package, because azidentity caches tokens per instance and a fresh
+// one per call makes every call shell out to azd again.
+//
+// The first token is fetched here rather than lazily on the first request:
+// that call is the one that flakes, and paying for it up front means the rest
+// of the fixture runs against a cached token.
+func liveClient() (*eval_api.EvalClient, error) {
+	credOnce.Do(func() {
+		cred, credErr = azidentity.NewAzureDeveloperCLICredential(
+			&azidentity.AzureDeveloperCLICredentialOptions{})
+		if credErr != nil {
+			return
+		}
+		credErr = retryCredentialFlake(func() error {
+			_, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{
+				Scopes: []string{"https://ai.azure.com/.default"},
+			})
+			return err
+		})
+	})
+	if credErr != nil {
+		return nil, credErr
+	}
+	return eval_api.NewEvalClient(endpoint, cred), nil
+}
+
+// retryCredentialFlake reruns a request that failed only because azd's token
+// helper exited non-zero.
+//
+// It is the same failure the harness retries around the binary, for the same
+// reason: nothing was sent, and the alternative is a suite that fails on a
+// different test each run for a reason unrelated to the code. Any other error
+// is returned immediately.
+func retryCredentialFlake(fn func() error) error {
+	var err error
+	for attempt := range 4 {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * 2 * time.Second)
+		}
+		if err = fn(); err == nil || !strings.Contains(err.Error(), credentialFlake) {
+			return err
+		}
+	}
+	return err
+}
+
+// sharedEval returns the fixture, building it on first use.
+//
+// A failure here fails the calling test rather than skipping it: every test
+// that asks for the fixture is testing something that cannot be exercised
+// without one, and a suite that goes green because its subject was missing is
+// worse than one that goes red.
+func sharedEval(t *testing.T) *evalFixture {
+	t.Helper()
+	fixtureOnce.Do(func() {
+		start := time.Now()
+		fixture, fixtureErr = buildFixture(t.Logf)
+		t.Logf("fixture ready in %s", time.Since(start).Round(time.Second))
+	})
+	if fixtureErr != nil {
+		t.Fatalf("building the shared eval the command tests run against: %v", fixtureErr)
+	}
+	return fixture
+}
+
+func fixtureModel() string {
+	if model := os.Getenv("AZURE_AI_EVAL_MODEL"); model != "" {
+		return model
+	}
+	return defaultFixtureModel
+}
+
+// resolveFixtureAgent names the agent the fixture evaluates.
+//
+// It reads /agents, not /assistants: they are different collections, and an
+// eval target resolves against the former. Naming an assistant is accepted by
+// the create and then fails the run with "resources not found".
+func resolveFixtureAgent(ctx context.Context) (string, error) {
+	if name := os.Getenv("AZURE_AI_EVAL_AGENT"); name != "" {
+		return name, nil
+	}
+
+	// Builds the shared credential if it does not exist yet; the token below
+	// comes from it.
+	if _, err := liveClient(); err != nil {
+		return "", err
+	}
+
+	token, err := cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{"https://ai.azure.com/.default"},
+	})
+	if err != nil {
+		return "", fmt.Errorf("acquiring a token to list agents: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodGet, endpoint+"/agents?api-version="+fixtureAPIVersion, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token.Token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("listing the project's agents: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf(
+			"listing the project's agents returned %d; set AZURE_AI_EVAL_AGENT to name one",
+			resp.StatusCode)
+	}
+
+	var listing struct {
+		Data []struct {
+			Name string `json:"name"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listing); err != nil {
+		return "", err
+	}
+	for _, a := range listing.Data {
+		if a.Name != "" {
+			return a.Name, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"this project has no agent in /agents, so an agent-target run cannot be built; " +
+			"deploy an agent or set AZURE_AI_EVAL_AGENT")
+}
+
+func buildFixture(logf func(string, ...any)) (*evalFixture, error) {
+	ctx := context.Background()
+
+	client, err := liveClient()
+	if err != nil {
+		return nil, fmt.Errorf("acquiring an azd credential: %w", err)
+	}
+
+	agent, err := resolveFixtureAgent(ctx)
+	if err != nil {
+		return nil, err
+	}
+	logf("evaluating agent %q", agent)
+
+	evaluatorName := "builtin.task_adherence"
+	evalID, err := createFixtureEval(ctx, client, evaluatorName)
+	if err != nil {
+		return nil, err
+	}
+	logf("created eval %s", evalID)
+
+	first, err := startFixtureRun(ctx, client, evalID, agent, "first")
+	if err != nil {
+		return nil, err
+	}
+	second, err := startFixtureRun(ctx, client, evalID, agent, "second")
+	if err != nil {
+		return nil, err
+	}
+	logf("started runs %s and %s", first, second)
+
+	// Polled together: they are independent, and serializing them doubles the
+	// slowest part of the suite for nothing.
+	errs := make(chan error, 2)
+	for _, runID := range []string{first, second} {
+		go func(id string) { errs <- awaitCompleted(ctx, client, evalID, id, logf) }(runID)
+	}
+	for range 2 {
+		if err := <-errs; err != nil {
+			return nil, err
+		}
+	}
+
+	return &evalFixture{
+		// The criterion is named without the builtin. prefix, and that is the
+		// name results are reported under.
+		EvaluatorName: strings.TrimPrefix(evaluatorName, "builtin."),
+		EvalID:        evalID,
+		AgentName:     agent,
+		FirstRunID:    first,
+		SecondRunID:   second,
+	}, nil
+}
+
+func createFixtureEval(
+	ctx context.Context,
+	client *eval_api.EvalClient,
+	evaluatorName string,
+) (string, error) {
+	criterionName := strings.TrimPrefix(evaluatorName, "builtin.")
+
+	var group *eval_api.OpenAIEval
+	if err := retryCredentialFlake(func() error {
+		var err error
+		group, err = client.CreateOpenAIEval(ctx, &eval_api.CreateOpenAIEvalRequest{
+			Name: uniqueName("azdcli-fixture"),
+			DataSourceConfig: &eval_api.DataSourceConfig{
+				Type:                "custom",
+				IncludeSampleSchema: true,
+				ItemSchema: map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"query": map[string]any{"type": "string"}},
+				},
+			},
+			TestingCriteria: []eval_api.TestingCriterion{{
+				Type:          "azure_ai_evaluator",
+				Name:          criterionName,
+				EvaluatorName: evaluatorName,
+				DataMapping: map[string]string{
+					"query":            "{{item.query}}",
+					"response":         "{{sample.output_items}}",
+					"tool_calls":       "{{sample.tool_calls}}",
+					"tool_definitions": "{{sample.tool_definitions}}",
+				},
+				InitializationParameters: map[string]any{
+					"model":           fixtureModel(),
+					"deployment_name": fixtureModel(),
+				},
+			}},
+		})
+		return err
+	}); err != nil {
+		return "", fmt.Errorf("creating the fixture eval: %w", err)
+	}
+	deferTeardown(func() {
+		_ = client.DeleteOpenAIEval(context.Background(), group.ID)
+	})
+	return group.ID, nil
+}
+
+func startFixtureRun(
+	ctx context.Context,
+	client *eval_api.EvalClient,
+	evalID, agentName, label string,
+) (string, error) {
+	rows := make([]map[string]any, 0, len(fixtureQueries))
+	for _, q := range fixtureQueries {
+		rows = append(rows, map[string]any{"query": q})
+	}
+
+	ds := eval_api.NewAgentTargetDataSource(agentName, nil)
+	ds.SetFileContent(rows)
+
+	var run *eval_api.OpenAIEvalRun
+	if err := retryCredentialFlake(func() error {
+		var err error
+		run, err = client.CreateOpenAIEvalRun(ctx, evalID, &eval_api.CreateOpenAIEvalRunRequest{
+			Name:       uniqueName("azdcli-" + label),
+			DataSource: ds,
+		})
+		return err
+	}); err != nil {
+		return "", fmt.Errorf("starting the %s run: %w", label, err)
+	}
+	return run.ID, nil
+}
+
+var terminalRunStatus = map[string]bool{
+	"completed": true, "failed": true, "canceled": true, "cancelled": true, "error": true,
+}
+
+// awaitCompleted requires the run to have scored something.
+//
+// A run whose every sample errors still reports completed, so the status alone
+// would let the whole suite run against an eval that measured nothing.
+func awaitCompleted(
+	ctx context.Context,
+	client *eval_api.EvalClient,
+	evalID, runID string,
+	logf func(string, ...any),
+) error {
+	deadline := time.Now().Add(15 * time.Minute)
+	for {
+		var run *eval_api.OpenAIEvalRun
+		if err := retryCredentialFlake(func() error {
+			var err error
+			run, err = client.GetOpenAIEvalRun(ctx, evalID, runID)
+			return err
+		}); err != nil {
+			return fmt.Errorf("polling run %s: %w", runID, err)
+		}
+		if terminalRunStatus[strings.ToLower(run.Status)] {
+			if strings.ToLower(run.Status) != "completed" {
+				return fmt.Errorf("run %s finished as %q: %s", runID, run.Status, run.Failure())
+			}
+			if run.ResultCounts == nil {
+				return fmt.Errorf("run %s completed without reporting counts", runID)
+			}
+			if run.ResultCounts.Passed+run.ResultCounts.Failed == 0 {
+				return fmt.Errorf(
+					"run %s completed without scoring any row (errored=%d); the fixture "+
+						"would prove nothing", runID, run.ResultCounts.Errored)
+			}
+			logf("run %s completed: passed=%d failed=%d errored=%d",
+				runID, run.ResultCounts.Passed, run.ResultCounts.Failed, run.ResultCounts.Errored)
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("run %s did not finish in time (last status %q)", runID, run.Status)
+		}
+		time.Sleep(10 * time.Second)
+	}
+}

--- a/cli/azd/extensions/azure.ai.evaluations/tests/cli/generate_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/tests/cli/generate_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build live
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Generation submits a job that costs model time and takes minutes, so what is
+// exercised here is everything up to that point: the flag combinations each
+// command refuses and the spec it parses. No test here submits a job.
+//
+// There is one command per artifact, so nothing suppresses anything: a caller
+// who already has a dataset simply does not run `dataset generate`.
+
+// TestCLIGenerateRefusesBadFlagCombinations covers the mistakes that must cost
+// nothing to make. Each is decided locally, so a user finds out before a job is
+// billed.
+func TestCLIGenerateRefusesBadFlagCombinations(t *testing.T) {
+	dir := t.TempDir()
+	instruction := filepath.Join(dir, "instruction.md")
+	require.NoError(t, os.WriteFile(instruction, []byte("test refunds"), 0o600))
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{{
+		name: "the two instruction sources are mutually exclusive",
+		args: []string{"generate", "--dataset", "--dataset-name", "d", "--target", "a",
+			"--agent-instruction", "inline", "--agent-instruction-file", instruction},
+		want: "agent-instruction-file",
+	}, {
+		name: "below the minimum sample size",
+		args: []string{"generate", "--dataset", "--dataset-name", "d", "--target", "a",
+			"--max-samples", "14"},
+		want: "between 15 and 1000",
+	}, {
+		name: "above the maximum sample size",
+		args: []string{"generate", "--dataset", "--dataset-name", "d", "--target", "a",
+			"--max-samples", "1001"},
+		want: "between 15 and 1000",
+	}, {
+		name: "a missing instruction file names the flag",
+		args: []string{"generate", "--dataset", "--dataset-name", "d", "--target", "a",
+			"--agent-instruction-file", filepath.Join(dir, "absent.md")},
+		want: "--agent-instruction-file",
+	}, {
+		name: "generating a dataset needs a model deployment",
+		args: []string{"generate", "--dataset", "--dataset-name", "d",
+			"--agent-instruction", "inline"},
+		want: "--generation-model",
+	}, {
+		name: "generating an evaluator needs a model deployment",
+		args: []string{"generate", "--evaluator", "--evaluator-name", "e",
+			"--agent-instruction", "inline"},
+		want: "--generation-model",
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := requireFailure(t, runIn(t, dir, tc.args...))
+			require.Contains(t, r.Combined(), tc.want)
+		})
+	}
+}
+
+// TestCLIGenerateNamesTheArtifact pins where the name comes from. The composite
+// takes no positional, so with neither a name nor a target there is nothing to
+// call the artifact, and the refusal has to name both ways out.
+func TestCLIGenerateNamesTheArtifact(t *testing.T) {
+	r := requireFailure(t, runIn(t, t.TempDir(), "generate", "--dataset"))
+
+	require.Contains(t, r.Combined(), "--dataset-name")
+	require.Contains(t, r.Combined(), "--target")
+}
+
+// TestCLIGenerateNoPromptNamesWhatIsMissing is the CI case: with nothing to
+// prompt with, the process has to end saying which flag to pass.
+//
+// The target is no longer among them — it is read from the eval's declaration —
+// but the generation model has no other source, so it is the one input a bare
+// directory cannot supply.
+//
+// The target names an agent that does not exist, and that is load-bearing: a
+// real one supplies a deployment, and then nothing is missing to report.
+func TestCLIGenerateNoPromptNamesWhatIsMissing(t *testing.T) {
+	r := requireFailure(t, runIn(t, t.TempDir(),
+		"generate", "--dataset", "--dataset-name", "d", "--target", "a", "--no-prompt"))
+	require.Contains(t, r.Combined(), "--generation-model")
+}
+
+// TestCLIGenerateDatasetFlagsDoNotApplyToTheEvaluator asserts the scoping the
+// help promises is real.
+//
+// One command now carries both artifacts' settings, so cobra can no longer
+// refuse --max-samples on a rubric. What must still hold is that it is not
+// *validated* against a generation that does not use it: narrowing to the
+// evaluator has to get past the sample-size check, and fail on the model it
+// genuinely lacks instead.
+func TestCLIGenerateDatasetFlagsDoNotApplyToTheEvaluator(t *testing.T) {
+	r := requireFailure(t, runIn(t, t.TempDir(), "generate", "--evaluator",
+		"--evaluator-name", "e", "--target", "a", "--max-samples", "20"))
+
+	require.NotContains(t, r.Combined(), "between 15 and 1000",
+		"--max-samples shapes the dataset, so it must not be validated for a rubric")
+	require.Contains(t, r.Combined(), "--generation-model",
+		"it should get as far as the input it actually lacks")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/tests/cli/handoff_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/tests/cli/handoff_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build live
+
+// The CI path: start a run without waiting, read the handoff, come back for
+// the result later. Everything here is what a pipeline does, so it is driven
+// through the binary exactly the way a pipeline would.
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCLIStartNoWaitEmitsTheHandoff pins the JSON a pipeline reads.
+//
+// A script captures the run id here and reattaches to it in a later step, so
+// the field names are a contract. Emitting the service's run object instead
+// would make that script depend on a shape this extension does not control.
+func TestCLIStartNoWaitEmitsTheHandoff(t *testing.T) {
+	f := sharedEval(t)
+
+	r := requireSuccess(t, run(t,
+		"run", "start", "--eval", f.EvalID, "--no-wait", "-o", "json"))
+
+	var handoff struct {
+		RunID     string `json:"run_id"`
+		EvalID    string `json:"eval_id"`
+		Status    string `json:"status"`
+		CreatedAt string `json:"created_at"`
+	}
+	r.JSON(t, &handoff)
+
+	require.NotEmpty(t, handoff.RunID, "a pipeline has nothing to reattach to without run_id")
+	assert.Equal(t, f.EvalID, handoff.EvalID)
+	assert.NotEmpty(t, handoff.Status)
+
+	// Started, not finished: this is the whole point of --no-wait, and a
+	// command that quietly blocked would pass every other assertion here.
+	assert.NotEqual(t, "completed", handoff.Status)
+
+	deferTeardown(func() {
+		runQuietly("run", "cancel", handoff.RunID, "--eval", f.EvalID)
+	})
+
+	// The id it handed back has to be one the next step can use.
+	shown := requireSuccess(t, run(t,
+		"run", "show", handoff.RunID, "--eval", f.EvalID, "-o", "json"))
+	var reattached struct {
+		ID string `json:"id"`
+	}
+	shown.JSON(t, &reattached)
+	assert.Equal(t, handoff.RunID, reattached.ID,
+		"the run id in the handoff must be the one `run show` resolves")
+}
+
+// TestCLIStartNoWaitTellsAPersonHowToReattach covers the same path without
+// -o json, where what matters is that the printed command is one that works
+// rather than a sentence containing a placeholder.
+func TestCLIStartNoWaitTellsAPersonHowToReattach(t *testing.T) {
+	f := sharedEval(t)
+
+	r := requireSuccess(t, run(t, "run", "start", "--eval", f.EvalID, "--no-wait"))
+
+	assert.Contains(t, r.Stdout, "Reattach with: azd ai eval run show")
+	assert.Contains(t, r.Stdout, f.EvalID,
+		"the reattach line must carry the eval id, not a placeholder for it")
+	assert.NotContains(t, r.Stdout, "<",
+		"nothing printed for a person to copy may contain a placeholder")
+
+	var runID string
+	for _, field := range strings.Fields(r.Stdout) {
+		if strings.HasPrefix(field, "evalrun_") {
+			runID = field
+			break
+		}
+	}
+	require.NotEmpty(t, runID, "the run id must be printed:\n%s", r.Stdout)
+	deferTeardown(func() { runQuietly("run", "cancel", runID, "--eval", f.EvalID) })
+}

--- a/cli/azd/extensions/azure.ai.evaluations/tests/cli/harness_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/tests/cli/harness_test.go
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build live
+
+// Package cli drives the built binary as a subprocess.
+//
+// The other live tests call the client layer directly, which proves the API
+// paths work but says nothing about the command surface on top of them: flag
+// parsing, mutual exclusion, prompting, --no-prompt, exit codes, the rendered
+// tables, and whether -o json emits what a script can actually consume. Those
+// are the parts a user touches, and until now nothing exercised them against a
+// real service.
+//
+//	go test -tags live -v ./tests/cli/...
+//
+// Required:
+//
+//	AZURE_AI_EVAL_E2E_LIVE=1
+//	FOUNDRY_PROJECT_ENDPOINT=https://<account>.services.ai.azure.com/api/projects/<project>
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	binaryPath string
+	endpoint   string
+)
+
+// TestMain builds the extension once so every test runs the same binary a user
+// would, rather than an in-process command tree that skips main's wiring.
+func TestMain(m *testing.M) {
+	if os.Getenv("AZURE_AI_EVAL_E2E_LIVE") != "1" {
+		fmt.Fprintln(os.Stderr, "set AZURE_AI_EVAL_E2E_LIVE=1 to run the CLI tests")
+		os.Exit(0)
+	}
+
+	endpoint = strings.TrimSuffix(os.Getenv("FOUNDRY_PROJECT_ENDPOINT"), "/")
+	if endpoint == "" {
+		fmt.Fprintln(os.Stderr, "FOUNDRY_PROJECT_ENDPOINT is required")
+		os.Exit(1)
+	}
+
+	dir, err := os.MkdirTemp("", "azdeval-cli")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "creating a temp dir: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(dir)
+
+	binaryPath = filepath.Join(dir, "azdeval"+exeSuffix())
+	build := exec.Command("go", "build", "-o", binaryPath, ".")
+	build.Dir = "../.."
+	if out, err := build.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "building the extension: %v\n%s\n", err, out)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	// The shared eval outlives any single test, so it cannot be released with
+	// t.Cleanup without taking it away from the tests that run after.
+	runTeardown()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+func exeSuffix() string {
+	if os.PathSeparator == '\\' {
+		return ".exe"
+	}
+	return ""
+}
+
+// result is one invocation of the binary.
+type result struct {
+	Args     []string
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// Combined is stdout and stderr together, for assertions that do not care
+// which stream carried the message.
+func (r result) Combined() string { return r.Stdout + r.Stderr }
+
+// JSON decodes stdout, failing the test when the command did not emit
+// something a script could consume.
+func (r result) JSON(t *testing.T, into any) {
+	t.Helper()
+	require.NoError(t, json.Unmarshal([]byte(r.Stdout), into),
+		"-o json must emit parseable JSON on stdout; got:\n%s", r.Stdout)
+}
+
+// run invokes the binary with the project endpoint already supplied.
+func run(t *testing.T, args ...string) result {
+	t.Helper()
+	return runIn(t, "", args...)
+}
+
+// credentialFlake is azd's token helper failing under rapid sequential calls.
+//
+// Every invocation here is a fresh process, so each one shells out to azd for
+// a token, and azd intermittently exits non-zero doing it. Retrying is safe
+// because no request was made, and the alternative is a suite that fails on a
+// different test each run for a reason that has nothing to do with the code.
+const credentialFlake = "AzureDeveloperCLICredential: exit status 1"
+
+// runIn invokes the binary with a working directory, for commands that write
+// files.
+func runIn(t *testing.T, dir string, args ...string) result {
+	t.Helper()
+
+	res := invoke(t, dir, args...)
+	for attempt := 0; attempt < 2 && strings.Contains(res.Combined(), credentialFlake); attempt++ {
+		t.Logf("azd credential flaked; retrying `%s`", strings.Join(args, " "))
+		time.Sleep(2 * time.Second)
+		res = invoke(t, dir, args...)
+	}
+	require.NotContains(t, res.Combined(), credentialFlake,
+		"azd could not produce a token after retries; run `azd auth login` and try again")
+	return res
+}
+
+func invoke(t *testing.T, dir string, args ...string) result {
+	t.Helper()
+
+	full := append([]string{}, args...)
+	if !hasFlag(args, "--project-endpoint") && needsEndpoint(args) {
+		full = append(full, "--project-endpoint", endpoint)
+	}
+
+	cmd := exec.Command(binaryPath, full...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	code := 0
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		code = exitErr.ExitCode()
+	} else if err != nil {
+		t.Fatalf("could not run %v: %v", full, err)
+	}
+
+	res := result{Args: full, Stdout: stdout.String(), Stderr: stderr.String(), ExitCode: code}
+	t.Logf("$ azd ai eval %s -> exit %d", strings.Join(args, " "), res.ExitCode)
+	return res
+}
+
+func hasFlag(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// needsEndpoint keeps --project-endpoint off the commands that reject it.
+func needsEndpoint(args []string) bool {
+	for _, a := range args {
+		switch a {
+		case "init", "--help", "-h":
+			return false
+		}
+	}
+	return true
+}
+
+// requireSuccess fails with the command's own output, which is what a user
+// would have seen.
+func requireSuccess(t *testing.T, r result) result {
+	t.Helper()
+	require.Equalf(t, 0, r.ExitCode,
+		"expected `%s` to succeed\nstdout:\n%s\nstderr:\n%s",
+		strings.Join(r.Args, " "), r.Stdout, r.Stderr)
+	return r
+}
+
+// requireFailure asserts a non-zero exit, so a command that silently succeeds
+// where it should refuse is caught.
+func requireFailure(t *testing.T, r result) result {
+	t.Helper()
+	require.NotEqualf(t, 0, r.ExitCode,
+		"expected `%s` to fail\nstdout:\n%s\nstderr:\n%s",
+		strings.Join(r.Args, " "), r.Stdout, r.Stderr)
+	return r
+}
+
+func uniqueName(prefix string) string {
+	return fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+}

--- a/cli/azd/extensions/azure.ai.evaluations/tests/cli/rubric_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/tests/cli/rubric_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build live
+
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A rubric is the other kind of evaluator: a JSON file of weighted dimensions,
+// graded by a judge model rather than by code. It shares nothing with the code
+// path on the wire beyond the route, so publishing one had never been
+// exercised against a real project.
+
+// writeRubric lays down a rubric file and returns its path.
+func writeRubric(t *testing.T, dimensions string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "rubric.json")
+	require.NoError(t, os.WriteFile(path,
+		[]byte(`{"dimensions":`+dimensions+`}`), 0o600))
+	return path
+}
+
+// evaluatorDocument is what `evaluator show` prints.
+type evaluatorDocument struct {
+	Name          string `json:"name"`
+	Version       string `json:"version"`
+	EvaluatorType string `json:"evaluator_type"`
+	Definition    struct {
+		Type       string `json:"type"`
+		Dimensions []struct {
+			ID          string `json:"id"`
+			Description string `json:"description"`
+			Weight      int    `json:"weight"`
+		} `json:"dimensions"`
+		DataSchema     map[string]any `json:"data_schema"`
+		InitParameters map[string]any `json:"init_parameters"`
+		Metrics        map[string]any `json:"metrics"`
+	} `json:"definition"`
+	SupportedEvaluationLevels []string `json:"supported_evaluation_levels"`
+}
+
+// TestCLIRubricRoundTrip publishes a rubric, reads it back, and republishes it.
+func TestCLIRubricRoundTrip(t *testing.T) {
+	name := uniqueName("azdcli_rubric")
+	rubric := writeRubric(t, `[
+		{"id":"tone","description":"Is the answer polite?","weight":5},
+		{"id":"accuracy","description":"Is the answer correct?","weight":10}
+	]`)
+
+	created := requireSuccess(t, run(t, "evaluator", "create", name, "--from-file", rubric))
+	require.Contains(t, created.Stdout, "version 1")
+	t.Cleanup(func() {
+		run(t, "evaluator", "delete", name, "--version", "1")
+	})
+
+	shown := requireSuccess(t, run(t, "evaluator", "show", name, "-o", "json"))
+	var doc evaluatorDocument
+	shown.JSON(t, &doc)
+
+	require.Equal(t, name, doc.Name)
+	require.Equal(t, "1", doc.Version)
+	require.Equal(t, "custom", doc.EvaluatorType)
+	require.Equal(t, "rubric", doc.Definition.Type,
+		"the discriminator is what tells the service which definition kind it holds")
+
+	require.Len(t, doc.Definition.Dimensions, 2)
+	byID := map[string]int{}
+	for _, d := range doc.Definition.Dimensions {
+		byID[d.ID] = d.Weight
+		require.NotEmpty(t, d.Description, "a dimension's description is what the judge grades against")
+	}
+	require.Equal(t, 5, byID["tone"])
+	require.Equal(t, 10, byID["accuracy"])
+
+	// The rubric named only dimensions. Everything else is filled in by the
+	// service, and a caller reading the definition back gets those defaults
+	// rather than what was sent — including the judge model the evaluator will
+	// require at run time.
+	require.NotEmpty(t, doc.Definition.DataSchema,
+		"the service supplies a rubric's data schema; the author never writes one")
+	require.NotEmpty(t, doc.Definition.InitParameters)
+	require.NotEmpty(t, doc.Definition.Metrics)
+	require.NotEmpty(t, doc.SupportedEvaluationLevels)
+
+	// Every registration publishes a new immutable version, which is what
+	// `update` means for an evaluator.
+	republished := requireSuccess(t, run(t, "evaluator", "update", name, "--from-file", rubric))
+	require.Contains(t, republished.Stdout, "version 2",
+		"updating must advance the version rather than overwrite")
+	t.Cleanup(func() {
+		run(t, "evaluator", "delete", name, "--version", "2")
+	})
+
+	// The earlier version stays reachable, which is what makes a published
+	// version safe to reference from a config.
+	pinned := requireSuccess(t, run(t, "evaluator", "show", name, "--version", "1", "-o", "json"))
+	var first evaluatorDocument
+	pinned.JSON(t, &first)
+	require.Equal(t, "1", first.Version)
+}
+
+// TestCLIRubricWeightMustBeAnIntegerFromOneToTen covers the validation a
+// hand-authored rubric is most likely to trip.
+//
+// The service runs two separate checks and they answer differently: a
+// fractional weight is rejected for not being an integer, an out-of-range one
+// for being out of range. Both are asserted because a caller only ever sees
+// one of them, and both have to say what a legal weight is.
+func TestCLIRubricWeightMustBeAnIntegerFromOneToTen(t *testing.T) {
+	cases := []struct {
+		name   string
+		weight string
+	}{
+		{"fractional", "2.5"},
+		{"zero", "0"},
+		{"above ten", "11"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rubric := writeRubric(t,
+				`[{"id":"tone","description":"Is the answer polite?","weight":`+tc.weight+`}]`)
+
+			r := requireFailure(t, run(t, "evaluator", "create",
+				uniqueName("azdcli_badweight"), "--from-file", rubric))
+			require.Contains(t, r.Combined(), "between 1 and 10",
+				"the refusal must say what a legal weight is")
+		})
+	}
+
+	// A weight the service accepts, so the cases above are failing on the
+	// weight rather than on the rubric shape they share.
+	name := uniqueName("azdcli_goodweight")
+	ok := writeRubric(t, `[{"id":"tone","description":"Is the answer polite?","weight":1}]`)
+	requireSuccess(t, run(t, "evaluator", "create", name, "--from-file", ok))
+	t.Cleanup(func() {
+		run(t, "evaluator", "delete", name, "--version", "1")
+	})
+}
+
+// TestCLIRubricNeedsDimensions covers the local check, which costs nothing and
+// names the field the service would not.
+func TestCLIRubricNeedsDimensions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rubric.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"criteria":[]}`), 0o600))
+
+	r := requireFailure(t, run(t, "evaluator", "create",
+		uniqueName("azdcli_nodims"), "--from-file", path))
+	require.Contains(t, r.Combined(), "dimensions")
+}
+
+// TestCLIEvaluatorShowAcceptsAFullDocument proves `evaluator show -o json`
+// emits JSON a script can consume, whatever the definition kind. It renders the
+// service's body rather than a typed struct, so nothing else pins that it stays
+// parseable. The bare command renders the human detail view instead.
+func TestCLIEvaluatorShowAcceptsAFullDocument(t *testing.T) {
+	name := uniqueName("azdcli_rubricdoc")
+
+	// The wrapped form: a whole evaluator document rather than a bare
+	// definition. Both are accepted, and generated rubrics arrive wrapped.
+	path := filepath.Join(t.TempDir(), "rubric.json")
+	require.NoError(t, os.WriteFile(path, []byte(
+		`{"name":"ignored","definition":{"dimensions":[{"id":"tone","description":"polite","weight":3}]}}`,
+	), 0o600))
+
+	requireSuccess(t, run(t, "evaluator", "create", name, "--from-file", path))
+	t.Cleanup(func() {
+		run(t, "evaluator", "delete", name, "--version", "1")
+	})
+
+	shown := requireSuccess(t, run(t, "evaluator", "show", name, "-o", "json"))
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal([]byte(shown.Stdout), &raw),
+		"evaluator show must emit parseable JSON:\n%s", shown.Stdout)
+
+	// The flag names the evaluator, so a name inside the file must not win.
+	require.Equal(t, name, raw["name"],
+		"--name must decide the evaluator's name, not the document's own field")
+	require.NotContains(t, strings.ToLower(shown.Stdout), `"name": "ignored"`)
+
+	// Reconciliation tells people to adopt a remote change by writing it over
+	// the local definition with --output-file, so the flag has to exist and has
+	// to land the same document the service holds.
+	adopted := filepath.Join(t.TempDir(), "adopted.json")
+	requireSuccess(t, run(t, "evaluator", "show", name, "--output-file", adopted))
+
+	body, err := os.ReadFile(adopted)
+	require.NoError(t, err)
+	var written map[string]any
+	require.NoError(t, json.Unmarshal(body, &written),
+		"--output-file must write parseable JSON:\n%s", string(body))
+	require.Equal(t, name, written["name"])
+	require.Contains(t, written, "definition",
+		"adopting a remote change needs the definition, not just its identity")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/tests/cli/run_ops_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/tests/cli/run_ops_test.go
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build live
+
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type runSummary struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Status       string `json:"status"`
+	ResultCounts *struct {
+		Passed  int `json:"passed"`
+		Failed  int `json:"failed"`
+		Errored int `json:"errored"`
+	} `json:"result_counts"`
+}
+
+func TestCLIRunList(t *testing.T) {
+	f := sharedEval(t)
+
+	t.Run("table", func(t *testing.T) {
+		r := requireSuccess(t, run(t, "run", "list", "--eval", f.EvalID))
+		// These are the columns the spec's `run list` sample prints, in the
+		// spec's own wording. The old RUN ID/NAME/RESULTS set predates it.
+		for _, header := range []string{
+			"RUN", "DATASET", "STARTED", "STATUS", "SAMPLES", "PASS RATE",
+		} {
+			require.Containsf(t, r.Stdout, header, "the listing lost its %s column", header)
+		}
+		require.Contains(t, r.Stdout, f.FirstRunID)
+		require.Contains(t, r.Stdout, f.SecondRunID)
+		require.Regexp(t, `\d+\.\d+%`, r.Stdout,
+			"the listing must summarise each run's pass rate, not just its status")
+	})
+
+	t.Run("json", func(t *testing.T) {
+		r := requireSuccess(t, run(t, "run", "list", "--eval", f.EvalID, "-o", "json"))
+		require.True(t, strings.HasPrefix(strings.TrimSpace(r.Stdout), "["),
+			"a list must be a bare array, not the service's envelope")
+
+		var runs []runSummary
+		r.JSON(t, &runs)
+		require.GreaterOrEqual(t, len(runs), 2)
+
+		byID := map[string]runSummary{}
+		for _, entry := range runs {
+			byID[entry.ID] = entry
+		}
+		first, ok := byID[f.FirstRunID]
+		require.True(t, ok, "the eval's own run is missing from its listing")
+		require.Equal(t, "completed", first.Status)
+		require.NotNil(t, first.ResultCounts)
+		require.Equal(t, len(fixtureQueries),
+			first.ResultCounts.Passed+first.ResultCounts.Failed,
+			"every dataset row must be accounted for by a verdict")
+	})
+
+	// The client has always taken a limit; until recently the command did not
+	// expose one, so a service-side truncation would have passed unnoticed.
+	t.Run("limit", func(t *testing.T) {
+		r := requireSuccess(t, run(t, "run", "list", "--eval", f.EvalID, "--limit", "1", "-o", "json"))
+		var runs []runSummary
+		r.JSON(t, &runs)
+		require.Len(t, runs, 1, "--limit must reach the service")
+	})
+
+	t.Run("unknown eval is brief", func(t *testing.T) {
+		r := requireFailure(t, run(t, "run", "list", "--eval", "eval_azdcli_no_such_eval"))
+		require.Less(t, len(r.Combined()), 600,
+			"a not-found must stay short, not dump the service body:\n%s", r.Combined())
+		require.Contains(t, r.Combined(), "eval_azdcli_no_such_eval")
+	})
+}
+
+func TestCLIRunShow(t *testing.T) {
+	f := sharedEval(t)
+
+	t.Run("by run id", func(t *testing.T) {
+		r := requireSuccess(t, run(t, "run", "show", f.FirstRunID, "--eval", f.EvalID))
+		require.Contains(t, r.Stdout, f.FirstRunID)
+		require.Contains(t, r.Stdout, "status")
+		require.Contains(t, r.Stdout, "completed")
+		require.Regexp(t, `\d+ passed, \d+ failed, \d+ errored`, r.Stdout)
+		require.Contains(t, r.Stdout, "report")
+	})
+
+	// Without --run-id the command has to pick one, and outside an azd
+	// environment there is no remembered id to fall back on, so what is
+	// exercised is the listing path.
+	t.Run("defaults to the most recent run", func(t *testing.T) {
+		listed := requireSuccess(t, run(t, "run", "list", "--eval", f.EvalID, "--limit", "1", "-o", "json"))
+		var newest []runSummary
+		listed.JSON(t, &newest)
+		require.Len(t, newest, 1)
+
+		r := requireSuccess(t, run(t, "run", "show", "--eval", f.EvalID, "-o", "json"))
+		var shown runSummary
+		r.JSON(t, &shown)
+		require.Equal(t, newest[0].ID, shown.ID,
+			"the default must be the run the listing puts first")
+	})
+
+	// A remembered run that no longer resolves falls through to the eval's
+	// latest, but one named explicitly must not: silently showing a different
+	// run than the one asked for is worse than saying it is gone.
+	//
+	// Only the substitution is asserted. Unlike `run list` and `run delete`,
+	// this path does not shorten the service's body, so the message runs to
+	// about 1700 characters of raw JSON — recorded in the report rather than
+	// pinned here, since pinning it would make the length a requirement.
+	t.Run("an unknown run id is reported, not silently replaced", func(t *testing.T) {
+		r := requireFailure(t, run(t, "run", "show", "evalrun_azdcli_nope", "--eval", f.EvalID))
+		require.Contains(t, r.Combined(), "evalrun_azdcli_nope",
+			"the failure must name the run that was asked for")
+		require.NotContains(t, r.Combined(), f.FirstRunID,
+			"an explicit --run-id must not fall back to another run")
+	})
+}
+
+// TestCLIRunCancelAndDelete covers both halves of cancel, and the delete that
+// follows it, against a single in-flight run: each run costs a minute of
+// service time, so the two happy paths share one.
+//
+// The service answers a cancel on a finished run with success, so without the
+// guard the command would tell a user it had stopped something it had not.
+func TestCLIRunCancelAndDelete(t *testing.T) {
+	f := sharedEval(t)
+
+	t.Run("a finished run is refused", func(t *testing.T) {
+		r := requireFailure(t, run(t, "run", "cancel", f.FirstRunID, "--eval", f.EvalID))
+		require.Contains(t, r.Combined(), "already finished")
+		require.Contains(t, r.Combined(), "completed")
+	})
+
+	// Delete is covered as far as the service honours it.
+	//
+	// The removal itself is not asserted, because whether it happens is the
+	// service's to decide and it has changed under this test once already: it
+	// used to accept the DELETE and leave the run readable minutes later, and it
+	// now reaps a cancelled run promptly enough that the DELETE can even answer
+	// 404. What is asserted is that the command reaches the right resource — a
+	// real run is accepted, an unknown one is refused — which is the part that
+	// would break if the route or the id handling regressed.
+	t.Run("an in-flight run is cancelled, and the delete is accepted", func(t *testing.T) {
+		runID := startCancellableRun(t, f)
+
+		cancelled := requireSuccess(t, run(t, "run", "cancel", runID, "--eval", f.EvalID))
+		require.Contains(t, cancelled.Stdout, runID)
+		require.Contains(t, cancelled.Stdout, "is now")
+
+		shown := requireSuccess(t, run(t, "run", "show", runID, "--eval", f.EvalID, "-o", "json"))
+		var after runSummary
+		shown.JSON(t, &after)
+		require.NotEqual(t, "completed", after.Status,
+			"a cancelled run must not go on to complete")
+
+		deleted := requireSuccess(t, run(t, "run", "delete", runID, "--eval", f.EvalID))
+		require.Contains(t, deleted.Stdout, "Deleted run")
+		require.Contains(t, deleted.Stdout, runID)
+
+		// Either outcome is the service's prerogative; what matters is that the
+		// answer is about this run and not a failure of some other kind.
+		still := run(t, "run", "show", runID, "--eval", f.EvalID, "-o", "json")
+		if still.ExitCode == 0 {
+			var survivor runSummary
+			still.JSON(t, &survivor)
+			t.Logf("still readable after delete (status %q); the service accepted "+
+				"the request without removing anything", survivor.Status)
+		} else {
+			require.Contains(t, still.Combined(), runID,
+				"a read of a deleted run must still name the run it could not find")
+			t.Log("gone after delete; the service removed it")
+		}
+	})
+
+	// Deleting is not undoable, so the id is required rather than defaulted to
+	// whichever run happens to be newest.
+	t.Run("delete requires the run id", func(t *testing.T) {
+		r := requireFailure(t, run(t, "run", "delete", "--eval", f.EvalID))
+		require.Contains(t, r.Combined(), "accepts 1 arg")
+	})
+
+	t.Run("deleting an unknown run is reported briefly", func(t *testing.T) {
+		r := requireFailure(t, run(t, "run", "delete", "evalrun_azdcli_nope", "--eval", f.EvalID))
+		require.Contains(t, r.Combined(), "evalrun_azdcli_nope")
+		require.Less(t, len(r.Combined()), 600,
+			"a not-found must stay short, not dump the service body:\n%s", r.Combined())
+	})
+}
+
+// startCancellableRun adds a run to the fixture's eval and returns it before it
+// can finish.
+//
+// An agent-target run invokes the agent once per row and is judged after that,
+// which takes far longer than the second it takes to issue the cancel; a run
+// that finished first would turn the cancel test into an assertion about the
+// guard it is not testing.
+func startCancellableRun(t *testing.T, f *evalFixture) string {
+	t.Helper()
+
+	client, err := liveClient()
+	require.NoError(t, err)
+
+	runID, err := startFixtureRun(context.Background(), client, f.EvalID, f.AgentName, "cancelme")
+	require.NoError(t, err, "starting a run to cancel")
+	t.Cleanup(func() {
+		_ = client.DeleteOpenAIEvalRun(context.Background(), f.EvalID, runID)
+	})
+	return runID
+}

--- a/cli/azd/extensions/azure.ai.evaluations/tests/cli/run_output_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/tests/cli/run_output_test.go
@@ -1,0 +1,247 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build live
+
+package cli
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The fixture is judged by a model, so no test here may assert how many rows
+// passed. What is under test is the command, and the properties that hold
+// whatever the judge decided: every dataset row comes back, every row carries a
+// verdict and a score, and filtering by verdict returns a subset that agrees
+// with the totals.
+
+// resultsPayload is what `results show -o json` emits: the run and the rows.
+type resultsPayload struct {
+	Run struct {
+		ID           string `json:"id"`
+		Status       string `json:"status"`
+		ResultCounts struct {
+			Total   int `json:"total"`
+			Passed  int `json:"passed"`
+			Failed  int `json:"failed"`
+			Errored int `json:"errored"`
+		} `json:"result_counts"`
+		PerTestingCriteria []struct {
+			TestingCriteria string `json:"testing_criteria"`
+			Passed          int    `json:"passed"`
+			Failed          int    `json:"failed"`
+		} `json:"per_testing_criteria_results"`
+	} `json:"run"`
+	OutputItems []struct {
+		ID             string         `json:"id"`
+		Status         string         `json:"status"`
+		DataSourceItem map[string]any `json:"datasource_item"`
+		Results        []struct {
+			Name   string   `json:"name"`
+			Score  *float64 `json:"score"`
+			Passed bool     `json:"passed"`
+		} `json:"results"`
+	} `json:"output_items"`
+}
+
+// TestCLIResultsShowRendersTheRows is the difference between `results show` and
+// `run show`: the totals say how many failed, these say which.
+func TestCLIResultsShowRendersTheRows(t *testing.T) {
+	f := sharedEval(t)
+
+	r := requireSuccess(t, run(t, "run", "output", "list", f.FirstRunID, "--eval", f.EvalID))
+
+	require.Contains(t, r.Stdout, f.FirstRunID)
+	require.Contains(t, r.Stdout, "Totals:")
+	require.Contains(t, r.Stdout, "CRITERION")
+	require.Contains(t, r.Stdout, f.EvaluatorName)
+
+	// One row per evaluated sample, which is what makes "how many should I go
+	// and look at" answerable by counting lines.
+	for _, header := range []string{"ITEM", "SAMPLE", "FAILED EVALUATORS", "REASON"} {
+		require.Containsf(t, r.Stdout, header, "the listing lost its %s column", header)
+	}
+	require.NotContains(t, r.Stdout, "EVALUATOR  ",
+		"a per-verdict table would list a sample once per evaluator")
+
+	// The fixture's rows all pass, so every row names no failing evaluator.
+	require.Contains(t, r.Stdout, "Report:")
+}
+
+func TestCLIResultsShowJSON(t *testing.T) {
+	f := sharedEval(t)
+
+	payload := resultsFor(t, f.EvalID, f.FirstRunID)
+
+	require.Equal(t, f.FirstRunID, payload.Run.ID)
+	require.Equal(t, "completed", payload.Run.Status)
+	require.Equal(t, len(fixtureQueries), payload.Run.ResultCounts.Total)
+	require.Zero(t, payload.Run.ResultCounts.Errored,
+		"an errored row means the fixture measured nothing")
+
+	require.Len(t, payload.Run.PerTestingCriteria, 1)
+	require.Equal(t, f.EvaluatorName, payload.Run.PerTestingCriteria[0].TestingCriteria)
+
+	// The rows are the reason this command exists, and a run reporting counts
+	// while returning none would still satisfy everything above.
+	require.Len(t, payload.OutputItems, len(fixtureQueries),
+		"every dataset row must come back as an item")
+
+	passed := 0
+	for _, item := range payload.OutputItems {
+		require.NotEmpty(t, item.DataSourceItem["query"],
+			"each row must carry the column it was evaluated on")
+		require.Len(t, item.Results, 1)
+		require.Equal(t, f.EvaluatorName, item.Results[0].Name)
+		require.NotNil(t, item.Results[0].Score, "a scored row must report its score")
+		if item.Results[0].Passed {
+			passed++
+		}
+	}
+	require.Equal(t, payload.Run.ResultCounts.Passed, passed,
+		"the per-row verdicts must agree with the totals")
+}
+
+// TestCLIResultsShowFailedOnly asserts the filter removes rows rather than
+// merely relabelling them.
+//
+// The service has no verdict filter — its `status` selects on execution status,
+// so `status=failed` returns errored rows, not failing ones — which makes this
+// entirely the CLI's own work and worth testing directly.
+func TestCLIResultsShowFailedOnly(t *testing.T) {
+	f := sharedEval(t)
+
+	payload := resultsFor(t, f.EvalID, f.FirstRunID)
+
+	// One rendered row is one evaluator's verdict on one sample, so the count
+	// to expect is failing *results*, not failing rows: a sample that fails two
+	// evaluators is two lines. `ResultCounts.Failed` answers the other question.
+	failing := 0
+	for _, item := range payload.OutputItems {
+		for _, r := range item.Results {
+			if !r.Passed {
+				failing++
+			}
+		}
+	}
+
+	r := requireSuccess(t, run(t, "run", "output", "list", f.FirstRunID,
+		"--eval", f.EvalID, "--failed-only"))
+
+	if failing == 0 {
+		// Saying so is not the same as printing an empty table.
+		require.Contains(t, r.Stdout, "No failing rows.")
+		return
+	}
+
+	require.NotContains(t, r.Stdout, " pass ",
+		"--failed-only must drop the rows that passed")
+
+	// Matched on a word boundary so the per-criterion table's FAILED column
+	// header is not counted as a verdict.
+	verdicts := regexp.MustCompile(`\bFAIL\b`).FindAllString(r.Stdout, -1)
+	require.Equal(t, failing, len(verdicts),
+		"every failing verdict must appear exactly once:\n%s", r.Stdout)
+}
+
+// resultsFor reads a run's results as JSON, which several tests need before
+// they can decide what the rendered output should say.
+func resultsFor(t *testing.T, evalID, runID string) resultsPayload {
+	t.Helper()
+	r := requireSuccess(t, run(t, "run", "output", "list", runID, "--eval", evalID, "-o", "json"))
+	var payload resultsPayload
+	r.JSON(t, &payload)
+	return payload
+}
+
+func TestCLIResultsExport(t *testing.T) {
+	f := sharedEval(t)
+
+	t.Run("json to stdout", func(t *testing.T) {
+		r := requireSuccess(t, run(t, "run", "output", "export", f.FirstRunID,
+			"--eval", f.EvalID, "--format", "json"))
+
+		var exported struct {
+			ID           string `json:"id"`
+			Status       string `json:"status"`
+			ResultCounts struct {
+				Total  int `json:"total"`
+				Passed int `json:"passed"`
+				Failed int `json:"failed"`
+			} `json:"result_counts"`
+		}
+		r.JSON(t, &exported)
+		require.Equal(t, f.FirstRunID, exported.ID)
+		require.Equal(t, "completed", exported.Status)
+		require.Equal(t, len(fixtureQueries), exported.ResultCounts.Total)
+	})
+
+	t.Run("csv to stdout", func(t *testing.T) {
+		r := requireSuccess(t, run(t, "run", "output", "export", f.FirstRunID,
+			"--eval", f.EvalID, "--format", "csv"))
+
+		rows, err := csv.NewReader(strings.NewReader(r.Stdout)).ReadAll()
+		require.NoError(t, err, "--format csv must emit parseable CSV:\n%s", r.Stdout)
+		require.Len(t, rows, 2, "a header and one row per criterion")
+		require.Equal(t,
+			[]string{"run_id", "status", "testing_criteria", "passed", "failed"}, rows[0])
+		require.Equal(t, f.FirstRunID, rows[1][0])
+		require.Equal(t, "completed", rows[1][1])
+		require.Equal(t, f.EvaluatorName, rows[1][2])
+	})
+
+	t.Run("output-file writes the path instead of stdout", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "results.csv")
+
+		r := requireSuccess(t, runIn(t, dir, "run", "output", "export", f.FirstRunID,
+			"--eval", f.EvalID, "--format", "csv", "--output-file", path))
+		require.Empty(t, strings.TrimSpace(r.Stdout),
+			"--output-file redirects the payload; leaving it on stdout too would double it")
+
+		body, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Contains(t, string(body), "run_id,status,criterion,passed,failed")
+		require.Contains(t, string(body), f.FirstRunID)
+	})
+
+	t.Run("an unknown format is refused", func(t *testing.T) {
+		r := requireFailure(t, run(t, "run", "output", "export", f.FirstRunID,
+			"--eval", f.EvalID, "--format", "xml"))
+		require.Contains(t, r.Combined(), `--format "xml" is not supported`)
+		// The refusal has to name jsonl too, or it repeats the bug where the
+		// guard advertised a narrower set than the exporter can write.
+		require.Contains(t, r.Combined(), "use csv, json or jsonl")
+	})
+
+	t.Run("jsonl is accepted, not just advertised", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "results.jsonl")
+		requireSuccess(t, run(t, "run", "output", "export", f.FirstRunID,
+			"--eval", f.EvalID, "--format", "jsonl", "--output-file", path))
+
+		body, err := os.ReadFile(path)
+		require.NoError(t, err)
+		lines := strings.Split(strings.TrimSpace(string(body)), "\n")
+		require.NotEmpty(t, lines)
+		// Every line has to stand alone as an object, otherwise it is JSON
+		// wearing a .jsonl name.
+		for _, line := range lines {
+			var row map[string]any
+			require.NoError(t, json.Unmarshal([]byte(line), &row))
+		}
+	})
+}
+
+func TestCLIResultsUnknownEvalIsBrief(t *testing.T) {
+	r := requireFailure(t, run(t, "run", "output", "list", "--eval", "eval_does_not_exist"))
+	require.Contains(t, r.Combined(), "eval_does_not_exist")
+	require.NotContains(t, r.Combined(), "RESPONSE 404")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/tests/hero/init_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/tests/hero/init_test.go
@@ -1,0 +1,388 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+//go:build hero
+
+// Package hero drives the hero scenarios through real azd, with the extension
+// installed the way a user installs it.
+//
+// The CLI suite in ../cli runs the extension binary directly, which covers the
+// command surface but cannot reach `init`: `init` resolves the project and
+// edits azure.yaml over azd's gRPC channel, so without azd hosting the process
+// there is nothing on the other end. That is not a detail — it is the first
+// command in Scenario 1 and the one that produces the local diff every later
+// step depends on, and until now the only thing asserting its output was a
+// unit test calling the scaffold function directly. A unit test cannot see the
+// service entry azd writes, the detection that reads the project, or the
+// terminal output the spec pins line for line.
+//
+//	azd x pack --rebuild
+//	azd extension install azure.ai.evaluations --source local
+//	go test -tags hero -v ./tests/hero/...
+package hero
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// reinstall is what to run when the installed extension is not this code.
+//
+// `azd x pack` rewrites the artifacts but leaves the checksum in the local
+// registry alone when the version has not changed, so a plain reinstall then
+// fails validation. Bumping the version in extension.yaml is the way through.
+const reinstall = "  azd x pack --rebuild\n" +
+	"  azd extension uninstall azure.ai.evaluations\n" +
+	"  azd extension install azure.ai.evaluations --source local\n"
+
+// TestMain refuses to run against an azd that cannot reach the extension, or
+// that is hosting a different build of it.
+//
+// Skipping would be worse than failing here: these tests exist because nothing
+// else covers the azd-hosted path, so a silent skip returns the suite to the
+// state it was in before they were written. Running against a stale install is
+// worse still — it reports on code that is not the code under test, which is
+// the one outcome a test must never produce.
+func TestMain(m *testing.M) {
+	if os.Getenv("AZURE_AI_EVAL_HERO") != "1" {
+		fmt.Fprintf(os.Stderr,
+			"set AZURE_AI_EVAL_HERO=1 to run the hero scenarios. They need azd "+
+				"hosting this extension:\n%s", reinstall)
+		os.Exit(0)
+	}
+
+	hosted, err := exec.Command("azd", "ai", "eval", "init", "--help").CombinedOutput()
+	if err != nil || !strings.Contains(string(hosted), "Scaffold evaluation config") {
+		fmt.Fprintf(os.Stderr,
+			"azd cannot reach the evaluations extension. Install it first:\n%s\n%s\n",
+			reinstall, hosted)
+		os.Exit(1)
+	}
+
+	if err := requireCurrentInstall(string(hosted)); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n\n%s", err, reinstall)
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+// requireCurrentInstall compares the installed extension's help against this
+// working tree's, so a stale install fails loudly instead of quietly reporting
+// on the wrong binary.
+//
+// Help text is the cheapest available fingerprint that actually moves: it
+// carries every command and flag, which is what these tests assert on, and it
+// costs one build rather than a version stamp nobody remembers to bump.
+func requireCurrentInstall(hosted string) error {
+	dir, err := os.MkdirTemp("", "azdeval-hero")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
+
+	binary := filepath.Join(dir, "azdeval"+exeSuffix())
+	build := exec.Command("go", "build", "-o", binary, ".")
+	build.Dir = "../.."
+	if out, err := build.CombinedOutput(); err != nil {
+		return fmt.Errorf("building this working tree to compare against: %v\n%s", err, out)
+	}
+
+	local, err := exec.Command(binary, "init", "--help").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("reading this working tree's help: %w", err)
+	}
+
+	if normalize(string(local)) != normalize(hosted) {
+		return fmt.Errorf(
+			"azd is hosting a different build of this extension.\n"+
+				"installed:\n%s\nthis working tree:\n%s",
+			normalize(hosted), normalize(string(local)))
+	}
+	return nil
+}
+
+func exeSuffix() string {
+	if os.PathSeparator == '\\' {
+		return ".exe"
+	}
+	return ""
+}
+
+// project writes a minimal azd project for `init` to attach to.
+//
+// It declares the two services detection reads — the Foundry project and the
+// agent — because what `init` writes into azure.yaml depends on which of them
+// exist, and a project with neither would exercise only the fallback.
+func project(t *testing.T, agent string) string {
+	t.Helper()
+	dir := t.TempDir()
+	body := fmt.Sprintf(`name: support-app
+services:
+  ai-project:
+    host: azure.ai.project
+  %s:
+    host: azure.ai.agent
+`, agent)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "azure.yaml"), []byte(body), 0o600))
+	return dir
+}
+
+// azdEval runs the extension through azd, in dir.
+func azdEval(t *testing.T, dir string, args ...string) (string, int) {
+	t.Helper()
+
+	cmd := exec.Command("azd", append([]string{"ai", "eval"}, args...)...)
+	cmd.Dir = dir
+	var out strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	code := 0
+	if err := cmd.Run(); err != nil {
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("could not run azd ai eval %v: %v", args, err)
+		}
+		code = exitErr.ExitCode()
+	}
+
+	// azd prints its own upgrade notice to stderr, which is not the command's
+	// output and would break an exact comparison.
+	text := dropUpgradeNotice(out.String())
+	t.Logf("$ azd ai eval %s -> exit %d\n%s", strings.Join(args, " "), code, text)
+	return text, code
+}
+
+// dropUpgradeNotice removes azd's "Update available" banner and everything
+// after it, which azd appends regardless of the command.
+func dropUpgradeNotice(s string) string {
+	if i := strings.Index(s, "Update available:"); i >= 0 {
+		s = s[:i]
+	}
+	return strings.TrimRight(s, " \r\n\t")
+}
+
+// normalize makes terminal output comparable across platforms.
+func normalize(s string) string {
+	return strings.ReplaceAll(dropUpgradeNotice(s), "\r\n", "\n")
+}
+
+// TestHeroScenario1ColdStart is the first half of Scenario 1: the offline
+// baseline `init` writes, asserted against the terminal block the spec shows.
+//
+// The output is compared whole rather than by keyword. Every line of it is a
+// promise the spec makes to a reader deciding whether to adopt this — which
+// files appear, what was detected, what to run next — and a keyword assertion
+// would pass while the reader's terminal said something else.
+func TestHeroScenario1ColdStart(t *testing.T) {
+	const (
+		agent = "support-agent"
+		judge = "gpt-5.6-luna"
+	)
+	dir := project(t, agent)
+
+	// The evaluator and judge are passed rather than prompted for, because the
+	// spec's two `?` lines are answers to prompts and a test has no terminal to
+	// answer them at.
+	out, code := azdEval(t, dir, "init",
+		"--target", agent, "--source", "traces",
+		"--evaluator", "builtin.task_adherence", "--judge-model", judge)
+	require.Zero(t, code, "init makes no service calls, so nothing can fail it here")
+
+	want := `(✓) Done: Detected agent target: support-agent
+(✓) Done: Using data source: traces (Application Insights)
+(✓) Done: Judge model deployment: gpt-5.6-luna
+
+Created
+  evals/azure.eval.yaml             evaluation configuration
+  azure.yaml                        added service 'support-agent-evals'
+
+Next: azd up
+      azd ai eval run start`
+
+	require.Equal(t, want, normalize(out))
+}
+
+// Scenario 1's second half: the azure.eval.yaml the terminal block promised. The spec
+// prints this file, so its shape is as much a promise as the output above —
+// and it is the file a reader reviews before running `azd up`.
+func TestHeroScenario1WritesTheDocumentedConfig(t *testing.T) {
+	dir := project(t, "support-agent")
+
+	_, code := azdEval(t, dir, "init",
+		"--target", "support-agent", "--source", "traces",
+		"--evaluator", "builtin.task_adherence", "--judge-model", "gpt-5.6-luna")
+	require.Zero(t, code)
+
+	body, err := os.ReadFile(filepath.Join(dir, "evals", "azure.eval.yaml"))
+	require.NoError(t, err)
+	text := string(body)
+
+	require.Contains(t, text, "name: support-agent-trace-eval")
+	require.Contains(t, text, "type: traces")
+	require.Contains(t, text, "agent_name: support-agent",
+		"a trace run has no target, so agent_name is what scopes it")
+	require.Contains(t, text, "max_traces: 20",
+		"a first run is bounded rather than taking the service default of 1000")
+	require.Contains(t, text, "evaluator: builtin.task_adherence")
+	require.Contains(t, text, "model: gpt-5.6-luna",
+		"the judge is written per evaluator reference as initialization_parameters.model")
+
+	require.NotContains(t, text, "datasets:",
+		"there is no file to register, so the catalog is absent rather than empty")
+	require.NotContains(t, text, "target:",
+		"a trace run invokes nothing")
+}
+
+// `init` is offline, and being offline is the property that makes its output a
+// reviewable local diff. A service call here would also make the command fail
+// for a user who has not authenticated yet, which is exactly when they run it.
+func TestHeroInitMakesNoServiceCalls(t *testing.T) {
+	dir := project(t, "support-agent")
+
+	cmd := exec.Command("azd", "ai", "eval", "init",
+		"--target", "support-agent", "--evaluator", "builtin.task_adherence",
+		"--judge-model", "m")
+	cmd.Dir = dir
+	// A proxy pointing nowhere fails any outbound request, so a command that
+	// stays offline is unaffected and one that does not cannot be mistaken for
+	// working.
+	cmd.Env = append(os.Environ(),
+		"HTTPS_PROXY=http://127.0.0.1:9",
+		"HTTP_PROXY=http://127.0.0.1:9",
+		"NO_PROXY=",
+	)
+
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "init must not need the network:\n%s", out)
+}
+
+// The eval service has to be declared in azure.yaml before azd will act on it.
+// Printing the block and leaving the edit to the reader was enough, once, to
+// make the documented flow stop working between `init` and `azd up`.
+func TestHeroInitWiresTheServiceIntoTheProject(t *testing.T) {
+	dir := project(t, "support-agent")
+
+	_, code := azdEval(t, dir, "init", "--target", "support-agent",
+		"--evaluator", "builtin.task_adherence", "--judge-model", "m")
+	require.Zero(t, code)
+
+	root, err := os.ReadFile(filepath.Join(dir, "azure.yaml"))
+	require.NoError(t, err)
+	text := string(root)
+
+	require.Contains(t, text, "support-agent-evals:",
+		"the service is named for the agent it evaluates")
+	require.Contains(t, text, "host: azure.ai.eval")
+	require.Contains(t, text, "$ref: ./evals/azure.eval.yaml")
+
+	// azd owns the edit, so everything the project already declared survives it.
+	require.Contains(t, text, "name: support-app")
+	require.Contains(t, text, "host: azure.ai.project")
+	require.Contains(t, text, "host: azure.ai.agent")
+
+	// The eval reads both, so azd has to deploy both first.
+	require.Regexp(t, `(?s)support-agent-evals:.*uses:.*ai-project.*support-agent`, text)
+}
+
+// Running `init` twice must not deploy the same eval twice. The service key is
+// the eval's name, so the second run recognizes its own work.
+func TestHeroInitIsIdempotent(t *testing.T) {
+	dir := project(t, "support-agent")
+	args := []string{"init", "--target", "support-agent",
+		"--evaluator", "builtin.task_adherence", "--judge-model", "m"}
+
+	_, code := azdEval(t, dir, args...)
+	require.Zero(t, code)
+	first, err := os.ReadFile(filepath.Join(dir, "azure.yaml"))
+	require.NoError(t, err)
+
+	out, code := azdEval(t, dir, args...)
+	require.NotZero(t, code, "the scaffold already exists, so a second run must refuse")
+	require.Contains(t, out, "--force", "the refusal has to say how to proceed")
+
+	second, err := os.ReadFile(filepath.Join(dir, "azure.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, string(first), string(second),
+		"a refused init must not have edited the project")
+
+	// With --force the files are rewritten, and the service is still declared
+	// exactly once.
+	out, code = azdEval(t, dir, append(args, "--force")...)
+	require.Zero(t, code, out)
+
+	third, err := os.ReadFile(filepath.Join(dir, "azure.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(string(third), "host: azure.ai.eval"),
+		"a second eval service would deploy the same eval twice")
+	require.Contains(t, normalize(out), "already declares service 'support-agent-evals'")
+}
+
+// Evals attach to a project; they do not create one. Naming the command that
+// makes a project is more use than a transport error from the gRPC channel
+// that was not there.
+func TestHeroInitNeedsAnAzdProject(t *testing.T) {
+	dir := t.TempDir()
+
+	out, code := azdEval(t, dir, "init", "--target", "support-agent", "--no-prompt")
+	require.NotZero(t, code)
+	require.Contains(t, out, "azd init")
+	require.NotContains(t, strings.ToLower(out), "grpc",
+		"a missing project must not surface as a transport error")
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Empty(t, entries, "a refused init must leave nothing behind")
+}
+
+// Passing --evaluator replaces the defaults, which is how a caller opts out of
+// rubric generation — so the "next" steps must stop offering to generate one.
+func TestHeroInitExplicitEvaluatorsOptOutOfGeneration(t *testing.T) {
+	dir := project(t, "support-agent")
+
+	out, code := azdEval(t, dir, "init",
+		"--target", "support-agent", "--judge-model", "m",
+		"--evaluator", "builtin.task_adherence")
+	require.Zero(t, code, out)
+
+	text := normalize(out)
+	require.NotContains(t, text, "evaluator generate",
+		"nothing was scheduled to be generated, so nothing should be suggested")
+
+	body, err := os.ReadFile(filepath.Join(dir, "evals", "azure.eval.yaml"))
+	require.NoError(t, err)
+	require.Contains(t, string(body), "evaluator: builtin.task_adherence")
+	require.NotContains(t, string(body), "support-agent-quality",
+		"the default rubric was replaced, not added to")
+}
+
+// A supplied dataset is not generated either, so `init` has nothing left to
+// suggest and must not send the reader to a command that would submit a job
+// for an artifact they already have.
+func TestHeroInitSuppliedDatasetIsNotGenerated(t *testing.T) {
+	dir := project(t, "support-agent")
+
+	out, code := azdEval(t, dir, "init",
+		"--target", "support-agent", "--judge-model", "m",
+		"--dataset", "prod-golden",
+		"--evaluator", "builtin.task_adherence")
+	require.Zero(t, code, out)
+
+	text := normalize(out)
+	require.NotContains(t, text, "dataset generate")
+	require.Contains(t, text, "Next: azd up",
+		"with nothing left to generate, the next step is the deploy")
+
+	body, err := os.ReadFile(filepath.Join(dir, "evals", "azure.eval.yaml"))
+	require.NoError(t, err)
+	require.Contains(t, string(body), "dataset: prod-golden")
+	require.NotContains(t, string(body), "source:",
+		"a registered dataset has nothing to upload")
+}


### PR DESCRIPTION
Slice 2 of 2: the command surface.

- `internal/cmd` -- every `azd ai eval ...` command, its rendering and gating
- `main.go`
- the black-box CLI and hero test suites

The packages this imports are in slice 1, so this half will not build on its
own. That is expected: it exists to be read, not merged.

---

**This PR is temporary and will be closed without merging.**

PR #9500 is 38,117 lines, so Copilot declines to review it:
"exceeds the maximum number of lines (20,000)". It has declined 110 times.
This is one of two slices that split that PR along its dependency seam so
each half fits under the limit and can actually be reviewed.

Review comments will be addressed on #9500, then these slices closed.
Please do not merge, and do not spend maintainer review time here --
the real PR is #9500.