### PR TITLE
fix: relay structured extension errors across nested gRPC

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/exterrors/errors.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/exterrors/errors.go
@@ -192,6 +192,9 @@ func FromHost(err error, operation, contextMessage string) error {
 	}
 
 	actionable := azdext.ActionableErrorDetailFromError(err)
+	if relayedErr := relayedExtensionErrorFromStatus(st); relayedErr != nil {
+		return applyActionableErrorDetail(azdext.UnwrapError(relayedErr), actionable)
+	}
 	if serviceDetail := serviceErrorDetailFromStatus(st); serviceDetail != nil {
 		code := serviceDetail.GetErrorCode()
 		if code == "" && serviceDetail.GetStatusCode() > 0 {
@@ -309,6 +312,45 @@ func serviceErrorDetailFromStatus(st *status.Status) *azdext.ServiceErrorDetail 
 		}
 	}
 	return nil
+}
+
+func relayedExtensionErrorFromStatus(st *status.Status) *azdext.ExtensionError {
+	if st == nil {
+		return nil
+	}
+	for _, detail := range st.Details() {
+		if relayedErr, ok := detail.(*azdext.ExtensionError); ok {
+			return relayedErr
+		}
+	}
+	return nil
+}
+
+func applyActionableErrorDetail(err error, actionable *azdext.ActionableErrorDetail) error {
+	if actionable == nil {
+		return err
+	}
+
+	if serviceErr, ok := errors.AsType[*azdext.ServiceError](err); ok {
+		if actionable.GetSuggestion() != "" {
+			serviceErr.Suggestion = actionable.GetSuggestion()
+		}
+		if len(actionable.GetLinks()) > 0 {
+			serviceErr.Links = azdext.UnwrapErrorLinks(actionable.GetLinks())
+		}
+		return serviceErr
+	}
+	if localErr, ok := errors.AsType[*azdext.LocalError](err); ok {
+		if actionable.GetSuggestion() != "" {
+			localErr.Suggestion = actionable.GetSuggestion()
+		}
+		if len(actionable.GetLinks()) > 0 {
+			localErr.Links = azdext.UnwrapErrorLinks(actionable.GetLinks())
+		}
+		return localErr
+	}
+
+	return err
 }
 
 // IsCancellation checks if an error represents user cancellation

--- a/cli/azd/extensions/azure.ai.agents/internal/exterrors/errors_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/exterrors/errors_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/azure/azure-dev/cli/azd/pkg/errorhandler"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -81,6 +82,126 @@ func TestFromHostPreservesServiceDetails(t *testing.T) {
 	assert.Equal(t, "management.azure.com", serviceErr.ServiceName)
 	assert.Equal(t, "request the required role and retry", serviceErr.Suggestion)
 	assert.Contains(t, serviceErr.Message, "container publish failed")
