### PR TITLE
[TEMP - do not merge] review slice: run results consistency (AB#5530202)

### DIFF
--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating.go
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/spf13/cobra"
+)
+
+// Gating is opt-in. A completed run with failing samples exits 0 without
+// --fail-on: failing samples are the expected output of a working evaluation,
+// not a tool error, and `run start` is used constantly in the inner loop. A
+// default that returned non-zero on any failure would break a build the first
+// time a noisy grader disagreed.
+//
+// The separate exit code matters more than the flag. It lets a pipeline tell
+// "the evaluation regressed" from "the evaluation could not run", which are
+// different failures with different owners.
+
+// exitCodeGateBreached is returned when a run completed but missed its
+// threshold.
+const exitCodeGateBreached = 2
+
+// gate is a parsed --fail-on threshold.
+type gate struct {
+	set        bool
+	anyFailure bool
+	passRate   float64
+}
+
+// parseGate reads the --fail-on value. An empty value means no gating.
+func parseGate(spec string) (gate, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return gate{}, nil
+	}
+	if spec == "any-failure" {
+		return gate{set: true, anyFailure: true}, nil
+	}
+
+	rate, ok := strings.CutPrefix(spec, "pass-rate=")
+	if !ok {
+		return gate{}, messages.FailOnInvalid(spec)
+	}
+	value, err := strconv.ParseFloat(rate, 64)
+	if err != nil {
+		return gate{}, messages.FailOnRateNotNumber(rate)
+	}
+	// NaN parses, then passes both range checks, and then loses every
+	// comparison it is put in -- so a pipeline that asked to be gated would
+	// never be, and nothing would say so.
+	if math.IsNaN(value) {
+		return gate{}, messages.FailOnRateNotNumber(rate)
+	}
+	if value < 0 || value > 1 {
+		return gate{}, messages.FailOnRateOutOfRange(value)
+	}
+	return gate{set: true, passRate: value}, nil
+}
+
+// scoredPassRate is the one definition of a run's pass rate: the share of the
+// rows an evaluator actually scored.
+//
+// Errored and skipped rows are outside the denominator because nothing graded
+// them, and an infrastructure failure is not a quality signal. This is what the
+// portal reports and what `--fail-on pass-rate` compares against, so the two
+// figures a reader sees two lines apart cannot disagree.
+//
+// ok is false when nothing was scored at all: a rate over no rows is not zero,
+// it is absent, and the caller has to say so rather than print it.
+//
+// The consequence is worth stating. A run where almost everything errored can
+// now report a high rate off the few rows that survived, so the count that did
+// not score is printed beside it.
+func scoredPassRate(counts *eval_api.EvalRunResultCounts) (rate float64, scored int, ok bool) {
+	if counts == nil {
+		return 0, 0, false
+	}
+	scored = counts.Passed + counts.Failed
+	if scored <= 0 {
+		return 0, 0, false
+	}
+	return float64(counts.Passed) / float64(scored), scored, true
+}
+
+// breach reports why the run missed the threshold, or empty when it met it.
+//
+// A run that scored nothing at all breaches every threshold rather than
+// dividing by zero — "no rows passed" is the honest reading of an empty result.
+func (g gate) breach(counts *eval_api.EvalRunResultCounts) string {
+	if !g.set {
+		return ""
+	}
+	if counts == nil {
+		return messages.GateNoResultCounts()
+	}
+	// Checked before any-failure as well as before the rate: a run that graded
+	// nothing has not passed, and reading zero unpassed rows as success let an
+	// empty run clear the gate that exists to catch exactly that.
+	if counts.Total == 0 {
+		return messages.GateNoRowsScored()
+	}
+	if g.anyFailure {
+		// Deliberately stricter than the rate: this counts a row nothing could
+		// grade against the run, because "everything passed" is not true of a
+		// run that failed to grade half of what it was given.
+		unpassed := counts.Total - counts.Passed
+		if unpassed > 0 {
+			return messages.GateSamplesDidNotPass(unpassed, counts.Total)
+		}
+		return ""
+	}
+	actual, _, ok := scoredPassRate(counts)
+	if !ok {
+		return messages.GateNoRowsScored()
+	}
+	if actual < g.passRate {
+		return messages.GatePassRateBelow(actual, g.passRate)
+	}
+	return ""
+}
+
+// gateBreachMessage is what a breached gate prints, kept separate from the
+// exit so the wording can be tested: it is the block the spec's CI scenario
+// shows, and a pipeline's logs are where it is read.
+func gateBreachMessage(reason string) string {
+	return messages.GateBreached(reason)
+}
+
+// applyGate ends the process with exit code 2 when the run missed its
+// threshold.
+//
+// It exits here rather than returning an error because the extension SDK's
+// Run collapses every error to exit 1, and the whole point of the flag is a
+// code a pipeline can tell apart from an operational failure.
+func applyGate(cmd *cobra.Command, g gate, run *eval_api.OpenAIEvalRun) {
+	if run == nil {
+		return
+	}
+	// Rows nothing could grade are outside the rate, so a run that errored on
+	// most of what it was given can clear a threshold on the few that survived.
+	// That is the cost of measuring quality over scored rows only, and the gate
+	// is where it has to be said: this is the line a pipeline log keeps.
+	if g.set && !g.anyFailure {
+		if c := run.ResultCounts; c != nil {
+			if _, scored, ok := scoredPassRate(c); ok && c.Total > scored {
+				fmt.Fprint(os.Stderr,
+					messages.Warning(messages.GateSawUnscoredRows(c.Total-scored, c.Total)))
+			}
+		}
+	}
+	reason := g.breach(run.ResultCounts)
+	if reason == "" {
+		return
+	}
+	fmt.Fprint(os.Stderr, gateBreachMessage(reason))
+	os.Exit(exitCodeGateBreached)
+}
+
+func addFailOnFlag(cmd *cobra.Command, target *string) {
+	// States the observed code rather than the one this process exits with: azd
+	// collapses an extension's exit code, and a pipeline author who reads 2 here
+	// writes a condition that never fires.
+	cmd.Flags().StringVar(target, "fail-on", "",
+		"Fail when the run misses this threshold: any-failure, or pass-rate=<0..1>. "+
+			"pass-rate is measured over the rows that were scored, so rows nothing "+
+			"could grade are outside it; any-failure counts them against the run. "+
+			"Exits 1.")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_conformance_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_conformance_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The spec's CI scenario prints this block verbatim, and a pipeline's log is
+// where it is read. Both lines are asserted whole: the marker is what tells a
+// reader this is a gate rather than a crash, and the ERROR: line is what the
+// azd style guide reserves for a terminal failure.
+func TestGateBreachMessageMatchesTheScenario(t *testing.T) {
+	msg := gateBreachMessage("pass rate 76.0% is below the required 80.0%")
+
+	assert.Equal(t,
+		"(x) Failed: Evaluation gate: pass rate 76.0% is below the required 80.0%\n\n"+
+			"ERROR: evaluation quality gate not met.\n",
+		msg)
+}
+
+// Exit 2 is the whole point of --fail-on: a pipeline has to tell "the
+// evaluation regressed" apart from "the tool could not run", which is exit 1.
+func TestGateBreachUsesItsOwnExitCode(t *testing.T) {
+	assert.Equal(t, 2, exitCodeGateBreached,
+		"the spec's exit table gives 2 to a breached threshold")
+}
+
+// The spec's exit table: a completed run is 0 whatever it scored, and a run
+// that errored rather than completed is an operational failure.
+func TestRunCompletedSeparatesRegressionFromFailureToRun(t *testing.T) {
+	for _, status := range []string{"completed", "Completed", ""} {
+		assert.NoErrorf(t, runCompleted(&eval_api.OpenAIEvalRun{ID: "r", Status: status}),
+			"%q is a run that produced results, so its score decides the outcome", status)
+	}
+
+	for _, status := range []string{"failed", "errored", "canceled"} {
+		err := runCompleted(&eval_api.OpenAIEvalRun{ID: "r1", Status: status})
+		require.Errorf(t, err, "%q never produced results, so it did not regress", status)
+		assert.Contains(t, err.Error(), status)
+		assert.Contains(t, err.Error(), "r1")
+	}
+}
+
+// pass-rate is passed/(passed+failed): the share of the rows something actually
+// graded. Errored and skipped rows are outside it, because an infrastructure
+// failure is not a quality signal, and this is the figure the portal reports.
+//
+// The cost is real and deliberate: a run with two passes and thirteen errors
+// scores a perfect rate. `any-failure` is the gate that still counts those, and
+// a pass-rate gate warns when it judged only part of a run.
+func TestPassRateIsMeasuredOverTheRowsThatWereScored(t *testing.T) {
+	g, err := parseGate("pass-rate=0.8")
+	require.NoError(t, err)
+
+	// 2 passed, 1 failed, 1 errored: 2 of 3 scored is 66.7%, below 80%.
+	breach := g.breach(&eval_api.EvalRunResultCounts{Total: 4, Passed: 2, Failed: 1, Errored: 1})
+	require.NotEmpty(t, breach, "a scored row that failed still counts")
+	assert.Contains(t, breach, "66.7%")
+
+	// The same run without the failure: everything scored, passed, so the
+	// errored row does not drag a quality number down on its own.
+	assert.Empty(t, g.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 2, Errored: 1}),
+		"nothing graded the errored row, so it is not evidence of a regression")
+
+	assert.Empty(t, g.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 3}))
+}
+
+// any-failure is the same concern as the rate above asked as a yes or no, and
+// it was the untested half: the gate counts everything that is not a pass, so
+// replacing that with the Failed count alone let a run whose rows errored
+// report success, and no test noticed.
+func TestAnyFailureCountsErroredAndSkippedAsUnpassed(t *testing.T) {
+	g, err := parseGate("any-failure")
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, g.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 2, Errored: 1}),
+		"a row that errored did not pass")
+	assert.NotEmpty(t, g.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 2, Skipped: 1}),
+		"a row that was skipped did not pass either")
+	assert.NotEmpty(t, g.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 2, Failed: 1}))
+
+	assert.Empty(t, g.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 3}),
+		"every row passed, so there is nothing to report")
+}
+
+// A run that scored nothing breaches every threshold rather than dividing by
+// zero. "No rows passed" is the honest reading of an empty result.
+func TestEmptyRunBreachesEveryThreshold(t *testing.T) {
+	g, err := parseGate("pass-rate=0.1")
+	require.NoError(t, err)
+
+	breach := g.breach(&eval_api.EvalRunResultCounts{})
+
+	assert.NotEmpty(t, breach)
+	assert.NotContains(t, breach, "NaN", "dividing by zero must not reach the message")
+}
+
+// --fail-on belongs to the commands that wait for a terminal state, so a
+// pipeline that started a run asynchronously can still gate where it reattaches.
+func TestFailOnSitsOnTheWaitingCommands(t *testing.T) {
+	for _, path := range []string{"run start", "run show"} {
+		assert.NotNilf(t, find(t, path).Flags().Lookup("fail-on"),
+			"%s waits for a terminal state, so it can gate on one", path)
+	}
+
+	usage := find(t, "run start").Flags().Lookup("fail-on").Usage
+	for _, form := range []string{"any-failure", "pass-rate"} {
+		assert.Containsf(t, usage, form, "--fail-on accepts %q, so its help has to say so", form)
+	}
+	assert.Contains(t, strings.ToLower(usage), "1",
+		"the help has to name the exit code a caller observes, which is the only reason to use the flag")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_silent_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_silent_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A gate is the whole reason a pipeline runs this command, so the ways it can
+// silently stop gating matter more than the ways it can fire.
+
+// NaN parses, clears both range checks, and then loses every comparison it is
+// put in. A pipeline written this way believes it is gated and is not.
+func TestFailOnRejectsAThresholdThatCanNeverFire(t *testing.T) {
+	for _, spec := range []string{"pass-rate=NaN", "pass-rate=nan", "pass-rate=-nan"} {
+		_, err := parseGate(spec)
+		require.Errorf(t, err, "%s would disable the gate while looking like one", spec)
+	}
+
+	// The range check already covers infinities; this pins that it still does.
+	for _, spec := range []string{"pass-rate=Inf", "pass-rate=-Inf", "pass-rate=1.5", "pass-rate=-0.1"} {
+		_, err := parseGate(spec)
+		require.Errorf(t, err, "%s is not a pass rate", spec)
+	}
+
+	g, err := parseGate("pass-rate=0.8")
+	require.NoError(t, err)
+	assert.True(t, g.set)
+	assert.InDelta(t, 0.8, g.passRate, 1e-9)
+}
+
+// A run that graded nothing has not passed. The pass-rate gate always said so;
+// any-failure computed Total-Passed, which is zero for an empty run, and let it
+// through -- the one shape a gate exists to catch.
+func TestEveryGateBreachesOnARunThatScoredNothing(t *testing.T) {
+	empty := &eval_api.EvalRunResultCounts{Total: 0}
+
+	anyFailure, err := parseGate("any-failure")
+	require.NoError(t, err)
+	assert.NotEmpty(t, anyFailure.breach(empty),
+		"an empty run must not clear an any-failure gate")
+
+	rate, err := parseGate("pass-rate=0.8")
+	require.NoError(t, err)
+	assert.NotEmpty(t, rate.breach(empty))
+
+	// A gate that was never asked for stays silent whatever the counts.
+	assert.Empty(t, gate{}.breach(empty))
+}
+
+// The ordinary cases still behave, so the empty-run guard did not swallow them.
+func TestGatesStillJudgeRunsThatScoredSomething(t *testing.T) {
+	anyFailure, err := parseGate("any-failure")
+	require.NoError(t, err)
+
+	assert.Empty(t, anyFailure.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 3}),
+		"every row passed, so there is nothing to report")
+	assert.NotEmpty(t, anyFailure.breach(&eval_api.EvalRunResultCounts{Total: 3, Passed: 2}),
+		"one row did not pass")
+
+	rate, err := parseGate("pass-rate=0.8")
+	require.NoError(t, err)
+	// Spelled out with Failed rather than left to total, because the rate is
+	// measured over what was scored: passed plus failed.
+	assert.Empty(t, rate.breach(&eval_api.EvalRunResultCounts{Total: 10, Passed: 9, Failed: 1}))
+	assert.NotEmpty(t, rate.breach(&eval_api.EvalRunResultCounts{Total: 10, Passed: 7, Failed: 3}))
+
+	// Counts the service never sent are not a pass.
+	assert.NotEmpty(t, rate.breach(nil))
+}
+
+// The spec puts --fail-on on the commands that wait. A run still in progress
+// has partial counts, so gating it can fail a run that would have passed --
+// and silently skipping the gate would leave a pipeline believing it is
+// protected when it is not.
+func TestOnlyATerminalRunCanBeGated(t *testing.T) {
+	// Read from the polling vocabulary instead of a second copy of it. Spelling
+	// the list out here is what hid "error" being gateable: the test agreed with
+	// the bug.
+	for status := range terminalRunStates {
+		assert.Truef(t, runIsTerminal(&eval_api.OpenAIEvalRun{Status: status}),
+			"the poller stops on %q, so its counts are final", status)
+	}
+	assert.True(t, runIsTerminal(&eval_api.OpenAIEvalRun{Status: ""}),
+		"a run the service reported no status for is gated on the counts it gave")
+
+	for _, status := range []string{"in_progress", "queued", "running"} {
+		assert.Falsef(t, runIsTerminal(&eval_api.OpenAIEvalRun{Status: status}),
+			"%q is still moving, so its counts are partial", status)
+	}
+
+	assert.False(t, runIsTerminal(nil), "no run is not a finished run")
+
+	err := messages.GateNeedsATerminalRun("evalrun_1", "in_progress")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--wait", "the way out has to be named")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/gating_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGate(t *testing.T) {
+	t.Run("empty means no gating", func(t *testing.T) {
+		g, err := parseGate("")
+		require.NoError(t, err)
+		require.False(t, g.set)
+		require.Empty(t, g.breach(&eval_api.EvalRunResultCounts{Total: 3}),
+			"an unset gate must never breach")
+	})
+
+	t.Run("any-failure", func(t *testing.T) {
+		g, err := parseGate("any-failure")
+		require.NoError(t, err)
+		require.True(t, g.anyFailure)
+	})
+
+	t.Run("pass-rate", func(t *testing.T) {
+		g, err := parseGate("pass-rate=0.8")
+		require.NoError(t, err)
+		require.InDelta(t, 0.8, g.passRate, 1e-9)
+	})
+
+	for _, bad := range []string{"passrate=0.8", "pass-rate=abc", "pass-rate=1.5", "pass-rate=-1", "sometimes"} {
+		t.Run("refuses "+bad, func(t *testing.T) {
+			_, err := parseGate(bad)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestGateBreach(t *testing.T) {
+	anyFailure, err := parseGate("any-failure")
+	require.NoError(t, err)
+	eighty, err := parseGate("pass-rate=0.8")
+	require.NoError(t, err)
+
+	t.Run("any-failure passes only when every row passed", func(t *testing.T) {
+		require.Empty(t, anyFailure.breach(&eval_api.EvalRunResultCounts{Total: 2, Passed: 2}))
+		require.NotEmpty(t, anyFailure.breach(&eval_api.EvalRunResultCounts{Total: 2, Passed: 1, Failed: 1}))
+	})
+
+	// Errored rows sit outside the rate: nothing graded them, so they are not
+	// evidence of a regression. `any-failure` is the gate that counts them.
+	t.Run("errored rows are outside the rate", func(t *testing.T) {
+		counts := &eval_api.EvalRunResultCounts{Total: 12, Passed: 8, Failed: 2, Errored: 2}
+		require.Equal(t, "", eighty.breach(counts), "8 of the 10 scored passed, which meets 0.8")
+
+		counts = &eval_api.EvalRunResultCounts{Total: 13, Passed: 7, Failed: 3, Errored: 3}
+		require.NotEmpty(t, eighty.breach(counts), "7 of the 10 scored is under 0.8")
+
+		counts = &eval_api.EvalRunResultCounts{Total: 10, Passed: 8, Errored: 2}
+		require.Empty(t, eighty.breach(counts),
+			"everything that was scored passed, so the errored rows do not breach it")
+	})
+
+	// The wording is pinned because the hero scenario shows it verbatim.
+	t.Run("reads as a percentage", func(t *testing.T) {
+		counts := &eval_api.EvalRunResultCounts{Total: 1000, Passed: 764, Failed: 236}
+		require.Equal(t,
+			"pass rate 76.4% is below the required 80.0%",
+			eighty.breach(counts))
+	})
+
+	// A run that scored nothing has no defensible pass rate, and treating it as
+	// 100% would let a broken evaluation hold a gate open.
+	t.Run("a run that scored nothing breaches", func(t *testing.T) {
+		require.NotEmpty(t, eighty.breach(&eval_api.EvalRunResultCounts{Total: 0}))
+		require.NotEmpty(t, eighty.breach(nil))
+	})
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run.go
@@ -1,0 +1,1159 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/dataset_api"
+	"azureaieval/internal/pkg/eval_api"
+	"azureaieval/internal/project"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// Terminal run states reported by the service.
+var terminalRunStates = map[string]bool{
+	"completed": true,
+	"failed":    true,
+	"canceled":  true,
+	"cancelled": true,
+	"error":     true,
+}
+
+// runCompleted turns a run that did not complete into an error, so that a
+// caller who waited for it exits non-zero.
+//
+// The results have already been printed by the time this is asked, which is
+// the point: a run that errored has a reason worth reading, and reporting it
+// and then exiting 0 tells a pipeline the evaluation passed. It is checked
+// before the gate because the gate's exit code means "the evaluation
+// regressed", and a run that never produced results has not regressed — it did
+// not run. Distinguishing those two is what the separate code is for.
+func runCompleted(run *eval_api.OpenAIEvalRun) error {
+	if run == nil {
+		return nil
+	}
+	switch strings.ToLower(run.Status) {
+	case "completed", "":
+		return nil
+	}
+	return messages.RunFinishedWithStatus(run.ID, run.Status)
+}
+
+// runIsTerminal reports whether the run has stopped moving.
+//
+// A gate read from a run still in progress is read from partial counts: it can
+// fail a run that would have passed, and it can pass one that has not finished
+// failing.
+//
+// Derived from the polling vocabulary rather than repeating it: a state the
+// poller stops waiting on is a state whose counts are final, and keeping two
+// lists let "error" fall out of this one -- which told anyone gating an errored
+// run to pass --wait, on a run that had already stopped. The empty status is
+// the one deliberate difference: polling keeps waiting on a run the service has
+// not described yet, while a gate reads the counts it was handed.
+func runIsTerminal(run *eval_api.OpenAIEvalRun) bool {
+	if run == nil {
+		return false
+	}
+	status := strings.ToLower(run.Status)
+	return status == "" || terminalRunStates[status]
+}
+
+// newRunCommand builds the run group.
+//
+// `run` is a group, not an executable verb: once `run output` exists, a bare
+// `run` would make `azd ai eval run list` read as "run the thing called list".
+func newRunCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Start and inspect evaluation runs.",
+	}
+	addRunSubcommands(cmd)
+	cmd.AddCommand(buildRunCommand(
+		"start", "Start a run of an eval that has been deployed."))
+	return cmd
+}
+
+// buildRunCommand builds `run start`.
+func buildRunCommand(use, short string) *cobra.Command {
+	var (
+		groupName   string
+		datasetName string
+		runName     string
+		maxSamples  int
+		wait        bool
+		failOn      string
+		endpointFlg string
+		evalPath    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			out := cmd.OutOrStdout()
+
+			// Parsed before any network work, so a malformed threshold costs
+			// nothing to find out about.
+			threshold, err := parseGate(failOn)
+			if err != nil {
+				return err
+			}
+			// A gate is a verdict on a result. Returning before there is one
+			// used to drop the gate silently, so `--no-wait --fail-on ...`
+			// exited 0 however the run turned out -- a pipeline that believes
+			// it is gated and is not.
+			if !wait && threshold.set {
+				return messages.GateNeedsTheWait()
+			}
+			// resolveMaxSamples reads anything not above zero as "no cap", so a
+			// negative one sent the whole dataset to a billed run.
+			if maxSamples < 0 {
+				return messages.NegativeMaxSamplesFlag(maxSamples)
+			}
+
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			// One flag takes a name or an id. A declared name also brings the
+			// declaration, which is what says where rows come from; a bare id
+			// has none, so the pairing comes from the eval's previous run.
+			evalDir, err := ec.evalDir(ctx, evalPath)
+			if err != nil {
+				return err
+			}
+			ref, err := ec.resolveEvalRef(ctx, evalDir, chooseEvalIn(cmd, evalDir, groupName))
+			if err != nil {
+				return err
+			}
+			evalID := ref.ID
+			group := ref.Eval
+			configPath := ref.ConfigPath
+
+			if datasetName != "" {
+				if !ref.Declared() {
+					return messages.DatasetOverrideNeedsDeclaredEval()
+				}
+				if _, ok := ref.Config.DatasetDeclaration(datasetName); !ok {
+					return messages.DatasetNotInCatalog(
+						datasetName, filepath.ToSlash(configPath))
+				}
+				// The eval keeps its own declaration; only this run reads elsewhere.
+				overridden := *group
+				overridden.Dataset = datasetName
+				overridden.Source = nil
+				group = &overridden
+			}
+
+			if ref.Declared() {
+				if err := ec.checkDatasetRegistered(ctx, ref.Config, group, configPath); err != nil {
+					return err
+				}
+			}
+
+			var dataSource *eval_api.EvalRunDataSource
+			switch {
+			case group == nil:
+				dataSource, err = ec.reuseDataSourceFromLastRun(ctx, evalID)
+			default:
+				dataSource, err = ec.buildRunDataSource(
+					ctx, group, configPath, resolveMaxSamples(maxSamples, group))
+			}
+			if err != nil {
+				return err
+			}
+
+			if runName == "" {
+				base := "eval"
+				if group != nil {
+					base = group.Name
+				}
+				runName = fmt.Sprintf("%s-%s", base, time.Now().UTC().Format("20060102-150405"))
+			}
+
+			metadata := map[string]string{}
+			if lvl := resolveLevel(group); lvl != "" {
+				metadata["evaluation_level"] = lvl
+			}
+			// The eval carries its name in its own metadata, but a run is read
+			// on its own, and an id is not what the author called it.
+			if group != nil && group.Name != "" {
+				metadata[metaEvalName] = group.Name
+			}
+			// Recorded per run, not read from the configuration at list time:
+			// comparing two runs is the point of that listing, and the dataset
+			// under an eval can change between them. A source-backed run scored
+			// no dataset, so it records none.
+			if group != nil && group.Dataset != "" && group.Source == nil {
+				metadata[metaDataset] = group.Dataset
+				if v := ec.getEnvValue(ctx, versionKey("dataset", group.Dataset)); v != "" {
+					metadata[metaDatasetVersion] = v
+				}
+			}
+
+			run, err := ec.evalClient.CreateOpenAIEvalRun(ctx, evalID, &eval_api.CreateOpenAIEvalRunRequest{
+				Name:       runName,
+				DataSource: dataSource,
+				Metadata:   metadata,
+			})
+			if err != nil {
+				return messages.StartingRun(err)
+			}
+
+			// Remembered per group as well as globally: a single shared key
+			// belongs to whichever group ran last, so another group asking for
+			// "the last run" would be handed one that is not its own.
+			ec.remember(ctx, idKey("evalrun", evalID), run.ID)
+			if err := ec.setEnvValue(ctx, envKeyEvalRunID, run.ID); err != nil {
+				// Persisting the run id is a convenience for later commands.
+				// Reported on stdout because azd does not surface an
+				// extension's stderr, and skipped outside a project.
+				if !errors.Is(err, errNoAzdEnvironment) && !isJSON(cmd) {
+					fmt.Fprint(out, messages.Warning(err))
+				}
+			}
+
+			if !wait {
+				if isJSON(cmd) {
+					return emitJSON(out, startedRun(run, evalID, group))
+				}
+				fmt.Fprint(out, messages.RunStarted(run.ID, run.Status))
+				fmt.Fprint(out, messages.ReattachToRun(run.ID, evalID))
+				return nil
+			}
+
+			final, err := ec.pollRun(ctx, evalID, run.ID, out, isJSON(cmd))
+			if errors.Is(err, errWaitBudgetSpent) {
+				// A gate asked for a verdict that never arrived. Exiting 0 here
+				// would tell a pipeline the gate passed, which is the silent
+				// drop --no-wait is refused for, reached by running long.
+				if threshold.set {
+					return messages.GateOutlivedTheWait(run.ID, waitBudget)
+				}
+				// The run did not fail, the wait ran out. Same contract as
+				// --no-wait: exit 0 and say how to pick it back up.
+				if isJSON(cmd) {
+					return emitJSON(out, startedRun(run, evalID, group))
+				}
+				fmt.Fprint(out, messages.WaitBudgetSpent(run.ID, waitBudget))
+				fmt.Fprint(out, messages.ReattachToRun(run.ID, evalID))
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			final = ec.withPortalLink(ctx, evalID, final)
+
+			if isJSON(cmd) {
+				if err := emitJSON(out, final); err != nil {
+					return err
+				}
+			} else if err := renderRun(out, final, ec.runMeans(ctx, evalID, final)); err != nil {
+				return err
+			}
+
+			// Last, so that the results are reported whether or not the gate
+			// holds: a pipeline that only learns it failed is worse off than
+			// one that can see by how much.
+			if err := runCompleted(final); err != nil {
+				return err
+			}
+			applyGate(cmd, threshold, final)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&groupName, "eval", "",
+		"Name of the eval to run, or its id. Defaults to the only one declared.")
+	cmd.Flags().StringVar(&datasetName, "dataset", "",
+		"Catalog dataset to read instead of the one the eval declares. "+
+			"Must satisfy the eval's column schema.")
+	cmd.Flags().StringVar(&runName, "name", "", "Name for this run. Defaults to the eval name plus a timestamp.")
+	cmd.Flags().IntVar(&maxSamples, "max-samples", 0,
+		"Cap the rows sent from the dataset.")
+	cmd.Flags().BoolVar(&wait, "wait", true, "Block until the run reaches a terminal state.")
+	addFailOnFlag(cmd, &failOn)
+	// The spec documents --no-wait, and cobra does not derive it from a bool.
+	var noWait bool
+	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Submit the run and return immediately.")
+	cmd.PreRun = func(*cobra.Command, []string) {
+		if noWait {
+			wait = false
+		}
+	}
+	cmd.MarkFlagsMutuallyExclusive("wait", "no-wait")
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	addEvalPathFlag(cmd, &evalPath)
+
+	return cmd
+}
+
+// checkDatasetRegistered fails when the group's local dataset has edits that
+// were never deployed.
+//
+// A run sends a local dataset inline, so without this the run would evaluate
+// content that no registered version corresponds to: the results are attributed
+// to the eval but cannot be traced back to a dataset version, which
+// makes them impossible to reproduce or compare.
+//
+// The check only applies once a deploy has recorded a fingerprint. Before that
+// there is nothing to have drifted from, and running is how a group first comes
+// into existence.
+func (ec *evalContext) checkDatasetRegistered(
+	ctx context.Context,
+	cfg *project.EvalConfig,
+	group *project.Eval,
+	configPath string,
+) error {
+	localPath := localDatasetPath(configPath, group)
+	if localPath == "" {
+		return nil
+	}
+
+	decl, ok := cfg.DatasetDeclaration(group.Dataset)
+	if !ok {
+		return nil
+	}
+
+	recorded := ec.getEnvValue(ctx, project.FingerprintKey("dataset", decl.Name))
+	if recorded == "" {
+		return nil
+	}
+
+	digest, err := project.Fingerprint(localPath)
+	if err != nil {
+		// Reading the file is the run's problem to report, not this check's.
+		return nil
+	}
+	if digest == recorded {
+		return nil
+	}
+
+	return messages.DatasetHasUnregisteredEdits(decl.Name, ec.deployCommand(ctx))
+}
+
+// reuseDataSourceFromLastRun rebuilds a run's data source from the group's most
+// recent run.
+//
+// `--eval-id` deliberately ignores the config, but a run still needs a target
+// and a dataset, and an eval carries neither: the group holds only its
+// testing criteria, and the dataset travels on the run. The previous run is the
+// only place that pairing survives, so re-running a group means repeating what
+// it last ran.
+func (ec *evalContext) reuseDataSourceFromLastRun(
+	ctx context.Context,
+	evalID string,
+) (*eval_api.EvalRunDataSource, error) {
+	list, err := ec.evalClient.ListOpenAIEvalRuns(ctx, evalID, 1)
+	if err != nil {
+		if eval_api.IsNotFound(err) {
+			// The eval itself is missing, which is worth saying plainly rather
+			// than as forty lines of the 404 that discovered it.
+			return nil, messages.EvalNotFound(evalID)
+		}
+		return nil, messages.ReadingPreviousRuns(evalID, err)
+	}
+	if list == nil || len(list.Data) == 0 || list.Data[0].DataSource == nil {
+		return nil, messages.EvalHasNoPreviousRun(evalID)
+	}
+	return pinReusedTraceWindow(list.Data[0].DataSource), nil
+}
+
+// legacyTraceLookbackHours is the window a legacy source with no lookback ran
+// under: the service's own default of seven days.
+//
+// Recorded here because the old data source had no start bound of its own --
+// it carried agent_name, lookback_hours, end_time and max_traces, and nothing
+// else -- so a run that set no lookback was graded over whatever the service
+// chose. Carrying such a run forward with no start at all would widen it to all
+// of history instead.
+const legacyTraceLookbackHours = 24 * 7
+
+// pinReusedTraceWindow closes the window a reattached run repeats.
+//
+// A run reached by id repeats whatever data source the last one sent, and a
+// trace window with a start and no end means "up to now". Replaying it a week
+// later grades a week more than the run it was copied from, and the run after
+// that more again, so the span grows without limit and nothing says so.
+//
+// A window with no start at all is repeated as it stands: it says "everything",
+// which is what it said when it was recorded, and closing it would freeze a
+// declaration that never asked to be bounded. So is a window that already has
+// an end, which cannot widen and is not this function's to move.
+//
+// It is graded over the span it covers rather than the span it covered: the
+// declaration is where a window that should move with each run comes from, and
+// a run reached by id has no declaration to read. Freezing it once is the
+// closest a shape with no lookback can come to one.
+//
+// Pinning the end at now also excludes traces the service has not finished
+// ingesting, which an open end would have picked up on the next run.
+//
+// The argument is never modified: what the previous run sent is history, and a
+// caller that logs or emits it should see what was recorded.
+func pinReusedTraceWindow(ds *eval_api.EvalRunDataSource) *eval_api.EvalRunDataSource {
+	switch {
+	case ds == nil:
+		return ds
+	case ds.Type == eval_api.EvalRunDataSourceTypeTraces:
+		return upgradeLegacyTraceSource(ds)
+	case ds.Type == eval_api.EvalRunDataSourceTypeTracePreview:
+		if ds.TraceSource == nil || ds.TraceSource.EndTime != 0 || ds.TraceSource.StartTime == 0 {
+			return ds
+		}
+		pinned := *ds
+		filter := *ds.TraceSource
+		filter.EndTime = time.Now().Unix()
+		pinned.TraceSource = &filter
+		return &pinned
+	default:
+		return ds
+	}
+}
+
+// upgradeLegacyTraceSource carries a run recorded under the old trace shape
+// onto the one that keeps what it is given.
+//
+// Without it, an eval whose last run predates the change would keep sending the
+// version-blind source for good, and nothing would say so.
+func upgradeLegacyTraceSource(ds *eval_api.EvalRunDataSource) *eval_api.EvalRunDataSource {
+	// Without an agent the preview shape carries no filter at all, and
+	// omitempty drops it: the reattached run would read every agent's spans,
+	// a broader and costlier query than the one it is repeating. Repeating
+	// what was recorded is the lesser wrong.
+	if ds.AgentName == "" {
+		return ds
+	}
+	end := time.Now()
+	if ds.EndTime > 0 {
+		end = time.Unix(ds.EndTime, 0)
+		// A recorded end in the future would close the window after the last
+		// trace that exists, which reads nothing past now and says nothing.
+		if end.After(time.Now()) {
+			end = time.Now()
+		}
+	}
+	// The recorded values are whatever an older build sent, from before the
+	// bounds existed, so they are clamped rather than trusted: a lookback beyond
+	// what a window may cover reaches back further than any trace was recorded,
+	// and the reattached run reads nothing.
+	hours := ds.LookbackHours
+	if hours <= 0 || hours > project.MaxLookbackHours {
+		hours = legacyTraceLookbackHours
+	}
+	start := end.Add(-time.Duration(hours) * time.Hour)
+	// A recorded end early enough to put the start at or before the epoch would
+	// send a bound the wire drops, or a negative one -- the same silence a
+	// declaration is refused for. Reaching back from now instead keeps the
+	// length of the window the run asked for.
+	if start.Unix() <= 0 {
+		end = time.Now()
+		start = end.Add(-time.Duration(hours) * time.Hour)
+	}
+	// Only reachable on a machine whose clock is set before about 1980, where
+	// even now minus the longest window a declaration may name lands in the
+	// pre-epoch. Dropping the bound says "everything", which is at least what
+	// the legacy shape said when it carried no start.
+	if start.Unix() <= 0 {
+		start = time.Time{}
+	}
+	// A negative cap is no cap at all, and leaving it off means the service's
+	// own default of a thousand traces -- a bigger, costlier run than the one
+	// being repeated. The cap `init` writes is bounded and can be raised in the
+	// declaration, which is the only place a considered value can come from.
+	maxTraces := ds.MaxTraces
+	if maxTraces < 0 {
+		maxTraces = project.DefaultScaffoldMaxTraces
+	}
+	// The old shape carried no version, so this pins nothing that was not
+	// pinned before; it stops the service choosing differently run to run only
+	// once the declaration names one.
+	return eval_api.NewTracePreviewDataSource(ds.AgentName, "", start, end, maxTraces)
+}
+
+// runnableEval refuses a declaration this run could not carry out.
+//
+// The rules live with the check the configuration runs, so the two cannot come
+// to different conclusions about the same eval. Only the wrapper differs: the
+// configuration has an index to name and a run does not.
+func runnableEval(group *project.Eval) error {
+	if err := project.ValidateRunnable(group); err != nil {
+		return messages.InEval(group.Name, err)
+	}
+	return nil
+}
+
+// buildRunDataSource binds the eval's rows to the run.
+//
+// Three shapes, in the order the configuration decides them. A `source:` block
+// hands the gathering to the service and sends nothing local. Otherwise the
+// rows come from a dataset, and `target:` says what to invoke for each one --
+// including nothing at all, when the rows already hold both sides.
+//
+// This is where a declaration is refused, not merely where it is read. Resolving
+// an eval by name does not validate what it says about itself, and a run reached
+// by id has no declaration to validate, so every contradiction the configuration
+// names has to be answered here as well. Settling one by evaluation order sends
+// a request that succeeds and grades something the file did not ask for.
+func (ec *evalContext) buildRunDataSource(
+	ctx context.Context,
+	group *project.Eval,
+	configPath string,
+	maxSamples int,
+) (*eval_api.EvalRunDataSource, error) {
+	if group == nil {
+		return nil, messages.NoEvalToRun()
+	}
+	if err := runnableEval(group); err != nil {
+		return nil, err
+	}
+	if group.Dataset != "" && configPath != "" && !datasetIsDeclared(configPath, group) {
+		return nil, messages.InEval(group.Name, messages.DatasetNotDeclared(group.Dataset))
+	}
+
+	if group.Source != nil {
+		switch group.Source.Type {
+		case project.SourceTypeTraces:
+			return tracesDataSource(group)
+		default:
+			return responsesDataSource(group)
+		}
+	}
+
+	var ds *eval_api.EvalRunDataSource
+	switch {
+	case group.Target == nil || group.Target.Name == "":
+		// Nothing to invoke: the dataset is scored as it stands.
+		ds = eval_api.NewDatasetOnlyDataSource()
+	case group.Target.Type == project.TargetTypeModel:
+		ds = eval_api.NewModelTargetDataSource(group.Target.Name)
+	default:
+		ds = eval_api.NewAgentTargetDataSource(group.Target.Name, nil)
+	}
+
+	if group.Dataset == "" {
+		return nil, messages.EvalHasNoDataset(group.Name)
+	}
+
+	// A local source is read from disk; anything else is already registered and
+	// has to be fetched. Either way the rows are sent inline, because a run's
+	// file_id means an uploaded file and a dataset name is not one: sending the
+	// name is rejected with "invalid data source file ids".
+	localPath := localDatasetPath(configPath, group)
+	if localPath == "" {
+		items, err := ec.readRegisteredDataset(ctx, group.Dataset, maxSamples)
+		if err != nil {
+			return nil, err
+		}
+		ds.SetFileContent(items)
+		return ds, nil
+	}
+
+	items, err := readJSONL(localPath, maxSamples)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, messages.DatasetFileEmpty(localPath)
+	}
+	ds.SetFileContent(items)
+	return ds, nil
+}
+
+// tracesDataSource evaluates conversations the agent already had.
+//
+// The service reads them from Application Insights, so the agent has to be
+// emitting gen_ai.input.messages / gen_ai.output.messages for anything to be
+// found. `agent_name` filters the traces; it is not a target, because a trace
+// run invokes nothing.
+func tracesDataSource(group *project.Eval) (*eval_api.EvalRunDataSource, error) {
+	// runnableEval has already refused an empty one; read rather than assumed,
+	// because the agent name is what the whole request is about.
+	agent := project.TraceAgentName(group.Source, group.Target)
+	if agent == "" {
+		return nil, messages.InEval(group.Name, messages.TraceSourceNeedsAnAgent())
+	}
+
+	start, end, err := traceWindow(group.Name, group.Source)
+	if err != nil {
+		return nil, err
+	}
+	return eval_api.NewTracePreviewDataSource(
+		agent,
+		group.Source.AgentVersion,
+		start,
+		end,
+		group.Source.MaxTraces,
+	), nil
+}
+
+// traceWindow resolves the bounds of the span a trace run reads.
+//
+// The rules live in the project package, with the check the configuration runs,
+// so a source is judged the same way whichever door the eval came through.
+func traceWindow(evalName string, source *project.SourceDecl) (start, end time.Time, err error) {
+	start, end, err = project.ValidateSource(source)
+	if err != nil {
+		return time.Time{}, time.Time{}, messages.InEval(evalName, err)
+	}
+	return start, end, nil
+}
+
+// responsesDataSource evaluates responses the project already stored.
+func responsesDataSource(group *project.Eval) (*eval_api.EvalRunDataSource, error) {
+	if len(group.Source.ResponseIDs) == 0 {
+		return nil, messages.InEval(group.Name, messages.ResponsesSourceNeedsResponseIDs())
+	}
+	return eval_api.NewResponsesDataSource(group.Source.ResponseIDs, group.Source.MaxTurns), nil
+}
+
+// readRegisteredDataset fetches a published dataset's rows, optionally keeping
+// only the first n.
+//
+// The rows have to be fetched because a run cannot reference a dataset by
+// name: `file_id` means an uploaded file, and passing a dataset name there is
+// rejected. Fetching also makes --max-samples mean the same thing whether the
+// dataset is local or published, which a file reference could not — that
+// source carries no row limit.
+func (ec *evalContext) readRegisteredDataset(
+	ctx context.Context,
+	name string,
+	maxSamples int,
+) ([]map[string]any, error) {
+	version := ec.getEnvValue(ctx, versionKey("dataset", name))
+	if version == "" {
+		versions, err := ec.datasetClient.ListDatasetVersions(ctx, name, ProjectEndpointAPIVersion)
+		if err != nil {
+			return nil, messages.ReadingDataset(name, err)
+		}
+		if versions != nil {
+			version = dataset_api.LatestVersion(versions.Value)
+		}
+	}
+	if version == "" {
+		return nil, messages.DatasetHasNoVersionsToRead(name)
+	}
+
+	content, err := ec.datasetClient.DownloadDatasetContent(
+		ctx, name, version, ProjectEndpointAPIVersion)
+	if err != nil {
+		return nil, messages.ReadingDatasetVersion(name, version, err)
+	}
+
+	items, err := readJSONLBytes(content, maxSamples)
+	if err != nil {
+		return nil, messages.ReadingDatasetVersion(name, version, err)
+	}
+	if len(items) == 0 {
+		return nil, messages.DatasetVersionEmpty(name, version)
+	}
+	return items, nil
+}
+
+// datasetColumnsFromPath reads one row to learn the dataset's shape. An empty
+// path, or an unreadable file, yields nil.
+func datasetColumnsFromPath(localPath string) map[string]bool {
+	if localPath == "" {
+		return nil
+	}
+	// One row is enough to learn the shape.
+	items, err := readJSONL(localPath, 1)
+	if err != nil || len(items) == 0 {
+		return nil
+	}
+	columns := make(map[string]bool, len(items[0]))
+	for name := range items[0] {
+		columns[name] = true
+	}
+	return columns
+}
+
+// localDatasetPath resolves the dataset's local source relative to the config
+// file, returning empty when the dataset is registered rather than local.
+func localDatasetPath(configPath string, group *project.Eval) string {
+	cfg, err := project.LoadEvalConfig(configPath)
+	if err != nil || group == nil {
+		return ""
+	}
+	decl, ok := cfg.DatasetDeclaration(group.Dataset)
+	if !ok || decl.Source == "" {
+		return ""
+	}
+	if filepath.IsAbs(decl.Source) {
+		return decl.Source
+	}
+	return filepath.Join(filepath.Dir(configPath), decl.Source)
+}
+
+// datasetIsDeclared says whether the configuration's catalog holds the dataset
+// this eval names.
+//
+// Without it a mistyped name falls through to a registry read and comes back as
+// a 404 for a dataset nobody ever registered, which sends the reader to the
+// service rather than to the line they mistyped. Answered yes when there is no
+// configuration to ask: an eval reached by id has no catalog.
+func datasetIsDeclared(configPath string, group *project.Eval) bool {
+	cfg, err := project.LoadEvalConfig(configPath)
+	if err != nil || cfg == nil {
+		return true
+	}
+	_, ok := cfg.DatasetDeclaration(group.Dataset)
+	return ok
+}
+
+// readJSONL reads newline-delimited JSON, optionally truncating to limit rows.
+func readJSONL(path string, limit int) ([]map[string]any, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, messages.ReadingDataset(path, err)
+	}
+	defer f.Close()
+
+	items, err := scanJSONL(f, limit)
+	if err != nil {
+		return nil, messages.ReadingDataset(path, err)
+	}
+	return items, nil
+}
+
+// readJSONLBytes parses JSONL already in memory, which is how a registered
+// dataset arrives.
+func readJSONLBytes(content []byte, limit int) ([]map[string]any, error) {
+	return scanJSONL(bytes.NewReader(content), limit)
+}
+
+// scanJSONL reads rows until the limit is reached, so a subset costs only the
+// rows it needs to parse.
+func scanJSONL(r io.Reader, limit int) ([]map[string]any, error) {
+	var items []map[string]any
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	line := 0
+	for scanner.Scan() {
+		line++
+		text := strings.TrimSpace(scanner.Text())
+		if text == "" {
+			continue
+		}
+		var row map[string]any
+		if err := json.Unmarshal([]byte(text), &row); err != nil {
+			return nil, messages.JSONLLineInvalid(line, err)
+		}
+		items = append(items, row)
+		if limit > 0 && len(items) >= limit {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+// resolveLevel prefers the flag, then the eval's own declaration.
+// resolveLevel is the eval's declared scoring granularity.
+//
+// There is no per-run override: the level decides the row mapping, so two
+// levels under one eval would put incomparable result sets in the same history,
+// and it would bypass the supported_evaluation_levels check `azd up` does
+// against the declared level. A second level is a second eval.
+func resolveLevel(group *project.Eval) string {
+	if group != nil {
+		return group.EvaluationLevel
+	}
+	return ""
+}
+
+// resolveMaxSamples prefers the flag, then the eval's own declaration, matching
+// how the evaluation level resolves.
+//
+// Without this, max_samples parsed and did nothing: an eval that caps its
+// sample count in config would send the whole dataset, and only a flag on every
+// invocation would honour the cap.
+func resolveMaxSamples(flag int, group *project.Eval) int {
+	if flag > 0 {
+		return flag
+	}
+	if group != nil && group.MaxSamples > 0 {
+		return group.MaxSamples
+	}
+	return 0
+}
+
+// errWaitBudgetSpent says the run outlived the wait, not that anything failed.
+//
+// It is handled where --no-wait is: the run is still going server-side, so the
+// caller is handed the same reattach line and the same exit code.
+var errWaitBudgetSpent = errors.New("wait budget spent")
+
+// waitBudget bounds a foreground wait.
+//
+// Not a policy about how long an evaluation may take -- it is a guard against
+// waiting on a run that will never reach a terminal state. Runs are scored
+// sequentially at roughly 40s a sample, so this clears a few hundred samples
+// before it ever fires.
+const waitBudget = 2 * time.Hour
+
+// pollRun waits for the run to reach a terminal state, reporting status changes.
+func (ec *evalContext) pollRun(
+	ctx context.Context,
+	evalID, runID string,
+	out interface{ Write([]byte) (int, error) },
+	jsonMode bool,
+) (*eval_api.OpenAIEvalRun, error) {
+	const interval = 5 * time.Second
+	lastStatus := ""
+	deadline := time.Now().Add(waitBudget)
+
+	for {
+		run, err := ec.evalClient.GetOpenAIEvalRun(ctx, evalID, runID)
+		if err != nil {
+			return nil, messages.PollingRun(runID, err)
+		}
+		if run.Status != lastStatus {
+			lastStatus = run.Status
+			if !jsonMode {
+				fmt.Fprint(out, messages.RunStatusLine(run.Status))
+			}
+		}
+		if terminalRunStates[strings.ToLower(run.Status)] {
+			return run, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, errWaitBudgetSpent
+		}
+		select {
+		case <-ctx.Done():
+			// Name what is still running, or the run is lost to whoever
+			// interrupted the wait.
+			return nil, messages.WaitInterrupted(runID, ctx.Err())
+		case <-time.After(interval):
+		}
+	}
+}
+
+// startedRunHandoff is what `run start --no-wait -o json` returns.
+//
+// It is a handoff rather than a dump of the service object. The pipeline that
+// started the run has to come back for it later, and doing that needs exactly
+// three things: the run, the eval it belongs to, and a name a human can read
+// in the log that reports it. The service object carries none of the third and
+// buries the first two under the data source, the metadata and every field the
+// API happens to return, so a script reading it would depend on a shape this
+// extension does not control.
+type startedRunHandoff struct {
+	RunID    string `json:"run_id"`
+	EvalID   string `json:"eval_id"`
+	EvalName string `json:"eval_name,omitempty"`
+	// Which rows the run scored. A pipeline that records only a pass rate
+	// cannot say later what the rate was measured against.
+	Dataset        string `json:"dataset,omitempty"`
+	DatasetVersion string `json:"dataset_version,omitempty"`
+	Status         string `json:"status,omitempty"`
+	CreatedAt      string `json:"created_at,omitempty"`
+}
+
+// startedRun builds the handoff.
+func startedRun(
+	run *eval_api.OpenAIEvalRun,
+	evalID string,
+	group *project.Eval,
+) startedRunHandoff {
+	handoff := startedRunHandoff{
+		RunID:     run.ID,
+		EvalID:    evalID,
+		Status:    run.Status,
+		CreatedAt: timestampString(run.CreatedAt),
+	}
+	// Read back from the run rather than the configuration, so the handoff
+	// names what this run scored and not what the file says today. The create
+	// response does not always echo metadata, so the declaration is the
+	// fallback for the name.
+	handoff.Dataset = run.Metadata[metaDataset]
+	handoff.DatasetVersion = run.Metadata[metaDatasetVersion]
+	// Absent with --eval-id, where there is no config to take a name from.
+	if group != nil {
+		handoff.EvalName = group.Name
+		if handoff.Dataset == "" {
+			handoff.Dataset = group.Dataset
+		}
+	}
+	return handoff
+}
+
+// timestampString renders a service timestamp as RFC 3339.
+//
+// The field arrives as epoch seconds on a run and as a formatted string
+// elsewhere, so passing it through would hand a script a value whose type
+// depends on which route produced it.
+func timestampString(value any) string {
+	switch t := value.(type) {
+	case nil:
+		return ""
+	case string:
+		// Normalized, not passed through: the service returns sub-second
+		// precision and an offset here and epoch seconds elsewhere, so two
+		// listings would otherwise spell the same instant differently.
+		if parsed, err := time.Parse(time.RFC3339, t); err == nil {
+			return parsed.UTC().Format(time.RFC3339)
+		}
+		return t
+	case float64:
+		return time.Unix(int64(t), 0).UTC().Format(time.RFC3339)
+	case int64:
+		return time.Unix(t, 0).UTC().Format(time.RFC3339)
+	case json.Number:
+		if seconds, err := t.Int64(); err == nil {
+			return time.Unix(seconds, 0).UTC().Format(time.RFC3339)
+		}
+		return t.String()
+	default:
+		return fmt.Sprint(value)
+	}
+}
+
+// runMeans reads the run's rows to average each evaluator's score.
+//
+// Best effort: the summary is worth printing without the column, and a run
+// that scored nothing has no rows to read.
+func (ec *evalContext) runMeans(
+	ctx context.Context,
+	evalID string,
+	run *eval_api.OpenAIEvalRun,
+) map[string]float64 {
+	if run == nil || run.ResultCounts == nil || run.ResultCounts.Total == 0 {
+		return nil
+	}
+	items, err := ec.evalClient.ListOutputItems(ctx, evalID, run.ID, 0)
+	if err != nil || items == nil {
+		return nil
+	}
+	return criteriaMeans(items.Data)
+}
+
+// timestampTime reads a service timestamp, which arrives as epoch seconds on a
+// run and as a formatted string elsewhere.
+func timestampTime(value any) time.Time {
+	switch t := value.(type) {
+	case float64:
+		return time.Unix(int64(t), 0).UTC()
+	case int64:
+		return time.Unix(t, 0).UTC()
+	case string:
+		if parsed, err := time.Parse(time.RFC3339, t); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+// renderRun prints what a person needs after waiting for a run.
+//
+// means carries each criterion's average score, which the run summary does not
+// return; it is nil when the rows were not fetched, and the column is dropped.
+func renderRun(
+	out interface{ Write([]byte) (int, error) },
+	run *eval_api.OpenAIEvalRun,
+	means map[string]float64,
+) error {
+	fmt.Fprintln(out)
+	renderRunHeader(out, run)
+
+	// A run that failed carries why, and it is usually the only actionable
+	// thing in the response — dropping it leaves the caller with just the word
+	// "failed".
+	if why := run.Failure(); why != "" {
+		fmt.Fprintf(out, "\n%s\n", why)
+	}
+
+	renderCriteriaTable(out, run.PerTestingCriteria, means)
+
+	// Counted over samples, not over verdicts: a sample that failed two
+	// evaluators is one sample to go and look at, and reporting it as two
+	// overstates how much is wrong.
+	if c := run.ResultCounts; c != nil && c.Total > 0 {
+		if rate, scored, ok := scoredPassRate(c); ok {
+			fmt.Fprint(out, messages.OverallPassRate(
+				fmt.Sprintf("%.1f%%", rate*100), c.Passed, scored, c.Total-scored))
+		}
+		if c.Errored > 0 {
+			fmt.Fprint(out, messages.SamplesErrored(c.Errored))
+		}
+		if c.Failed > 0 {
+			fmt.Fprint(out, messages.ViewFailingSamples())
+		}
+	}
+
+	if url := runLink(run.ReportURL, run.PortalURL); url != "" {
+		fmt.Fprint(out, messages.ReportLink(color.CyanString(url)))
+	}
+	return nil
+}
+
+// renderRunHeader prints the run's identity above the per-evaluator table.
+//
+// The eval is named from the metadata the extension wrote at create time,
+// because the run carries only an id and the id is not what anyone declared.
+func renderRunHeader(out interface{ Write([]byte) (int, error) }, run *eval_api.OpenAIEvalRun) {
+	fmt.Fprintf(out, "%-10s %s\n", "Run", run.ID)
+	if name := run.Metadata[metaEvalName]; name != "" {
+		fmt.Fprintf(out, "%-10s %s\n", "Eval", name)
+	} else if run.EvalID != "" {
+		fmt.Fprintf(out, "%-10s %s\n", "Eval", run.EvalID)
+	}
+	if ds := runDatasetLine(run.Metadata); ds != "" {
+		fmt.Fprintf(out, "%-10s %s\n", "Dataset", ds)
+	}
+	fmt.Fprintf(out, "%-10s %s\n", "Status", run.Status)
+	if c := run.ResultCounts; c != nil && c.Total > 0 {
+		fmt.Fprintf(out, "%-10s %d\n", "Samples", c.Total)
+	}
+	if d := runDuration(run); d != "" {
+		fmt.Fprintf(out, "%-10s %s\n", "Duration", d)
+	}
+}
+
+// runDuration reports how long the run took, or "" when either end is missing.
+func runDuration(run *eval_api.OpenAIEvalRun) string {
+	start, end := timestampTime(run.CreatedAt), timestampTime(run.ModifiedAt)
+	if start.IsZero() || end.IsZero() || !end.After(start) {
+		return ""
+	}
+	d := end.Sub(start).Round(time.Second)
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	return fmt.Sprintf("%dm%02ds", int(d.Minutes()), int(d.Seconds())%60)
+}
+
+// renderCriteriaTable prints one row per evaluator.
+//
+// Sorted by name so two runs of the same eval read the same way; the service
+// returns the criteria in whatever order it evaluated them.
+func renderCriteriaTable(
+	out interface{ Write([]byte) (int, error) },
+	results []eval_api.EvalRunCriteriaResult,
+	means map[string]float64,
+) {
+	if len(results) == 0 {
+		return
+	}
+
+	sorted := append([]eval_api.EvalRunCriteriaResult(nil), results...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].TestingCriteria < sorted[j].TestingCriteria
+	})
+
+	width := len("EVALUATOR")
+	for _, r := range sorted {
+		if n := len(r.TestingCriteria); n > width {
+			width = n
+		}
+	}
+
+	fmt.Fprintf(out, "\n%-*s  %4s  %4s  %9s", width, "EVALUATOR", "PASS", "FAIL", "PASS RATE")
+	fmt.Fprintf(out, "%s\n", meanHeader(means))
+	fmt.Fprintf(out, "%s  %s  %s  %s%s\n",
+		strings.Repeat("-", width), "----", "----", "---------", meanRule(means))
+
+	for _, r := range sorted {
+		scored := r.Passed + r.Failed
+		fmt.Fprintf(out, "%-*s  %4d  %4d  %9s",
+			width, r.TestingCriteria, r.Passed, r.Failed, formatRate(r.Passed, scored))
+		if means != nil {
+			if mean, ok := means[r.TestingCriteria]; ok {
+				fmt.Fprintf(out, "  %10.1f", mean)
+			} else {
+				fmt.Fprintf(out, "  %10s", "-")
+			}
+		}
+		fmt.Fprintln(out)
+		// Errors are not failures — the evaluator never reached a verdict —
+		// so they are named rather than folded into the fail column, where
+		// they would look like a quality problem.
+		if r.Errored > 0 {
+			fmt.Fprintf(out, "%-*s  %s\n", width, "", errorNote(r.Errored))
+		}
+	}
+}
+
+// meanHeader and meanRule add the score column only when there are scores.
+func meanHeader(means map[string]float64) string {
+	if means == nil {
+		return ""
+	}
+	return fmt.Sprintf("  %10s", "MEAN SCORE")
+}
+
+func meanRule(means map[string]float64) string {
+	if means == nil {
+		return ""
+	}
+	return "  " + strings.Repeat("-", 10)
+}
+
+// criteriaMeans averages each evaluator's score over the rows it scored.
+//
+// The run summary reports pass and fail counts but no score, so a table that
+// shows how close a passing evaluator came to failing has to read the rows.
+// Errored and unscored rows are left out rather than counted as zero, which
+// would drag the average toward a number no evaluator produced.
+func criteriaMeans(items []eval_api.OutputItem) map[string]float64 {
+	sums := map[string]float64{}
+	counts := map[string]int{}
+	for _, item := range items {
+		for _, r := range item.Results {
+			if !r.Score.Defined() {
+				continue
+			}
+			name := r.Name
+			if name == "" {
+				name = r.Metric
+			}
+			sums[name] += float64(r.Score)
+			counts[name]++
+		}
+	}
+	if len(counts) == 0 {
+		return nil
+	}
+	means := make(map[string]float64, len(counts))
+	for name, n := range counts {
+		means[name] = sums[name] / float64(n)
+	}
+	return means
+}
+
+// errorNote describes rows an evaluator could not score.
+func errorNote(errored int) string {
+	return messages.ErroredNotScored(errored)
+}
+
+// formatRate renders a share as a percentage, and a rate over nothing as a
+// dash: 0.0%% would read as a total failure rather than as no data.
+func formatRate(part, whole int) string {
+	if whole <= 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%.1f%%", float64(part)/float64(whole)*100)
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_list_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_list_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Scenario 3 answers "did my change help?" by reading two rows of `run list`,
+// which only works if a row carries when it ran and how it scored. The columns
+// were RUN ID / NAME / STATUS / RESULTS, so the question the scenario exists to
+// answer could not be.
+func TestRunListColumnsMatchTheScenario(t *testing.T) {
+	counts := &eval_api.EvalRunResultCounts{Total: 15, Passed: 14, Failed: 1}
+
+	assert.Equal(t, "15", sampleCount(counts),
+		"a rate over 15 samples and one over 200 are not the same claim")
+	assert.Equal(t, "93.3%", runPassRate(counts),
+		"the scenario compares 80.0% against 93.3%, so the row has to carry the rate")
+}
+
+// The rate is the gate's arithmetic: passed over the rows that were scored,
+// with errored and skipped outside it. A row a reader gates on must not
+// disagree with the gate that acts on it.
+//
+// The list is the one view that shows a rate next to a sample count, so it also
+// carries how many rows the rate covers. Without that, two passes and one
+// errored row read as SAMPLES 3, PASS RATE 100.0%.
+func TestRunListPassRateAgreesWithTheGate(t *testing.T) {
+	counts := &eval_api.EvalRunResultCounts{Total: 4, Passed: 2, Failed: 1, Errored: 1}
+
+	assert.Equal(t, "66.7% (3 scored)", runPassRate(counts),
+		"2 of the 3 rows that were scored passed, here and in the gate")
+
+	g, err := parseGate("pass-rate=0.8")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, g.breach(counts),
+		"the same counts that read 66.7% must breach an 80% threshold")
+
+	// The errored row is outside the rate rather than counted as a failure, and
+	// the cell says so rather than reading as a clean sweep of the run.
+	assert.Equal(t, "100.0% (2 scored)",
+		runPassRate(&eval_api.EvalRunResultCounts{Total: 3, Passed: 2, Errored: 1}),
+		"nothing graded the errored row, so it is not a miss, but the rate is not the whole run")
+
+	// Nothing unscored, nothing to qualify.
+	assert.Equal(t, "75.0%",
+		runPassRate(&eval_api.EvalRunResultCounts{Total: 4, Passed: 3, Failed: 1}),
+		"every row was scored, so the bare rate is the whole story")
+}
+
+// A run that has not scored yet has no rate to show. An empty cell says that;
+// "0.0%" would say the run failed.
+func TestRunListOmitsARateItCannotCompute(t *testing.T) {
+	assert.Empty(t, runPassRate(nil))
+	assert.Empty(t, runPassRate(&eval_api.EvalRunResultCounts{}))
+	assert.Empty(t, sampleCount(nil))
+}
+
+// Timestamps are RFC3339 in UTC, whichever shape the service sent. The service
+// answers with epoch seconds on some routes and a string on others, and a list
+// that renders both would not sort.
+func TestRunListTimestampsAreRFC3339UTC(t *testing.T) {
+	assert.Equal(t, "2026-08-01T09:15:22Z", timestampString(float64(1785575722)))
+	assert.Equal(t, "2026-08-01T09:15:22Z", timestampString(int64(1785575722)))
+	assert.Equal(t, "2026-08-01T09:15:22Z", timestampString("2026-08-01T09:15:22Z"))
+	assert.Empty(t, timestampString(nil))
+}
+
+// The table shows one rate per run because a column per evaluator stops being
+// readable as soon as two runs score different evaluators. That makes `-o json`
+// the only place a per-evaluator breakdown can be read, and the service does
+// return it on the list route, so the runs go out unprojected.
+//
+// This pins the field name and that it survives marshalling. It does not catch
+// someone replacing the emitted type with a projection, which is the way this
+// would actually be lost -- that needs the command harness the reconciler tests
+// now have.
+func TestRunListJSONCarriesThePerEvaluatorBreakdown(t *testing.T) {
+	var buf bytes.Buffer
+	runs := []eval_api.OpenAIEvalRun{{
+		ID: "evalrun_1",
+		PerTestingCriteria: []eval_api.EvalRunCriteriaResult{
+			{TestingCriteria: "task_adherence", Passed: 14, Failed: 1},
+		},
+	}}
+
+	require.NoError(t, emitJSONList(&buf, runs))
+
+	assert.Contains(t, buf.String(), `"per_testing_criteria_results"`,
+		"the only place a script can read a per-evaluator result")
+	assert.Contains(t, buf.String(), "task_adherence")
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_ops.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_ops.go
@@ -1,0 +1,413 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// addRunSubcommands attaches the atomic run operations.
+//
+// `azd ai eval run` is a group rather than a verb; these are the operations it
+// groups, each reachable without the config file.
+func addRunSubcommands(cmd *cobra.Command) {
+	cmd.AddCommand(
+		newRunListCommand(),
+		newRunShowCommand(),
+		newRunCancelCommand(),
+		newRunDeleteCommand(),
+		newRunOutputCommand(),
+	)
+}
+
+func newRunListCommand() *cobra.Command {
+	var (
+		endpointFlg string
+		groupName   string
+		limit       int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List runs for an eval.",
+		Long: "List runs for an eval.\n\n" +
+			"The table carries one pass rate per run. A per-evaluator breakdown " +
+			"cannot fit a column each and stay readable when runs score different " +
+			"evaluators, so `-o json` carries it instead, under " +
+			"`per_testing_criteria_results` on every run.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			evalID, err := resolveEvalID(cmd, ec, groupName)
+			if err != nil {
+				return err
+			}
+
+			list, err := ec.evalClient.ListOpenAIEvalRuns(ctx, evalID, limit)
+			if err != nil {
+				if eval_api.IsNotFound(err) {
+					return messages.EvalNotDeployed(evalID, ec.deployCommand(ctx))
+				}
+				return messages.ListingRuns(evalID, err)
+			}
+			if isJSON(cmd) {
+				// Emitted whole, unlike `run start`, which hands back a small
+				// handoff. The table cannot show a per-evaluator breakdown, so
+				// this is the only place a script can read one; narrowing these
+				// to the table's columns would drop it silently.
+				var runs []eval_api.OpenAIEvalRun
+				if list != nil {
+					runs = list.Data
+				}
+				return emitJSONList(cmd.OutOrStdout(), runs)
+			}
+			if list == nil || len(list.Data) == 0 {
+				fmt.Fprint(cmd.OutOrStdout(), messages.EvalHasNoRunsLine(evalID))
+				return nil
+			}
+
+			rows := make([][]string, 0, len(list.Data))
+			for _, run := range list.Data {
+				rows = append(rows, []string{
+					run.ID,
+					runDataset(run.Metadata),
+					timestampString(run.CreatedAt),
+					run.Status,
+					sampleCount(run.ResultCounts),
+					runPassRate(run.ResultCounts),
+				})
+			}
+			return emitTable(cmd.OutOrStdout(),
+				[]string{"RUN", "DATASET", "STARTED", "STATUS", "SAMPLES", "PASS RATE"}, rows)
+		},
+	}
+	addEvalFlag(cmd, &groupName)
+	// Registered wherever a declared name is resolved, so a configuration
+	// outside ./evals can be addressed by every command, not just `run start`.
+	addEvalPathFlag(cmd, new(string))
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"Return at most this many runs. Omit for the service default.")
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+func newRunShowCommand() *cobra.Command {
+	var (
+		endpointFlg string
+		groupName   string
+		wait        bool
+		failOn      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "show [run]",
+		Short: "Show a single run.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			threshold, err := parseGate(failOn)
+			if err != nil {
+				return err
+			}
+
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			evalID, err := resolveEvalID(cmd, ec, groupName)
+			if err != nil {
+				return err
+			}
+
+			runID := firstArg(args)
+			run, err := ec.latestOrNamedRun(cmd, evalID, runID, runID != "")
+			if err != nil {
+				return err
+			}
+			run = ec.withPortalLink(ctx, evalID, run)
+
+			// Reattaching to a run started asynchronously: the pipeline that
+			// gates on it is often not the one that started it.
+			//
+			// Only a caller that waited is told a bad status through the exit
+			// code. Without --wait this is an inspection command: it was asked
+			// what happened, and answering that is a success whatever the
+			// answer.
+			gateOnStatus := wait
+			if wait {
+				run, err = ec.pollRun(ctx, evalID, run.ID, cmd.OutOrStdout(), isJSON(cmd))
+				if err != nil {
+					return err
+				}
+			}
+
+			// The spec puts --fail-on on the commands that wait. Gating a run
+			// that is still moving would read partial counts; ignoring the flag
+			// would leave a pipeline believing it is gated when it is not.
+			if threshold.set && !runIsTerminal(run) {
+				return messages.GateNeedsATerminalRun(run.ID, run.Status)
+			}
+
+			if isJSON(cmd) {
+				if err := emitJSON(cmd.OutOrStdout(), run); err != nil {
+					return err
+				}
+				if gateOnStatus {
+					if err := runCompleted(run); err != nil {
+						return err
+					}
+				}
+				applyGate(cmd, threshold, run)
+				return nil
+			}
+
+			out := cmd.OutOrStdout()
+			fmt.Fprint(out, messages.RunHeading(run.ID))
+			fmt.Fprint(out, messages.RunNameLine(run.Name))
+			fmt.Fprint(out, messages.RunStatusDetail(run.Status))
+			if counts := summarizeCounts(run.ResultCounts); counts != "" {
+				fmt.Fprint(out, messages.RunResultsLine(counts))
+			}
+			if url := runLink(run.ReportURL, run.PortalURL); url != "" {
+				fmt.Fprint(out, messages.RunReportLine(color.CyanString(url)))
+			}
+			if gateOnStatus {
+				if err := runCompleted(run); err != nil {
+					return err
+				}
+			}
+			applyGate(cmd, threshold, run)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&wait, "wait", false,
+		"Block until the run reaches a terminal state before reporting.")
+	addFailOnFlag(cmd, &failOn)
+	addEvalFlag(cmd, &groupName)
+	// Registered wherever a declared name is resolved, so a configuration
+	// outside ./evals can be addressed by every command, not just `run start`.
+	addEvalPathFlag(cmd, new(string))
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// firstArg returns the positional argument, or empty when none was given.
+func firstArg(args []string) string {
+	if len(args) > 0 {
+		return args[0]
+	}
+	return ""
+}
+
+func newRunCancelCommand() *cobra.Command {
+	var (
+		endpointFlg string
+		groupName   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "cancel [run]",
+		Short: "Cancel an in-flight run.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			evalID, err := resolveEvalID(cmd, ec, groupName)
+			if err != nil {
+				return err
+			}
+
+			runID := firstArg(args)
+			target, err := ec.latestOrNamedRun(cmd, evalID, runID, runID != "")
+			if err != nil {
+				return err
+			}
+			// Cancelling a run that already finished is a no-op worth naming,
+			// since the service reports success either way. Lowercased to match
+			// the polling path: the service's casing is not guaranteed.
+			if terminalRunStates[strings.ToLower(target.Status)] {
+				return messages.RunAlreadyFinished(target.ID, target.Status)
+			}
+
+			canceled, err := ec.evalClient.CancelOpenAIEvalRun(ctx, evalID, target.ID)
+			if err != nil {
+				return messages.CancellingRun(target.ID, err)
+			}
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), canceled)
+			}
+			status := canceled.Status
+			if status == "" {
+				status = "cancelling"
+			}
+			fmt.Fprint(cmd.OutOrStdout(), messages.RunIsNow(target.ID, status))
+			return nil
+		},
+	}
+	addEvalFlag(cmd, &groupName)
+	// Registered wherever a declared name is resolved, so a configuration
+	// outside ./evals can be addressed by every command, not just `run start`.
+	addEvalPathFlag(cmd, new(string))
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// newRunDeleteCommand removes a run.
+//
+// Runs accumulate — every `run start` adds one — and a run that evaluated the
+// wrong dataset or target is noise in every later listing. The run is required
+// rather than defaulted to the most recent, because deleting is not undoable
+// and "the latest one" is a poor thing to guess at.
+func newRunDeleteCommand() *cobra.Command {
+	var (
+		endpointFlg string
+		groupName   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "delete <run>",
+		Short: "Delete a run.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			runID := args[0]
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			evalID, err := resolveEvalID(cmd, ec, groupName)
+			if err != nil {
+				return err
+			}
+
+			if err := ec.evalClient.DeleteOpenAIEvalRun(ctx, evalID, runID); err != nil {
+				if eval_api.IsNotFound(err) {
+					return messages.RunNotFound(runID, evalID)
+				}
+				return messages.DeletingRun(runID, err)
+			}
+
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), map[string]string{
+					"id": runID, "eval_id": evalID, "status": "deleted",
+				})
+			}
+			fmt.Fprint(cmd.OutOrStdout(), messages.RunDeleted(runID))
+			return nil
+		},
+	}
+	addEvalFlag(cmd, &groupName)
+	// Registered wherever a declared name is resolved, so a configuration
+	// outside ./evals can be addressed by every command, not just `run start`.
+	addEvalPathFlag(cmd, new(string))
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+func summarizeCounts(counts *eval_api.EvalRunResultCounts) string {
+	if counts == nil {
+		return ""
+	}
+	return messages.CountsSummary(counts.Passed, counts.Failed, counts.Errored)
+}
+
+// metaDataset and metaDatasetVersion record which rows a run scored. The run's
+// own data source cannot answer it: the rows travel inline, so the name that
+// selected them is not in the request the service keeps.
+const (
+	metaDataset        = "azd_dataset"
+	metaDatasetVersion = "azd_dataset_version"
+	// metaEvalName is the eval's declared name, recorded on the run because a
+	// run is read on its own and an id is not what the author called it.
+	metaEvalName = "azd_eval"
+	// metaAgent is the agent an eval targets.
+	metaAgent = "azd_agent"
+	// metaDescription carries an eval's description: the create request has no
+	// field of its own for it.
+	metaDescription = "azd_description"
+)
+
+// runDataset renders the dataset a run scored, versioned when a version was
+// recorded with it.
+//
+// A run started before this was recorded shows nothing rather than the name in
+// the configuration today, which is the one thing the column exists to detect
+// having changed.
+func runDataset(metadata map[string]string) string {
+	name := metadata[metaDataset]
+	if name == "" {
+		return ""
+	}
+	if version := metadata[metaDatasetVersion]; version != "" {
+		return fmt.Sprintf("%s (v%s)", name, version)
+	}
+	return name
+}
+
+// runDatasetLine is the same fact spelled for a detail view, where there is
+// room for the whole word.
+func runDatasetLine(metadata map[string]string) string {
+	name := metadata[metaDataset]
+	if name == "" {
+		return ""
+	}
+	if version := metadata[metaDatasetVersion]; version != "" {
+		return fmt.Sprintf("%s (version %s)", name, version)
+	}
+	return name
+}
+
+// sampleCount is how many rows the run scored, which is what makes two rows of
+// `run list` comparable: a rate over 15 samples and one over 200 are not the
+// same claim.
+func sampleCount(counts *eval_api.EvalRunResultCounts) string {
+	if counts == nil {
+		return ""
+	}
+	return strconv.Itoa(counts.Total)
+}
+
+// runPassRate is the same scored pass rate the gate uses, so a row a reader
+// gates on cannot disagree with the gate.
+//
+// The rate is followed by the rows it was measured over whenever that is fewer
+// than the run's samples. Without it the comparison view reads a run of two
+// passes and one errored row as SAMPLES 3, PASS RATE 100.0%, which is the one
+// place the scored denominator was not stated and so the one place a partly
+// errored run looked perfect.
+func runPassRate(counts *eval_api.EvalRunResultCounts) string {
+	rate, scored, ok := scoredPassRate(counts)
+	if !ok {
+		return ""
+	}
+	out := fmt.Sprintf("%.1f%%", rate*100)
+	if counts.Total > scored {
+		out += fmt.Sprintf(" (%d scored)", scored)
+	}
+	return out
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_output.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_output.go
@@ -1,0 +1,701 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"azureaieval/internal/messages"
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+// newRunOutputCommand groups the per-sample views of a run.
+//
+// `run show` is the summary - how many passed. These are the rows: which ones
+// failed, and why.
+func newRunOutputCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "output",
+		Short: "Inspect the per-sample results of a run.",
+	}
+	cmd.AddCommand(
+		newRunOutputListCommand(),
+		newRunOutputShowCommand(),
+		newRunOutputExportCommand(),
+	)
+	return cmd
+}
+
+func newRunOutputListCommand() *cobra.Command {
+	var (
+		failedOnly  bool
+		outFile     string
+		endpointFlg string
+		groupName   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list [run]",
+		Short: "List the per-sample results of a run.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			evalID, err := resolveEvalID(cmd, ec, groupName)
+			if err != nil {
+				return err
+			}
+
+			runID := firstArg(args)
+			run, err := ec.latestOrNamedRun(cmd, evalID, runID, runID != "")
+			if err != nil {
+				return err
+			}
+
+			// The run carries totals and a per-criterion breakdown. The output
+			// items are the rows themselves, which is what "which one failed,
+			// and why" needs. A run that never produced any still renders its
+			// totals rather than failing.
+			items, err := ec.evalClient.ListOutputItems(ctx, evalID, run.ID, 0)
+			if err != nil {
+				return messages.ReadingRunResults(run.ID, err)
+			}
+			rows := items.Data
+			if failedOnly {
+				kept := make([]eval_api.OutputItem, 0, len(rows))
+				for _, it := range rows {
+					if it.Failed() {
+						kept = append(kept, it)
+					}
+				}
+				rows = kept
+			}
+
+			// A bare array, as every other list emits. Wrapping the rows beside
+			// the run made `-o json` the one listing a script could not iterate,
+			// and it failed silently: the loop walked the two keys instead. The
+			// run itself is what `run show` answers.
+			if outFile != "" {
+				f, err := os.Create(outFile)
+				if err != nil {
+					return messages.Creating(outFile, err)
+				}
+				if err := emitJSONList(f, rows); err != nil {
+					_ = f.Close()
+					return err
+				}
+				// The last write is flushed by Close, so discarding its error
+				// reports success over a file that stops mid-row.
+				if err := f.Close(); err != nil {
+					return messages.Writing(outFile, err)
+				}
+				return nil
+			}
+			if isJSON(cmd) {
+				return emitJSONList(cmd.OutOrStdout(), rows)
+			}
+			return renderResults(cmd.OutOrStdout(), run, rows, failedOnly)
+		},
+	}
+
+	cmd.Flags().BoolVar(&failedOnly, "failed-only", false, "Show only the rows that failed.")
+	cmd.Flags().StringVar(&outFile, "output-file", "", "Write JSON results to this path.")
+	addEvalFlag(cmd, &groupName)
+	// Registered wherever a declared name is resolved, so a configuration
+	// outside ./evals can be addressed by every command, not just `run start`.
+	addEvalPathFlag(cmd, new(string))
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// newRunOutputShowCommand reads one evaluated row by its id.
+//
+// The listing truncates the input and the reason to keep a table readable, so
+// this is how the whole of either is seen.
+func newRunOutputShowCommand() *cobra.Command {
+	var (
+		runID       string
+		endpointFlg string
+		groupName   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "show <output-item>",
+		Short: "Show a single evaluated row.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			itemID := args[0]
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			evalID, err := resolveEvalID(cmd, ec, groupName)
+			if err != nil {
+				return err
+			}
+
+			run, err := ec.latestOrNamedRun(cmd, evalID, runID, runID != "")
+			if err != nil {
+				return err
+			}
+
+			item, err := ec.evalClient.GetOutputItem(ctx, evalID, run.ID, itemID)
+			if err != nil {
+				if eval_api.IsNotFound(err) {
+					return messages.OutputItemNotFound(itemID, run.ID)
+				}
+				return messages.ReadingOutputItem(itemID, err)
+			}
+			if isJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), item)
+			}
+			return renderOutputItem(cmd.OutOrStdout(), item)
+		},
+	}
+
+	cmd.Flags().StringVar(&runID, "run", "", "Run the item belongs to. Defaults to the most recent run.")
+	addEvalFlag(cmd, &groupName)
+	// Registered wherever a declared name is resolved, so a configuration
+	// outside ./evals can be addressed by every command, not just `run start`.
+	addEvalPathFlag(cmd, new(string))
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// writeExport renders a run in the requested export format.
+//
+// Separate from the command so the file path can close explicitly and report
+// the failure. A deferred Close cannot reach an unnamed return, so discarding
+// it exits 0 over an export that stops mid-row.
+func writeExport(w io.Writer, format string, run *eval_api.OpenAIEvalRun) error {
+	switch format {
+	case formatCSV:
+		return writeResultsCSV(w, run)
+	case formatJSON:
+		return emitJSON(w, run)
+	case formatJSONL:
+		return writeResultsJSONL(w, run)
+	default:
+		return messages.ExportFormatUnsupported(
+			format, formatCSV, formatJSON, formatJSONL)
+	}
+}
+
+func newRunOutputExportCommand() *cobra.Command {
+	var (
+		format      string
+		outFile     string
+		endpointFlg string
+		groupName   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "export [run]",
+		Short: "Export run results as CSV, JSON or JSONL.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format = strings.ToLower(format)
+			// Checked against the same set the writer switches on: this guard
+			// used to name only json and csv, so --format jsonl was refused by a
+			// CLI whose own help offered it.
+			switch format {
+			case formatCSV, formatJSON, formatJSONL:
+			default:
+				return messages.ExportFormatUnsupported(
+					format, formatCSV, formatJSON, formatJSONL)
+			}
+
+			ctx := cmd.Context()
+			ec, err := newEvalContext(ctx, endpointFlg)
+			if err != nil {
+				return err
+			}
+			defer ec.Close()
+
+			evalID, err := resolveEvalID(cmd, ec, groupName)
+			if err != nil {
+				return err
+			}
+
+			runID := firstArg(args)
+			run, err := ec.latestOrNamedRun(cmd, evalID, runID, runID != "")
+			if err != nil {
+				return err
+			}
+
+			if outFile == "" {
+				return writeExport(cmd.OutOrStdout(), format, run)
+			}
+
+			f, createErr := os.Create(outFile)
+			if createErr != nil {
+				return messages.Creating(outFile, createErr)
+			}
+			writeErr := writeExport(f, format, run)
+			// The last write is flushed by Close, so discarding its error
+			// reports success over a file that stops mid-row.
+			closeErr := f.Close()
+			if writeErr != nil {
+				return writeErr
+			}
+			if closeErr != nil {
+				return messages.Writing(outFile, closeErr)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&format, "format", formatCSV,
+		fmt.Sprintf("Output format: %s, %s or %s.", formatCSV, formatJSON, formatJSONL))
+	cmd.Flags().StringVar(&outFile, "output-file", "", "Write to this path instead of stdout.")
+	addEvalFlag(cmd, &groupName)
+	// Registered wherever a declared name is resolved, so a configuration
+	// outside ./evals can be addressed by every command, not just `run start`.
+	addEvalPathFlag(cmd, new(string))
+	cmd.Flags().StringVar(&endpointFlg, "project-endpoint", "", "Foundry project endpoint.")
+	return cmd
+}
+
+// resolveEvalID resolves the eval a run command is about, from --eval or from
+// the declaration the configuration holds.
+//
+// --eval accepts a name or a raw id on the one flag: an eval created outside a
+// project has no declaration to name, and the environment records one id per
+// name, so editing a declaration leaves every run of the previous eval
+// reachable only by id.
+//
+// It takes no positional argument, deliberately. The positional on `run show`,
+// `run cancel` and `run output *` is a *run* id, and a signature that accepted
+// either would let one be resolved as the other -- a destructive verb aimed at
+// a resource picked by accident.
+//
+// It reads no EVAL_ID either. Every deploy writes that key, so nothing tells a
+// value meant for this declaration from one left behind by the eval it
+// replaced; `run cancel` used to cancel a run of an eval the file no longer
+// described. The declaration is asked instead, which is how `run start`
+// decides it, so the two doors cannot pick different evals.
+func resolveEvalID(cmd *cobra.Command, ec *evalContext, groupName string) (string, error) {
+	evalDir, err := ec.evalDir(cmd.Context(), evalPathFlag(cmd))
+	if err != nil {
+		return "", err
+	}
+	// The same prompt `run start` gets. Without it a project declaring two
+	// evals could start a run by answering a question, and then not list,
+	// show or cancel it without repeating the answer as a flag.
+	ref, err := ec.resolveEvalRef(cmd.Context(), evalDir, chooseEvalIn(cmd, evalDir, groupName))
+	if err != nil {
+		return "", err
+	}
+	return ref.ID, nil
+}
+
+// addEvalFlag registers the flag that says which eval a command acts on. It
+// takes a name from the configuration or a raw service id, which is why there
+// is no second --eval-id beside it.
+func addEvalFlag(cmd *cobra.Command, target *string) {
+	cmd.Flags().StringVar(target, "eval", "",
+		"Name of the eval declared in the configuration, or its id.")
+}
+
+// addEvalPathFlag registers --path on a command that reads the configuration.
+//
+// It defaults to empty rather than to ./evals so that "not given" stays
+// distinguishable from "given the default", which is what lets the path `init`
+// recorded take effect in between.
+func addEvalPathFlag(cmd *cobra.Command, target *string) {
+	// No backticks: pflag reads a word in back quotes as the value placeholder,
+	// so `init` rendered the flag as "--path init" instead of "--path string".
+	cmd.Flags().StringVar(target, "path", "",
+		"Directory holding azure.eval.yaml. Defaults to the path init used, then ./evals.")
+}
+
+// evalPathFlag reads --path from whichever command is resolving a declared
+// name, so every one of them can be told where the configuration is.
+//
+// Read off the command rather than threaded through seven call sites. Without
+// it only `run start` offered the flag, so a configuration outside ./evals
+// could be run and then not listed, shown or cancelled -- the fallback that
+// covers the difference is a path recorded in the azd environment, which a
+// --project-endpoint caller does not have.
+func evalPathFlag(cmd *cobra.Command) string {
+	if f := cmd.Flags().Lookup("path"); f != nil {
+		return f.Value.String()
+	}
+	return ""
+}
+
+// latestOrNamedRun returns the named run, or the most recent one for the eval.
+//
+// explicit says whether the caller named the run rather than leaving it to
+// default. A remembered run that no longer resolves is worth falling through
+// on; one that was asked for by name is not.
+//
+// The remembered id is preferred over the service's listing, and deliberately.
+// Listing looks like the fix for two concurrent starts leaving this key holding
+// whichever wrote last, but ListOpenAIEvalRuns sends no order parameter, so
+// "the first row" is not promised to be the newest; and `run cancel` defaults
+// through here, so guessing would cancel a run this environment never started.
+// The remembered id is at least scoped to the environment that made it.
+func (ec *evalContext) latestOrNamedRun(
+	cmd *cobra.Command,
+	evalID, runID string,
+	explicit bool,
+) (*eval_api.OpenAIEvalRun, error) {
+	ctx := cmd.Context()
+
+	// The remembered run is per group. A single shared one belongs to whichever
+	// group ran last, and asking another group for it returns 404 rather than
+	// that group's own latest run.
+	if runID == "" {
+		runID = ec.getEnvValue(ctx, idKey("evalrun", evalID))
+	}
+	if runID != "" {
+		run, err := ec.evalClient.GetOpenAIEvalRun(ctx, evalID, runID)
+		if err == nil {
+			return run, nil
+		}
+		if explicit {
+			return nil, messages.ReadingRun(runID, err)
+		}
+	}
+
+	list, err := ec.evalClient.ListOpenAIEvalRuns(ctx, evalID, 1)
+	if err != nil {
+		if eval_api.IsNotFound(err) {
+			return nil, messages.EvalNotDeployed(evalID, ec.deployCommand(ctx))
+		}
+		return nil, messages.ListingRuns(evalID, err)
+	}
+	if list == nil || len(list.Data) == 0 {
+		return nil, messages.EvalHasNoRuns(evalID)
+	}
+	return &list.Data[0], nil
+}
+
+// renderOutputItem is the detail view for one evaluated row.
+//
+// This was the one `show` that emitted raw JSON whatever was asked for, which
+// made the command a person reaches for after a failing listing the hardest one
+// to read. The listing truncates the reason to a cell; this is where the whole
+// of it lives, so the reasons are printed in full rather than wrapped or cut.
+//
+// Results are grouped by evaluator: a rubric reports one result per dimension,
+// all carrying the evaluator's name, and printing them flat would read as
+// several evaluators that happen to share a name.
+func renderOutputItem(w io.Writer, item *eval_api.OutputItem) error {
+	if item == nil {
+		return messages.OutputItemEmpty()
+	}
+	if err := emitDetail(w, []field{
+		{"Item", item.ID},
+		{"Run", item.RunID},
+		{"Status", item.Status},
+	}); err != nil {
+		return err
+	}
+
+	order := make([]string, 0, len(item.Results))
+	byName := make(map[string][]eval_api.OutputResult, len(item.Results))
+	for _, r := range item.Results {
+		if _, seen := byName[r.Name]; !seen {
+			order = append(order, r.Name)
+		}
+		byName[r.Name] = append(byName[r.Name], r)
+	}
+
+	for _, name := range order {
+		results := byName[name]
+		fmt.Fprintln(w)
+
+		// The service repeats the evaluator's name in `metric` for a
+		// single-score evaluator, so a group is only worth nesting when its
+		// results name dimensions of their own.
+		if len(results) == 1 && (results[0].Metric == "" || results[0].Metric == name) {
+			r := results[0]
+			fmt.Fprint(w, messages.OutputItemVerdict(
+				name, formatScore(r.Score), verdictWord(r)))
+			if r.Reason != "" {
+				fmt.Fprint(w, messages.OutputItemReason(r.Reason))
+			}
+			continue
+		}
+
+		fmt.Fprint(w, messages.OutputItemEvaluator(name))
+		for _, r := range results {
+			label := r.Metric
+			if label == "" {
+				label = r.Name
+			}
+			fmt.Fprint(w, messages.OutputItemMetric(
+				label, formatScore(r.Score), verdictWord(r)))
+			if r.Reason != "" {
+				fmt.Fprint(w, messages.OutputItemReason(r.Reason))
+			}
+		}
+	}
+	return nil
+}
+
+// verdictWord spells a boolean the way the rest of the output does.
+func verdictWord(r eval_api.OutputResult) string {
+	if !r.Judged() {
+		// The evaluator returned no verdict, which is not the same as returning
+		// a failing one -- it says nothing about the sample.
+		return "no verdict"
+	}
+	if r.DidPass() {
+		return "pass"
+	}
+	return "fail"
+}
+
+// formatScore prints a judge's score at the two decimals the scale carries.
+// formatScore shows a score, or a dash where there is none. An evaluator that
+// errored on a row still sends a result, and its score decodes to NaN; printing
+// that verbatim put "NaN" in the SCORE column.
+func formatScore(score eval_api.LenientFloat) string {
+	if !score.Defined() {
+		return "-"
+	}
+	return strconv.FormatFloat(float64(score), 'f', 2, 64)
+}
+
+// meanScoreOf averages a sample's scores so the list can tell a bare pass from
+// a strong one. Pass/fail alone sent anyone asking "how well?" to the portal.
+//
+// Rows an evaluator errored on are left out rather than counted, the same rule
+// criteriaMeans applies to the summary: averaging a NaN in makes the whole
+// sample read NaN, and counting it as zero drags the mean toward a number no
+// evaluator produced.
+func meanScoreOf(results []eval_api.OutputResult) string {
+	total := 0.0
+	scored := 0
+	for _, r := range results {
+		if !r.Score.Defined() {
+			continue
+		}
+		total += float64(r.Score)
+		scored++
+	}
+	if scored == 0 {
+		return "-"
+	}
+	return strconv.FormatFloat(total/float64(scored), 'f', 2, 64)
+}
+
+func renderResults(
+	w io.Writer,
+	run *eval_api.OpenAIEvalRun,
+	items []eval_api.OutputItem,
+	failedOnly bool,
+) error {
+	fmt.Fprint(w, messages.RunStatusHeading(run.ID, run.Status))
+
+	if c := run.ResultCounts; c != nil {
+		fmt.Fprint(w, messages.ResultTotals(c.Passed, c.Failed, c.Errored))
+	}
+
+	if len(run.PerTestingCriteria) > 0 {
+		rows := make([][]string, 0, len(run.PerTestingCriteria))
+		for _, cr := range run.PerTestingCriteria {
+			if failedOnly && cr.Failed == 0 {
+				continue
+			}
+			rows = append(rows, []string{
+				cr.TestingCriteria,
+				strconv.Itoa(cr.Passed),
+				strconv.Itoa(cr.Failed),
+			})
+		}
+		if len(rows) > 0 {
+			if err := emitTable(w, []string{"CRITERION", "PASSED", "FAILED"}, rows); err != nil {
+				return err
+			}
+		}
+	}
+
+	// The rows are the point of `results show`: totals say how many failed,
+	// these say which and why.
+	if len(items) == 0 {
+		if failedOnly {
+			fmt.Fprint(w, messages.NoFailingRows())
+		} else {
+			fmt.Fprint(w, messages.NoRowsScored())
+		}
+	} else {
+		fmt.Fprintln(w)
+		rows := make([][]string, 0, len(items))
+		var rowsFailed, rowsUnscored int
+		for _, it := range items {
+			// One row per evaluated sample, not per verdict: a sample that
+			// failed three evaluators is one sample to go and look at, and
+			// listing it three times buries how much is actually wrong.
+			//
+			// An evaluator that returned no verdict is held apart from one that
+			// returned a failing verdict. Both keep the row, because the row is
+			// still worth looking at, but naming an errored evaluator among the
+			// ones the sample failed states something about the sample that
+			// nothing measured.
+			var failed, unjudged []string
+			reason := ""
+			for _, r := range it.Results {
+				switch {
+				case !r.Judged():
+					unjudged = append(unjudged, r.Name)
+				case r.DidPass():
+					continue
+				default:
+					failed = append(failed, r.Name)
+				}
+				if reason == "" {
+					reason = r.Reason
+				}
+			}
+			// The same predicate `-o json` filters on, so the two views of
+			// --failed-only cannot disagree about which rows went wrong.
+			if failedOnly && !it.Failed() {
+				continue
+			}
+			verdicts := strings.Join(failed, ", ")
+			if len(unjudged) > 0 {
+				note := strings.Join(unjudged, ", ") + " (no verdict)"
+				if verdicts == "" {
+					verdicts = note
+				} else {
+					verdicts += "; " + note
+				}
+			}
+			if verdicts == "" {
+				verdicts = "-"
+			}
+			if len(failed) > 0 {
+				rowsFailed++
+			} else {
+				rowsUnscored++
+			}
+			// No position column. It numbered within the current filter, so the
+			// same sample carried a different number depending on the flags while
+			// reading like an identifier -- and ITEM already carries the id, which
+			// is what `run output show` accepts.
+			rows = append(rows, []string{
+				it.ID,
+				meanScoreOf(it.Results),
+				truncate(verdicts, 40),
+				truncate(reason, 44),
+			})
+		}
+		// Only the first failure's reason fits a cell; `run output show` has
+		// the rest.
+		if err := emitTable(w,
+			[]string{"ITEM", "SCORE", "EVALUATORS", "REASON"},
+			rows); err != nil {
+			return err
+		}
+		// Counting unscored rows as failures put a number here that contradicted
+		// the totals two lines above, which is what a reader compares it with.
+		if failedOnly && len(rows) > 0 {
+			fmt.Fprint(w, messages.SamplesNeedingALook(rowsFailed, rowsUnscored))
+		}
+	}
+
+	if url := runLink(run.ReportURL, run.PortalURL); url != "" {
+		fmt.Fprint(w, messages.ReportLinkAfterRows(color.CyanString(url)))
+	}
+	return nil
+}
+
+// truncate keeps a table readable when a reason runs to a paragraph. The full
+// text is always in `-o json`.
+func truncate(s string, n int) string {
+	s = strings.ReplaceAll(strings.ReplaceAll(s, "\n", " "), "\r", "")
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}
+
+func writeResultsCSV(w io.Writer, run *eval_api.OpenAIEvalRun) error {
+	cw := csv.NewWriter(w)
+
+	// Named as the service names it, and as the jsonl export already did, so a
+	// pipeline reading both formats needs one spelling rather than two.
+	if err := cw.Write([]string{"run_id", "status", "testing_criteria", "passed", "failed"}); err != nil {
+		return err
+	}
+	if len(run.PerTestingCriteria) == 0 {
+		if err := cw.Write([]string{run.ID, run.Status, "", "", ""}); err != nil {
+			return err
+		}
+		return flushCSV(cw)
+	}
+	for _, cr := range run.PerTestingCriteria {
+		if err := cw.Write([]string{
+			run.ID, run.Status, cr.TestingCriteria,
+			strconv.Itoa(cr.Passed), strconv.Itoa(cr.Failed),
+		}); err != nil {
+			return err
+		}
+	}
+	return flushCSV(cw)
+}
+
+// flushCSV reports what the buffer swallowed.
+//
+// csv.Writer buffers, so a disk that filled or a pipe that closed shows up only
+// in Error() after the final Flush. Deferring the flush and returning nil made
+// `run output export` report success over a file it had not finished writing.
+func flushCSV(cw *csv.Writer) error {
+	cw.Flush()
+	return cw.Error()
+}
+
+// Export formats. csv is the default because the results are a table and a
+// build artifact is normally read by a spreadsheet or a diff.
+const (
+	formatCSV   = "csv"
+	formatJSON  = "json"
+	formatJSONL = "jsonl"
+)
+
+// writeResultsJSONL emits one criterion per line, which is what a downstream
+// job can stream without holding the whole run in memory.
+func writeResultsJSONL(w io.Writer, run *eval_api.OpenAIEvalRun) error {
+	enc := json.NewEncoder(w)
+	if len(run.PerTestingCriteria) == 0 {
+		return enc.Encode(map[string]any{"run_id": run.ID, "status": run.Status})
+	}
+	for _, cr := range run.PerTestingCriteria {
+		if err := enc.Encode(map[string]any{
+			"run_id":           run.ID,
+			"status":           run.Status,
+			"testing_criteria": cr.TestingCriteria,
+			"passed":           cr.Passed,
+			"failed":           cr.Failed,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_render_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/run_render_test.go
@@ -1,0 +1,261 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scoredRun is a run the way the service returns one, with rows attached.
+func scoredRows() []eval_api.OutputItem {
+	return []eval_api.OutputItem{
+		{
+			ID: "oi_1",
+			Results: []eval_api.OutputResult{
+				{Name: "relevance", Passed: new(true), Score: 5},
+				{Name: "coherence", Passed: new(true), Score: 4},
+			},
+		},
+		{
+			ID: "oi_2",
+			Results: []eval_api.OutputResult{
+				{Name: "relevance", Passed: new(false), Score: 1, Reason: "Answered a different question."},
+				{Name: "coherence", Passed: new(false), Score: 2, Reason: "Rambled."},
+			},
+		},
+	}
+}
+
+// One evaluated sample is one row. Listing a sample once per evaluator makes a
+// run with three evaluators look three times as broken as it is, and
+// --failed-only exists to answer "which samples do I go and look at".
+func TestRenderResultsIsOneRowPerSample(t *testing.T) {
+	var out bytes.Buffer
+	run := &eval_api.OpenAIEvalRun{ID: "evalrun_1", Status: "completed"}
+	require.NoError(t, renderResults(&out, run, scoredRows(), false))
+
+	text := out.String()
+	assert.Equal(t, 1, strings.Count(text, "oi_2"),
+		"a sample that failed two evaluators must still be one row:\n%s", text)
+
+	for _, header := range []string{"ITEM", "SCORE", "EVALUATORS", "REASON"} {
+		assert.Containsf(t, text, header, "the listing lost its %s column", header)
+	}
+
+	// The old SAMPLE column numbered within the current filter, so the same
+	// sample carried a different number depending on the flags while reading
+	// like an identifier. ITEM carries the id `run output show` accepts.
+	assert.NotContains(t, text, "SAMPLE",
+		"a position that changes with the filter must not sit beside the id")
+	assert.NotContains(t, text, "FAILED EVALUATORS",
+		"the column also carries evaluators that returned no verdict, which did not fail")
+}
+
+// The failing row has to name every evaluator that failed it, because that is
+// what says whether the sample is broken or one evaluator is.
+func TestRenderResultsNamesEveryFailedEvaluator(t *testing.T) {
+	var out bytes.Buffer
+	run := &eval_api.OpenAIEvalRun{ID: "evalrun_1", Status: "completed"}
+	require.NoError(t, renderResults(&out, run, scoredRows(), true))
+
+	text := out.String()
+	assert.Contains(t, text, "relevance, coherence")
+	assert.Contains(t, text, "Answered a different question.",
+		"the first failure's reason is what the row is looked at for")
+	assert.NotContains(t, text, "oi_1", "--failed-only must drop the passing sample")
+	assert.Contains(t, text, "1 sample(s) failed at least one evaluator.")
+}
+
+// The footer is read against the totals printed a few lines above it, so it
+// cannot count a row nothing scored as a row that failed. The reported run
+// closed "13 sample(s) failed at least one evaluator" over totals that said 5
+// failed and 8 errored.
+func TestFailedOnlyFooterHoldsUnscoredRowsApart(t *testing.T) {
+	items := []eval_api.OutputItem{
+		{ID: "oi_fail", Results: []eval_api.OutputResult{
+			{Name: "relevance", Passed: new(false), Score: 1, Reason: "Answered a different question."},
+		}},
+		// No verdict: the evaluator errored on this row rather than scoring it.
+		{ID: "oi_unscored", Results: []eval_api.OutputResult{{Name: "relevance"}}},
+	}
+
+	var out bytes.Buffer
+	run := &eval_api.OpenAIEvalRun{ID: "evalrun_1", Status: "completed"}
+	require.NoError(t, renderResults(&out, run, items, true))
+
+	text := out.String()
+	assert.Contains(t, text, "1 sample(s) failed at least one evaluator, and 1 could not be scored.",
+		"the two have to be counted apart:\n%s", text)
+	assert.NotContains(t, text, "2 sample(s) failed",
+		"an unscored row is not a failing one")
+	assert.Contains(t, text, "(no verdict)",
+		"and the row itself has to say which evaluator returned nothing")
+}
+
+// The run summary carries pass and fail counts but no score, so the mean has
+// to be averaged over the rows an evaluator actually scored.
+func TestCriteriaMeans(t *testing.T) {
+	means := criteriaMeans(scoredRows())
+	assert.InDelta(t, 3.0, means["relevance"], 0.001)
+	assert.InDelta(t, 3.0, means["coherence"], 0.001)
+
+	assert.Nil(t, criteriaMeans(nil), "no rows means no column, not a column of zeroes")
+}
+
+// An unscored row is not a zero. Counting it as one drags the average toward a
+// number no evaluator produced.
+func TestCriteriaMeansIgnoresUnscoredRows(t *testing.T) {
+	rows := []eval_api.OutputItem{
+		{Results: []eval_api.OutputResult{{Name: "relevance", Score: 4, Passed: new(true)}}},
+		{Results: []eval_api.OutputResult{{Name: "relevance"}}},
+	}
+	// The zero value of a score is undefined, not 0.0.
+	rows[1].Results[0].Score = eval_api.LenientFloat(0)
+
+	means := criteriaMeans(rows)
+	require.Contains(t, means, "relevance")
+	assert.InDelta(t, 2.0, means["relevance"], 0.001,
+		"a defined zero counts; this pins the arithmetic so the undefined case is visible")
+}
+
+// The header the spec documents, and the identity a person needs to know which
+// run they are looking at.
+func TestRenderRunHeaderNamesTheEval(t *testing.T) {
+	run := &eval_api.OpenAIEvalRun{
+		ID:           "evalrun_9",
+		EvalID:       "eval_9",
+		Status:       "completed",
+		Metadata:     map[string]string{"azd_eval": "support-agent-smoke"},
+		ResultCounts: &eval_api.EvalRunResultCounts{Total: 15, Passed: 12, Failed: 3},
+		CreatedAt:    float64(1785801525),
+		ModifiedAt:   float64(1785802119),
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, renderRun(&out, run, map[string]float64{"relevance": 4.1}))
+	text := out.String()
+
+	assert.Contains(t, text, "Run        evalrun_9")
+	assert.Contains(t, text, "Eval       support-agent-smoke",
+		"the declared name is what the author recognizes, not the service id")
+	assert.Contains(t, text, "Status     completed")
+	assert.Contains(t, text, "Samples    15")
+	assert.Contains(t, text, "Duration   9m54s")
+}
+
+// Without the metadata the extension writes at create time there is no
+// declared name, so the id is the honest answer rather than a blank.
+func TestRenderRunHeaderFallsBackToTheEvalID(t *testing.T) {
+	var out bytes.Buffer
+	run := &eval_api.OpenAIEvalRun{ID: "evalrun_9", EvalID: "eval_9", Status: "queued"}
+	require.NoError(t, renderRun(&out, run, nil))
+	assert.Contains(t, out.String(), "Eval       eval_9")
+}
+
+// The score column is dropped rather than filled with dashes when the rows
+// were never read, so the table does not imply the run produced no scores.
+func TestRenderRunOmitsTheScoreColumnWithoutMeans(t *testing.T) {
+	run := &eval_api.OpenAIEvalRun{
+		ID: "evalrun_9", Status: "completed",
+		PerTestingCriteria: []eval_api.EvalRunCriteriaResult{{TestingCriteria: "relevance", Passed: 2}},
+	}
+
+	var without bytes.Buffer
+	require.NoError(t, renderRun(&without, run, nil))
+	assert.NotContains(t, without.String(), "MEAN SCORE")
+
+	var with bytes.Buffer
+	require.NoError(t, renderRun(&with, run, map[string]float64{"relevance": 4.15}))
+	assert.Contains(t, with.String(), "MEAN SCORE")
+	assert.Contains(t, with.String(), "4.2", "the mean is shown to one decimal")
+}
+
+// `run output show` is what a person opens after a failing listing, so it has
+// to be readable. It used to emit raw JSON whatever was asked for.
+func TestRenderOutputItemIsNotJSON(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, renderOutputItem(&out, &eval_api.OutputItem{
+		ID:     "oi_01JQZY7K3R",
+		RunID:  "evalrun_1",
+		Status: "fail",
+		Results: []eval_api.OutputResult{{
+			Name:   "builtin.task_adherence",
+			Score:  0.35,
+			Passed: new(false),
+			Reason: "Task abandoned after the first clarifying question.",
+		}},
+	}))
+
+	text := out.String()
+	assert.NotContains(t, text, `"results"`, "the detail view must not be JSON")
+	for _, want := range []string{
+		"Item", "oi_01JQZY7K3R",
+		"Status", "fail",
+		"builtin.task_adherence", "0.35",
+		"Task abandoned after the first clarifying question.",
+	} {
+		assert.Contains(t, text, want)
+	}
+}
+
+// The listing truncates the reason to a cell, so this view exists to carry the
+// whole of it. Cutting it here would leave it readable nowhere.
+func TestRenderOutputItemKeepsTheWholeReason(t *testing.T) {
+	reason := strings.Repeat("a reason that runs well past any column width. ", 8)
+
+	var out bytes.Buffer
+	require.NoError(t, renderOutputItem(&out, &eval_api.OutputItem{
+		ID:      "oi_1",
+		Status:  "fail",
+		Results: []eval_api.OutputResult{{Name: "relevance", Passed: new(false), Reason: reason}},
+	}))
+
+	assert.Contains(t, out.String(), reason)
+}
+
+// A rubric reports one result per dimension, all carrying the evaluator's
+// name. Printed flat they read as several evaluators that share a name.
+func TestRenderOutputItemGroupsARubricsDimensions(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, renderOutputItem(&out, &eval_api.OutputItem{
+		ID:     "oi_1",
+		Status: "fail",
+		Results: []eval_api.OutputResult{
+			{Name: "support-agent-quality", Metric: "resolves_issue", Score: 1, Passed: new(false)},
+			{Name: "support-agent-quality", Metric: "cites_policy", Score: 5, Passed: new(true)},
+			{Name: "builtin.task_adherence", Score: 0.35, Passed: new(false)},
+		},
+	}))
+
+	text := out.String()
+	assert.Equal(t, 1, strings.Count(text, "support-agent-quality"),
+		"the evaluator is named once, above its dimensions:\n%s", text)
+	for _, want := range []string{"resolves_issue", "cites_policy", "builtin.task_adherence"} {
+		assert.Contains(t, text, want)
+	}
+}
+
+// The service echoes the evaluator's name in `metric` for a single-score
+// evaluator. Nesting that reads as a dimension that happens to share its
+// evaluator's name.
+func TestRenderOutputItemDoesNotNestASelfNamedMetric(t *testing.T) {
+	var out bytes.Buffer
+	require.NoError(t, renderOutputItem(&out, &eval_api.OutputItem{
+		ID:     "oi_1",
+		Status: "completed",
+		Results: []eval_api.OutputResult{
+			{Name: "task_adherence", Metric: "task_adherence", Score: 1, Passed: new(true)},
+		},
+	}))
+
+	assert.Equal(t, 1, strings.Count(out.String(), "task_adherence"),
+		"the evaluator must be named once:\n%s", out.String())
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/cmd/score_display_test.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/cmd/score_display_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"math"
+	"testing"
+
+	"azureaieval/internal/pkg/eval_api"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An evaluator that errored on a row still sends a result, and its score
+// decodes to NaN. criteriaMeans has always skipped those -- its comment says
+// counting them as zero "would drag the average toward a number no evaluator
+// produced" -- but the per-sample column averaged them in, so one errored
+// evaluator made the whole sample read NaN.
+func TestASampleScoreLeavesOutWhatWasNotScored(t *testing.T) {
+	undefined := eval_api.LenientFloat(math.NaN())
+
+	cases := []struct {
+		name    string
+		results []eval_api.OutputResult
+		want    string
+	}{
+		{
+			name:    "no results at all",
+			results: nil,
+			want:    "-",
+		},
+		{
+			name: "every evaluator scored",
+			results: []eval_api.OutputResult{
+				{Score: 1.0}, {Score: 0.5},
+			},
+			want: "0.75",
+		},
+		{
+			name: "one evaluator errored",
+			results: []eval_api.OutputResult{
+				{Score: 4.0}, {Score: undefined},
+			},
+			want: "4.00",
+		},
+		{
+			name: "nothing was scored",
+			results: []eval_api.OutputResult{
+				{Score: undefined}, {Score: undefined},
+			},
+			want: "-",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, meanScoreOf(tc.results))
+		})
+	}
+}
+
+// The same rule for a single score: a dash says "not scored", where NaN says
+// nothing a reader can use.
+func TestAScoreThatIsNotANumberShowsAsAbsent(t *testing.T) {
+	assert.Equal(t, "-", formatScore(eval_api.LenientFloat(math.NaN())))
+	assert.Equal(t, "-", formatScore(eval_api.LenientFloat(math.Inf(1))))
+	assert.Equal(t, "0.75", formatScore(eval_api.LenientFloat(0.75)))
+	assert.Equal(t, "0.00", formatScore(eval_api.LenientFloat(0)),
+		"a real zero is a score and must still be shown")
+}
+
+// The gate compares exact values while the message rounds, so a rate just under
+// the threshold could be reported as below itself. The spec's hero scenario
+// shows one decimal, so that is kept for every case where the two differ.
+func TestAGateBreachNeverReportsARateAsBelowItself(t *testing.T) {
+	gate, err := parseGate("pass-rate=0.8")
+	require.NoError(t, err)
+
+	breach := gate.breach(&eval_api.EvalRunResultCounts{Total: 10000, Passed: 7996, Failed: 2004})
+	require.NotEmpty(t, breach, "7996/10000 is under 0.8 and must breach")
+	assert.NotContains(t, breach, "80.0% is below the required 80.0%",
+		"a line saying a rate is below itself tells a reader nothing")
+	assert.Contains(t, breach, "79.96%")
+
+	// The wording the spec shows is unchanged wherever rounding does not collide.
+	assert.Equal(t,
+		"pass rate 76.4% is below the required 80.0%",
+		gate.breach(&eval_api.EvalRunResultCounts{Total: 1000, Passed: 764, Failed: 236}))
+}

--- a/cli/azd/extensions/azure.ai.evaluations/internal/messages/messages.go
+++ b/cli/azd/extensions/azure.ai.evaluations/internal/messages/messages.go
@@ -1,0 +1,2691 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Package messages holds every string this extension shows a user.
+//
+// One file, so the whole voice of the CLI can be reviewed in one sitting and a
+// wording change never has to be hunted through the command tree. The only
+// extension package it imports is exterrors, which holds no wording of its own,
+// so every other package can use this one.
+//
+// Conventions, so the set stays consistent:
+//
+//   - Errors state what went wrong and, where there is one, the way out.
+//     Lowercase, no trailing period: azd renders them after "ERROR: ".
+//   - A name the user chose is quoted with %q; an identifier the service
+//     assigned is not, because it is already unmistakable.
+//   - A filesystem path goes through filepath.ToSlash first. %q escapes a
+//     Windows separator, so `evals\eval.yaml` prints as "evals\\eval.yaml" and
+//     a reader who copies it back gets a path that does not exist.
+//   - Progress and success lines are sentences with a capital and no period.
+//   - A printed line carries its own newlines, so a call site is a bare Fprint.
+//   - Nothing here decides *whether* to print. That stays at the call site.
+package messages
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"azureaieval/internal/exterrors"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+)
+
+// ---------------------------------------------------------------------------
+// Running an eval
+// ---------------------------------------------------------------------------
+
+// NoEvalToRun reports a run with nothing resolved to run.
+func NoEvalToRun() error {
+	return errors.New("no eval to run")
+}
+
+// EvalHasNoDataset reports an eval whose rows cannot be located.
+//
+// Named separately from the traces and responses cases because the way out is
+// different: this one is answered by a dataset, not by a source block.
+func EvalHasNoDataset(eval string) error {
+	return fmt.Errorf(
+		"eval %q references no dataset and declares no source. Add a dataset: to "+
+			"score rows you supply, or a source: to score traces or stored responses",
+		eval)
+}
+
+// DatasetFileEmpty reports a local dataset file that parsed but held no rows.
+func DatasetFileEmpty(path string) error {
+	return fmt.Errorf("dataset file %q has no rows", filepath.ToSlash(path))
+}
+
+// DatasetOverrideNeedsDeclaredEval reports --dataset passed against a bare id.
+func DatasetOverrideNeedsDeclaredEval() error {
+	return errors.New(
+		"--dataset overrides the dataset an eval declares, so it needs a " +
+			"declared eval; pass --eval with a name from the configuration")
+}
+
+// DatasetNotInCatalog reports a --dataset the configuration does not declare.
+func DatasetNotInCatalog(dataset, configPath string) error {
+	return fmt.Errorf("dataset %q is not in the catalog in %s", dataset, filepath.ToSlash(configPath))
+}
+
+// NothingToGenerateFrom refuses a generation request carrying no sources.
+//
+// The service answers one with "At least one source is required", wrapped in a
+// 400 and thirty lines of JSON. Nothing about that names the two things a
+// reader can actually supply.
+func NothingToGenerateFrom() error {
+	return errors.New(
+		"nothing to generate from: pass --target <agent> to seed from an " +
+			"agent's instructions, or declare one under target: in the eval " +
+			"configuration. A trace-backed eval names its agent under source:, " +
+			"which selects traces to read and does not seed generation")
+}
+
+// SelectEvaluatorsPrompt asks which references the eval grades on.
+func SelectEvaluatorsPrompt() string {
+	return "Select evaluators to grade with:"
+}
+
+// SelectingEvaluators reports a failed evaluator prompt.
+func SelectingEvaluators(err error) error {
+	return fmt.Errorf("selecting evaluators: %w", err)
+}
+
+// NoEvaluatorsChosen reports an eval that would grade on nothing.
+func NoEvaluatorsChosen() error {
+	return errors.New(
+		"an eval has to grade on at least one evaluator: select one, or pass " +
+			"--evaluator")
+}
+
+// GateNeedsTheWait refuses a gate on a run the command will not wait for.
+//
+// The two flags together read as "start it and tell me if it regressed", but
+// the verdict does not exist yet when --no-wait returns, so the gate was
+// silently dropped and the command exited 0 however the run turned out.
+func GateNeedsTheWait() error {
+	return errors.New(
+		"--fail-on needs a result to judge, and --no-wait returns before there " +
+			"is one. Drop --no-wait, or reattach with `azd ai eval run show " +
+			"<run> --wait --fail-on <gate>`")
+}
+
+// GateOutlivedTheWait reports a gate that never got a verdict because the run
+// outlived the wait.
+//
+// Without a gate this is not a failure and exits 0, which is why the run was
+// reported and the reattach line printed. With one, exiting 0 tells a pipeline
+// the gate passed when nothing was ever judged -- the same silent drop
+// GateNeedsTheWait refuses up front, arrived at by running long instead.
+func GateOutlivedTheWait(runID string, budget time.Duration) error {
+	return fmt.Errorf(
+		"run %s outlived the %s wait, so --fail-on never got a result to judge. "+
+			"The run is still going: reattach with `azd ai eval run show %s "+
+			"--wait --fail-on <gate>`", runID, budget, runID)
+}
+
+// DatasetHasUnregisteredEdits reports local rows no deployed version holds.
+func DatasetHasUnregisteredEdits(dataset, deployCmd string) error {
+	return fmt.Errorf(
+		"dataset %q has local edits that are not registered.\n"+
+			"  Run `%s` to register them, or `--eval <id>` to run against "+
+			"an existing eval",
+		dataset, deployCmd)
+}
+
+// StartingRun reports the service refusing to start the run.
+func StartingRun(err error) error {
+	return fmt.Errorf("starting the evaluation run: %w", err)
+}
+
+// RunStarted reports a submitted run that was not waited on.
+func RunStarted(runID, status string) string {
+	return fmt.Sprintf("Started run %s (status: %s)\n", runID, status)
+}
+
+// ReattachToRun says how to come back to a run started with --no-wait.
+func ReattachToRun(runID, evalID string) string {
+	return fmt.Sprintf("Reattach with: azd ai eval run show %s --eval %s\n", runID, evalID)
+}
+
+// ReadingPreviousRuns reports a failure to look up what an eval last ran.
+func ReadingPreviousRuns(evalID string, err error) error {
+	return fmt.Errorf("reading previous runs of eval %s: %w", evalID, err)
+}
+
+// EvalHasNoPreviousRun reports an eval named by id that has nothing to repeat.
+func EvalHasNoPreviousRun(evalID string) error {
+	return fmt.Errorf(
+		"eval %s has no previous run to repeat, so there is no target or dataset "+
+			"to reuse.\n"+
+			"  Run it from the config once with `azd ai eval run start`, or name an "+
+			"eval that declares one with `--eval`",
+		evalID)
+}
+
+// PollingRun reports a failure while waiting for a run to finish.
+func PollingRun(runID string, err error) error {
+	return fmt.Errorf("polling run %s: %w", runID, err)
+}
+
+// WaitBudgetSpent reports a run that outlived the foreground wait.
+func WaitBudgetSpent(runID string, budget time.Duration) string {
+	return fmt.Sprintf(
+		"Run %s is still going after %s, so the wait stopped, not the run.\n",
+		runID, budget)
+}
+
+// WaitInterrupted reports a wait cut short, naming the run still in flight.
+func WaitInterrupted(runID string, err error) error {
+	return fmt.Errorf(
+		"stopped waiting on run %s, which is still running: %w. "+
+			"Pick it back up with `azd ai eval run show %s`",
+		runID, err, runID)
+}
+
+// RunStatusLine reports a status change seen while polling.
+func RunStatusLine(status string) string {
+	return fmt.Sprintf("  status: %s\n", status)
+}
+
+// RunFinishedWithStatus reports a run that ended in something other than completed.
+func RunFinishedWithStatus(runID, status string) error {
+	return fmt.Errorf("run %s finished with status %s", runID, status)
+}
+
+// OverallPassRate reports the share of the rows an evaluator scored that passed
+// every evaluator.
+//
+// The denominator is named rather than left as a bare fraction. Rows nothing
+// could grade are outside it, so a run that errored on most of its samples can
+// report a high rate, and "of N scored" is what stops that reading as a verdict
+// on the whole run. It is also the figure `--fail-on pass-rate` compares.
+func OverallPassRate(rate string, passed, scored, unscored int) string {
+	if unscored > 0 {
+		return fmt.Sprintf("\nOverall pass rate: %s  (%d of %d scored; %d not scored)\n",
+			rate, passed, scored, unscored)
+	}
+	return fmt.Sprintf("\nOverall pass rate: %s  (%d/%d)\n", rate, passed, scored)
+}
+
+// SamplesErrored reports rows the run could not score at all.
+func SamplesErrored(errored int) string {
+	return fmt.Sprintf("%d sample(s) errored and were not scored.\n", errored)
+}
+
+// ViewFailingSamples points at the command that lists the rows that failed.
+func ViewFailingSamples() string {
+	return "\nView failing samples: azd ai eval run output list --failed-only\n"
+}
+
+// ErroredNotScored annotates an evaluator's row with what it could not score.
+func ErroredNotScored(errored int) string {
+	return fmt.Sprintf("(%d errored, not scored)", errored)
+}
+
+// ReportLink closes a run summary with the one link the run has.
+func ReportLink(url string) string {
+	return fmt.Sprintf("Report: %s\n", url)
+}
+
+// EvalNotDeployed reports an eval id the project does not hold.
+func EvalNotDeployed(evalID, deployCmd string) error {
+	return fmt.Errorf(
+		"no eval %q in this project; "+
+			"`%s` creates the ones your config declares", evalID, deployCmd)
+}
+
+// NoEnvironmentToRememberEval reports an eval whose id had nowhere to be kept.
+//
+// `create` publishes the eval and records its id in the azd environment. With
+// no environment there is nowhere to record it, so create reports success and
+// the next command cannot find what it made. Saying "not deployed" there sends
+// the reader to deploy it again, which lands in the same place.
+func NoEnvironmentToRememberEval(eval string) error {
+	return fmt.Errorf(
+		"eval %q may exist in the project, but this directory has no azd "+
+			"environment to have recorded its id in. Create one with "+
+			"`azd env new <name>` and run `azd ai eval create` again, or name "+
+			"the eval's id with --eval", eval)
+}
+
+// EvalNotDeployedYet reports a declared eval that no deploy has created.
+func EvalNotDeployedYet(eval, deployCmd string) error {
+	return fmt.Errorf(
+		"eval %q is declared but has not been deployed to this environment yet; "+
+			"run `%s` first", eval, deployCmd)
+}
+
+// NoEvalNamedOrDeclared reports a command with no eval to act on.
+func NoEvalNamedOrDeclared(configPath string) error {
+	return fmt.Errorf(
+		"no eval was named and none is declared in %s; pass --eval with a name or an id",
+		filepath.ToSlash(configPath))
+}
+
+// ListingRuns reports a failure to list an eval's runs.
+func ListingRuns(evalID string, err error) error {
+	return fmt.Errorf("listing runs for %q: %w", evalID, err)
+}
+
+// EvalHasNoRunsLine reports an eval with no runs to list.
+func EvalHasNoRunsLine(evalID string) string {
+	return fmt.Sprintf("Eval %s has no runs yet.\n", evalID)
+}
+
+// EvalHasNoRuns reports an eval with no run to fall back on.
+func EvalHasNoRuns(evalID string) error {
+	return fmt.Errorf("eval %s has no runs yet", evalID)
+}
+
+// ReadingRun reports a failure to read the run the caller named.
+func ReadingRun(runID string, err error) error {
+	return fmt.Errorf("reading run %s: %w", runID, err)
+}
+
+// RunHeading opens the detail view of one run.
+func RunHeading(runID string) string {
+	return fmt.Sprintf("Run %s\n", runID)
+}
+
+// RunNameLine reports the run's name in the detail view.
+func RunNameLine(name string) string {
+	return fmt.Sprintf("  name    : %s\n", name)
+}
+
+// RunStatusDetail reports the run's status in the detail view.
+func RunStatusDetail(status string) string {
+	return fmt.Sprintf("  status  : %s\n", status)
+}
+
+// RunResultsLine reports the run's counts in the detail view.
+func RunResultsLine(counts string) string {
+	return fmt.Sprintf("  results : %s\n", counts)
+}
+
+// RunReportLine reports the run's one link in the detail view.
+func RunReportLine(url string) string {
+	return fmt.Sprintf("  report  : %s\n", url)
+}
+
+// CountsSummary renders a run's verdict counts on one line.
+func CountsSummary(passed, failed, errored int) string {
+	return fmt.Sprintf("%d passed, %d failed, %d errored", passed, failed, errored)
+}
+
+// RunAlreadyFinished reports a cancel asked of a run that already ended.
+func RunAlreadyFinished(runID, status string) error {
+	return fmt.Errorf("run %s already finished with status %q", runID, status)
+}
+
+// CancellingRun reports the service refusing to cancel the run.
+func CancellingRun(runID string, err error) error {
+	return fmt.Errorf("cancelling run %s: %w", runID, err)
+}
+
+// RunIsNow reports the state a cancelled run moved to.
+func RunIsNow(runID, status string) string {
+	return fmt.Sprintf("Run %s is now %s\n", runID, status)
+}
+
+// RunNotFound reports a run id the eval does not hold.
+func RunNotFound(runID, evalID string) error {
+	return fmt.Errorf("no run %q on eval %q", runID, evalID)
+}
+
+// DeletingRun reports the service refusing to delete the run.
+func DeletingRun(runID string, err error) error {
+	return fmt.Errorf("deleting run %s: %w", runID, err)
+}
+
+// RunDeleted confirms a deleted run.
+func RunDeleted(runID string) string {
+	return fmt.Sprintf("Deleted run %s\n", runID)
+}
+
+// ReadingRunResults reports a failure to read a run's per-sample rows.
+func ReadingRunResults(runID string, err error) error {
+	return fmt.Errorf("reading the results of run %s: %w", runID, err)
+}
+
+// OutputItemNotFound reports an output item the run does not hold.
+func OutputItemNotFound(itemID, runID string) error {
+	return fmt.Errorf(
+		"no output item %q on run %s; "+
+			"`azd ai eval run output list` shows the ones there are",
+		itemID, runID)
+}
+
+// ReadingOutputItem reports a failure to read one evaluated row.
+func ReadingOutputItem(itemID string, err error) error {
+	return fmt.Errorf("reading output item %q: %w", itemID, err)
+}
+
+// RunStatusHeading opens the per-sample view of a run.
+func RunStatusHeading(runID, status string) string {
+	return fmt.Sprintf("Run %s  status: %s\n", runID, status)
+}
+
+// ResultTotals reports a run's verdict counts above the rows.
+func ResultTotals(passed, failed, errored int) string {
+	return fmt.Sprintf("Totals: %d passed, %d failed, %d errored\n\n", passed, failed, errored)
+}
+
+// NoFailingRows reports a --failed-only listing with nothing in it.
+func NoFailingRows() string {
+	return "\nNo failing rows.\n"
+}
+
+// NoRowsScored reports a run that has produced no rows yet.
+func NoRowsScored() string {
+	return "\nNo rows have been scored yet.\n"
+}
+
+// SamplesNeedingALook closes a --failed-only listing, holding the rows that
+// failed apart from the rows nothing managed to score.
+//
+// One count covering both contradicted the totals printed two lines above it,
+// which is what a reader compares it with: a run reporting 5 failed and 8
+// errored closed with "13 sample(s) failed at least one evaluator".
+func SamplesNeedingALook(failed, unscored int) string {
+	if unscored == 0 {
+		return fmt.Sprintf("\n%d sample(s) failed at least one evaluator.\n", failed)
+	}
+	if failed == 0 {
+		return fmt.Sprintf("\n%d sample(s) could not be scored.\n", unscored)
+	}
+	return fmt.Sprintf(
+		"\n%d sample(s) failed at least one evaluator, and %d could not be scored.\n",
+		failed, unscored)
+}
+
+// GateSawUnscoredRows warns that a pass-rate gate judged only part of the run.
+//
+// The rate excludes rows nothing could grade, so a run that errored on most of
+// its samples can clear a threshold on the few that survived. The gate is the
+// one place a pipeline is guaranteed to read, so it is said there rather than
+// left for someone to notice in the summary.
+func GateSawUnscoredRows(unscored, total int) error {
+	return fmt.Errorf(
+		"%d of %d samples were not scored, so the pass rate this gate read covers "+
+			"only the rest; use --fail-on any-failure to count them against the run",
+		unscored, total)
+}
+
+// GeneratedNameNotAFileName reports a generated artifact name that would not
+// stay inside the output directory, or that would produce a file whose name is
+// read as a flag by whatever the path is handed to next.
+func GeneratedNameNotAFileName(kind, name string) error {
+	return fmt.Errorf(
+		"%s name %q cannot be used as a file name: remove any of / \\ : , "+
+			"do not start with -, and do not use . or ..",
+		kind, name)
+}
+
+// OutputItemEmpty reports a row the service acknowledged but returned nothing
+// for, which is a service fault rather than a missing item.
+func OutputItemEmpty() error {
+	return errors.New("the service returned no content for this output item")
+}
+
+// NotARegularFile reports an --output-file that names a directory or a device.
+func NotARegularFile(path string) error {
+	return fmt.Errorf("%s is not a regular file, so it will not be overwritten", filepath.ToSlash(path))
+}
+
+// CannotWriteInDirectory reports a destination directory that cannot be written
+// to. A missing directory is reported as such: the wrapped error names the
+// temporary file the writer chose, which the caller never asked for.
+func CannotWriteInDirectory(dir string, err error) error {
+	if errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("%s does not exist", filepath.ToSlash(dir))
+	}
+	return fmt.Errorf("cannot write in %s: %w", dir, err)
+}
+
+// OutputItemVerdict is one evaluator's line in `run output show`.
+func OutputItemVerdict(evaluator, score, verdict string) string {
+	return fmt.Sprintf("%s  %s  %s\n", evaluator, score, verdict)
+}
+
+// OutputItemEvaluator heads the dimensions of a rubric that scored per metric.
+func OutputItemEvaluator(evaluator string) string {
+	return evaluator + "\n"
+}
+
+// OutputItemMetric is one scored dimension under its evaluator.
+func OutputItemMetric(metric, score, verdict string) string {
+	return fmt.Sprintf("  %s  %s  %s\n", metric, score, verdict)
+}
+
+// OutputItemReason is the judge's explanation, indented under its verdict.
+func OutputItemReason(reason string) string {
+	return fmt.Sprintf("  %s\n", reason)
+}
+
+// ReportLinkAfterRows closes a per-sample listing with the run's one link.
+func ReportLinkAfterRows(url string) string {
+	return fmt.Sprintf("\nReport: %s\n", url)
+}
+
+// ExportFormatUnsupported reports an --format the export command cannot write.
+func ExportFormatUnsupported(format, csv, json, jsonl string) error {
+	return fmt.Errorf(
+		"--format %q is not supported; use %s, %s or %s",
+		format, csv, json, jsonl)
+}
+
+// FailOnInvalid reports a --fail-on value that is neither form of threshold.
+func FailOnInvalid(spec string) error {
+	return fmt.Errorf("--fail-on must be any-failure or pass-rate=<0..1>, got %q", spec)
+}
+
+// FailOnRateNotNumber reports a --fail-on pass rate that will not parse.
+func FailOnRateNotNumber(rate string) error {
+	return fmt.Errorf("--fail-on pass-rate must be a number, got %q", rate)
+}
+
+// FailOnRateOutOfRange reports a --fail-on pass rate outside 0..1.
+func FailOnRateOutOfRange(value float64) error {
+	return fmt.Errorf("--fail-on pass-rate must be between 0 and 1, got %v", value)
+}
+
+// GateNoResultCounts reports a gate that has nothing to measure against.
+func GateNoResultCounts() string {
+	return "the run reported no result counts, so the threshold cannot be checked"
+}
+
+// GateSamplesDidNotPass reports an any-failure gate that was breached.
+func GateSamplesDidNotPass(unpassed, total int) string {
+	return fmt.Sprintf("%d of %d samples did not pass", unpassed, total)
+}
+
+// GateNoRowsScored reports a pass-rate gate over a run that scored nothing.
+func GateNoRowsScored() string {
+	return "the run scored no rows, so its pass rate is below any threshold"
+}
+
+// GatePassRateBelow reports a pass-rate gate that was breached.
+//
+// One decimal, which is what the spec's hero scenario shows -- except when that
+// rounds the actual rate onto the threshold. The gate compares exact values, so
+// 7996/10000 breaches 0.8 while both read "80.0%", and the line would say a
+// rate is below itself. Only that case is given more precision.
+func GatePassRateBelow(actual, required float64) string {
+	shown := fmt.Sprintf("%.1f", actual*100)
+	if shown == fmt.Sprintf("%.1f", required*100) {
+		shown = strconv.FormatFloat(actual*100, 'f', -1, 64)
+	}
+	return fmt.Sprintf("pass rate %s%% is below the required %.1f%%",
+		shown, required*100)
+}
+
+// GateBreached is the block a breached gate leaves in a pipeline's log.
+func GateBreached(reason string) string {
+	return fmt.Sprintf("%s Evaluation gate: %s\n\nERROR: evaluation quality gate not met.\n",
+		failedMark, reason)
+}
+
+// ---------------------------------------------------------------------------
+// Generation
+// ---------------------------------------------------------------------------
+
+// GeneratedNameNeedsATarget reports a generation that can name neither the
+// artifact nor the agent to derive its name from.
+func GeneratedNameNeedsATarget(kind string) error {
+	return fmt.Errorf(
+		"no name for the generated %s and no target to derive one from: "+
+			"pass --%s-name, or --target", kind, kind)
+}
+
+// GenerationFailed labels one half of a composite generate that did not finish.
+//
+// The label goes inside a structured error rather than around it: azd
+// serializes a LocalError's own message and drops any wrapper, so wrapping
+// would throw away the one word saying which job failed.
+func GenerationFailed(kind string, err error) error {
+	var local *azdext.LocalError
+	if errors.As(err, &local) {
+		labelled := *local
+		labelled.Message = "generating the " + kind + ": " + local.Message
+		return &labelled
+	}
+	return fmt.Errorf("generating the %s: %w", kind, err)
+}
+
+// multiError presents several failures as one line while keeping every cause
+// reachable through errors.Is and errors.As.
+//
+// errors.Join would keep the causes but renders them one per line, and this is
+// a single error the CLI prints after "ERROR: ".
+type multiError struct {
+	msg    string
+	causes []error
+}
+
+func (m *multiError) Error() string   { return m.msg }
+func (m *multiError) Unwrap() []error { return m.causes }
+
+// SomeGenerationsFailed reports a composite generate where at least one job
+// did not finish. The others may well have.
+//
+// Two structured failures of the same category stay structured, so an expired
+// login still arrives as an auth error carrying its suggestion rather than as
+// a flat string.
+func SomeGenerationsFailed(failures []error) error {
+	if len(failures) == 1 {
+		return failures[0]
+	}
+
+	parts := make([]string, 0, len(failures))
+	for _, f := range failures {
+		parts = append(parts, f.Error())
+	}
+	joined := strings.Join(parts, "; ")
+
+	var first *azdext.LocalError
+	if !errors.As(failures[0], &first) {
+		return &multiError{msg: joined, causes: failures}
+	}
+	for _, f := range failures[1:] {
+		var other *azdext.LocalError
+		if !errors.As(f, &other) || other.Category != first.Category {
+			return &multiError{msg: joined, causes: failures}
+		}
+	}
+	merged := *first
+	merged.Message = joined
+	return &merged
+}
+
+// GenerationStarting announces a job before it is submitted, so a long
+// generation is not silent while it runs.
+func GenerationStarting(kind, name string) string {
+	return fmt.Sprintf("  Starting %s generation for %q...\n", kind, name)
+}
+
+// GenerationModelRequired reports a generation with no deployment to run on.
+//
+// Reached only when the target agent could not supply one either, so the flag
+// is the whole of the way out.
+func GenerationModelRequired() error {
+	return errors.New("a model deployment is required to generate: pass --generation-model")
+}
+
+// ReadingInstructionFile reports an --agent-instruction-file that would not read.
+func ReadingInstructionFile(path string, err error) error {
+	return fmt.Errorf("reading --agent-instruction-file %q: %w", filepath.ToSlash(path), err)
+}
+
+// InstructionFileEmpty reports an --agent-instruction-file with nothing in it.
+func InstructionFileEmpty(path string) error {
+	return fmt.Errorf("--agent-instruction-file %q is empty", filepath.ToSlash(path))
+}
+
+// ReadingInstructions reports a declared instructions file that would not read.
+func ReadingInstructions(named string, err error) error {
+	return fmt.Errorf("reading instructions %q: %w", named, err)
+}
+
+// SeedingFromFile names the local file generation was seeded from.
+func SeedingFromFile(path string) string {
+	return fmt.Sprintf("  Seeding generation from %s.\n", filepath.ToSlash(path))
+}
+
+// SeedingFromAgent names the agent whose published instructions seeded generation.
+func SeedingFromAgent(agent string) string {
+	return fmt.Sprintf("  Seeding generation from the instructions of agent %q.\n", agent)
+}
+
+// WarningAgentUnreadable reports an agent that could not supply context.
+//
+// A misspelled --target is the common cause and answers 404, whose body is ten
+// lines of URL, status rule and nested JSON for a fact that fits on one.
+func WarningAgentUnreadable(agent string, err error) string {
+	if notFound(err) {
+		return fmt.Sprintf("  warning: no agent %q in this project, so generation "+
+			"has no agent context to work from\n", agent)
+	}
+	return fmt.Sprintf("  warning: could not read agent %q for generation context: %v\n",
+		agent, err)
+}
+
+// notFound reports a service answer of 404.
+//
+// Written here rather than imported from eval_api, because that package imports
+// this one for its own wording and the dependency only goes one way.
+func notFound(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
+}
+
+// WarningAgentSeedFailedRetrying reports the retry that drops the agent source.
+func WarningAgentSeedFailedRetrying(agent string) string {
+	return fmt.Sprintf(
+		"  warning: generating from agent %q failed in the service; "+
+			"retrying from the instruction alone.\n", agent)
+}
+
+// GeneratingRubric reports a rubric generation job about to be submitted.
+func GeneratingRubric(name string) string {
+	return fmt.Sprintf("Generating rubric %s...\n", name)
+}
+
+// GeneratingDataset reports a dataset generation job about to be submitted.
+func GeneratingDataset(name string, samples int) string {
+	return fmt.Sprintf("Generating dataset %s (%d samples)...\n", name, samples)
+}
+
+// SubmittingRubricJob reports the service refusing the rubric job.
+func SubmittingRubricJob(err error) error {
+	return fmt.Errorf("submitting the rubric generation job: %w", err)
+}
+
+// SubmittingDataJob reports the service refusing the data generation job.
+func SubmittingDataJob(err error) error {
+	return fmt.Errorf("submitting the data generation job: %w", err)
+}
+
+// RubricGeneration reports a rubric job that did not finish successfully.
+func RubricGeneration(err error) error {
+	return fmt.Errorf("rubric generation: %w", err)
+}
+
+// DataGeneration reports a data job that did not finish successfully.
+func DataGeneration(err error) error {
+	return fmt.Errorf("data generation: %w", err)
+}
+
+// RubricJobReturnedNoResult reports a completed rubric job with nothing to write.
+func RubricJobReturnedNoResult() error {
+	return errors.New("the rubric generation job returned no result")
+}
+
+// DataJobReturnedNoDataset reports a completed data job with nothing to fetch.
+func DataJobReturnedNoDataset() error {
+	return errors.New("the data generation job returned no dataset reference")
+}
+
+// ReadingGeneratedDataset reports the generated dataset not being there to read.
+func ReadingGeneratedDataset(name string, err error) error {
+	return fmt.Errorf("reading the generated dataset %q: %w", name, err)
+}
+
+// DownloadingGeneratedDataset reports a failure to fetch the generated rows.
+func DownloadingGeneratedDataset(name string, err error) error {
+	return fmt.Errorf("downloading the generated dataset %q: %w", name, err)
+}
+
+// AgentSeededGenerationFailing explains the service-side failure that hits
+// every agent, so the caller does not retry against a deterministic failure.
+func AgentSeededGenerationFailing(err error, agent string) error {
+	return fmt.Errorf(
+		"%w\n\n"+
+			"This job seeded generation from agent %q. Agent-seeded data generation is "+
+			"currently failing in the service for every agent, so retrying will not help.\n"+
+			"Workarounds: supply your own dataset with --dataset, or run without --target "+
+			"to generate from the instruction alone.",
+		err, agent)
+}
+
+// FromPromptNeedsInstruction reports --from prompt with nothing to prompt with.
+func FromPromptNeedsInstruction() string {
+	return "--from prompt needs --agent-instruction or --agent-instruction-file"
+}
+
+// FromAgentNeedsTarget reports --from agent with no agent to read.
+func FromAgentNeedsTarget() string {
+	return "--from agent needs a target agent; pass --target, " +
+		"or declare one under target: in azure.eval.yaml"
+}
+
+// FromFileNotASource reports --from file, which generation has no path for.
+func FromFileNotASource() string {
+	return "--from file is not a generation source; " +
+		"register the file with `azd ai eval dataset create` instead"
+}
+
+// FromNotBuildable reports a --from this plan cannot satisfy.
+func FromNotBuildable(kind string) string {
+	return fmt.Sprintf("--from %s cannot be built from this plan", kind)
+}
+
+// UnbuildableSources reports every --from the plan could not honour at once.
+func UnbuildableSources(reasons []string) error {
+	return errors.New(strings.Join(reasons, "; "))
+}
+
+// JobSubmitted reports the id of a job started with --no-wait.
+func JobSubmitted(jobID string) string {
+	return fmt.Sprintf("  submitted job %s\n", jobID)
+}
+
+// ReattachToJob says how to come back to a job started with --no-wait.
+//
+// The selector is part of the line because `job` requires it: the two
+// collections share an id shape, so an id alone does not say which to call.
+func ReattachToJob(selector, jobID string) string {
+	return fmt.Sprintf("\nReattach with: azd ai eval job show %s --%s\n", jobID, selector)
+}
+
+// WroteArtifact reports where a generated artifact landed.
+func WroteArtifact(path string) string {
+	return fmt.Sprintf("%s Downloaded %s\n", doneMark, filepath.ToSlash(path))
+}
+
+// ArtifactExists reports a generation that would overwrite a checked-in file.
+func ArtifactExists(path string) error {
+	return fmt.Errorf(
+		"%s already exists; pass --force to overwrite it, or --output-dir to write elsewhere",
+		path)
+}
+
+// JobKindRequired reports a job command that does not say which collection.
+func JobKindRequired() error {
+	return errors.New("pass --dataset or --evaluator to say which generation jobs to act on")
+}
+
+// ListingJobs reports a failure to list one kind of generation job.
+func ListingJobs(kind string, err error) error {
+	return fmt.Errorf("listing %s generation jobs: %w", kind, err)
+}
+
+// NoJobs reports a project with no generation jobs of that kind.
+func NoJobs(kind string) string {
+	return fmt.Sprintf("No %s generation jobs found.\n", kind)
+}
+
+// JobLine renders one generation job in a listing or a detail view.
+func JobLine(jobID, status string) string {
+	return fmt.Sprintf("%s  %s\n", jobID, status)
+}
+
+// JobErrorLine reports why a generation job failed.
+func JobErrorLine(message string) string {
+	return fmt.Sprintf("error: %s\n", message)
+}
+
+// JobCancelled confirms a cancelled generation job.
+func JobCancelled(kind, jobID, status string) string {
+	return fmt.Sprintf("Cancelled %s generation job %s (%s)\n", kind, jobID, status)
+}
+
+// JobDeleted confirms a deleted generation job record.
+func JobDeleted(kind, jobID string) string {
+	return fmt.Sprintf("Deleted %s generation job %s\n", kind, jobID)
+}
+
+// JobNotFound reports a job id that is not in this group, naming the other one.
+//
+// Phrased to avoid an article before the kind: "a evaluator" is what the
+// obvious wording produces.
+func JobNotFound(kind, jobID, other string) error {
+	return fmt.Errorf(
+		"no %s generation job %q in this project; try the %s job group",
+		kind, jobID, other)
+}
+
+// JobActionFailed reports a job operation that was not a read, so the sentence
+// names what was attempted. A delete that reports "reading" sends the reader
+// looking for a read that never happened.
+func JobActionFailed(action, kind, jobID string, err error) error {
+	return fmt.Errorf("%s %s generation job %s: %w", action, kind, jobID, err)
+}
+
+// JobFailedWithReason reports a polled job that failed and said why.
+func JobFailedWithReason(status, message string) string {
+	return fmt.Sprintf("job failed with status %q: %s", status, message)
+}
+
+// JobFailed reports a polled job that failed without saying why.
+func JobFailed(status string) string {
+	return fmt.Sprintf("job failed with status %q", status)
+}
+
+// PollerTimedOut reports a job that was still running when polling gave up.
+func PollerTimedOut(operationID string, attempts int) string {
+	return fmt.Sprintf("operation %s did not complete within %d attempts",
+		operationID, attempts)
+}
+
+// OperationIDEmpty reports a poll with nothing to poll for.
+func OperationIDEmpty() error {
+	return errors.New("operation ID is empty")
+}
+
+// ---------------------------------------------------------------------------
+// Datasets
+// ---------------------------------------------------------------------------
+
+// ReadingDataset reports a dataset that could not be read, by name or by path.
+func ReadingDataset(dataset string, err error) error {
+	return fmt.Errorf("reading dataset %q: %w", dataset, err)
+}
+
+// DatasetHasNoVersionsToRead reports a registered dataset with nothing published.
+func DatasetHasNoVersionsToRead(dataset string) error {
+	return fmt.Errorf("dataset %q has no versions to read", dataset)
+}
+
+// ReadingDatasetVersion reports one version of a dataset failing to read.
+func ReadingDatasetVersion(dataset, version string, err error) error {
+	return fmt.Errorf("reading dataset %q version %s: %w", dataset, version, err)
+}
+
+// CheckingDataset reports the read that decides whether a name is already
+// taken. It is worth its own message because that read is what separates
+// `create` from `update`, and a failure answered as "not there" turns a create
+// into a silent update.
+func CheckingDataset(dataset string, err error) error {
+	return fmt.Errorf(
+		"checking whether dataset %q already exists: %w", dataset, err)
+}
+
+// DatasetVersionEmpty reports a published version that holds no rows.
+func DatasetVersionEmpty(dataset, version string) error {
+	return fmt.Errorf("dataset %q version %s has no rows", dataset, version)
+}
+
+// JSONLLineInvalid reports a row that is not JSON, by line.
+func JSONLLineInvalid(line int, err error) error {
+	return fmt.Errorf("line %d is not valid JSON: %w", line, err)
+}
+
+// JSONLRowInvalid reports a row that is not JSON before the file is published.
+func JSONLRowInvalid(path string, line int, err error) error {
+	return fmt.Errorf(
+		"%s line %d is not valid JSON: %w. Every line must be one JSON object",
+		path, line, err)
+}
+
+// JSONLRowEmpty reports a row that parses to nothing to evaluate.
+func JSONLRowEmpty(path string, line int) error {
+	return fmt.Errorf("%s line %d is an empty object, which evaluates to nothing", path, line)
+}
+
+// JSONLNoRows reports a dataset file with nothing in it to evaluate.
+func JSONLNoRows(path string) error {
+	return fmt.Errorf("%s has no rows to evaluate", filepath.ToSlash(path))
+}
+
+// ReadingFromFile reports a --from-file that would not stat.
+func ReadingFromFile(path string, err error) error {
+	return fmt.Errorf("reading --from-file %q: %w", filepath.ToSlash(path), err)
+}
+
+// FromFileMustBeJSONL reports a --from-file that is not a dataset.
+func FromFileMustBeJSONL(path string) error {
+	return fmt.Errorf(
+		"--from-file must be a .jsonl file or a directory containing one, got %q",
+		filepath.ToSlash(path))
+}
+
+// FromFileDirectoryHasNoJSONL reports a directory with nothing to upload.
+func FromFileDirectoryHasNoJSONL(dir string) error {
+	return fmt.Errorf("no .jsonl file in %q; --from-file needs one to upload", filepath.ToSlash(dir))
+}
+
+// FromFileDirectoryIsAmbiguous refuses to guess which dataset was meant.
+func FromFileDirectoryIsAmbiguous(dir string, names []string) error {
+	return fmt.Errorf(
+		"%q holds %d .jsonl files (%s); name the one to upload with --from-file",
+		filepath.ToSlash(dir), len(names), strings.Join(names, ", "))
+}
+
+// InvalidDatasetName reports a name the service will not accept.
+func InvalidDatasetName(name string) error {
+	return invalidAssetName("dataset", name)
+}
+
+// InvalidEvaluatorName reports a name the service will not accept.
+func InvalidEvaluatorName(name string) error {
+	return invalidAssetName("evaluator", name)
+}
+
+func invalidAssetName(kind, name string) error {
+	return fmt.Errorf(
+		"%s name %q is invalid: use letters, digits, dashes and underscores, "+
+			"up to 255 characters", kind, name)
+}
+
+// RegisteringDataset reports the service refusing to publish the dataset.
+func RegisteringDataset(dataset string, err error) error {
+	return fmt.Errorf("registering dataset %q: %w", dataset, err)
+}
+
+// DatasetRegistered confirms a published dataset version.
+func DatasetRegistered(dataset, version string) string {
+	return fmt.Sprintf("Registered dataset %s version %s\n", dataset, version)
+}
+
+// ListingDatasets reports a failure to list the project's datasets.
+func ListingDatasets(err error) error {
+	return fmt.Errorf("listing datasets: %w", err)
+}
+
+// ListingDatasetVersions reports a failure to list one dataset's versions.
+func ListingDatasetVersions(dataset string, err error) error {
+	return fmt.Errorf("listing versions of dataset %q: %w", dataset, err)
+}
+
+// NoDatasets reports a project with no datasets to list.
+func NoDatasets() string {
+	return "No datasets found.\n"
+}
+
+// NoDatasetVersions reports a name whose versions listed nothing.
+//
+// Listing a name that does not exist is not an error — a delete is checked for
+// idempotence this way — so this has to read as an answer about that name
+// rather than as a report about the project, which holds other datasets.
+//
+// The suggested command carries no placeholder, so it pastes and runs; the file
+// is the one thing only the caller knows, and is named outside the command.
+func NoDatasetVersions(dataset string) string {
+	return fmt.Sprintf("No versions of dataset %q. Publish one with "+
+		"`azd ai eval dataset create %s` and a --from-file path.\n", dataset, dataset)
+}
+
+// ResolvingLatestDatasetVersion reports a failure to find what "latest" means.
+func ResolvingLatestDatasetVersion(dataset string, err error) error {
+	return fmt.Errorf("resolving the latest version of %q: %w", dataset, err)
+}
+
+// DatasetNotFound reports a name the project does not hold.
+//
+// The service answers an unknown name with an empty version list rather than a
+// 404, and a dataset cannot exist with no versions, so an empty list means the
+// dataset is absent rather than empty.
+func DatasetNotFound(dataset string) error {
+	return fmt.Errorf(
+		"no dataset %q in this project; "+
+			"`azd ai eval dataset list` shows the ones there are", dataset)
+}
+
+// DatasetVersionNotFoundWithHint reports a dataset version the project does not hold.
+func DatasetVersionNotFoundWithHint(dataset, version string) error {
+	return fmt.Errorf(
+		"no dataset %q at version %q in this project; "+
+			"`azd ai eval dataset versions list %s` shows the ones there are", dataset, version, dataset)
+}
+
+// DatasetVersionNotFound reports a dataset version there is nothing to delete at.
+func DatasetVersionNotFound(dataset, version string) error {
+	return fmt.Errorf("no dataset %q at version %q in this project", dataset, version)
+}
+
+// DeletingDatasetVersion reports the service refusing the delete.
+func DeletingDatasetVersion(dataset, version string, err error) error {
+	return fmt.Errorf("deleting dataset %q version %q: %w", dataset, version, err)
+}
+
+// DatasetDeleted confirms a deleted dataset version.
+func DatasetDeleted(dataset, version string) string {
+	return fmt.Sprintf("Deleted dataset %s version %s\n", dataset, version)
+}
+
+// DatasetProblem attributes a failure to the dataset it happened under.
+func DatasetProblem(dataset string, err error) error {
+	return fmt.Errorf("dataset %q: %w", dataset, err)
+}
+
+// DatasetSource reports a declared source that is not on disk.
+func DatasetSource(path string, err error) error {
+	return fmt.Errorf("dataset source %q: %w", filepath.ToSlash(path), err)
+}
+
+// DatasetNotGeneratedYet reports a declared dataset whose rows are not written
+// yet.
+//
+// `init` declares the dataset it plans and names the command that produces it,
+// so reaching a deploy without one is an ordering mistake rather than a broken
+// configuration. Said plainly, because the bare stat failure underneath is a
+// Windows syscall name and a path with doubled separators.
+//
+// Both callers wrap this with DatasetProblem, which names the dataset, so this
+// does not name it again.
+func DatasetNotGeneratedYet(dataset, path string) error {
+	return fmt.Errorf(
+		"its rows %s have not been generated yet. "+
+			"Run `azd ai eval generate --dataset --dataset-name %s` to write them, "+
+			"or point the declaration at a .jsonl you already have",
+		filepath.ToSlash(path), dataset)
+}
+
+// DatasetNotLocalNorFound reports a source-less dataset the project rejected.
+func DatasetNotLocalNorFound(dataset string, err error) error {
+	return fmt.Errorf(
+		"dataset %q has no local source and could not be found on the project: %w",
+		dataset, err)
+}
+
+// DatasetNotLocalNorRegistered reports a source-less dataset nobody published.
+func DatasetNotLocalNorRegistered(dataset string) error {
+	return fmt.Errorf(
+		"dataset %q has no local source and is not registered on the project", dataset)
+}
+
+// DatasetVersionConflict reports a pinned version the local file disagrees with.
+func DatasetVersionConflict(dataset, version string) error {
+	return fmt.Errorf(
+		"dataset %q version %s already exists and the local file differs from it. "+
+			"Raise `version:` to publish the change, or drop it to let each "+
+			"deploy take the next version",
+		dataset, version)
+}
+
+// DatasetDrifted reports a version published outside this configuration since
+// the last deploy.
+//
+// `azd ai eval dataset update` publishes without recording the per-dataset
+// version the reconciler reads, so it is a likely cause and naming it saves the
+// reader looking for a colleague who did nothing. "Pull the newer content
+// locally" was the other half of the old advice and is a no-op when the bytes
+// already match, which is the common case.
+func DatasetDrifted(dataset, latest, recorded string) error {
+	return fmt.Errorf(
+		"dataset %q is at version %s on the project but %s was recorded at the last deploy; "+
+			"something published outside this configuration, which `azd ai eval dataset update` "+
+			"on the same dataset also does. Pin it with `version: %s` on the dataset to deploy "+
+			"what is already there, or publish a new version from the configuration's source, "+
+			"then deploy again",
+		dataset, latest, recorded, latest)
+}
+
+// ReadingDatasetDirectory reports the upload scan failing to read the directory.
+func ReadingDatasetDirectory(err error) error {
+	return fmt.Errorf("reading directory: %w", err)
+}
+
+// DatasetFileHasNoRows reports an empty dataset file, refused before upload.
+func DatasetFileHasNoRows(name string) error {
+	return fmt.Errorf(
+		"dataset file %q has no rows, so there would be nothing to evaluate", name)
+}
+
+// NoJSONLInDirectory reports an upload directory holding no dataset.
+func NoJSONLInDirectory(dir string) error {
+	return fmt.Errorf("no .jsonl file found in %s", filepath.ToSlash(dir))
+}
+
+// ReadingDatasetFromDir reports the upload failing to gather the local rows.
+func ReadingDatasetFromDir(dir string, err error) error {
+	return fmt.Errorf("reading dataset from %s: %w", dir, err)
+}
+
+// StartingPendingUpload reports the service refusing to open an upload.
+func StartingPendingUpload(err error) error {
+	return fmt.Errorf("starting pending upload: %w", err)
+}
+
+// NoUploadURI reports an accepted upload the service gave nowhere to write to.
+func NoUploadURI() error {
+	return errors.New("no upload SAS URI returned from startPendingUpload")
+}
+
+// UploadingBlob reports the dataset content failing to upload.
+func UploadingBlob(err error) error {
+	return fmt.Errorf("uploading blob: %w", err)
+}
+
+// ReadingDownloadCredentials reports the service refusing to hand out a read URI.
+func ReadingDownloadCredentials(dataset string, err error) error {
+	return fmt.Errorf("reading download credentials for %q: %w", dataset, err)
+}
+
+// NoDownloadURI reports a dataset the service gave nowhere to read from.
+func NoDownloadURI(dataset string) error {
+	return fmt.Errorf("no download URI returned for dataset %q", dataset)
+}
+
+// ListingDatasetContent reports a failure to list what a dataset version holds.
+func ListingDatasetContent(dataset string, err error) error {
+	return fmt.Errorf("listing the content of dataset %q: %w", dataset, err)
+}
+
+// DatasetHasNoFile reports a dataset version with nothing to download.
+func DatasetHasNoFile(dataset string) error {
+	return fmt.Errorf("dataset %q holds no downloadable file", dataset)
+}
+
+// ---------------------------------------------------------------------------
+// Evaluators
+// ---------------------------------------------------------------------------
+
+// EvaluatorNeedsFields reports required inputs the dataset does not carry.
+func EvaluatorNeedsFields(evaluator string, missing []string) error {
+	return fmt.Errorf(
+		"evaluator %q requires %s, which the dataset does not provide; "+
+			"add %s to the dataset, or bind it with `data_mapping`",
+		evaluator, quoteList(missing), pluralColumns(missing))
+}
+
+// EvaluatorLevelUnsupported reports an evaluation level the evaluator refuses.
+func EvaluatorLevelUnsupported(evaluator, level string, supported []string) error {
+	return fmt.Errorf(
+		"evaluator %q does not support evaluation level %q; it supports %s",
+		evaluator, level, quoteList(supported))
+}
+
+// EvaluatorNeedsInitParams reports required initialization parameters left unset.
+func EvaluatorNeedsInitParams(evaluator string, missing []string) error {
+	return fmt.Errorf(
+		"evaluator %q requires %s; set it under the evaluator's "+
+			"`initialization_parameters` in the eval config",
+		evaluator, quoteList(missing))
+}
+
+// ReadingEvaluator reports an evaluator that could not be read, by name or path.
+func ReadingEvaluator(evaluator string, err error) error {
+	return fmt.Errorf("reading evaluator %q: %w", evaluator, err)
+}
+
+// EvaluatorProblem attributes a failure to the evaluator it happened under.
+func EvaluatorProblem(evaluator string, err error) error {
+	return fmt.Errorf("evaluator %q: %w", evaluator, err)
+}
+
+// EvaluatorSource reports a declared source that is not on disk.
+func EvaluatorSource(path string, err error) error {
+	return fmt.Errorf("evaluator source %q: %w", filepath.ToSlash(path), err)
+}
+
+// EvaluatorNotGeneratedYet reports a declared evaluator whose definition has
+// not been written yet.
+//
+// `init` declares the rubric it plans and names the command that produces it,
+// so reaching a deploy without one is an ordering mistake rather than a broken
+// configuration. Said plainly, because the bare stat failure underneath is a
+// Windows syscall name and a path with doubled separators.
+//
+// Both callers wrap this with EvaluatorProblem, which names the evaluator, so
+// this does not name it again.
+func EvaluatorNotGeneratedYet(evaluator, path string) error {
+	return fmt.Errorf(
+		"its definition %s has not been generated yet. "+
+			"Run `azd ai eval generate --evaluator --evaluator-name %s` to write it, "+
+			"or drop the evaluator from azure.eval.yaml",
+		filepath.ToSlash(path), evaluator)
+}
+
+// CheckingEvaluatorExists reports a failure to tell create from update.
+func CheckingEvaluatorExists(evaluator string, err error) error {
+	return fmt.Errorf("checking whether evaluator %q exists: %w", evaluator, err)
+}
+
+// RegisteringEvaluator reports the service refusing to publish the evaluator.
+func RegisteringEvaluator(evaluator string, err error) error {
+	return fmt.Errorf("registering evaluator %q: %w", evaluator, err)
+}
+
+// EvaluatorRegistered confirms a published evaluator version.
+func EvaluatorRegistered(evaluator, version string) string {
+	return fmt.Sprintf("Registered evaluator %s version %s\n", evaluator, version)
+}
+
+// AssetAlreadyExists reports `create` asked of a name already in use.
+func AssetAlreadyExists(kind, name string) error {
+	return fmt.Errorf("%s %q already exists: use `update` to publish a new version", kind, name)
+}
+
+// AssetDoesNotExist reports `update` asked of a name nobody registered.
+func AssetDoesNotExist(kind, name string) error {
+	return fmt.Errorf("%s %q does not exist: use `create` to register it", kind, name)
+}
+
+// DefinitionNotJSONObject reports an evaluator definition that is not an object.
+func DefinitionNotJSONObject(err error) error {
+	return fmt.Errorf("the definition is not a JSON object: %w", err)
+}
+
+// NotValidJSON reports an evaluator file that will not parse at all.
+func NotValidJSON(err error) error {
+	return fmt.Errorf("not valid JSON: %w", err)
+}
+
+// RubricMissingDimensions reports a file that is neither rubric nor document.
+func RubricMissingDimensions() error {
+	return errors.New(
+		"expected a rubric definition with 'dimensions', or a document with 'definition'")
+}
+
+// ListingEvaluators reports a failure to list the project's evaluators.
+func ListingEvaluators(err error) error {
+	return fmt.Errorf("listing evaluators: %w", err)
+}
+
+// ListingEvaluatorVersions reports a failure to list one evaluator's versions.
+func ListingEvaluatorVersions(evaluator string, err error) error {
+	return fmt.Errorf("listing versions of evaluator %q: %w", evaluator, err)
+}
+
+// NoEvaluators reports a project with no evaluators to list.
+func NoEvaluators() string {
+	return "No evaluators found.\n"
+}
+
+// EvaluatorNotFound reports an evaluator the project does not hold.
+func EvaluatorNotFound(evaluator string) error {
+	return fmt.Errorf(
+		"no evaluator %q in this project; "+
+			"`azd ai eval evaluator list` shows the ones there are", evaluator)
+}
+
+// EvaluatorVersionNotFound reports an evaluator version there is nothing to delete at.
+func EvaluatorVersionNotFound(evaluator, version string) error {
+	return fmt.Errorf("no evaluator %q at version %q in this project", evaluator, version)
+}
+
+// DeletingEvaluatorVersion reports the service refusing the delete.
+func DeletingEvaluatorVersion(evaluator, version string, err error) error {
+	return fmt.Errorf("deleting evaluator %q version %q: %w", evaluator, version, err)
+}
+
+// EvaluatorDeleted confirms a deleted evaluator version.
+func EvaluatorDeleted(evaluator, version string) string {
+	return fmt.Sprintf("Deleted evaluator %s version %s\n", evaluator, version)
+}
+
+// EvaluatorNotLocalNorFound reports a source-less evaluator the project rejected.
+func EvaluatorNotLocalNorFound(evaluator string, err error) error {
+	return fmt.Errorf(
+		"evaluator %q has no local source and could not be found on the project: %w",
+		evaluator, err)
+}
+
+// EvaluatorDrifted reports a version published outside this configuration since
+// the last deploy.
+//
+// `azd ai eval evaluator update` publishes without recording the version the
+// reconciler reads, so it is a likely cause and naming it saves the reader
+// looking for a colleague who did nothing.
+func EvaluatorDrifted(evaluator, remote, recorded string) error {
+	return fmt.Errorf(
+		"evaluator %q is at version %s on the project but %s was recorded at the last "+
+			"deploy, and the local definition does not match it: something published a "+
+			"version outside this configuration, which `azd ai eval evaluator update` on "+
+			"the same evaluator also does. Publishing over it would leave that change "+
+			"behind, so bring version %s into the declared source and deploy again, or "+
+			"delete that version if it was a mistake",
+		evaluator, remote, recorded, remote)
+}
+
+// EvaluatorVersionNotAdvancing reports a publish the service kept answering with
+// a version that already existed.
+func EvaluatorVersionNotAdvancing(evaluator, version string, waited fmt.Stringer) error {
+	return fmt.Errorf(
+		"publishing evaluator %q kept returning version %s, which already "+
+			"existed. The service was still assigning that version after %s, so "+
+			"version %s now holds what was just published and any eval bound to "+
+			"it is scoring against it",
+		evaluator, version, waited, version)
+}
+
+// EvaluatorHasNoVersions reports an evaluator nothing was ever published under.
+func EvaluatorHasNoVersions(evaluator string) error {
+	return fmt.Errorf("evaluator %q has no versions", evaluator)
+}
+
+// EvaluatorHasNoUsableVersion reports versions none of which can be resolved.
+func EvaluatorHasNoUsableVersion(evaluator string) error {
+	return fmt.Errorf("evaluator %q has no usable version", evaluator)
+}
+
+// BareEvaluatorEntry reports an evaluators: entry written as a plain string.
+func BareEvaluatorEntry(name string) error {
+	return fmt.Errorf(
+		"an evaluator entry is a mapping, not a bare string: "+
+			"write `- evaluator: %s`", name)
+}
+
+// EvaluatorsMustBeSequence reports an evaluators: block that is not a list.
+func EvaluatorsMustBeSequence(kind any) error {
+	return fmt.Errorf("evaluators must be a sequence, got %v", kind)
+}
+
+// EvaluatorsMustBeList reports an evaluators: block that is not a JSON array.
+func EvaluatorsMustBeList(err error) error {
+	return fmt.Errorf("evaluators must be a list: %w", err)
+}
+
+// DecodingEvaluatorName reports an evaluator entry whose name will not decode.
+func DecodingEvaluatorName(err error) error {
+	return fmt.Errorf("decoding evaluator name: %w", err)
+}
+
+// DecodingEvaluator reports an evaluator entry that will not decode.
+func DecodingEvaluator(err error) error {
+	return fmt.Errorf("decoding evaluator: %w", err)
+}
+
+// EvaluatorEntryMissingEvaluator reports an entry that names no evaluator.
+func EvaluatorEntryMissingEvaluator() error {
+	return errors.New("evaluator entry is missing 'evaluator'")
+}
+
+// EvaluatorEntryMustBeMapping reports an entry that is neither map nor string.
+func EvaluatorEntryMustBeMapping(kind any) error {
+	return fmt.Errorf("evaluator entry must be a mapping, got %v", kind)
+}
+
+// ---------------------------------------------------------------------------
+// Deploy and reconcile
+// ---------------------------------------------------------------------------
+
+// EvalConfigInvalid reports a configuration a deploy will not act on.
+func EvalConfigInvalid(err error) error {
+	return fmt.Errorf("eval config is invalid: %w", err)
+}
+
+// ServiceCarriesNoConfig reports an azure.yaml entry with nothing to deploy.
+func ServiceCarriesNoConfig(service string) error {
+	return fmt.Errorf(
+		"service %q carries no eval configuration; expected evaluators, datasets, or evals",
+		service)
+}
+
+// ResolvingServiceRefs reports a $ref that could not be followed.
+func ResolvingServiceRefs(err error) error {
+	return fmt.Errorf("resolving $ref in the eval service configuration: %w", err)
+}
+
+// ReadingServiceConfig reports the service entry failing to serialize.
+func ReadingServiceConfig(err error) error {
+	return fmt.Errorf("reading the eval service configuration: %w", err)
+}
+
+// ReconcilingDataset reports the dataset a deploy has reached.
+func ReconcilingDataset(dataset string) string {
+	return fmt.Sprintf("Reconciling dataset %s", dataset)
+}
+
+// ReconcilingEvaluator reports the evaluator a deploy has reached.
+func ReconcilingEvaluator(evaluator string) string {
+	return fmt.Sprintf("Reconciling evaluator %s", evaluator)
+}
+
+// ReconcilingEval reports the eval a deploy has reached.
+func ReconcilingEval(eval string) string {
+	return fmt.Sprintf("Reconciling eval %s", eval)
+}
+
+// PublishedVersion reports an artifact a deploy published.
+func PublishedVersion(kind, name, version string) string {
+	return fmt.Sprintf("Published %s %s version %s", kind, name, version)
+}
+
+// UnchangedAtVersion reports an artifact a deploy left alone.
+func UnchangedAtVersion(kind, name, version string) string {
+	return fmt.Sprintf("%s %s is unchanged at version %s",
+		strings.ToUpper(kind[:1])+kind[1:], name, version)
+}
+
+// EvalProblem attributes a failure to the eval it happened under.
+func EvalProblem(eval string, err error) error {
+	return fmt.Errorf("eval %q: %w", eval, err)
+}
+
+// EvalCreatedProgress and EvalUnchangedProgress are the deploy-time equivalents
+// of EvalCreated and EvalUnchanged, without the status marks azd adds itself.
+func EvalCreatedProgress(eval, id string) string {
+	return fmt.Sprintf("Created eval %s (%s)", eval, id)
+}
+
+func EvalUnchangedProgress(eval, id string) string {
+	return fmt.Sprintf("Eval %s is unchanged (%s)", eval, id)
+}
+
+// EvalCreated confirms a single eval created outside a full deploy.
+func EvalCreated(eval, id string) string {
+	return fmt.Sprintf("%s Created eval: %s (%s)\n", doneMark, eval, id)
+}
+
+// EvalUnchanged reports an eval a create found already in place.
+//
+// An eval is immutable, so re-running create against an unedited declaration
+// creates nothing. Saying "Created" there claims work that did not happen, and
+// hides the one thing worth checking: that the id, and so the run history
+// hanging off it, survived.
+func EvalUnchanged(eval, id string) string {
+	return fmt.Sprintf("%s Eval %s is unchanged (%s)\n", skippedMark, eval, id)
+}
+
+// ListingEvals reports a failure to list the project's evals.
+func ListingEvals(err error) error {
+	return fmt.Errorf("listing evals: %w", err)
+}
+
+// NoEvals reports a project with no evals to list.
+func NoEvals() string {
+	return "No evals found.\n"
+}
+
+// EvalNotFound reports an eval id the project does not hold.
+func EvalNotFound(evalID string) error {
+	return fmt.Errorf(
+		"no eval %q in this project; "+
+			"`azd ai eval list` shows the ones there are", evalID)
+}
+
+// AmbiguousEvalName reports a name carried by more than one eval.
+//
+// An eval is immutable, so editing a declaration creates another under the same
+// name and leaves the previous one holding its run history. Deleting takes the
+// runs with it, so which one is meant has to be said rather than guessed.
+func AmbiguousEvalName(name string, ids []string) error {
+	return fmt.Errorf(
+		"%d evals are named %q, and deleting one discards its runs, so name the "+
+			"id instead: %s", len(ids), name, strings.Join(ids, ", "))
+}
+
+// EvalGone reports an eval id there is nothing to delete at.
+func EvalGone(evalID string) error {
+	return fmt.Errorf("no eval %q in this project", evalID)
+}
+
+// ReadingEval reports a failure to read one eval.
+func ReadingEval(evalID string, err error) error {
+	return fmt.Errorf("reading eval %q: %w", evalID, err)
+}
+
+// DeletingEval reports the service refusing the delete.
+func DeletingEval(evalID string, err error) error {
+	return fmt.Errorf("deleting eval %q: %w", evalID, err)
+}
+
+// EvalDeleted confirms a deleted eval.
+func EvalDeleted(evalID string) string {
+	return fmt.Sprintf("Deleted eval %s\n", evalID)
+}
+
+// Hashing reports a local artifact that could not be fingerprinted.
+func Hashing(path string, err error) error {
+	return fmt.Errorf("hashing %q: %w", filepath.ToSlash(path), err)
+}
+
+// HashingEval reports an eval declaration that could not be fingerprinted.
+func HashingEval(eval string, err error) error {
+	return fmt.Errorf("hashing eval %q: %w", eval, err)
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+// NoAzdProject reports a command that found no project to attach to.
+func NoAzdProject() error {
+	return errors.New(
+		"no azd project found in this directory. Run `azd init` first, " +
+			"or run this from the root of an existing one; the eval service is added to " +
+			"its azure.yaml")
+}
+
+// ConnectingToAzd reports the azd daemon being unreachable.
+func ConnectingToAzd(err error) error {
+	return fmt.Errorf("connecting to azd: %w", err)
+}
+
+// CreatingCredential reports the Azure credential failing to build.
+func CreatingCredential(err error) error {
+	return fmt.Errorf("creating Azure credential: %w", err)
+}
+
+// ErrNoAzdEnvironment reports that there is no azd environment to persist into.
+var ErrNoAzdEnvironment = errors.New("no active azd environment")
+
+// NoAzdEnvironmentToWrite reports a value with nowhere to be remembered.
+func NoAzdEnvironmentToWrite(key string) error {
+	return fmt.Errorf("%w to write %s into", ErrNoAzdEnvironment, key)
+}
+
+// WritingEnvValue reports the azd environment refusing a write.
+func WritingEnvValue(key string, err error) error {
+	return fmt.Errorf("writing %s to the azd environment: %w", key, err)
+}
+
+// BuildingServiceEntry reports the eval service entry failing to build.
+func BuildingServiceEntry(err error) error {
+	return fmt.Errorf("building the eval service entry: %w", err)
+}
+
+// AddingServiceTo reports azd refusing to add the eval service.
+func AddingServiceTo(rootConfig string, err error) error {
+	return fmt.Errorf("adding the eval service to %s: %w", rootConfig, err)
+}
+
+// SourceNotADataSource reports an --source that names nothing rows come from.
+func SourceNotADataSource(source, dataset, traces string) error {
+	return fmt.Errorf("--source %q is not a data source; use %q or %q", source, dataset, traces)
+}
+
+// TracesTakesNoDataset reports --dataset paired with a trace-backed eval.
+func TracesTakesNoDataset() error {
+	return errors.New("--source traces reads production traces, so it takes no --dataset")
+}
+
+// MaxTracesNeedsTraceSource reports --max-traces without a trace-backed eval.
+func MaxTracesNeedsTraceSource() error {
+	return errors.New("--max-traces caps a trace-backed eval; pass --source traces")
+}
+
+// MaxTracesMustBePositive reports a negative --max-traces.
+func MaxTracesMustBePositive() error {
+	return errors.New("--max-traces must be positive")
+}
+
+// EvalAlreadyDeclared reports an init that would overwrite a hand-tuned eval.
+func EvalAlreadyDeclared(eval, configPath string) error {
+	return fmt.Errorf(
+		"an eval named %q already exists in %s; choose another name with --name, "+
+			"or pass --force to replace it. `init` only adds: editing an eval is a file edit",
+		eval, configPath)
+}
+
+// CreatingDatasetsDir reports the datasets directory failing to be created.
+func CreatingDatasetsDir(err error) error {
+	return fmt.Errorf("creating the datasets directory: %w", err)
+}
+
+// CreatingEvaluatorsDir reports the evaluators directory failing to be created.
+func CreatingEvaluatorsDir(err error) error {
+	return fmt.Errorf("creating the evaluators directory: %w", err)
+}
+
+// DetectedTarget reports the agent the scaffolded eval will evaluate.
+func DetectedTarget(target string) string {
+	return fmt.Sprintf("%s Detected agent target: %s\n", doneMark, target)
+}
+
+// NoAgentToEvaluate reports a project declaring no agent service.
+func NoAgentToEvaluate() error {
+	return errors.New(
+		"this project declares no agent service to evaluate. Add one, or name an " +
+			"existing agent with --target")
+}
+
+// AmbiguousAgentTarget reports several agents where only one can be scaffolded.
+func AmbiguousAgentTarget(agents []string) error {
+	return fmt.Errorf(
+		"this project declares more than one agent (%s), so --target says which to "+
+			"evaluate", strings.Join(agents, ", "))
+}
+
+// SelectAgentPrompt asks which agent the eval is for.
+func SelectAgentPrompt() string {
+	return "Select the agent to evaluate:"
+}
+
+// SelectingAgent reports a failed agent prompt.
+func SelectingAgent(err error) error {
+	return fmt.Errorf("selecting an agent to evaluate: %w", err)
+}
+
+// JudgeModelRequired reports a scaffold that has no deployment to judge with.
+//
+// Reached when the project declares no model deployment to read one from, so
+// the flag is the whole of the way out. Failing here is deliberate: the judging
+// built-ins declare the deployment as required, so a config written without one
+// is rejected by the service later, far from the command that wrote it.
+func JudgeModelRequired() error {
+	return errors.New(
+		"a model deployment is required to judge with: pass --judge-model. " +
+			"This project declares no deployments, and the azd environment sets no " +
+			"AZURE_AI_MODEL_DEPLOYMENT_NAME")
+}
+
+// EvaluatorRefEmpty reports an --evaluator that carries no name, which is what
+// a stray comma leaves behind.
+func EvaluatorRefEmpty() error {
+	return errors.New("--evaluator was given an empty reference: name an evaluator, " +
+		"or use builtin.<name> for a built-in")
+}
+
+// EvaluatorRefMalformed reports a reference no evaluator can be found under.
+func EvaluatorRefMalformed(ref string) error {
+	return fmt.Errorf("%q is not an evaluator reference: repeat --evaluator, or separate "+
+		"them with commas, and use builtin.<name> for a built-in", ref)
+}
+
+// GateNeedsATerminalRun refuses to gate a run that is still moving.
+//
+// The counts are partial until the run stops, so a threshold read from them
+// can fail a run that would have passed. Ignoring the flag instead would leave
+// a pipeline believing it is gated when it is not.
+func GateNeedsATerminalRun(runID, status string) error {
+	return fmt.Errorf(
+		"run %s is %s, so --fail-on has only partial results to judge: "+
+			"add --wait to gate once it finishes",
+		runID, status)
+}
+
+// InEvalAt says which declaration an error came from.
+//
+// The source rules are checked in one place and reported from two, because the
+// same file is read when it is validated and again when a run is built. Only
+// the first of those has an index to name.
+func InEvalAt(i int, eval string, err error) error {
+	return fmt.Errorf("evals[%d] (%s): %w", i, eval, err)
+}
+
+// InEval says which eval an error came from, where there is no index.
+func InEval(eval string, err error) error {
+	return fmt.Errorf("eval %q: %w", eval, err)
+}
+
+// TraceWindowNotATime reports a window bound that is not a timestamp.
+func TraceWindowNotATime(field, value string) error {
+	return fmt.Errorf(
+		"source.%s is %q, which is not a time: use RFC 3339, "+
+			"for example 2026-08-18T09:00:00Z",
+		field, value)
+}
+
+// TraceWindowBoundUnusable reports a bound that parses but says nothing.
+//
+// Both this layer and the wire read a zero as "no bound", so a bound that
+// resolves to one would be dropped from the request rather than applied.
+func TraceWindowBoundUnusable(field, value string) error {
+	return fmt.Errorf(
+		"source.%s is %q, which is not a time any traces were recorded at: "+
+			"give a time the agent was running",
+		field, value)
+}
+
+// TraceWindowEndsBeforeItStarts reports a window that can hold no traces.
+func TraceWindowEndsBeforeItStarts(start, end string) error {
+	return fmt.Errorf(
+		"source.end_time %q is not after source.start_time %q, "+
+			"so the window holds no traces",
+		end, start)
+}
+
+// TraceWindowOverSpecified reports a window declared twice over.
+//
+// lookback_hours measures back from where the window closes and start_time is
+// an absolute bound, so a file carrying both does not say which was meant.
+func TraceWindowOverSpecified() error {
+	return errors.New(
+		"source declares both start_time and lookback_hours, which are two ways " +
+			"of saying where the window opens: keep one")
+}
+
+// NegativeLookbackHours reports a lookback that is not a length.
+func NegativeLookbackHours(hours int) error {
+	return fmt.Errorf(
+		"source.lookback_hours is %d, and how far back to look cannot be "+
+			"negative: give the hours to look back",
+		hours)
+}
+
+// LookbackTooLarge reports a lookback beyond the span a window may cover.
+func LookbackTooLarge(hours, limit int) error {
+	return fmt.Errorf(
+		"source.lookback_hours is %d, which is beyond the %d hours a window can "+
+			"reach back: give a shorter lookback, or replace it with a start_time",
+		hours, limit)
+}
+
+// MaxTracesUnusable reports a negative cap written into the file.
+//
+// The flag that writes it is already guarded; this catches the file being
+// edited afterwards, where a negative value is sent as-is and the run comes
+// back empty.
+func MaxTracesUnusable(maxTraces int) error {
+	return fmt.Errorf(
+		"source.max_traces is %d: give a positive cap, or leave it out to use "+
+			"the service's default",
+		maxTraces)
+}
+
+// SourceFieldsNotRead reports fields the declared source type ignores.
+func SourceFieldsNotRead(sourceType string, fields []string) error {
+	if len(fields) == 1 {
+		return fmt.Errorf(
+			"source declares %s, which a %q source does not read: "+
+				"remove it, or change the type to one that does",
+			fields[0], sourceType)
+	}
+	return fmt.Errorf(
+		"source declares %s, which a %q source does not read: "+
+			"remove them, or change the type to one that does",
+		strings.Join(fields, ", "), sourceType)
+}
+
+// MaxTurnsUnusable reports a turn cap a run could not apply.
+func MaxTurnsUnusable(maxTurns int) error {
+	return fmt.Errorf(
+		"source.max_turns is %d: give a positive cap, or leave it out to use "+
+			"the service's default",
+		maxTurns)
+}
+
+// LookbackReachesTooFarBack reports a lookback that lands on an unusable start.
+func LookbackReachesTooFarBack(hours int) error {
+	return fmt.Errorf(
+		"source.lookback_hours is %d, which opens the window before any trace "+
+			"was recorded: give a shorter lookback",
+		hours)
+}
+
+// AmbiguousJudgeModel reports several deployments where only one can be used.
+func AmbiguousJudgeModel(models []string) error {
+	return fmt.Errorf(
+		"this project declares more than one model deployment (%s), so "+
+			"--judge-model says which the graders judge with", strings.Join(models, ", "))
+}
+
+// SelectJudgeModelPrompt asks which deployment the graders judge with.
+func SelectJudgeModelPrompt() string {
+	return "Select the model deployment the graders judge with:"
+}
+
+// SelectEvalPrompt asks which of the declared evals a command means.
+func SelectEvalPrompt() string {
+	return "Select the eval to use:"
+}
+
+// SelectingJudgeModel reports a failed judge model prompt.
+func SelectingJudgeModel(err error) error {
+	return fmt.Errorf("selecting a judge model deployment: %w", err)
+}
+
+// UsingTraceSource reports a scaffold that reads production traces.
+//
+// Naming Application Insights is a claim about the project, so it is only made
+// when a connection was actually found. `init` makes no service calls and
+// cannot verify one it did not see.
+func UsingTraceSource(connected bool) string {
+	if connected {
+		return fmt.Sprintf("%s Using data source: traces (Application Insights)\n", doneMark)
+	}
+	return fmt.Sprintf(
+		"%s Using data source: traces. No Application Insights connection is recorded "+
+			"in this environment, so the run finds rows only if the project has one\n",
+		doneMark)
+}
+
+// JudgeModelDeployment reports the deployment the graders will judge with.
+func JudgeModelDeployment(model string) string {
+	return fmt.Sprintf("%s Judge model deployment: %s\n", doneMark, model)
+}
+
+// GradingWith reports the evaluators the scaffold settled on.
+//
+// Omitting --evaluator picks them, so without this the one thing `init` decided
+// on the reader's behalf is the one thing it does not mention.
+func GradingWith(evaluators []string) string {
+	return fmt.Sprintf("%s Grading with: %s\n", doneMark, strings.Join(evaluators, ", "))
+}
+
+// createdHeading opens the list of what a scaffold wrote.
+func createdHeading() string {
+	return "\nCreated\n"
+}
+
+// ScaffoldHeading opens the list of what a scaffold wrote. `init` appends to an
+// existing configuration rather than replacing it, and a reader who sees
+// "Created" over a file they already had reasonably fears it was overwritten.
+func ScaffoldHeading(existed bool) string {
+	if existed {
+		return "\nUpdated\n"
+	}
+	return createdHeading()
+}
+
+// createdConfigLine names the configuration a scaffold wrote.
+func createdConfigLine(configPath string) string {
+	return fmt.Sprintf("  %-33s evaluation configuration\n", configPath)
+}
+
+// ScaffoldConfigLine names the configuration a scaffold wrote or added to.
+func ScaffoldConfigLine(configPath string, existed bool) string {
+	if existed {
+		return fmt.Sprintf("  %-33s evaluation configuration (eval added)\n", configPath)
+	}
+	return createdConfigLine(configPath)
+}
+
+// AddedServiceLine reports the eval service being added to the root config.
+func AddedServiceLine(rootConfig, service string) string {
+	return fmt.Sprintf("  %-33s added service '%s'\n", rootConfig, service)
+}
+
+// AlreadyDeclaresServiceLine reports a root config that already referenced the eval.
+func AlreadyDeclaresServiceLine(rootConfig, service string) string {
+	return fmt.Sprintf("  %-33s already declares service '%s'\n", rootConfig, service)
+}
+
+// FirstNextStep opens the list of commands to run after a scaffold.
+func FirstNextStep(step string) string {
+	return fmt.Sprintf("\nNext: %s\n", step)
+}
+
+// FurtherNextStep continues the list of commands to run after a scaffold.
+func FurtherNextStep(step string) string {
+	return fmt.Sprintf("      %s\n", step)
+}
+
+// CreatedCatalogFile reports a configuration created to hold a catalog entry.
+func CreatedCatalogFile(configPath string) string {
+	return fmt.Sprintf("%s Created %s with the catalog entry\n", doneMark, filepath.ToSlash(configPath))
+}
+
+// AddedToCatalog reports a generated artifact recorded in the configuration.
+func AddedToCatalog(kind, artifact, configPath string) string {
+	return fmt.Sprintf("%s Added %s %s to %s\n", doneMark, kind, artifact, filepath.ToSlash(configPath))
+}
+
+// ArtifactDescription names a catalogued artifact, with its version when there is one.
+func ArtifactDescription(name, version string) string {
+	if version == "" || version == "latest" {
+		return fmt.Sprintf("'%s'", name)
+	}
+	return fmt.Sprintf("'%s' (version %s)", name, version)
+}
+
+// NoEvalsDeclared reports a configuration with nothing to act on.
+//
+// The same sentence wherever it is reached. `generate` writes the dataset and
+// evaluator it made into the catalog but declares no eval, so a `create` or a
+// run straight afterwards lands here, and both need to be told the same way
+// out.
+func NoEvalsDeclared() error {
+	return errors.New(
+		"no eval is declared; `azd ai eval init` declares one. " +
+			"`generate` only adds the dataset and evaluator it made")
+}
+
+// SeveralEvalsDeclared reports an unnamed eval where guessing would be wrong.
+// The two commands that hit this name their eval differently, so neither form
+// can be recommended on its own: `create` takes it as an argument, the run
+// commands take --eval.
+func SeveralEvalsDeclared(count int, names []string) error {
+	return fmt.Errorf(
+		"this configuration declares %d evals (%s); name the one you mean, "+
+			"as an argument to `create` or with --eval on the run commands",
+		count, strings.Join(names, ", "))
+}
+
+// EvalNotDeclared reports a name the configuration does not carry.
+func EvalNotDeclared(eval string, names []string) error {
+	// "this configuration has" with nothing after it is a sentence that stops
+	// mid-clause, which is what an empty list produces.
+	if len(names) == 0 {
+		return fmt.Errorf("eval %q is not declared, and this configuration declares none", eval)
+	}
+	return fmt.Errorf(
+		"eval %q is not declared; this configuration has %s",
+		eval, strings.Join(names, ", "))
+}
+
+// AtLeastOneEvalRequired reports it on the way to deploying.
+//
+// One sentence for one fact: the deploy door and the run door reach this from
+// different directions and both need the same way out.
+func AtLeastOneEvalRequired() error {
+	return NoEvalsDeclared()
+}
+
+// EvalNameRequired reports an eval entry with no name.
+func EvalNameRequired(index int) error {
+	return fmt.Errorf("evals[%d]: 'name' is required", index)
+}
+
+// DuplicateEvalName reports two evals answering to the same name.
+func DuplicateEvalName(index int, eval string) error {
+	return fmt.Errorf("evals[%d]: duplicate eval name %q", index, eval)
+}
+
+// EvalsIdenticalApartFromName reports two evals nothing can tell apart once deployed.
+func EvalsIdenticalApartFromName(index int, eval, first string) error {
+	return fmt.Errorf(
+		"evals[%d] (%s): identical to %q apart from its name and description; "+
+			"give them different evaluators, datasets or settings, or declare one",
+		index, eval, first)
+}
+
+// DatasetNameRequired reports a catalog entry with no name.
+func DatasetNameRequired(index int) error {
+	return fmt.Errorf("datasets[%d]: 'name' is required", index)
+}
+
+// DuplicateDatasetName reports two catalog entries answering to the same name.
+func DuplicateDatasetName(index int, dataset string) error {
+	return fmt.Errorf("datasets[%d]: duplicate dataset name %q", index, dataset)
+}
+
+// EvaluatorNameRequired reports a catalog entry with no name.
+func EvaluatorNameRequired(index int) error {
+	return fmt.Errorf("evaluators[%d]: 'name' is required", index)
+}
+
+// DuplicateEvaluatorName reports two catalog entries answering to the same name.
+func DuplicateEvaluatorName(index int, evaluator string) error {
+	return fmt.Errorf("evaluators[%d]: duplicate evaluator name %q", index, evaluator)
+}
+
+// BuiltinNeedsNoCatalogEntry reports a built-in declared as though it were custom.
+func BuiltinNeedsNoCatalogEntry(index int, evaluator string) error {
+	return fmt.Errorf(
+		"evaluators[%d] (%s): a built-in needs no catalog entry; reference it "+
+			"straight from an eval", index, evaluator)
+}
+
+// EvaluatorVersionWithSource reports a pin the service would assign anyway.
+func EvaluatorVersionWithSource(index int, evaluator string) error {
+	return fmt.Errorf(
+		"evaluators[%d] (%s): `version` cannot be set with `source`, because the "+
+			"service assigns the version when it publishes. Drop `version` to "+
+			"publish this file, or drop `source` to reference a version already "+
+			"on the project", index, evaluator)
+}
+
+// DatasetAndSourceDeclareTheSameThing reports it where there is no index.
+func DatasetAndSourceDeclareTheSameThing() error {
+	return errors.New("`dataset` and `source` both say where rows come from; declare one")
+}
+
+// NoEvalToValidate reports a declaration that is not there at all.
+func NoEvalToValidate() error {
+	return errors.New("no eval declaration to check")
+}
+
+// DatasetNotInDatasetsCatalog reports an eval naming a dataset nobody declared.
+func DatasetNotInDatasetsCatalog(index int, eval, dataset string) error {
+	return InEvalAt(index, eval, DatasetNotDeclared(dataset))
+}
+
+// DatasetNotDeclared reports it where there is no index.
+func DatasetNotDeclared(dataset string) error {
+	return fmt.Errorf("dataset %q is not in the datasets catalog", dataset)
+}
+
+// SourceTypeMissing reports it where there is no index.
+func SourceTypeMissing() error {
+	return errors.New("source.type is required")
+}
+
+// SourceTypeNotSupported reports the same, where there is no index to name.
+func SourceTypeNotSupported(got, traces, responses string) error {
+	return fmt.Errorf("source.type %q is not supported; use %q or %q", got, traces, responses)
+}
+
+// TraceSourceNeedsAnAgent reports it where there is no index.
+//
+// A target names one too, unless it names a model: a deployment name matches
+// no spans, so it is not an answer to whose conversations to read.
+func TraceSourceNeedsAnAgent() error {
+	return errors.New(
+		"source.agent_name is required for a trace source, " +
+			"or declare an agent target.name")
+}
+
+// ResponsesSourceNeedsResponseIDs reports it where there is no index.
+func ResponsesSourceNeedsResponseIDs() error {
+	return errors.New("source.response_ids is required for a responses source")
+}
+
+// AtLeastOneEvaluatorRequired reports an eval that scores nothing.
+func AtLeastOneEvaluatorRequired(index int, eval string) error {
+	return fmt.Errorf("evals[%d] (%s): at least one evaluator is required", index, eval)
+}
+
+// EvaluatorFieldRequired reports an evaluators: entry with no evaluator named.
+func EvaluatorFieldRequired(evalIndex, refIndex int) error {
+	return fmt.Errorf("evals[%d].evaluators[%d]: 'evaluator' is required", evalIndex, refIndex)
+}
+
+// DuplicateCriterion reports two result rows nothing could tell apart.
+func DuplicateCriterion(evalIndex, refIndex int, criterion string) error {
+	return fmt.Errorf(
+		"evals[%d].evaluators[%d]: duplicate criterion %q; give one a `name`",
+		evalIndex, refIndex, criterion)
+}
+
+// EvaluatorNotInCatalog reports a reference to an evaluator nobody declared.
+func EvaluatorNotInCatalog(evalIndex, refIndex int, evaluator string) error {
+	return fmt.Errorf(
+		"evals[%d].evaluators[%d]: evaluator %q is not in the evaluators catalog",
+		evalIndex, refIndex, evaluator)
+}
+
+// TargetTypeNotSupported reports it where there is no index.
+func TargetTypeNotSupported(got, agent, model string) error {
+	return fmt.Errorf("target.type %q is not supported; use %q or %q", got, agent, model)
+}
+
+// EvaluationLevelNotSupported reports it where there is no index.
+func EvaluationLevelNotSupported(got, turn, conversation string) error {
+	return fmt.Errorf("evaluation_level %q is invalid; expected %q or %q", got, turn, conversation)
+}
+
+// TraceSourceCannotReadAModelTarget reports a trace eval pointed at a deployment.
+//
+// Its own sentence, because the general advice is "declare an agent target",
+// which here reads as an invitation to relabel the deployment -- producing a
+// filter that matches no spans and a run that reports nothing.
+func TraceSourceCannotReadAModelTarget(name string) error {
+	return fmt.Errorf(
+		"source.agent_name is required for a trace source: target %q is a model "+
+			"deployment, and traces are recorded against an agent, not a deployment",
+		name)
+}
+
+// TargetNameMissing reports it where there is no index.
+func TargetNameMissing() error {
+	return errors.New(
+		"target.name is required; remove the target: to score the dataset as it stands")
+}
+
+// AmbiguousEvalConfig reports a directory holding both configuration names.
+func AmbiguousEvalConfig(current, legacy string) error {
+	return fmt.Errorf(
+		"%s and %s are both present, and azure.yaml can reference only one of them. "+
+			"Keep %s and delete the other, or point the service's $ref at the one you want",
+		filepath.ToSlash(current), filepath.ToSlash(legacy), filepath.ToSlash(current))
+}
+
+// ReadingEvalConfig reports a configuration file that would not read.
+func ReadingEvalConfig(path string, err error) error {
+	if errors.Is(err, fs.ErrNotExist) {
+		return noEvalConfig(path)
+	}
+	return fmt.Errorf("reading eval config %q: %w", filepath.ToSlash(path), err)
+}
+
+// noEvalConfig reports a command run before anything scaffolded a config.
+//
+// The bare read failure underneath is a Windows syscall phrase about a path,
+// which describes the symptom of running `create` before `init` without naming
+// either command.
+//
+// Still unwraps to fs.ErrNotExist, because callers that tolerate an absent
+// configuration — OpenEvalConfig, and the reference resolution above it — decide
+// that by asking, and a nicer sentence that stopped answering would turn every
+// one of those into a failure.
+func noEvalConfig(path string) error {
+	return &missingFileError{
+		msg: fmt.Sprintf(
+			"no eval configuration at %s; run `azd ai eval init` to scaffold one",
+			filepath.ToSlash(path)),
+	}
+}
+
+type missingFileError struct{ msg string }
+
+func (e *missingFileError) Error() string { return e.msg }
+func (e *missingFileError) Unwrap() error { return fs.ErrNotExist }
+
+// ParsingEvalConfig reports a configuration file that would not parse.
+func ParsingEvalConfig(path string, err error) error {
+	return fmt.Errorf("parsing eval config %q: %w", filepath.ToSlash(path), err)
+}
+
+// SerializingEvalConfig reports a configuration that would not serialize.
+func SerializingEvalConfig(err error) error {
+	return fmt.Errorf("serializing eval config: %w", err)
+}
+
+// WritingEvalConfig reports a configuration file that would not be written.
+func WritingEvalConfig(path string, err error) error {
+	return fmt.Errorf("writing eval config %q: %w", filepath.ToSlash(path), err)
+}
+
+// ErrAmbiguousAgentService reports that a target name matched more than one service.
+var ErrAmbiguousAgentService = errors.New("more than one agent service matches")
+
+// AmbiguousAgentService reports a --target that names no single set of instructions.
+func AmbiguousAgentService(agent string, matched []string) error {
+	return fmt.Errorf(
+		"%w %q: %s. Name one of them with --target, or pass the text with "+
+			"--agent-instruction",
+		ErrAmbiguousAgentService, agent, strings.Join(matched, ", "))
+}
+
+// InstructionFileUnreadable reports optimize metadata pointing at a missing file.
+func InstructionFileUnreadable(metadataPath, named string, err error) error {
+	return fmt.Errorf(
+		"%s names instruction_file %q, which could not be read: %w",
+		metadataPath, named, err)
+}
+
+// ListingTruncated reports a page walk that stopped before the end.
+//
+// Worth saying out loud rather than logging: a short evaluator listing resolves
+// the latest version from the pages that arrived, so a truncated one can pick
+// an older version and report nothing unusual.
+func ListingTruncated(pages int) error {
+	return fmt.Errorf(
+		"stopped reading the listing after %d pages, so it may be incomplete", pages)
+}
+
+// ServiceRefPointsElsewhere reports an existing service entry wired to a
+// different configuration than the one just scaffolded.
+func ServiceRefPointsElsewhere(serviceName, have, want string) error {
+	return fmt.Errorf(
+		"service %q already points at %s, and the configuration just written is "+
+			"%s; point the service's $ref at the one you want, or scaffold with "+
+			"--path %s", serviceName, have, want, have)
+}
+
+// InstructionFileOutsideProject reports metadata pointing outside the project.
+//
+// The pointer is read from a file in the checkout, so it is only as trustworthy
+// as the checkout: an absolute path or one climbing out with `..` would read
+// something the project does not contain and send it on as agent instructions.
+func InstructionFileOutsideProject(metadataPath, named string) error {
+	return fmt.Errorf(
+		"%s names instruction_file %q, which is outside the project; "+
+			"name a path inside it", metadataPath, named)
+}
+
+// FromNotASource reports a --from value the generation service has no path for.
+func FromNotASource(from string, sources []string) error {
+	return fmt.Errorf(
+		"--from %q is not a source; use one of %s",
+		from, strings.Join(sources, ", "))
+}
+
+// ConfigLockUnavailable reports a config lock that could not be taken.
+//
+// Not fatal, and said out loud for that reason: the work goes ahead unlocked,
+// so a lost update afterwards has no other explanation on record.
+func ConfigLockUnavailable(evalDir string, err error) error {
+	if err == nil {
+		return fmt.Errorf(
+			"another process is still updating %s, so this update is not "+
+				"serialized against it", filepath.ToSlash(evalDir))
+	}
+	return fmt.Errorf(
+		"could not lock %s, so this update is not serialized against other "+
+			"processes: %w", filepath.ToSlash(evalDir), err)
+}
+
+// InvalidNextLink reports a pagination link the service sent that will not parse.
+func InvalidNextLink(link string, err error) error {
+	return fmt.Errorf("invalid nextLink %q: %w", link, err)
+}
+
+// NextLinkOffOrigin reports a pagination link pointing somewhere other than the
+// project endpoint. Following it would send the caller's token to that host.
+func NextLinkOffOrigin(origin string) error {
+	return fmt.Errorf("refusing to follow nextLink to %s: it is not the project endpoint", origin)
+}
+
+// PageLinkLeftTheService reports a paging link pointing somewhere else.
+//
+// The link arrives in a response body and this client sends an Authorization
+// header, so following one to another host would send the token there.
+func PageLinkLeftTheService(expected, got string) error {
+	return fmt.Errorf(
+		"the service returned a paging link for %q while this client is "+
+			"talking to %q, so it was not followed", got, expected)
+}
+
+// SampleSizeOutOfRange reports a row count the generation service would reject.
+func SampleSizeOutOfRange(min, max, got int) error {
+	return fmt.Errorf("sample size must be between %d and %d, got %d", min, max, got)
+}
+
+// MaxSamplesNegative reports a declared row cap below zero.
+//
+// Anything not above zero reads as "no cap", so this used to send the whole
+// dataset to a run that is billed per row -- the opposite of what a cap asks
+// for, and silent.
+func MaxSamplesNegative(got int) error {
+	return fmt.Errorf(
+		"max_samples cannot be negative, got %d. "+
+			"Remove it to send every row, or set the number of rows to send", got)
+}
+
+// NegativeMaxSamplesFlag reports the same thing given on the command line.
+func NegativeMaxSamplesFlag(got int) error {
+	return fmt.Errorf(
+		"--max-samples cannot be negative, got %d. "+
+			"Omit it to send every row, or give the number of rows to send", got)
+}
+
+// FlagDoesNotApply reports a flag given to a generate that produces nothing it
+// could affect.
+//
+// Each of these is read while building one kind of artifact and ignored while
+// building the other, so given for the wrong one they were accepted and
+// dropped: `--evaluator --max-samples 50` produced a rubric and said nothing
+// about the 50.
+func FlagDoesNotApply(flag, narrowedBy string) error {
+	return fmt.Errorf(
+		"--%s has no effect on what %s generates. "+
+			"Drop --%s, or drop %s to generate both", flag, narrowedBy, flag, narrowedBy)
+}
+
+// NegativeTraceDays reports a trace window below zero.
+//
+// Zero already means "do not read traces", so a negative value has nothing
+// left to mean; it used to be accepted and treated as zero, which silently
+// produced a rubric with none of the trace seeding that was asked for.
+func NegativeTraceDays(got int) error {
+	return fmt.Errorf(
+		"--trace-days cannot be negative, got %d. "+
+			"Use 0 to seed the rubric from no traces, or the number of days to read", got)
+}
+
+// OutputDirNeedsTheWait reports an output directory that nothing will be
+// written to.
+//
+// --no-wait returns as soon as the job is submitted, so there is no artifact
+// to place. Accepting both left the caller waiting for a file that was never
+// coming.
+func OutputDirNeedsTheWait() error {
+	return errors.New(
+		"--output-dir has nothing to write to with --no-wait, which returns " +
+			"before the artifact exists. Drop --no-wait, or collect the " +
+			"artifact later with `azd ai eval job show`")
+}
+
+// EndpointEmpty reports a project endpoint given as blank.
+func EndpointEmpty() error {
+	return exterrors.Validation(
+		exterrors.CodeInvalidParameter,
+		"project endpoint must not be empty",
+		"provide a Foundry project endpoint URL "+
+			"(e.g. https://<account>.services.ai.azure.com/api/projects/<project>)",
+	)
+}
+
+// EndpointUnparseable reports a project endpoint that is not a URL.
+func EndpointUnparseable(err error) error {
+	return exterrors.Validation(
+		exterrors.CodeInvalidParameter,
+		fmt.Sprintf("invalid project endpoint URL: %v", err),
+		"provide a valid https:// Foundry project endpoint URL",
+	)
+}
+
+// EndpointNotHTTPS reports a project endpoint on the wrong scheme.
+func EndpointNotHTTPS() error {
+	return exterrors.Validation(
+		exterrors.CodeInvalidParameter,
+		"project endpoint must use https",
+		"provide an https:// URL",
+	)
+}
+
+// EndpointNotFoundryHost reports a project endpoint pointing somewhere else.
+func EndpointNotFoundryHost(host, suffix string) error {
+	return exterrors.Validation(
+		exterrors.CodeInvalidParameter,
+		fmt.Sprintf(
+			"project endpoint host %q is not a recognized Foundry host (*%s)",
+			host, suffix,
+		),
+		"the host must end with "+suffix,
+	)
+}
+
+// EndpointHasPort reports a project endpoint carrying an explicit port.
+func EndpointHasPort(host string) error {
+	return exterrors.Validation(
+		exterrors.CodeInvalidParameter,
+		fmt.Sprintf("project endpoint host %q must not include a port", host),
+		"remove the explicit port from the URL",
+	)
+}
+
+// NoEndpoint reports a project endpoint that no source could supply.
+func NoEndpoint() error {
+	return exterrors.Dependency(
+		exterrors.CodeMissingProjectEndpoint,
+		"no Foundry project endpoint resolved",
+		"persist a workspace default with `azd ai project set <endpoint>`, "+
+			"or set FOUNDRY_PROJECT_ENDPOINT (or AZURE_AI_PROJECT_ENDPOINT) "+
+			"in the active azd environment, "+
+			"or export FOUNDRY_PROJECT_ENDPOINT (or AZURE_AI_PROJECT_ENDPOINT) in your shell",
+	)
+}
+
+// ProjectContextClient reports the config helper failing to build.
+func ProjectContextClient(err error) error {
+	return fmt.Errorf("getProjectContext: %w", err)
+}
+
+// ProjectContextRead reports the persisted project context failing to read.
+func ProjectContextRead(err error) error {
+	return fmt.Errorf("getProjectContext: failed to read config: %w", err)
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+// Progress markers from the azd style guide, so the extension's lines sit
+// alongside core's without a second vocabulary.
+const (
+	doneMark    = "(✓) Done:"    // finished successfully
+	skippedMark = "(-) Skipped:" // intentionally not done, not a failure
+	failedMark  = "(x) Failed:"  // the step did not complete
+)
+
+// Warning reports a problem that is not worth failing the command over.
+func Warning(err error) string {
+	return fmt.Sprintf("warning: %v\n", err)
+}
+
+// PortalLink closes a detail view with the asset's portal URL.
+func PortalLink(url string) string {
+	return fmt.Sprintf("Portal: %s\n", url)
+}
+
+// FlagRequired reports a value the command needs and cannot settle itself.
+//
+// It used to add "(running with --no-prompt)", which was untrue at every call
+// site: none of them prompts, so the parenthetical named a flag the caller had
+// not passed and implied that dropping it would make the command ask.
+func FlagRequired(name string) error {
+	return fmt.Errorf("--%s is required", name)
+}
+
+// Creating reports a directory or file that could not be created.
+func Creating(path string, err error) error {
+	return fmt.Errorf("creating %q: %w", filepath.ToSlash(path), err)
+}
+
+// Serializing reports a value that could not be written out.
+func Serializing(path string, err error) error {
+	return fmt.Errorf("serializing %q: %w", filepath.ToSlash(path), err)
+}
+
+// Writing reports a file that could not be written.
+func Writing(path string, err error) error {
+	return fmt.Errorf("writing %q: %w", filepath.ToSlash(path), err)
+}
+
+// ReadingPath reports a file or directory that could not be read.
+func ReadingPath(path string, err error) error {
+	return fmt.Errorf("reading %s: %w", path, err)
+}
+
+// quoteList renders names as a readable "a", "b" and "c".
+func quoteList(values []string) string {
+	if len(values) == 0 {
+		return "nothing"
+	}
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, fmt.Sprintf("%q", value))
+	}
+	sort.Strings(quoted)
+	if len(quoted) == 1 {
+		return quoted[0]
+	}
+	return strings.Join(quoted[:len(quoted)-1], ", ") + " and " + quoted[len(quoted)-1]
+}
+
+// pluralColumns agrees with however many columns are missing.
+func pluralColumns(values []string) string {
+	if len(values) == 1 {
+		return "that column"
+	}
+	return "those columns"
+}
+
+// ---------------------------------------------------------------------------
+// Talking to the service
+// ---------------------------------------------------------------------------
+
+// InvalidEndpointURL reports a client built on an endpoint that will not parse.
+func InvalidEndpointURL(err error) error {
+	return fmt.Errorf("invalid endpoint URL: %w", err)
+}
+
+// InvalidRequestPath reports a request path that will not parse.
+func InvalidRequestPath(path string, err error) error {
+	return fmt.Errorf("invalid request path %q: %w", path, err)
+}
+
+// CreatingRequest reports a request that could not be built.
+func CreatingRequest(err error) error {
+	return fmt.Errorf("failed to create request: %w", err)
+}
+
+// MarshalingRequest reports a request body that would not serialize.
+func MarshalingRequest(err error) error {
+	return fmt.Errorf("failed to marshal request: %w", err)
+}
+
+// SettingRequestBody reports a request body that would not attach.
+func SettingRequestBody(err error) error {
+	return fmt.Errorf("failed to set request body: %w", err)
+}
+
+// RequestFailed reports a request that never reached an answer.
+//
+// A credential that cannot mint a token fails here rather than as a 401, and
+// the SDK's own text for it names neither azd nor the way out. isCredentialFailure
+// decides which is which; see it for how.
+//
+// The hint is in the message as well as the suggestion because the suggestion
+// is not rendered on every surface, and it offers a retry first: this call
+// shells out to `azd auth token`, which has been seen to fail transiently
+// against a login that was perfectly valid -- measured once at over 70 seconds,
+// long enough to lose to a deadline.
+func RequestFailed(err error) error {
+	if isCredentialUnavailable(err) {
+		// Not an expired login, and `azd auth login` cannot be run to fix it.
+		return exterrors.Auth(
+			exterrors.CodeAuthFailed,
+			fmt.Sprintf(
+				"could not get a token for the Foundry project because azd itself "+
+					"could not be run: %v", err),
+			"check that `azd` is installed and on PATH")
+	}
+	if isCredentialFailure(err) {
+		return exterrors.Auth(
+			exterrors.CodeLoginExpired,
+			fmt.Sprintf(
+				"could not get a token for the Foundry project: %v. "+
+					"Try again; if it keeps failing, run `azd auth login`", err),
+			"try the command again, then `azd auth login` if it keeps failing")
+	}
+	return fmt.Errorf("HTTP request failed: %w", err)
+}
+
+// isCredentialUnavailable reports the credential never having run at all, as
+// opposed to running and being refused.
+//
+// azidentity's credentialUnavailableError is unexported, so this matches the
+// two messages it carries for that case. Worth separating because the answer
+// to both is not `azd auth login` -- you cannot log in with a tool that is not
+// on PATH.
+func isCredentialUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := err.Error()
+	return strings.Contains(text, "executable not found on path") ||
+		strings.Contains(text, "is not recognized")
+}
+
+// ServiceRefused turns an unauthorized answer into one that says what to do.
+// Every other status is left as the service reported it.
+func ServiceRefused(status int, err error) error {
+	if status == http.StatusUnauthorized || status == http.StatusForbidden {
+		return exterrors.Auth(
+			exterrors.CodeAuthFailed,
+			fmt.Sprintf(
+				"the Foundry project refused the request (HTTP %d): %v. "+
+					"Run `azd auth login`, and check you have access to this project",
+				status, err),
+			"run `azd auth login`, and check you have access to this project")
+	}
+	return err
+}
+
+// isCredentialFailure reports whether the request failed because no token could
+// be minted, rather than for any of the other reasons a request fails.
+//
+// Decided on the SDK's own error types. This used to also match the phrase
+// "failed to acquire a token" anywhere in the text, which any error is free to
+// contain -- a service that could not acquire a token bucket lease was told its
+// login had expired and to run `azd auth login`.
+//
+// The credential names stay as a fallback because credentialUnavailableError is
+// unexported: a credential that never ran can only be recognized by the name it
+// puts in its own message.
+func isCredentialFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var authFailed *azidentity.AuthenticationFailedError
+	var authRequired *azidentity.AuthenticationRequiredError
+	if errors.As(err, &authFailed) || errors.As(err, &authRequired) {
+		return true
+	}
+
+	text := err.Error()
+	for _, credential := range []string{
+		"AzureDeveloperCLICredential",
+		"DefaultAzureCredential",
+	} {
+		if strings.Contains(text, credential) {
+			return true
+		}
+	}
+	return false
+}
+
+// ReadingResponseBody reports a response that could not be read.
+func ReadingResponseBody(err error) error {
+	return fmt.Errorf("failed to read response body: %w", err)
+}
+
+// ParsingResponse reports a response that could not be parsed.
+func ParsingResponse(err error) error {
+	return fmt.Errorf("failed to parse response: %w", err)
+}
+
+// ParsingNumber reports a numeric field that did not arrive as a number.
+func ParsingNumber(data string, err error) error {
+	return fmt.Errorf("parsing number %s: %w", data, err)
+}
+
+// InvalidContainerURI reports a storage URI the service handed back unusable.
+func InvalidContainerURI(err error) error {
+	return fmt.Errorf("invalid container SAS URI: %w", err)
+}
+
+// CreatingUploadRequest reports the blob upload request failing to build.
+func CreatingUploadRequest(err error) error {
+	return fmt.Errorf("failed to create upload request: %w", err)
+}
+
+// UploadingBlobFailed reports the blob upload never reaching an answer.
+func UploadingBlobFailed(err error) error {
+	return fmt.Errorf("failed to upload blob: %w", err)
+}
+
+// BlobUploadStatus reports storage refusing the upload.
+func BlobUploadStatus(status int, body string) error {
+	return fmt.Errorf("blob upload failed with status %d: %s", status, body)
+}
+
+// CreatingDownloadRequest reports the dataset download request failing to build.
+func CreatingDownloadRequest(err error) error {
+	return fmt.Errorf("failed to create download request: %w", err)
+}
+
+// DownloadingDatasetBlob reports the dataset download never reaching an answer.
+func DownloadingDatasetBlob(err error) error {
+	return fmt.Errorf("failed to download dataset from blob: %w", err)
+}
+
+// BlobDownloadStatus reports storage refusing the download.
+func BlobDownloadStatus(status int) error {
+	return fmt.Errorf("blob download failed with status %d", status)
+}
+
+// ReadingDatasetContent reports a downloaded dataset that could not be read.
+func ReadingDatasetContent(err error) error {
+	return fmt.Errorf("failed to read dataset content: %w", err)
+}
+
+// CreatingListRequest reports the container listing request failing to build.
+func CreatingListRequest(err error) error {
+	return fmt.Errorf("failed to create list request: %w", err)
+}
+
+// ListingContainerBlobs reports the container listing never reaching an answer.
+func ListingContainerBlobs(err error) error {
+	return fmt.Errorf("failed to list container blobs: %w", err)
+}
+
+// ContainerListStatus reports storage refusing the listing.
+func ContainerListStatus(status int) error {
+	return fmt.Errorf("container list failed with status %d", status)
+}
+
+// ReadingListResponse reports a container listing that could not be read.
+func ReadingListResponse(err error) error {
+	return fmt.Errorf("failed to read list response: %w", err)
+}
+
+// CreatingBlobDownloadRequest reports the blob download request failing to build.
+func CreatingBlobDownloadRequest(err error) error {
+	return fmt.Errorf("failed to create blob download request: %w", err)
+}
+
+// DownloadingBlob reports one blob's download never reaching an answer.
+func DownloadingBlob(err error) error {
+	return fmt.Errorf("failed to download blob: %w", err)
+}
+
+// BlobDownloadStatusFor reports storage refusing one named blob.
+func BlobDownloadStatusFor(status int, blobName string) error {
+	return fmt.Errorf("blob download failed with status %d for %s", status, blobName)
+}
+
+// ReadingBlobContent reports a downloaded blob that could not be read.
+func ReadingBlobContent(err error) error {
+	return fmt.Errorf("failed to read blob content: %w", err)
+}
+
+// ParsingProjectResourceID reports a project ARM id that will not parse.
+func ParsingProjectResourceID(err error) error {
+	return fmt.Errorf("failed to parse project resource ID: %w", err)
+}
+
+// EncodingSubscriptionID reports a subscription that would not encode for a URL.
+func EncodingSubscriptionID(err error) error {
+	return fmt.Errorf("failed to encode subscription ID: %w", err)
+}
+
+// NotAFoundryProjectResourceID reports an ARM id that names something else.
+func NotAFoundryProjectResourceID(resourceID string) error {
+	return fmt.Errorf(
+		"resource ID does not represent a Foundry project (missing parent account): %s",
+		resourceID)
+}
+
+// InvalidSubscriptionID reports a subscription id that is not a GUID.
+func InvalidSubscriptionID(err error) error {
+	return fmt.Errorf("invalid subscription ID format: %w", err)
+}
+
+// CouldNotReadAgentForModel reports a target agent whose deployment could not
+// be read, leaving generation without a default model.
+func CouldNotReadAgentForModel(agent string, err error) string {
+	if notFound(err) {
+		return fmt.Sprintf("  warning: no agent %q in this project, so there is no "+
+			"deployment to default to; pass --generation-model\n", agent)
+	}
+	return fmt.Sprintf("  warning: could not read agent %q for its deployment: %v\n", agent, err)
+}


### PR DESCRIPTION
Review-only slice of an increment to #9500. **Will be closed without merging.**

#9500 is 38k lines and Copilot declines anything over its 20,000 line limit,
so pushes to it get no machine review. This carries only the files the
increment touches, at their new state, so the diff is small enough to review.
It will not build on its own -- the rest of the extension is not here.

The real change is on `fix/bug-5530202-results-consistency`, which merges into `feat/azure-ai-evaluations-consolidated`.

Please do not merge, and do not spend maintainer review time here.