### PR TITLE
fix: provide resource-specific quota guidance

### DIFF
--- a/.github/workflows/lint-bicep.yml
+++ b/.github/workflows/lint-bicep.yml
@@ -7,6 +7,8 @@ on:
       - eng/scripts/Test-BicepLint.ps1
       - .github/workflows/lint-bicep.yml
     
+
+
 jobs:
   bicep-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-bicep.yml
+++ b/.github/workflows/lint-bicep.yml
@@ -8,6 +8,8 @@ on:
       - .github/workflows/lint-bicep.yml
     
 
+permissions:
+  contents: read
 
 jobs:
   bicep-lint:
@@ -16,14 +18,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Upgrade bicep
         run: |
-          bicep_path="$(which bicep)"
-          temp_path="$(mktemp)"
-          trap 'rm -f "$temp_path"' EXIT
-          curl --fail --location --retry 5 --retry-all-errors \
-            --retry-delay 2 --retry-max-time 60 \
-            --output "$temp_path" \
-            https://github.com/Azure/bicep/releases/download/v0.45.15/bicep-linux-x64
-          sudo install -m 0755 "$temp_path" "$bicep_path"
+          which bicep
+          sudo curl -o "$(which bicep)" -L https://github.com/Azure/bicep/releases/download/v0.45.15/bicep-linux-x64
+          sudo chmod +x "$(which bicep)"
       - name: Lint .bicep files
         run: $ErrorActionPreference='Continue'; eng/scripts/Test-BicepLint.ps1 -Verbose
         shell: pwsh

--- a/.github/workflows/lint-bicep.yml
+++ b/.github/workflows/lint-bicep.yml
@@ -7,10 +7,6 @@ on:
       - eng/scripts/Test-BicepLint.ps1
       - .github/workflows/lint-bicep.yml
     
-
-permissions:
-  contents: read
-
 jobs:
   bicep-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-bicep.yml
+++ b/.github/workflows/lint-bicep.yml
@@ -16,9 +16,14 @@ jobs:
       - uses: actions/checkout@v6
       - name: Upgrade bicep
         run: |
-          which bicep
-          sudo curl -o "$(which bicep)" -L https://github.com/Azure/bicep/releases/download/v0.45.15/bicep-linux-x64
-          sudo chmod +x "$(which bicep)"
+          bicep_path="$(which bicep)"
+          temp_path="$(mktemp)"
+          trap 'rm -f "$temp_path"' EXIT
+          curl --fail --location --retry 5 --retry-all-errors \
+            --retry-delay 2 --retry-max-time 60 \
+            --output "$temp_path" \
+            https://github.com/Azure/bicep/releases/download/v0.45.15/bicep-linux-x64
+          sudo install -m 0755 "$temp_path" "$bicep_path"
       - name: Lint .bicep files
         run: $ErrorActionPreference='Continue'; eng/scripts/Test-BicepLint.ps1 -Verbose
         shell: pwsh

--- a/cli/azd/extensions/azure.ai.projects/README.md
+++ b/cli/azd/extensions/azure.ai.projects/README.md
@@ -35,4 +35,9 @@ azd env set AZURE_AI_PROJECT_ID "/subscriptions/<subscription-id>/resourceGroups
 
 `azd ai agent init` sets this value when initialized against an existing project. An endpoint-only service with no resources to reconcile does not require it.
 
+When provisioning reports insufficient Cognitive Services quota, check usage for the target region with
+`az cognitiveservices usage list --location <region>` or request a quota increase in the Azure portal. If an
+existing Foundry project should be reused instead, configure its endpoint and set `AZURE_AI_PROJECT_ID` to the
+full project resource ID before retrying.
+
 The `azd ai project set`, `show`, and `unset` commands manage the default Foundry project endpoint context. They do not currently author the project service in `azure.yaml`.

--- a/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"google.golang.org/grpc/codes"
@@ -230,10 +231,10 @@ func armErrorResponseContainsCognitiveServicesQuota(
 }
 
 func cognitiveServicesResource(value string) bool {
-	return strings.Contains(
-		strings.ToLower(value),
-		cognitiveServicesAccountsResourceType,
-	)
+	value = strings.Trim(strings.TrimSpace(value), "'\"")
+	resourceType, err := arm.ParseResourceType(value)
+	return err == nil &&
+		strings.EqualFold(resourceType.String(), cognitiveServicesAccountsResourceType)
 }
 
 // IsCancellation reports whether an operation was cancelled.

--- a/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors.go
@@ -154,8 +154,7 @@ func quotaSuggestionForResponse(responseErr *azcore.ResponseError) string {
 		}
 	}
 
