### PR TITLE
Add new extension checks to azd code reviewer

### DIFF
--- a/.github/skills/azd-code-reviewer/SKILL.md
+++ b/.github/skills/azd-code-reviewer/SKILL.md
@@ -1,22 +1,21 @@
 ---
+# cspell:ignore triaging worktree dedup
 name: azd-code-reviewer
 description: "Reviews GitHub pull requests by applying multiple specialist lenses (security, Go expert, architect, testing, UX, docs, PM, Azure, novice customer), triaging findings for signal-to-noise, and returning structured inline comments. Use for: review PR, look at this PR, give feedback on PR, check this PR, code review, PR feedback."
 license: MIT
 metadata:
-  version: "1.0"
+  version: "1.1"
 ---
 
-# Code Review
+# Code review
 
 Reviews GitHub PRs by applying a panel of specialist review lenses to the diff, filtering for high-signal findings, and returning structured comments for the host to post.
 
-For any issue identified by this skill, please put "azd-code-reviewer" on the comment as well, so we can identify those issues externally.
+## Operating environment
 
-## Operating Environment
+This skill usually runs inside an automated review harness (e.g., Copilot Code Review). It assumes:
 
-This skill runs inside an automated review harness (e.g., Copilot Code Review). It assumes:
-
-- **The diff and PR context are already provided** by the harness. No PR fetching, repo cloning, branch checkout, or worktree creation.
+- **The diff and PR context are already provided** by the harness. In an interactive invocation without that context, use read-only `git` and `gh` commands to discover the current branch diff and PR metadata. Do not change branches or the worktree.
 - **No interactive user.** No `ask the user` flows, no walkthroughs, no "want to proceed?" gates. The skill produces findings and returns them.
 - **No build or test execution.** Test code is reviewed statically.
 - **The harness handles posting.** The skill returns structured findings; the harness creates the review.
@@ -27,19 +26,23 @@ If the host is interactive (e.g., a chat agent invoking the skill manually), the
 
 ### Step 1: Read the diff and PR context
 
-Use whatever PR metadata, diff, and changed-file list the harness provides. Do not attempt to fetch additional context with `gh`, `git`, or network calls. If supplementary context (linked issues, prior review comments) is available, use it. If not, proceed with what you have.
+Use whatever PR metadata, diff, and changed-file list the harness provides. In an interactive invocation where these are missing, discover them with read-only `git` and `gh` commands. If supplementary context such as linked issues or prior review comments is available, use it.
 
-### Step 2: Apply review lenses
+### Step 2: Detect review cases
+
+If the PR introduces a new top-level directory under `cli/azd/extensions/`, load [new-extension.md](new-extension.md) and apply its onboarding review. Treat a directory as new when the changed-file metadata marks it as added, or when the PR adds its manifest, module, and entry point together.
+
+### Step 3: Apply review lenses
 
 Load [reviewers.md](reviewers.md) and apply each of the 9 fixed lenses to the diff. Then scan the changed files for the domain signals listed in `reviewers.md` and apply matching domain lenses. Each lens produces zero or more findings in the structured format defined in `reviewers.md`.
 
 **The reviewing agent is the same LLM** — these lenses are _perspectives to apply sequentially or in parallel_, not separate subagents. The host may parallelize lens application if supported, but a single-pass application of all lenses to the same diff is equally valid.
 
-### Step 3: Triage findings
+### Step 4: Triage findings
 
 Load [findings.md](findings.md). Apply the self-reflection pass: drop low-signal findings according to the dismissal triggers, merge duplicates across lenses, group by file, and sort by line.
 
-### Step 4: Voice and format
+### Step 5: Voice and format
 
 Still in `findings.md`. Apply the voice rules to every finding's text. Build the review body (one sentence + optional bullets for non-line findings). Return the final findings in the format the harness expects.
 
