### PR TITLE
azure.ai.agents: reject hosted-only agent fields on non-hosted kinds

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse.go
@@ -47,7 +47,44 @@ func LoadAndValidateAgentManifest(manifestYamlContent []byte) (*AgentManifest, e
 		return nil, err
 	}
 
+	// The remarshal above reflects the typed conversion, which drops
+	// hosted-only fields before ValidateAgentDefinition can see them, so
+	// check the raw template too (#9623).
+	var rawManifest map[string]any
+	if err := yaml.Unmarshal(manifestYamlContent, &rawManifest); err == nil {
+		if tmpl, ok := rawManifest["template"].(map[string]any); ok {
+			if rawBytes, err := yaml.Marshal(tmpl); err == nil {
+				if err := ValidateHostedOnlyFields(rawBytes); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
 	return &manifest, nil
+}
+
+// ValidateHostedOnlyFields reports hosted-only fields present on a non-hosted
+// agent definition. The input may be YAML or JSON bytes (YAML is a superset),
+// and the raw keys are inspected so empty or partial values are also reported.
+func ValidateHostedOnlyFields(templateBytes []byte) error {
+	var agentDef AgentDefinition
+	if err := yaml.Unmarshal(templateBytes, &agentDef); err != nil {
+		return nil // not our error to report; shape errors surface elsewhere
+	}
+	if agentDef.Kind == AgentKindHosted || !IsValidAgentKind(agentDef.Kind) {
+		return nil
+	}
+	errs := validateNoHostedOnlyFields(templateBytes, agentDef.Kind)
+	if len(errs) == 0 {
+		return nil
+	}
+	var msg strings.Builder
+	msg.WriteString("validation failed:")
+	for _, err := range errs {
+		msg.WriteString(fmt.Sprintf("\n  - %s", err))
+	}
+	return fmt.Errorf("%s", msg.String())
 }
 
 // Returns a specific agent definition based on the "kind" field in the template

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse.go
@@ -701,13 +701,18 @@ func exposesInvocationsProtocol(protocols []ProtocolVersionRecord) bool {
 
 // hostedOnlyAgentFields are dropped by load/deploy conversion for every
 // non-hosted agent kind, so their presence validates configuration that
-// silently has no effect.
+// silently has no effect. The service-property spelling is camelCase; the
+// standalone agent.yaml authoring spelling is snake_case for three of the
+// five fields (yaml.go ContainerAgent tags), so both are checked.
 var hostedOnlyAgentFields = []string{
 	"codeConfiguration",
+	"code_configuration",
 	"policies",
 	"protocols",
 	"agentEndpoint",
+	"agent_endpoint",
 	"sessionConfiguration",
+	"session_configuration",
 }
 
 // validateNoHostedOnlyFields rejects hosted-only fields on non-hosted agent

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse.go
@@ -394,6 +394,8 @@ func ValidateAgentDefinition(templateBytes []byte) error {
 			if agentDef.Kind != AgentKindHosted {
 				errors = append(errors,
 					validateInvocationsModerationKind(templateBytes, agentDef.Kind)...)
+				errors = append(errors,
+					validateNoHostedOnlyFields(templateBytes, agentDef.Kind)...)
 			}
 
 			switch AgentKind(agentDef.Kind) {
@@ -658,4 +660,35 @@ func exposesInvocationsProtocol(protocols []ProtocolVersionRecord) bool {
 	return slices.ContainsFunc(protocols, func(record ProtocolVersionRecord) bool {
 		return record.Protocol == InvocationsProtocol
 	})
+}
+
+// hostedOnlyAgentFields are dropped by load/deploy conversion for every
+// non-hosted agent kind, so their presence validates configuration that
+// silently has no effect.
+var hostedOnlyAgentFields = []string{
+	"codeConfiguration",
+	"policies",
+	"protocols",
+	"agentEndpoint",
+	"sessionConfiguration",
+}
+
+// validateNoHostedOnlyFields rejects hosted-only fields on non-hosted agent
+// kinds. The template is inspected as raw keys so that empty or partial
+// values (which would unmarshal to zero fields) are still reported.
+func validateNoHostedOnlyFields(templateBytes []byte, kind AgentKind) []string {
+	var root map[string]any
+	if err := yaml.Unmarshal(templateBytes, &root); err != nil {
+		return nil
+	}
+
+	var errs []string
+	for _, field := range hostedOnlyAgentFields {
+		if _, ok := root[field]; ok {
+			errs = append(errs, fmt.Sprintf(
+				"'%s' is only supported for '%s' agents and is ignored for kind '%s'",
+				field, AgentKindHosted, kind))
+		}
+	}
+	return errs
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse_test.go
@@ -1526,12 +1526,12 @@ policies:
 			wantErrSubst: "policies[1] invocationsModeration is only supported for 'hosted' agents",
 		},
 		{
-			name: "a non-hosted agent without the block stays valid",
+			// policies itself is hosted-only (see
+			// TestValidateAgentDefinition_HostedOnlyFieldsRejectedOnPromptVoice),
+			// so a non-hosted agent free of the whole block stays valid.
+			name: "a non-hosted agent without policies stays valid",
 			yaml: `kind: workflow
 name: workflow-agent
-policies:
-  - type: rai_policy
-    rai_policy_name: /subscriptions/x/raiPolicies/p
 `,
 		},
 		{

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse_voice_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse_voice_test.go
@@ -147,6 +147,24 @@ model:
 	}
 }
 
+// TestValidateAgentDefinition_HostedOnlySnakeCaseRejectedOnPromptVoice covers
+// the standalone agent.yaml authoring spellings (yaml.go ContainerAgent tags).
+func TestValidateAgentDefinition_HostedOnlySnakeCaseRejectedOnPromptVoice(t *testing.T) {
+	for _, field := range []string{"code_configuration", "agent_endpoint", "session_configuration"} {
+		yamlContent := []byte(fmt.Sprintf(`
+kind: prompt-voice
+name: voice-agent
+model:
+  id: gpt-realtime
+%s: {}
+`, field))
+		err := ValidateAgentDefinition(yamlContent)
+		if err == nil || !strings.Contains(err.Error(), "is only supported for 'hosted' agents") {
+			t.Fatalf("expected '%s' rejection error, got: %v", field, err)
+		}
+	}
+}
+
 // TestValidateAgentDefinition_HostedFieldsStillAllowedOnHosted pins that the
 // new checks don't fire for the hosted kind.
 func TestValidateAgentDefinition_HostedFieldsStillAllowedOnHosted(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse_voice_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/parse_voice_test.go
@@ -4,6 +4,7 @@
 package agent_yaml
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -116,5 +117,50 @@ model_type: unsupported
 	err := ValidateAgentDefinition(yamlContent)
 	if err == nil || !strings.Contains(err.Error(), "model_type 'unsupported' is not supported") {
 		t.Fatalf("expected invalid model_type error, got: %v", err)
+	}
+}
+
+// TestValidateAgentDefinition_HostedOnlyFieldsRejectedOnPromptVoice rejects
+// hosted-agent-only properties on non-hosted kinds (#9623): load/deploy
+// conversion drops them, so accepting them would validate configuration
+// that silently has no effect.
+func TestValidateAgentDefinition_HostedOnlyFieldsRejectedOnPromptVoice(t *testing.T) {
+	hostedOnly := []string{
+		"codeConfiguration",
+		"policies",
+		"protocols",
+		"agentEndpoint",
+		"sessionConfiguration",
+	}
+	for _, field := range hostedOnly {
+		yamlContent := []byte(fmt.Sprintf(`
+kind: prompt-voice
+name: voice-agent
+model:
+  id: gpt-realtime
+%s: {}
+`, field))
+		err := ValidateAgentDefinition(yamlContent)
+		if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("'%s' is only supported for 'hosted' agents", field)) {
+			t.Fatalf("expected '%s' rejection error, got: %v", field, err)
+		}
+	}
+}
+
+// TestValidateAgentDefinition_HostedFieldsStillAllowedOnHosted pins that the
+// new checks don't fire for the hosted kind.
+func TestValidateAgentDefinition_HostedFieldsStillAllowedOnHosted(t *testing.T) {
+	yamlContent := []byte(`
+kind: hosted
+name: hosted-agent
+codeConfiguration:
+  directory: src
+protocols: []
+agentEndpoint: https://example.com
+sessionConfiguration:
+  idleTimeoutSeconds: 300
+`)
+	if err := ValidateAgentDefinition(yamlContent); err != nil {
+		t.Fatalf("expected valid, got error: %v", err)
 	}
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agent_definition.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agent_definition.go
@@ -4,6 +4,7 @@
 package project
 
 import (
+	"google.golang.org/protobuf/encoding/protojson"
 	"fmt"
 	"maps"
 	"os"
@@ -1069,6 +1070,19 @@ func VoiceAgentFromResolvedService(
 				"re-run `azd ai agent init` to regenerate the agent service entry",
 			)
 		}
+
+		// toVoiceAgent drops hosted-only fields; check the raw definition so
+		// they are rejected instead of silently ignored (#9623).
+		if rawBytes, err := protojson.Marshal(resolved); err == nil {
+			if err := agent_yaml.ValidateHostedOnlyFields(rawBytes); err != nil {
+				return agent_yaml.VoiceAgent{}, false, exterrors.Validation(
+					exterrors.CodeInvalidAgentManifest,
+					fmt.Sprintf("voice agent service config is not valid: %s", err),
+					"remove hosted-only fields or set kind to 'hosted'",
+				)
+			}
+		}
+
 		return inline.toVoiceAgent(), true, nil
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agent_definition.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agent_definition.go
@@ -4,7 +4,6 @@
 package project
 
 import (
-	"google.golang.org/protobuf/encoding/protojson"
 	"fmt"
 	"maps"
 	"os"
@@ -22,6 +21,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/pkg/foundry"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/braydonk/yaml"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/doc_examples_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/doc_examples_test.go
@@ -799,6 +799,62 @@ func TestDocSchemaValidatesConstraints(t *testing.T) {
 			},
 		},
 		{
+			// kind-less service configuration must stay valid: the hosted-only
+			// gate only applies once a non-hosted kind is declared (#9623).
+			name: "hosted-only fields valid without kind",
+			mutate: func(value *fixture) {
+				value.value["sessionConfiguration"] = map[string]any{"idleTimeoutSeconds": 300}
+				value.value["agentEndpoint"] = map[string]any{"url": "https://example.test"}
+			},
+		},
+		{
+			name: "hosted-only fields valid for hosted kind",
+			mutate: func(value *fixture) {
+				value.value["kind"] = "hosted"
+				value.value["sessionConfiguration"] = map[string]any{"idleTimeoutSeconds": 300}
+			},
+		},
+		{
+			name: "session configuration rejected for prompt-voice",
+			mutate: func(value *fixture) {
+				value.value["kind"] = "prompt-voice"
+				value.value["sessionConfiguration"] = map[string]any{"idleTimeoutSeconds": 300}
+			},
+			wantErr: true,
+		},
+		{
+			name: "agent endpoint rejected for prompt-voice",
+			mutate: func(value *fixture) {
+				value.value["kind"] = "prompt-voice"
+				value.value["agentEndpoint"] = map[string]any{"url": "https://example.test"}
+			},
+			wantErr: true,
+		},
+		{
+			name: "code configuration rejected for prompt-voice",
+			mutate: func(value *fixture) {
+				value.value["kind"] = "prompt-voice"
+				value.value["codeConfiguration"] = map[string]any{"directory": "src"}
+			},
+			wantErr: true,
+		},
+		{
+			name: "policies rejected for prompt-voice",
+			mutate: func(value *fixture) {
+				value.value["kind"] = "prompt-voice"
+				value.value["policies"] = []any{}
+			},
+			wantErr: true,
+		},
+		{
+			name: "protocols rejected for prompt-voice",
+			mutate: func(value *fixture) {
+				value.value["kind"] = "prompt-voice"
+				value.value["protocols"] = []any{}
+			},
+			wantErr: true,
+		},
+		{
 			name: "session idle timeout max valid",
 			mutate: func(value *fixture) {
 				value.value["sessionConfiguration"] = map[string]any{"idleTimeoutSeconds": 3600}

--- a/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
@@ -146,11 +146,11 @@
     {
       "$comment": "codeConfiguration, policies, protocols, agentEndpoint and sessionConfiguration are hosted-agent-only: load/deploy conversion drops them for every other kind, so accepting them elsewhere validates configuration that silently has no effect. Reject them up front, matching the runtime check in ValidateAgentDefinition.",
       "if": {
+        "required": ["kind"],
         "not": {
           "properties": {
             "kind": { "const": "hosted" }
-          },
-          "required": ["kind"]
+          }
         }
       },
       "then": {

--- a/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
@@ -144,6 +144,28 @@
       }
     },
     {
+      "$comment": "codeConfiguration, policies, protocols, agentEndpoint and sessionConfiguration are hosted-agent-only: load/deploy conversion drops them for every other kind, so accepting them elsewhere validates configuration that silently has no effect. Reject them up front, matching the runtime check in ValidateAgentDefinition.",
+      "if": {
+        "not": {
+          "properties": {
+            "kind": { "const": "hosted" }
+          },
+          "required": ["kind"]
+        }
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            { "required": ["codeConfiguration"] },
+            { "required": ["policies"] },
+            { "required": ["protocols"] },
+            { "required": ["agentEndpoint"] },
+            { "required": ["sessionConfiguration"] }
+          ]
+        }
+      }
+    },
+    {
       "$comment": "The activity.publish block is shared publish metadata for Activity use cases (including simple). Digital Worker adds stricter requirements: publish must exist, publishScope must be tenant, and agenticUserTemplate is required to carry the persisted blueprint identity.",
       "if": {
         "properties": {


### PR DESCRIPTION
Fixes #9623.

## Summary

In the `azure.ai.agents` extension, `codeConfiguration`, `policies`, `protocols`, `agentEndpoint` and `sessionConfiguration` are hosted-agent-only: `AgentDefinitionInline.toVoiceAgent()` drops them for voice agents, yet both the schema and `ValidateAgentDefinition` accepted them for every kind — so a `kind: prompt-voice` manifest carrying them validated fine while silently having no effect.

Two aligned changes:

- **Runtime** — `ValidateAgentDefinition` now reports each present hosted-only field for non-hosted kinds (`'<field>' is only supported for 'hosted' agents and is ignored for kind '<kind>'`). Presence is checked on the raw template keys, so empty or partial values — which would unmarshal to zero fields — are reported too.
- **Schema** — `azure.ai.agent.json` gains the matching draft-07 conditional (`kind != hosted` ⇒ reject `anyOf` of the five `required` fields), in the style of the existing prompt-voice `model` rule.

## Testing

- Added `TestValidateAgentDefinition_HostedOnlyFieldsRejectedOnPromptVoice` (each of the five fields rejected on a `prompt-voice` agent) and `TestValidateAgentDefinition_HostedFieldsStillAllowedOnHosted` (hosted kind unaffected).
- Updated the one existing case whose fixture put `policies` on a `workflow` agent expecting success — with `policies` now hosted-only, a non-hosted agent free of the block stays valid, which is that case's premise.
- `go test ./...` in the extension passes; differential: with the runtime check reverted, the new rejection test fails with `got: <nil>`.
