### PR TITLE
Align AKS file permissions with azd standards

### DIFF
--- a/cli/azd/pkg/tools/kubectl/kube_config.go
+++ b/cli/azd/pkg/tools/kubectl/kube_config.go
@@ -50,14 +50,12 @@ func (kcm *KubeConfigManager) SaveKubeConfig(ctx context.Context, configName str
 		return "", fmt.Errorf("failed marshalling KubeConfig to yaml: %w", err)
 	}
 
-	// Create .kube config folder if it doesn't already exist
-	if err := os.MkdirAll(kcm.configPath, osutil.PermissionDirectory); err != nil {
+	if err := ensureKubeConfigDirectory(kcm.configPath); err != nil {
 		return "", fmt.Errorf("failed creating .kube config directory, %w", err)
 	}
 
 	outFilePath := filepath.Join(kcm.configPath, configName)
-	err = os.WriteFile(outFilePath, kubeConfigRaw, osutil.PermissionFile)
-	if err != nil {
+	if err := writeKubeConfig(outFilePath, kubeConfigRaw); err != nil {
 		return "", fmt.Errorf("failed writing kube config file: %w", err)
 	}
 
@@ -93,9 +91,12 @@ func (kcm *KubeConfigManager) MergeConfigs(ctx context.Context, newConfigName st
 	}
 
 	kubeConfigRaw := []byte(res.Stdout)
+	if err := ensureKubeConfigDirectory(kcm.configPath); err != nil {
+		return "", fmt.Errorf("failed securing .kube config directory, %w", err)
+	}
+
 	outFilePath := filepath.Join(kcm.configPath, newConfigName)
-	err = os.WriteFile(outFilePath, kubeConfigRaw, osutil.PermissionFile)
-	if err != nil {
+	if err := writeKubeConfig(outFilePath, kubeConfigRaw); err != nil {
 		return "", fmt.Errorf("failed writing new kube config: %w", err)
 	}
 
@@ -122,4 +123,34 @@ func getKubeConfigDir() (string, error) {
 		return "", fmt.Errorf("cannot get user home directory: %w", err)
 	}
 	return filepath.Join(userHomeDir, ".kube"), nil
+}
+
+func ensureKubeConfigDirectory(path string) error {
+	if err := os.MkdirAll(path, osutil.PermissionDirectoryOwnerOnly); err != nil {
+		return err
+	}
+
+	return os.Chmod(path, osutil.PermissionDirectoryOwnerOnly)
+}
+
+func writeKubeConfig(path string, contents []byte) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, osutil.PermissionFileOwnerOnly)
+	if err != nil {
+		return err
+	}
+
+	if err := file.Chmod(osutil.PermissionFileOwnerOnly); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Truncate(0); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if _, err := file.Write(contents); err != nil {
+		_ = file.Close()
+		return err
+	}
+
+	return file.Close()
 }

--- a/cli/azd/pkg/tools/kubectl/kube_config_test.go
+++ b/cli/azd/pkg/tools/kubectl/kube_config_test.go
@@ -5,11 +5,14 @@ package kubectl
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/exec"
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/test/mocks"
 	"github.com/stretchr/testify/require"
 )
@@ -25,19 +28,11 @@ func Test_MergeKubeConfig(t *testing.T) {
 	cli := NewCli(mockContext.CommandRunner)
 	kubeConfigManager, err := NewKubeConfigManager(cli)
 	require.NoError(t, err)
+	kubeConfigManager.configPath = filepath.Join(t.TempDir(), ".kube")
 
 	config1 := createTestCluster("cluster1", "user1")
 	config2 := createTestCluster("cluster2", "user2")
 	config3 := createTestCluster("cluster3", "user3")
-
-	defer func() {
-		err := kubeConfigManager.DeleteKubeConfig(*mockContext.Context, "config1")
-		require.NoError(t, err)
-		err = kubeConfigManager.DeleteKubeConfig(*mockContext.Context, "config2")
-		require.NoError(t, err)
-		err = kubeConfigManager.DeleteKubeConfig(*mockContext.Context, "config3")
-		require.NoError(t, err)
-	}()
 
 	kubeConfigPath, err := kubeConfigManager.SaveKubeConfig(*mockContext.Context, "config1", config1)
 	require.NoError(t, err)
@@ -58,6 +53,72 @@ func Test_MergeKubeConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, kubeConfigPath)
 	require.Contains(t, kubeConfigPath, filepath.Join(".kube", "config"))
