### PR TITLE
Fix optional extension flag values in Fig specs

### DIFF
--- a/cli/azd/docs/extensions/extension-framework.md
+++ b/cli/azd/docs/extensions/extension-framework.md
@@ -350,7 +350,7 @@ The metadata JSON includes:
   - `usage`: Usage template string
   - `examples`: Example usages with description and command
   - `args`: Positional arguments with name, description, required flag
-  - `flags`: Command flags with name, shorthand, type, default, validValues
+  - `flags`: Command flags with name, shorthand, type, default, and validValues. `valueOptional` marks a value-taking flag that can be used without an explicit value.
   - `subcommands`: Nested subcommand definitions
   - `hidden`, `aliases`, `deprecated`: Optional command metadata
 - **`configuration`**: Optional configuration schemas:

--- a/cli/azd/internal/figspec/extension_metadata.go
+++ b/cli/azd/internal/figspec/extension_metadata.go
@@ -95,7 +95,8 @@ func convertExtensionFlag(flag extensions.Flag) Option {
 	// Handle flag arguments (non-bool flags need args)
 	if flag.Type != "bool" && flag.Type != "" {
 		arg := Arg{
-			Name: flag.Name,
+			Name:       flag.Name,
+			IsOptional: flag.ValueOptional,
 		}
 
 		// Add valid values as suggestions

--- a/cli/azd/internal/figspec/extension_metadata_test.go
+++ b/cli/azd/internal/figspec/extension_metadata_test.go
@@ -268,6 +268,7 @@ func TestConvertExtensionFlag(t *testing.T) {
 		wantRepeatable  bool
 		wantDangerous   bool
 		wantArgsCount   int
+		wantArgOptional bool
 		wantSuggestions []string
 	}{
 		{
@@ -301,6 +302,19 @@ func TestConvertExtensionFlag(t *testing.T) {
 			wantDangerous:   false,
 			wantArgsCount:   1,
 			wantSuggestions: []string{"json", "table", "yaml"},
+		},
+		{
+			name: "flag with optional value",
+			flag: extensions.Flag{
+				Name:          "infra",
+				Description:   "Infrastructure provider",
+				Type:          "string",
+				ValueOptional: true,
+			},
+			wantName:        []string{"--infra"},
+			wantDesc:        "Infrastructure provider",
+			wantArgsCount:   1,
+			wantArgOptional: true,
 		},
 		{
 			name: "required flag",
@@ -361,8 +375,11 @@ func TestConvertExtensionFlag(t *testing.T) {
 			require.Equal(t, tt.wantDangerous, result.IsDangerous)
 			require.Len(t, result.Args, tt.wantArgsCount)
 
-			if tt.wantArgsCount > 0 && tt.wantSuggestions != nil {
-				require.Equal(t, tt.wantSuggestions, result.Args[0].Suggestions)
+			if tt.wantArgsCount > 0 {
+				require.Equal(t, tt.wantArgOptional, result.Args[0].IsOptional)
+				if tt.wantSuggestions != nil {
+					require.Equal(t, tt.wantSuggestions, result.Args[0].Suggestions)
+				}
 			}
 		})
 	}

--- a/cli/azd/internal/figspec/spec_builder.go
+++ b/cli/azd/internal/figspec/spec_builder.go
@@ -259,6 +259,7 @@ func (sb *SpecBuilder) generateFlagArgs(flag *pflag.Flag, ctx *FlagContext) []Ar
 	if sb.flagArgsProvider != nil {
 		if customArg := sb.flagArgsProvider.GetFlagArgs(ctx); customArg != nil {
 			arg = *customArg
+			arg.IsOptional = arg.IsOptional || flag.NoOptDefVal != ""
 		}
 	}
 

--- a/cli/azd/internal/figspec/spec_builder.go
+++ b/cli/azd/internal/figspec/spec_builder.go
@@ -250,7 +250,10 @@ func (sb *SpecBuilder) generateFlagArgs(flag *pflag.Flag, ctx *FlagContext) []Ar
 		return nil
 	}
 
-	arg := Arg{Name: flag.Name}
+	arg := Arg{
+		Name:       flag.Name,
+		IsOptional: flag.NoOptDefVal != "",
+	}
 
 	// Apply customizations (name, description)
 	if sb.flagArgsProvider != nil {

--- a/cli/azd/internal/figspec/spec_builder_test.go
+++ b/cli/azd/internal/figspec/spec_builder_test.go
@@ -372,6 +372,20 @@ func TestGenerateFlagArgs(t *testing.T) {
 		require.True(t, args[0].IsOptional)
 	})
 
+	t.Run("custom_flag_arg_preserves_optional_value", func(t *testing.T) {
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.String("from-package", "", "Package path")
+		f := fs.Lookup("from-package")
+		f.NoOptDefVal = "."
+		ctx := &FlagContext{Flag: f, CommandPath: "azd deploy"}
+
+		sb := newTestSpecBuilder(false)
+		args := sb.generateFlagArgs(f, ctx)
+		require.Len(t, args, 1)
+		require.Equal(t, "file-path|image-tag", args[0].Name)
+		require.True(t, args[0].IsOptional)
+	})
+
 	t.Run("empty_type_returns_nil", func(t *testing.T) {
 		// A flag with empty type should be treated like a boolean
 		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)

--- a/cli/azd/internal/figspec/spec_builder_test.go
+++ b/cli/azd/internal/figspec/spec_builder_test.go
@@ -359,6 +359,19 @@ func TestGenerateFlagArgs(t *testing.T) {
 		require.Equal(t, "output", args[0].Name)
 	})
 
+	t.Run("flag_with_optional_value_returns_optional_arg", func(t *testing.T) {
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.String("infra", "", "Infrastructure provider")
+		f := fs.Lookup("infra")
+		f.NoOptDefVal = "bicep"
+		ctx := &FlagContext{Flag: f, CommandPath: "azd test"}
+
+		sb := newTestSpecBuilder(false)
+		args := sb.generateFlagArgs(f, ctx)
+		require.Len(t, args, 1)
+		require.True(t, args[0].IsOptional)
+	})
+
 	t.Run("empty_type_returns_nil", func(t *testing.T) {
 		// A flag with empty type should be treated like a boolean
 		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)

--- a/cli/azd/pkg/azdext/metadata_generator.go
+++ b/cli/azd/pkg/azdext/metadata_generator.go
@@ -143,12 +143,14 @@ func generateFlags(cmd *cobra.Command) []extensions.Flag {
 			return
 		}
 
+		flagType := getFlagType(flag)
 		flagMeta := extensions.Flag{
-			Name:        flag.Name,
-			Shorthand:   flag.Shorthand,
-			Description: flag.Usage,
-			Type:        getFlagType(flag),
-			Hidden:      flag.Hidden,
+			Name:          flag.Name,
+			Shorthand:     flag.Shorthand,
+			Description:   flag.Usage,
+			Type:          flagType,
+			ValueOptional: flagType != "bool" && flag.NoOptDefVal != "",
+			Hidden:        flag.Hidden,
 		}
 
 		if flag.DefValue != "" {

--- a/cli/azd/pkg/azdext/metadata_generator_test.go
+++ b/cli/azd/pkg/azdext/metadata_generator_test.go
@@ -269,6 +269,7 @@ func TestGenerateExtensionMetadata_FlagTypes(t *testing.T) {
 	boolFlag := findFlag(flags, "bool-flag")
 	require.NotNil(t, boolFlag)
 	assert.Equal(t, "bool", boolFlag.Type)
+	assert.False(t, boolFlag.ValueOptional)
 
 	intFlag := findFlag(flags, "int-flag")
 	require.NotNil(t, intFlag)
@@ -281,6 +282,21 @@ func TestGenerateExtensionMetadata_FlagTypes(t *testing.T) {
 	intSliceFlag := findFlag(flags, "int-slice-flag")
 	require.NotNil(t, intSliceFlag)
 	assert.Equal(t, "intArray", intSliceFlag.Type)
+}
+
+func TestGenerateExtensionMetadata_OptionalFlagValue(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "test-ext"}
+	testCmd := &cobra.Command{Use: "test"}
+	testCmd.Flags().String("infra", "", "Infrastructure provider")
+	testCmd.Flags().Lookup("infra").NoOptDefVal = "bicep"
+	rootCmd.AddCommand(testCmd)
+
+	metadata := GenerateExtensionMetadata("1.0", "test.extension", rootCmd)
+
+	require.Len(t, metadata.Commands, 1)
+	infraFlag := findFlag(metadata.Commands[0].Flags, "infra")
+	require.NotNil(t, infraFlag)
+	assert.True(t, infraFlag.ValueOptional)
 }
 
 // Helper function to find a flag by name

--- a/cli/azd/pkg/extensions/command_resolver.go
+++ b/cli/azd/pkg/extensions/command_resolver.go
@@ -106,7 +106,8 @@ func parseFlags(args []string, flags []Flag) []string {
 		if f.Name == "" {
 			continue
 		}
-		switch strings.ToLower(f.Type) {
+		flagType := strings.ToLower(f.Type)
+		switch flagType {
 		case "bool":
 			fs.BoolP(f.Name, f.Shorthand, false, "")
 		case "int":
@@ -117,6 +118,15 @@ func parseFlags(args []string, flags []Flag) []string {
 			fs.StringSliceP(f.Name, f.Shorthand, nil, "")
 		default: // string and any unknown types
 			fs.StringP(f.Name, f.Shorthand, "", "")
+		}
+
+		if f.ValueOptional && flagType != "bool" {
+			// The resolver only records flag presence, so any parseable value can stand in for NoOptDefVal.
+			noOptDefVal := "true"
+			if flagType == "int" || flagType == "intarray" {
+				noOptDefVal = "0"
+			}
+			fs.Lookup(f.Name).NoOptDefVal = noOptDefVal
 		}
 	}
 

--- a/cli/azd/pkg/extensions/command_resolver.go
+++ b/cli/azd/pkg/extensions/command_resolver.go
@@ -121,7 +121,7 @@ func parseFlags(args []string, flags []Flag) []string {
 		}
 
 		if f.ValueOptional && flagType != "bool" {
-			// The resolver only records flag presence, so any parseable value can stand in for NoOptDefVal.
+			// The resolver only records flag presence, so any valid value can stand in for NoOptDefVal.
 			noOptDefVal := "true"
 			if flagType == "int" || flagType == "intarray" {
 				noOptDefVal = "0"

--- a/cli/azd/pkg/extensions/command_resolver_test.go
+++ b/cli/azd/pkg/extensions/command_resolver_test.go
@@ -420,6 +420,70 @@ func TestResolveCommandFlagsAllTypes(t *testing.T) {
 			args: []string{"run", "-abc"},
 			want: []string{"all", "brief", "color"},
 		},
+		{
+			name: "OptionalStringFlagBeforeAnotherFlag",
+			metadata: &ExtensionCommandMetadata{
+				Commands: []Command{
+					{
+						Name: []string{"run"},
+						Flags: []Flag{
+							{Name: "infra", Type: "string", ValueOptional: true},
+							{Name: "verbose", Shorthand: "v", Type: "bool"},
+						},
+					},
+				},
+			},
+			args: []string{"run", "--infra", "--verbose"},
+			want: []string{"infra", "verbose"},
+		},
+		{
+			name: "OptionalIntFlagBeforeAnotherFlag",
+			metadata: &ExtensionCommandMetadata{
+				Commands: []Command{
+					{
+						Name: []string{"run"},
+						Flags: []Flag{
+							{Name: "count", Type: "int", ValueOptional: true},
+							{Name: "verbose", Shorthand: "v", Type: "bool"},
+						},
+					},
+				},
+			},
+			args: []string{"run", "--count", "--verbose"},
+			want: []string{"count", "verbose"},
+		},
+		{
+			name: "OptionalStringArrayFlagBeforeAnotherFlag",
+			metadata: &ExtensionCommandMetadata{
+				Commands: []Command{
+					{
+						Name: []string{"run"},
+						Flags: []Flag{
+							{Name: "tags", Type: "stringArray", ValueOptional: true},
+							{Name: "verbose", Shorthand: "v", Type: "bool"},
+						},
+					},
+				},
+			},
+			args: []string{"run", "--tags", "--verbose"},
+			want: []string{"tags", "verbose"},
+		},
+		{
+			name: "OptionalIntArrayFlagBeforeAnotherFlag",
+			metadata: &ExtensionCommandMetadata{
+				Commands: []Command{
+					{
+						Name: []string{"run"},
+						Flags: []Flag{
+							{Name: "ports", Type: "intArray", ValueOptional: true},
+							{Name: "verbose", Shorthand: "v", Type: "bool"},
+						},
+					},
+				},
+			},
+			args: []string{"run", "--ports", "--verbose"},
+			want: []string{"ports", "verbose"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cli/azd/pkg/extensions/metadata.go
+++ b/cli/azd/pkg/extensions/metadata.go
@@ -81,6 +81,8 @@ type Flag struct {
 	Default any `json:"default,omitempty"`
 	// Required indicates if the flag is required
 	Required bool `json:"required,omitempty"`
+	// ValueOptional indicates if the flag can be provided without an explicit value
+	ValueOptional bool `json:"valueOptional,omitempty"`
 	// ValidValues contains the allowed values for the flag
 	ValidValues []string `json:"validValues,omitempty"`
 	// Hidden indicates if the flag should be hidden from help output

--- a/cli/azd/pkg/extensions/metadata_test.go
+++ b/cli/azd/pkg/extensions/metadata_test.go
@@ -41,12 +41,13 @@ func TestExtensionCommandMetadata_Marshaling(t *testing.T) {
 				},
 				Flags: []Flag{
 					{
-						Name:        "format",
-						Shorthand:   "f",
-						Description: "Output format",
-						Type:        "string",
-						Default:     "text",
-						ValidValues: []string{"text", "json"},
+						Name:          "format",
+						Shorthand:     "f",
+						Description:   "Output format",
+						Type:          "string",
+						Default:       "text",
+						ValueOptional: true,
+						ValidValues:   []string{"text", "json"},
 					},
 					{
 						Name:        "verbose",
@@ -65,6 +66,7 @@ func TestExtensionCommandMetadata_Marshaling(t *testing.T) {
 	assert.Contains(t, string(data), `"schemaVersion":"1.0"`)
 	assert.Contains(t, string(data), `"id":"microsoft.azd.demo"`)
 	assert.Contains(t, string(data), `"name":["demo","greet"]`)
+	assert.Contains(t, string(data), `"valueOptional":true`)
 }
 
 func TestExtensionMetadata_UnmarshalJSON(t *testing.T) {
@@ -98,6 +100,7 @@ func TestExtensionMetadata_UnmarshalJSON(t *testing.T) {
 						"description": "Output format",
 						"type": "string",
 						"default": "text",
+						"valueOptional": true,
 						"validValues": ["text", "json"]
 					}
 				]
@@ -128,6 +131,7 @@ func TestExtensionMetadata_UnmarshalJSON(t *testing.T) {
 	assert.Equal(t, "f", cmd.Flags[0].Shorthand)
 	assert.Equal(t, "string", cmd.Flags[0].Type)
 	assert.Equal(t, "text", cmd.Flags[0].Default)
+	assert.True(t, cmd.Flags[0].ValueOptional)
 	assert.Equal(t, []string{"text", "json"}, cmd.Flags[0].ValidValues)
 }
 


### PR DESCRIPTION
### Summary

This PR adds core SDK support for preserving optional flag values when extension metadata is converted into a Fig completion spec.

Flags backed by Cobra `NoOptDefVal` can now emit `valueOptional: true` in extension metadata. Fig maps that field to `isOptional: true`, and the extension telemetry resolver preserves the same optional-value parsing behaviour. Native Cobra commands derive Fig optionality directly from `NoOptDefVal`.

This is the core SDK portion of #9661. The `azure.ai.agents` extension must update its azd dependency and publish a new release before its `--infra` metadata includes `valueOptional`, so #9661 should remain open until that follow-up ships.

### Example

`--infra` accepts either a bare flag or an explicit provider:

```sh
azd ai agent init --infra
azd ai agent init --infra=terraform
```

After `azure.ai.agents` is rebuilt against this SDK change, its generated Fig argument will change from:

```ts
args: [{ name: "infra" }]
```

to:

```ts
args: [{ name: "infra", isOptional: true }]
```

After a bare `--infra`, IntelliSense will continue suggesting other flags instead of treating the next token as the provider.

### Testing

Added focused coverage for metadata generation, extension conversion, native flag conversion, telemetry flag resolution, and JSON compatibility.