### PR TITLE
refactor: enhance error handling for container publishing and add tests

### DIFF
--- a/cli/azd/internal/grpcserver/container_service.go
+++ b/cli/azd/internal/grpcserver/container_service.go
@@ -5,11 +5,14 @@ package grpcserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/azure/azure-dev/cli/azd/internal/mapper"
 	"github.com/azure/azure-dev/cli/azd/pkg/async"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/azure/azure-dev/cli/azd/pkg/containerregistry"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/input"
 	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
@@ -25,6 +28,33 @@ type containerService struct {
 	lazyServiceManager  *lazy.Lazy[project.ServiceManager]
 	lazyProject         *lazy.Lazy[*project.ProjectConfig]
 	lazyEnvironment     *lazy.Lazy[*environment.Environment]
+}
+
+func mapContainerPublishError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if _, ok := errors.AsType[*azcore.ResponseError](err); ok ||
+		errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+
+	remoteBuildErr, ok := errors.AsType[*containerregistry.RemoteBuildRunError](err)
+	if !ok {
+		return err
+	}
+
+	diagnosticCode := remoteBuildErr.DiagnosticCode()
+	if diagnosticCode == "" {
+		return err
+	}
+
+	return &azdext.LocalError{
+		Message:  err.Error(),
+		Code:     "container_publish_" + diagnosticCode,
+		Category: azdext.LocalErrorCategoryInternal,
+	}
 }
 
 func NewContainerService(
@@ -208,7 +238,7 @@ func (c *containerService) Publish(
 
 	publishResult, err := containerHelper.Publish(ctx, serviceConfig, serviceContext, targetResource, env, progress, nil)
 	if err != nil {
-		return nil, err
+		return nil, mapContainerPublishError(err)
 	}
 
 	// Use mapper to convert ServicePublishResult to proto

--- a/cli/azd/internal/grpcserver/container_service_test.go
+++ b/cli/azd/internal/grpcserver/container_service_test.go
@@ -4,10 +4,15 @@
 package grpcserver
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/azure/azure-dev/cli/azd/pkg/containerregistry"
 	"github.com/azure/azure-dev/cli/azd/pkg/environment"
 	"github.com/azure/azure-dev/cli/azd/pkg/lazy"
 	"github.com/azure/azure-dev/cli/azd/pkg/project"
@@ -273,4 +278,99 @@ func TestContainerService_Publish_ServiceManagerError(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "service manager error")
+}
+
+func TestMapContainerPublishError_RemoteBuildRun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status armcontainerregistry.RunStatus
+		code   string
+	}{
+		{
+			name:   "failed",
+			status: armcontainerregistry.RunStatusFailed,
+			code:   "container_publish_acr_run_failed",
+		},
+		{
+			name:   "error",
+			status: armcontainerregistry.RunStatusError,
+			code:   "container_publish_acr_run_error",
+		},
+		{
+			name:   "timeout",
+			status: armcontainerregistry.RunStatusTimeout,
+			code:   "container_publish_acr_run_timeout",
+		},
+		{
+			name:   "canceled",
+			status: armcontainerregistry.RunStatusCanceled,
+			code:   "container_publish_acr_run_canceled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := fmt.Errorf("publish wrapper: %w", &containerregistry.RemoteBuildRunError{
+				Status: tt.status,
+			})
+			mapped := mapContainerPublishError(err)
+
+			var localErr *azdext.LocalError
+			require.ErrorAs(t, mapped, &localErr)
+			require.Equal(t, tt.code, localErr.Code)
+			require.Equal(t, azdext.LocalErrorCategoryInternal, localErr.Category)
+			require.Equal(t, err.Error(), localErr.Message)
+		})
+	}
+}
+
+func TestMapContainerPublishError_PreservesUnclassifiedErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "unknown remote build status",
+			err: fmt.Errorf("publish wrapper: %w", &containerregistry.RemoteBuildRunError{
+				Status: armcontainerregistry.RunStatusSucceeded,
+			}),
+		},
+		{
+			name: "plain error",
+			err:  errors.New("publish failed"),
+		},
+		{
+			name: "canceled",
+			err:  fmt.Errorf("publish canceled: %w", context.Canceled),
+		},
+		{
+			name: "deadline exceeded",
+			err:  fmt.Errorf("publish deadline: %w", context.DeadlineExceeded),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Same(t, tt.err, mapContainerPublishError(tt.err))
+		})
+	}
+}
+
+func TestMapContainerPublishError_PreservesResponseError(t *testing.T) {
+	t.Parallel()
+
+	responseErr := &azcore.ResponseError{StatusCode: 500}
+	remoteBuildErr := &containerregistry.RemoteBuildRunError{
+		Status: armcontainerregistry.RunStatusFailed,
+	}
+	err := errors.Join(responseErr, remoteBuildErr)
+
+	require.Same(t, err, mapContainerPublishError(err))
 }