@@ -48,11 +51,12 @@ Still in `findings.md`. Apply the voice rules to every finding's text. Build the
 - **Silence over noise.** If a lens has nothing meaningful to say, it returns nothing. No invented concerns. Fewer, better comments is the goal.
 - **Codebase context matters.** Review the change in context — read surrounding code, not just the diff. Cross-file logic errors are the most common real bugs.
 - **Independence.** The reviewing agent builds its own understanding. It does not share assumptions with whatever generated the code.
-- **Findings must be actionable.** Every comment must suggest a specific change or raise a specific concern the author can act on.
+- **Findings must be useful.** Critical, suggestion, and nit comments must give the author something specific to act on. Praise must name a concrete pattern worth preserving.
 
-## Bundled Resources
+## Bundled resources
 
 | File                 | Contents                                                                                       |
 | -------------------- | ---------------------------------------------------------------------------------------------- |
 | `reviewers.md`       | 9 fixed lens definitions, dynamic domain detection rules, shared ground rules, findings format |
 | `findings.md`        | Self-reflection triage, dismissal triggers, merge/dedup, voice rules, review body guidance     |
+| `new-extension.md`   | New first-party extension scaffolding, repository wiring, release, and handoff checks          |

--- a/.github/skills/azd-code-reviewer/SKILL.md
+++ b/.github/skills/azd-code-reviewer/SKILL.md
@@ -30,7 +30,7 @@ Use whatever PR metadata, diff, and changed-file list the harness provides. In a
 
 ### Step 2: Detect review cases
 
-If the PR introduces a new top-level directory under `cli/azd/extensions/`, load [new-extension.md](new-extension.md) and apply its onboarding review. Treat a directory as new when the changed-file metadata marks it as added, or when the PR adds its manifest, module, and entry point together.
+If added files are under a top-level path in `cli/azd/extensions/` that did not exist before the PR, load [new-extension.md](new-extension.md) and apply its onboarding review. An added `extension.yaml` is enough to trigger the new-extension review because a dependency-only extension pack may have no module or entry point.
 
 ### Step 3: Apply review lenses
 

--- a/.github/skills/azd-code-reviewer/findings.md
+++ b/.github/skills/azd-code-reviewer/findings.md
@@ -2,13 +2,13 @@
 
 Self-reflection triage, voice rules, and output format for the review.
 
-## Self-Reflection Pass
+## Self-reflection pass
 
 Before emitting findings, run a quality filter. The goal is high signal-to-noise — the author should want to act on most findings.
 
 For each finding, evaluate:
 
-1. **Is this actionable?** Does it suggest a specific change or raise a specific concern? Vague observations are not actionable.
+1. **Is this useful?** Criticism must suggest a specific change or raise a specific concern. Praise must identify a concrete pattern worth preserving.
 2. **Is this correct?** Does the finding accurately reflect what the code does? Cross-check against the actual diff — findings based on misreading the code should be dismissed.
 3. **Is this worth the author's time?** Would a senior engineer comment on this in a real review, or would they let it go?
 4. **Is this a duplicate?** If multiple lenses flagged the same concern, keep the most detailed version and note which lenses agreed.
@@ -21,15 +21,15 @@ Dismiss a finding if ANY of these apply:
 - **Restates the PR description** — "this PR adds X" without identifying a problem with X.
 - **Vague "consider" without alternative** — "consider handling errors better" with no specific suggestion.
 - **Already addressed in existing review comments** — another reviewer already raised this and the author responded (only applies if prior comments are available).
-- **Outside the diff** — references code that was not changed in this PR (unless it is a cross-file logic error caused by the change).
+- **Outside the diff** — references code unrelated to the PR. Missing companion changes required by the PR, including absent scaffold files, remain in scope.
 - **Hypothetical concern with no evidence** — "this could be a problem if..." where the scenario is unlikely given the context.
 
 Classify each finding:
 
-- **Keep** — actionable, correct, worth the author's time.
+- **Keep** — useful, correct, worth the author's time.
 - **Drop** — low value, vague, likely false positive, or not worth mentioning.
 
-## Merge and Deduplicate
+## Merge and deduplicate
 
 After filtering kept findings:
 