+}
+
+func TestFromHostPreservesRelayedServiceError(t *testing.T) {
+	source := &azdext.ServiceError{
+		Message:     "could not get Foundry project",
+		ErrorCode:   "get_foundry_project.AuthorizationFailed",
+		StatusCode:  http.StatusForbidden,
+		ServiceName: "management.azure.com",
+		Suggestion:  "request the required role",
+		Links: []errorhandler.ErrorLink{{
+			URL:   "https://aka.ms/foundry-project-access",
+			Title: "Foundry project access",
+		}},
+	}
+	st, err := status.New(codes.Unknown, "container publish failed").WithDetails(azdext.WrapError(source))
+	require.NoError(t, err)
+
+	result := FromHost(st.Err(), OpContainerPublish, "container publish failed")
+
+	var serviceErr *azdext.ServiceError
+	require.ErrorAs(t, result, &serviceErr)
+	assert.Equal(t, source.Message, serviceErr.Message)
+	assert.Equal(t, source.ErrorCode, serviceErr.ErrorCode)
+	assert.Equal(t, source.StatusCode, serviceErr.StatusCode)
+	assert.Equal(t, source.ServiceName, serviceErr.ServiceName)
+	assert.Equal(t, source.Suggestion, serviceErr.Suggestion)
+	assert.Equal(t, source.Links, serviceErr.Links)
+}
+
+func TestFromHostPreservesRelayedLocalError(t *testing.T) {
+	source := &azdext.LocalError{
+		Message:    "invalid Foundry project resource ID",
+		Code:       "invalid_ai_project_id",
+		Category:   azdext.LocalErrorCategoryValidation,
+		Suggestion: "verify AZURE_AI_PROJECT_ID",
+		Links: []errorhandler.ErrorLink{{
+			URL:   "https://aka.ms/azd-ai-project-id",
+			Title: "Foundry project configuration",
+		}},
+	}
+	st, err := status.New(codes.Unknown, "container publish failed").WithDetails(azdext.WrapError(source))
+	require.NoError(t, err)
+
+	result := FromHost(st.Err(), OpContainerPublish, "container publish failed")
+
+	var localErr *azdext.LocalError
+	require.ErrorAs(t, result, &localErr)
+	assert.Equal(t, source.Message, localErr.Message)
+	assert.Equal(t, source.Code, localErr.Code)
+	assert.Equal(t, source.Category, localErr.Category)
+	assert.Equal(t, source.Suggestion, localErr.Suggestion)
+	assert.Equal(t, source.Links, localErr.Links)
+}
+
+func TestFromHost_RelayedErrorUsesOuterActionableGuidance(t *testing.T) {
+	source := &azdext.ServiceError{
+		Message:     "could not get Foundry project",
+		ErrorCode:   "get_foundry_project.AuthorizationFailed",
+		StatusCode:  http.StatusForbidden,
+		ServiceName: "management.azure.com",
+		Suggestion:  "request the required role",
+		Links: []errorhandler.ErrorLink{{
+			URL:   "https://aka.ms/foundry-project-access",
+			Title: "Foundry project access",
+		}},
+	}
+	st, err := status.New(codes.Unknown, "container publish failed").WithDetails(
+		azdext.WrapError(source),
+		&azdext.ActionableErrorDetail{
+			Suggestion: "refresh the environment and retry",
+			Links: []*azdext.ErrorLink{{
+				Url:   "https://aka.ms/azd-env-refresh",
+				Title: "Environment refresh",
+			}},
+		},
+	)
+	require.NoError(t, err)
+
+	result := FromHost(st.Err(), OpContainerPublish, "container publish failed")
+
+	var serviceErr *azdext.ServiceError
+	require.ErrorAs(t, result, &serviceErr)
+	assert.Equal(t, source.ErrorCode, serviceErr.ErrorCode)
+	assert.Equal(t, "refresh the environment and retry", serviceErr.Suggestion)
+	assert.Equal(t, []errorhandler.ErrorLink{{
+		URL:   "https://aka.ms/azd-env-refresh",
+		Title: "Environment refresh",
+	}}, serviceErr.Links)
+}
+
+func TestFromHost_PrioritizesCancellationAndAuthentication(t *testing.T) {
+	relayed := azdext.WrapError(&azdext.LocalError{
+		Message:  "invalid project",
+		Code:     "invalid_ai_project_id",
+		Category: azdext.LocalErrorCategoryValidation,
+	})
+
+	t.Run("cancellation", func(t *testing.T) {
+		st, err := status.New(codes.Canceled, "cancelled").WithDetails(relayed)
+		require.NoError(t, err)
+
+		result := FromHost(st.Err(), OpContainerPublish, "container publish failed")
+
+		var localErr *azdext.LocalError
+		require.ErrorAs(t, result, &localErr)
+		assert.Equal(t, azdext.LocalErrorCategoryUser, localErr.Category)
+		assert.Equal(t, CodeCancelled, localErr.Code)
+	})
+
+	t.Run("authentication", func(t *testing.T) {
+		st, err := status.New(codes.Unauthenticated, "not logged in").WithDetails(relayed)
+		require.NoError(t, err)
+
+		result := FromHost(st.Err(), OpContainerPublish, "container publish failed")
+
+		var localErr *azdext.LocalError
+		require.ErrorAs(t, result, &localErr)
+		assert.Equal(t, azdext.LocalErrorCategoryAuth, localErr.Category)
+		assert.Equal(t, CodeNotLoggedIn, localErr.Code)
+	})
 }
 
 func TestInternalFromErrorPreservesStructuredError(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -2175,6 +2175,52 @@ func TestPublish_PreservesHostServiceDetails(t *testing.T) {
 	require.Equal(t, "management.azure.com", serviceErr.ServiceName)
 }
 
+func TestPublish_PreservesRelayedHostServiceError(t *testing.T) {
+	t.Parallel()
+
+	source := &azdext.ServiceError{
+		Message:     "could not get Foundry project",
+		ErrorCode:   "get_foundry_project.AuthorizationFailed",
+		StatusCode:  403,
+		ServiceName: "management.azure.com",
+		Suggestion:  "request the required role",
+	}
+	st, err := status.New(codes.Unknown, "container publish failed").WithDetails(azdext.WrapError(source))
+	require.NoError(t, err)
+
+	publishErr := publishWithContainerError(t, st.Err())
+
+	serviceErr, ok := errors.AsType[*azdext.ServiceError](publishErr)
+	require.True(t, ok)
+	require.Equal(t, source.Message, serviceErr.Message)
+	require.Equal(t, source.ErrorCode, serviceErr.ErrorCode)
+	require.Equal(t, source.StatusCode, serviceErr.StatusCode)
+	require.Equal(t, source.ServiceName, serviceErr.ServiceName)
+	require.Equal(t, source.Suggestion, serviceErr.Suggestion)
+}
+
+func TestPublish_PreservesRelayedHostLocalError(t *testing.T) {
+	t.Parallel()
+
+	source := &azdext.LocalError{
+		Message:    "invalid Foundry project resource ID",
+		Code:       "invalid_ai_project_id",
+		Category:   azdext.LocalErrorCategoryValidation,
+		Suggestion: "verify AZURE_AI_PROJECT_ID",
+	}
+	st, err := status.New(codes.Unknown, "container publish failed").WithDetails(azdext.WrapError(source))
+	require.NoError(t, err)
+
+	publishErr := publishWithContainerError(t, st.Err())
+
+	localErr, ok := errors.AsType[*azdext.LocalError](publishErr)
+	require.True(t, ok)
+	require.Equal(t, source.Message, localErr.Message)
+	require.Equal(t, source.Code, localErr.Code)
+	require.Equal(t, source.Category, localErr.Category)
+	require.Equal(t, source.Suggestion, localErr.Suggestion)
+}
+
 func publishWithContainerError(t *testing.T, publishErr error) error {
 	t.Helper()
 

--- a/cli/azd/internal/grpcserver/errors.go
+++ b/cli/azd/internal/grpcserver/errors.go
@@ -40,8 +40,9 @@ func mapHostError(err error) error {
 	suggestionErr, hasSuggestion := errors.AsType[*internal.ErrorWithSuggestion](err)
 	isAuthErr := isAuthError(err)
 	responseErr, hasResponseError := errors.AsType[*azcore.ResponseError](err)
+	relayedErr := relayedExtensionError(err)
 	existingStatus, hasExistingStatus := azdext.GRPCStatusFromError(err)
-	if !hasSuggestion && !isAuthErr && !hasResponseError {
+	if !hasSuggestion && !isAuthErr && !hasResponseError && relayedErr == nil {
 		return err
 	}
 
@@ -60,11 +61,23 @@ func mapHostError(err error) error {
 	if hasSuggestion {
 		st = withActionableErrorDetail(st, suggestionErr)
 	}
-	if hasResponseError && !hasServiceErrorDetail(st) {
+	if relayedErr != nil {
+		st = withRelayedExtensionErrorDetail(st, relayedErr)
+	} else if hasResponseError && !hasServiceErrorDetail(st) {
 		st = withServiceErrorDetail(st, responseErr)
 	}
 
 	return st.Err()
+}
+
+func relayedExtensionError(err error) *azdext.ExtensionError {
+	if _, ok := errors.AsType[*azdext.ServiceError](err); ok {
+		return azdext.WrapError(err)
+	}
+	if _, ok := errors.AsType[*azdext.LocalError](err); ok {
+		return azdext.WrapError(err)
+	}
+	return nil
 }
 
 func hostErrorStatus(
@@ -95,6 +108,34 @@ func hasServiceErrorDetail(st *status.Status) bool {
 	}
 
 	return false
+}
+
+func hasRelayedExtensionErrorDetail(st *status.Status) bool {
+	if st == nil {
+		return false
+	}
+
+	for _, detail := range st.Details() {
+		if _, ok := detail.(*azdext.ExtensionError); ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func withRelayedExtensionErrorDetail(st *status.Status, relayedErr *azdext.ExtensionError) *status.Status {
+	if st == nil || relayedErr == nil || hasRelayedExtensionErrorDetail(st) {
+		return st
+	}
+
+	withDetails, detailErr := st.WithDetails(relayedErr)
+	if detailErr != nil {
+		log.Printf("failed to attach relayed extension error detail to gRPC status: %v", detailErr)
+		return st
+	}
+
+	return withDetails
 }
 
 func withServiceErrorDetail(st *status.Status, responseErr *azcore.ResponseError) *status.Status {

--- a/cli/azd/internal/grpcserver/server_test.go
+++ b/cli/azd/internal/grpcserver/server_test.go
@@ -323,6 +323,82 @@ func Test_Server_StreamInterceptor(t *testing.T) {
 	})
 }
 
+func TestServer_RelaysExtensionErrorOverGRPC(t *testing.T) {
+	serviceErr := &azdext.ServiceError{
+		Message:     "could not get Foundry project",
+		ErrorCode:   "get_foundry_project.AuthorizationFailed",
+		StatusCode:  http.StatusForbidden,
+		ServiceName: "management.azure.com",
+	}
+	server := NewServer(
+		azdext.UnimplementedProjectServiceServer{},
+		azdext.UnimplementedEnvironmentServiceServer{},
+		azdext.UnimplementedPromptServiceServer{},
+		azdext.UnimplementedUserConfigServiceServer{},
+		azdext.UnimplementedDeploymentServiceServer{},
+		azdext.UnimplementedEventServiceServer{},
+		azdext.UnimplementedComposeServiceServer{},
+		azdext.UnimplementedWorkflowServiceServer{},
+		azdext.UnimplementedExtensionServiceServer{},
+		azdext.UnimplementedServiceTargetServiceServer{},
+		azdext.UnimplementedFrameworkServiceServer{},
+		&relayingContainerService{
+			err: fmt.Errorf("resolving target resource via external service target: %w", serviceErr),
+		},
+		azdext.UnimplementedAccountServiceServer{},
+		azdext.UnimplementedAiModelServiceServer{},
+		azdext.UnimplementedCopilotServiceServer{},
+		azdext.UnimplementedProvisioningServiceServer{},
+		azdext.UnimplementedValidationServiceServer{},
+		newTelemetryService(stubExtensionLookup{}),
+	)
+	serverInfo, err := server.Start()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, server.Stop())
+	}()
+
+	extension := &extensions.Extension{
+		Id:        "azd.internal.test",
+		Namespace: "test",
+	}
+	accessToken, err := GenerateExtensionToken(extension, serverInfo)
+	require.NoError(t, err)
+
+	client, err := azdext.NewAzdClient(azdext.WithAddress(serverInfo.Address))
+	require.NoError(t, err)
+	defer client.Close()
+
+	_, err = client.Container().Publish(
+		azdext.WithAccessToken(t.Context(), accessToken),
+		&azdext.ContainerPublishRequest{},
+	)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Unknown, st.Code())
+	require.Contains(t, st.Message(), "resolving target resource via external service target")
+
+	relayed := requireRelayedExtensionError(t, st)
+	recovered := azdext.UnwrapError(relayed)
+	var recoveredServiceErr *azdext.ServiceError
+	require.ErrorAs(t, recovered, &recoveredServiceErr)
+	require.Equal(t, serviceErr, recoveredServiceErr)
+}
+
+type relayingContainerService struct {
+	azdext.UnimplementedContainerServiceServer
+	err error
+}
+
+func (s *relayingContainerService) Publish(
+	ctx context.Context,
+	req *azdext.ContainerPublishRequest,
+) (*azdext.ContainerPublishResponse, error) {
+	return nil, s.err
+}
+
 func Test_mapHostError(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -489,6 +565,106 @@ func TestMapHostError_ResponseErrorPreservesServiceDetails(t *testing.T) {
 	require.Equal(t, "TooManyRequests", detail.GetErrorCode())
 	require.Equal(t, int32(http.StatusTooManyRequests), detail.GetStatusCode())
 	require.Equal(t, "registry.azurecr.io", detail.GetServiceName())
+	require.Empty(t, relayedExtensionErrorDetails(st))
+}
+
+func TestMapHostError_RelaysExtensionServiceError(t *testing.T) {
+	t.Parallel()
+
+	serviceErr := &azdext.ServiceError{
+		Message:     "could not get Foundry project",
+		ErrorCode:   "get_foundry_project.AuthorizationFailed",
+		StatusCode:  http.StatusForbidden,
+		ServiceName: "management.azure.com",
+		Suggestion:  "request the required role",
+		Links: []errorhandler.ErrorLink{{
+			URL:   "https://aka.ms/foundry-project-access",
+			Title: "Foundry project access",
+		}},
+	}
+	wrapped := fmt.Errorf("resolving target resource via external service target: %w", serviceErr)
+
+	st, ok := status.FromError(mapHostError(wrapped))
+	require.True(t, ok)
+	require.Equal(t, codes.Unknown, st.Code())
+	require.Equal(t, wrapped.Error(), st.Message())
+	require.Empty(t, serviceErrorDetails(st))
+
+	relayed := requireRelayedExtensionError(t, st)
+	recovered := azdext.UnwrapError(relayed)
+	var recoveredServiceErr *azdext.ServiceError
+	require.ErrorAs(t, recovered, &recoveredServiceErr)
+	require.Equal(t, serviceErr.Message, recoveredServiceErr.Message)
+	require.Equal(t, serviceErr.ErrorCode, recoveredServiceErr.ErrorCode)
+	require.Equal(t, serviceErr.StatusCode, recoveredServiceErr.StatusCode)
+	require.Equal(t, serviceErr.ServiceName, recoveredServiceErr.ServiceName)
+	require.Equal(t, serviceErr.Suggestion, recoveredServiceErr.Suggestion)
+	require.Equal(t, serviceErr.Links, recoveredServiceErr.Links)
+}
+
+func TestMapHostError_RelaysExtensionLocalError(t *testing.T) {
+	t.Parallel()
+
+	localErr := &azdext.LocalError{
+		Message:    "invalid Foundry project resource ID",
+		Code:       "invalid_ai_project_id",
+		Category:   azdext.LocalErrorCategoryValidation,
+		Suggestion: "verify AZURE_AI_PROJECT_ID",
+		Links: []errorhandler.ErrorLink{{
+			URL:   "https://aka.ms/azd-ai-project-id",
+			Title: "Foundry project configuration",
+		}},
+	}
+	errWithSuggestion := &internal.ErrorWithSuggestion{
+		Err:        fmt.Errorf("resolving target resource via external service target: %w", localErr),
+		Message:    "Could not resolve the target resource.",
+		Suggestion: "run azd env refresh and retry",
+		Links: []errorhandler.ErrorLink{{
+			URL:   "https://aka.ms/azd-env-refresh",
+			Title: "Environment refresh",
+		}},
+	}
+
+	st, ok := status.FromError(mapHostError(errWithSuggestion))
+	require.True(t, ok)
+	require.Equal(t, codes.Unknown, st.Code())
+	require.Equal(t, errWithSuggestion.Message, st.Message())
+
+	actionable := azdext.ActionableErrorDetailFromStatus(st)
+	require.NotNil(t, actionable)
+	require.Equal(t, errWithSuggestion.Suggestion, actionable.GetSuggestion())
+	require.Equal(t, azdext.WrapErrorLinks(errWithSuggestion.Links), actionable.GetLinks())
+
+	relayed := requireRelayedExtensionError(t, st)
+	recovered := azdext.UnwrapError(relayed)
+	var recoveredLocalErr *azdext.LocalError
+	require.ErrorAs(t, recovered, &recoveredLocalErr)
+	require.Equal(t, localErr.Message, recoveredLocalErr.Message)
+	require.Equal(t, localErr.Code, recoveredLocalErr.Code)
+	require.Equal(t, localErr.Category, recoveredLocalErr.Category)
+	require.Equal(t, localErr.Suggestion, recoveredLocalErr.Suggestion)
+	require.Equal(t, localErr.Links, recoveredLocalErr.Links)
+}
+
+func TestMapHostError_DoesNotDuplicateRelayedExtensionError(t *testing.T) {
+	t.Parallel()
+
+	localErr := &azdext.LocalError{
+		Message:  "invalid project",
+		Code:     "invalid_ai_project_id",
+		Category: azdext.LocalErrorCategoryValidation,
+	}
+	baseStatus, err := status.New(codes.Unknown, "request failed").WithDetails(azdext.WrapError(localErr))
+	require.NoError(t, err)
+
+	wrapped := &hostErrorChain{
+		error:  localErr,
+		status: baseStatus,
+	}
+
+	st, ok := status.FromError(mapHostError(wrapped))
+	require.True(t, ok)
+	require.Len(t, relayedExtensionErrorDetails(st), 1)
 }
 
 func TestMapHostError_ResponseErrorUsesURLHostname(t *testing.T) {
@@ -616,9 +792,26 @@ func serviceErrorDetails(st *status.Status) []*azdext.ServiceErrorDetail {
 	return result
 }
 
+func relayedExtensionErrorDetails(st *status.Status) []*azdext.ExtensionError {
+	var result []*azdext.ExtensionError
+	for _, detail := range st.Details() {
+		if relayedErr, ok := detail.(*azdext.ExtensionError); ok {
+			result = append(result, relayedErr)
+		}
+	}
+	return result
+}
+
 func requireServiceErrorDetail(t *testing.T, st *status.Status) *azdext.ServiceErrorDetail {
 	t.Helper()
 	details := serviceErrorDetails(st)
+	require.Len(t, details, 1)
+	return details[0]
+}
+
+func requireRelayedExtensionError(t *testing.T, st *status.Status) *azdext.ExtensionError {
+	t.Helper()
+	details := relayedExtensionErrorDetails(st)
 	require.Len(t, details, 1)
 	return details[0]
 }


### PR DESCRIPTION
## Summary

- Relay wrapped `azdext.ServiceError` and `azdext.LocalError` values as a single `ExtensionError` gRPC status detail when nested host calls return extension-originated structured errors.
- Restore relayed structured errors in `azure.ai.agents` without adding a second operation prefix.
- Preserve existing host-native `azcore.ResponseError` handling, gRPC status messages, authentication behavior, actionable guidance, and generic-error fallbacks.

Closes #9635