### PR TITLE
fix(lazy): synchronize value access

### DIFF
--- a/cli/azd/pkg/lazy/lazy.go
+++ b/cli/azd/pkg/lazy/lazy.go
@@ -10,12 +10,12 @@ type InitializerFn[T comparable] func() (T, error)
 // A data structure that will lazily load an instance of the underlying type
 // from the specified initializer
 type Lazy[T comparable] struct {
-	initialized  bool
-	initializer  InitializerFn[T]
-	value        T
-	error        error
-	getValueLock sync.Mutex
-	setValueLock sync.Mutex
+	initialized     bool
+	initializer     InitializerFn[T]
+	value           T
+	error           error
+	initializerLock sync.Mutex
+	valueLock       sync.Mutex
 }
 
 // Creates a new Lazy[T]
@@ -33,30 +33,52 @@ func From[T comparable](value T) *Lazy[T] {
 // Gets the value of the configured initializer
 // Initializer will only run once on success
 func (l *Lazy[T]) GetValue() (T, error) {
-	// Only allow a single caller to get a value at one time.
-	// Additional calls will block until current call is complete
-	l.getValueLock.Lock()
-	defer l.getValueLock.Unlock()
-
-	if !l.initialized {
-		value, err := l.initializer()
-		if err == nil {
-			l.SetValue(value)
-		} else {
-			l.error = err
-		}
+	l.valueLock.Lock()
+	if l.initialized {
+		value, err := l.value, l.error
+		l.valueLock.Unlock()
+		return value, err
 	}
+	l.valueLock.Unlock()
 
+	// Only one caller runs the initializer. SetValue remains available while the
+	// initializer runs, including when the initializer itself calls SetValue.
+	l.initializerLock.Lock()
+	defer l.initializerLock.Unlock()
+
+	l.valueLock.Lock()
+	if l.initialized {
+		value, err := l.value, l.error
+		l.valueLock.Unlock()
+		return value, err
+	}
+	l.valueLock.Unlock()
+
+	value, err := l.initializer()
+
+	l.valueLock.Lock()
+	defer l.valueLock.Unlock()
+	if l.initialized {
+		return l.value, l.error
+	}
+	if err == nil {
+		l.setValue(value)
+	} else {
+		l.error = err
+	}
 	return l.value, l.error
 }
 
-// Sets a value on the lazy type
+// SetValue sets the resolved value and clears any prior error. It may be called
+// while the initializer is running; the explicit value then takes precedence
+// over that initializer's result.
 func (l *Lazy[T]) SetValue(value T) {
-	// Only allow a single caller to get a value at one time.
-	// Additional calls will block until current call is complete
-	l.setValueLock.Lock()
-	defer l.setValueLock.Unlock()
+	l.valueLock.Lock()
+	defer l.valueLock.Unlock()
+	l.setValue(value)
+}
 
+func (l *Lazy[T]) setValue(value T) {
 	l.value = value
 	l.error = nil
 	l.initialized = true

--- a/cli/azd/pkg/lazy/lazy_test.go
+++ b/cli/azd/pkg/lazy/lazy_test.go
@@ -5,8 +5,8 @@ package lazy
 
 import (
 	"errors"
+	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -107,37 +107,106 @@ func Test_Lazy_SetValue(t *testing.T) {
 
 func Test_Lazy_GetValue_Concurrent(t *testing.T) {
 	expected := "test"
-	callCount := 0
+	var callCount atomic.Int32
+	initializerStarted := make(chan struct{})
+	releaseInitializer := make(chan struct{})
 
 	initFn := func() (string, error) {
-		callCount++
-		// justified: simulates a slow initializer so both goroutines are guaranteed to
-		// reach GetValue() before init completes, verifying only one runs the initFn.
-		time.Sleep(time.Millisecond * 200)
+		callCount.Add(1)
+		close(initializerStarted)
+		<-releaseInitializer
 		return expected, nil
 	}
 
 	instance := NewLazy(initFn)
 
-	var actual string
-	var err error
-
-	res := make(chan bool, 2)
-
-	go func() {
-		actual, err = instance.GetValue()
-		res <- true
-	}()
+	type result struct {
+		value string
+		err   error
+	}
+	results := make(chan result, 2)
+	gettersStarted := make(chan struct{}, 2)
 
 	go func() {
-		actual, err = instance.GetValue()
-		res <- true
+		gettersStarted <- struct{}{}
+		value, err := instance.GetValue()
+		results <- result{value: value, err: err}
 	}()
+	<-initializerStarted
 
-	done := <-res
+	go func() {
+		gettersStarted <- struct{}{}
+		value, err := instance.GetValue()
+		results <- result{value: value, err: err}
+	}()
+	<-gettersStarted
+	<-gettersStarted
+	close(releaseInitializer)
 
-	require.True(t, done)
-	require.Equal(t, expected, actual)
+	for range 2 {
+		result := <-results
+		require.Equal(t, expected, result.value)
+		require.NoError(t, result.err)
+	}
+	require.Equal(t, int32(1), callCount.Load())
+}
+
+func Test_Lazy_InitializerCanSetValue(t *testing.T) {
+	var instance *Lazy[string]
+	instance = NewLazy(func() (string, error) {
+		instance.SetValue("from setter")
+		return "from initializer", nil
+	})
+
+	value, err := instance.GetValue()
 	require.NoError(t, err)
-	require.Equal(t, 1, callCount)
+	require.Equal(t, "from setter", value)
+
+	value, err = instance.GetValue()
+	require.NoError(t, err)
+	require.Equal(t, "from setter", value)
+}
+
+func Test_Lazy_SetValueWinsOverRunningInitializer(t *testing.T) {
+	tests := []struct {
+		name           string
+		initializerErr error
+	}{
+		{name: "initializer succeeds"},
+		{name: "initializer fails", initializerErr: errors.New("initializer failed")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			initializerStarted := make(chan struct{})
+			releaseInitializer := make(chan struct{})
+			instance := NewLazy(func() (string, error) {
+				close(initializerStarted)
+				<-releaseInitializer
+				return "from initializer", test.initializerErr
+			})
+
+			type result struct {
+				value string
+				err   error
+			}
+			resultCh := make(chan result, 1)
+			go func() {
+				value, err := instance.GetValue()
+				resultCh <- result{value: value, err: err}
+			}()
+			<-initializerStarted
+
+			instance.SetValue("from setter")
+			close(releaseInitializer)
+
+			got := <-resultCh
+			require.NoError(t, got.err)
+			require.Equal(t, "from setter", got.value)
+
+			value, err := instance.GetValue()
+			require.NoError(t, err)
+			require.Equal(t, "from setter", value)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Core prerequisite for #9089.

- synchronize all `Lazy` state reads and writes while keeping initializer execution reentrant
- preserve existing retry-after-error behavior
- make an explicit `SetValue` win over an in-flight initializer result
- add deterministic regression coverage for concurrent getters and setters

This PR is intentionally limited to `pkg/lazy`. A stacked extension-framework PR uses the race-free cache update when applying guarded project configuration patches.

## Testing

- `go test ./pkg/lazy -count=100`
- `golangci-lint run ./pkg/lazy/... --timeout 10m0s`
- `go fix -diff ./pkg/lazy/...` (no changes)

`go test -race` is unavailable in this Windows environment because the installed Go toolchain has CGO disabled; the tests use channel barriers to exercise the relevant initializer/setter ordering without timing sleeps.