@@ -38,19 +38,18 @@ After filtering kept findings:
 3. Deduplicate: if multiple lenses flagged the same file + line + similar concern, merge into one finding. Note all contributing lenses in the detail.
 4. Tag each finding with severity: **critical** / **suggestion** / **nit** / **praise**.
 
-## Voice Rules
+## Voice rules
 
 All review text — the review body AND inline comments — follows these rules:
 
 - Lead with the technical point. No preamble.
 - Short, direct sentences.
-- "None of these are blocking — just flagging" prefix for nit-level groups.
-- "I think we need..." for suggestions you feel strongly about.
 - No "Great PR!" or "Thanks for the contribution!" openers.
 - No emoji, no exclamation marks for enthusiasm.
 - When uncertain, say "I might be wrong, but..." or "I'm curious about..." rather than hedging with "perhaps consider...".
+- Append `<!-- azd-code-reviewer -->` to every inline comment and non-line finding bullet. Do not add the marker to the one-sentence review sentiment.
 
-## Build the Review Body
+## Build the review body
 
 The review body is the top-level comment on the review. Keep it **one sentence** — a quick overall sentiment. The review body is not threaded (nobody can reply to it directly), so it is the wrong place for substantive feedback. All real findings go in inline comments.
 
@@ -63,9 +62,9 @@ Examples:
 
 Match the tone to the severity mix: if everything is nits/praise, keep it positive. If there are critical findings, signal that briefly.
 
-**Findings that don't map to a diff line:** If any kept findings could not be pinned to a specific line (cross-cutting concern, or about a file as a whole), add them as a short bulleted list below the one-liner. Keep each bullet to one sentence. This is the only case where the body exceeds one line.
+**Findings that do not map to a diff line.** If a kept finding cannot be pinned to a specific line, add it as a short bullet below the one-line review body. Keep each bullet to one sentence. This is the only case where the body exceeds one line.
 
-## Output Format
+## Output format
 
 Return the final review as a structured object the harness can post:
 
@@ -75,7 +74,7 @@ comments:
   - path: "relative/path/to/file.go"
     line: 42
     severity: critical | suggestion | nit | praise
