### PR TITLE
feat(skills): reconcile archive-backed skill services

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
@@ -423,6 +423,32 @@ func TestStageAzureYamlTemplate_LocalRenamesToAzureYaml(t *testing.T) {
 	require.True(t, fileExists(filepath.Join(staging, "agents", "main.py")))
 }
 
+func TestStageAzureYamlTemplate_PreservesSkillService(t *testing.T) {
+	sampleDir := t.TempDir()
+	pointer := filepath.Join(sampleDir, "sample.yaml")
+	content := `name: foundry-simple
+services:
+  summarize:
+    host: azure.ai.skill
+    instructions: Summarize the user's input.
+  assistant:
+    host: azure.ai.agent
+    uses:
+      - summarize
+    kind: hosted
+`
+	require.NoError(t, os.WriteFile(pointer, []byte(content), 0600))
+
+	flags := &initFlags{manifestPointer: pointer}
+	staging, cleanup, err := stageAzureYamlTemplate(t.Context(), flags, nil, nil)
+	require.NoError(t, err)
+	defer cleanup()
+
+	staged, err := os.ReadFile(filepath.Join(staging, "azure.yaml"))
+	require.NoError(t, err)
+	require.YAMLEq(t, content, string(staged))
+}
+
 func TestAdoptedServiceHasCodeConfig(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt_test.go
@@ -32,8 +32,13 @@ func TestInspectAzureYaml(t *testing.T) {
 services:
   ai-project:
     host: azure.ai.project
+  summarize:
+    host: azure.ai.skill
+    instructions: Summarize the user's input.
   assistant:
     host: azure.ai.agent
+    uses:
+      - summarize
     kind: hosted
 `,
 			wantServices:     true,

--- a/cli/azd/extensions/azure.ai.skills/README.md
+++ b/cli/azd/extensions/azure.ai.skills/README.md
@@ -47,6 +47,52 @@ manual zip step.
 All commands accept the standard cross-cutting flags: `-p` / `--project-endpoint`,
 `--output table|json`, `--no-prompt`, and `--debug`.
 
+## Composing skills in `azure.yaml`
+
+Declare a skill as its own service to reconcile it with `azd deploy` or
+`azd up`:
+
+```yaml
+services:
+  triage-rules:
+    host: azure.ai.skill
+    description: Rules for triaging incoming issues
+    instructions: Classify the issue, identify its owner, and recommend next steps.
+    license: MIT
+    compatibility: gpt-5
+    metadata:
+      owner: support
+    tools:
+      - web_search
+
+  support-agent:
+    host: azure.ai.agent
+    uses:
+      - triage-rules
+    skill: triage-rules
+```
+
+`instructions` can also reference a `.md` or `.txt` file. To preserve a
+complete skill package, use `archive` instead of the inline fields:
+
+```yaml
+services:
+  triage-rules:
+    host: azure.ai.skill
+    archive: ./skills/triage-rules
+```
+
+`archive` accepts a `.zip` file or a directory with `SKILL.md` at its root.
+Relative instruction and archive paths resolve from the service's `project`
+path when set, otherwise from the directory containing `azure.yaml`. Parent
+traversal (`..`) is rejected.
+
+Deploying the skill creates a new immutable default version and publishes
+readiness markers for dependent agent services. A consuming agent must list
+the skill service in `uses:` so azd deploys it first. Removing the service from
+`azure.yaml` stops azd managing the skill but does not delete it; use
+`azd ai skill delete` for deletion.
+
 ## Project endpoint resolution
 
 The Foundry project endpoint is resolved in this order:

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target.go
@@ -4,12 +4,16 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
+	"azureaiskills/internal/exterrors"
 	"azureaiskills/internal/foundry/envkey"
 	"azureaiskills/internal/pkg/skill_api"
 
@@ -27,15 +31,19 @@ var _ azdext.ServiceTargetProvider = (*skillServiceTarget)(nil)
 // entry (see schemas/azure.ai.skill.json). The skill name is the azure.yaml
 // service key, not a body field.
 type skillServiceConfig struct {
-	Description  string   `json:"description,omitempty"`
-	Instructions string   `json:"instructions,omitempty"`
-	Tools        []string `json:"tools,omitempty"`
+	Description   string            `json:"description,omitempty"`
+	Instructions  string            `json:"instructions,omitempty"`
+	License       string            `json:"license,omitempty"`
+	Compatibility string            `json:"compatibility,omitempty"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	Tools         []string          `json:"tools,omitempty"`
+	Archive       string            `json:"archive,omitempty"`
 }
 
 // skillServiceTarget upserts a Foundry skill declared as an azure.ai.skill
-// service. Deploy creates a new default skill version from the entry's inline
-// instructions; the resource name is the service key. Package and Publish are
-// no-ops because a skill has no build artifact.
+// service. Deploy creates a new default skill version from either inline
+// content or an archive reference; the resource name is the service key.
+// Package and Publish are no-ops because a skill has no build artifact.
 type skillServiceTarget struct {
 	azdClient     *azdext.AzdClient
 	serviceConfig *azdext.ServiceConfig
@@ -120,9 +128,9 @@ func (p *skillServiceTarget) Publish(
 }
 
 // Deploy upserts the skill by creating a new default version from the entry's
-// instructions. Re-running deploy creates another immutable version rather than
-// failing. Removing the service from azure.yaml stops azd managing the skill but
-// does not delete it (use `azd ai skill delete`).
+// inline content or archive reference. Re-running deploy creates another
+// immutable version rather than failing. Removing the service from azure.yaml
+// stops azd managing the skill but does not delete it (use `azd ai skill delete`).
 func (p *skillServiceTarget) Deploy(
 	ctx context.Context,
 	serviceConfig *azdext.ServiceConfig,
@@ -134,16 +142,41 @@ func (p *skillServiceTarget) Deploy(
 	if err != nil {
 		return nil, err
 	}
-	instructions, err := resolveSkillInstructions(serviceConfig, cfg.Instructions)
-	if err != nil {
+	if err := validateSkillServiceConfig(serviceConfig.GetName(), cfg); err != nil {
 		return nil, err
 	}
-	if instructions == "" {
-		return nil, fmt.Errorf("skill service %q requires instructions", serviceConfig.GetName())
-	}
 
-	if progress != nil {
-		progress(fmt.Sprintf("Upserting skill %q", serviceConfig.GetName()))
+	var (
+		inlineContent *skill_api.SkillInlineContent
+		archive       *preparedSkillArchive
+	)
+	if strings.TrimSpace(cfg.Archive) != "" {
+		projectPath, err := p.resolveProjectPath(ctx)
+		if err != nil {
+			return nil, err
+		}
+		archivePath, err := resolveSkillArchivePath(projectPath, serviceConfig, cfg.Archive)
+		if err != nil {
+			return nil, err
+		}
+		archive, err = prepareSkillArchive(archivePath)
+		if err != nil {
+			return nil, err
+		}
+		defer archive.Reader.Close()
+	} else {
+		projectPath := ""
+		if isInstructionFilePath(cfg.Instructions) {
+			projectPath, err = p.resolveProjectPath(ctx)
+			if err != nil {
+				return nil, err
+			}
+		}
+		instructions, err := resolveSkillInstructions(projectPath, serviceConfig, cfg.Instructions)
+		if err != nil {
+			return nil, err
+		}
+		inlineContent = skillInlineContent(cfg, instructions)
 	}
 
 	skillCtx, err := resolveSkillContext(ctx, "")
@@ -151,20 +184,34 @@ func (p *skillServiceTarget) Deploy(
 		return nil, err
 	}
 
-	version, err := skillCtx.client.CreateVersionInline(
-		ctx,
-		serviceConfig.GetName(),
-		skill_api.CreateVersionRequest{
-			InlineContent: &skill_api.SkillInlineContent{
-				Description:  cfg.Description,
-				Instructions: instructions,
-				AllowedTools: cfg.Tools,
+	if progress != nil {
+		progress(fmt.Sprintf("Upserting skill %q", serviceConfig.GetName()))
+	}
+
+	var version *skill_api.SkillVersion
+	if archive != nil {
+		version, err = skillCtx.client.CreateVersionFromZip(
+			ctx,
+			serviceConfig.GetName(),
+			archive.Name,
+			archive.Reader,
+			true,
+		)
+	} else {
+		version, err = skillCtx.client.CreateVersionInline(
+			ctx,
+			serviceConfig.GetName(),
+			skill_api.CreateVersionRequest{
+				InlineContent: inlineContent,
+				Default:       true,
 			},
-			Default: true,
-		},
-	)
+		)
+	}
 	if err != nil {
-		return nil, fmt.Errorf("upserting skill %q: %w", serviceConfig.GetName(), err)
+		return nil, exterrors.ServiceFromAzure(err, exterrors.OpReconcileSkill)
+	}
+	if version == nil {
+		return nil, fmt.Errorf("upserting skill %q returned no version", serviceConfig.GetName())
 	}
 	envName, err := p.currentEnv(ctx)
 	if err != nil {
@@ -182,6 +229,61 @@ func (p *skillServiceTarget) Deploy(
 	}
 
 	return &azdext.ServiceDeployResult{}, nil
+}
+
+func (p *skillServiceTarget) resolveProjectPath(ctx context.Context) (string, error) {
+	response, err := p.azdClient.Project().Get(ctx, &azdext.EmptyRequest{})
+	if err != nil {
+		return "", fmt.Errorf("get azd project path for skill service: %w", err)
+	}
+	if response == nil || response.GetProject() == nil {
+		return "", fmt.Errorf("azd project is unavailable")
+	}
+	projectPath := strings.TrimSpace(response.GetProject().GetPath())
+	if projectPath == "" {
+		return "", fmt.Errorf("azd project path is empty")
+	}
+	return projectPath, nil
+}
+
+func validateSkillServiceConfig(name string, cfg *skillServiceConfig) error {
+	hasArchive := strings.TrimSpace(cfg.Archive) != ""
+	hasInline := strings.TrimSpace(cfg.Description) != "" ||
+		strings.TrimSpace(cfg.Instructions) != "" ||
+		strings.TrimSpace(cfg.License) != "" ||
+		strings.TrimSpace(cfg.Compatibility) != "" ||
+		len(cfg.Metadata) > 0 ||
+		len(cfg.Tools) > 0
+
+	if hasArchive && hasInline {
+		return exterrors.Validation(
+			exterrors.CodeInvalidParameter,
+			fmt.Sprintf(
+				"skill service %q cannot combine archive with inline skill fields",
+				name,
+			),
+			"configure either archive, or inline description/instructions/license/compatibility/metadata/tools",
+		)
+	}
+	if !hasArchive && strings.TrimSpace(cfg.Instructions) == "" {
+		return exterrors.Validation(
+			exterrors.CodeMissingRequiredField,
+			fmt.Sprintf("skill service %q requires instructions or archive", name),
+			"set instructions to inline text/a .md or .txt path, or set archive to a .zip/directory path",
+		)
+	}
+	return nil
+}
+
+func skillInlineContent(cfg *skillServiceConfig, instructions string) *skill_api.SkillInlineContent {
+	return &skill_api.SkillInlineContent{
+		Description:   cfg.Description,
+		Instructions:  instructions,
+		License:       cfg.License,
+		Compatibility: cfg.Compatibility,
+		Metadata:      cfg.Metadata,
+		AllowedTools:  cfg.Tools,
+	}
 }
 
 func publishSkillMarkers(
@@ -230,7 +332,11 @@ func parseSkillServiceConfig(svc *azdext.ServiceConfig) (*skillServiceConfig, er
 	return cfg, nil
 }
 
-func resolveSkillInstructions(svc *azdext.ServiceConfig, instructions string) (string, error) {
+func resolveSkillInstructions(
+	projectPath string,
+	svc *azdext.ServiceConfig,
+	instructions string,
+) (string, error) {
 	if !isInstructionFilePath(instructions) {
 		return instructions, nil
 	}
@@ -244,18 +350,119 @@ func resolveSkillInstructions(svc *azdext.ServiceConfig, instructions string) (s
 			return "", fmt.Errorf(
 				"skill instructions path %q must not contain '..' or escape the service directory", instructions)
 		}
-		baseDir := svc.GetRelativePath()
-		if baseDir == "" {
-			baseDir = "."
-		}
-		path = filepath.Join(baseDir, path)
+		path = filepath.Join(skillServiceRoot(projectPath, svc), path)
 	}
 
 	data, err := readFileWithLimit(path)
 	if err != nil {
 		return "", err
 	}
-	return string(data), nil
+	resolved := string(data)
+	if strings.TrimSpace(resolved) == "" {
+		return "", exterrors.Validation(
+			exterrors.CodeMissingRequiredField,
+			fmt.Sprintf("skill service %q resolved to empty instructions", svc.GetName()),
+			"add content to the instructions file, or set instructions to inline text",
+		)
+	}
+	return resolved, nil
+}
+
+type preparedSkillArchive struct {
+	Name   string
+	Reader io.ReadCloser
+}
+
+func resolveSkillArchivePath(
+	projectPath string,
+	svc *azdext.ServiceConfig,
+	archive string,
+) (string, error) {
+	path := strings.TrimSpace(archive)
+	if filepath.IsAbs(path) {
+		return path, nil
+	}
+	if hasParentTraversal(path) {
+		return "", exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf(
+				"skill archive path %q must not contain '..' or escape the service directory",
+				archive,
+			),
+			"move the archive inside the service directory and use a relative path without '..'",
+		)
+	}
+	return filepath.Join(skillServiceRoot(projectPath, svc), path), nil
+}
+
+func skillServiceRoot(projectPath string, svc *azdext.ServiceConfig) string {
+	servicePath := strings.TrimSpace(svc.GetRelativePath())
+	if filepath.IsAbs(servicePath) {
+		return servicePath
+	}
+	if strings.TrimSpace(projectPath) == "" {
+		projectPath = "."
+	}
+	if servicePath == "" {
+		return projectPath
+	}
+	return filepath.Join(projectPath, servicePath)
+}
+
+func prepareSkillArchive(path string) (*preparedSkillArchive, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf("cannot inspect skill archive %s: %s", path, err),
+			"verify the archive or directory exists and is readable",
+		)
+	}
+
+	if info.IsDir() {
+		if _, found, err := skill_api.LocateSkillMdInDir(path); err != nil {
+			return nil, exterrors.Validation(
+				exterrors.CodeInvalidSkillFile,
+				fmt.Sprintf("cannot inspect SKILL.md in %s: %s", path, err),
+				"verify the directory is readable and SKILL.md is a regular file",
+			)
+		} else if !found {
+			return nil, exterrors.Validation(
+				exterrors.CodeInvalidSkillFile,
+				fmt.Sprintf("skill archive directory %s does not contain SKILL.md at its root", path),
+				"add SKILL.md to the directory root or reference a .zip archive",
+			)
+		}
+
+		data, err := skill_api.ArchiveDirectory(path, skill_api.ArchiveOptions{})
+		if err != nil {
+			return nil, classifyArchiveDirectoryError(err, path)
+		}
+		return &preparedSkillArchive{
+			Name:   filepath.Base(filepath.Clean(path)) + ".zip",
+			Reader: io.NopCloser(bytes.NewReader(data)),
+		}, nil
+	}
+
+	if !strings.EqualFold(filepath.Ext(path), ".zip") {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf("skill archive %s must be a .zip file or a directory containing SKILL.md", path),
+			"set archive to a .zip file or a directory containing SKILL.md",
+		)
+	}
+	file, err := os.Open(path) //nolint:gosec // user-authored azure.yaml path opened on user's behalf
+	if err != nil {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf("cannot open skill archive %s: %s", path, err),
+			"verify the archive is readable",
+		)
+	}
+	return &preparedSkillArchive{
+		Name:   filepath.Base(path),
+		Reader: file,
+	}, nil
 }
 
 // hasParentTraversal reports whether a relative path contains a ".." segment
@@ -270,7 +477,11 @@ func hasParentTraversal(p string) bool {
 }
 
 func isInstructionFilePath(instructions string) bool {
-	switch strings.ToLower(filepath.Ext(strings.TrimSpace(instructions))) {
+	value := strings.TrimSpace(instructions)
+	if strings.ContainsAny(value, "\r\n") {
+		return false
+	}
+	switch strings.ToLower(filepath.Ext(value)) {
 	case ".md", ".txt":
 		return true
 	default:

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target.go
@@ -459,6 +459,13 @@ func prepareSkillArchive(path string) (*preparedSkillArchive, error) {
 			"set archive to a .zip file or a directory containing SKILL.md",
 		)
 	}
+	if info.Size() > skill_api.MaxUploadBytes {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf("skill archive %s exceeds the 25 MB upload size limit", path),
+			"reduce the archive size to 25 MB or less",
+		)
+	}
 	file, err := os.Open(path) //nolint:gosec // user-authored azure.yaml path opened on user's behalf
 	if err != nil {
 		return nil, exterrors.Validation(

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target.go
@@ -444,6 +444,14 @@ func prepareSkillArchive(path string) (*preparedSkillArchive, error) {
 		}, nil
 	}
 
+	if !info.Mode().IsRegular() {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidSkillFile,
+			fmt.Sprintf("skill archive %s must be a regular .zip file", path),
+			"set archive to a regular .zip file or a directory containing SKILL.md",
+		)
+	}
+
 	if !strings.EqualFold(filepath.Ext(path), ".zip") {
 		return nil, exterrors.Validation(
 			exterrors.CodeInvalidSkillFile,

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target_test.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -70,9 +71,14 @@ func TestParseSkillServiceConfig_ServiceLevel(t *testing.T) {
 	t.Parallel()
 
 	props, err := structpb.NewStruct(map[string]any{
-		"description":  "code review skill",
-		"instructions": "Review code for correctness.",
-		"tools":        []any{"code_interpreter"},
+		"description":   "code review skill",
+		"instructions":  "Review code for correctness.",
+		"license":       "MIT",
+		"compatibility": "gpt-5",
+		"metadata": map[string]any{
+			"owner": "platform",
+		},
+		"tools": []any{"code_interpreter"},
 	})
 	require.NoError(t, err)
 
@@ -84,6 +90,9 @@ func TestParseSkillServiceConfig_ServiceLevel(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "code review skill", cfg.Description)
 	assert.Equal(t, "Review code for correctness.", cfg.Instructions)
+	assert.Equal(t, "MIT", cfg.License)
+	assert.Equal(t, "gpt-5", cfg.Compatibility)
+	assert.Equal(t, map[string]string{"owner": "platform"}, cfg.Metadata)
 	assert.Equal(t, []string{"code_interpreter"}, cfg.Tools)
 }
 
@@ -114,26 +123,141 @@ func TestParseSkillServiceConfig_Empty(t *testing.T) {
 	assert.Empty(t, cfg.Instructions)
 }
 
+func TestParseSkillServiceConfig_Archive(t *testing.T) {
+	t.Parallel()
+
+	props, err := structpb.NewStruct(map[string]any{
+		"archive": "skills/code-review",
+	})
+	require.NoError(t, err)
+
+	cfg, err := parseSkillServiceConfig(&azdext.ServiceConfig{
+		Name:                 "code-review",
+		Host:                 aiSkillHost,
+		AdditionalProperties: props,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "skills/code-review", cfg.Archive)
+}
+
+func TestValidateSkillServiceConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  skillServiceConfig
+		wantErr string
+	}{
+		{
+			name:   "inline",
+			config: skillServiceConfig{Instructions: "Review code."},
+		},
+		{
+			name:   "archive",
+			config: skillServiceConfig{Archive: "skills/review"},
+		},
+		{
+			name: "archive with inline fields",
+			config: skillServiceConfig{
+				Archive:      "skills/review",
+				Instructions: "Review code.",
+			},
+			wantErr: "cannot combine archive",
+		},
+		{
+			name:    "missing content",
+			config:  skillServiceConfig{Description: "Review code"},
+			wantErr: "requires instructions or archive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateSkillServiceConfig("review", &tt.config)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSkillInlineContent_PreservesSkillMdFields(t *testing.T) {
+	t.Parallel()
+
+	content := skillInlineContent(&skillServiceConfig{
+		Description:   "Review code",
+		License:       "MIT",
+		Compatibility: "gpt-5",
+		Metadata:      map[string]string{"owner": "platform"},
+		Tools:         []string{"code_interpreter"},
+	}, "Review for correctness.")
+
+	assert.Equal(t, "Review code", content.Description)
+	assert.Equal(t, "Review for correctness.", content.Instructions)
+	assert.Equal(t, "MIT", content.License)
+	assert.Equal(t, "gpt-5", content.Compatibility)
+	assert.Equal(t, map[string]string{"owner": "platform"}, content.Metadata)
+	assert.Equal(t, []string{"code_interpreter"}, content.AllowedTools)
+}
+
 func TestResolveSkillInstructions_Inline(t *testing.T) {
 	t.Parallel()
 
-	got, err := resolveSkillInstructions(&azdext.ServiceConfig{Name: "inline"}, "Review code for correctness.")
+	got, err := resolveSkillInstructions(
+		"",
+		&azdext.ServiceConfig{Name: "inline"},
+		"Review code for correctness.",
+	)
 	require.NoError(t, err)
 	assert.Equal(t, "Review code for correctness.", got)
+}
+
+func TestResolveSkillInstructions_MultilineBodyEndingInFileExtensionIsInline(t *testing.T) {
+	t.Parallel()
+
+	instructions := "# Rules\nSee CONTRIBUTING.md"
+	got, err := resolveSkillInstructions("", &azdext.ServiceConfig{Name: "inline"}, instructions)
+	require.NoError(t, err)
+	assert.Equal(t, instructions, got)
 }
 
 func TestResolveSkillInstructions_FilePath(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "instructions.md"), []byte("Review from file."), 0600))
+	projectDir := t.TempDir()
+	serviceDir := filepath.Join(projectDir, "skills", "review")
+	require.NoError(t, os.MkdirAll(serviceDir, 0750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(serviceDir, "instructions.md"),
+		[]byte("Review from file."),
+		0600,
+	))
 
 	got, err := resolveSkillInstructions(
-		&azdext.ServiceConfig{Name: "file", RelativePath: dir},
+		projectDir,
+		&azdext.ServiceConfig{Name: "file", RelativePath: filepath.Join("skills", "review")},
 		"instructions.md",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "Review from file.", got)
+}
+
+func TestResolveSkillInstructions_EmptyFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "instructions.md"), []byte(" \n"), 0600))
+
+	_, err := resolveSkillInstructions(
+		"",
+		&azdext.ServiceConfig{Name: "empty", RelativePath: dir},
+		"instructions.md",
+	)
+	require.ErrorContains(t, err, "resolved to empty instructions")
 }
 
 // TestResolveSkillInstructions_PathTraversal verifies a relative instructions
