### PR TITLE
fix repeatly optimization

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - [[#9596]](https://github.com/Azure/azure-dev/pull/9596) Reject agent manifests that declare multiple `rai_policy` entries instead of silently discarding additional policies.
 - [[#9679]](https://github.com/Azure/azure-dev/pull/9679) Prompt users to provision after agent initialization adds a standalone Foundry connection service.
+- [[#9719]](https://github.com/Azure/azure-dev/pull/9719) Advance the local optimization baseline to the promoted candidate after deploy (archiving the previous baseline as `baseline_<job-id>`) so repeated `azd ai agent optimize` rounds build on the deployed configuration instead of restarting from the original.
 
 ## 1.0.0-beta.11 (2026-08-20)
 

--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -11,7 +11,6 @@
 
 - [[#9596]](https://github.com/Azure/azure-dev/pull/9596) Reject agent manifests that declare multiple `rai_policy` entries instead of silently discarding additional policies.
 - [[#9679]](https://github.com/Azure/azure-dev/pull/9679) Prompt users to provision after agent initialization adds a standalone Foundry connection service.
-- [[#9719]](https://github.com/Azure/azure-dev/pull/9719) Advance the local optimization baseline to the promoted candidate after deploy (archiving the previous baseline as `baseline_<job-id>`) so repeated `azd ai agent optimize` rounds build on the deployed configuration instead of restarting from the original.
 
 ## 1.0.0-beta.11 (2026-08-20)
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
@@ -464,6 +464,7 @@ func postdeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *a
 			}
 		}()
 		reportSvcOptimizationDeployment(ctx, azdClient, svc, envName, endpoint,
+			serviceDirFromProject(args.Project.Path, svc),
 			func(endpoint string) *optimize_api.OptimizeClient {
 				return optimize_api.NewOptimizeClient(endpoint, cred)
 			},

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
@@ -292,6 +292,19 @@ func isHostedAgentService(svc *azdext.ServiceConfig, proj *azdext.ProjectConfig)
 	return err == nil && isHosted
 }
 
+// hostedAgentServices returns the hosted azure.ai.agent services declared in
+// proj. It is used to detect services that share a source directory (and thus a
+// single .agent_configs/baseline) before advancing an optimization baseline.
+func hostedAgentServices(proj *azdext.ProjectConfig) []*azdext.ServiceConfig {
+	var hosted []*azdext.ServiceConfig
+	for _, svc := range proj.Services {
+		if isHostedAgentService(svc, proj) {
+			hosted = append(hosted, svc)
+		}
+	}
+	return hosted
+}
+
 // duplicateAgentNameGroup is a Foundry agent name referenced by more than one
 // azure.ai.agent service, with the colliding azure.yaml service keys sorted for
 // stable output.
@@ -464,7 +477,7 @@ func postdeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *a
 			}
 		}()
 		reportSvcOptimizationDeployment(ctx, azdClient, svc, envName, endpoint,
-			serviceDirFromProject(args.Project.Path, svc),
+			baselineAdvancementDir(args.Project.Path, svc, hostedAgentServices(args.Project)),
 			func(endpoint string) *optimize_api.OptimizeClient {
 				return optimize_api.NewOptimizeClient(endpoint, cred)
 			},

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen.go
@@ -292,19 +292,6 @@ func isHostedAgentService(svc *azdext.ServiceConfig, proj *azdext.ProjectConfig)
 	return err == nil && isHosted
 }
 
-// hostedAgentServices returns the hosted azure.ai.agent services declared in
-// proj. It is used to detect services that share a source directory (and thus a
-// single .agent_configs/baseline) before advancing an optimization baseline.
-func hostedAgentServices(proj *azdext.ProjectConfig) []*azdext.ServiceConfig {
-	var hosted []*azdext.ServiceConfig
-	for _, svc := range proj.Services {
-		if isHostedAgentService(svc, proj) {
-			hosted = append(hosted, svc)
-		}
-	}
-	return hosted
-}
-
 // duplicateAgentNameGroup is a Foundry agent name referenced by more than one
 // azure.ai.agent service, with the colliding azure.yaml service keys sorted for
 // stable output.
@@ -477,7 +464,7 @@ func postdeployHandler(ctx context.Context, azdClient *azdext.AzdClient, args *a
 			}
 		}()
 		reportSvcOptimizationDeployment(ctx, azdClient, svc, envName, endpoint,
-			baselineAdvancementDir(args.Project.Path, svc, hostedAgentServices(args.Project)),
+			baselineAdvancementDir(args.Project.Path, svc),
 			func(endpoint string) *optimize_api.OptimizeClient {
 				return optimize_api.NewOptimizeClient(endpoint, cred)
 			},

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"azureaiagent/internal/pkg/agents/opt_eval"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeAgentConfigDir creates a minimal agent config version directory with the
+// given instruction text and optional skill files under configsDir/<name>.
+func writeAgentConfigDir(t *testing.T, configsDir, name, instruction string, skills map[string]string) {
+	t.Helper()
+	dir := filepath.Join(configsDir, name)
+	require.NoError(t, os.MkdirAll(dir, 0750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, opt_eval.MetadataFile),
+		[]byte("instruction_file: "+opt_eval.InstructionFile+"\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, opt_eval.InstructionFile), []byte(instruction), 0600))
+	for rel, content := range skills {
+		p := filepath.Join(dir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0750))
+		require.NoError(t, os.WriteFile(p, []byte(content), 0600))
+	}
+}
+
+func TestAdvanceBaselineToCandidate_ReplacesBaseline(t *testing.T) {
+	t.Parallel()
+
+	serviceDir := t.TempDir()
+	configsDir := filepath.Join(serviceDir, opt_eval.AgentConfigsDir)
+
+	// Baseline holds the original config plus a stale skill file that the
+	// candidate no longer has; it must not survive the swap.
+	writeAgentConfigDir(t, configsDir, opt_eval.BaselineDir, "original instructions",
+		map[string]string{filepath.Join(opt_eval.SkillsDir, "old.md"): "old skill"})
+	writeAgentConfigDir(t, configsDir, "candidate_abc", "optimized instructions",
+		map[string]string{filepath.Join(opt_eval.SkillsDir, "new.md"): "new skill"})
+
+	require.NoError(t, advanceBaselineToCandidate(serviceDir, "candidate_abc", "job-1"))
+
+	baselineDir := filepath.Join(configsDir, opt_eval.BaselineDir)
+
+	// Baseline now carries the candidate's instructions.
+	got, err := os.ReadFile(filepath.Join(baselineDir, opt_eval.InstructionFile))
+	require.NoError(t, err)
+	assert.Equal(t, "optimized instructions", string(got))
+
+	// The candidate's skill replaced the stale baseline skill (clean replace).
+	_, err = os.Stat(filepath.Join(baselineDir, opt_eval.SkillsDir, "new.md"))
+	assert.NoError(t, err)
+	_, err = os.Stat(filepath.Join(baselineDir, opt_eval.SkillsDir, "old.md"))
+	assert.True(t, os.IsNotExist(err), "stale baseline skill should be removed")
+
+	// The previous baseline is archived (not deleted) as baseline_<job-id>.
+	archived, err := os.ReadFile(
+		filepath.Join(configsDir, opt_eval.BaselineDir+"_job-1", opt_eval.InstructionFile))
+	require.NoError(t, err)
+	assert.Equal(t, "original instructions", string(archived))
+	_, err = os.Stat(filepath.Join(configsDir, opt_eval.BaselineDir+"_job-1", opt_eval.SkillsDir, "old.md"))
+	assert.NoError(t, err, "archived baseline should retain its original files")
+
+	// The candidate directory is copied, not moved — it must still exist so the
+	// deploy pipeline can read it.
+	_, err = os.Stat(filepath.Join(configsDir, "candidate_abc", opt_eval.InstructionFile))
+	assert.NoError(t, err)
+
+	// No leftover staging directories.
+	entries, err := os.ReadDir(configsDir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".baseline-stage")
+	}
+}
+
+func TestAdvanceBaselineToCandidate_ArchiveCollisionReplaced(t *testing.T) {
+	t.Parallel()
+
+	serviceDir := t.TempDir()
+	configsDir := filepath.Join(serviceDir, opt_eval.AgentConfigsDir)
+
+	// A stale archive from a previous deploy of the same job already exists.
+	writeAgentConfigDir(t, configsDir, opt_eval.BaselineDir+"_job-1", "stale archive", nil)
+	writeAgentConfigDir(t, configsDir, opt_eval.BaselineDir, "current baseline", nil)
+	writeAgentConfigDir(t, configsDir, "candidate_abc", "optimized instructions", nil)
+
+	require.NoError(t, advanceBaselineToCandidate(serviceDir, "candidate_abc", "job-1"))
+
+	// The archive is replaced with the baseline that was current at swap time.
+	archived, err := os.ReadFile(
+		filepath.Join(configsDir, opt_eval.BaselineDir+"_job-1", opt_eval.InstructionFile))
+	require.NoError(t, err)
+	assert.Equal(t, "current baseline", string(archived))
+}
+
+func TestAdvanceBaselineToCandidate_NoJobIDRemovesBaseline(t *testing.T) {
+	t.Parallel()
+
+	serviceDir := t.TempDir()
+	configsDir := filepath.Join(serviceDir, opt_eval.AgentConfigsDir)
+	writeAgentConfigDir(t, configsDir, opt_eval.BaselineDir, "original", nil)
+	writeAgentConfigDir(t, configsDir, "candidate_abc", "optimized", nil)
+
+	// An unsafe job ID falls back to removal — no archive is created.
+	require.NoError(t, advanceBaselineToCandidate(serviceDir, "candidate_abc", "../evil"))
+
+	got, err := os.ReadFile(filepath.Join(configsDir, opt_eval.BaselineDir, opt_eval.InstructionFile))
+	require.NoError(t, err)
+	assert.Equal(t, "optimized", string(got))
+
+	entries, err := os.ReadDir(configsDir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), opt_eval.BaselineDir+"_", "no archive should be created")
+	}
+}
+
+func TestAdvanceBaselineToCandidate_NoOps(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty service dir", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, advanceBaselineToCandidate("", "candidate_abc", "job-1"))
+	})
+
+	t.Run("empty candidate id", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, advanceBaselineToCandidate(t.TempDir(), "", "job-1"))
+	})
+
+	t.Run("candidate dir missing", func(t *testing.T) {
+		t.Parallel()
+		serviceDir := t.TempDir()
+		// Baseline exists but the candidate does not — leave baseline untouched.
+		configsDir := filepath.Join(serviceDir, opt_eval.AgentConfigsDir)
+		writeAgentConfigDir(t, configsDir, opt_eval.BaselineDir, "original", nil)
+
+		require.NoError(t, advanceBaselineToCandidate(serviceDir, "candidate_missing", "job-1"))
+
+		got, err := os.ReadFile(filepath.Join(configsDir, opt_eval.BaselineDir, opt_eval.InstructionFile))
+		require.NoError(t, err)
+		assert.Equal(t, "original", string(got))
+	})
+}
+
+func TestAdvanceBaselineToCandidate_RejectsTraversal(t *testing.T) {
+	t.Parallel()
+
+	for _, id := range []string{"..", ".", filepath.Join("..", "escape"), "a/b"} {
+		err := advanceBaselineToCandidate(t.TempDir(), id, "job-1")
+		assert.Error(t, err, "candidate id %q should be rejected", id)
+	}
+}
+
+func TestServiceDirFromProject(t *testing.T) {
+	t.Parallel()
+
+	// Empty project path short-circuits before dereferencing svc.
+	assert.Equal(t, "", serviceDirFromProject("", nil))
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
@@ -10,6 +10,7 @@ import (
 
 	"azureaiagent/internal/pkg/agents/opt_eval"
 
+	azdext "github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -159,9 +160,27 @@ func TestAdvanceBaselineToCandidate_RejectsTraversal(t *testing.T) {
 	}
 }
 
-func TestServiceDirFromProject(t *testing.T) {
+func TestBaselineAdvancementDir(t *testing.T) {
 	t.Parallel()
 
-	// Empty project path short-circuits before dereferencing svc.
-	assert.Equal(t, "", serviceDirFromProject("", nil))
+	// Empty project path short-circuits (no local project on disk).
+	assert.Equal(t, "", baselineAdvancementDir("", &azdext.ServiceConfig{Name: "a"}, nil))
+
+	root := t.TempDir()
+
+	// A unique service resolves to its directory under the project root.
+	svcA := &azdext.ServiceConfig{Name: "a", RelativePath: "svc-a"}
+	assert.Equal(t, filepath.Join(root, "svc-a"), baselineAdvancementDir(root, svcA, []*azdext.ServiceConfig{svcA}))
+
+	// A traversing RelativePath escapes the root and is skipped.
+	svcEscape := &azdext.ServiceConfig{Name: "a", RelativePath: "../outside"}
+	assert.Equal(t, "", baselineAdvancementDir(root, svcEscape, []*azdext.ServiceConfig{svcEscape}))
+
+	// Two services sharing a source directory both skip advancement, since they
+	// share a single .agent_configs/baseline and may deploy in parallel.
+	shared1 := &azdext.ServiceConfig{Name: "one", RelativePath: "shared"}
+	shared2 := &azdext.ServiceConfig{Name: "two", RelativePath: "shared"}
+	peers := []*azdext.ServiceConfig{shared1, shared2}
+	assert.Equal(t, "", baselineAdvancementDir(root, shared1, peers))
+	assert.Equal(t, "", baselineAdvancementDir(root, shared2, peers))
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -81,7 +82,7 @@ func TestAdvanceBaselineToCandidate_ReplacesBaseline(t *testing.T) {
 	}
 }
 
-func TestAdvanceBaselineToCandidate_ArchiveCollisionReplaced(t *testing.T) {
+func TestAdvanceBaselineToCandidate_ArchiveCollisionPreserved(t *testing.T) {
 	t.Parallel()
 
 	serviceDir := t.TempDir()
@@ -94,11 +95,53 @@ func TestAdvanceBaselineToCandidate_ArchiveCollisionReplaced(t *testing.T) {
 
 	require.NoError(t, advanceBaselineToCandidate(serviceDir, "candidate_abc", "job-1"))
 
-	// The archive is replaced with the baseline that was current at swap time.
+	// The first archive for the job remains the original rollback snapshot.
 	archived, err := os.ReadFile(
 		filepath.Join(configsDir, opt_eval.BaselineDir+"_job-1", opt_eval.InstructionFile))
 	require.NoError(t, err)
-	assert.Equal(t, "current baseline", string(archived))
+	assert.Equal(t, "stale archive", string(archived))
+
+	baseline, err := os.ReadFile(
+		filepath.Join(configsDir, opt_eval.BaselineDir, opt_eval.InstructionFile))
+	require.NoError(t, err)
+	assert.Equal(t, "optimized instructions", string(baseline))
+}
+
+func TestAdvanceBaselineToCandidate_RestoresBaselineWhenPromotionFails(t *testing.T) {
+	t.Parallel()
+
+	serviceDir := t.TempDir()
+	configsDir := filepath.Join(serviceDir, opt_eval.AgentConfigsDir)
+	writeAgentConfigDir(t, configsDir, opt_eval.BaselineDir, "original", nil)
+	writeAgentConfigDir(t, configsDir, "candidate_abc", "optimized", nil)
+
+	promotionFailed := false
+	rename := func(oldPath, newPath string) error {
+		if filepath.Base(oldPath) != opt_eval.BaselineDir &&
+			newPath == filepath.Join(configsDir, opt_eval.BaselineDir) &&
+			!promotionFailed {
+			promotionFailed = true
+			return assert.AnError
+		}
+		return os.Rename(oldPath, newPath)
+	}
+
+	err := advanceBaselineToCandidateWithRename(
+		serviceDir,
+		"candidate_abc",
+		"job-1",
+		rename,
+	)
+	require.ErrorIs(t, err, assert.AnError)
+
+	baseline, readErr := os.ReadFile(
+		filepath.Join(configsDir, opt_eval.BaselineDir, opt_eval.InstructionFile))
+	require.NoError(t, readErr)
+	assert.Equal(t, "original", string(baseline))
+	archive, readErr := os.ReadFile(
+		filepath.Join(configsDir, opt_eval.BaselineDir+"_job-1", opt_eval.InstructionFile))
+	require.NoError(t, readErr)
+	assert.Equal(t, "original", string(archive))
 }
 
 func TestAdvanceBaselineToCandidate_NoJobIDRemovesBaseline(t *testing.T) {
@@ -149,6 +192,21 @@ func TestAdvanceBaselineToCandidate_NoOps(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "original", string(got))
 	})
+
+	t.Run("candidate path is a file", func(t *testing.T) {
+		t.Parallel()
+		serviceDir := t.TempDir()
+		configsDir := filepath.Join(serviceDir, opt_eval.AgentConfigsDir)
+		require.NoError(t, os.MkdirAll(configsDir, 0750))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(configsDir, "candidate_file"),
+			[]byte("not a directory"),
+			0600,
+		))
+
+		err := advanceBaselineToCandidate(serviceDir, "candidate_file", "job-1")
+		require.ErrorContains(t, err, "is not a directory")
+	})
 }
 
 func TestAdvanceBaselineToCandidate_RejectsTraversal(t *testing.T) {
@@ -158,6 +216,19 @@ func TestAdvanceBaselineToCandidate_RejectsTraversal(t *testing.T) {
 		err := advanceBaselineToCandidate(t.TempDir(), id, "job-1")
 		assert.Error(t, err, "candidate id %q should be rejected", id)
 	}
+}
+
+func TestCandidateConfigExists_AccessFailure(t *testing.T) {
+	t.Parallel()
+
+	accessErr := errors.New("access denied")
+	exists, err := candidateConfigExists("candidate", func(string) (os.FileInfo, error) {
+		return nil, accessErr
+	})
+
+	require.False(t, exists)
+	require.ErrorIs(t, err, accessErr)
+	require.ErrorContains(t, err, "accessing candidate config")
 }
 
 func TestBaselineAdvancementDir(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
@@ -144,6 +144,49 @@ func TestAdvanceBaselineToCandidate_RestoresBaselineWhenPromotionFails(t *testin
 	assert.Equal(t, "original", string(archive))
 }
 
+func TestAdvanceBaselineToCandidate_RemovesPartialBaselineWhenRestoreFails(t *testing.T) {
+	t.Parallel()
+
+	serviceDir := t.TempDir()
+	configsDir := filepath.Join(serviceDir, opt_eval.AgentConfigsDir)
+	writeAgentConfigDir(t, configsDir, opt_eval.BaselineDir, "original", nil)
+	writeAgentConfigDir(t, configsDir, "candidate_abc", "optimized", nil)
+
+	promotionFailed := false
+	rename := func(oldPath, newPath string) error {
+		if filepath.Base(oldPath) != opt_eval.BaselineDir &&
+			newPath == filepath.Join(configsDir, opt_eval.BaselineDir) &&
+			!promotionFailed {
+			promotionFailed = true
+			return assert.AnError
+		}
+		return os.Rename(oldPath, newPath)
+	}
+	restoreErr := errors.New("restore failed")
+	copyDir := func(src, dst string) error {
+		if filepath.Base(src) == opt_eval.BaselineDir+"_job-1" {
+			require.NoError(t, os.MkdirAll(dst, 0750))
+			require.NoError(t, os.WriteFile(filepath.Join(dst, "partial"), []byte("partial"), 0600))
+			return restoreErr
+		}
+		return copyDirectory(src, dst)
+	}
+
+	err := advanceBaselineToCandidateWithOps(
+		serviceDir,
+		"candidate_abc",
+		"job-1",
+		rename,
+		copyDir,
+	)
+	require.ErrorIs(t, err, assert.AnError)
+	require.ErrorContains(t, err, "restoring previous baseline: restore failed")
+	require.ErrorContains(t, err, "partial baseline removed")
+	assert.NoDirExists(t, filepath.Join(configsDir, opt_eval.BaselineDir))
+	assert.DirExists(t, filepath.Join(configsDir, opt_eval.BaselineDir+"_job-1"))
+	assert.DirExists(t, filepath.Join(configsDir, "candidate_abc"))
+}
+
 func TestAdvanceBaselineToCandidate_NoJobIDRemovesBaseline(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
@@ -125,7 +125,7 @@ func TestAdvanceBaselineToCandidate_ArchiveCollisionRestoresCurrentBaselineOnPro
 		return os.Rename(oldPath, newPath)
 	}
 
-	err := advanceBaselineToCandidateWithRename(serviceDir, "candidate_abc", "job-1", rename)
+	err := advanceBaselineToCandidateWithOps(serviceDir, "candidate_abc", "job-1", rename, copyDirectory)
 	require.ErrorIs(t, err, assert.AnError)
 
 	baseline, readErr := os.ReadFile(
@@ -158,11 +158,12 @@ func TestAdvanceBaselineToCandidate_RestoresBaselineWhenPromotionFails(t *testin
 		return os.Rename(oldPath, newPath)
 	}
 
-	err := advanceBaselineToCandidateWithRename(
+	err := advanceBaselineToCandidateWithOps(
 		serviceDir,
 		"candidate_abc",
 		"job-1",
 		rename,
+		copyDirectory,
 	)
 	require.ErrorIs(t, err, assert.AnError)
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
@@ -164,23 +164,15 @@ func TestBaselineAdvancementDir(t *testing.T) {
 	t.Parallel()
 
 	// Empty project path short-circuits (no local project on disk).
-	assert.Equal(t, "", baselineAdvancementDir("", &azdext.ServiceConfig{Name: "a"}, nil))
+	assert.Equal(t, "", baselineAdvancementDir("", &azdext.ServiceConfig{Name: "a"}))
 
 	root := t.TempDir()
 
 	// A unique service resolves to its directory under the project root.
 	svcA := &azdext.ServiceConfig{Name: "a", RelativePath: "svc-a"}
-	assert.Equal(t, filepath.Join(root, "svc-a"), baselineAdvancementDir(root, svcA, []*azdext.ServiceConfig{svcA}))
+	assert.Equal(t, filepath.Join(root, "svc-a"), baselineAdvancementDir(root, svcA))
 
 	// A traversing RelativePath escapes the root and is skipped.
 	svcEscape := &azdext.ServiceConfig{Name: "a", RelativePath: "../outside"}
-	assert.Equal(t, "", baselineAdvancementDir(root, svcEscape, []*azdext.ServiceConfig{svcEscape}))
-
-	// Two services sharing a source directory both skip advancement, since they
-	// share a single .agent_configs/baseline and may deploy in parallel.
-	shared1 := &azdext.ServiceConfig{Name: "one", RelativePath: "shared"}
-	shared2 := &azdext.ServiceConfig{Name: "two", RelativePath: "shared"}
-	peers := []*azdext.ServiceConfig{shared1, shared2}
-	assert.Equal(t, "", baselineAdvancementDir(root, shared1, peers))
-	assert.Equal(t, "", baselineAdvancementDir(root, shared2, peers))
+	assert.Equal(t, "", baselineAdvancementDir(root, svcEscape))
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"azureaiagent/internal/pkg/agents/opt_eval"
@@ -107,6 +108,37 @@ func TestAdvanceBaselineToCandidate_ArchiveCollisionPreserved(t *testing.T) {
 	assert.Equal(t, "optimized instructions", string(baseline))
 }
 
+func TestAdvanceBaselineToCandidate_ArchiveCollisionRestoresCurrentBaselineOnPromotionFailure(t *testing.T) {
+	t.Parallel()
+
+	serviceDir := t.TempDir()
+	configsDir := filepath.Join(serviceDir, opt_eval.AgentConfigsDir)
+	writeAgentConfigDir(t, configsDir, opt_eval.BaselineDir+"_job-1", "original baseline", nil)
+	writeAgentConfigDir(t, configsDir, opt_eval.BaselineDir, "current baseline", nil)
+	writeAgentConfigDir(t, configsDir, "candidate_abc", "optimized", nil)
+
+	rename := func(oldPath, newPath string) error {
+		if strings.Contains(filepath.Base(oldPath), ".baseline-stage-") &&
+			newPath == filepath.Join(configsDir, opt_eval.BaselineDir) {
+			return assert.AnError
+		}
+		return os.Rename(oldPath, newPath)
+	}
+
+	err := advanceBaselineToCandidateWithRename(serviceDir, "candidate_abc", "job-1", rename)
+	require.ErrorIs(t, err, assert.AnError)
+
+	baseline, readErr := os.ReadFile(
+		filepath.Join(configsDir, opt_eval.BaselineDir, opt_eval.InstructionFile))
+	require.NoError(t, readErr)
+	assert.Equal(t, "current baseline", string(baseline))
+
+	archive, readErr := os.ReadFile(
+		filepath.Join(configsDir, opt_eval.BaselineDir+"_job-1", opt_eval.InstructionFile))
+	require.NoError(t, readErr)
+	assert.Equal(t, "original baseline", string(archive))
+}
+
 func TestAdvanceBaselineToCandidate_RestoresBaselineWhenPromotionFails(t *testing.T) {
 	t.Parallel()
 
@@ -138,10 +170,7 @@ func TestAdvanceBaselineToCandidate_RestoresBaselineWhenPromotionFails(t *testin
 		filepath.Join(configsDir, opt_eval.BaselineDir, opt_eval.InstructionFile))
 	require.NoError(t, readErr)
 	assert.Equal(t, "original", string(baseline))
-	archive, readErr := os.ReadFile(
-		filepath.Join(configsDir, opt_eval.BaselineDir+"_job-1", opt_eval.InstructionFile))
-	require.NoError(t, readErr)
-	assert.Equal(t, "original", string(archive))
+	assert.NoDirExists(t, filepath.Join(configsDir, opt_eval.BaselineDir+"_job-1"))
 }
 
 func TestAdvanceBaselineToCandidate_RemovesPartialBaselineWhenRestoreFails(t *testing.T) {
@@ -154,17 +183,20 @@ func TestAdvanceBaselineToCandidate_RemovesPartialBaselineWhenRestoreFails(t *te
 
 	promotionFailed := false
 	rename := func(oldPath, newPath string) error {
-		if filepath.Base(oldPath) != opt_eval.BaselineDir &&
-			newPath == filepath.Join(configsDir, opt_eval.BaselineDir) &&
-			!promotionFailed {
-			promotionFailed = true
-			return assert.AnError
+		if newPath == filepath.Join(configsDir, opt_eval.BaselineDir) {
+			if !promotionFailed {
+				promotionFailed = true
+				return assert.AnError
+			}
+			if strings.Contains(filepath.Base(oldPath), ".baseline-rollback-") {
+				return errors.New("restore rename failed")
+			}
 		}
 		return os.Rename(oldPath, newPath)
 	}
-	restoreErr := errors.New("restore failed")
+	restoreErr := errors.New("restore copy failed")
 	copyDir := func(src, dst string) error {
-		if filepath.Base(src) == opt_eval.BaselineDir+"_job-1" {
+		if strings.Contains(filepath.Base(src), ".baseline-rollback-") {
 			require.NoError(t, os.MkdirAll(dst, 0750))
 			require.NoError(t, os.WriteFile(filepath.Join(dst, "partial"), []byte("partial"), 0600))
 			return restoreErr
@@ -180,11 +212,23 @@ func TestAdvanceBaselineToCandidate_RemovesPartialBaselineWhenRestoreFails(t *te
 		copyDir,
 	)
 	require.ErrorIs(t, err, assert.AnError)
-	require.ErrorContains(t, err, "restoring previous baseline: restore failed")
+	require.ErrorContains(t, err, "restoring rollback: restore rename failed")
+	require.ErrorContains(t, err, "copying rollback: restore copy failed")
 	require.ErrorContains(t, err, "partial baseline removed")
 	assert.NoDirExists(t, filepath.Join(configsDir, opt_eval.BaselineDir))
-	assert.DirExists(t, filepath.Join(configsDir, opt_eval.BaselineDir+"_job-1"))
+	assert.NoDirExists(t, filepath.Join(configsDir, opt_eval.BaselineDir+"_job-1"))
 	assert.DirExists(t, filepath.Join(configsDir, "candidate_abc"))
+
+	entries, readErr := os.ReadDir(configsDir)
+	require.NoError(t, readErr)
+	assert.Condition(t, func() bool {
+		for _, entry := range entries {
+			if strings.Contains(entry.Name(), ".baseline-rollback-") {
+				return true
+			}
+		}
+		return false
+	}, "the exact previous baseline should remain in the rollback directory")
 }
 
 func TestAdvanceBaselineToCandidate_NoJobIDRemovesBaseline(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_baseline_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"azureaiagent/internal/pkg/agents/opt_eval"
 
@@ -47,7 +48,7 @@ func TestAdvanceBaselineToCandidate_ReplacesBaseline(t *testing.T) {
 	writeAgentConfigDir(t, configsDir, "candidate_abc", "optimized instructions",
 		map[string]string{filepath.Join(opt_eval.SkillsDir, "new.md"): "new skill"})
 
-	require.NoError(t, advanceBaselineToCandidate(serviceDir, "candidate_abc", "job-1"))
+	require.NoError(t, advanceBaselineToCandidate(configsDir, "candidate_abc", "job-1"))
 
 	baselineDir := filepath.Join(configsDir, opt_eval.BaselineDir)
 
@@ -94,7 +95,7 @@ func TestAdvanceBaselineToCandidate_ArchiveCollisionPreserved(t *testing.T) {
 	writeAgentConfigDir(t, configsDir, opt_eval.BaselineDir, "current baseline", nil)
 	writeAgentConfigDir(t, configsDir, "candidate_abc", "optimized instructions", nil)
 
-	require.NoError(t, advanceBaselineToCandidate(serviceDir, "candidate_abc", "job-1"))
+	require.NoError(t, advanceBaselineToCandidate(configsDir, "candidate_abc", "job-1"))
 
 	// The first archive for the job remains the original rollback snapshot.
 	archived, err := os.ReadFile(
@@ -125,7 +126,7 @@ func TestAdvanceBaselineToCandidate_ArchiveCollisionRestoresCurrentBaselineOnPro
 		return os.Rename(oldPath, newPath)
 	}
 
-	err := advanceBaselineToCandidateWithOps(serviceDir, "candidate_abc", "job-1", rename, copyDirectory)
+	err := advanceBaselineToCandidateWithOps(configsDir, "candidate_abc", "job-1", rename, copyDirectory)
 	require.ErrorIs(t, err, assert.AnError)
 
 	baseline, readErr := os.ReadFile(
@@ -159,7 +160,7 @@ func TestAdvanceBaselineToCandidate_RestoresBaselineWhenPromotionFails(t *testin
 	}
 
 	err := advanceBaselineToCandidateWithOps(
-		serviceDir,
+		configsDir,
 		"candidate_abc",
 		"job-1",
 		rename,
@@ -206,7 +207,7 @@ func TestAdvanceBaselineToCandidate_RemovesPartialBaselineWhenRestoreFails(t *te
 	}
 
 	err := advanceBaselineToCandidateWithOps(
-		serviceDir,
+		configsDir,
 		"candidate_abc",
 		"job-1",
 		rename,
@@ -241,7 +242,7 @@ func TestAdvanceBaselineToCandidate_NoJobIDRemovesBaseline(t *testing.T) {
 	writeAgentConfigDir(t, configsDir, "candidate_abc", "optimized", nil)
 
 	// An unsafe job ID falls back to removal — no archive is created.
-	require.NoError(t, advanceBaselineToCandidate(serviceDir, "candidate_abc", "../evil"))
+	require.NoError(t, advanceBaselineToCandidate(configsDir, "candidate_abc", "../evil"))
 
 	got, err := os.ReadFile(filepath.Join(configsDir, opt_eval.BaselineDir, opt_eval.InstructionFile))
 	require.NoError(t, err)
@@ -257,7 +258,7 @@ func TestAdvanceBaselineToCandidate_NoJobIDRemovesBaseline(t *testing.T) {
 func TestAdvanceBaselineToCandidate_NoOps(t *testing.T) {
 	t.Parallel()
 
-	t.Run("empty service dir", func(t *testing.T) {
+	t.Run("empty configs dir", func(t *testing.T) {
 		t.Parallel()
 		assert.NoError(t, advanceBaselineToCandidate("", "candidate_abc", "job-1"))
 	})
@@ -274,7 +275,7 @@ func TestAdvanceBaselineToCandidate_NoOps(t *testing.T) {
 		configsDir := filepath.Join(serviceDir, opt_eval.AgentConfigsDir)
 		writeAgentConfigDir(t, configsDir, opt_eval.BaselineDir, "original", nil)
 
-		require.NoError(t, advanceBaselineToCandidate(serviceDir, "candidate_missing", "job-1"))
+		require.NoError(t, advanceBaselineToCandidate(configsDir, "candidate_missing", "job-1"))
 
 		got, err := os.ReadFile(filepath.Join(configsDir, opt_eval.BaselineDir, opt_eval.InstructionFile))
 		require.NoError(t, err)
@@ -292,7 +293,7 @@ func TestAdvanceBaselineToCandidate_NoOps(t *testing.T) {
 			0600,
 		))
 
-		err := advanceBaselineToCandidate(serviceDir, "candidate_file", "job-1")
+		err := advanceBaselineToCandidate(configsDir, "candidate_file", "job-1")
 		require.ErrorContains(t, err, "is not a directory")
 	})
 }
@@ -327,11 +328,122 @@ func TestBaselineAdvancementDir(t *testing.T) {
 
 	root := t.TempDir()
 
-	// A unique service resolves to its directory under the project root.
+	// A unique service resolves to its .agent_configs directory under the project root.
 	svcA := &azdext.ServiceConfig{Name: "a", RelativePath: "svc-a"}
-	assert.Equal(t, filepath.Join(root, "svc-a"), baselineAdvancementDir(root, svcA))
+	assert.Equal(
+		t,
+		filepath.Join(root, "svc-a", opt_eval.AgentConfigsDir),
+		baselineAdvancementDir(root, svcA),
+	)
 
 	// A traversing RelativePath escapes the root and is skipped.
 	svcEscape := &azdext.ServiceConfig{Name: "a", RelativePath: "../outside"}
 	assert.Equal(t, "", baselineAdvancementDir(root, svcEscape))
+}
+
+func TestBaselineAdvancementDir_RejectsAgentConfigsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	serviceDir := filepath.Join(root, "svc")
+	require.NoError(t, os.MkdirAll(serviceDir, 0750))
+	outside := t.TempDir()
+	link := filepath.Join(serviceDir, opt_eval.AgentConfigsDir)
+	if err := os.Symlink(outside, link); err != nil {
+		if errors.Is(err, os.ErrPermission) || os.IsPermission(err) ||
+			strings.Contains(strings.ToLower(err.Error()), "privilege") {
+			t.Skipf("symlink creation not permitted: %v", err)
+		}
+		require.NoError(t, err)
+	}
+
+	svc := &azdext.ServiceConfig{Name: "a", RelativePath: "svc"}
+	assert.Equal(t, "", baselineAdvancementDir(root, svc))
+}
+
+func TestBaselineAdvancementDir_CanonicalizesInProjectSymlink(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	realServiceDir := filepath.Join(root, "real-service")
+	configsDir := filepath.Join(realServiceDir, opt_eval.AgentConfigsDir)
+	require.NoError(t, os.MkdirAll(configsDir, 0750))
+	link := filepath.Join(root, "linked-service")
+	if err := os.Symlink(realServiceDir, link); err != nil {
+		if errors.Is(err, os.ErrPermission) || os.IsPermission(err) ||
+			strings.Contains(strings.ToLower(err.Error()), "privilege") {
+			t.Skipf("symlink creation not permitted: %v", err)
+		}
+		require.NoError(t, err)
+	}
+
+	svc := &azdext.ServiceConfig{Name: "a", RelativePath: "linked-service"}
+	assert.Equal(t, configsDir, baselineAdvancementDir(root, svc))
+}
+
+func TestAdvanceBaselineToCandidate_SerializesSharedConfigsDir(t *testing.T) {
+	configsDir := filepath.Join(t.TempDir(), opt_eval.AgentConfigsDir)
+	writeAgentConfigDir(t, configsDir, opt_eval.BaselineDir, "original", nil)
+	writeAgentConfigDir(t, configsDir, "candidate_a", "candidate a", nil)
+	writeAgentConfigDir(t, configsDir, "candidate_b", "candidate b", nil)
+
+	firstCopyStarted := make(chan struct{})
+	releaseFirstCopy := make(chan struct{})
+	secondCopyStarted := make(chan struct{})
+	firstDone := make(chan error, 1)
+	secondDone := make(chan error, 1)
+
+	go func() {
+		firstDone <- advanceBaselineToCandidateWithOps(
+			configsDir,
+			"candidate_a",
+			"job-a",
+			os.Rename,
+			func(src, dst string) error {
+				if filepath.Base(src) == "candidate_a" {
+					close(firstCopyStarted)
+					<-releaseFirstCopy
+				}
+				return copyDirectory(src, dst)
+			},
+		)
+	}()
+	<-firstCopyStarted
+
+	go func() {
+		secondDone <- advanceBaselineToCandidateWithOps(
+			configsDir,
+			"candidate_b",
+			"job-b",
+			os.Rename,
+			func(src, dst string) error {
+				if filepath.Base(src) == "candidate_b" {
+					close(secondCopyStarted)
+				}
+				return copyDirectory(src, dst)
+			},
+		)
+	}()
+
+	select {
+	case <-secondCopyStarted:
+		t.Fatal("second baseline swap entered while the first swap held the directory lock")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseFirstCopy)
+	require.NoError(t, <-firstDone)
+	require.NoError(t, <-secondDone)
+
+	select {
+	case <-secondCopyStarted:
+	default:
+		t.Fatal("second baseline swap did not run after the first swap completed")
+	}
+
+	baseline, err := os.ReadFile(
+		filepath.Join(configsDir, opt_eval.BaselineDir, opt_eval.InstructionFile),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "candidate b", string(baseline))
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
@@ -13,9 +13,11 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"azureaiagent/internal/pkg/agents/eval_api"
+	"azureaiagent/internal/pkg/agents/opt_eval"
 	"azureaiagent/internal/pkg/agents/optimize_api"
 
 	azdext "github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -278,13 +280,18 @@ func terminalHyperlink(url, text string) string {
 
 // reportOptimizationDeployments reports optimization candidate deployments to the optimization service.
 // For each hosted agent service, if AGENT_{KEY}_OPTIMIZATION_CANDIDATE_ID is set in
-// the azd environment, it calls the promote API and then clears the env var.
+// the azd environment, it calls the promote API, advances the local baseline config
+// to the promoted candidate, and then clears the env var.
 // This is best-effort — failures are logged but do not block the deploy.
+//
+// projectPath is the azd project root used to locate each service's local
+// .agent_configs directory; it may be empty when unavailable (e.g. in tests),
+// in which case baseline advancement is skipped.
 func reportOptimizationDeployments(
 	ctx context.Context,
 	azdClient *azdext.AzdClient,
 	hostedAgents []*azdext.ServiceConfig,
-	envName, projectEndpoint string,
+	envName, projectEndpoint, projectPath string,
 	newClient func(endpoint string) *optimize_api.OptimizeClient,
 ) {
 	log.Printf("postdeploy: reporting optimization deployments for %d hosted agents", len(hostedAgents))
@@ -296,9 +303,93 @@ func reportOptimizationDeployments(
 					log.Printf("postdeploy: optimization reporting panicked for %s: %v", svc.Name, r)
 				}
 			}()
-			reportSvcOptimizationDeployment(ctx, azdClient, svc, envName, projectEndpoint, newClient)
+			serviceDir := serviceDirFromProject(projectPath, svc)
+			reportSvcOptimizationDeployment(ctx, azdClient, svc, envName, projectEndpoint, serviceDir, newClient)
 		}()
 	}
+}
+
+// serviceDirFromProject resolves the absolute service directory for svc within
+// the azd project. Returns "" when projectPath is empty so callers can treat a
+// missing project root as "skip local filesystem work".
+func serviceDirFromProject(projectPath string, svc *azdext.ServiceConfig) string {
+	if projectPath == "" {
+		return ""
+	}
+	return filepath.Join(projectPath, svc.GetRelativePath())
+}
+
+// advanceBaselineToCandidate replaces the service's local baseline agent config
+// with the promoted candidate's config so the next optimization round starts
+// from the deployed configuration rather than the original. The previous
+// baseline is archived as baseline_<job-id> (rather than deleted) for
+// rollback/audit; when no usable jobID is available it is removed instead.
+//
+// It is a no-op when serviceDir or candidateID is empty, or when the candidate
+// config directory does not exist locally (e.g. remote-only deploy flows). The
+// candidate directory is copied (not moved) so the deploy pipeline can still
+// read it, and the swap is staged so a mid-copy failure leaves the existing
+// baseline intact.
+func advanceBaselineToCandidate(serviceDir, candidateID, jobID string) error {
+	if serviceDir == "" || candidateID == "" {
+		return nil
+	}
+
+	// The candidate ID is read from the azd environment; guard against path
+	// traversal before joining it into a filesystem path.
+	if !isSafePathSegment(candidateID) {
+		return fmt.Errorf("invalid candidate id %q", candidateID)
+	}
+
+	configsDir := filepath.Join(serviceDir, opt_eval.AgentConfigsDir)
+	candidateDir := filepath.Join(configsDir, candidateID)
+	baselineDir := filepath.Join(configsDir, opt_eval.BaselineDir)
+
+	// Only advance when the candidate config exists locally.
+	if info, err := os.Stat(candidateDir); err != nil || !info.IsDir() {
+		return nil
+	}
+
+	// Stage the candidate config into a temp dir next to baseline, so a mid-copy
+	// failure leaves the existing baseline intact.
+	stageDir, err := os.MkdirTemp(configsDir, ".baseline-stage-*")
+	if err != nil {
+		return fmt.Errorf("staging baseline: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(stageDir) }()
+
+	if err := copyDirectory(candidateDir, stageDir); err != nil {
+		return fmt.Errorf("copying candidate config: %w", err)
+	}
+
+	// Retire the previous baseline before installing the new one. Prefer
+	// archiving it as baseline_<job-id> for rollback/audit; fall back to
+	// removal when the job ID is missing or unsafe as a path segment.
+	if _, err := os.Stat(baselineDir); err == nil {
+		if jobID != "" && isSafePathSegment(jobID) {
+			archiveDir := filepath.Join(configsDir, opt_eval.BaselineDir+"_"+jobID)
+			// Replace any existing archive for this job so Rename succeeds.
+			if err := os.RemoveAll(archiveDir); err != nil {
+				return fmt.Errorf("clearing previous baseline archive: %w", err)
+			}
+			if err := os.Rename(baselineDir, archiveDir); err != nil {
+				return fmt.Errorf("archiving previous baseline: %w", err)
+			}
+		} else if err := os.RemoveAll(baselineDir); err != nil {
+			return fmt.Errorf("removing old baseline: %w", err)
+		}
+	}
+
+	if err := os.Rename(stageDir, baselineDir); err != nil {
+		return fmt.Errorf("promoting baseline: %w", err)
+	}
+	return nil
+}
+
+// isSafePathSegment reports whether name is a single, non-traversing path
+// segment safe to join into a filesystem path.
+func isSafePathSegment(name string) bool {
+	return name != "" && name == filepath.Base(name) && name != "." && name != ".."
 }
 
 // reportSvcOptimizationDeployment reports a single service's optimization candidate.
@@ -306,7 +397,7 @@ func reportSvcOptimizationDeployment(
 	ctx context.Context,
 	azdClient *azdext.AzdClient,
 	svc *azdext.ServiceConfig,
-	envName, projectEndpoint string,
+	envName, projectEndpoint, serviceDir string,
 	newClient func(endpoint string) *optimize_api.OptimizeClient,
 ) {
 	serviceKey := toServiceKey(svc.Name)
@@ -366,6 +457,16 @@ func reportSvcOptimizationDeployment(
 	}
 
 	log.Printf("postdeploy: successfully promoted candidate %s for %s", candidateResp.Value, svc.Name)
+
+	// Advance the local baseline config to the promoted candidate so a
+	// subsequent optimization round starts from the deployed configuration
+	// instead of the original. The previous baseline is archived as
+	// baseline_<job-id>. Best-effort; never blocks deploy.
+	if err := advanceBaselineToCandidate(serviceDir, candidateResp.Value, jobID); err != nil {
+		log.Printf("postdeploy: failed to advance baseline for %s: %v", svc.Name, err)
+	} else if serviceDir != "" {
+		log.Printf("postdeploy: advanced baseline to candidate %s for %s", candidateResp.Value, svc.Name)
+	}
 
 	// Clear the candidate ID after successful reporting.
 	if _, err := azdClient.Environment().SetValue(ctx, &azdext.SetEnvRequest{

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
@@ -304,7 +304,7 @@ func reportOptimizationDeployments(
 					log.Printf("postdeploy: optimization reporting panicked for %s: %v", svc.Name, r)
 				}
 			}()
-			serviceDir := baselineAdvancementDir(projectPath, svc, hostedAgents)
+			serviceDir := baselineAdvancementDir(projectPath, svc)
 			reportSvcOptimizationDeployment(ctx, azdClient, svc, envName, projectEndpoint, serviceDir, newClient)
 		}()
 	}
@@ -317,15 +317,10 @@ func reportOptimizationDeployments(
 //   - projectPath is empty (no local project on disk),
 //   - the service path cannot be safely resolved under the project root — for
 //     example a RelativePath from azure.yaml containing ".." that escapes the
-//     root, or
-//   - svc shares its resolved source directory with another hosted agent. Those
-//     services share a single .agent_configs/baseline, and their deploy steps
-//     may run in parallel, so advancing here would nondeterministically clobber
-//     a peer's promoted baseline.
+//     root.
 func baselineAdvancementDir(
 	projectPath string,
 	svc *azdext.ServiceConfig,
-	hostedAgents []*azdext.ServiceConfig,
 ) string {
 	if projectPath == "" {
 		return ""
@@ -335,22 +330,6 @@ func baselineAdvancementDir(
 	if err != nil {
 		log.Printf("postdeploy: skipping baseline advancement for %s: %v", svc.Name, err)
 		return ""
-	}
-
-	for _, peer := range hostedAgents {
-		if peer == nil || peer.Name == svc.Name {
-			continue
-		}
-		peerDir, err := paths.JoinAllowRoot(projectPath, peer.GetRelativePath())
-		if err != nil {
-			continue
-		}
-		if isSamePath(peerDir, serviceDir) {
-			log.Printf(
-				"postdeploy: skipping baseline advancement for %s: shares source directory with %s",
-				svc.Name, peer.Name)
-			return ""
-		}
 	}
 
 	return serviceDir
@@ -431,7 +410,9 @@ func isSafePathSegment(name string) bool {
 
 // reportSvcOptimizationDeployment reports a single service's optimization candidate.
 // serviceDir is the validated local service directory used for baseline
-// advancement, or "" to skip it (see baselineAdvancementDir).
+// advancement, or "" to skip it (see baselineAdvancementDir). Services that
+// share this directory also share baseline state; users running their
+// optimizations in parallel are responsible for retaining the desired baseline.
 func reportSvcOptimizationDeployment(
 	ctx context.Context,
 	azdClient *azdext.AzdClient,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
@@ -348,14 +348,7 @@ func baselineAdvancementDir(
 // read it, and the swap is staged so a mid-copy failure leaves the existing
 // baseline intact.
 func advanceBaselineToCandidate(serviceDir, candidateID, jobID string) error {
-	return advanceBaselineToCandidateWithRename(serviceDir, candidateID, jobID, os.Rename)
-}
-
-func advanceBaselineToCandidateWithRename(
-	serviceDir, candidateID, jobID string,
-	rename func(string, string) error,
-) error {
-	return advanceBaselineToCandidateWithOps(serviceDir, candidateID, jobID, rename, copyDirectory)
+	return advanceBaselineToCandidateWithOps(serviceDir, candidateID, jobID, os.Rename, copyDirectory)
 }
 
 func advanceBaselineToCandidateWithOps(

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
@@ -552,11 +552,12 @@ func warnBaselineAdvancementFailure(
 		"WARNING: candidate %q was promoted for service %q, but the local optimization baseline "+
 			"could not be updated: %v\n"+
 			"Before starting the next optimization round, set this candidate as its baseline by running:\n"+
-			"  azd ai agent optimize apply --candidate %q\n"+
+			"  azd ai agent optimize apply --agent %q --candidate %q\n"+
 			"  azd deploy %q\n",
 		candidateID,
 		serviceName,
 		err,
+		serviceName,
 		candidateID,
 		serviceName,
 	))

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
@@ -15,7 +15,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 
 	"azureaiagent/internal/pkg/agents/eval_api"
 	"azureaiagent/internal/pkg/agents/opt_eval"
@@ -23,6 +25,7 @@ import (
 	"azureaiagent/internal/pkg/paths"
 
 	azdext "github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -305,14 +308,14 @@ func reportOptimizationDeployments(
 					log.Printf("postdeploy: optimization reporting panicked for %s: %v", svc.Name, r)
 				}
 			}()
-			serviceDir := baselineAdvancementDir(projectPath, svc)
-			reportSvcOptimizationDeployment(ctx, azdClient, svc, envName, projectEndpoint, serviceDir, newClient)
+			configsDir := baselineAdvancementDir(projectPath, svc)
+			reportSvcOptimizationDeployment(ctx, azdClient, svc, envName, projectEndpoint, configsDir, newClient)
 		}()
 	}
 }
 
-// baselineAdvancementDir resolves the validated local directory used for svc's
-// baseline advancement, or "" when advancement must be skipped.
+// baselineAdvancementDir resolves the validated local .agent_configs directory
+// used for svc's baseline advancement, or "" when advancement must be skipped.
 //
 // It returns "" (skip, no error surfaced) when:
 //   - projectPath is empty (no local project on disk),
@@ -327,13 +330,47 @@ func baselineAdvancementDir(
 		return ""
 	}
 
-	serviceDir, err := paths.JoinAllowRoot(projectPath, svc.GetRelativePath())
+	configsDir, err := paths.JoinAllowRoot(
+		projectPath,
+		svc.GetRelativePath(),
+		opt_eval.AgentConfigsDir,
+	)
 	if err != nil {
 		log.Printf("postdeploy: skipping baseline advancement for %s: %v", svc.Name, err)
 		return ""
 	}
 
-	return serviceDir
+	resolvedConfigsDir, err := filepath.EvalSymlinks(configsDir)
+	if err == nil {
+		return filepath.Clean(resolvedConfigsDir)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		log.Printf("postdeploy: skipping baseline advancement for %s: %v", svc.Name, err)
+		return ""
+	}
+
+	// .agent_configs may not exist yet. Canonicalize its existing service
+	// directory so aliases still share one lock key when the directory is created.
+	resolvedServiceDir, err := filepath.EvalSymlinks(filepath.Dir(configsDir))
+	if err == nil {
+		return filepath.Join(filepath.Clean(resolvedServiceDir), opt_eval.AgentConfigsDir)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		log.Printf("postdeploy: skipping baseline advancement for %s: %v", svc.Name, err)
+		return ""
+	}
+	return configsDir
+}
+
+var baselineAdvancementLocks sync.Map
+
+func baselineAdvancementLock(configsDir string) *sync.Mutex {
+	key := filepath.Clean(configsDir)
+	if runtime.GOOS == "windows" {
+		key = strings.ToLower(key)
+	}
+	lock, _ := baselineAdvancementLocks.LoadOrStore(key, &sync.Mutex{})
+	return lock.(*sync.Mutex)
 }
 
 // advanceBaselineToCandidate replaces the service's local baseline agent config
@@ -347,16 +384,16 @@ func baselineAdvancementDir(
 // candidate directory is copied (not moved) so the deploy pipeline can still
 // read it, and the swap is staged so a mid-copy failure leaves the existing
 // baseline intact.
-func advanceBaselineToCandidate(serviceDir, candidateID, jobID string) error {
-	return advanceBaselineToCandidateWithOps(serviceDir, candidateID, jobID, os.Rename, copyDirectory)
+func advanceBaselineToCandidate(configsDir, candidateID, jobID string) error {
+	return advanceBaselineToCandidateWithOps(configsDir, candidateID, jobID, os.Rename, copyDirectory)
 }
 
 func advanceBaselineToCandidateWithOps(
-	serviceDir, candidateID, jobID string,
+	configsDir, candidateID, jobID string,
 	rename func(string, string) error,
 	copyDir func(string, string) error,
 ) error {
-	if serviceDir == "" || candidateID == "" {
+	if configsDir == "" || candidateID == "" {
 		return nil
 	}
 
@@ -366,7 +403,10 @@ func advanceBaselineToCandidateWithOps(
 		return fmt.Errorf("invalid candidate id %q", candidateID)
 	}
 
-	configsDir := filepath.Join(serviceDir, opt_eval.AgentConfigsDir)
+	lock := baselineAdvancementLock(configsDir)
+	lock.Lock()
+	defer lock.Unlock()
+
 	candidateDir := filepath.Join(configsDir, candidateID)
 	baselineDir := filepath.Join(configsDir, opt_eval.BaselineDir)
 
@@ -503,16 +543,35 @@ func isSafePathSegment(name string) bool {
 	return name != "" && name == filepath.Base(name) && name != "." && name != ".."
 }
 
+func warnBaselineAdvancementFailure(
+	writer io.Writer,
+	serviceName, candidateID string,
+	err error,
+) {
+	fmt.Fprintf(writer, "%s", output.WithWarningFormat(
+		"WARNING: candidate %q was promoted for service %q, but the local optimization baseline "+
+			"could not be updated: %v\n"+
+			"Before starting the next optimization round, set this candidate as its baseline by running:\n"+
+			"  azd ai agent optimize apply --candidate %q\n"+
+			"  azd deploy %q\n",
+		candidateID,
+		serviceName,
+		err,
+		candidateID,
+		serviceName,
+	))
+}
+
 // reportSvcOptimizationDeployment reports a single service's optimization candidate.
-// serviceDir is the validated local service directory used for baseline
+// configsDir is the validated local .agent_configs directory used for baseline
 // advancement, or "" to skip it (see baselineAdvancementDir). Services that
-// share this directory also share baseline state; users running their
-// optimizations in parallel are responsible for retaining the desired baseline.
+// share this directory also share baseline state; their local swaps are
+// serialized to prevent interleaved filesystem mutations.
 func reportSvcOptimizationDeployment(
 	ctx context.Context,
 	azdClient *azdext.AzdClient,
 	svc *azdext.ServiceConfig,
-	envName, projectEndpoint string, serviceDir string,
+	envName, projectEndpoint string, configsDir string,
 	newClient func(endpoint string) *optimize_api.OptimizeClient,
 ) {
 	serviceKey := toServiceKey(svc.Name)
@@ -577,9 +636,9 @@ func reportSvcOptimizationDeployment(
 	// subsequent optimization round starts from the deployed configuration
 	// instead of the original. The previous baseline is archived as
 	// baseline_<job-id>. Best-effort; never blocks deploy.
-	if err := advanceBaselineToCandidate(serviceDir, candidateResp.Value, jobID); err != nil {
-		log.Printf("postdeploy: failed to advance baseline for %s: %v", svc.Name, err)
-	} else if serviceDir != "" {
+	if err := advanceBaselineToCandidate(configsDir, candidateResp.Value, jobID); err != nil {
+		warnBaselineAdvancementFailure(os.Stderr, svc.Name, candidateResp.Value, err)
+	} else if configsDir != "" {
 		log.Printf("postdeploy: advanced baseline to candidate %s for %s", candidateResp.Value, svc.Name)
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
@@ -355,6 +355,14 @@ func advanceBaselineToCandidateWithRename(
 	serviceDir, candidateID, jobID string,
 	rename func(string, string) error,
 ) error {
+	return advanceBaselineToCandidateWithOps(serviceDir, candidateID, jobID, rename, copyDirectory)
+}
+
+func advanceBaselineToCandidateWithOps(
+	serviceDir, candidateID, jobID string,
+	rename func(string, string) error,
+	copyDir func(string, string) error,
+) error {
 	if serviceDir == "" || candidateID == "" {
 		return nil
 	}
@@ -386,7 +394,7 @@ func advanceBaselineToCandidateWithRename(
 	}
 	defer func() { _ = os.RemoveAll(stageDir) }()
 
-	if err := copyDirectory(candidateDir, stageDir); err != nil {
+	if err := copyDir(candidateDir, stageDir); err != nil {
 		return fmt.Errorf("copying candidate config: %w", err)
 	}
 
@@ -418,9 +426,28 @@ func advanceBaselineToCandidateWithRename(
 
 	if err := rename(stageDir, baselineDir); err != nil {
 		if archiveDir != "" {
-			if restoreErr := copyDirectory(archiveDir, baselineDir); restoreErr != nil {
+			if restoreErr := copyDir(archiveDir, baselineDir); restoreErr != nil {
+				if cleanupErr := os.RemoveAll(baselineDir); cleanupErr != nil {
+					log.Printf(
+						"warning: failed to restore previous baseline from %s and failed to remove partial baseline at %s: %v",
+						archiveDir,
+						baselineDir,
+						cleanupErr,
+					)
+					return fmt.Errorf(
+						"promoting baseline: %w; restoring previous baseline: %v; removing partial baseline: %v",
+						err,
+						restoreErr,
+						cleanupErr,
+					)
+				}
+				log.Printf(
+					"warning: failed to restore previous baseline from %s; removed partial baseline at %s",
+					archiveDir,
+					baselineDir,
+				)
 				return fmt.Errorf(
-					"promoting baseline: %w; restoring previous baseline: %v",
+					"promoting baseline: %w; restoring previous baseline: %v; partial baseline removed",
 					err,
 					restoreErr,
 				)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
@@ -9,6 +9,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -347,6 +348,13 @@ func baselineAdvancementDir(
 // read it, and the swap is staged so a mid-copy failure leaves the existing
 // baseline intact.
 func advanceBaselineToCandidate(serviceDir, candidateID, jobID string) error {
+	return advanceBaselineToCandidateWithRename(serviceDir, candidateID, jobID, os.Rename)
+}
+
+func advanceBaselineToCandidateWithRename(
+	serviceDir, candidateID, jobID string,
+	rename func(string, string) error,
+) error {
 	if serviceDir == "" || candidateID == "" {
 		return nil
 	}
@@ -362,7 +370,11 @@ func advanceBaselineToCandidate(serviceDir, candidateID, jobID string) error {
 	baselineDir := filepath.Join(configsDir, opt_eval.BaselineDir)
 
 	// Only advance when the candidate config exists locally.
-	if info, err := os.Stat(candidateDir); err != nil || !info.IsDir() {
+	candidateExists, err := candidateConfigExists(candidateDir, os.Stat)
+	if err != nil {
+		return err
+	}
+	if !candidateExists {
 		return nil
 	}
 
@@ -378,17 +390,25 @@ func advanceBaselineToCandidate(serviceDir, candidateID, jobID string) error {
 		return fmt.Errorf("copying candidate config: %w", err)
 	}
 
-	// Retire the previous baseline before installing the new one. Prefer
-	// archiving it as baseline_<job-id> for rollback/audit; fall back to
-	// removal when the job ID is missing or unsafe as a path segment.
+	archiveDir := ""
+	if jobID != "" && isSafePathSegment(jobID) {
+		archiveDir = filepath.Join(configsDir, opt_eval.BaselineDir+"_"+jobID)
+	}
+
+	// Archive the previous baseline only when this job does not already have an
+	// archive. On a retry, preserve the first rollback snapshot and remove the
+	// current baseline before installing the staged candidate.
 	if _, err := os.Stat(baselineDir); err == nil {
-		if jobID != "" && isSafePathSegment(jobID) {
-			archiveDir := filepath.Join(configsDir, opt_eval.BaselineDir+"_"+jobID)
-			// Replace any existing archive for this job so Rename succeeds.
-			if err := os.RemoveAll(archiveDir); err != nil {
-				return fmt.Errorf("clearing previous baseline archive: %w", err)
+		archiveExists := false
+		if archiveDir != "" {
+			if _, err := os.Stat(archiveDir); err == nil {
+				archiveExists = true
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("checking previous baseline archive: %w", err)
 			}
-			if err := os.Rename(baselineDir, archiveDir); err != nil {
+		}
+		if archiveDir != "" && !archiveExists {
+			if err := rename(baselineDir, archiveDir); err != nil {
 				return fmt.Errorf("archiving previous baseline: %w", err)
 			}
 		} else if err := os.RemoveAll(baselineDir); err != nil {
@@ -396,10 +416,36 @@ func advanceBaselineToCandidate(serviceDir, candidateID, jobID string) error {
 		}
 	}
 
-	if err := os.Rename(stageDir, baselineDir); err != nil {
+	if err := rename(stageDir, baselineDir); err != nil {
+		if archiveDir != "" {
+			if restoreErr := copyDirectory(archiveDir, baselineDir); restoreErr != nil {
+				return fmt.Errorf(
+					"promoting baseline: %w; restoring previous baseline: %v",
+					err,
+					restoreErr,
+				)
+			}
+		}
 		return fmt.Errorf("promoting baseline: %w", err)
 	}
 	return nil
+}
+
+func candidateConfigExists(
+	candidateDir string,
+	stat func(string) (os.FileInfo, error),
+) (bool, error) {
+	info, err := stat(candidateDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("accessing candidate config: %w", err)
+	}
+	if !info.IsDir() {
+		return false, fmt.Errorf("candidate config %q is not a directory", candidateDir)
+	}
+	return true, nil
 }
 
 // isSafePathSegment reports whether name is a single, non-traversing path

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
@@ -403,57 +403,86 @@ func advanceBaselineToCandidateWithOps(
 		archiveDir = filepath.Join(configsDir, opt_eval.BaselineDir+"_"+jobID)
 	}
 
-	// Archive the previous baseline only when this job does not already have an
-	// archive. On a retry, preserve the first rollback snapshot and remove the
-	// current baseline before installing the staged candidate.
-	if _, err := os.Stat(baselineDir); err == nil {
-		archiveExists := false
-		if archiveDir != "" {
-			if _, err := os.Stat(archiveDir); err == nil {
-				archiveExists = true
-			} else if !errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("checking previous baseline archive: %w", err)
-			}
-		}
-		if archiveDir != "" && !archiveExists {
-			if err := rename(baselineDir, archiveDir); err != nil {
-				return fmt.Errorf("archiving previous baseline: %w", err)
-			}
-		} else if err := os.RemoveAll(baselineDir); err != nil {
-			return fmt.Errorf("removing old baseline: %w", err)
+	archiveExists := false
+	if archiveDir != "" {
+		if _, err := os.Stat(archiveDir); err == nil {
+			archiveExists = true
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("checking previous baseline archive: %w", err)
 		}
 	}
 
+	// Move the active baseline aside until the staged candidate is installed.
+	// This exact rollback copy is restored if installation fails, including on
+	// retries where an older archive for the same job already exists.
+	rollbackDir := ""
+	if _, err := os.Stat(baselineDir); err == nil {
+		rollbackDir, err = os.MkdirTemp(configsDir, ".baseline-rollback-*")
+		if err != nil {
+			return fmt.Errorf("creating baseline rollback path: %w", err)
+		}
+		if err := os.Remove(rollbackDir); err != nil {
+			return fmt.Errorf("preparing baseline rollback path: %w", err)
+		}
+		if err := rename(baselineDir, rollbackDir); err != nil {
+			return fmt.Errorf("retiring current baseline: %w", err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("checking current baseline: %w", err)
+	}
+
 	if err := rename(stageDir, baselineDir); err != nil {
-		if archiveDir != "" {
-			if restoreErr := copyDir(archiveDir, baselineDir); restoreErr != nil {
-				if cleanupErr := os.RemoveAll(baselineDir); cleanupErr != nil {
+		if rollbackDir != "" {
+			if restoreErr := rename(rollbackDir, baselineDir); restoreErr != nil {
+				if copyErr := copyDir(rollbackDir, baselineDir); copyErr != nil {
+					if cleanupErr := os.RemoveAll(baselineDir); cleanupErr != nil {
+						log.Printf(
+							"warning: baseline restore and partial cleanup failed: rollback=%s baseline=%s error=%v",
+							rollbackDir,
+							baselineDir,
+							cleanupErr,
+						)
+						return fmt.Errorf(
+							"promoting baseline: %w; restoring rollback: %w; copying rollback: %w; "+
+								"removing partial baseline: %w",
+							err,
+							restoreErr,
+							copyErr,
+							cleanupErr,
+						)
+					}
 					log.Printf(
-						"warning: failed to restore previous baseline from %s and failed to remove partial baseline at %s: %v",
-						archiveDir,
-						baselineDir,
-						cleanupErr,
+						"warning: baseline restore failed; removed partial baseline and preserved rollback at %s",
+						rollbackDir,
 					)
 					return fmt.Errorf(
-						"promoting baseline: %w; restoring previous baseline: %v; removing partial baseline: %v",
+						"promoting baseline: %w; restoring rollback: %w; copying rollback: %w; "+
+							"partial baseline removed",
 						err,
 						restoreErr,
+						copyErr,
+					)
+				}
+				if cleanupErr := os.RemoveAll(rollbackDir); cleanupErr != nil {
+					log.Printf(
+						"warning: restored baseline by copy but failed to remove rollback at %s: %v",
+						rollbackDir,
 						cleanupErr,
 					)
 				}
-				log.Printf(
-					"warning: failed to restore previous baseline from %s; removed partial baseline at %s",
-					archiveDir,
-					baselineDir,
-				)
-				return fmt.Errorf(
-					"promoting baseline: %w; restoring previous baseline: %v; partial baseline removed",
-					err,
-					restoreErr,
-				)
 			}
 		}
 		return fmt.Errorf("promoting baseline: %w", err)
+	}
+
+	if rollbackDir != "" {
+		if archiveDir != "" && !archiveExists {
+			if err := rename(rollbackDir, archiveDir); err != nil {
+				return fmt.Errorf("archiving previous baseline: %w", err)
+			}
+		} else if err := os.RemoveAll(rollbackDir); err != nil {
+			return fmt.Errorf("removing baseline rollback: %w", err)
+		}
 	}
 	return nil
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers.go
@@ -19,6 +19,7 @@ import (
 	"azureaiagent/internal/pkg/agents/eval_api"
 	"azureaiagent/internal/pkg/agents/opt_eval"
 	"azureaiagent/internal/pkg/agents/optimize_api"
+	"azureaiagent/internal/pkg/paths"
 
 	azdext "github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/fatih/color"
@@ -291,7 +292,7 @@ func reportOptimizationDeployments(
 	ctx context.Context,
 	azdClient *azdext.AzdClient,
 	hostedAgents []*azdext.ServiceConfig,
-	envName, projectEndpoint, projectPath string,
+	envName, projectEndpoint string, projectPath string,
 	newClient func(endpoint string) *optimize_api.OptimizeClient,
 ) {
 	log.Printf("postdeploy: reporting optimization deployments for %d hosted agents", len(hostedAgents))
@@ -303,20 +304,56 @@ func reportOptimizationDeployments(
 					log.Printf("postdeploy: optimization reporting panicked for %s: %v", svc.Name, r)
 				}
 			}()
-			serviceDir := serviceDirFromProject(projectPath, svc)
+			serviceDir := baselineAdvancementDir(projectPath, svc, hostedAgents)
 			reportSvcOptimizationDeployment(ctx, azdClient, svc, envName, projectEndpoint, serviceDir, newClient)
 		}()
 	}
 }
 
-// serviceDirFromProject resolves the absolute service directory for svc within
-// the azd project. Returns "" when projectPath is empty so callers can treat a
-// missing project root as "skip local filesystem work".
-func serviceDirFromProject(projectPath string, svc *azdext.ServiceConfig) string {
+// baselineAdvancementDir resolves the validated local directory used for svc's
+// baseline advancement, or "" when advancement must be skipped.
+//
+// It returns "" (skip, no error surfaced) when:
+//   - projectPath is empty (no local project on disk),
+//   - the service path cannot be safely resolved under the project root — for
+//     example a RelativePath from azure.yaml containing ".." that escapes the
+//     root, or
+//   - svc shares its resolved source directory with another hosted agent. Those
+//     services share a single .agent_configs/baseline, and their deploy steps
+//     may run in parallel, so advancing here would nondeterministically clobber
+//     a peer's promoted baseline.
+func baselineAdvancementDir(
+	projectPath string,
+	svc *azdext.ServiceConfig,
+	hostedAgents []*azdext.ServiceConfig,
+) string {
 	if projectPath == "" {
 		return ""
 	}
-	return filepath.Join(projectPath, svc.GetRelativePath())
+
+	serviceDir, err := paths.JoinAllowRoot(projectPath, svc.GetRelativePath())
+	if err != nil {
+		log.Printf("postdeploy: skipping baseline advancement for %s: %v", svc.Name, err)
+		return ""
+	}
+
+	for _, peer := range hostedAgents {
+		if peer == nil || peer.Name == svc.Name {
+			continue
+		}
+		peerDir, err := paths.JoinAllowRoot(projectPath, peer.GetRelativePath())
+		if err != nil {
+			continue
+		}
+		if isSamePath(peerDir, serviceDir) {
+			log.Printf(
+				"postdeploy: skipping baseline advancement for %s: shares source directory with %s",
+				svc.Name, peer.Name)
+			return ""
+		}
+	}
+
+	return serviceDir
 }
 
 // advanceBaselineToCandidate replaces the service's local baseline agent config
@@ -393,11 +430,13 @@ func isSafePathSegment(name string) bool {
 }
 
 // reportSvcOptimizationDeployment reports a single service's optimization candidate.
+// serviceDir is the validated local service directory used for baseline
+// advancement, or "" to skip it (see baselineAdvancementDir).
 func reportSvcOptimizationDeployment(
 	ctx context.Context,
 	azdClient *azdext.AzdClient,
 	svc *azdext.ServiceConfig,
-	envName, projectEndpoint, serviceDir string,
+	envName, projectEndpoint string, serviceDir string,
 	newClient func(endpoint string) *optimize_api.OptimizeClient,
 ) {
 	serviceKey := toServiceKey(svc.Name)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers_test.go
@@ -128,7 +128,7 @@ func TestReportOptimizationDeployments_NoAgents(t *testing.T) {
 
 	// Should complete without calling any API.
 	reportOptimizationDeployments(
-		t.Context(), azdClient, nil, "dev", "https://unused.example.com",
+		t.Context(), azdClient, nil, "dev", "https://unused.example.com", "",
 		newTestOptimizeClient,
 	)
 }
@@ -160,7 +160,7 @@ func TestReportOptimizationDeployments_Success_ClearsCandidate(t *testing.T) {
 	agents := []*azdext.ServiceConfig{{Name: "my-agent"}}
 
 	reportOptimizationDeployments(
-		t.Context(), azdClient, agents, "dev", srv.URL,
+		t.Context(), azdClient, agents, "dev", srv.URL, "",
 		newTestOptimizeClient,
 	)
 
@@ -196,7 +196,7 @@ func TestReportOptimizationDeployments_MissingCandidateID_Skips(t *testing.T) {
 
 	agents := []*azdext.ServiceConfig{{Name: "svc"}}
 	reportOptimizationDeployments(
-		t.Context(), azdClient, agents, "dev", srv.URL,
+		t.Context(), azdClient, agents, "dev", srv.URL, "",
 		newTestOptimizeClient,
 	)
 
@@ -225,7 +225,7 @@ func TestReportOptimizationDeployments_MissingVersion_Skips(t *testing.T) {
 
 	agents := []*azdext.ServiceConfig{{Name: "svc"}}
 	reportOptimizationDeployments(
-		t.Context(), azdClient, agents, "dev", srv.URL,
+		t.Context(), azdClient, agents, "dev", srv.URL, "",
 		newTestOptimizeClient,
 	)
 
@@ -253,7 +253,7 @@ func TestReportOptimizationDeployments_APIFailure_DoesNotClearCandidate(t *testi
 
 	agents := []*azdext.ServiceConfig{{Name: "svc"}}
 	reportOptimizationDeployments(
-		t.Context(), azdClient, agents, "dev", srv.URL,
+		t.Context(), azdClient, agents, "dev", srv.URL, "",
 		newTestOptimizeClient,
 	)
 
@@ -298,7 +298,7 @@ func TestReportOptimizationDeployments_MultipleAgents(t *testing.T) {
 	}
 
 	reportOptimizationDeployments(
-		t.Context(), azdClient, agents, "dev", srv.URL,
+		t.Context(), azdClient, agents, "dev", srv.URL, "",
 		newTestOptimizeClient,
 	)
 
@@ -336,7 +336,7 @@ func TestReportOptimizationDeployments_ServiceNameWithDashes(t *testing.T) {
 
 	agents := []*azdext.ServiceConfig{{Name: "my-cool-agent"}}
 	reportOptimizationDeployments(
-		t.Context(), azdClient, agents, "dev", srv.URL,
+		t.Context(), azdClient, agents, "dev", srv.URL, "",
 		newTestOptimizeClient,
 	)
 
@@ -363,7 +363,7 @@ func TestReportOptimizationDeployments_PanicRecovery(t *testing.T) {
 	// prevent this from crashing the caller.
 	assert.NotPanics(t, func() {
 		reportOptimizationDeployments(
-			t.Context(), azdClient, agents, "dev", "https://unused",
+			t.Context(), azdClient, agents, "dev", "https://unused", "",
 			func(_ string) *optimize_api.OptimizeClient {
 				panic("boom")
 			},

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers_test.go
@@ -32,7 +32,11 @@ func TestWarnBaselineAdvancementFailure(t *testing.T) {
 	assert.Contains(t, output.String(), `candidate "cand-123" was promoted for service "my-agent"`)
 	assert.Contains(t, output.String(), "Before starting the next optimization round")
 	assert.Contains(t, output.String(), "set this candidate as its baseline")
-	assert.Contains(t, output.String(), "azd ai agent optimize apply --candidate \"cand-123\"")
+	assert.Contains(
+		t,
+		output.String(),
+		"azd ai agent optimize apply --agent \"my-agent\" --candidate \"cand-123\"",
+	)
 	assert.Contains(t, output.String(), "azd deploy \"my-agent\"")
 	assert.Contains(t, output.String(), assert.AnError.Error())
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_helpers_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -21,6 +22,20 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
+
+func TestWarnBaselineAdvancementFailure(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	warnBaselineAdvancementFailure(&output, "my-agent", "cand-123", assert.AnError)
+
+	assert.Contains(t, output.String(), `candidate "cand-123" was promoted for service "my-agent"`)
+	assert.Contains(t, output.String(), "Before starting the next optimization round")
+	assert.Contains(t, output.String(), "set this candidate as its baseline")
+	assert.Contains(t, output.String(), "azd ai agent optimize apply --candidate \"cand-123\"")
+	assert.Contains(t, output.String(), "azd deploy \"my-agent\"")
+	assert.Contains(t, output.String(), assert.AnError.Error())
+}
 
 func TestOptimizeConnectionFlags_Resolve_AllEmpty(t *testing.T) {
 	t.Setenv("FOUNDRY_PROJECT_ENDPOINT", "")


### PR DESCRIPTION
## Pull request overview

Advances the local optimization baseline after a candidate is successfully deployed.

**Changes:**
- Resolves service-local agent configuration paths.
- Copies promoted candidates into the baseline and archives prior baselines.
- Adds baseline rotation tests and postdeploy wiring.

### File changes

| File | Description |
| ---- | ----------- |
| `optimize_helpers.go` | Implements baseline advancement and archival. |
| `optimize_helpers_test.go` | Updates reporting calls for project paths. |
| `optimize_baseline_test.go` | Tests baseline replacement and path validation. |
| `listen.go` | Passes the service directory during postdeploy. |

Fixes #9951
