### PR TITLE
feat: add foundry skill user agent in azd ai agent

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_foundry_endpoint.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_foundry_endpoint.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+
+	"azureaiagent/internal/pkg/useragent"
 )
 
 // foundryProbeTimeout caps the per-probe HTTP round trip. The design
@@ -316,7 +318,7 @@ func makeRealProbeFoundryEndpoint(apiVersion string) func(context.Context, strin
 		}
 		req.Header.Set("Authorization", "Bearer "+tok.Token)
 		req.Header.Set("Accept", "application/json")
-		req.Header.Set("User-Agent", "azd-ai-agent-doctor")
+		req.Header.Set("User-Agent", useragent.Doctor())
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/connections/pkg/connections/data_client.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/connections/pkg/connections/data_client.go
@@ -16,6 +16,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
+
+	"azureaiagent/internal/pkg/useragent"
 )
 
 const dataPlaneAPIVersion = "v1"
@@ -37,7 +39,7 @@ func NewDataClient(endpoint string, cred azcore.TokenCredential) *DataClient {
 				nil,
 			),
 			azsdk.NewMsCorrelationPolicy(),
-			azsdk.NewUserAgentPolicy("azd-ext-azure-ai-connection/0.1.0"),
+			azsdk.NewUserAgentPolicy(useragent.Connection()),
 		},
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
@@ -16,13 +16,14 @@ import (
 	"strconv"
 	"time"
 
-	"azureaiagent/internal/pkg/useragent"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
+
+	"azureaiagent/internal/pkg/useragent"
 )
 
 // AgentClient provides methods for interacting with the Azure AI Agents API

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
@@ -16,7 +16,7 @@ import (
 	"strconv"
 	"time"
 
-	"azureaiagent/internal/version"
+	"azureaiagent/internal/pkg/useragent"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -60,8 +60,6 @@ func (o *SessionRequestOptions) ApplyHeaders(headers http.Header) {
 
 // NewAgentClient creates a new AgentClient
 func NewAgentClient(endpoint string, cred azcore.TokenCredential) *AgentClient {
-	userAgent := fmt.Sprintf("azd-ext-azure-ai-agents/%s", version.Version)
-
 	clientOptions := &policy.ClientOptions{
 		Logging: policy.LogOptions{
 			AllowedHeaders: []string{"X-Ms-Correlation-Request-Id", "X-Request-Id"},
@@ -72,7 +70,7 @@ func NewAgentClient(endpoint string, cred azcore.TokenCredential) *AgentClient {
 		PerCallPolicies: []policy.Policy{
 			runtime.NewBearerTokenPolicy(cred, []string{"https://ai.azure.com/.default"}, nil),
 			azsdk.NewMsCorrelationPolicy(),
-			azsdk.NewUserAgentPolicy(userAgent),
+			azsdk.NewUserAgentPolicy(useragent.Default()),
 		},
 	}
 
@@ -812,7 +810,7 @@ func (c *AgentClient) GetAgentSessionLogStream(
 	}
 
 	req.Header.Set("Authorization", "Bearer "+token.Token)
-	req.Header.Set("User-Agent", fmt.Sprintf("azd-ext-azure-ai-agents/%s", version.Version))
+	req.Header.Set("User-Agent", useragent.Default())
 	options.ApplyHeaders(req.Header)
 
 	httpClient := &http.Client{}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/dataset_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/dataset_api/operations.go
@@ -15,13 +15,14 @@ import (
 	"net/url"
 	"strings"
 
-	"azureaiagent/internal/pkg/useragent"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
+
+	"azureaiagent/internal/pkg/useragent"
 )
 
 // API path prefix for dataset endpoints.

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/dataset_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/dataset_api/operations.go
@@ -15,7 +15,7 @@ import (
 	"net/url"
 	"strings"
 
-	"azureaiagent/internal/version"
+	"azureaiagent/internal/pkg/useragent"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -35,8 +35,6 @@ type DatasetClient struct {
 
 // NewDatasetClient creates a new DatasetClient.
 func NewDatasetClient(endpoint string, cred azcore.TokenCredential) *DatasetClient {
-	userAgent := fmt.Sprintf("azd-ext-azure-ai-agents/%s", version.Version)
-
 	clientOptions := &policy.ClientOptions{
 		Logging: policy.LogOptions{
 			AllowedHeaders: []string{"X-Ms-Correlation-Request-Id", "X-Request-Id"},
@@ -45,7 +43,7 @@ func NewDatasetClient(endpoint string, cred azcore.TokenCredential) *DatasetClie
 		PerCallPolicies: []policy.Policy{
 			runtime.NewBearerTokenPolicy(cred, []string{"https://ai.azure.com/.default"}, nil),
 			azsdk.NewMsCorrelationPolicy(),
-			azsdk.NewUserAgentPolicy(userAgent),
+			azsdk.NewUserAgentPolicy(useragent.Default()),
 		},
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/eval_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/eval_api/operations.go
@@ -14,7 +14,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"azureaiagent/internal/version"
+	"azureaiagent/internal/pkg/useragent"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -40,8 +40,6 @@ type EvalClient struct {
 
 // NewEvalClient creates a new EvalClient.
 func NewEvalClient(endpoint string, cred azcore.TokenCredential) *EvalClient {
-	userAgent := fmt.Sprintf("azd-ext-azure-ai-agents/%s", version.Version)
-
 	clientOptions := &policy.ClientOptions{
 		Logging: policy.LogOptions{
 			AllowedHeaders: []string{"X-Ms-Correlation-Request-Id", "X-Request-Id"},
@@ -50,7 +48,7 @@ func NewEvalClient(endpoint string, cred azcore.TokenCredential) *EvalClient {
 		PerCallPolicies: []policy.Policy{
 			runtime.NewBearerTokenPolicy(cred, []string{"https://ai.azure.com/.default"}, nil),
 			azsdk.NewMsCorrelationPolicy(),
-			azsdk.NewUserAgentPolicy(userAgent),
+			azsdk.NewUserAgentPolicy(useragent.Default()),
 		},
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/eval_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/eval_api/operations.go
@@ -14,13 +14,14 @@ import (
 	"net/url"
 	"strconv"
 
-	"azureaiagent/internal/pkg/useragent"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
+
+	"azureaiagent/internal/pkg/useragent"
 )
 
 // API path prefixes for eval service endpoints.

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/client.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/client.go
@@ -15,7 +15,7 @@ import (
 	"net/http"
 	netURL "net/url"
 
-	"azureaiagent/internal/version"
+	"azureaiagent/internal/pkg/useragent"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -48,8 +48,6 @@ func (foundryFeaturesPolicy) Do(req *policy.Request) (*http.Response, error) {
 
 // NewOptimizeClient creates a new OptimizeClient with the given endpoint and credential.
 func NewOptimizeClient(endpoint string, cred azcore.TokenCredential) *OptimizeClient {
-	userAgent := fmt.Sprintf("azd-ext-azure-ai-agents/%s", version.Version)
-
 	clientOptions := &policy.ClientOptions{
 		Logging: policy.LogOptions{
 			AllowedHeaders: []string{"X-Ms-Correlation-Request-Id", "X-Request-Id"},
@@ -58,7 +56,7 @@ func NewOptimizeClient(endpoint string, cred azcore.TokenCredential) *OptimizeCl
 		PerCallPolicies: []policy.Policy{
 			runtime.NewBearerTokenPolicy(cred, []string{"https://ai.azure.com/.default"}, nil),
 			azsdk.NewMsCorrelationPolicy(),
-			azsdk.NewUserAgentPolicy(userAgent),
+			azsdk.NewUserAgentPolicy(useragent.Default()),
 			foundryFeaturesPolicy{},
 		},
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/client.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/optimize_api/client.go
@@ -15,13 +15,14 @@ import (
 	"net/http"
 	netURL "net/url"
 
-	"azureaiagent/internal/pkg/useragent"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
+
+	"azureaiagent/internal/pkg/useragent"
 )
 
 // OptimizeClient provides methods for interacting with the Agents Optimization API.

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/azure/client_options.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/azure/client_options.go
@@ -5,8 +5,7 @@ package azure
 
 import (
 	"azureaiagent/internal/pkg/recordproxy"
-	"azureaiagent/internal/version"
-	"fmt"
+	"azureaiagent/internal/pkg/useragent"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -17,8 +16,6 @@ import (
 // NewArmClientOptions creates a new arm.ClientOptions with standard policies for Azure SDK clients.
 // This includes correlation headers, user agent, and logging configuration.
 func NewArmClientOptions() *arm.ClientOptions {
-	userAgent := fmt.Sprintf("azd-ext-azure-ai-agents/%s", version.Version)
-
 	opts := &arm.ClientOptions{
 		ClientOptions: policy.ClientOptions{
 			Logging: policy.LogOptions{
@@ -26,7 +23,7 @@ func NewArmClientOptions() *arm.ClientOptions {
 			},
 			PerCallPolicies: []policy.Policy{
 				azsdk.NewMsCorrelationPolicy(),
-				azsdk.NewUserAgentPolicy(userAgent),
+				azsdk.NewUserAgentPolicy(useragent.Default()),
 			},
 		},
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/azure/client_options.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/azure/client_options.go
@@ -4,13 +4,15 @@
 package azure
 
 import (
-	"azureaiagent/internal/pkg/recordproxy"
-	"azureaiagent/internal/pkg/useragent"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
+
+	"azureaiagent/internal/pkg/recordproxy"
+	"azureaiagent/internal/pkg/useragent"
 )
 
 // NewArmClientOptions creates a new arm.ClientOptions with standard policies for Azure SDK clients.

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/azure/foundry_memory_store_client.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/azure/foundry_memory_store_client.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 
-	"azureaiagent/internal/version"
+	"azureaiagent/internal/pkg/useragent"
 )
 
 // memoryStoreAPIVersion is the data-plane API version for the Foundry Memory Store API (preview).
@@ -42,8 +42,6 @@ func NewFoundryMemoryStoreClient(
 	endpoint string,
 	cred azcore.TokenCredential,
 ) *FoundryMemoryStoreClient {
-	userAgent := fmt.Sprintf("azd-ext-azure-ai-agents/%s", version.Version)
-
 	clientOptions := &policy.ClientOptions{
 		Logging: policy.LogOptions{
 			AllowedHeaders: []string{azsdk.MsCorrelationIdHeader, "X-Request-Id"},
@@ -52,7 +50,7 @@ func NewFoundryMemoryStoreClient(
 		PerCallPolicies: []policy.Policy{
 			runtime.NewBearerTokenPolicy(cred, []string{"https://ai.azure.com/.default"}, nil),
 			azsdk.NewMsCorrelationPolicy(),
-			azsdk.NewUserAgentPolicy(userAgent),
+			azsdk.NewUserAgentPolicy(useragent.Default()),
 		},
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/azure/foundry_projects_client.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/azure/foundry_projects_client.go
@@ -4,7 +4,6 @@
 package azure
 
 import (
-	"azureaiagent/internal/version"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -17,6 +16,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
+
+	"azureaiagent/internal/pkg/useragent"
 )
 
 // FoundryProjectsClient provides methods to interact with Microsoft Foundry projects
@@ -42,8 +43,6 @@ func NewFoundryProjectsClient(
 
 	baseEndpoint := fmt.Sprintf("https://%s.services.ai.azure.com/api/projects/%s", accountName, projectName)
 
-	userAgent := fmt.Sprintf("azd-ext-azure-ai-agents/%s", version.Version)
-
 	clientOptions := &policy.ClientOptions{
 		Logging: policy.LogOptions{
 			AllowedHeaders: []string{azsdk.MsCorrelationIdHeader},
@@ -51,7 +50,7 @@ func NewFoundryProjectsClient(
 		PerCallPolicies: []policy.Policy{
 			runtime.NewBearerTokenPolicy(cred, []string{"https://ai.azure.com/.default"}, nil),
 			azsdk.NewMsCorrelationPolicy(),
-			azsdk.NewUserAgentPolicy(userAgent),
+			azsdk.NewUserAgentPolicy(useragent.Default()),
 		},
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/azure/foundry_toolsets_client.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/azure/foundry_toolsets_client.go
@@ -19,7 +19,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/azure/azure-dev/cli/azd/pkg/azsdk"
 
-	"azureaiagent/internal/version"
+	"azureaiagent/internal/pkg/useragent"
 )
 
 const (
@@ -37,8 +37,6 @@ func NewFoundryToolboxClient(
 	endpoint string,
 	cred azcore.TokenCredential,
 ) *FoundryToolboxClient {
-	userAgent := fmt.Sprintf("azd-ext-azure-ai-agents/%s", version.Version)
-
 	clientOptions := &policy.ClientOptions{
 		Logging: policy.LogOptions{
 			AllowedHeaders: []string{azsdk.MsCorrelationIdHeader, "X-Request-Id"},
@@ -47,7 +45,7 @@ func NewFoundryToolboxClient(
 		PerCallPolicies: []policy.Policy{
 			runtime.NewBearerTokenPolicy(cred, []string{"https://ai.azure.com/.default"}, nil),
 			azsdk.NewMsCorrelationPolicy(),
-			azsdk.NewUserAgentPolicy(userAgent),
+			azsdk.NewUserAgentPolicy(useragent.Default()),
 		},
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/useragent/user_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/useragent/user_agent.go
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Package useragent builds User-Agent values for the azure.ai.agents extension.
+package useragent
+
+import (
+	"os"
+	"strings"
+
+	"azureaiagent/internal/version"
+)
+
+const (
+	azureDevUserAgentEnv  = "AZURE_DEV_USER_AGENT"
+	foundrySkillEnvValue  = "microsoft_foundry_skill"
+	foundrySkillUserAgent = "microsoft-foundry-skill/1.0"
+	defaultUserAgent      = "azd-ext-azure-ai-agents"
+	connectionUserAgent   = "azd-ext-azure-ai-connection/0.1.0"
+	doctorUserAgent       = "azd-ai-agent-doctor"
+)
+
+// Default returns the default azure.ai.agents extension User-Agent value.
+func Default() string {
+	return withExecutionEnv(defaultUserAgent + "/" + version.Version)
+}
+
+// Connection returns the User-Agent for Foundry connection requests.
+func Connection() string {
+	return withExecutionEnv(connectionUserAgent)
+}
+
+// Doctor returns the User-Agent for Foundry doctor requests.
+func Doctor() string {
+	return withExecutionEnv(doctorUserAgent)
+}
+
+func withExecutionEnv(userAgent string) string {
+	return withSkill(userAgent)
+}
+
+func withSkill(userAgent string) string {
+	if !strings.Contains(os.Getenv(azureDevUserAgentEnv), foundrySkillEnvValue) {
+		return userAgent
+	}
+	if userAgent == "" {
+		return foundrySkillUserAgent
+	}
+	return userAgent + "," + foundrySkillUserAgent
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/useragent/user_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/useragent/user_agent_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package useragent
+
+import (
+	"testing"
+
+	"azureaiagent/internal/version"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefault(t *testing.T) {
+	tests := []struct {
+		name         string
+		environment  string
+		wantSkillTag bool
+	}{
+		{name: "no marker"},
+		{name: "unrelated value", environment: "other-client/1.0"},
+		{name: "skill marker", environment: foundrySkillEnvValue, wantSkillTag: true},
+		{
+			name:         "skill marker with another value",
+			environment:  "azure_app_space_portal:v1.0.0 " + foundrySkillEnvValue,
+			wantSkillTag: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(azureDevUserAgentEnv, test.environment)
+
+			want := defaultUserAgent + "/" + version.Version
+			if test.wantSkillTag {
+				want += "," + foundrySkillUserAgent
+			}
+
+			require.Equal(t, want, Default())
+		})
+	}
+}
+
+func TestValuesDoNotForwardEnvironmentValue(t *testing.T) {
+	t.Setenv(azureDevUserAgentEnv, "other-client/1.0 "+foundrySkillEnvValue)
+
+	require.Equal(t, connectionUserAgent+","+foundrySkillUserAgent, Connection())
+	require.Equal(t, doctorUserAgent+","+foundrySkillUserAgent, Doctor())
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/useragent/user_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/useragent/user_agent_test.go
@@ -6,9 +6,9 @@ package useragent
 import (
 	"testing"
 
-	"azureaiagent/internal/version"
-
 	"github.com/stretchr/testify/require"
+
+	"azureaiagent/internal/version"
 )
 
 func TestDefault(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a Foundry Skill User-Agent to requests sent by the `azure.ai.agents` extension to Microsoft Foundry services.

When `AZURE_DEV_USER_AGENT` contains `microsoft_foundry_skill`, existing Foundry service request User-Agent values append `microsoft-foundry-skill/1.0`.

This enables Foundry service-side attribution.

## Validation

- Added unit tests for User-Agent construction
- Verified the environment value is not forwarded
- Ran affected Go tests
- Ran `go build ./...`

Fixes: https://github.com/Azure/azure-dev/issues/9727