### PR TITLE
fix(pipelines): skip extension PR publishing for forks

### DIFF
--- a/eng/pipelines/templates/stages/publish-extension-pr.yml
+++ b/eng/pipelines/templates/stages/publish-extension-pr.yml
@@ -9,11 +9,13 @@ parameters:
 stages:
   - stage: PublishExtensionForPR
     dependsOn: BuildAndTest
+    # Fork builds cannot access the service connections required to publish bundles or comment on PRs.
     condition: >-
       and(
         succeeded(),
         ne(variables['Skip.Release'], 'true'),
-        eq(variables['Build.Reason'], 'PullRequest')
+        eq(variables['Build.Reason'], 'PullRequest'),
+        ne(variables['System.PullRequest.IsFork'], 'True')
       )
 
     variables:


### PR DESCRIPTION
Part of #9669

### Issue

This PR prevents extension pipelines from failing on fork PRs while the team consults EngSys about the permanent ADO configuration.

ADO currently suppresses the service connections used to upload PR bundles and mint the GitHub App token for fork builds. The upload task is skipped, then the comment task fails with `gh: Bad credentials (HTTP 401)`.

### Change

This PR skips the shared `PublishExtensionForPR` stage when `System.PullRequest.IsFork` is `True`. Build and test stages still run for forks. PRs from branches in `Azure/azure-dev` continue to publish bundles and post installation comments.

This is a temporary workaround. #9669 tracks the proper ADO pipeline configuration and removal of this guard.

### Behaviour at a glance

| PR source | Before | After |
|---|---|---|
| Branch in `Azure/azure-dev` | Build, publish bundle, and post comment | No change |
| Fork | Build succeeds, upload is skipped, comment fails with HTTP 401 | Build succeeds and PR publishing is skipped |

### Testing

No automated tests were run. The change only adds an ADO stage condition using the predefined `System.PullRequest.IsFork` variable.
