### PR TITLE
fix(routines): resolve service manifest references

### DIFF
--- a/cli/azd/extensions/azure.ai.routines/README.md
+++ b/cli/azd/extensions/azure.ai.routines/README.md
@@ -2,6 +2,21 @@
 
 Manage Microsoft Foundry Routines from your terminal. (Preview)
 
+## Reference a routine manifest
+
+An `azure.ai.routine` service can load its routine definition from a local YAML
+or JSON file. Properties beside `$ref` override values from the referenced file.
+
+```yaml
+services:
+  nightly-summary:
+    host: azure.ai.routine
+    $ref: ./routines/nightly-summary.yaml
+    enabled: false
+```
+
+References are resolved during `azd deploy`. Remote URLs are not supported.
+
 ## Timeout configuration
 
 Routine read API calls default to a 30-second HTTP request timeout.

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_manifest.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_manifest.go
@@ -18,14 +18,14 @@ import (
 
 // readRoutineManifest reads and parses a routine manifest from a YAML or JSON file.
 func readRoutineManifest(path string) (*routines.Routine, error) {
-	// #nosec G304 - path is provided by the user via --file and is intentional
+	// #nosec G304 - --file and local azure.yaml $ref paths are trusted user config.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, exterrors.Dependency(
 				exterrors.CodeFileNotFound,
 				fmt.Sprintf("routine manifest file not found: %s", path),
-				"verify the path or rerun without --file",
+				"verify the path exists and points to a routine manifest",
 			)
 		}
 		return nil, exterrors.Dependency(

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_manifest_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_manifest_test.go
@@ -5,12 +5,14 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"azure.ai.routines/internal/pkg/routines"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -69,7 +71,10 @@ action:
 func TestReadRoutineManifest_FileNotFound(t *testing.T) {
 	t.Parallel()
 	_, err := readRoutineManifest("/nonexistent/path/routine.yaml")
-	assert.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Contains(t, localErr.Suggestion, "verify the path exists")
+	assert.NotContains(t, localErr.Suggestion, "--file")
 }
 
 func TestReadRoutineManifest_UnsupportedExtension(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target.go
@@ -7,7 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
+	"net/url"
+	"path/filepath"
+	"strings"
 
+	"azure.ai.routines/internal/exterrors"
 	"azure.ai.routines/internal/pkg/routines"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -112,7 +117,15 @@ func (p *routineServiceTarget) Deploy(
 	targetResource *azdext.TargetResource,
 	progress azdext.ProgressReporter,
 ) (*azdext.ServiceDeployResult, error) {
-	body, err := parseRoutineServiceConfig(serviceConfig)
+	projectRoot := ""
+	if routineServiceHasRef(serviceConfig) {
+		projectResp, err := p.projectClient.Get(ctx, &azdext.EmptyRequest{})
+		if err != nil {
+			return nil, fmt.Errorf("reading project for routine %q: %w", serviceConfig.GetName(), err)
+		}
+		projectRoot = projectResp.GetProject().GetPath()
+	}
+	body, err := parseRoutineServiceConfig(serviceConfig, projectRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +163,7 @@ func (p *routineServiceTarget) Deploy(
 // parseRoutineServiceConfig binds the service-level (inline) routine keys to the
 // routine API model, falling back to the deprecated config: shape for azure.yaml
 // files written before the per-resource service split.
-func parseRoutineServiceConfig(svc *azdext.ServiceConfig) (*routines.Routine, error) {
+func parseRoutineServiceConfig(svc *azdext.ServiceConfig, projectRoot string) (*routines.Routine, error) {
 	props := svc.GetAdditionalProperties()
 	if props == nil || len(props.GetFields()) == 0 {
 		props = svc.GetConfig()
@@ -159,7 +172,15 @@ func parseRoutineServiceConfig(svc *azdext.ServiceConfig) (*routines.Routine, er
 	if props == nil {
 		return body, nil
 	}
-	b, err := json.Marshal(props.AsMap())
+	values := props.AsMap()
+	if _, hasRef := values["$ref"]; hasRef {
+		resolved, err := resolveRoutineServiceRef(values, projectRoot)
+		if err != nil {
+			return nil, err
+		}
+		values = resolved
+	}
+	b, err := json.Marshal(values)
 	if err != nil {
 		return nil, fmt.Errorf("encoding routine service %q config: %w", svc.GetName(), err)
 	}
@@ -167,6 +188,65 @@ func parseRoutineServiceConfig(svc *azdext.ServiceConfig) (*routines.Routine, er
 		return nil, fmt.Errorf("parsing routine service %q config: %w", svc.GetName(), err)
 	}
 	return body, nil
+}
+
+func routineServiceHasRef(svc *azdext.ServiceConfig) bool {
+	props := svc.GetAdditionalProperties()
+	if props == nil || len(props.GetFields()) == 0 {
+		props = svc.GetConfig()
+	}
+	if props == nil {
+		return false
+	}
+	_, found := props.GetFields()["$ref"]
+	return found
+}
+
+func resolveRoutineServiceRef(values map[string]any, projectRoot string) (map[string]any, error) {
+	ref, ok := values["$ref"].(string)
+	if !ok || strings.TrimSpace(ref) == "" {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidRoutineManifest,
+			"routine service $ref must be a non-empty string",
+			"set $ref to a local .yaml, .yml, or .json routine manifest",
+		)
+	}
+	refPath := strings.TrimSpace(ref)
+	if !filepath.IsAbs(refPath) {
+		parsed, err := url.Parse(refPath)
+		if (parsed != nil && parsed.IsAbs()) || (err != nil && strings.Contains(refPath, "://")) {
+			return nil, exterrors.Validation(
+				exterrors.CodeInvalidRoutineManifest,
+				fmt.Sprintf("remote routine service $ref %q is not supported", refPath),
+				"set $ref to a local .yaml, .yml, or .json routine manifest",
+			)
+		}
+		if projectRoot == "" {
+			return nil, exterrors.Validation(
+				exterrors.CodeInvalidRoutineManifest,
+				"cannot resolve routine service $ref without an azure.yaml project path",
+				"run the command from an initialized azd project",
+			)
+		}
+		refPath = filepath.Join(projectRoot, refPath)
+	}
+	referenced, err := readRoutineManifest(refPath)
+	if err != nil {
+		return nil, err
+	}
+	data, err := json.Marshal(referenced)
+	if err != nil {
+		return nil, fmt.Errorf("encoding referenced routine service: %w", err)
+	}
+	resolved := map[string]any{}
+	if err := json.Unmarshal(data, &resolved); err != nil {
+		return nil, fmt.Errorf("decoding referenced routine service: %w", err)
+	}
+
+	overlay := maps.Clone(values)
+	delete(overlay, "$ref")
+	maps.Copy(resolved, overlay)
+	return resolved, nil
 }
 
 // newRoutineServiceClient resolves the project endpoint (from the active azd
@@ -200,6 +280,11 @@ func newRoutineServiceClient(ctx context.Context) (*routines.Client, error) {
 // concrete *azdext.AzdClient lets tests supply a fake: the client's
 // project field is unexported and no option overrides it.
 type serviceConfigReader interface {
+	Get(
+		ctx context.Context,
+		in *azdext.EmptyRequest,
+		opts ...grpc.CallOption,
+	) (*azdext.GetProjectResponse, error)
 	GetServiceConfigValue(
 		ctx context.Context,
 		in *azdext.GetServiceConfigValueRequest,

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target_test.go
@@ -5,7 +5,12 @@ package cmd
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"azure.ai.routines/internal/exterrors"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/assert"
@@ -31,7 +36,7 @@ func TestParseRoutineServiceConfig_ServiceLevel(t *testing.T) {
 		Name:                 "nightly",
 		Host:                 aiRoutineHost,
 		AdditionalProperties: props,
-	})
+	}, "")
 	require.NoError(t, err)
 	assert.Equal(t, "nightly summary", body.Description)
 	require.NotNil(t, body.Enabled)
@@ -55,9 +60,132 @@ func TestParseRoutineServiceConfig_ConfigFallback(t *testing.T) {
 		Name:   "legacy",
 		Host:   aiRoutineHost,
 		Config: props,
-	})
+	}, "")
 	require.NoError(t, err)
 	assert.Equal(t, "legacy", body.Description)
+}
+
+func TestParseRoutineServiceConfig_FileRef(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "routine.yaml"),
+		[]byte("description: referenced routine\n"+
+			"triggers:\n"+
+			"  default:\n"+
+			"    type: schedule\n"+
+			"    cron_expression: \"0 2 * * *\"\n"+
+			"action:\n"+
+			"  type: invoke_agent_responses_api\n"+
+			"  agent_name: summarizer\n"+
+			"  input:\n"+
+			"    $ref: literal-payload-reference\n"+
+			"    project: literal-project-value\n"+
+			"    instructions: literal-instructions.md\n"),
+		0o600,
+	))
+	props, err := structpb.NewStruct(map[string]any{"$ref": "./routine.yaml"})
+	require.NoError(t, err)
+
+	body, err := parseRoutineServiceConfig(&azdext.ServiceConfig{
+		Name:                 "nightly",
+		Host:                 aiRoutineHost,
+		AdditionalProperties: props,
+	}, root)
+	require.NoError(t, err)
+	assert.Equal(t, "referenced routine", body.Description)
+	assert.Equal(t, "0 2 * * *", body.Triggers["default"].CronExpression)
+	require.NotNil(t, body.Action)
+	assert.Equal(t, "summarizer", body.Action.AgentName)
+	assert.Equal(t, map[string]any{
+		"$ref":         "literal-payload-reference",
+		"project":      "literal-project-value",
+		"instructions": "literal-instructions.md",
+	}, body.Action.Input)
+}
+
+func TestParseRoutineServiceConfig_FileRefOverlay(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "routine.yaml"),
+		[]byte("description: referenced routine\nenabled: true\n"),
+		0o600,
+	))
+	props, err := structpb.NewStruct(map[string]any{
+		"$ref":        "./routine.yaml",
+		"description": "inline override",
+	})
+	require.NoError(t, err)
+
+	body, err := parseRoutineServiceConfig(&azdext.ServiceConfig{
+		Name:                 "nightly",
+		Host:                 aiRoutineHost,
+		AdditionalProperties: props,
+	}, root)
+	require.NoError(t, err)
+	assert.Equal(t, "inline override", body.Description)
+	require.NotNil(t, body.Enabled)
+	assert.True(t, *body.Enabled)
+}
+
+func TestResolveRoutineServiceRef_AbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "routine.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("description: absolute routine\n"), 0o600))
+
+	resolved, err := resolveRoutineServiceRef(map[string]any{"$ref": path}, "")
+	require.NoError(t, err)
+	assert.Equal(t, "absolute routine", resolved["description"])
+}
+
+func TestResolveRoutineServiceRef_LocalPathWithPercent(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "100%-ready.yaml"),
+		[]byte("description: percent routine\n"),
+		0o600,
+	))
+
+	resolved, err := resolveRoutineServiceRef(map[string]any{"$ref": "./100%-ready.yaml"}, root)
+	require.NoError(t, err)
+	assert.Equal(t, "percent routine", resolved["description"])
+}
+
+func TestResolveRoutineServiceRef_ValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		values      map[string]any
+		projectRoot string
+		message     string
+	}{
+		{name: "non-string", values: map[string]any{"$ref": 42}, projectRoot: t.TempDir(), message: "non-empty string"},
+		{name: "empty", values: map[string]any{"$ref": "  "}, projectRoot: t.TempDir(), message: "non-empty string"},
+		{name: "remote", values: map[string]any{"$ref": "https://example.com/routine.yaml"}, projectRoot: t.TempDir(), message: "not supported"},
+		{name: "malformed remote", values: map[string]any{"$ref": "https://example.com/%zz"}, projectRoot: t.TempDir(), message: "not supported"},
+		{name: "missing project path", values: map[string]any{"$ref": "./routine.yaml"}, message: "without an azure.yaml project path"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := resolveRoutineServiceRef(test.values, test.projectRoot)
+			localErr, ok := errors.AsType[*azdext.LocalError](err)
+			require.True(t, ok)
+			assert.Equal(t, exterrors.CodeInvalidRoutineManifest, localErr.Code)
+			assert.Equal(t, azdext.LocalErrorCategoryValidation, localErr.Category)
+			assert.Contains(t, localErr.Message, test.message)
+			assert.NotEmpty(t, localErr.Suggestion)
+		})
+	}
 }
 
 func TestExpandRoutineValue(t *testing.T) {
@@ -85,6 +213,14 @@ func TestExpandRoutineValue(t *testing.T) {
 // fakeServiceConfigReader reports a fixed env-declared result.
 type fakeServiceConfigReader struct {
 	found bool
+}
+
+func (f fakeServiceConfigReader) Get(
+	context.Context,
+	*azdext.EmptyRequest,
+	...grpc.CallOption,
+) (*azdext.GetProjectResponse, error) {
+	return &azdext.GetProjectResponse{Project: &azdext.ProjectConfig{}}, nil
 }
 
 func (f fakeServiceConfigReader) GetServiceConfigValue(

--- a/cli/azd/extensions/azure.ai.routines/schemas/azure.ai.routine.json
+++ b/cli/azd/extensions/azure.ai.routines/schemas/azure.ai.routine.json
@@ -6,6 +6,10 @@
   "type": "object",
   "additionalProperties": true,
   "properties": {
+    "$ref": {
+      "type": "string",
+      "description": "Local YAML or JSON routine manifest path. Sibling service properties override referenced values."
+    },
     "description": {
       "type": "string",
       "description": "Description of the routine."


### PR DESCRIPTION
## Summary

First standalone slice of #9089.

- resolve local YAML/JSON `$ref` definitions for `azure.ai.routine` services during `azd deploy`
- apply service-level sibling properties as shallow overrides without interpreting arbitrary `action.input` or trigger payload fields
- reject remote references with structured validation guidance
- document and schema-declare the routine service `$ref` contract

This PR is independently mergeable and contains no command-authoring changes. The follow-up stacked PR adds `--add-to-project` authoring from `routine create` and `update`.

## Testing

- `golangci-lint run --timeout 10m0s`
- `go fix -diff ./...` (no changes)
- `go test ./... -count=1`
- `go build ./...`
- targeted tests for local, absolute, percent-containing, remote, malformed, and shallow-overlay references
- cspell and schema JSON validation