@@ -144,10 +268,92 @@ func TestResolveSkillInstructions_PathTraversal(t *testing.T) {
 
 	for _, instructions := range []string{"../secret.md", "../../etc/passwd.txt", "sub/../../escape.md"} {
 		_, err := resolveSkillInstructions(
+			"",
 			&azdext.ServiceConfig{Name: "traversal", RelativePath: t.TempDir()},
 			instructions,
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "must not contain '..'")
 	}
+}
+
+func TestResolveSkillArchivePath_PathTraversal(t *testing.T) {
+	t.Parallel()
+
+	for _, archive := range []string{"../skill.zip", "../../secret", "sub/../../escape.zip"} {
+		_, err := resolveSkillArchivePath(
+			t.TempDir(),
+			&azdext.ServiceConfig{Name: "traversal", RelativePath: "skills"},
+			archive,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must not contain '..'")
+	}
+}
+
+func TestResolveSkillPaths_FromNestedWorkingDirectory(t *testing.T) {
+	projectDir := t.TempDir()
+	serviceDir := filepath.Join(projectDir, "skills")
+	nestedDir := filepath.Join(projectDir, "scripts", "nested")
+	require.NoError(t, os.MkdirAll(serviceDir, 0750))
+	require.NoError(t, os.MkdirAll(nestedDir, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(serviceDir, "instructions.md"), []byte("Review."), 0600))
+	t.Chdir(nestedDir)
+
+	service := &azdext.ServiceConfig{Name: "code-review", RelativePath: "skills"}
+	instructions, err := resolveSkillInstructions(projectDir, service, "instructions.md")
+	require.NoError(t, err)
+	assert.Equal(t, "Review.", instructions)
+
+	archive, err := resolveSkillArchivePath(projectDir, service, "code-review")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(projectDir, "skills", "code-review"), archive)
+}
+
+func TestPrepareSkillArchive_Directory(t *testing.T) {
+	t.Parallel()
+
+	dir := writeSkillDir(t, "code-review")
+	archive, err := prepareSkillArchive(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = archive.Reader.Close() })
+
+	assert.Equal(t, filepath.Base(dir)+".zip", archive.Name)
+	data, err := io.ReadAll(archive.Reader)
+	require.NoError(t, err)
+	assert.NotEmpty(t, data)
+}
+
+func TestPrepareSkillArchive_Zip(t *testing.T) {
+	t.Parallel()
+
+	path := writeZipWithSkillMd(t, "code-review")
+	archive, err := prepareSkillArchive(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = archive.Reader.Close() })
+
+	assert.Equal(t, filepath.Base(path), archive.Name)
+	data, err := io.ReadAll(archive.Reader)
+	require.NoError(t, err)
+	assert.NotEmpty(t, data)
+}
+
+func TestPrepareSkillArchive_RejectsDirectoryWithoutSkillMd(t *testing.T) {
+	t.Parallel()
+
+	archive, err := prepareSkillArchive(t.TempDir())
+	require.ErrorContains(t, err, "does not contain SKILL.md")
+	assert.Nil(t, archive)
+}
+
+func TestPrepareSkillArchive_RejectsUnsupportedFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "SKILL.md")
+	require.NoError(t, os.WriteFile(path, []byte("instructions"), 0600))
+
+	archive, err := prepareSkillArchive(path)
+	require.Error(t, err)
+	assert.Nil(t, archive)
+	assert.Contains(t, err.Error(), ".zip")
 }

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -356,4 +357,18 @@ func TestPrepareSkillArchive_RejectsUnsupportedFile(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, archive)
 	assert.Contains(t, err.Error(), ".zip")