-	if strings.EqualFold(responseErr.ErrorCode, insufficientQuotaCode) ||
-		strings.Contains(strings.ToLower(responseErr.Error()), strings.ToLower(insufficientQuotaCode)) {
+	if strings.EqualFold(responseErr.ErrorCode, insufficientQuotaCode) {
 		return GenericQuotaSuggestion()
 	}
 

--- a/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors.go
@@ -16,9 +16,12 @@
 package exterrors
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -89,6 +92,10 @@ func ServiceFromAzure(err error, operation string) error {
 		if code == "" {
 			code = fmt.Sprintf("%d", responseErr.StatusCode)
 		}
+		suggestion := ""
+		if responseErrorContainsCode(responseErr, "InsufficientQuota") {
+			suggestion = CognitiveServicesQuotaSuggestion()
+		}
 		return &azdext.ServiceError{
 			Message: fmt.Sprintf(
 				"%s: %s",
@@ -98,6 +105,7 @@ func ServiceFromAzure(err error, operation string) error {
 			ErrorCode:   fmt.Sprintf("%s.%s", operation, code),
 			StatusCode:  responseErr.StatusCode,
 			ServiceName: serviceName,
+			Suggestion:  suggestion,
 		}
 	}
 	if IsCancellation(err) {
@@ -107,6 +115,62 @@ func ServiceFromAzure(err error, operation string) error {
 		operation,
 		fmt.Sprintf("%s: %s", operation, err.Error()),
 	)
+}
+
+// CognitiveServicesQuotaSuggestion returns guidance for quota errors returned
+// while provisioning a Foundry account, project, or deployment.
+func CognitiveServicesQuotaSuggestion() string {
+	return "Check Cognitive Services usage for the deployment region with " +
+		"`az cognitiveservices usage list --location <region>` or request a " +
+		"quota increase in the Azure portal. If you want to reuse an existing " +
+		"Foundry project, configure its endpoint and set `AZURE_AI_PROJECT_ID` " +
+		"to the full project resource ID before retrying (or initialize with " +
+		"`azd ai agent init --project-id <full-project-resource-id>`)."
+}
+
+type armErrorResponse struct {
+	Code    string              `json:"code"`
+	Details []*armErrorResponse `json:"details"`
+	Error   *armErrorResponse   `json:"error"`
+}
+
+func responseErrorContainsCode(responseErr *azcore.ResponseError, code string) bool {
+	if strings.EqualFold(responseErr.ErrorCode, code) {
+		return true
+	}
+
+	if responseErr.RawResponse != nil && responseErr.RawResponse.Body != nil {
+		bodyReader := responseErr.RawResponse.Body
+		body, err := io.ReadAll(bodyReader)
+		_ = bodyReader.Close()
+		responseErr.RawResponse.Body = io.NopCloser(bytes.NewReader(body))
+		if err == nil {
+			var payload armErrorResponse
+			if json.Unmarshal(body, &payload) == nil && armErrorContainsCode(&payload, code) {
+				return true
+			}
+		}
+	}
+
+	return strings.Contains(strings.ToLower(responseErr.Error()), strings.ToLower(code))
+}
+
+func armErrorContainsCode(err *armErrorResponse, code string) bool {
+	if err == nil {
+		return false
+	}
+	if strings.EqualFold(err.Code, code) {
+		return true
+	}
+	if armErrorContainsCode(err.Error, code) {
+		return true
+	}
+	for _, detail := range err.Details {
+		if armErrorContainsCode(detail, code) {
+			return true
+		}
+	}
+	return false
 }
 
 // IsCancellation reports whether an operation was cancelled.

--- a/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors.go
@@ -25,9 +25,15 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+)
+
+const (
+	cognitiveServicesAccountsResourceType = "microsoft.cognitiveservices/accounts"
+	insufficientQuotaCode                 = "InsufficientQuota"
 )
 
 // Validation returns a validation [azdext.LocalError] for user-input or
@@ -92,10 +98,6 @@ func ServiceFromAzure(err error, operation string) error {
 		if code == "" {
 			code = fmt.Sprintf("%d", responseErr.StatusCode)
 		}
-		suggestion := ""
-		if responseErrorContainsCode(responseErr, "InsufficientQuota") {
-			suggestion = CognitiveServicesQuotaSuggestion()
-		}
 		return &azdext.ServiceError{
 			Message: fmt.Sprintf(
 				"%s: %s",
@@ -105,7 +107,7 @@ func ServiceFromAzure(err error, operation string) error {
 			ErrorCode:   fmt.Sprintf("%s.%s", operation, code),
 			StatusCode:  responseErr.StatusCode,
 			ServiceName: serviceName,
-			Suggestion:  suggestion,
+			Suggestion:  quotaSuggestionForResponse(responseErr),
 		}
 	}
 	if IsCancellation(err) {
@@ -128,49 +130,111 @@ func CognitiveServicesQuotaSuggestion() string {
 		"`azd ai agent init --project-id <full-project-resource-id>`)."
 }
 
-type armErrorResponse struct {
-	Code    string              `json:"code"`
-	Details []*armErrorResponse `json:"details"`
-	Error   *armErrorResponse   `json:"error"`
+// GenericQuotaSuggestion returns generic quota guidance.
+func GenericQuotaSuggestion() string {
+	return "Check the quota and current usage for the affected resource provider " +
+		"in the Azure portal, or request a quota increase."
 }
 
-func responseErrorContainsCode(responseErr *azcore.ResponseError, code string) bool {
-	if strings.EqualFold(responseErr.ErrorCode, code) {
-		return true
+// QuotaSuggestionForARMError returns guidance for an ARM quota error.
+func QuotaSuggestionForARMError(err *armresources.ErrorResponse) string {
+	if !armErrorResponseContainsCode(err, insufficientQuotaCode) {
+		return ""
 	}
+	if armErrorResponseContainsCognitiveServicesQuota(err, "") {
+		return CognitiveServicesQuotaSuggestion()
+	}
+	return GenericQuotaSuggestion()
+}
 
-	if responseErr.RawResponse != nil && responseErr.RawResponse.Body != nil {
-		bodyReader := responseErr.RawResponse.Body
-		body, err := io.ReadAll(bodyReader)
-		_ = bodyReader.Close()
-		responseErr.RawResponse.Body = io.NopCloser(bytes.NewReader(body))
-		if err == nil {
-			var payload armErrorResponse
-			if json.Unmarshal(body, &payload) == nil && armErrorContainsCode(&payload, code) {
-				return true
-			}
+func quotaSuggestionForResponse(responseErr *azcore.ResponseError) string {
+	if payload := responseErrorPayload(responseErr); payload != nil {
+		if suggestion := QuotaSuggestionForARMError(payload); suggestion != "" {
+			return suggestion
 		}
 	}
 
-	return strings.Contains(strings.ToLower(responseErr.Error()), strings.ToLower(code))
+	if strings.EqualFold(responseErr.ErrorCode, insufficientQuotaCode) ||
+		strings.Contains(strings.ToLower(responseErr.Error()), strings.ToLower(insufficientQuotaCode)) {
+		return GenericQuotaSuggestion()
+	}
+
+	return ""
 }
 
-func armErrorContainsCode(err *armErrorResponse, code string) bool {
+func responseErrorPayload(responseErr *azcore.ResponseError) *armresources.ErrorResponse {
+	if responseErr.RawResponse == nil || responseErr.RawResponse.Body == nil {
+		return nil
+	}
+
+	bodyReader := responseErr.RawResponse.Body
+	body, err := io.ReadAll(bodyReader)
+	_ = bodyReader.Close()
+	responseErr.RawResponse.Body = io.NopCloser(bytes.NewReader(body))
+	if err != nil {
+		return nil
+	}
+
+	var envelope struct {
+		Error *armresources.ErrorResponse `json:"error"`
+	}
+	if json.Unmarshal(body, &envelope) == nil && envelope.Error != nil {
+		return envelope.Error
+	}
+
+	var payload armresources.ErrorResponse
+	if json.Unmarshal(body, &payload) == nil && payload.Code != nil {
+		return &payload
+	}
+
+	return nil
+}
+
+func armErrorResponseContainsCode(err *armresources.ErrorResponse, code string) bool {
 	if err == nil {
 		return false
 	}
-	if strings.EqualFold(err.Code, code) {
-		return true
-	}
-	if armErrorContainsCode(err.Error, code) {
+	if err.Code != nil && strings.EqualFold(*err.Code, code) {
 		return true
 	}
 	for _, detail := range err.Details {
-		if armErrorContainsCode(detail, code) {
+		if armErrorResponseContainsCode(detail, code) {
 			return true
 		}
 	}
 	return false
+}
+
+func armErrorResponseContainsCognitiveServicesQuota(
+	err *armresources.ErrorResponse,
+	inheritedTarget string,
+) bool {
+	if err == nil {
+		return false
+	}
+
+	target := inheritedTarget
+	if err.Target != nil {
+		target = *err.Target
+	}
+	if err.Code != nil && strings.EqualFold(*err.Code, insufficientQuotaCode) &&
+		(cognitiveServicesResource(target) ||
+			(err.Message != nil && cognitiveServicesResource(*err.Message))) {
+		return true
+	}
+	for _, detail := range err.Details {
+		if armErrorResponseContainsCognitiveServicesQuota(detail, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func cognitiveServicesResource(value string) bool {
+	return strings.Contains(
+		strings.ToLower(value),
+		cognitiveServicesAccountsResourceType,
+	)
 }
 
 // IsCancellation reports whether an operation was cancelled.

--- a/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors_test.go
@@ -104,3 +104,34 @@ func TestServiceFromAzure_UnrelatedErrorHasNoSuggestion(t *testing.T) {
 	require.True(t, ok)
 	assert.Empty(t, serviceErr.Suggestion)
 }
+
+func TestServiceFromAzure_QuotaCodeInResourceNameHasNoSuggestion(t *testing.T) {
+	response := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Body: io.NopCloser(strings.NewReader(`{
+			"error": {
+				"code": "InvalidTemplate",
+				"target": "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/InsufficientQuota",
+				"message": "The resource name is not valid."
+			}
+		}`)),
+		Request: &http.Request{
+			URL: &url.URL{
+				Scheme: "https",
+				Host:   "management.azure.com",
+				Path:   "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/InsufficientQuota",
+			},
+		},
+	}
+	err := &azcore.ResponseError{
+		ErrorCode:   "InvalidTemplate",
+		StatusCode:  http.StatusBadRequest,
+		RawResponse: response,
+	}
+
+	result := ServiceFromAzure(err, OpArmDeploymentCreate)
+
+	serviceErr, ok := errors.AsType[*azdext.ServiceError](result)
+	require.True(t, ok)
+	assert.Empty(t, serviceErr.Suggestion)
+}

--- a/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors_test.go
@@ -84,6 +84,41 @@ func TestServiceFromAzure_CognitiveServicesQuotaUsesFoundryGuidance(t *testing.T
 	assert.NotContains(t, serviceErr.Suggestion, "az vm list-usage")
 }
 
+func TestServiceFromAzure_CognitiveServicesChildQuotaUsesGenericGuidance(t *testing.T) {
+	target := "/subscriptions/sub/resourceGroups/rg/providers/" +
+		"Microsoft.CognitiveServices/accounts/ai-account/deployments/model"
+	response := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Body: io.NopCloser(strings.NewReader(`{
+			"error": {
+				"code": "InvalidTemplateDeployment",
+				"details": [{
+					"code": "InsufficientQuota",
+					"target": "` + target + `",
+					"message": "Insufficient quota."
+				}]
+			}
+		}`)),
+		Request: &http.Request{
+			Host: "management.azure.com",
+			URL:  &url.URL{Scheme: "https", Host: "management.azure.com"},
+		},
+	}
+	err := &azcore.ResponseError{
+		ErrorCode:   "InvalidTemplateDeployment",
+		StatusCode:  http.StatusBadRequest,
+		RawResponse: response,
+	}
+
+	result := ServiceFromAzure(err, OpArmDeploymentCreate)
+
+	serviceErr, ok := errors.AsType[*azdext.ServiceError](result)
+	require.True(t, ok)
+	assert.Contains(t, serviceErr.Suggestion, "affected resource provider")
+	assert.NotContains(t, serviceErr.Suggestion, "az cognitiveservices usage list")
+	assert.NotContains(t, serviceErr.Suggestion, "AZURE_AI_PROJECT_ID")
+}
+
 func TestServiceFromAzure_UnrelatedErrorHasNoSuggestion(t *testing.T) {
 	response := &http.Response{
 		StatusCode: http.StatusBadRequest,

--- a/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package exterrors
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceFromAzure_NestedInsufficientQuota(t *testing.T) {
+	response := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Body: io.NopCloser(strings.NewReader(`{
+			"error": {
+				"code": "InvalidTemplateDeployment",
+				"details": [{
+					"code": "InsufficientQuota",
+					"message": "Cannot create/update/move resource 'ai-account'."
+				}]
+			}
+		}`)),
+		Request: &http.Request{
+			Host: "management.azure.com",
+			URL:  &url.URL{Scheme: "https", Host: "management.azure.com"},
+		},
+	}
+	err := &azcore.ResponseError{
+		ErrorCode:   "InvalidTemplateDeployment",
+		StatusCode:  http.StatusBadRequest,
+		RawResponse: response,
+	}
+
+	result := ServiceFromAzure(err, OpArmDeploymentCreate)
+
+	serviceErr, ok := result.(*azdext.ServiceError)
+	require.True(t, ok)
+	assert.Contains(t, serviceErr.Suggestion, "az cognitiveservices usage list --location <region>")
+	assert.Contains(t, serviceErr.Suggestion, "AZURE_AI_PROJECT_ID")
+	assert.NotContains(t, serviceErr.Suggestion, "az vm list-usage")
+}
+
+func TestServiceFromAzure_UnrelatedErrorHasNoSuggestion(t *testing.T) {
+	response := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"code":"InvalidTemplate"}}`)),
+		Request: &http.Request{
+			URL: &url.URL{Scheme: "https", Host: "management.azure.com"},
+		},
+	}
+	err := &azcore.ResponseError{
+		ErrorCode:   "InvalidTemplate",
+		StatusCode:  http.StatusBadRequest,
+		RawResponse: response,
+	}
+
+	result := ServiceFromAzure(err, OpArmDeploymentCreate)
+
+	serviceErr, ok := result.(*azdext.ServiceError)
+	require.True(t, ok)
+	assert.Empty(t, serviceErr.Suggestion)
+}

--- a/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors_test.go
@@ -4,6 +4,7 @@
 package exterrors
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -41,7 +42,7 @@ func TestServiceFromAzure_NestedInsufficientQuota(t *testing.T) {
 
 	result := ServiceFromAzure(err, OpArmDeploymentCreate)
 
-	serviceErr, ok := result.(*azdext.ServiceError)
+	serviceErr, ok := errors.AsType[*azdext.ServiceError](result)
 	require.True(t, ok)
 	assert.Contains(t, serviceErr.Suggestion, "az cognitiveservices usage list --location <region>")
 	assert.Contains(t, serviceErr.Suggestion, "AZURE_AI_PROJECT_ID")
@@ -64,7 +65,7 @@ func TestServiceFromAzure_UnrelatedErrorHasNoSuggestion(t *testing.T) {
 
 	result := ServiceFromAzure(err, OpArmDeploymentCreate)
 
-	serviceErr, ok := result.(*azdext.ServiceError)
+	serviceErr, ok := errors.AsType[*azdext.ServiceError](result)
 	require.True(t, ok)
 	assert.Empty(t, serviceErr.Suggestion)
 }

--- a/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/exterrors/errors_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestServiceFromAzure_NestedInsufficientQuota(t *testing.T) {
+func TestServiceFromAzure_NonCognitiveServicesQuotaUsesGenericGuidance(t *testing.T) {
 	response := &http.Response{
 		StatusCode: http.StatusBadRequest,
 		Body: io.NopCloser(strings.NewReader(`{
@@ -25,7 +25,42 @@ func TestServiceFromAzure_NestedInsufficientQuota(t *testing.T) {
 				"code": "InvalidTemplateDeployment",
 				"details": [{
 					"code": "InsufficientQuota",
-					"message": "Cannot create/update/move resource 'ai-account'."
+					"target": "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerRegistry/registries/registry",
+					"message": "Insufficient quota."
+				}]
+			}
+		}`)),
+		Request: &http.Request{
+			Host: "management.azure.com",
+			URL:  &url.URL{Scheme: "https", Host: "management.azure.com"},
+		},
+	}
+	err := &azcore.ResponseError{
+		ErrorCode:   "InvalidTemplateDeployment",
+		StatusCode:  http.StatusBadRequest,
+		RawResponse: response,
+	}
+
+	result := ServiceFromAzure(err, OpArmDeploymentCreate)
+
+	serviceErr, ok := errors.AsType[*azdext.ServiceError](result)
+	require.True(t, ok)
+	assert.Contains(t, serviceErr.Suggestion, "affected resource provider")
+	assert.NotContains(t, serviceErr.Suggestion, "az cognitiveservices usage list")
+	assert.NotContains(t, serviceErr.Suggestion, "AZURE_AI_PROJECT_ID")
+	assert.NotContains(t, serviceErr.Suggestion, "az vm list-usage")
+}
+
+func TestServiceFromAzure_CognitiveServicesQuotaUsesFoundryGuidance(t *testing.T) {
+	response := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Body: io.NopCloser(strings.NewReader(`{
+			"error": {
+				"code": "InvalidTemplateDeployment",
+				"details": [{
+					"code": "InsufficientQuota",
+					"target": "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/ai-account",
+					"message": "Insufficient quota."
 				}]
 			}
 		}`)),

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/preview_helpers.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/preview_helpers.go
@@ -163,8 +163,8 @@ func shortenResourceID(id string) string {
 func whatIfFailure(r armresources.WhatIfOperationResult) error {
 	if r.Error != nil {
 		suggestion := "fix the underlying ARM error and retry `azd provision --preview`"
-		if armErrorResponseContainsCode(r.Error, "InsufficientQuota") {
-			suggestion = exterrors.CognitiveServicesQuotaSuggestion()
+		if quotaSuggestion := exterrors.QuotaSuggestionForARMError(r.Error); quotaSuggestion != "" {
+			suggestion = quotaSuggestion
 		}
 		return exterrors.Validation(
 			exterrors.CodeArmWhatIfFailed,
@@ -180,24 +180,6 @@ func whatIfFailure(r armresources.WhatIfOperationResult) error {
 		)
 	}
 	return nil
-}
-
-func armErrorResponseContainsCode(
-	err *armresources.ErrorResponse,
-	code string,
-) bool {
-	if err == nil {
-		return false
-	}
-	if err.Code != nil && strings.EqualFold(*err.Code, code) {
-		return true
-	}
-	for _, detail := range err.Details {
-		if armErrorResponseContainsCode(detail, code) {
-			return true
-		}
-	}
-	return false
 }
 
 // formatArmErrorResponse flattens an ARM ErrorResponse into a single line,

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/preview_helpers.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/preview_helpers.go
@@ -162,10 +162,14 @@ func shortenResourceID(id string) string {
 // validation) that would otherwise look like "0 changes".
 func whatIfFailure(r armresources.WhatIfOperationResult) error {
 	if r.Error != nil {
+		suggestion := "fix the underlying ARM error and retry `azd provision --preview`"
+		if armErrorResponseContainsCode(r.Error, "InsufficientQuota") {
+			suggestion = exterrors.CognitiveServicesQuotaSuggestion()
+		}
 		return exterrors.Validation(
 			exterrors.CodeArmWhatIfFailed,
 			"ARM what-if reported a failure: "+formatArmErrorResponse(r.Error),
-			"fix the underlying ARM error and retry `azd provision --preview`",
+			suggestion,
 		)
 	}
 	if r.Status != nil && !strings.EqualFold(*r.Status, "Succeeded") {
@@ -176,6 +180,24 @@ func whatIfFailure(r armresources.WhatIfOperationResult) error {
 		)
 	}
 	return nil
+}
+
+func armErrorResponseContainsCode(
+	err *armresources.ErrorResponse,
+	code string,
+) bool {
+	if err == nil {
+		return false
+	}
+	if err.Code != nil && strings.EqualFold(*err.Code, code) {
+		return true
+	}
+	for _, detail := range err.Details {
+		if armErrorResponseContainsCode(detail, code) {
+			return true
+		}
+	}
+	return false
 }
 
 // formatArmErrorResponse flattens an ARM ErrorResponse into a single line,

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/preview_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/preview_helpers_test.go
@@ -228,6 +228,9 @@ func TestWhatIfFailure_InlineErrorIsSurfaced(t *testing.T) {
 	assert.Contains(t, local.Message, "InvalidTemplateDeployment")
 	assert.Contains(t, local.Message, "InsufficientQuota")
 	assert.NotEmpty(t, local.Suggestion)
+	assert.Contains(t, local.Suggestion, "az cognitiveservices usage list --location <region>")
+	assert.Contains(t, local.Suggestion, "AZURE_AI_PROJECT_ID")
+	assert.NotContains(t, local.Suggestion, "az vm list-usage")
 }
 
 func TestWhatIfFailure_NonSucceededStatus(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.projects/internal/provisioning/preview_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.projects/internal/provisioning/preview_helpers_test.go
@@ -199,7 +199,7 @@ func TestWhatIfFailure_Success(t *testing.T) {
 	}
 }
 
-func TestWhatIfFailure_InlineErrorIsSurfaced(t *testing.T) {
+func TestWhatIfFailure_UnknownQuotaUsesGenericGuidance(t *testing.T) {
 	t.Parallel()
 
 	// ARM returns HTTP 200 with Properties.Error populated for
@@ -228,9 +228,35 @@ func TestWhatIfFailure_InlineErrorIsSurfaced(t *testing.T) {
 	assert.Contains(t, local.Message, "InvalidTemplateDeployment")
 	assert.Contains(t, local.Message, "InsufficientQuota")
 	assert.NotEmpty(t, local.Suggestion)
+	assert.Contains(t, local.Suggestion, "affected resource provider")
+	assert.NotContains(t, local.Suggestion, "az cognitiveservices usage list")
+	assert.NotContains(t, local.Suggestion, "AZURE_AI_PROJECT_ID")
+}
+
+func TestWhatIfFailure_CognitiveServicesQuotaUsesFoundryGuidance(t *testing.T) {
+	t.Parallel()
+
+	inner := &armresources.ErrorResponse{
+		Code:    new("InsufficientQuota"),
+		Message: new("Insufficient quota."),
+		Target: new(
+			"/subscriptions/sub/resourceGroups/rg/providers/" +
+				"Microsoft.CognitiveServices/accounts/ai-account",
+		),
+	}
+	err := whatIfFailure(armresources.WhatIfOperationResult{
+		Error: &armresources.ErrorResponse{
+			Code:    new("InvalidTemplateDeployment"),
+			Message: new("Preflight validation failed."),
+			Details: []*armresources.ErrorResponse{inner},
+		},
+	})
+	require.Error(t, err)
+
+	local, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
 	assert.Contains(t, local.Suggestion, "az cognitiveservices usage list --location <region>")
 	assert.Contains(t, local.Suggestion, "AZURE_AI_PROJECT_ID")
-	assert.NotContains(t, local.Suggestion, "az vm list-usage")
 }
 
 func TestWhatIfFailure_NonSucceededStatus(t *testing.T) {

--- a/cli/azd/pkg/azapi/azure_deployment_error.go
+++ b/cli/azd/pkg/azapi/azure_deployment_error.go
@@ -16,6 +16,10 @@ type DeploymentErrorLine struct {
 	Code string
 	// The message that represents the error
 	Message string
+	// The ARM target associated with the error, if provided.
+	Target string
+	// The resource type associated with Target after deployment context resolution.
+	ResourceType string
 	// Inner errors
 	Inner []*DeploymentErrorLine
 }
@@ -137,7 +141,7 @@ func generateErrorOutput(err *DeploymentErrorLine) []string {
 
 func getErrorsFromMap(errorMap map[string]any) *DeploymentErrorLine {
 	var output *DeploymentErrorLine
-	var code, message string
+	var code, message, target string
 
 	// Size of nested output is not known ahead of time.
 	nestedOutput := []*DeploymentErrorLine{}
@@ -154,6 +158,10 @@ func getErrorsFromMap(errorMap map[string]any) *DeploymentErrorLine {
 				nestedOutput = append(nestedOutput, getErrorsFromMap(messageMap))
 			} else {
 				message = rawMessage
+			}
+		case "target":
+			if value != nil {
+				target = fmt.Sprint(value)
 			}
 		case "error":
 			errorMap, ok := value.(map[string]any)
@@ -185,7 +193,9 @@ func getErrorsFromMap(errorMap map[string]any) *DeploymentErrorLine {
 
 	// Omit generic deployment failed messages
 	if code == "DeploymentFailed" || code == "ResourceDeploymentFailure" {
-		return newErrorLine("", errorMessage, nestedOutput)
+		output = newErrorLine("", errorMessage, nestedOutput)
+		output.Target = target
+		return output
 	}
 
 	if code != "" && message != "" {
@@ -195,6 +205,7 @@ func getErrorsFromMap(errorMap map[string]any) *DeploymentErrorLine {
 	}
 
 	output = newErrorLine(code, errorMessage, nestedOutput)
+	output.Target = target
 
 	return output
 }

--- a/cli/azd/pkg/azapi/azure_deployment_error_test.go
+++ b/cli/azd/pkg/azapi/azure_deployment_error_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -158,4 +159,17 @@ func Test_AzureDeploymentError_ErrorsAs_DeploymentErrorLine(t *testing.T) {
 	var line *DeploymentErrorLine
 	require.True(t, errors.As(deployErr, &line),
 		"errors.As should find DeploymentErrorLine in tree")
+}
+
+func Test_DeploymentErrorLine_Target(t *testing.T) {
+	jsonErr := `{"error":{"code":"DeploymentFailed","details":[` +
+		`{"code":"InsufficientQuota","target":"ai-account",` +
+		`"message":"Cannot create/update/move resource 'ai-account'."}]}}`
+	deployErr := NewAzureDeploymentError(
+		"test", jsonErr, DeploymentOperationValidate)
+
+	require.NotNil(t, deployErr.Details)
+	require.Len(t, deployErr.Details.Inner, 1)
+	require.Len(t, deployErr.Details.Inner[0].Inner, 1)
+	assert.Equal(t, "ai-account", deployErr.Details.Inner[0].Inner[0].Target)
 }

--- a/cli/azd/pkg/azapi/deployment_error_integration_test.go
+++ b/cli/azd/pkg/azapi/deployment_error_integration_test.go
@@ -78,6 +78,41 @@ func TestPipeline_DeploymentErrorLine_QuotaNestedInDeployment(t *testing.T) {
 	assert.Equal(t, "Quota insufficient.", result.Message)
 }
 
+func TestSuggestions_InsufficientQuota_CognitiveServicesAccount(t *testing.T) {
+	deployErr := NewAzureDeploymentError(
+		"Deployment Failed",
+		`{"error":{"code":"DeploymentFailed","details":[`+
+			`{"code":"InsufficientQuota","message":"Cannot create/update/move resource 'ai-account'."}]}}`,
+		DeploymentOperationDeploy,
+	)
+	require.NotNil(t, deployErr.Details)
+	require.Len(t, deployErr.Details.Inner, 1)
+	require.Len(t, deployErr.Details.Inner[0].Inner, 1)
+	deployErr.Details.Inner[0].Inner[0].ResourceType = "Microsoft.CognitiveServices/accounts"
+
+	result := errorhandler.NewErrorHandlerPipeline(nil).Process(t.Context(), deployErr)
+
+	require.NotNil(t, result)
+	assert.Contains(t, result.Suggestion, "az cognitiveservices usage list --location <region>")
+	assert.NotContains(t, result.Suggestion, "az vm list-usage")
+}
+
+func TestSuggestions_InsufficientQuota_GenericDoesNotUseVMUsage(t *testing.T) {
+	deployErr := NewAzureDeploymentError(
+		"Deployment Failed",
+		`{"error":{"code":"DeploymentFailed","details":[`+
+			`{"code":"InsufficientQuota","message":"Cannot create/update/move resource 'storage'."}]}}`,
+		DeploymentOperationDeploy,
+	)
+
+	result := errorhandler.NewErrorHandlerPipeline(nil).Process(t.Context(), deployErr)
+
+	require.NotNil(t, result)
+	assert.NotContains(t, result.Suggestion, "az vm list-usage")
+	assert.NotContains(t, result.Suggestion, "az cognitiveservices usage list")
+	assert.Contains(t, result.Suggestion, "affected resource provider")
+}
+
 func TestPipeline_DeploymentErrorLine_ConflictWithKeyword(t *testing.T) {
 	// DeploymentFailed > Conflict with "soft-deleted" in message
 	deployErr := NewAzureDeploymentError(

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -2618,7 +2618,7 @@ func (p *BicepProvider) validateProvision(
 	skipArmPreflight bool,
 ) (canceled bool, err error) {
 	// Local (client-side) provision validation, traced under the validation.provision event.
-	canceled, err = p.traceLocalProvisionValidation(
+	valCtx, canceled, err := p.traceLocalProvisionValidation(
 		ctx, target, modulePath, armTemplate, armParameters, skipLocalValidation)
 	if err != nil || canceled {
 		return canceled, err
@@ -2630,12 +2630,13 @@ func (p *BicepProvider) validateProvision(
 	if skipArmPreflight {
 		return false, nil
 	}
-	return false, target.ValidatePreflight(ctx, armTemplate, armParameters, tags, options)
+	err = target.ValidatePreflight(ctx, armTemplate, armParameters, tags, options)
+	return false, annotateDeploymentErrorResources(err, valCtx, armTemplate)
 }
 
 // traceLocalProvisionValidation runs (or skips) azd's local provision validation within the
 // `validation.provision` telemetry span and records the outcome attributes. It returns the
-// same (canceled, err) semantics as validateProvision for the local step.
+// validation context and the same (canceled, err) semantics as validateProvision for the local step.
 func (p *BicepProvider) traceLocalProvisionValidation(
 	ctx context.Context,
 	target infra.Deployment,
@@ -2643,7 +2644,7 @@ func (p *BicepProvider) traceLocalProvisionValidation(
 	armTemplate azure.RawArmTemplate,
 	armParameters azure.ArmParameters,
 	skipLocalValidation bool,
-) (canceled bool, err error) {
+) (valCtx *validationContext, canceled bool, err error) {
 	ctx, span := tracing.Start(ctx, events.ProvisionValidationEvent)
 	defer func() {
 		span.EndWithStatus(err)
@@ -2662,16 +2663,16 @@ func (p *BicepProvider) traceLocalProvisionValidation(
 		span.SetAttributes(fields.ProvisionValidationDiagnosticsKey.StringSlice([]string{}))
 		span.SetAttributes(fields.ProvisionValidationWarningCountKey.Int(0))
 		span.SetAttributes(fields.ProvisionValidationErrorCountKey.Int(0))
-		return false, nil
+		return nil, false, nil
 	}
 
 	return p.runLocalProvisionValidation(ctx, span, target, modulePath, armTemplate, armParameters)
 }
 
 // runLocalProvisionValidation executes azd's local (client-side) provision validation
-// pipeline and reports findings to the user. It returns (canceled, err) using the same
-// semantics as validateProvision (canceled=true means provisioning should be skipped with
-// exit code 0).
+// pipeline and reports findings to the user. It returns the validation context and
+// (canceled, err) using the same semantics as validateProvision (canceled=true means
+// provisioning should be skipped with exit code 0).
 func (p *BicepProvider) runLocalProvisionValidation(
 	ctx context.Context,
 	span tracing.Span,
@@ -2679,7 +2680,7 @@ func (p *BicepProvider) runLocalProvisionValidation(
 	modulePath string,
 	armTemplate azure.RawArmTemplate,
 	armParameters azure.ArmParameters,
-) (canceled bool, err error) {
+) (valCtx *validationContext, canceled bool, err error) {
 	// Local validation catches common issues without requiring a network round-trip.
 	// Resolve the environment location for RG-scoped deployments: prefer the actual
 	// resource group location (if the RG already exists), then fall back to AZURE_LOCATION.
@@ -2713,7 +2714,7 @@ func (p *BicepProvider) runLocalProvisionValidation(
 	valCtx, results, err := validator.validate(ctx, p.console, armTemplate, armParameters)
 	if err != nil {
 		p.setProvisionValidationOutcome(span, provisionValidationOutcomeError, nil)
-		return false, fmt.Errorf("local provision validation failed: %w", err)
+		return nil, false, fmt.Errorf("local provision validation failed: %w", err)
 	}
 
 	// Dispatch to extension-provided validation checks for the "arm-provision" check type.
@@ -2825,7 +2826,7 @@ func (p *BicepProvider) runLocalProvisionValidation(
 			// This is not an internal failure, so no error is returned (exit code 0).
 			p.console.Message(ctx, "Validation detected errors, provisioning canceled.")
 			p.setProvisionValidationOutcome(span, provisionValidationOutcomeCanceledByErrors, diagnosticIDs)
-			return true, nil
+			return valCtx, true, nil
 		}
 
 		if report.HasWarnings() {
@@ -2838,14 +2839,14 @@ func (p *BicepProvider) runLocalProvisionValidation(
 				p.setProvisionValidationOutcome(
 					span, provisionValidationOutcomeError, diagnosticIDs,
 				)
-				return false, fmt.Errorf(
+				return valCtx, false, fmt.Errorf(
 					"prompting for validation confirmation: %w", promptErr,
 				)
 			}
 			if !continueDeployment {
 				// User chose not to continue — this is an intentional cancel, not a failure.
 				p.setProvisionValidationOutcome(span, provisionValidationOutcomeCanceledByUser, diagnosticIDs)
-				return true, nil
+				return valCtx, true, nil
 			}
 			p.setProvisionValidationOutcome(span, provisionValidationOutcomeWarningsAccepted, diagnosticIDs)
 		}
@@ -2853,7 +2854,7 @@ func (p *BicepProvider) runLocalProvisionValidation(
 		p.setProvisionValidationOutcome(span, provisionValidationOutcomePassed, nil)
 	}
 
-	return false, nil
+	return valCtx, false, nil
 }
 
 // setProvisionValidationOutcome records the validation outcome on both the span and as a usage-level

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -1111,13 +1111,22 @@ func (p *BicepProvider) Preview(ctx context.Context) (*provisioning.DeployPrevie
 		planned.Parameters,
 	)
 	if err != nil {
-		return nil, err
+		return nil, annotateDeploymentErrorResources(
+			err,
+			nil,
+			planned.RawArmTemplate,
+		)
 	}
 
 	if deployPreviewResult.Error != nil {
-		return nil, azapi.NewAzureDeploymentErrorFromResponse(
+		err := azapi.NewAzureDeploymentErrorFromResponse(
 			deployPreviewResult.Error,
 			azapi.DeploymentOperationPreview,
+		)
+		return nil, annotateDeploymentErrorResources(
+			err,
+			nil,
+			planned.RawArmTemplate,
 		)
 	}
 

--- a/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go
@@ -931,6 +931,7 @@ func (p *BicepProvider) Deploy(ctx context.Context) (*provisioning.DeployResult,
 	//   - provision.preflight=off   → skip the server-side ARM provision validation call.
 	skipValidation := false
 	skipArmPreflight := false
+	var valCtx *validationContext
 	var userConfigManager config.UserConfigManager
 	if err := p.serviceLocator.Resolve(&userConfigManager); err == nil {
 		if userConfig, err := userConfigManager.Load(); err == nil {
@@ -940,7 +941,9 @@ func (p *BicepProvider) Deploy(ctx context.Context) (*provisioning.DeployResult,
 
 	if !skipValidation || !skipArmPreflight {
 		p.console.ShowSpinner(ctx, "Validating deployment", input.Step)
-		canceled, validationErr := p.validateProvision(
+		var canceled bool
+		var validationErr error
+		valCtx, canceled, validationErr = p.validateProvision(
 			ctx,
 			deployment,
 			p.path,
@@ -1049,6 +1052,7 @@ func (p *BicepProvider) Deploy(ctx context.Context) (*provisioning.DeployResult,
 		planned.Parameters,
 		deploymentTags,
 		optionsMap,
+		valCtx,
 	)
 
 	// Try to atomically claim the "completed" state. If the interrupt
@@ -2601,7 +2605,7 @@ func resolveProvisionValidationGates(userConfig config.Config) (skipValidation b
 // server-side ARM call runs outside that span so its failures/latency are not attributed
 // to azd's local validation event.
 //
-// It returns (canceled, err) where:
+// It returns (validation context, canceled, err) where:
 //   - canceled=true, err=nil: validation detected issues and provisioning should be skipped
 //     (exit code 0).
 //   - canceled=false, err!=nil: the validation itself failed to run (exit code 1).
@@ -2616,22 +2620,22 @@ func (p *BicepProvider) validateProvision(
 	options map[string]any,
 	skipLocalValidation bool,
 	skipArmPreflight bool,
-) (canceled bool, err error) {
+) (valCtx *validationContext, canceled bool, err error) {
 	// Local (client-side) provision validation, traced under the validation.provision event.
-	valCtx, canceled, err := p.traceLocalProvisionValidation(
+	valCtx, canceled, err = p.traceLocalProvisionValidation(
 		ctx, target, modulePath, armTemplate, armParameters, skipLocalValidation)
 	if err != nil || canceled {
-		return canceled, err
+		return valCtx, canceled, err
 	}
 
 	// Server-side ARM provision validation. Skipped independently via provision.preflight=off.
 	// This runs outside the validation.provision span on purpose so ARM preflight errors are
 	// not attributed to azd's local validation telemetry.
 	if skipArmPreflight {
-		return false, nil
+		return valCtx, false, nil
 	}
 	err = target.ValidatePreflight(ctx, armTemplate, armParameters, tags, options)
-	return false, annotateDeploymentErrorResources(err, valCtx, armTemplate)
+	return valCtx, false, annotateDeploymentErrorResources(err, valCtx, armTemplate)
 }
 
 // traceLocalProvisionValidation runs (or skips) azd's local provision validation within the
@@ -3403,8 +3407,10 @@ func (p *BicepProvider) deployModule(
 	armParameters azure.ArmParameters,
 	tags map[string]*string,
 	options map[string]any,
+	valCtx *validationContext,
 ) (*azapi.ResourceDeployment, error) {
-	return target.Deploy(ctx, armTemplate, armParameters, tags, options)
+	deployResult, err := target.Deploy(ctx, armTemplate, armParameters, tags, options)
+	return deployResult, annotateDeploymentErrorResources(err, valCtx, armTemplate)
 }
 
 // inputsParameter generates and updates input parameters for the Azure Resource Manager (ARM) template.

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_error_context.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_error_context.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 )
@@ -17,10 +18,9 @@ var deploymentResourceNamePattern = regexp.MustCompile(
 	`(?i)\bresource\s+['"]([^'"]+)['"]`,
 )
 
-// annotateDeploymentErrorResources adds resource types to ARM deployment error
-// lines when an error target can be matched to exactly one resolved template
-// resource. The original error is returned unchanged when the context is
-// unavailable or the target is ambiguous.
+// annotateDeploymentErrorResources adds ARM resource types to error lines.
+// It prefers full ARM targets and falls back to unique template matches.
+// The original error is returned unchanged when the target is ambiguous.
 func annotateDeploymentErrorResources(
 	err error,
 	valCtx *validationContext,
@@ -30,16 +30,12 @@ func annotateDeploymentErrorResources(
 		return nil
 	}
 
-	resources := deploymentResources(valCtx, armTemplate)
-	if len(resources) == 0 {
-		return err
-	}
-
 	deploymentErr, ok := errors.AsType[*azapi.AzureDeploymentError](err)
 	if !ok {
 		return err
 	}
 
+	resources := deploymentResources(valCtx, armTemplate)
 	annotateDeploymentErrorLine(deploymentErr.Details, resources, "")
 	return err
 }
@@ -81,8 +77,11 @@ func annotateDeploymentErrorLine(
 	}
 
 	if line.ResourceType == "" {
-		if resource, ok := uniqueDeploymentResource(target, resources); ok {
-			line.ResourceType = resource.Type
+		line.ResourceType = resourceTypeFromTarget(target)
+		if line.ResourceType == "" {
+			if resource, ok := uniqueDeploymentResource(target, resources); ok {
+				line.ResourceType = resource.Type
+			}
 		}
 	}
 
@@ -97,6 +96,20 @@ func resourceNameFromErrorMessage(message string) string {
 		return strings.TrimSpace(match[1])
 	}
 	return ""
+}
+
+func resourceTypeFromTarget(target string) string {
+	target = strings.Trim(strings.TrimSpace(target), "'\"")
+	if !strings.Contains(strings.ToLower(target), "/providers/") {
+		return ""
+	}
+
+	resourceType, err := arm.ParseResourceType(target)
+	if err != nil {
+		return ""
+	}
+
+	return resourceType.String()
 }
 
 func uniqueDeploymentResource(
@@ -117,8 +130,15 @@ func uniqueDeploymentResource(
 
 func deploymentResourceMatchesTarget(resource armTemplateResource, target string) bool {
 	target = strings.Trim(strings.TrimSpace(target), "'\"")
-	if target == "" || resource.Name == "" ||
-		strings.Contains(resource.Name, "[") {
+	if target == "" {
+		return false
+	}
+
+	if resourceType := resourceTypeFromTarget(target); resourceType != "" {
+		return strings.EqualFold(resource.Type, resourceType)
+	}
+
+	if resource.Name == "" || strings.Contains(resource.Name, "[") {
 		return false
 	}
 

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_error_context.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_error_context.go
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package bicep
+
+import (
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
+	"github.com/azure/azure-dev/cli/azd/pkg/azure"
+)
+
+var deploymentResourceNamePattern = regexp.MustCompile(
+	`(?i)\bresource\s+['"]([^'"]+)['"]`,
+)
+
+// annotateDeploymentErrorResources adds resource types to ARM deployment error
+// lines when an error target can be matched to exactly one resolved template
+// resource. The original error is returned unchanged when the context is
+// unavailable or the target is ambiguous.
+func annotateDeploymentErrorResources(
+	err error,
+	valCtx *validationContext,
+	armTemplate azure.RawArmTemplate,
+) error {
+	if err == nil {
+		return nil
+	}
+
+	resources := deploymentResources(valCtx, armTemplate)
+	if len(resources) == 0 {
+		return err
+	}
+
+	deploymentErr, ok := errors.AsType[*azapi.AzureDeploymentError](err)
+	if !ok {
+		return err
+	}
+
+	annotateDeploymentErrorLine(deploymentErr.Details, resources, "")
+	return err
+}
+
+func deploymentResources(
+	valCtx *validationContext,
+	rawArmTemplate azure.RawArmTemplate,
+) []armTemplateResource {
+	if valCtx != nil && len(valCtx.SnapshotResources) > 0 {
+		return valCtx.SnapshotResources
+	}
+
+	var template armTemplate
+	if jsonErr := json.Unmarshal(rawArmTemplate, &template); jsonErr != nil {
+		return nil
+	}
+
+	return flattenDeploymentResources(template.Resources)
+}
+
+func annotateDeploymentErrorLine(
+	line *azapi.DeploymentErrorLine,
+	resources []armTemplateResource,
+	inheritedTarget string,
+) {
+	if line == nil {
+		return
+	}
+
+	target := strings.TrimSpace(line.Target)
+	if target == "" {
+		target = resourceNameFromErrorMessage(line.Message)
+	}
+	if target == "" {
+		target = inheritedTarget
+	}
+	if line.Target == "" && target != "" {
+		line.Target = target
+	}
+
+	if line.ResourceType == "" {
+		if resource, ok := uniqueDeploymentResource(target, resources); ok {
+			line.ResourceType = resource.Type
+		}
+	}
+
+	for _, inner := range line.Inner {
+		annotateDeploymentErrorLine(inner, resources, target)
+	}
+}
+
+func resourceNameFromErrorMessage(message string) string {
+	match := deploymentResourceNamePattern.FindStringSubmatch(message)
+	if len(match) == 2 {
+		return strings.TrimSpace(match[1])
+	}
+	return ""
+}
+
+func uniqueDeploymentResource(
+	target string,
+	resources []armTemplateResource,
+) (armTemplateResource, bool) {
+	var match armTemplateResource
+	matchCount := 0
+	for _, resource := range resources {
+		if deploymentResourceMatchesTarget(resource, target) {
+			match = resource
+			matchCount++
+		}
+	}
+
+	return match, matchCount == 1
+}
+
+func deploymentResourceMatchesTarget(resource armTemplateResource, target string) bool {
+	target = strings.Trim(strings.TrimSpace(target), "'\"")
+	if target == "" || resource.Name == "" ||
+		strings.Contains(resource.Name, "[") {
+		return false
+	}
+
+	if strings.EqualFold(target, resource.Name) {
+		return true
+	}
+
+	expected := strings.Trim(
+		strings.TrimSpace(resource.Type+"/"+resource.Name),
+		"/",
+	)
+	target = strings.Trim(strings.TrimSpace(target), "/")
+	if _, after, ok := strings.Cut(target, "/providers/"); ok {
+		target = after
+	}
+
+	return strings.EqualFold(target, expected)
+}
+
+func flattenDeploymentResources(resources []armTemplateResource) []armTemplateResource {
+	flattened := make([]armTemplateResource, 0, len(resources))
+	for _, resource := range resources {
+		flattened = append(flattened, resource)
+		flattened = append(flattened, flattenDeploymentResources(resource.Resources)...)
+	}
+	return flattened
+}

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_error_context_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_error_context_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package bicep
+
+import (
+	"testing"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
+	"github.com/azure/azure-dev/cli/azd/pkg/azure"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnnotateDeploymentErrorResources_FromTarget(t *testing.T) {
+	err := azapi.NewAzureDeploymentError(
+		"Validation Error Details",
+		`{"error":{"code":"DeploymentFailed","details":[`+
+			`{"code":"InsufficientQuota","target":"ai-account",`+
+			`"message":"Insufficient quota."}]}}`,
+		azapi.DeploymentOperationValidate,
+	)
+
+	resources := []armTemplateResource{
+		{
+			Type: "Microsoft.CognitiveServices/accounts",
+			Name: "ai-account",
+		},
+	}
+
+	annotated := annotateDeploymentErrorLineForTest(err, resources)
+	require.NotNil(t, annotated)
+
+	deploymentErr, ok := annotated.(*azapi.AzureDeploymentError)
+	require.True(t, ok)
+	require.Len(t, deploymentErr.Details.Inner[0].Inner, 1)
+	require.Equal(
+		t,
+		"Microsoft.CognitiveServices/accounts",
+		deploymentErr.Details.Inner[0].Inner[0].ResourceType,
+	)
+}
+
+func TestAnnotateDeploymentErrorResources_FromMessage(t *testing.T) {
+	err := azapi.NewAzureDeploymentError(
+		"Validation Error Details",
+		`{"error":{"code":"DeploymentFailed","details":[`+
+			`{"code":"InsufficientQuota",`+
+			`"message":"Cannot create/update/move resource 'ai-account'."}]}}`,
+		azapi.DeploymentOperationValidate,
+	)
+	resources := []armTemplateResource{{
+		Type: "Microsoft.CognitiveServices/accounts",
+		Name: "ai-account",
+	}}
+
+	annotated := annotateDeploymentErrorLineForTest(err, resources)
+	deploymentErr, ok := annotated.(*azapi.AzureDeploymentError)
+	require.True(t, ok)
+	require.Len(t, deploymentErr.Details.Inner[0].Inner, 1)
+	require.Equal(
+		t,
+		"Microsoft.CognitiveServices/accounts",
+		deploymentErr.Details.Inner[0].Inner[0].ResourceType,
+	)
+}
+
+func TestAnnotateDeploymentErrorResources_FromCompiledTemplate(t *testing.T) {
+	err := azapi.NewAzureDeploymentError(
+		"Validation Error Details",
+		`{"error":{"code":"DeploymentFailed","details":[`+
+			`{"code":"InsufficientQuota",`+
+			`"message":"Cannot create/update/move resource 'ai-account'."}]}}`,
+		azapi.DeploymentOperationValidate,
+	)
+	template := azure.RawArmTemplate(`{
+		"$schema":"schema",
+		"contentVersion":"1.0.0.0",
+		"resources":[{
+			"type":"Microsoft.CognitiveServices/accounts",
+			"name":"ai-account"
+		}]
+	}`)
+
+	annotated := annotateDeploymentErrorResources(err, nil, template)
+	deploymentErr, ok := annotated.(*azapi.AzureDeploymentError)
+	require.True(t, ok)
+	require.Len(t, deploymentErr.Details.Inner[0].Inner, 1)
+	require.Equal(
+		t,
+		"Microsoft.CognitiveServices/accounts",
+		deploymentErr.Details.Inner[0].Inner[0].ResourceType,
+	)
+}
+
+func TestAnnotateDeploymentErrorResources_AmbiguousTargetFallsBack(t *testing.T) {
+	err := azapi.NewAzureDeploymentError(
+		"Validation Error Details",
+		`{"error":{"code":"DeploymentFailed","details":[`+
+			`{"code":"InsufficientQuota","target":"shared",`+
+			`"message":"Insufficient quota."}]}}`,
+		azapi.DeploymentOperationValidate,
+	)
+	resources := []armTemplateResource{
+		{Type: "Microsoft.CognitiveServices/accounts", Name: "shared"},
+		{Type: "Microsoft.Storage/storageAccounts", Name: "shared"},
+	}
+
+	annotated := annotateDeploymentErrorLineForTest(err, resources)
+	deploymentErr, ok := annotated.(*azapi.AzureDeploymentError)
+	require.True(t, ok)
+	require.Empty(t, deploymentErr.Details.Inner[0].Inner[0].ResourceType)
+}
+
+func TestDeploymentResources_UsesSnapshotBeforeTemplate(t *testing.T) {
+	valCtx := &validationContext{
+		SnapshotResources: []armTemplateResource{{
+			Type: "Microsoft.CognitiveServices/accounts",
+			Name: "resolved-account",
+		}},
+	}
+	template := azure.RawArmTemplate(`{
+		"$schema":"schema",
+		"contentVersion":"1.0.0.0",
+		"resources":[{"type":"Microsoft.Storage/storageAccounts","name":"template-account"}]
+	}`)
+
+	resources := deploymentResources(valCtx, template)
+	require.Len(t, resources, 1)
+	require.Equal(t, "resolved-account", resources[0].Name)
+}
+
+func annotateDeploymentErrorLineForTest(err error, resources []armTemplateResource) error {
+	return annotateDeploymentErrorResources(
+		err,
+		&validationContext{SnapshotResources: resources},
+		nil,
+	)
+}

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_error_context_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_error_context_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/stretchr/testify/require"
@@ -127,6 +128,89 @@ func TestAnnotateDeploymentErrorResources_AmbiguousTargetFallsBack(t *testing.T)
 	deploymentErr, ok := errors.AsType[*azapi.AzureDeploymentError](annotated)
 	require.True(t, ok)
 	require.Empty(t, deploymentErr.Details.Inner[0].Inner[0].ResourceType)
+}
+
+func TestAnnotateDeploymentErrorResources_ParameterizedNameFallsBack(t *testing.T) {
+	err := azapi.NewAzureDeploymentError(
+		"Preview Error Details",
+		`{"error":{"code":"DeploymentFailed","details":[`+
+			`{"code":"InsufficientQuota","target":"ai-account",`+
+			`"message":"Insufficient quota."}]}}`,
+		azapi.DeploymentOperationPreview,
+	)
+	template := azure.RawArmTemplate(`{
+		"$schema":"schema",
+		"contentVersion":"1.0.0.0",
+		"resources":[{
+			"type":"Microsoft.CognitiveServices/accounts",
+			"name":"[parameters('accountName')]"
+		}]
+	}`)
+
+	annotated := annotateDeploymentErrorResources(err, nil, template)
+	deploymentErr, ok := errors.AsType[*azapi.AzureDeploymentError](annotated)
+	require.True(t, ok)
+	require.Empty(t, deploymentErr.Details.Inner[0].Inner[0].ResourceType)
+}
+
+func TestAnnotatePreviewDeploymentErrors(t *testing.T) {
+	template := azure.RawArmTemplate(`{
+		"$schema":"schema",
+		"contentVersion":"1.0.0.0",
+		"resources":[{
+			"type":"Microsoft.CognitiveServices/accounts",
+			"name":"ai-account"
+		}]
+	}`)
+	target := "/subscriptions/sub/resourceGroups/rg/providers/" +
+		"Microsoft.CognitiveServices/accounts/ai-account"
+
+	t.Run("DeployPreview error", func(t *testing.T) {
+		err := azapi.NewAzureDeploymentError(
+			"Preview Error Details",
+			`{"error":{"code":"DeploymentFailed","details":[`+
+				`{"code":"InsufficientQuota","target":"`+target+`",`+
+				`"message":"Insufficient quota."}]}}`,
+			azapi.DeploymentOperationPreview,
+		)
+
+		annotated := annotateDeploymentErrorResources(
+			fmt.Errorf("deploying to resource group: %w", err),
+			nil,
+			template,
+		)
+		deploymentErr, ok := errors.AsType[*azapi.AzureDeploymentError](annotated)
+		require.True(t, ok)
+		require.Equal(
+			t,
+			"Microsoft.CognitiveServices/accounts",
+			deploymentErr.Details.Inner[0].Inner[0].ResourceType,
+		)
+	})
+
+	t.Run("what-if response error", func(t *testing.T) {
+		errResp := &armresources.ErrorResponse{
+			Code: new("DeploymentFailed"),
+			Details: []*armresources.ErrorResponse{{
+				Code:    new("InsufficientQuota"),
+				Target:  new(target),
+				Message: new("Insufficient quota."),
+			}},
+		}
+		err := azapi.NewAzureDeploymentErrorFromResponse(
+			errResp,
+			azapi.DeploymentOperationPreview,
+		)
+
+		annotated := annotateDeploymentErrorResources(err, nil, template)
+		deploymentErr, ok := errors.AsType[*azapi.AzureDeploymentError](annotated)
+		require.True(t, ok)
+		require.Equal(
+			t,
+			"Microsoft.CognitiveServices/accounts",
+			deploymentErr.Details.Inner[0].ResourceType,
+		)
+	})
 }
 
 func TestDeploymentResources_UsesSnapshotBeforeTemplate(t *testing.T) {

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_error_context_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_error_context_test.go
@@ -4,13 +4,30 @@
 package bicep
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
 	"github.com/azure/azure-dev/cli/azd/pkg/azure"
 	"github.com/stretchr/testify/require"
 )
+
+type deploymentErrorFake struct {
+	fakeDeployment
+	deployErr error
+}
+
+func (f *deploymentErrorFake) Deploy(
+	context.Context,
+	azure.RawArmTemplate,
+	azure.ArmParameters,
+	map[string]*string,
+	map[string]any,
+) (*azapi.ResourceDeployment, error) {
+	return nil, f.deployErr
+}
 
 func TestAnnotateDeploymentErrorResources_FromTarget(t *testing.T) {
 	err := azapi.NewAzureDeploymentError(
@@ -128,6 +145,48 @@ func TestDeploymentResources_UsesSnapshotBeforeTemplate(t *testing.T) {
 	resources := deploymentResources(valCtx, template)
 	require.Len(t, resources, 1)
 	require.Equal(t, "resolved-account", resources[0].Name)
+}
+
+func TestDeployModuleAnnotatesDeploymentErrors(t *testing.T) {
+	deploymentErr := azapi.NewAzureDeploymentError(
+		"Deployment Error Details",
+		`{"error":{"code":"DeploymentFailed","details":[`+
+			`{"code":"InsufficientQuota","target":"ai-account",`+
+			`"message":"Insufficient quota."}]}}`,
+		azapi.DeploymentOperationDeploy,
+	)
+	target := &deploymentErrorFake{
+		deployErr: fmt.Errorf("deploying: %w", deploymentErr),
+	}
+	template := azure.RawArmTemplate(`{
+		"$schema":"schema",
+		"contentVersion":"1.0.0.0",
+		"resources":[{
+			"type":"Microsoft.CognitiveServices/accounts",
+			"name":"ai-account"
+		}]
+	}`)
+
+	_, err := (&BicepProvider{}).deployModule(
+		t.Context(),
+		target,
+		template,
+		nil,
+		nil,
+		nil,
+		&validationContext{SnapshotResources: []armTemplateResource{{
+			Type: "Microsoft.CognitiveServices/accounts",
+			Name: "ai-account",
+		}}},
+	)
+
+	deploymentErr, ok := errors.AsType[*azapi.AzureDeploymentError](err)
+	require.True(t, ok)
+	require.Equal(
+		t,
+		"Microsoft.CognitiveServices/accounts",
+		deploymentErr.Details.Inner[0].Inner[0].ResourceType,
+	)
 }
 
 func annotateDeploymentErrorLineForTest(err error, resources []armTemplateResource) error {

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_error_context_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_error_context_test.go
@@ -153,6 +153,35 @@ func TestAnnotateDeploymentErrorResources_ParameterizedNameFallsBack(t *testing.
 	require.Empty(t, deploymentErr.Details.Inner[0].Inner[0].ResourceType)
 }
 
+func TestAnnotateDeploymentErrorResources_ParameterizedNameUsesFullTarget(t *testing.T) {
+	target := "/subscriptions/sub/resourceGroups/rg/providers/" +
+		"Microsoft.CognitiveServices/accounts/ai-account"
+	err := azapi.NewAzureDeploymentError(
+		"Preview Error Details",
+		`{"error":{"code":"DeploymentFailed","details":[`+
+			`{"code":"InsufficientQuota","target":"`+target+`",`+
+			`"message":"Insufficient quota."}]}}`,
+		azapi.DeploymentOperationPreview,
+	)
+	template := azure.RawArmTemplate(`{
+		"$schema":"schema",
+		"contentVersion":"1.0.0.0",
+		"resources":[{
+			"type":"Microsoft.CognitiveServices/accounts",
+			"name":"[parameters('accountName')]"
+		}]
+	}`)
+
+	annotated := annotateDeploymentErrorResources(err, nil, template)
+	deploymentErr, ok := errors.AsType[*azapi.AzureDeploymentError](annotated)
+	require.True(t, ok)
+	require.Equal(
+		t,
+		"Microsoft.CognitiveServices/accounts",
+		deploymentErr.Details.Inner[0].Inner[0].ResourceType,
+	)
+}
+
 func TestAnnotatePreviewDeploymentErrors(t *testing.T) {
 	template := azure.RawArmTemplate(`{
 		"$schema":"schema",

--- a/cli/azd/pkg/infra/provisioning/bicep/deployment_error_context_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/deployment_error_context_test.go
@@ -4,6 +4,7 @@
 package bicep
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azapi"
@@ -30,7 +31,7 @@ func TestAnnotateDeploymentErrorResources_FromTarget(t *testing.T) {
 	annotated := annotateDeploymentErrorLineForTest(err, resources)
 	require.NotNil(t, annotated)
 
-	deploymentErr, ok := annotated.(*azapi.AzureDeploymentError)
+	deploymentErr, ok := errors.AsType[*azapi.AzureDeploymentError](annotated)
 	require.True(t, ok)
 	require.Len(t, deploymentErr.Details.Inner[0].Inner, 1)
 	require.Equal(
@@ -54,7 +55,7 @@ func TestAnnotateDeploymentErrorResources_FromMessage(t *testing.T) {
 	}}
 
 	annotated := annotateDeploymentErrorLineForTest(err, resources)
-	deploymentErr, ok := annotated.(*azapi.AzureDeploymentError)
+	deploymentErr, ok := errors.AsType[*azapi.AzureDeploymentError](annotated)
 	require.True(t, ok)
 	require.Len(t, deploymentErr.Details.Inner[0].Inner, 1)
 	require.Equal(
@@ -82,7 +83,7 @@ func TestAnnotateDeploymentErrorResources_FromCompiledTemplate(t *testing.T) {
 	}`)
 
 	annotated := annotateDeploymentErrorResources(err, nil, template)
-	deploymentErr, ok := annotated.(*azapi.AzureDeploymentError)
+	deploymentErr, ok := errors.AsType[*azapi.AzureDeploymentError](annotated)
 	require.True(t, ok)
 	require.Len(t, deploymentErr.Details.Inner[0].Inner, 1)
 	require.Equal(
@@ -106,7 +107,7 @@ func TestAnnotateDeploymentErrorResources_AmbiguousTargetFallsBack(t *testing.T)
 	}
 
 	annotated := annotateDeploymentErrorLineForTest(err, resources)
-	deploymentErr, ok := annotated.(*azapi.AzureDeploymentError)
+	deploymentErr, ok := errors.AsType[*azapi.AzureDeploymentError](annotated)
 	require.True(t, ok)
 	require.Empty(t, deploymentErr.Details.Inner[0].Inner[0].ResourceType)
 }

--- a/cli/azd/pkg/infra/provisioning/bicep/provision_validation_gate_test.go
+++ b/cli/azd/pkg/infra/provisioning/bicep/provision_validation_gate_test.go
@@ -112,7 +112,7 @@ func TestValidateProvisionArmPreflightGate(t *testing.T) {
 			target := &recordingDeployment{}
 			p := &BicepProvider{}
 
-			canceled, err := p.validateProvision(
+			_, canceled, err := p.validateProvision(
 				t.Context(),
 				target,
 				"",

--- a/cli/azd/resources/error_suggestions.yaml
+++ b/cli/azd/resources/error_suggestions.yaml
@@ -111,12 +111,28 @@ rules:
   # ============================================================================
 
   - errorType: "DeploymentErrorLine"
+    regex: true
+    properties:
+      Code: "(?i)^InsufficientQuota$"
+      ResourceType: '(?i)^Microsoft\.CognitiveServices/accounts$'
+    message: "Your Cognitive Services account may have insufficient regional or subscription quota."
+    suggestion: >
+      Check Cognitive Services usage for the deployment region with
+      'az cognitiveservices usage list --location <region>' or request a
+      quota increase in the Azure portal.
+    links:
+      - url: "https://learn.microsoft.com/azure/ai-services/quotas-limits"
+        title: "Azure AI Services quotas and limits"
+      - url: "https://learn.microsoft.com/azure/quotas/quickstart-increase-quota-portal"
+        title: "Increase Azure subscription quotas"
+
+  - errorType: "DeploymentErrorLine"
     properties:
       Code: "InsufficientQuota"
     message: "Your subscription has insufficient quota for this resource."
     suggestion: >
-      Check current usage with 'az vm list-usage --location <region>'
-      or request a quota increase in the Azure portal.
+      Check the quota and current usage for the affected resource provider in
+      the Azure portal, or request a quota increase.
     links:
       - url: "https://learn.microsoft.com/azure/quotas/quickstart-increase-quota-portal"
         title: "Increase Azure subscription quotas"


### PR DESCRIPTION
## Summary

- Replace the global VM-specific `InsufficientQuota` suggestion with resource-agnostic guidance.
- Show Cognitive Services usage and Foundry project recovery guidance only when the ARM error explicitly identifies `Microsoft.CognitiveServices/accounts`.
- Use the same resource-aware classification for deployment, polling, and what-if errors in `azure.ai.projects`.
- Add regression coverage and document the quota and existing-project guidance.

## Why this is needed

A quota failure can come from any resource provider in a Foundry deployment, including user-supplied templates. VM or Foundry-specific instructions for an unrelated resource send users to the wrong service and do not help them recover.

## Approach

The core deployment path resolves ARM/Bicep errors to their resource types. The extension now uses a shared ARM error classifier and shows the Foundry-specific recovery path only when the error contains a Cognitive Services account resource identifier. When the affected resource cannot be identified, or belongs to another provider, it gives general quota guidance instead. This conservative fallback avoids incorrect recovery instructions while retaining the targeted guidance when it is supported by the error payload.

## E2E validation

- Core Bicep: `azd provision`, `azd provision --preview`, and `azd up` completed successfully.
- Microsoft Foundry: `azd provision`, `azd provision --preview`, and `azd up` completed successfully.
- Quota handling: Core and Foundry fixtures triggered real `InsufficientQuota` responses through preview, provision, and `up`. The commands surfaced the generic quota guidance without misclassifying the resource. The live Azure responses did not include a unique resource target, so the resource-specific guidance was not exercised in the live run; target-bearing cases are covered by regression tests.
- Cleanup: `azd down --force --purge --no-prompt` removed the disposable resource group and purged the Cognitive Services account. No shared resources were used or modified.
- Testing used an isolated PR profile and did not modify the default `azd` installation or configuration.
- The previous `bicep-lint` failure occurred while downloading Bicep because of a transient connection reset, before linting ran; it was unrelated to the quota guidance changes.

Fixes #7516