### PR TITLE
fix: prompt provision after connection init

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Release History
 
-## 1.0.0-beta.12 (Unreleased)
-
-### Bugs Fixed
-
-- Suggest `azd provision` after init writes standalone
-  `azure.ai.connection` services, based on the services actually emitted;
-  successful provision clears the pending signal.
-
 ## 1.0.0-beta.11 (2026-08-20)
 
 ### Features Added

--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 1.0.0-beta.12 (Unreleased)
+
+### Bugs Fixed
+
+- Suggest `azd provision` after init writes standalone
+  `azure.ai.connection` services, based on the services actually emitted;
+  successful provision clears the pending signal.
+
 ## 1.0.0-beta.11 (2026-08-20)
 
 ### Features Added

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -3412,14 +3412,21 @@ func (a *InitAction) addToProject(ctx context.Context, targetDir string, agentMa
 	// Emit the sibling Foundry resource services (project + deployments,
 	// connections, toolboxes) and wire the agent's uses: to them. A selected
 	// existing project contributes its endpoint so provision reuses it.
-	if err := emitResourceServices(
+	emittedConnections, err := emitResourceServices(
 		ctx, a.azdClient, a.serviceNameOverride,
 		projectNameHint(ctx, a.azdClient, a.environment.Name, a.selectedFoundryProject),
 		a.selectedFoundryProject.Endpoint(),
 		resourceDeployments, resourceConnections, resourceToolboxes,
-	); err != nil {
+	)
+	if err != nil {
 		return err
 	}
+	recordPendingConnectionProvision(
+		ctx,
+		a.azdClient,
+		a.environment.Name,
+		emittedConnections,
+	)
 
 	printAgentAddedMessage(agentDef.Name)
 
@@ -3491,7 +3498,7 @@ func (a *InitAction) addVoiceAgentToProject(
 	// project. Voice init emits no deployment/connection/toolbox siblings; managed
 	// models are service-hosted, and BYOM model deployments are referenced from
 	// azure.yaml and must already exist.
-	if err := emitResourceServices(
+	if _, err := emitResourceServices(
 		ctx, a.azdClient, a.serviceNameOverride,
 		projectNameHint(ctx, a.azdClient, a.environment.Name, a.selectedFoundryProject),
 		a.selectedFoundryProject.Endpoint(),

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -886,7 +886,7 @@ func (a *InitFromCodeAction) addToProject(
 	// Emit the sibling azure.ai.project service carrying the model deployments
 	// and wire the agent's uses: to it. A selected existing project contributes
 	// its endpoint so provision reuses it instead of creating a new project.
-	if err := emitResourceServices(
+	if _, err := emitResourceServices(
 		ctx, a.azdClient, agentServiceName,
 		projectNameHint(ctx, a.azdClient, a.environment.Name, a.selectedFoundryProject),
 		a.selectedFoundryProject.Endpoint(),

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
@@ -118,6 +118,15 @@ func TestResolveAfterInit(t *testing.T) {
 			wantTrailing:   "azd deploy",
 		},
 		{
+			name: "new connection in existing project → provision",
+			state: &State{
+				HasProjectEndpoint:      true,
+				PendingProvisionReasons: []string{"connection"},
+			},
+			wantPrimaryHas: "azd provision",
+			wantTrailing:   "azd deploy",
+		},
+		{
 			name: "provision needed with missing Azure context → env set before provision",
 			state: &State{
 				PendingProvisionReasons: []string{"project"},

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/pending_provision.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/pending_provision.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log"
 	"slices"
 	"strings"
 
@@ -45,6 +46,7 @@ const (
 	pendingReasonModelDeployment = "model_deployment"
 	pendingReasonACR             = "acr"
 	pendingReasonAppInsights     = "app_insights"
+	pendingReasonConnection      = "connection"
 )
 
 // parsePendingProvisionReasons splits the comma-separated env-var
@@ -105,6 +107,31 @@ func addPendingProvisionReason(
 		}
 		return append(slices.Clone(curr), reason)
 	})
+}
+
+// recordPendingConnectionProvision records a pending
+// connection reason after init writes at least one service.
+// Write failures are warnings so init is not rolled back.
+func recordPendingConnectionProvision(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	envName string,
+	emitted int,
+) {
+	if emitted <= 0 {
+		return
+	}
+	if _, err := addPendingProvisionReason(
+		ctx,
+		azdClient,
+		envName,
+		pendingReasonConnection,
+	); err != nil {
+		log.Printf(
+			"warning: could not record pending connection provision: %v",
+			err,
+		)
+	}
 }
 
 // removePendingProvisionReason drops a reason tag from the

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/pending_provision.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/pending_provision.go
@@ -109,9 +109,9 @@ func addPendingProvisionReason(
 	})
 }
 
-// recordPendingConnectionProvision records a pending
-// connection reason after init writes at least one service.
-// Write failures are warnings so init is not rolled back.
+// recordPendingConnectionProvision marks connections that need
+// provision after init writes a connection service.
+// A signal write failure only produces a warning.
 func recordPendingConnectionProvision(
 	ctx context.Context,
 	azdClient *azdext.AzdClient,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/pending_provision_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/pending_provision_test.go
@@ -204,6 +204,89 @@ func TestRemovePendingProvisionReason(t *testing.T) {
 	})
 }
 
+func TestRecordPendingConnectionProvision(t *testing.T) {
+	t.Parallel()
+
+	t.Run("emitted writes connection reason", func(t *testing.T) {
+		t.Parallel()
+
+		envServer := &testEnvironmentServiceServer{
+			environments: map[string]*azdext.Environment{
+				"test-env": {Name: "test-env"},
+			},
+		}
+		azdClient := newTestAzdClient(t, envServer, &testWorkflowServiceServer{})
+
+		recordPendingConnectionProvision(
+			context.Background(), azdClient, "test-env", 1)
+		require.Equal(
+			t,
+			pendingReasonConnection,
+			envServer.values["test-env"][pendingProvisionEnvVar],
+		)
+	})
+
+	t.Run("zero emitted is no-op", func(t *testing.T) {
+		t.Parallel()
+
+		envServer := &testEnvironmentServiceServer{
+			environments: map[string]*azdext.Environment{
+				"test-env": {Name: "test-env"},
+			},
+		}
+		azdClient := newTestAzdClient(t, envServer, &testWorkflowServiceServer{})
+
+		recordPendingConnectionProvision(
+			context.Background(), azdClient, "test-env", 0)
+		_, hit := envServer.values["test-env"][pendingProvisionEnvVar]
+		require.False(t, hit)
+	})
+
+	t.Run("zero emitted preserves existing reason", func(t *testing.T) {
+		t.Parallel()
+
+		envServer := &testEnvironmentServiceServer{
+			environments: map[string]*azdext.Environment{
+				"test-env": {Name: "test-env"},
+			},
+			values: map[string]map[string]string{
+				"test-env": {pendingProvisionEnvVar: "connection"},
+			},
+		}
+		azdClient := newTestAzdClient(t, envServer, &testWorkflowServiceServer{})
+
+		recordPendingConnectionProvision(
+			context.Background(), azdClient, "test-env", 0)
+		require.Equal(
+			t,
+			"connection",
+			envServer.values["test-env"][pendingProvisionEnvVar],
+		)
+	})
+
+	t.Run("sorts with existing reasons", func(t *testing.T) {
+		t.Parallel()
+
+		envServer := &testEnvironmentServiceServer{
+			environments: map[string]*azdext.Environment{
+				"test-env": {Name: "test-env"},
+			},
+			values: map[string]map[string]string{
+				"test-env": {pendingProvisionEnvVar: "project"},
+			},
+		}
+		azdClient := newTestAzdClient(t, envServer, &testWorkflowServiceServer{})
+
+		recordPendingConnectionProvision(
+			context.Background(), azdClient, "test-env", 2)
+		require.Equal(
+			t,
+			"connection,project",
+			envServer.values["test-env"][pendingProvisionEnvVar],
+		)
+	})
+}
+
 func TestClearPendingProvisionReasons(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services.go
@@ -59,8 +59,9 @@ func emitResourceServices(
 	deployments []project.Deployment,
 	connections []project.Connection,
 	toolboxes []project.Toolbox,
-) error {
+) (int, error) {
 	var agentUses []string
+	emittedConnections := 0
 
 	// Track every azure.yaml service key we emit so two resource names that
 	// sanitize to the same key (e.g. "my conn" and "myconn") fail fast instead
@@ -93,14 +94,14 @@ func emitResourceServices(
 		Deployments: deployments,
 	})
 	if err != nil {
-		return fmt.Errorf("marshaling project service config: %w", err)
+		return 0, fmt.Errorf("marshaling project service config: %w", err)
 	}
 	projectServiceName := resolveProjectServiceKey(ctx, azdClient, projectName, agentServiceName)
 	if err := reserveServiceName(usedNames, projectServiceName, "project service"); err != nil {
-		return err
+		return 0, err
 	}
 	if err := addResourceService(ctx, azdClient, projectServiceName, AiProjectHost, projectCfg, nil); err != nil {
-		return err
+		return 0, err
 	}
 	agentUses = append(agentUses, projectServiceName)
 
@@ -119,16 +120,17 @@ func emitResourceServices(
 			continue
 		}
 		if err := reserveServiceName(usedNames, connName, fmt.Sprintf("connection %q", conn.Name)); err != nil {
-			return err
+			return 0, err
 		}
 		connCfg, err := project.MarshalStruct(&conn)
 		if err != nil {
-			return fmt.Errorf("marshaling connection service %q config: %w", connName, err)
+			return 0, fmt.Errorf("marshaling connection service %q config: %w", connName, err)
 		}
 		if err := addResourceService(ctx, azdClient, connName, AiConnectionHost, connCfg, siblingUses); err != nil {
-			return err
+			return 0, err
 		}
 		agentUses = append(agentUses, connName)
+		emittedConnections++
 	}
 
 	for i := range toolboxes {
@@ -142,14 +144,14 @@ func emitResourceServices(
 			continue
 		}
 		if err := reserveServiceName(usedNames, toolboxName, fmt.Sprintf("toolbox %q", toolbox.Name)); err != nil {
-			return err
+			return 0, err
 		}
 		toolboxCfg, err := project.MarshalStruct(&toolbox)
 		if err != nil {
-			return fmt.Errorf("marshaling toolbox service %q config: %w", toolboxName, err)
+			return 0, fmt.Errorf("marshaling toolbox service %q config: %w", toolboxName, err)
 		}
 		if err := addResourceService(ctx, azdClient, toolboxName, AiToolboxHost, toolboxCfg, siblingUses); err != nil {
-			return err
+			return 0, err
 		}
 		agentUses = append(agentUses, toolboxName)
 	}
@@ -157,11 +159,11 @@ func emitResourceServices(
 	// Wire the agent service to its resource siblings so azd walks them first.
 	if len(agentUses) > 0 && agentServiceName != "" {
 		if err := setServiceUses(ctx, azdClient, agentServiceName, agentUses); err != nil {
-			return err
+			return 0, err
 		}
 	}
 
-	return nil
+	return emittedConnections, nil
 }
 
 // resolveProjectServiceKey picks the azure.yaml service key for the single

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services_test.go
@@ -588,7 +588,7 @@ func TestEmitResourceServices_AlwaysEmitsProjectService(t *testing.T) {
 	server := &recordingProjectServer{}
 	client := newProjectRecorderClient(t, server)
 
-	err := emitResourceServices(t.Context(), client, "myagent", "", "", nil, nil, nil)
+	_, err := emitResourceServices(t.Context(), client, "myagent", "", "", nil, nil, nil)
 	require.NoError(t, err)
 
 	server.mu.Lock()
@@ -610,7 +610,7 @@ func TestEmitResourceServices_WiresSiblingsToProject(t *testing.T) {
 	client := newProjectRecorderClient(t, server)
 
 	conns := []project.Connection{{Name: "myconn", Category: "ApiKey"}}
-	err := emitResourceServices(t.Context(), client, "myagent", "", "", nil, conns, nil)
+	_, err := emitResourceServices(t.Context(), client, "myagent", "", "", nil, conns, nil)
 	require.NoError(t, err)
 
 	server.mu.Lock()
@@ -624,6 +624,38 @@ func TestEmitResourceServices_WiresSiblingsToProject(t *testing.T) {
 
 	assert.Equal(t, []string{aiProjectServiceName}, server.uses["myconn"])
 	assert.Equal(t, []string{aiProjectServiceName, "myconn"}, server.uses["myagent"])
+}
+
+func TestEmitResourceServices_CountsEmittedConnections(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid connection returns 1", func(t *testing.T) {
+		server := &recordingProjectServer{}
+		client := newProjectRecorderClient(t, server)
+		conns := []project.Connection{{Name: "myconn", Category: "ApiKey"}}
+
+		got, err := emitResourceServices(
+			t.Context(), client, "myagent", "", "", nil, conns, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 1, got)
+	})
+
+	t.Run("blank name returns 0", func(t *testing.T) {
+		server := &recordingProjectServer{}
+		client := newProjectRecorderClient(t, server)
+		conns := []project.Connection{{Name: "   ", Category: "ApiKey"}}
+
+		got, err := emitResourceServices(
+			t.Context(), client, "myagent", "", "", nil, conns, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 0, got)
+
+		server.mu.Lock()
+		defer server.mu.Unlock()
+		for _, svc := range server.added {
+			assert.NotEqual(t, AiConnectionHost, svc.Host)
+		}
+	})
 }
 
 // TestEmitResourceServices_WritesServiceLevelProps verifies resource services are
@@ -643,7 +675,9 @@ func TestEmitResourceServices_WritesServiceLevelProps(t *testing.T) {
 		Sku:   project.DeploymentSku{Name: "GlobalStandard", Capacity: 10},
 	}}
 	conns := []project.Connection{{Name: "myconn", Category: "ApiKey", Target: "https://example", AuthType: "ApiKey"}}
-	require.NoError(t, emitResourceServices(t.Context(), client, "myagent", "", "", deployments, conns, nil))
+	_, err := emitResourceServices(
+		t.Context(), client, "myagent", "", "", deployments, conns, nil)
+	require.NoError(t, err)
 
 	server.mu.Lock()
 	defer server.mu.Unlock()
@@ -658,7 +692,7 @@ func TestEmitResourceServices_WritesServiceLevelProps(t *testing.T) {
 
 	// Init must write a project shape the owning extension can parse.
 	var projectCfg project.ServiceTargetAgentConfig
-	err := project.UnmarshalStruct(
+	err = project.UnmarshalStruct(
 		project.ServiceConfigProps(services["ai-project"]),
 		&projectCfg,
 	)
@@ -686,7 +720,9 @@ func TestEmitResourceServices_WritesEndpointForExistingProject(t *testing.T) {
 		server := &recordingProjectServer{}
 		client := newProjectRecorderClient(t, server)
 
-		require.NoError(t, emitResourceServices(t.Context(), client, "myagent", "", endpoint, nil, nil, nil))
+		_, err := emitResourceServices(
+			t.Context(), client, "myagent", "", endpoint, nil, nil, nil)
+		require.NoError(t, err)
 
 		server.mu.Lock()
 		defer server.mu.Unlock()
@@ -702,7 +738,9 @@ func TestEmitResourceServices_WritesEndpointForExistingProject(t *testing.T) {
 		server := &recordingProjectServer{}
 		client := newProjectRecorderClient(t, server)
 
-		require.NoError(t, emitResourceServices(t.Context(), client, "myagent", "", "", nil, nil, nil))
+		_, err := emitResourceServices(
+			t.Context(), client, "myagent", "", "", nil, nil, nil)
+		require.NoError(t, err)
 
 		server.mu.Lock()
 		defer server.mu.Unlock()
@@ -726,8 +764,9 @@ func TestEmitResourceServices_ProjectServiceKey(t *testing.T) {
 		server := &recordingProjectServer{}
 		client := newProjectRecorderClient(t, server)
 
-		require.NoError(t, emitResourceServices(
-			t.Context(), client, "myagent", "my-foundry-proj", "", nil, nil, nil))
+		_, err := emitResourceServices(
+			t.Context(), client, "myagent", "my-foundry-proj", "", nil, nil, nil)
+		require.NoError(t, err)
 
 		server.mu.Lock()
 		defer server.mu.Unlock()
@@ -746,8 +785,9 @@ func TestEmitResourceServices_ProjectServiceKey(t *testing.T) {
 
 		// A different project name is supplied, but the existing key wins so a
 		// repeated init does not create a second project service.
-		require.NoError(t, emitResourceServices(
-			t.Context(), client, "myagent", "a-new-name", "", nil, nil, nil))
+		_, err := emitResourceServices(
+			t.Context(), client, "myagent", "a-new-name", "", nil, nil, nil)
+		require.NoError(t, err)
 
 		server.mu.Lock()
 		defer server.mu.Unlock()
@@ -759,8 +799,9 @@ func TestEmitResourceServices_ProjectServiceKey(t *testing.T) {
 		server := &recordingProjectServer{}
 		client := newProjectRecorderClient(t, server)
 
-		require.NoError(t, emitResourceServices(
-			t.Context(), client, "myagent", "my agent", "", nil, nil, nil))
+		_, err := emitResourceServices(
+			t.Context(), client, "myagent", "my agent", "", nil, nil, nil)
+		require.NoError(t, err)
 
 		server.mu.Lock()
 		defer server.mu.Unlock()
@@ -773,8 +814,9 @@ func TestEmitResourceServices_ProjectServiceKey(t *testing.T) {
 		server := &recordingProjectServer{}
 		client := newProjectRecorderClient(t, server)
 
-		require.NoError(t, emitResourceServices(
-			t.Context(), client, "myagent", "", "", nil, nil, nil))
+		_, err := emitResourceServices(
+			t.Context(), client, "myagent", "", "", nil, nil, nil)
+		require.NoError(t, err)
 
 		server.mu.Lock()
 		defer server.mu.Unlock()


### PR DESCRIPTION
## Why this is needed

When `azd ai agent init` adds a standalone `azure.ai.connection`, users still need to run `azd provision`. Init should only record a pending connection when it actually writes the connection service. That avoids recording one when an invalid service name causes the service to be skipped.

## Why this approach

`emitResourceServices` now reports how many connection services it wrote. Init records `connection` only when that count is greater than zero and the signal update succeeds. If updating the signal fails, init logs a warning and continues. A later init without connection input leaves existing reasons alone. Existing reason sorting and deduplication, provision-first guidance, and cleanup after successful provision are unchanged.

Remote connection validation and the provisioning implementation are out of scope for this PR.

## Validation

- `go test ./internal/cmd/...`
- `git diff --check`

## E2E validation

- `azd ai agent init` with a valid connection manifest: PASS. It wrote the connection service, added `connection` to the pending-provision signal, and completed successfully.
- Interactive `azd ai agent init`: PASS. The `Next:` section included `azd provision` and `azd deploy`.
- Re-running `azd ai agent init` without connection input: PASS. The existing pending-provision signal stayed unchanged.
- `azd ai agent init` with a blank connection service name: PASS. It warned, skipped the connection, and did not add `connection` to the signal.
- `azd ai agent init` using local code: PASS. The from-code path completed through the shared resource-service code.

Closes: #9685