+
+	if runtime.GOOS != "windows" {
+		requirePermissions(t, kubeConfigManager.configPath, osutil.PermissionDirectoryOwnerOnly)
+		requirePermissions(t, filepath.Join(kubeConfigManager.configPath, "config1"), osutil.PermissionFileOwnerOnly)
+		requirePermissions(t, filepath.Join(kubeConfigManager.configPath, "config2"), osutil.PermissionFileOwnerOnly)
+		requirePermissions(t, filepath.Join(kubeConfigManager.configPath, "config3"), osutil.PermissionFileOwnerOnly)
+		requirePermissions(t, kubeConfigPath, osutil.PermissionFileOwnerOnly)
+	}
+
+	require.NoError(t, kubeConfigManager.DeleteKubeConfig(*mockContext.Context, "config1"))
+	_, err = os.Stat(filepath.Join(kubeConfigManager.configPath, "config1"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func Test_KubeConfigPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not support Unix permission bits")
+	}
+
+	mockContext := mocks.NewMockContext(t.Context())
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "kubectl config view")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		return exec.NewRunResult(0, "apiVersion: v1\nusers:\n- name: user\n  user:\n    token: secret\n", ""), nil
+	})
+
+	configPath := filepath.Join(t.TempDir(), ".kube")
+	require.NoError(t, os.Mkdir(configPath, osutil.PermissionDirectory))
+	require.NoError(t, os.Chmod(configPath, osutil.PermissionDirectory))
+
+	clusterConfigPath := filepath.Join(configPath, "cluster")
+	require.NoError(t, os.WriteFile(clusterConfigPath, []byte("old"), osutil.PermissionFile))
+	require.NoError(t, os.Chmod(clusterConfigPath, osutil.PermissionFile))
+	mergedConfigPath := filepath.Join(configPath, "config")
+	require.NoError(t, os.WriteFile(mergedConfigPath, []byte("old"), osutil.PermissionFile))
+	require.NoError(t, os.Chmod(mergedConfigPath, osutil.PermissionFile))
+
+	manager := &KubeConfigManager{
+		cli:        NewCli(mockContext.CommandRunner),
+		configPath: configPath,
+	}
+
+	savedPath, err := manager.SaveKubeConfig(
+		*mockContext.Context,
+		"cluster",
+		createTestCluster("cluster", "user"),
+	)
+	require.NoError(t, err)
+	require.Equal(t, clusterConfigPath, savedPath)
+
+	require.NoError(t, os.Chmod(configPath, osutil.PermissionDirectory))
+	mergedPath, err := manager.MergeConfigs(*mockContext.Context, "config", "cluster")
+	require.NoError(t, err)
+	require.Equal(t, mergedConfigPath, mergedPath)
+
+	requirePermissions(t, configPath, osutil.PermissionDirectoryOwnerOnly)
+	requirePermissions(t, clusterConfigPath, osutil.PermissionFileOwnerOnly)
+	requirePermissions(t, mergedConfigPath, osutil.PermissionFileOwnerOnly)
+}
+
+func requirePermissions(t *testing.T, path string, expected os.FileMode) {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, expected, info.Mode().Perm())
 }
 
 func createTestCluster(clusterName, username string) *KubeConfig {

--- a/cli/azd/pkg/tools/kubectl/kube_config_test.go
+++ b/cli/azd/pkg/tools/kubectl/kube_config_test.go
@@ -113,6 +113,78 @@ func Test_KubeConfigPermissions(t *testing.T) {
 	requirePermissions(t, mergedConfigPath, osutil.PermissionFileOwnerOnly)
 }
 
+func Test_EnsureKubeConfigDirectoryFailsWhenParentIsFile(t *testing.T) {
+	parentPath := filepath.Join(t.TempDir(), "file")
+	require.NoError(t, os.WriteFile(parentPath, nil, osutil.PermissionFile))
+
+	err := ensureKubeConfigDirectory(filepath.Join(parentPath, ".kube"))
+
+	require.Error(t, err)
+}
+
+func Test_WriteKubeConfigFailsWhenParentDoesNotExist(t *testing.T) {
+	err := writeKubeConfig(filepath.Join(t.TempDir(), "missing", "config"), []byte("config"))
+
+	require.Error(t, err)
+}
+
+func Test_SaveKubeConfigFailsWhenConfigPathIsFile(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), ".kube")
+	require.NoError(t, os.WriteFile(configPath, nil, osutil.PermissionFile))
+
+	manager := &KubeConfigManager{configPath: configPath}
+	_, err := manager.SaveKubeConfig(t.Context(), "config", createTestCluster("cluster", "user"))
+
+	require.ErrorContains(t, err, "failed creating .kube config directory")
+}
+
+func Test_MergeKubeConfigFailsWhenConfigPathIsFile(t *testing.T) {
+	mockContext := mocks.NewMockContext(t.Context())
+	mockContext.CommandRunner.When(func(args exec.RunArgs, command string) bool {
+		return strings.Contains(command, "kubectl config view")
+	}).RespondFn(func(args exec.RunArgs) (exec.RunResult, error) {
+		return exec.NewRunResult(0, "apiVersion: v1\n", ""), nil
+	})
+
+	configPath := filepath.Join(t.TempDir(), ".kube")
+	require.NoError(t, os.WriteFile(configPath, nil, osutil.PermissionFile))
+
+	manager := &KubeConfigManager{
+		cli:        NewCli(mockContext.CommandRunner),
+		configPath: configPath,
+	}
+	_, err := manager.MergeConfigs(*mockContext.Context, "config", "cluster")
+
+	require.ErrorContains(t, err, "failed securing .kube config directory")
+}
+
+func Test_AddOrUpdateContext(t *testing.T) {
+	manager := &KubeConfigManager{configPath: filepath.Join(t.TempDir(), ".kube")}
+
+	configPath, err := manager.AddOrUpdateContext(
+		t.Context(),
+		"cluster",
+		createTestCluster("cluster", "user"),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(manager.configPath, "cluster"), configPath)
+}
+
+func Test_AddOrUpdateContextFailsWhenConfigPathIsFile(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), ".kube")
+	require.NoError(t, os.WriteFile(configPath, nil, osutil.PermissionFile))
+
+	manager := &KubeConfigManager{configPath: configPath}
+	_, err := manager.AddOrUpdateContext(
+		t.Context(),
+		"cluster",
+		createTestCluster("cluster", "user"),
+	)
+
+	require.ErrorContains(t, err, "failed write new kube context file")
+}
+
 func requirePermissions(t *testing.T, path string, expected os.FileMode) {
 	t.Helper()
 


### PR DESCRIPTION
Aligns AKS file permissions with azd standards.

Fixes #9674.