--- a/cli/azd/pkg/containerregistry/remote_build.go
+++ b/cli/azd/pkg/containerregistry/remote_build.go
@@ -243,7 +243,7 @@ func (r *RemoteBuildManager) RunDockerBuildRequestWithLogs(
 				return err
 			}
 			if runRes.Properties == nil || runRes.Properties.Status == nil {
-				return errors.New("remote build status is missing")
+				return retry.RetryableError(errors.New("remote build status is missing"))
 			}
 
 			if !slices.Contains(terminalContainerRegistryRunStates, *runRes.Properties.Status) {

--- a/cli/azd/pkg/containerregistry/remote_build.go
+++ b/cli/azd/pkg/containerregistry/remote_build.go
@@ -242,7 +242,7 @@ func (r *RemoteBuildManager) RunDockerBuildRequestWithLogs(
 			if err != nil {
 				return err
 			}
-			if runRes.Properties.Status == nil {
+			if runRes.Properties == nil || runRes.Properties.Status == nil {
 				return errors.New("remote build status is missing")
 			}
 

--- a/cli/azd/pkg/containerregistry/remote_build.go
+++ b/cli/azd/pkg/containerregistry/remote_build.go
@@ -126,6 +126,41 @@ func (r *RemoteBuildManager) UploadBuildSource(
 	return sourceUploadRes.SourceUploadDefinition, nil
 }
 
+// RemoteBuildRunError represents a terminal failure reported by an Azure Container Registry remote build.
+type RemoteBuildRunError struct {
+	Status   armcontainerregistry.RunStatus
+	buildLog string
+}
+
+// Error returns the remote build failure and its existing user-facing build log.
+func (e *RemoteBuildRunError) Error() string {
+	if e == nil {
+		return "remote build failed"
+	}
+
+	return fmt.Sprintf("remote build failed: %s", e.buildLog)
+}
+
+// DiagnosticCode returns a stable suffix for the terminal ACR run status, or an empty string for an unknown status.
+func (e *RemoteBuildRunError) DiagnosticCode() string {
+	if e == nil {
+		return ""
+	}
+
+	switch e.Status {
+	case armcontainerregistry.RunStatusFailed:
+		return "acr_run_failed"
+	case armcontainerregistry.RunStatusError:
+		return "acr_run_error"
+	case armcontainerregistry.RunStatusTimeout:
+		return "acr_run_timeout"
+	case armcontainerregistry.RunStatusCanceled:
+		return "acr_run_canceled"
+	default:
+		return ""
+	}
+}
+
 // terminalContainerRegistryRunStates is the list of states we consider terminal when waiting for a container registry run
 // to complete. Unfortunately, in the current version of the armcontainerregistry package, the poller returned by
 // BeginScheduleRun treats all states as terminal and so calling `PollUntilDone` will return even if if the run is still
@@ -191,7 +226,6 @@ func (r *RemoteBuildManager) RunDockerBuildRequestWithLogs(
 	}
 
 	var buildLog bytes.Buffer
-
 	err = streamLogs(ctx, logBlobClient, io.MultiWriter(&buildLog, writer))
 	if err != nil {
 		return err
@@ -208,13 +242,19 @@ func (r *RemoteBuildManager) RunDockerBuildRequestWithLogs(
 			if err != nil {
 				return err
 			}
+			if runRes.Properties.Status == nil {
+				return errors.New("remote build status is missing")
+			}
 
 			if !slices.Contains(terminalContainerRegistryRunStates, *runRes.Properties.Status) {
 				return retry.RetryableError(errors.New("remote build still in progress"))
 			}
 
 			if *runRes.Properties.Status != armcontainerregistry.RunStatusSucceeded {
-				return fmt.Errorf("remote build failed: %v", buildLog.String())
+				return &RemoteBuildRunError{
+					Status:   *runRes.Properties.Status,
+					buildLog: buildLog.String(),
+				}
 			}
 
 			return nil

--- a/cli/azd/pkg/containerregistry/remote_build_test.go
+++ b/cli/azd/pkg/containerregistry/remote_build_test.go
@@ -384,6 +384,58 @@ func TestRunDockerBuildRequestWithLogs_TerminalStatus(t *testing.T) {
 	}
 }
 
+func TestRemoteBuildRunError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		status         armcontainerregistry.RunStatus
+		diagnosticCode string
+	}{
+		{
+			name:           "failed",
+			status:         armcontainerregistry.RunStatusFailed,
+			diagnosticCode: "acr_run_failed",
+		},
+		{
+			name:           "error",
+			status:         armcontainerregistry.RunStatusError,
+			diagnosticCode: "acr_run_error",
+		},
+		{
+			name:           "timeout",
+			status:         armcontainerregistry.RunStatusTimeout,
+			diagnosticCode: "acr_run_timeout",
+		},
+		{
+			name:           "canceled",
+			status:         armcontainerregistry.RunStatusCanceled,
+			diagnosticCode: "acr_run_canceled",
+		},
+		{
+			name:   "unknown",
+			status: armcontainerregistry.RunStatus("unknown"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := &RemoteBuildRunError{
+				Status:   tt.status,
+				buildLog: "remote output",
+			}
+			require.Equal(t, "remote build failed: remote output", err.Error())
+			require.Equal(t, tt.diagnosticCode, err.DiagnosticCode())
+		})
+	}
+
+	var nilErr *RemoteBuildRunError
+	require.Equal(t, "remote build failed", nilErr.Error())
+	require.Empty(t, nilErr.DiagnosticCode())
+}
+
 func TestTerminalContainerRegistryRunStates(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/pkg/containerregistry/remote_build_test.go
+++ b/cli/azd/pkg/containerregistry/remote_build_test.go
@@ -260,14 +260,16 @@ func TestRunDockerBuildRequestWithLogs_TerminalStatus(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name   string
-		status armcontainerregistry.RunStatus
+		name          string
+		status        armcontainerregistry.RunStatus
+		propertiesNil bool
 	}{
 		{name: "succeeded", status: armcontainerregistry.RunStatusSucceeded},
 		{name: "failed", status: armcontainerregistry.RunStatusFailed},
 		{name: "error", status: armcontainerregistry.RunStatusError},
 		{name: "timeout", status: armcontainerregistry.RunStatusTimeout},
 		{name: "canceled", status: armcontainerregistry.RunStatusCanceled},
+		{name: "missing properties", propertiesNil: true},
 	}
 
 	for _, tt := range tests {
@@ -312,8 +314,12 @@ func TestRunDockerBuildRequestWithLogs_TerminalStatus(t *testing.T) {
 
 				case strings.Contains(r.URL.Path, "/runs/run-id"):
 					runGetCalls.Add(1)
+					var runProperties *armcontainerregistry.RunProperties
+					if !tt.propertiesNil {
+						runProperties = &armcontainerregistry.RunProperties{Status: &tt.status}
+					}
 					response := armcontainerregistry.Run{
-						Properties: &armcontainerregistry.RunProperties{Status: &tt.status},
+						Properties: runProperties,
 					}
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusOK)
@@ -346,6 +352,10 @@ func TestRunDockerBuildRequestWithLogs_TerminalStatus(t *testing.T) {
 			require.Equal(t, int32(2), logHeadCalls.Load())
 			require.Equal(t, int32(1), runGetCalls.Load())
 			require.Equal(t, buildLog, output.String())
+			if tt.propertiesNil {
+				require.EqualError(t, err, "remote build status is missing")
+				return
+			}
 			if tt.status == armcontainerregistry.RunStatusSucceeded {
 				require.NoError(t, err)
 				return

--- a/cli/azd/pkg/containerregistry/remote_build_test.go
+++ b/cli/azd/pkg/containerregistry/remote_build_test.go
@@ -252,6 +252,111 @@ func TestRunDockerBuildRequestWithLogs_ScheduleRunError(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "BadRequest")
+	var responseErr *azcore.ResponseError
+	require.ErrorAs(t, err, &responseErr)
+}
+
+func TestRunDockerBuildRequestWithLogs_TerminalStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status armcontainerregistry.RunStatus
+	}{
+		{name: "succeeded", status: armcontainerregistry.RunStatusSucceeded},
+		{name: "failed", status: armcontainerregistry.RunStatusFailed},
+		{name: "error", status: armcontainerregistry.RunStatusError},
+		{name: "timeout", status: armcontainerregistry.RunStatusTimeout},
+		{name: "canceled", status: armcontainerregistry.RunStatusCanceled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			const buildLog = "remote build output\n"
+			var logHeadCalls atomic.Int32
+			var runGetCalls atomic.Int32
+
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.Contains(r.URL.Path, "scheduleRun"):
+					response := armcontainerregistry.RegistriesClientScheduleRunResponse{
+						Run: armcontainerregistry.Run{
+							Properties: &armcontainerregistry.RunProperties{RunID: new("run-id")},
+						},
+					}
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					require.NoError(t, json.NewEncoder(w).Encode(response))
+
+				case strings.Contains(r.URL.Path, "listLogSasUrl"):
+					logURL := "https://" + r.Host + "/logs/run.log?sig=abc"
+					response := armcontainerregistry.RunGetLogResult{LogLink: &logURL}
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					require.NoError(t, json.NewEncoder(w).Encode(response))
+
+				case strings.HasSuffix(r.URL.Path, "/logs/run.log"):
+					w.Header().Set("Content-Length", fmt.Sprint(len(buildLog)))
+					if r.Method == http.MethodHead {
+						if logHeadCalls.Add(1) > 1 {
+							w.Header().Set("x-ms-meta-complete", "true")
+						}
+						w.WriteHeader(http.StatusOK)
+					} else {
+						w.Header().Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", len(buildLog)-1, len(buildLog)))
+						w.WriteHeader(http.StatusPartialContent)
+						_, _ = io.WriteString(w, buildLog)
+					}
+
+				case strings.Contains(r.URL.Path, "/runs/run-id"):
+					runGetCalls.Add(1)
+					response := armcontainerregistry.Run{
+						Properties: &armcontainerregistry.RunProperties{Status: &tt.status},
+					}
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					require.NoError(t, json.NewEncoder(w).Encode(response))
+
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			t.Cleanup(srv.Close)
+
+			transport := &rewritingTransport{
+				inner: srv.Client(),
+				host:  mustParseURL(srv.URL).Host,
+			}
+			armOpts := armOptionsNoRetry(transport)
+			credProvider := mockaccount.SubscriptionCredentialProviderFunc(
+				func(_ context.Context, _ string) (azcore.TokenCredential, error) {
+					return &mocks.MockCredentials{}, nil
+				},
+			)
+			mgr := NewRemoteBuildManager(credProvider, armOpts)
+
+			var output strings.Builder
+			err := mgr.RunDockerBuildRequestWithLogs(
+				t.Context(), testSubscriptionID, testResourceGroup, testRegistryName,
+				&armcontainerregistry.DockerBuildRequest{}, &output,
+			)
+
+			require.Equal(t, int32(2), logHeadCalls.Load())
+			require.Equal(t, int32(1), runGetCalls.Load())
+			require.Equal(t, buildLog, output.String())
+			if tt.status == armcontainerregistry.RunStatusSucceeded {
+				require.NoError(t, err)
+				return
+			}
+
+			var remoteBuildErr *RemoteBuildRunError
+			require.ErrorAs(t, err, &remoteBuildErr)
+			require.Equal(t, tt.status, remoteBuildErr.Status)
+			require.Equal(t, "remote build failed: "+buildLog, err.Error())
+		})
+	}
 }
 
 func TestTerminalContainerRegistryRunStates(t *testing.T) {

--- a/cli/azd/pkg/containerregistry/remote_build_test.go
+++ b/cli/azd/pkg/containerregistry/remote_build_test.go
@@ -260,16 +260,26 @@ func TestRunDockerBuildRequestWithLogs_TerminalStatus(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		status        armcontainerregistry.RunStatus
-		propertiesNil bool
+		name                   string
+		status                 armcontainerregistry.RunStatus
+		missingPropertiesFirst bool
+		missingStatusFirst     bool
 	}{
 		{name: "succeeded", status: armcontainerregistry.RunStatusSucceeded},
 		{name: "failed", status: armcontainerregistry.RunStatusFailed},
 		{name: "error", status: armcontainerregistry.RunStatusError},
 		{name: "timeout", status: armcontainerregistry.RunStatusTimeout},
 		{name: "canceled", status: armcontainerregistry.RunStatusCanceled},
-		{name: "missing properties", propertiesNil: true},
+		{
+			name:                   "missing properties then succeeds",
+			status:                 armcontainerregistry.RunStatusSucceeded,
+			missingPropertiesFirst: true,
+		},
+		{
+			name:               "missing status then succeeds",
+			status:             armcontainerregistry.RunStatusSucceeded,
+			missingStatusFirst: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -313,10 +323,15 @@ func TestRunDockerBuildRequestWithLogs_TerminalStatus(t *testing.T) {
 					}
 
 				case strings.Contains(r.URL.Path, "/runs/run-id"):
-					runGetCalls.Add(1)
-					var runProperties *armcontainerregistry.RunProperties
-					if !tt.propertiesNil {
-						runProperties = &armcontainerregistry.RunProperties{Status: &tt.status}
+					runGetCall := runGetCalls.Add(1)
+					runProperties := &armcontainerregistry.RunProperties{Status: &tt.status}
+					if runGetCall == 1 {
+						switch {
+						case tt.missingPropertiesFirst:
+							runProperties = nil
+						case tt.missingStatusFirst:
+							runProperties.Status = nil
+						}
 					}
 					response := armcontainerregistry.Run{
 						Properties: runProperties,
@@ -350,12 +365,12 @@ func TestRunDockerBuildRequestWithLogs_TerminalStatus(t *testing.T) {
 			)
 
 			require.Equal(t, int32(2), logHeadCalls.Load())
-			require.Equal(t, int32(1), runGetCalls.Load())
-			require.Equal(t, buildLog, output.String())
-			if tt.propertiesNil {
-				require.EqualError(t, err, "remote build status is missing")
-				return
+			expectedRunGetCalls := int32(1)
+			if tt.missingPropertiesFirst || tt.missingStatusFirst {
+				expectedRunGetCalls = 2
 			}
+			require.Equal(t, expectedRunGetCalls, runGetCalls.Load())
+			require.Equal(t, buildLog, output.String())
 			if tt.status == armcontainerregistry.RunStatusSucceeded {
 				require.NoError(t, err)
 				return


### PR DESCRIPTION
## Summary

This change gives container publishing through Azure Container Registry remote builds status-specific diagnostics for extensions. It keeps the build log and still passes through the original Azure service and cancellation errors.

## Problem

Remote build failures were returned as generic errors. Extensions could not tell whether a run failed, hit an error, timed out, or was canceled, which made telemetry and user-facing error handling less precise.

## Approach

`RemoteBuildRunError` carries the ACR run status and build log. The gRPC container service converts known terminal failures into structured `LocalError` codes. Azure response errors and context cancellation errors remain unchanged.

## E2E Validation

| Command | Affected path | User-facing effect | |
|---|---|---|---|
| `azd publish` | Container image publishing through ACR remote build | Shows clear, stable diagnostics for failed, timed-out, or canceled builds. | Pass  |
| `azd deploy` | Builds, publishes, and deploys the service | Preserves the existing build-log message while exposing a structured error code. | Pass |
| `azd up` | Provisions infrastructure, publishes images, and deploys services | Surfaces the same actionable container-publish errors consistently across the full lifecycle. | Pass |

Fixes #9740