-    body: "Inline comment text following the voice rules. Tag with severity prefix, e.g. '[critical] ...'."
+    body: "[critical] Inline comment text following the voice rules. <!-- azd-code-reviewer -->"
 ```
 
 **Line constraint.** Every inline `line` value MUST be a line that appears in the diff (added or context lines on the `RIGHT` side). Findings that don't satisfy this go in the review body instead of `comments`.

--- a/.github/skills/azd-code-reviewer/new-extension.md
+++ b/.github/skills/azd-code-reviewer/new-extension.md
@@ -27,7 +27,7 @@ For Go extensions, check:
 - the Go version matches `cli/azd/go.mod`
 - `go.mod` has no local `replace` directives or azd SDK pseudo-versions
 - direct dependencies shared with core use the core version, unless `cli/azd/dependency-versions.json` records an exact, issue-linked temporary exception
-- the azd SDK version agrees with `requiredAzdVersion`
+- `requiredAzdVersion` reflects the earliest azd release compatible with the core APIs and behavior the extension uses
 
 Dependency synchronization does not cover indirect dependencies or extension manifest dependencies. Confirm manifest dependencies can be satisfied in the intended registry before publication, and track unresolved prerequisites in the manual handoff.
 

--- a/.github/skills/azd-code-reviewer/new-extension.md
+++ b/.github/skills/azd-code-reviewer/new-extension.md
@@ -35,6 +35,6 @@ Dependency synchronization does not cover indirect dependencies or extension man
 
 Registry updates and any resulting test snapshot updates should be handled in a follow-up PR, separate from the initial extension scaffolding.
 
-Check that the author plans to follow up with a member of the azd core team to register the release YAML as a new Azure DevOps pipeline under `azure-dev/extensions` and verify its access to the shared release infrastructure.
+For an executable extension with a release YAML, check that the author plans to follow up with a member of the azd core team to register it as a new Azure DevOps pipeline under `azure-dev/extensions` and verify its access to the shared release infrastructure.
 
 A contributor with repository permissions should create a matching `ext-*` GitHub label for issue tracking.

--- a/.github/skills/azd-code-reviewer/new-extension.md
+++ b/.github/skills/azd-code-reviewer/new-extension.md
@@ -1,0 +1,40 @@
+<!-- cspell:ignore golangci -->
+
+# New first-party extension review
+
+Apply this guide when a PR adds a top-level directory under `cli/azd/extensions/`.
+
+## 1. Classify the extension
+
+Classify it as an executable extension or a dependency-only extension pack before reviewing. Apply executable build, lint, release, capability, and ownership checks only where applicable. The internal scaffold supports Go executable extensions; review another language against the build and release approach proposed in the PR.
+
+## 2. Compare the current scaffold
+
+For a Go executable extension, compare the PR with `createInternalExtensionScaffold` in `cli/azd/extensions/microsoft.azd.extensions/internal/cmd/init.go` and the Go resources under `cli/azd/extensions/microsoft.azd.extensions/internal/resources/`. These show the current expected baseline, but an explained alternative may be appropriate.
+
+Check for easy-to-miss repository wiring such as the extension lint caller, spelling configuration, CODEOWNERS rule, release definition, PR bundle path, and relevant shared-template path filters. Raise a finding only when something needed by the proposed extension is missing or incompatible.
+
+Missing repository wiring has no diff line to anchor a comment to. Report it as a PR-level finding rather than dropping it during triage.
+
+## 3. Check the manifest contract
+
+Validate `extension.yaml`, then trace its ID, sanitized ID, version, public command path where present, capabilities, and dependencies through source, build, lint, release, and customer-facing examples.
+
+For each declared capability, follow its matching extension framework contract and check its implementation, registration, and applicable contract tests. If `providers` is present, check for `internal/cmd/providers_manifest_test.go` with `TestConfigureExtensionHostMatchesManifest` and for the extension lint workflow to call `.github/workflows/verify-ext-providers.yml`.
+
+For Go extensions, check:
+
+- the Go version matches `cli/azd/go.mod`
+- `go.mod` has no local `replace` directives or azd SDK pseudo-versions
+- direct dependencies shared with core use the core version, unless `cli/azd/dependency-versions.json` records an exact, issue-linked temporary exception
+- the azd SDK version agrees with `requiredAzdVersion`
+
+Dependency synchronization does not cover indirect dependencies or extension manifest dependencies. Confirm manifest dependencies can be satisfied in the intended registry before publication, and track unresolved prerequisites in the manual handoff.
+
+## 4. Check publication timing and handoff
+
+Registry updates and any resulting test snapshot updates should be handled in a follow-up PR, separate from the initial extension scaffolding.
+
+Check that the author plans to follow up with a member of the azd core team to register the release YAML as a new Azure DevOps pipeline under `azure-dev/extensions` and verify its access to the shared release infrastructure.
+
+A contributor with repository permissions should create a matching `ext-*` GitHub label for issue tracking.


### PR DESCRIPTION
Fixes #9665

### Summary

This PR teaches the azd code reviewer to check the repository wiring that is easy to miss when a pull request adds a first-party extension under `cli/azd/extensions/`.

### New extension reviews

The reviewer now loads a focused guide only when a PR introduces a new extension directory.

- Classifies executable extensions and dependency-only extension packs before applying build or release expectations.
- Compares Go extensions with the current `azd x init --internal` baseline while allowing intentional alternatives.
- Checks manifest identity, capability registration, provider contract tests, Go version alignment, shared dependency versions, and extension dependency availability.
- Keeps initial scaffolding separate from registry and snapshot updates.
- Calls out the manual handoff to the azd core team for Azure DevOps pipeline registration, while leaving label creation to contributors and publication to the extension team.

### Review quality

The shared findings guidance now treats concrete praise as useful feedback, keeps missing companion files in scope, and defines where the hidden `azd-code-reviewer` marker belongs without duplicating that rule in the main skill.

### Testing

Checked the skill links and repository references, Markdown formatting, and spelling.
