### PR TITLE
Fixing bug in azd where you could pick an incorrect pairing of reasoning level for a model

### DIFF
--- a/cli/azd/internal/agent/copilot_agent.go
+++ b/cli/azd/internal/agent/copilot_agent.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -37,6 +38,7 @@ import (
 type CopilotAgent struct {
 	// Dependencies
 	clientManager        *agentcopilot.CopilotClientManager
+	listModels           func(context.Context) ([]copilot.ModelInfo, error)
 	sessionConfigBuilder *agentcopilot.SessionConfigBuilder
 	cli                  *agentcopilot.CopilotCLI
 	consentManager       consent.ConsentManager
@@ -74,6 +76,11 @@ type cleanupTask struct {
 	fn   func() error
 }
 
+const (
+	selectAIModelMessage              = "Select AI model"
+	selectReasoningEffortLevelMessage = "Select reasoning effort level"
+)
+
 // Initialize handles first-run configuration (model/reasoning prompts), plugin install,
 // and Copilot client startup. If config already exists, returns current values without
 // prompting. Use WithForcePrompt() to always show prompts.
@@ -108,117 +115,15 @@ func (a *CopilotAgent) Initialize(ctx context.Context, opts ...InitOption) (resu
 	}
 
 	// Load current config
-	azdConfig, err := a.configManager.Load()
+	selectedModelID, selectedReasoningEffort, err := a.promptModelAndReasoning(ctx, options)
+
 	if err != nil {
 		return nil, err
-	}
-
-	existingModel, hasModel := azdConfig.GetString(agentcopilot.ConfigKeyModel)
-	existingEffort, hasEffort := azdConfig.GetString(agentcopilot.ConfigKeyReasoningEffort)
-
-	// Apply overrides
-	if a.modelOverride != "" {
-		existingModel = a.modelOverride
-		hasModel = true
-	}
-	if a.reasoningEffortOverride != "" {
-		existingEffort = a.reasoningEffortOverride
-		hasEffort = true
-	}
-
-	// If already configured and not forcing, return current config
-	if (hasModel || hasEffort) && !options.forcePrompt {
-		return &InitResult{
-			Model:           existingModel,
-			ReasoningEffort: existingEffort,
-			IsFirstRun:      false,
-		}, nil
-	}
-
-	// Prompt for reasoning effort
-	effortChoices := []*uxlib.SelectChoice{
-		{Value: "low", Label: "Low — fastest, lowest cost"},
-		{Value: "medium", Label: "Medium — balanced (recommended)"},
-		{Value: "high", Label: "High — more thorough, higher cost and premium requests"},
-	}
-
-	effortSelector := uxlib.NewSelect(&uxlib.SelectOptions{
-		Message:         "Select reasoning effort level",
-		HelpMessage:     "Higher reasoning uses more premium requests and may cost more. You can change this later.",
-		Choices:         effortChoices,
-		SelectedIndex:   new(1),
-		DisplayNumbers:  new(true),
-		EnableFiltering: new(false),
-		DisplayCount:    3,
-	})
-
-	effortIdx, err := effortSelector.Ask(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if effortIdx == nil {
-		return nil, fmt.Errorf("reasoning effort selection cancelled")
-	}
-	selectedEffort := effortChoices[*effortIdx].Value
-
-	// Prompt for model selection — fetch available models dynamically
-	modelChoices := []*uxlib.SelectChoice{
-		{Value: "", Label: "Default model (recommended)"},
-	}
-
-	// Client already started — list models
-	models, modelsErr := a.clientManager.ListModels(ctx)
-	if modelsErr == nil {
-		for _, m := range models {
-			label := m.Name
-			if m.DefaultReasoningEffort != "" {
-				label += fmt.Sprintf(" (%s)", m.DefaultReasoningEffort)
-			}
-			if m.Billing != nil && m.Billing.Multiplier != nil {
-				label += fmt.Sprintf(" (%.0fx)", *m.Billing.Multiplier)
-			}
-			modelChoices = append(modelChoices, &uxlib.SelectChoice{
-				Value: m.ID,
-				Label: label,
-			})
-		}
-	}
-
-	modelSelector := uxlib.NewSelect(&uxlib.SelectOptions{
-		Message:         "Select AI model",
-		HelpMessage:     "Premium models may use more requests. You can change this later.",
-		Choices:         modelChoices,
-		SelectedIndex:   new(0),
-		DisplayNumbers:  new(true),
-		EnableFiltering: new(true),
-		DisplayCount:    min(len(modelChoices), 10),
-	})
-
-	modelIdx, err := modelSelector.Ask(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if modelIdx == nil {
-		return nil, fmt.Errorf("model selection cancelled")
-	}
-	selectedModel := modelChoices[*modelIdx].Value
-
-	// Save to config
-	if err := azdConfig.Set(agentcopilot.ConfigKeyReasoningEffort, selectedEffort); err != nil {
-		return nil, fmt.Errorf("failed to save reasoning effort: %w", err)
-	}
-	if selectedModel != "" {
-		if err := azdConfig.Set(agentcopilot.ConfigKeyModel, selectedModel); err != nil {
-			return nil, fmt.Errorf("failed to save model: %w", err)
-		}
-	}
-	if err := a.configManager.Save(azdConfig); err != nil {
-		return nil, fmt.Errorf("failed to save config: %w", err)
 	}
 
 	return &InitResult{
-		Model:           selectedModel,
-		ReasoningEffort: selectedEffort,
+		Model:           selectedModelID,
+		ReasoningEffort: selectedReasoningEffort,
 		IsFirstRun:      true,
 	}, nil
 }
@@ -1198,6 +1103,159 @@ func (a *CopilotAgent) promptPluginInstall(ctx context.Context, plugin pluginSpe
 	}
 
 	return *result, nil
+}
+
+func (a *CopilotAgent) promptModelAndReasoning(ctx context.Context, options *initOptions) (modelID string, reasoningEffort string, err error) {
+	azdConfig, err := a.configManager.Load()
+	if err != nil {
+		return "", "", err
+	}
+
+	existingModel, hasModel := azdConfig.GetString(agentcopilot.ConfigKeyModel)
+	existingEffort, hasEffort := azdConfig.GetString(agentcopilot.ConfigKeyReasoningEffort)
+
+	// Apply overrides
+	if a.modelOverride != "" {
+		existingModel = a.modelOverride
+		hasModel = true
+	}
+
+	if a.reasoningEffortOverride != "" {
+		existingEffort = a.reasoningEffortOverride
+		hasEffort = true
+	}
+
+	// If already configured and not forcing, return current config
+	if (hasModel || hasEffort) && !options.forcePrompt {
+		return existingModel, existingEffort, nil
+	}
+
+	selectedModel, err := a.promptModel(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to select a model: %w", err)
+	}
+
+	modelID = ""
+
+	if selectedModel != nil {
+		modelID = selectedModel.ID
+		if err := azdConfig.Set(agentcopilot.ConfigKeyModel, selectedModel.ID); err != nil {
+			return "", "", fmt.Errorf("failed to save model: %w", err)
+		}
+
+		reasoningEffort, err = a.promptReasoningEffort(ctx, *selectedModel)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to select a reasoning effort: %w", err)
+		}
+		if reasoningEffort != "" {
+			if err := azdConfig.Set(agentcopilot.ConfigKeyReasoningEffort, reasoningEffort); err != nil {
+				return "", "", fmt.Errorf("failed to save reasoning effort: %w", err)
+			}
+		}
+	} else {
+		// ie, use the SDK/model default
+		reasoningEffort = ""
+	}
+
+	if err := azdConfig.Set(agentcopilot.ConfigKeyReasoningEffort, reasoningEffort); err != nil {
+		return "", "", fmt.Errorf("failed to save reasoning effort: %w", err)
+	}
+
+	if err := a.configManager.Save(azdConfig); err != nil {
+		return "", "", fmt.Errorf("failed to save config: %w", err)
+	}
+
+	return modelID, reasoningEffort, nil
+}
+
+// promptModel prompts the user to select a coding model, also allowing the user to choose a
+// default. If the default is chosen, the return is (nil, nil), and the caller should let the
+// copilot SDK just determine the model on its own.
+//
+// NOTE: if the user does not choose a model this implies that they also are not choosing a
+// reasoning level - we have no way of knowing what the valid choices would be.
+func (a *CopilotAgent) promptModel(ctx context.Context) (*copilot.ModelInfo, error) {
+	modelChoices := []string{"Default model (recommended)"}
+
+	// Client already started — list models
+	models, modelsErr := a.listModels(ctx)
+
+	slices.SortFunc(models, func(a, b copilot.ModelInfo) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	if modelsErr == nil {
+		for _, m := range models {
+			label := m.Name
+
+			if m.Billing != nil && m.Billing.Multiplier != nil {
+				label += fmt.Sprintf(" (%.0fx)", *m.Billing.Multiplier)
+			}
+
+			modelChoices = append(modelChoices, label)
+		}
+	}
+
+	modelIdx, err := a.console.Select(ctx, input.ConsoleOptions{
+		Message:      selectAIModelMessage,
+		Help:         "Premium models may use more requests. You can change this later.",
+		Options:      modelChoices,
+		DefaultValue: modelChoices[0],
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if modelIdx == 0 {
+		// user chose the "default" model - we don't know anything about the model they've chosen
+		// (at the moment)
+		return nil, nil
+	}
+
+	return &models[modelIdx-1], nil
+}
+
+// promptReasoningEffort prompts the user to pick their model's reasoning effort. These are
+// direct from Copilot, which (sometimes) also includes a recommended reasoning effort, which we show
+// with a (recommended) suffix in the picker.
+//
+// NOTE: in some cases models do not support configuring the reasoning - we return ("", nil), and the caller
+// must handle that.
+func (a *CopilotAgent) promptReasoningEffort(ctx context.Context, selectedModel copilot.ModelInfo) (string, error) {
+	if len(selectedModel.SupportedReasoningEfforts) == 0 {
+		// some models, like mai-code-flash, do not support configuring reasoning
+		return "", nil
+	}
+
+	var effortChoices []string
+
+	// we'll default to whatever middle of the road reasoning effort there is
+	// if there isn't a specifically recommended default.
+	defaultIdx := len(selectedModel.SupportedReasoningEfforts) / 2
+
+	for i, m := range selectedModel.SupportedReasoningEfforts {
+		label := m
+
+		if selectedModel.DefaultReasoningEffort == m {
+			// this is the default
+			defaultIdx = i
+
+			label += " (recommended)"
+		}
+
+		effortChoices = append(effortChoices, label)
+	}
+
+	effortIdx, err := a.console.Select(ctx, input.ConsoleOptions{
+		Message:      selectReasoningEffortLevelMessage,
+		Help:         "Higher reasoning may cost more. You can change this later.",
+		Options:      effortChoices,
+		DefaultValue: effortChoices[defaultIdx],
+	})
+	if err != nil {
+		return "", err
+	}
+	return selectedModel.SupportedReasoningEfforts[effortIdx], nil
 }
 
 // FormatSessionTime formats a timestamp string into a human-friendly relative time display.

--- a/cli/azd/internal/agent/copilot_agent.go
+++ b/cli/azd/internal/agent/copilot_agent.go
@@ -1133,10 +1133,18 @@ func (a *CopilotAgent) promptModelAndReasoning(ctx context.Context, options *ini
 
 	if selectedModel != nil {
 		modelID = selectedModel.ID
-		if err := azdConfig.Set(agentcopilot.ConfigKeyModel, selectedModel.ID); err != nil {
-			return nil, fmt.Errorf("failed to save model: %w", err)
-		}
+	} else {
+		// the user choosing "use default" (which is why selectedModel == nil) _is_ a choice, and
+		// we should reflect that by storing the empty model so we'll pass an empty model when creating
+		// the copilot session.
+		modelID = ""
+	}
 
+	if err := azdConfig.Set(agentcopilot.ConfigKeyModel, modelID); err != nil {
+		return nil, fmt.Errorf("failed to save model: %w", err)
+	}
+
+	if selectedModel != nil {
 		reasoningEffort, err = a.promptReasoningEffort(ctx, *selectedModel)
 		if err != nil {
 			return nil, fmt.Errorf("failed to select a reasoning effort: %w", err)

--- a/cli/azd/internal/agent/copilot_agent.go
+++ b/cli/azd/internal/agent/copilot_agent.go
@@ -1105,7 +1105,8 @@ func (a *CopilotAgent) promptPluginInstall(ctx context.Context, plugin pluginSpe
 	return *result, nil
 }
 
-func (a *CopilotAgent) promptModelAndReasoning(ctx context.Context, options *initOptions) (modelID string, reasoningEffort string, err error) {
+func (a *CopilotAgent) promptModelAndReasoning(ctx context.Context,
+	options *initOptions) (modelID string, reasoningEffort string, err error) {
 	azdConfig, err := a.configManager.Load()
 	if err != nil {
 		return "", "", err

--- a/cli/azd/internal/agent/copilot_agent.go
+++ b/cli/azd/internal/agent/copilot_agent.go
@@ -114,18 +114,7 @@ func (a *CopilotAgent) Initialize(ctx context.Context, opts ...InitOption) (resu
 		return nil, err
 	}
 
-	// Load current config
-	selectedModelID, selectedReasoningEffort, err := a.promptModelAndReasoning(ctx, options)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &InitResult{
-		Model:           selectedModelID,
-		ReasoningEffort: selectedReasoningEffort,
-		IsFirstRun:      true,
-	}, nil
+	return a.promptModelAndReasoning(ctx, options)
 }
 
 // SelectSession shows a UX picker with previous sessions for the current directory.
@@ -1105,11 +1094,10 @@ func (a *CopilotAgent) promptPluginInstall(ctx context.Context, plugin pluginSpe
 	return *result, nil
 }
 
-func (a *CopilotAgent) promptModelAndReasoning(ctx context.Context,
-	options *initOptions) (modelID string, reasoningEffort string, err error) {
+func (a *CopilotAgent) promptModelAndReasoning(ctx context.Context, options *initOptions) (*InitResult, error) {
 	azdConfig, err := a.configManager.Load()
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
 
 	existingModel, hasModel := azdConfig.GetString(agentcopilot.ConfigKeyModel)
@@ -1128,45 +1116,50 @@ func (a *CopilotAgent) promptModelAndReasoning(ctx context.Context,
 
 	// If already configured and not forcing, return current config
 	if (hasModel || hasEffort) && !options.forcePrompt {
-		return existingModel, existingEffort, nil
+		return &InitResult{
+			Model:           existingModel,
+			ReasoningEffort: existingEffort,
+			IsFirstRun:      false,
+		}, nil
 	}
 
 	selectedModel, err := a.promptModel(ctx)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to select a model: %w", err)
+		return nil, fmt.Errorf("failed to select a model: %w", err)
 	}
 
-	modelID = ""
+	modelID := ""
+	reasoningEffort := ""
 
 	if selectedModel != nil {
 		modelID = selectedModel.ID
 		if err := azdConfig.Set(agentcopilot.ConfigKeyModel, selectedModel.ID); err != nil {
-			return "", "", fmt.Errorf("failed to save model: %w", err)
+			return nil, fmt.Errorf("failed to save model: %w", err)
 		}
 
 		reasoningEffort, err = a.promptReasoningEffort(ctx, *selectedModel)
 		if err != nil {
-			return "", "", fmt.Errorf("failed to select a reasoning effort: %w", err)
+			return nil, fmt.Errorf("failed to select a reasoning effort: %w", err)
 		}
-		if reasoningEffort != "" {
-			if err := azdConfig.Set(agentcopilot.ConfigKeyReasoningEffort, reasoningEffort); err != nil {
-				return "", "", fmt.Errorf("failed to save reasoning effort: %w", err)
-			}
-		}
+
 	} else {
 		// ie, use the SDK/model default
 		reasoningEffort = ""
 	}
 
 	if err := azdConfig.Set(agentcopilot.ConfigKeyReasoningEffort, reasoningEffort); err != nil {
-		return "", "", fmt.Errorf("failed to save reasoning effort: %w", err)
+		return nil, fmt.Errorf("failed to save reasoning effort: %w", err)
 	}
 
 	if err := a.configManager.Save(azdConfig); err != nil {
-		return "", "", fmt.Errorf("failed to save config: %w", err)
+		return nil, fmt.Errorf("failed to save config: %w", err)
 	}
 
-	return modelID, reasoningEffort, nil
+	return &InitResult{
+		Model:           modelID,
+		ReasoningEffort: reasoningEffort,
+		IsFirstRun:      true,
+	}, nil
 }
 
 // promptModel prompts the user to select a coding model, also allowing the user to choose a

--- a/cli/azd/internal/agent/copilot_agent_factory.go
+++ b/cli/azd/internal/agent/copilot_agent_factory.go
@@ -63,6 +63,7 @@ func NewCopilotAgentFactory(
 func (f *CopilotAgentFactory) Create(ctx context.Context, opts ...AgentOption) (Agent, error) {
 	agent := &CopilotAgent{
 		clientManager:        f.clientManager,
+		listModels:           f.clientManager.ListModels,
 		sessionConfigBuilder: f.sessionConfigBuilder,
 		cli:                  f.cli,
 		consentManager:       f.consentManager,

--- a/cli/azd/internal/agent/copilot_agent_test.go
+++ b/cli/azd/internal/agent/copilot_agent_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package agent
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	agentcopilot "github.com/azure/azure-dev/cli/azd/internal/agent/copilot"
+	"github.com/azure/azure-dev/cli/azd/pkg/config"
+	"github.com/azure/azure-dev/cli/azd/pkg/input"
+	"github.com/azure/azure-dev/cli/azd/test/mocks"
+)
+
+func TestCopilotAgentPromptModelAndReasoning(t *testing.T) {
+	t.Run("ModelWithoutReasoningLevels", func(t *testing.T) {
+		args := copilotAgentTestArgs{
+			ExpectedModelID:         "model-with-no-reasoning",
+			ExpectedReasoningEffort: "",
+			Models: []copilot.ModelInfo{
+				{
+					ID:   "model-with-no-reasoning",
+					Name: "Model with no reasoning",
+				},
+				{
+					ID:                        "some random model that's not used",
+					Name:                      "some random model that's not used",
+					SupportedReasoningEfforts: []string{"low", "medium", "high"},
+					DefaultReasoningEffort:    "medium",
+				},
+			},
+		}
+
+		runCopilotAgentTest(t, args)
+	})
+
+	t.Run("ModelWithDefaultReasoning_ExplicitChoice", func(t *testing.T) {
+		args := copilotAgentTestArgs{
+			Models: []copilot.ModelInfo{
+				{
+					ID:                        "some random model that's not used",
+					Name:                      "some random model that's not used",
+					SupportedReasoningEfforts: []string{"low", "medium", "high"},
+					DefaultReasoningEffort:    "medium",
+				},
+				{
+					ID:                        "model-with-default-reasoning",
+					Name:                      "Model with default reasoning",
+					SupportedReasoningEfforts: []string{"pistachio", "vanilla", "radish"},
+					DefaultReasoningEffort:    "vanilla",
+				}},
+			ExpectedModelID:         "model-with-default-reasoning",
+			ExpectedReasoningEffort: "pistachio",
+		}
+		runCopilotAgentTest(t, args)
+	})
+
+	t.Run("ModelWithDefaultReasoning_TakeDefault", func(t *testing.T) {
+		args := copilotAgentTestArgs{
+			Models: []copilot.ModelInfo{
+				{
+					ID:                        "some random model that's not used",
+					Name:                      "some random model that's not used",
+					SupportedReasoningEfforts: []string{"low", "medium", "high"},
+					DefaultReasoningEffort:    "medium",
+				},
+				{
+					ID:                        "model-with-default-reasoning",
+					Name:                      "Model with default reasoning",
+					SupportedReasoningEfforts: []string{"pistachio", "vanilla", "radish"},
+					DefaultReasoningEffort:    "vanilla",
+				}},
+			ExpectedModelID:         "model-with-default-reasoning",
+			ExpectedReasoningEffort: "vanilla",
+		}
+		runCopilotAgentTest(t, args)
+	})
+
+	t.Run("ModelWithoutDefaultReasoning", func(t *testing.T) {
+		args := copilotAgentTestArgs{
+			Models: []copilot.ModelInfo{{
+				ID:                        "model-with-no-default-reasoning",
+				Name:                      "Model with no default reasoning",
+				SupportedReasoningEfforts: []string{"low", "medium", "high"},
+			}},
+			ExpectedModelID:         "model-with-no-default-reasoning",
+			ExpectedReasoningEffort: "medium",
+		}
+
+		runCopilotAgentTest(t, args)
+
+		// quick check with an even number of reasoning efforts...
+		args = copilotAgentTestArgs{
+			Models: []copilot.ModelInfo{{
+				ID:                        "model-with-no-default-reasoning",
+				Name:                      "Model with no default reasoning",
+				SupportedReasoningEfforts: []string{"radish", "summer squash", "pumpkin", "blueberry"},
+			}},
+			ExpectedModelID:         "model-with-no-default-reasoning",
+			ExpectedReasoningEffort: "summer squash",
+		}
+
+		runCopilotAgentTest(t, args)
+	})
+}
+
+type copilotAgentTestArgs struct {
+	Models                  []copilot.ModelInfo
+	ExpectedModelID         string
+	ExpectedReasoningEffort string
+}
+
+func runCopilotAgentTest(
+	t *testing.T, args copilotAgentTestArgs,
+) {
+	var agent *CopilotAgent
+	var configManager config.UserConfigManager
+	{
+		modelIdx := -1
+		var model copilot.ModelInfo
+
+		// before they're presented, the model names are sorted by Name so they
+		// group properly (we need to do the same here to pick the right idx)
+		slices.SortFunc(args.Models, func(a, b copilot.ModelInfo) int {
+			return strings.Compare(a.Name, b.Name)
+		})
+
+		for i, m := range args.Models {
+			if m.ID == args.ExpectedModelID {
+				// small hack - the models are shifted by 1, since the first model in the
+				// select-list is "Default model", which basically bypasses any configuration
+				// and let's copilot choose.
+				modelIdx = i + 1
+				model = m
+				break
+			}
+		}
+
+		require.NotEqual(t, -1, modelIdx, "model ID you passed for the test isn't in your list of models")
+
+		mockContext := mocks.NewMockContext(t.Context())
+		mockContext.Console.WhenSelect(func(options input.ConsoleOptions) bool {
+			return options.Message == selectAIModelMessage
+		}).Respond(modelIdx)
+
+		if len(model.SupportedReasoningEfforts) > 0 {
+			// find the right reasoning index
+			reasoningIdx := -1
+
+			for i, re := range model.SupportedReasoningEfforts {
+				if re == args.ExpectedReasoningEffort {
+					reasoningIdx = i
+					break
+				}
+			}
+
+			require.NotEqualf(t, -1, reasoningIdx,
+				"reasoning you passed for the test isn't in the reasoning list for your model %s", model.ID)
+
+			mockContext.Console.WhenSelect(func(options input.ConsoleOptions) bool {
+				if options.Message != selectReasoningEffortLevelMessage {
+					return false
+				}
+
+				if model.DefaultReasoningEffort == "" {
+					// if there's no default value in the model we don't tag a specific level, the default
+					// is just the lowest reasoning level, but it's not listed as 'recommended'.
+					return options.DefaultValue == model.SupportedReasoningEfforts[len(model.SupportedReasoningEfforts)/2]
+				} else if options.DefaultValue != model.DefaultReasoningEffort+" (recommended)" {
+					return false
+				}
+
+				return true
+			}).Respond(reasoningIdx)
+		}
+
+		configManager = config.NewUserConfigManager(mockContext.ConfigManager)
+
+		agent = &CopilotAgent{
+			console:       mockContext.Console,
+			configManager: configManager,
+			listModels: func(context.Context) ([]copilot.ModelInfo, error) {
+				return args.Models, nil
+			},
+		}
+	}
+
+	modelID, reasoningEffort, err := agent.promptModelAndReasoning(t.Context(), &initOptions{})
+	require.NoError(t, err)
+
+	require.Equal(t, args.ExpectedModelID, modelID)
+	require.Equal(t, args.ExpectedReasoningEffort, reasoningEffort)
+
+	// quick check -what we're returning here matches what's stored in the configuration
+	userConfig, err := configManager.Load()
+	require.NoError(t, err)
+
+	storedModelID, hasModel := userConfig.GetString(agentcopilot.ConfigKeyModel)
+	require.True(t, hasModel)
+	assert.Equal(t, modelID, storedModelID)
+
+	if args.ExpectedReasoningEffort == "" {
+		storedReasoningEffort, hasEffort := userConfig.GetString(agentcopilot.ConfigKeyReasoningEffort)
+		require.True(t, hasEffort)
+		assert.Equal(t, "", storedReasoningEffort)
+	} else {
+		storedReasoningEffort, hasEffort := userConfig.GetString(agentcopilot.ConfigKeyReasoningEffort)
+		require.True(t, hasEffort)
+		assert.Equal(t, args.ExpectedReasoningEffort, storedReasoningEffort)
+	}
+}

--- a/cli/azd/internal/agent/copilot_agent_test.go
+++ b/cli/azd/internal/agent/copilot_agent_test.go
@@ -21,27 +21,32 @@ import (
 
 func TestCopilotAgentPromptModelAndReasoning(t *testing.T) {
 	t.Run("ModelConfigurationAlreadyInConfig", func(t *testing.T) {
-		mockContext := mocks.NewMockContext(t.Context())
-		userConfig := config.NewEmptyConfig()
+		runCopilotAgentTest(t, copilotAgentTestArgs{
+			Models: []copilot.ModelInfo{{
+				ID:   "configured-model",
+				Name: "Configured model",
+			}},
 
-		require.NoError(t, userConfig.Set(agentcopilot.ConfigKeyModel, "configured-model"))
-		require.NoError(t, userConfig.Set(agentcopilot.ConfigKeyReasoningEffort, "configured-effort"))
+			// stored config values
+			ExpectedModelID:         "configured-model",
+			ExpectedReasoningEffort: "configured-effort",
 
-		mockContext.ConfigManager.WithConfig(userConfig)
+			// without 'forcePrompt' we'll just returned the already stored config values
+			ExistingModelID:         "configured-model",
+			ExistingReasoningEffort: "configured-effort",
+		})
+	})
 
-		// IsFirstRun is reported in a few ways - via telemetry and via RPC to extensions
-		// It gets set to true if we end up prompting the user to enter in model details
-		agent := &CopilotAgent{
-			console:       mockContext.Console,
-			configManager: config.NewUserConfigManager(mockContext.ConfigManager),
-		}
-
-		result, err := agent.promptModelAndReasoning(t.Context(), &initOptions{})
-
-		require.NoError(t, err)
-		assert.Equal(t, "configured-model", result.Model)
-		assert.Equal(t, "configured-effort", result.ReasoningEffort)
-		assert.False(t, result.IsFirstRun, "user already had configuration stored")
+	t.Run("ForcePromptDefaultClearsExistingConfiguration", func(t *testing.T) {
+		runCopilotAgentTest(t, copilotAgentTestArgs{
+			Models: []copilot.ModelInfo{{
+				ID:   "configured-model",
+				Name: "Configured model",
+			}},
+			ExistingModelID:         "configured-model",
+			ExistingReasoningEffort: "configured-effort",
+			ForcePrompt:             true,
+		})
 	})
 
 	t.Run("ModelWithoutReasoningLevels", func(t *testing.T) {
@@ -136,9 +141,27 @@ func TestCopilotAgentPromptModelAndReasoning(t *testing.T) {
 }
 
 type copilotAgentTestArgs struct {
-	Models                  []copilot.ModelInfo
-	ExpectedModelID         string
+	Models []copilot.ModelInfo
+
+	// ExpectedModelID is what we expect the model ID to be after the user prompts have completed.
+	// (this will also be checked in the user config).
+	ExpectedModelID string
+
+	// ExpectedReasoningEffort is what we expect the reasoning effort to be after the user prompts have completed.
+	// (this will also be checked in the user config).
 	ExpectedReasoningEffort string
+
+	// ExistingModelID is a model ID that's already saved in the user config
+	// (as if they'd already gone through the prompting workflow)
+	ExistingModelID string
+
+	// ExistingReasoningEffort is the reasoning effort that's already saved in
+	// the user config (as if they'd already gone through the prompting workflow)
+	ExistingReasoningEffort string
+
+	// ForcePrompt toggles the 'forcePrompt' option in copilot agent to _always_ prompt the user
+	// even if something is already stored.
+	ForcePrompt bool
 }
 
 func runCopilotAgentTest(
@@ -156,20 +179,36 @@ func runCopilotAgentTest(
 			return strings.Compare(a.Name, b.Name)
 		})
 
-		for i, m := range args.Models {
-			if m.ID == args.ExpectedModelID {
-				// small hack - the models are shifted by 1, since the first model in the
-				// select-list is "Default model", which basically bypasses any configuration
-				// and let's copilot choose.
-				modelIdx = i + 1
-				model = m
-				break
+		if args.ExpectedModelID == "" {
+			modelIdx = 0 // ie (the 'default' model choice in our select-prompt)
+		} else {
+			for i, m := range args.Models {
+				if m.ID == args.ExpectedModelID {
+					// small hack - the models are shifted by 1, since the first model in the
+					// select-list is "Default model", which basically bypasses any configuration
+					// and let's copilot choose.
+					modelIdx = i + 1
+					model = m
+					break
+				}
 			}
+
+			require.NotEqual(t, -1, modelIdx, "model ID you passed for the test isn't in your list of models")
 		}
 
-		require.NotEqual(t, -1, modelIdx, "model ID you passed for the test isn't in your list of models")
-
 		mockContext := mocks.NewMockContext(t.Context())
+		userConfig := config.NewEmptyConfig()
+
+		if args.ExistingModelID != "" {
+			require.NoError(t, userConfig.Set(agentcopilot.ConfigKeyModel, args.ExistingModelID))
+		}
+
+		if args.ExistingReasoningEffort != "" {
+			require.NoError(t, userConfig.Set(agentcopilot.ConfigKeyReasoningEffort, args.ExistingReasoningEffort))
+		}
+
+		mockContext.ConfigManager.WithConfig(userConfig)
+
 		mockContext.Console.WhenSelect(func(options input.ConsoleOptions) bool {
 			return options.Message == selectAIModelMessage
 		}).Respond(modelIdx)
@@ -216,12 +255,14 @@ func runCopilotAgentTest(
 		}
 	}
 
-	result, err := agent.promptModelAndReasoning(t.Context(), &initOptions{})
+	result, err := agent.promptModelAndReasoning(t.Context(), &initOptions{forcePrompt: args.ForcePrompt})
 	require.NoError(t, err)
 
 	require.Equal(t, args.ExpectedModelID, result.Model)
 	require.Equal(t, args.ExpectedReasoningEffort, result.ReasoningEffort)
-	require.True(t, result.IsFirstRun)
+
+	hasExistingConfig := args.ExistingModelID != "" || args.ExistingReasoningEffort != ""
+	assert.Equal(t, !hasExistingConfig || args.ForcePrompt, result.IsFirstRun)
 
 	// quick check -what we're returning here matches what's stored in the configuration
 	userConfig, err := configManager.Load()

--- a/cli/azd/internal/agent/copilot_agent_test.go
+++ b/cli/azd/internal/agent/copilot_agent_test.go
@@ -20,6 +20,30 @@ import (
 )
 
 func TestCopilotAgentPromptModelAndReasoning(t *testing.T) {
+	t.Run("ModelConfigurationAlreadyInConfig", func(t *testing.T) {
+		mockContext := mocks.NewMockContext(t.Context())
+		userConfig := config.NewEmptyConfig()
+
+		require.NoError(t, userConfig.Set(agentcopilot.ConfigKeyModel, "configured-model"))
+		require.NoError(t, userConfig.Set(agentcopilot.ConfigKeyReasoningEffort, "configured-effort"))
+
+		mockContext.ConfigManager.WithConfig(userConfig)
+
+		// IsFirstRun is reported in a few ways - via telemetry and via RPC to extensions
+		// It gets set to true if we end up prompting the user to enter in model details
+		agent := &CopilotAgent{
+			console:       mockContext.Console,
+			configManager: config.NewUserConfigManager(mockContext.ConfigManager),
+		}
+
+		result, err := agent.promptModelAndReasoning(t.Context(), &initOptions{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "configured-model", result.Model)
+		assert.Equal(t, "configured-effort", result.ReasoningEffort)
+		assert.False(t, result.IsFirstRun, "user already had configuration stored")
+	})
+
 	t.Run("ModelWithoutReasoningLevels", func(t *testing.T) {
 		args := copilotAgentTestArgs{
 			ExpectedModelID:         "model-with-no-reasoning",
@@ -192,11 +216,12 @@ func runCopilotAgentTest(
 		}
 	}
 
-	modelID, reasoningEffort, err := agent.promptModelAndReasoning(t.Context(), &initOptions{})
+	result, err := agent.promptModelAndReasoning(t.Context(), &initOptions{})
 	require.NoError(t, err)
 
-	require.Equal(t, args.ExpectedModelID, modelID)
-	require.Equal(t, args.ExpectedReasoningEffort, reasoningEffort)
+	require.Equal(t, args.ExpectedModelID, result.Model)
+	require.Equal(t, args.ExpectedReasoningEffort, result.ReasoningEffort)
+	require.True(t, result.IsFirstRun)
 
 	// quick check -what we're returning here matches what's stored in the configuration
 	userConfig, err := configManager.Load()
@@ -204,7 +229,7 @@ func runCopilotAgentTest(
 
 	storedModelID, hasModel := userConfig.GetString(agentcopilot.ConfigKeyModel)
 	require.True(t, hasModel)
-	assert.Equal(t, modelID, storedModelID)
+	assert.Equal(t, result.Model, storedModelID)
 
 	if args.ExpectedReasoningEffort == "" {
 		storedReasoningEffort, hasEffort := userConfig.GetString(agentcopilot.ConfigKeyReasoningEffort)


### PR DESCRIPTION
Prior to this, azd would ask the user to pick the reasoning level for a model _before_ picking the model. This meant the list of reasoning efforts was hardcoded, and might not match what the model could actually do, which would lead to errors later on when actually trying to use copilot.

This PR changes things to ask for model _first_, and then using the returned metadata to use the recommended default reasoning level, and to only display the actual reasoning efforts for the model. Also, it just makes a bit more sense, and lines up more with how other tools work.

Fixes #9591