### PR TITLE
docs: update Copilot instructions from PR review patterns

### DIFF
--- a/.github/instructions/extensions.instructions.md
+++ b/.github/instructions/extensions.instructions.md
@@ -16,3 +16,37 @@ applyTo:
 - Follow extension guidelines in: cli/azd/docs/extensions/extensions-style-guide.md. If the work
   violates any of these principles, include a link to the guide so the user can read it and get
   ahead of some of the problems.
+
+- **Reject explicitly-set flags that cannot take effect; never silently drop them.** When a flag is
+  explicitly supplied (check via `cmd.Flags().Changed("<flag>")`) but the selected code path ignores
+  it — for example, `--inspector-port` with `--no-client`, or any agent-creation flag during a
+  reuse flow, or init-only flags during a standalone-eject run — return a clear error that names the
+  conflicting inputs. Automation scripts that pass explicit flags and receive a success exit code
+  must be able to trust that those flags were honored. Use `exterrors.CodeConflictingArguments` for
+  flag/flag conflicts and `exterrors.Validation` for semantic violations.
+
+  _Source: [#9366](https://github.com/Azure/azure-dev/pull/9366), [#9404](https://github.com/Azure/azure-dev/pull/9404), [#9407](https://github.com/Azure/azure-dev/pull/9407), [#9422](https://github.com/Azure/azure-dev/pull/9422)_
+
+- **Redact credentials from URLs before printing to terminal, logs, or error messages.** URLs may
+  carry credentials in the userinfo component (`user:pass@host`) or in the query string (SAS
+  tokens, `sig=` parameters). Clear `URL.User` and drop `RawQuery` and `Fragment` before passing a
+  URL to any output function, error message, or log call. `redactURL` in
+  `cli/azd/pkg/azdext/pagination.go` and `redactURLForDebug` in
+  `cli/azd/extensions/azure.ai.training/pkg/client` show the shape, but both only strip the query
+  and fragment, so clear the userinfo as well. This applies to download URLs, clone URLs, registry
+  addresses, and any URL stored in artifacts or uploaded CI outputs. Add a non-disclosure test that
+  feeds a credential-bearing URL and asserts no sensitive portion appears in the output.
+
+  _Source: [#9361](https://github.com/Azure/azure-dev/pull/9361), [#9415](https://github.com/Azure/azure-dev/pull/9415), [#9417](https://github.com/Azure/azure-dev/pull/9417)_
+
+- **Route every user-visible message through the caller's `io.Writer`**; never write directly to
+  `os.Stdout` or `os.Stderr` inside extension command handlers or their helpers, including debug
+  and diagnostic paths. See "Keep terminal output on the injected writer" in `cli/azd/AGENTS.md`.
+
+  _Source: [#9291](https://github.com/Azure/azure-dev/pull/9291), [#9366](https://github.com/Azure/azure-dev/pull/9366)_
+
+- **When behavior narrows, narrow the help text and doc comments with it.** A comment that still
+  says a function "runs eject" after it was restricted to projects that already declare a Foundry
+  service is a recurring review finding. See "Help text consistency" in `cli/azd/AGENTS.md`.
+
+  _Source: [#9329](https://github.com/Azure/azure-dev/pull/9329), [#9407](https://github.com/Azure/azure-dev/pull/9407), [#9422](https://github.com/Azure/azure-dev/pull/9422)_

--- a/.github/instructions/extensions.instructions.md
+++ b/.github/instructions/extensions.instructions.md
@@ -26,8 +26,6 @@ applyTo:
   report flag conflicts with `exterrors.Validation(exterrors.CodeConflictingArguments, message,
   suggestion)`. Otherwise, follow the extension's established validation-error pattern.
 
-  _Source: [#9366](https://github.com/Azure/azure-dev/pull/9366), [#9404](https://github.com/Azure/azure-dev/pull/9404), [#9407](https://github.com/Azure/azure-dev/pull/9407), [#9422](https://github.com/Azure/azure-dev/pull/9422)_
-
 - **Redact credentials from URLs before printing to terminal, logs, or error messages.** URLs may
   carry credentials in the userinfo component (`user:pass@host`) or in the query string (SAS
   tokens, `sig=` parameters). Clear `URL.User` and drop `RawQuery` and `Fragment` before passing a
@@ -38,17 +36,9 @@ applyTo:
   addresses, and any URL stored in artifacts or uploaded CI outputs. Add a non-disclosure test that
   feeds a credential-bearing URL and asserts no sensitive portion appears in the output.
 
-  _Source: [#9361](https://github.com/Azure/azure-dev/pull/9361), [#9415](https://github.com/Azure/azure-dev/pull/9415), [#9417](https://github.com/Azure/azure-dev/pull/9417)_
-
 - **Keep output on the injected writer when a command handler or helper receives one**; do not bypass
   it with direct writes to `os.Stdout` or `os.Stderr`, including in debug and diagnostic paths.
   Extensions that do not expose a writer must follow their local `AGENTS.md` output conventions.
   See "Keep terminal output on the injected writer" in `cli/azd/AGENTS.md`.
 
-  _Source: [#9291](https://github.com/Azure/azure-dev/pull/9291), [#9366](https://github.com/Azure/azure-dev/pull/9366)_
-
-- **When behavior narrows, narrow the help text and doc comments with it.** A comment that still
-  says a function "runs eject" after it was restricted to projects that already declare a Foundry
-  service is a recurring review finding. See "Help text consistency" in `cli/azd/AGENTS.md`.
-
-  _Source: [#9329](https://github.com/Azure/azure-dev/pull/9329), [#9407](https://github.com/Azure/azure-dev/pull/9407), [#9422](https://github.com/Azure/azure-dev/pull/9422)_
+- When behavior narrows, narrow the help text and doc comments with it.

--- a/.github/instructions/extensions.instructions.md
+++ b/.github/instructions/extensions.instructions.md
@@ -22,8 +22,9 @@ applyTo:
   it — for example, `--inspector-port` with `--no-client`, or any agent-creation flag during a
   reuse flow, or init-only flags during a standalone-eject run — return a clear error that names the
   conflicting inputs. Automation scripts that pass explicit flags and receive a success exit code
-  must be able to trust that those flags were honored. Use `exterrors.CodeConflictingArguments` for
-  flag/flag conflicts and `exterrors.Validation` for semantic violations.
+  must be able to trust that those flags were honored. In extensions that provide `internal/exterrors`,
+  report flag conflicts with `exterrors.Validation(exterrors.CodeConflictingArguments, message,
+  suggestion)`. Otherwise, follow the extension's established validation-error pattern.
 
   _Source: [#9366](https://github.com/Azure/azure-dev/pull/9366), [#9404](https://github.com/Azure/azure-dev/pull/9404), [#9407](https://github.com/Azure/azure-dev/pull/9407), [#9422](https://github.com/Azure/azure-dev/pull/9422)_
 
@@ -39,9 +40,10 @@ applyTo:
 
   _Source: [#9361](https://github.com/Azure/azure-dev/pull/9361), [#9415](https://github.com/Azure/azure-dev/pull/9415), [#9417](https://github.com/Azure/azure-dev/pull/9417)_
 
-- **Route every user-visible message through the caller's `io.Writer`**; never write directly to
-  `os.Stdout` or `os.Stderr` inside extension command handlers or their helpers, including debug
-  and diagnostic paths. See "Keep terminal output on the injected writer" in `cli/azd/AGENTS.md`.
+- **Keep output on the injected writer when a command handler or helper receives one**; do not bypass
+  it with direct writes to `os.Stdout` or `os.Stderr`, including in debug and diagnostic paths.
+  Extensions that do not expose a writer must follow their local `AGENTS.md` output conventions.
+  See "Keep terminal output on the injected writer" in `cli/azd/AGENTS.md`.
 
   _Source: [#9291](https://github.com/Azure/azure-dev/pull/9291), [#9366](https://github.com/Azure/azure-dev/pull/9366)_
 

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -30,4 +30,5 @@ all existing imports or declarations.
 ## CLI behavior and domain filtering
 
 - When reviewing command input resolution, explicit CLI args and flags should win over defaults. Do not prompt the user toward a different default when they provided a valid new value; reserve prompts for ambiguous choices and preserve deterministic `--no-prompt` behavior for CI/scripts.
+- When reviewing flag validation: if a flag was explicitly set (verifiable via `cmd.Flags().Changed("<name>")`) but the code path would silently ignore it, that is a bug. Reject the combination with a clear error — "success with dropped flags" breaks automation scripts.
 - When filtering AI models or quota data by location, keep location-specific usage data associated with only the models available in that location. Empty or unknown usage data from an unrelated location must not make a model eligible elsewhere; add regression coverage for cross-location quota cases.

--- a/.vscode/cspell.misc.yaml
+++ b/.vscode/cspell.misc.yaml
@@ -88,6 +88,12 @@ overrides:
           - azureai
           - entra
           - flexconsumption
+    - filename: .github/instructions/**/*.md
+      words:
+          - azdext
+          - Chdir
+          - exterrors
+          - userinfo
     - filename: docs/architecture/**/*.md
       words:
           - azapi


### PR DESCRIPTION
Implements the instruction updates proposed in #9507.

## What changed

`.github/instructions/extensions.instructions.md` gains four review rules derived from recurring review findings:

1. **Reject explicitly-set flags that cannot take effect.** If a flag is set but the selected code path ignores it, return an error naming the conflict rather than exiting 0 with the flag silently dropped. Extensions with `internal/exterrors` use `exterrors.Validation(exterrors.CodeConflictingArguments, message, suggestion)`; other extensions follow their established validation-error pattern.
2. **Redact credentials from URLs** before printing to terminal, logs, or error messages, including the userinfo component.
3. **Keep output on an injected writer when one is available.** Extensions without a writer continue to follow their local output conventions.
4. **When behavior narrows, narrow the help text and doc comments with it.**

`.github/instructions/go.instructions.md` gains one bullet on flag validation in the existing "CLI behavior and domain filtering" section.

`.vscode/cspell.misc.yaml` gains a `.github/instructions/**/*.md` override for the new vocabulary.

## Curation applied

Rules 3 and 4 repeated guidance already present in `cli/azd/AGENTS.md` ("Keep terminal output on the injected writer" at line 417 and "Help text consistency" at line 259). Both are trimmed to scoped statements plus cross-references instead of duplicating the full guidance. Rule 3 is limited to handlers and helpers that actually receive a writer, preserving extension-specific output contracts. Rule 4 is trimmed to a single sentence.

Rule 2 originally suggested adding a new URL-redaction helper. The repository already has `redactURL` in `cli/azd/pkg/azdext/pagination.go` and `redactURLForDebug` in `cli/azd/extensions/azure.ai.training/pkg/client`, so the rule points at those and notes that both only strip the query and fragment, leaving userinfo intact.

Per-rule `_Source:` attribution lines were dropped to save token space.

## Also fixed

`.github/instructions/go.instructions.md` already contained `Chdir`, which the `cspell-misc` check flags. That check does not run on changes limited to `cli/`, `ext/vscode/`, `ext/devcontainer/`, `eng/`, or `templates/`, so it went unnoticed. This PR triggers the check, so the word is included in the new override.

## Verification

`cspell lint '**/*' --config ./.vscode/cspell.misc.yaml` passes: 59 files checked, 0 issues.

## Follow-up, not in this PR

`redactURL` (`cli/azd/pkg/azdext/pagination.go:319`) and `redactURLForDebug` (`cli/azd/extensions/azure.ai.training/pkg/client/client.go:250`) clear `RawQuery` and `Fragment` but leave `u.User`, so credential-bearing userinfo can still reach error and diagnostic output.

Closes #9507