### PR TITLE
Lower hosted agent session idle timeout minimum to 120 seconds

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/README.md
+++ b/cli/azd/extensions/azure.ai.agents/README.md
@@ -288,7 +288,7 @@ seconds).
 
 Details:
 
-- `idleTimeoutSeconds` must be between **300 and 3600** seconds (inclusive).
+- `idleTimeoutSeconds` must be between **120 and 3600** seconds (inclusive).
   Values outside that range are rejected at deploy time and by schema
   validation.
 - In the deprecated on-disk `agent.yaml` shape the keys are snake_case

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
@@ -297,7 +297,7 @@ type ContainerConfigurationAPI struct {
 // its own defaults.
 type SessionConfigurationAPI struct {
 	// IdleTimeoutSeconds maps to session_configuration.idle_timeout_seconds. Valid
-	// range is 300–3600 (inclusive). When the field is unset the whole
+	// range is 120–3600 (inclusive). When the field is unset the whole
 	// session_configuration block is omitted and the service default (900) applies.
 	IdleTimeoutSeconds int `json:"idle_timeout_seconds"`
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_yaml/yaml.go
@@ -245,7 +245,7 @@ const DefaultDependencyResolution = "remote_build"
 // contract. When omitted, the service applies its own default.
 const (
 	// MinSessionIdleTimeoutSeconds is the smallest accepted idle timeout.
-	MinSessionIdleTimeoutSeconds = 300
+	MinSessionIdleTimeoutSeconds = 120
 	// MaxSessionIdleTimeoutSeconds is the largest accepted idle timeout.
 	MaxSessionIdleTimeoutSeconds = 3600
 )
@@ -253,7 +253,7 @@ const (
 // SessionConfiguration configures the runtime session behavior of a hosted agent.
 type SessionConfiguration struct {
 	// IdleTimeoutSeconds is the idle duration, in seconds, before a session's
-	// sandbox is suspended. Valid range is 300–3600 (inclusive). When nil,
+	// sandbox is suspended. Valid range is 120–3600 (inclusive). When nil,
 	// session_configuration is omitted from the request and the service default
 	// (900 seconds) applies.
 	IdleTimeoutSeconds *int `json:"idleTimeoutSeconds,omitempty" yaml:"idle_timeout_seconds,omitempty"`

--- a/cli/azd/extensions/azure.ai.agents/internal/project/doc_examples_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/doc_examples_test.go
@@ -795,7 +795,7 @@ func TestDocSchemaValidatesConstraints(t *testing.T) {
 		{
 			name: "session idle timeout min valid",
 			mutate: func(value *fixture) {
-				value.value["sessionConfiguration"] = map[string]any{"idleTimeoutSeconds": 300}
+				value.value["sessionConfiguration"] = map[string]any{"idleTimeoutSeconds": 120}
 			},
 		},
 		{
@@ -807,7 +807,7 @@ func TestDocSchemaValidatesConstraints(t *testing.T) {
 		{
 			name: "session idle timeout below min",
 			mutate: func(value *fixture) {
-				value.value["sessionConfiguration"] = map[string]any{"idleTimeoutSeconds": 299}
+				value.value["sessionConfiguration"] = map[string]any{"idleTimeoutSeconds": 119}
 			},
 			wantErr: true,
 		},

--- a/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/Agent.json
@@ -139,8 +139,8 @@
               "properties": {
                 "idleTimeoutSeconds": {
                   "type": "integer",
-                  "description": "Idle duration in seconds before a session's sandbox is suspended. Range 300–3600 (inclusive). Defaults to 900 when omitted.",
-                  "minimum": 300,
+                  "description": "Idle duration in seconds before a session's sandbox is suspended. Range 120–3600 (inclusive). Defaults to 900 when omitted.",
+                  "minimum": 120,
                   "maximum": 3600
                 }
               }

--- a/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
@@ -241,8 +241,8 @@
       "properties": {
         "idleTimeoutSeconds": {
           "type": "integer",
-          "description": "Idle duration in seconds before a session's sandbox is suspended. Range 300–3600 (inclusive). Defaults to 900 when omitted.",
-          "minimum": 300,
+          "description": "Idle duration in seconds before a session's sandbox is suspended. Range 120–3600 (inclusive). Defaults to 900 when omitted.",
+          "minimum": 120,
           "maximum": 3600
         }
       },


### PR DESCRIPTION
## Summary

Relaxes the client-side validation floor for `sessionConfiguration.idleTimeoutSeconds` on hosted agents from **300** to **120** seconds (2 minutes), ahead of the corresponding upcoming server-side change. The maximum remains **3600** seconds.

This follows up on #9612, which introduced `sessionConfiguration.idleTimeoutSeconds` support in the `azure.ai.agents` extension.

## Changes

- **`agent_yaml/yaml.go`** — `MinSessionIdleTimeoutSeconds` 300 → 120; updated doc comment.
- **`agent_api/models.go`** — updated range in doc comment to 120–3600.
- **`schemas/azure.ai.agent.json`** & **`schemas/Agent.json`** — `minimum` 300 → 120; updated descriptions.
- **`README.md`** — "between **120 and 3600** seconds".
- **`doc_examples_test.go`** — min-valid boundary → 120, below-min → 119.

## Behavior

- Values from 120 to 3600 seconds (inclusive) are now accepted.
- Omitting the setting is unchanged: `session_configuration` is left out of the request and the service applies its default (900 seconds).

## Tests

- Boundary tests use the `Min/MaxSessionIdleTimeoutSeconds` constants and adapt automatically.
- `gofmt` clean, `go build ./...` passes, and full `agent_yaml` + `project` package tests pass.

> Note: The matching server-side change is rolling out separately; this relaxes the client floor so it's ready when the server accepts the lower bound.