### PR TITLE
fix(routines): resolve service manifest references

### DIFF
--- a/cli/azd/extensions/azure.ai.routines/README.md
+++ b/cli/azd/extensions/azure.ai.routines/README.md
@@ -2,6 +2,21 @@
 
 Manage Microsoft Foundry Routines from your terminal. (Preview)
 
+## Reference a routine manifest
+
+An `azure.ai.routine` service can load its routine definition from a local YAML
+or JSON file. Properties beside `$ref` override values from the referenced file.
+
+```yaml
+services:
+  nightly-summary:
+    host: azure.ai.routine
+    $ref: ./routines/nightly-summary.yaml
+    enabled: false
+```
+
+References are resolved during `azd deploy`. Remote URLs are not supported.
+
 ## Timeout configuration
 
 Routine read API calls default to a 30-second HTTP request timeout.

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_manifest.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_manifest.go
@@ -18,14 +18,14 @@ import (
 
 // readRoutineManifest reads and parses a routine manifest from a YAML or JSON file.
 func readRoutineManifest(path string) (*routines.Routine, error) {
-	// #nosec G304 - path is provided by the user via --file and is intentional
+	// #nosec G304 - --file and local azure.yaml $ref paths are trusted user config.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, exterrors.Dependency(
 				exterrors.CodeFileNotFound,
 				fmt.Sprintf("routine manifest file not found: %s", path),
-				"verify the path or rerun without --file",
+				"verify the path exists and points to a routine manifest",
 			)
 		}
 		return nil, exterrors.Dependency(

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_manifest_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/routine_manifest_test.go
@@ -5,12 +5,14 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"azure.ai.routines/internal/pkg/routines"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -69,7 +71,10 @@ action:
 func TestReadRoutineManifest_FileNotFound(t *testing.T) {
 	t.Parallel()
 	_, err := readRoutineManifest("/nonexistent/path/routine.yaml")
-	assert.Error(t, err)
+	localErr, ok := errors.AsType[*azdext.LocalError](err)
+	require.True(t, ok)
+	assert.Contains(t, localErr.Suggestion, "verify the path exists")
+	assert.NotContains(t, localErr.Suggestion, "--file")
 }
 
 func TestReadRoutineManifest_UnsupportedExtension(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target.go
@@ -7,7 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
+	"path/filepath"
+	"regexp"
+	"strings"
 
+	"azure.ai.routines/internal/exterrors"
 	"azure.ai.routines/internal/pkg/routines"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -112,7 +117,11 @@ func (p *routineServiceTarget) Deploy(
 	targetResource *azdext.TargetResource,
 	progress azdext.ProgressReporter,
 ) (*azdext.ServiceDeployResult, error) {
-	body, err := parseRoutineServiceConfig(serviceConfig)
+	projectRoot, err := routineProjectRoot(ctx, p.projectClient, serviceConfig)
+	if err != nil {
+		return nil, err
+	}
+	body, err := parseRoutineServiceConfig(serviceConfig, projectRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +159,7 @@ func (p *routineServiceTarget) Deploy(
 // parseRoutineServiceConfig binds the service-level (inline) routine keys to the
 // routine API model, falling back to the deprecated config: shape for azure.yaml
 // files written before the per-resource service split.
-func parseRoutineServiceConfig(svc *azdext.ServiceConfig) (*routines.Routine, error) {
+func parseRoutineServiceConfig(svc *azdext.ServiceConfig, projectRoot string) (*routines.Routine, error) {
 	props := svc.GetAdditionalProperties()
 	if props == nil || len(props.GetFields()) == 0 {
 		props = svc.GetConfig()
@@ -159,7 +168,15 @@ func parseRoutineServiceConfig(svc *azdext.ServiceConfig) (*routines.Routine, er
 	if props == nil {
 		return body, nil
 	}
-	b, err := json.Marshal(props.AsMap())
+	values := props.AsMap()
+	if _, hasRef := values["$ref"]; hasRef {
+		resolved, err := resolveRoutineServiceRef(values, projectRoot)
+		if err != nil {
+			return nil, err
+		}
+		values = resolved
+	}
+	b, err := json.Marshal(values)
 	if err != nil {
 		return nil, fmt.Errorf("encoding routine service %q config: %w", svc.GetName(), err)
 	}
@@ -167,6 +184,81 @@ func parseRoutineServiceConfig(svc *azdext.ServiceConfig) (*routines.Routine, er
 		return nil, fmt.Errorf("parsing routine service %q config: %w", svc.GetName(), err)
 	}
 	return body, nil
+}
+
+func routineServiceHasRef(svc *azdext.ServiceConfig) bool {
+	props := svc.GetAdditionalProperties()
+	if props == nil || len(props.GetFields()) == 0 {
+		props = svc.GetConfig()
+	}
+	if props == nil {
+		return false
+	}
+	_, found := props.GetFields()["$ref"]
+	return found
+}
+
+func routineProjectRoot(
+	ctx context.Context,
+	projectClient serviceConfigReader,
+	service *azdext.ServiceConfig,
+) (string, error) {
+	if !routineServiceHasRef(service) {
+		return "", nil
+	}
+	projectResp, err := projectClient.Get(ctx, &azdext.EmptyRequest{})
+	if err != nil {
+		return "", fmt.Errorf("reading project for routine %q: %w", service.GetName(), err)
+	}
+	return projectResp.GetProject().GetPath(), nil
+}
+
+var remoteRoutineRefPattern = regexp.MustCompile(`(?i)^[a-z][a-z0-9+.-]*://`)
+
+func resolveRoutineServiceRef(values map[string]any, projectRoot string) (map[string]any, error) {
+	ref, ok := values["$ref"].(string)
+	if !ok || strings.TrimSpace(ref) == "" {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidRoutineManifest,
+			"routine service $ref must be a non-empty string",
+			"set $ref to a local .yaml, .yml, or .json routine manifest",
+		)
+	}
+	refPath := strings.TrimSpace(ref)
+	if !filepath.IsAbs(refPath) {
+		if remoteRoutineRefPattern.MatchString(refPath) {
+			return nil, exterrors.Validation(
+				exterrors.CodeInvalidRoutineManifest,
+				"remote routine service $ref is not supported",
+				"set $ref to a local .yaml, .yml, or .json routine manifest",
+			)
+		}
+		if projectRoot == "" {
+			return nil, exterrors.Validation(
+				exterrors.CodeInvalidRoutineManifest,
+				"cannot resolve routine service $ref without an azure.yaml project path",
+				"run the command from an initialized azd project",
+			)
+		}
+		refPath = filepath.Join(projectRoot, refPath)
+	}
+	referenced, err := readRoutineManifest(refPath)
+	if err != nil {
+		return nil, err
+	}
+	data, err := json.Marshal(referenced)
+	if err != nil {
+		return nil, fmt.Errorf("encoding referenced routine service: %w", err)
+	}
+	resolved := map[string]any{}
+	if err := json.Unmarshal(data, &resolved); err != nil {
+		return nil, fmt.Errorf("decoding referenced routine service: %w", err)
+	}
+
+	overlay := maps.Clone(values)
+	delete(overlay, "$ref")
+	maps.Copy(resolved, overlay)
+	return resolved, nil
 }
 
 // newRoutineServiceClient resolves the project endpoint (from the active azd
@@ -200,6 +292,11 @@ func newRoutineServiceClient(ctx context.Context) (*routines.Client, error) {
 // concrete *azdext.AzdClient lets tests supply a fake: the client's
 // project field is unexported and no option overrides it.
 type serviceConfigReader interface {
+	Get(
+		ctx context.Context,
+		in *azdext.EmptyRequest,
+		opts ...grpc.CallOption,
+	) (*azdext.GetProjectResponse, error)
 	GetServiceConfigValue(
 		ctx context.Context,
 		in *azdext.GetServiceConfigValueRequest,

--- a/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target_test.go
+++ b/cli/azd/extensions/azure.ai.routines/internal/cmd/service_target_test.go
@@ -5,7 +5,13 @@ package cmd
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"azure.ai.routines/internal/exterrors"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/assert"
@@ -31,7 +37,7 @@ func TestParseRoutineServiceConfig_ServiceLevel(t *testing.T) {
 		Name:                 "nightly",
 		Host:                 aiRoutineHost,
 		AdditionalProperties: props,
-	})
+	}, "")
 	require.NoError(t, err)
 	assert.Equal(t, "nightly summary", body.Description)
 	require.NotNil(t, body.Enabled)
@@ -55,9 +61,167 @@ func TestParseRoutineServiceConfig_ConfigFallback(t *testing.T) {
 		Name:   "legacy",
 		Host:   aiRoutineHost,
 		Config: props,
-	})
+	}, "")
 	require.NoError(t, err)
 	assert.Equal(t, "legacy", body.Description)
+}
+
+func TestParseRoutineServiceConfig_FileRef(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "routine.yaml"),
+		[]byte("description: referenced routine\n"+
+			"triggers:\n"+
+			"  default:\n"+
+			"    type: schedule\n"+
+			"    cron_expression: \"0 2 * * *\"\n"+
+			"action:\n"+
+			"  type: invoke_agent_responses_api\n"+
+			"  agent_name: summarizer\n"+
+			"  input:\n"+
+			"    $ref: literal-payload-reference\n"+
+			"    project: literal-project-value\n"+
+			"    instructions: literal-instructions.md\n"),
+		0o600,
+	))
+	props, err := structpb.NewStruct(map[string]any{"$ref": "./routine.yaml"})
+	require.NoError(t, err)
+
+	body, err := parseRoutineServiceConfig(&azdext.ServiceConfig{
+		Name:                 "nightly",
+		Host:                 aiRoutineHost,
+		AdditionalProperties: props,
+	}, root)
+	require.NoError(t, err)
+	assert.Equal(t, "referenced routine", body.Description)
+	assert.Equal(t, "0 2 * * *", body.Triggers["default"].CronExpression)
+	require.NotNil(t, body.Action)
+	assert.Equal(t, "summarizer", body.Action.AgentName)
+	assert.Equal(t, map[string]any{
+		"$ref":         "literal-payload-reference",
+		"project":      "literal-project-value",
+		"instructions": "literal-instructions.md",
+	}, body.Action.Input)
+}
+
+func TestParseRoutineServiceConfig_FileRefOverlay(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "routine.yaml"),
+		[]byte("description: referenced routine\nenabled: true\n"),
+		0o600,
+	))
+	props, err := structpb.NewStruct(map[string]any{
+		"$ref":        "./routine.yaml",
+		"description": "inline override",
+	})
+	require.NoError(t, err)
+
+	body, err := parseRoutineServiceConfig(&azdext.ServiceConfig{
+		Name:                 "nightly",
+		Host:                 aiRoutineHost,
+		AdditionalProperties: props,
+	}, root)
+	require.NoError(t, err)
+	assert.Equal(t, "inline override", body.Description)
+	require.NotNil(t, body.Enabled)
+	assert.True(t, *body.Enabled)
+}
+
+func TestResolveRoutineServiceRef_AbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "routine.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("description: absolute routine\n"), 0o600))
+
+	resolved, err := resolveRoutineServiceRef(map[string]any{"$ref": path}, "")
+	require.NoError(t, err)
+	assert.Equal(t, "absolute routine", resolved["description"])
+}
+
+func TestResolveRoutineServiceRef_LocalPathWithPercent(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "100%-ready.yaml"),
+		[]byte("description: percent routine\n"),
+		0o600,
+	))
+
+	resolved, err := resolveRoutineServiceRef(map[string]any{"$ref": "./100%-ready.yaml"}, root)
+	require.NoError(t, err)
+	assert.Equal(t, "percent routine", resolved["description"])
+}
+
+func TestRemoteRoutineRefPattern(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, remoteRoutineRefPattern.MatchString("https://example.com/routine.yaml"))
+	assert.True(t, remoteRoutineRefPattern.MatchString("git+https://example.com/routine.yaml"))
+	assert.False(t, remoteRoutineRefPattern.MatchString("routine:v1.yaml"))
+	assert.False(t, remoteRoutineRefPattern.MatchString("./routine.yaml"))
+}
+
+func TestResolveRoutineServiceRef_ValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	markers := []string{"marker-user", "marker-password", "marker-signature"}
+	remoteRef := fmt.Sprintf(
+		"https://%s:%s@example.com/routine.yaml?sig=%s",
+		markers[0], markers[1], markers[2],
+	)
+	tests := []struct {
+		name        string
+		values      map[string]any
+		projectRoot string
+		message     string
+		notContains []string
+	}{
+		{
+			name: "non-string", values: map[string]any{"$ref": 42},
+			projectRoot: t.TempDir(), message: "non-empty string",
+		},
+		{
+			name: "empty", values: map[string]any{"$ref": "  "},
+			projectRoot: t.TempDir(), message: "non-empty string",
+		},
+		{
+			name:        "remote",
+			values:      map[string]any{"$ref": remoteRef},
+			projectRoot: t.TempDir(), message: "not supported",
+			notContains: append(markers, "example.com"),
+		},
+		{
+			name: "malformed remote", values: map[string]any{"$ref": "https://example.com/%zz"},
+			projectRoot: t.TempDir(), message: "not supported",
+		},
+		{
+			name: "missing project path", values: map[string]any{"$ref": "./routine.yaml"},
+			message: "without an azure.yaml project path",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := resolveRoutineServiceRef(test.values, test.projectRoot)
+			localErr, ok := errors.AsType[*azdext.LocalError](err)
+			require.True(t, ok)
+			assert.Equal(t, exterrors.CodeInvalidRoutineManifest, localErr.Code)
+			assert.Equal(t, azdext.LocalErrorCategoryValidation, localErr.Category)
+			assert.Contains(t, localErr.Message, test.message)
+			for _, secret := range test.notContains {
+				assert.NotContains(t, localErr.Message, secret)
+			}
+			assert.NotEmpty(t, localErr.Suggestion)
+		})
+	}
 }
 
 func TestExpandRoutineValue(t *testing.T) {
@@ -84,7 +248,19 @@ func TestExpandRoutineValue(t *testing.T) {
 
 // fakeServiceConfigReader reports a fixed env-declared result.
 type fakeServiceConfigReader struct {
-	found bool
+	found       bool
+	projectPath string
+	getErr      error
+}
+
+func (f fakeServiceConfigReader) Get(
+	context.Context,
+	*azdext.EmptyRequest,
+	...grpc.CallOption,
+) (*azdext.GetProjectResponse, error) {
+	return &azdext.GetProjectResponse{
+		Project: &azdext.ProjectConfig{Path: f.projectPath},
+	}, f.getErr
 }
 
 func (f fakeServiceConfigReader) GetServiceConfigValue(
@@ -93,6 +269,35 @@ func (f fakeServiceConfigReader) GetServiceConfigValue(
 	...grpc.CallOption,
 ) (*azdext.GetServiceConfigValueResponse, error) {
 	return &azdext.GetServiceConfigValueResponse{Found: f.found}, nil
+}
+
+func TestRoutineProjectRoot(t *testing.T) {
+	t.Parallel()
+
+	refProperties, err := structpb.NewStruct(map[string]any{"$ref": "./routine.yaml"})
+	require.NoError(t, err)
+	root, err := routineProjectRoot(
+		t.Context(),
+		fakeServiceConfigReader{projectPath: "/project"},
+		&azdext.ServiceConfig{Name: "nightly", AdditionalProperties: refProperties},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "/project", root)
+
+	root, err = routineProjectRoot(
+		t.Context(),
+		fakeServiceConfigReader{getErr: assert.AnError},
+		&azdext.ServiceConfig{Name: "inline"},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, root)
+
+	_, err = routineProjectRoot(
+		t.Context(),
+		fakeServiceConfigReader{getErr: assert.AnError},
+		&azdext.ServiceConfig{Name: "nightly", AdditionalProperties: refProperties},
+	)
+	require.ErrorIs(t, err, assert.AnError)
 }
 
 func TestRoutineEnvironmentValuesEmptyDeclaredIsolates(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.routines/schemas/azure.ai.routine.json
+++ b/cli/azd/extensions/azure.ai.routines/schemas/azure.ai.routine.json
@@ -6,6 +6,10 @@
   "type": "object",
   "additionalProperties": true,
   "properties": {
+    "$ref": {
+      "type": "string",
+      "description": "Local YAML or JSON routine manifest path. Sibling service properties override referenced values."
+    },
     "description": {
       "type": "string",
       "description": "Description of the routine."


### PR DESCRIPTION
## Summary

- resolve local YAML and JSON `$ref` definitions for `azure.ai.routine` services during `azd deploy`
- apply service-level sibling properties as shallow overrides
- keep nested `action.input.$ref` values opaque because they are Routine payload, not file includes
- reject remote references with structured validation guidance without echoing sensitive URL content
- document and schema-declare the Routine service `$ref` contract

Fixes #9089.

This is the first Routine-only stage of #9089. It changes only `cli/azd/extensions/azure.ai.routines/**` and contains no shared azd framework changes. The stacked follow-up #9736 adds opt-in project authoring from Routine commands.

The resolver intentionally handles only the service-root `$ref`. The shared recursive Foundry resolver is not used because it would interpret nested Routine payload fields such as `action.input.$ref` as file includes.

## Testing

- `go test ./... -count=1`
- `golangci-lint run --timeout 10m0s`
- `go build ./...`
- `go fix -diff ./...` (no changes)
- targeted coverage for local, absolute, percent-containing, colon-containing, remote, malformed, and shallow-overlay references
- direct coverage for deploy-time project-root lookup, inline services that require no lookup, and lookup failures