+}
+
+func TestPrepareSkillArchive_RejectsNonRegularZip(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("creating a symbolic link requires elevated privileges on Windows")
+	}
+
+	path := filepath.Join(t.TempDir(), "skill.zip")
+	require.NoError(t, os.Symlink(os.DevNull, path))
+
+	archive, err := prepareSkillArchive(path)
+	require.ErrorContains(t, err, "must be a regular .zip file")
+	assert.Nil(t, archive)
 }

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/service_target_test.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"testing"
 
+	"azureaiskills/internal/pkg/skill_api"
+
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -357,6 +359,20 @@ func TestPrepareSkillArchive_RejectsUnsupportedFile(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, archive)
 	assert.Contains(t, err.Error(), ".zip")
+}
+
+func TestPrepareSkillArchive_RejectsOversizedZip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "skill.zip")
+	file, err := os.Create(path) //nolint:gosec // test creates a file in t.TempDir
+	require.NoError(t, err)
+	require.NoError(t, file.Truncate(skill_api.MaxUploadBytes+1))
+	require.NoError(t, file.Close())
+
+	archive, err := prepareSkillArchive(path)
+	require.ErrorContains(t, err, "exceeds the 25 MB upload size limit")
+	assert.Nil(t, archive)
 }
 
 func TestPrepareSkillArchive_RejectsNonRegularZip(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.skills/internal/exterrors/codes.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/exterrors/codes.go
@@ -28,10 +28,11 @@ const (
 // Operation names for ServiceFromAzure errors. Prefixed to the Azure code,
 // e.g. "create_skill.NotFound".
 const (
-	OpCreateSkill   = "create_skill"
-	OpUpdateSkill   = "update_skill"
-	OpDeleteSkill   = "delete_skill"
-	OpGetSkill      = "get_skill"
-	OpListSkills    = "list_skills"
-	OpDownloadSkill = "download_skill"
+	OpCreateSkill    = "create_skill"
+	OpUpdateSkill    = "update_skill"
+	OpDeleteSkill    = "delete_skill"
+	OpGetSkill       = "get_skill"
+	OpListSkills     = "list_skills"
+	OpDownloadSkill  = "download_skill"
+	OpReconcileSkill = "reconcile_skill"
 )

--- a/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/client.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/pkg/skill_api/client.go
@@ -41,6 +41,8 @@ const (
 	// match the archive uncompressed limit; a legitimate zip is far smaller
 	// after compression, so this only trips on egregious responses.
 	MaxDownloadBytes = 512 * 1024 * 1024
+	// MaxUploadBytes is the service limit for skill-version archive uploads.
+	MaxUploadBytes = 25 * 1024 * 1024
 
 	//nolint:gosec // OAuth scope identifier, not a credential
 	BearerScope = "https://ai.azure.com/.default"

--- a/cli/azd/extensions/azure.ai.skills/schemas/azure.ai.skill.json
+++ b/cli/azd/extensions/azure.ai.skills/schemas/azure.ai.skill.json
@@ -12,12 +12,31 @@
     },
     "instructions": {
       "type": "string",
-      "description": "Inline instruction text, or a file path (.md, .txt) the extension reads at deploy time. A relative path resolves from the service path when set, otherwise from the current project directory."
+      "description": "Inline instruction text, or a file path (.md, .txt) the extension reads at deploy time. A relative path resolves from the service path when set, otherwise from the directory containing azure.yaml."
+    },
+    "license": {
+      "type": "string",
+      "description": "License name or reference from SKILL.md front matter."
+    },
+    "compatibility": {
+      "type": "string",
+      "description": "Compatibility requirements from SKILL.md front matter."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "String metadata values from SKILL.md front matter.",
+      "additionalProperties": {
+        "type": "string"
+      }
     },
     "tools": {
       "type": "array",
       "description": "Tool type names the skill uses (must be declared on a toolbox the agent references, or attached directly to the agent's tools list).",
       "items": { "type": "string" }
+    },
+    "archive": {
+      "type": "string",
+      "description": "Path to a .zip skill package or a directory containing SKILL.md. Mutually exclusive with inline skill fields. A relative path resolves from the service path when set, otherwise from the directory containing azure.yaml."
     }
   }
 }


### PR DESCRIPTION
## Summary

Implements the deploy-time reconciliation portion of #9088 in the owning `azure.ai.skills` extension.

- Reconciles complete inline skill content, including license, compatibility, metadata, and tools.
- Adds `archive` support for `.zip` packages and directories containing root-level `SKILL.md`.
- Resolves relative instruction and archive paths from the azd project plus the service `project` path, with parent-traversal protection.
- Preserves the existing legacy `config:` fallback and skill dependency readiness markers.
- Documents skill composition through `uses:` and adds an agent + skill adoption regression case.

This intentionally leaves command-driven `azure.yaml` authoring for the second stage of #9088, where the command UX is still being decided. It supersedes the deploy/reconcile portion of #9116 without carrying forward the unresolved `--save-to-azure-yaml` surface.

## Validation

- `go test ./... -count=1` in `azure.ai.skills` with isolated azd config
- `go build ./...` and `golangci-lint run ./...` in `azure.ai.skills`
- `go test ./internal/cmd -run TestInspectAzureYaml -count=1` in `azure.ai.agents`
- `mage checkDependencyVersions`
- `mage preflight` (all checks passed)