### PR TITLE
fix: harden AI coding agent detection

### DIFF
--- a/cli/azd/docs/environment-variables.md
+++ b/cli/azd/docs/environment-variables.md
@@ -60,6 +60,46 @@ integration.
 | `AZD_DEPLOY_{SERVICE}_SLOT_NAME` | Sets the App Service deployment slot target for a service. Replace `{SERVICE}` with the uppercase service name (hyphens become underscores). Set to `production` to deploy to the main app, or a slot name (e.g., `staging`). When slots exist and this is not set, `--no-prompt` mode fails with an error listing available targets. Applies to `host: appservice` only; Function Apps always deploy to the main site. |
 | `AZD_DEPLOY_{SERVICE}_SKIP_STATUS_CHECK` | If `true`, skips deployment status tracking for the named Linux App Service after the zip deployment request is accepted. By default, azd waits up to five minutes without a deployment status change. Each new status resets the five-minute wait. If the status remains unchanged, azd completes deployment with a warning. Useful when the target web app is intentionally stopped. Parsed as a boolean (`true`/`false`/`1`/`0`). `{SERVICE}` follows the same naming rules as `AZD_DEPLOY_{SERVICE}_SLOT_NAME`. |
 
+## AI Agent Detection
+
+`azd` detects when it is launched by a known AI coding agent and adjusts its behavior. Unless
+explicitly overridden, agent detection automatically enables no-prompt mode and treats the session
+as non-TTY. Detection checks the environment-variable markers below first, followed by known
+substrings in [`AZURE_DEV_USER_AGENT`](#telemetry--tracing), and then parent-process names.
+
+These markers are normally set by the agents; `azd` only reads them. When several markers are set,
+the first matching row wins. Exact-value markers must match the documented string and do not use the
+general boolean parsing convention. All other markers must contain a non-empty value.
+
+When the detected agent determines `execution.environment`, `azd` records only the fixed base value
+in the last column; fixed environment modifiers may be appended. Marker values are not added to
+telemetry by the agent-detection path.
+
+| Variable | Match | Detected agent (`execution.environment`) |
+| --- | --- | --- |
+| `AI_AGENT` | Exactly `github_copilot_app_agent` | GitHub Copilot App |
+| `AI_AGENT` | Exactly `github_copilot_vscode_agent` | GitHub Copilot VSCode |
+| `CODEX_CI` | Exactly `1` | Codex |
+| `CODEX_THREAD_ID` | Non-empty | Codex |
+| `CODEX_SESSION_ID` | Non-empty | Codex |
+| `CURSOR_AGENT` | Exactly `1` | Cursor |
+| `CURSOR_CONVERSATION_ID` | Non-empty | Cursor |
+| `CLAUDE_CODE` | Non-empty | Claude Code |
+| `CLAUDE_CODE_ENTRYPOINT` | Non-empty | Claude Code |
+| `GITHUB_COPILOT_CLI` | Non-empty | GitHub Copilot CLI |
+| `GH_COPILOT` | Non-empty | GitHub Copilot CLI |
+| `COPILOT_CLI` | Non-empty | GitHub Copilot CLI |
+| `GEMINI_CLI` | Non-empty | Gemini |
+| `GEMINI_CLI_NO_RELAUNCH` | Non-empty | Gemini |
+| `OPENCODE` | Non-empty | OpenCode |
+
+As a last resort, parent-process detection recognizes the `codex`, `claude`, `gemini`, `opencode`,
+and GitHub Copilot CLI executable names. It intentionally does not recognize `Cursor.exe`, because
+that name also identifies the regular Cursor desktop application.
+
+To disable all agent detection, set `AZD_DISABLE_AGENT_DETECT` to any non-empty value. This override
+is intended for tests and tooling and is unsupported for general use.
+
 ## azd exec
 
 The `azd exec` command runs commands and scripts with the active azd environment loaded into the child
@@ -182,7 +222,7 @@ specific version of the tool installed on the machine.
 | Variable | Description |
 | --- | --- |
 | `AZURE_DEV_COLLECT_TELEMETRY` | If false, disables telemetry collection. Telemetry is enabled by default. |
-| `AZURE_DEV_USER_AGENT` | Appends a custom string to the `User-Agent` header sent with Azure requests. |
+| `AZURE_DEV_USER_AGENT` | Appends a custom string to the `User-Agent` header sent with Azure requests. It is also inspected for [AI agent detection](#ai-agent-detection) using case-insensitive substring matching. |
 | `TRACEPARENT` | The W3C Trace Context `traceparent` header for distributed tracing. Automatically set by `azd` on extension processes for trace propagation. Not typically set by users. |
 | `TRACESTATE` | The W3C Trace Context `tracestate` header for vendor-specific trace data. Automatically set by `azd` alongside `TRACEPARENT`. Not typically set by users. |
 

--- a/cli/azd/docs/environment-variables.md
+++ b/cli/azd/docs/environment-variables.md
@@ -97,9 +97,6 @@ As a last resort, parent-process detection recognizes the `codex`, `claude`, `ge
 and GitHub Copilot CLI executable names. It intentionally does not recognize `Cursor.exe`, because
 that name also identifies the regular Cursor desktop application.
 
-To disable all agent detection, set `AZD_DISABLE_AGENT_DETECT` to any non-empty value. This override
-is intended for tests and tooling and is unsupported for general use.
-
 ## azd exec
 
 The `azd exec` command runs commands and scripts with the active azd environment loaded into the child
@@ -308,6 +305,7 @@ These variables are used by the Terraform provider integration to authenticate w
 | `AZD_DEBUG_DOTNET_APPHOST_IGNORE_UNSUPPORTED_RESOURCES` | If true, ignores unsupported resources in Aspire app host. |
 | `AZD_DEBUG_SERVER_DEBUG_ENDPOINTS` | If true, enables debug endpoints in server mode. |
 | `AZD_DEBUG_EXPERIMENTATION_TAS_ENDPOINT` | Overrides the experimentation TAS endpoint URL. |
+| `AZD_DISABLE_AGENT_DETECT` | If set to any non-empty value, disables AI agent detection. Used by tests and tooling that need interactive behavior. |
 | `AZD_SUBSCRIPTIONS_FETCH_MAX_CONCURRENCY` | Limits the maximum concurrency when fetching subscriptions. |
 | `DEPLOYMENT_STACKS_BYPASS_STACK_OUT_OF_SYNC_ERROR` | If true, bypasses Deployment Stacks out-of-sync errors. |
 

--- a/cli/azd/internal/runcontext/agentdetect/detect_env.go
+++ b/cli/azd/internal/runcontext/agentdetect/detect_env.go
@@ -32,10 +32,8 @@ var knownEnvVarPatterns = []envVarPattern{
 		agentType:     AgentTypeGitHubCopilotVSCode,
 	},
 
-	// Claude Code - Anthropic's coding agent
-	{envVar: "CLAUDE_CODE", agentType: AgentTypeClaudeCode},
-	{envVar: "CLAUDE_CODE_ENTRYPOINT", agentType: AgentTypeClaudeCode},
-
+	// Session-scoped Codex and Cursor markers take precedence over Claude markers
+	// that may be inherited by nested tools.
 	// Codex - OpenAI's coding agent
 	{envVar: "CODEX_CI", expectedValue: "1", agentType: AgentTypeCodex},
 	{envVar: "CODEX_THREAD_ID", agentType: AgentTypeCodex},
@@ -44,6 +42,10 @@ var knownEnvVarPatterns = []envVarPattern{
 	// Cursor - Cursor's coding agent
 	{envVar: "CURSOR_AGENT", expectedValue: "1", agentType: AgentTypeCursor},
 	{envVar: "CURSOR_CONVERSATION_ID", agentType: AgentTypeCursor},
+
+	// Claude Code - Anthropic's coding agent
+	{envVar: "CLAUDE_CODE", agentType: AgentTypeClaudeCode},
+	{envVar: "CLAUDE_CODE_ENTRYPOINT", agentType: AgentTypeClaudeCode},
 
 	// GitHub Copilot CLI
 	{envVar: "GITHUB_COPILOT_CLI", agentType: AgentTypeGitHubCopilotCLI},
@@ -62,7 +64,7 @@ var knownEnvVarPatterns = []envVarPattern{
 func detectFromEnvVars() AgentInfo {
 	for _, pattern := range knownEnvVarPatterns {
 		value, exists := os.LookupEnv(pattern.envVar)
-		if !exists || (pattern.expectedValue != "" && value != pattern.expectedValue) {
+		if !exists || value == "" || (pattern.expectedValue != "" && value != pattern.expectedValue) {
 			continue
 		}
 

--- a/cli/azd/internal/runcontext/agentdetect/detect_process.go
+++ b/cli/azd/internal/runcontext/agentdetect/detect_process.go
@@ -15,6 +15,13 @@ var processNamePatterns = []struct {
 	agentType  AgentType
 	exactMatch bool
 }{
+	// Codex - OpenAI's coding agent
+	{
+		patterns:  []string{"codex"},
+		agentType: AgentTypeCodex,
+		// Avoid classifying unrelated executable paths containing "codex".
+		exactMatch: true,
+	},
 	// Claude Code (Anthropic) - installed via npm, homebrew, or direct download
 	{
 		patterns:  []string{"claude", "claude-code"},

--- a/cli/azd/internal/runcontext/agentdetect/detect_test.go
+++ b/cli/azd/internal/runcontext/agentdetect/detect_test.go
@@ -115,7 +115,7 @@ func TestDetectFromEnvVars(t *testing.T) {
 		},
 		{
 			name:          "Claude Code via CLAUDE_CODE_ENTRYPOINT",
-			envVars:       map[string]string{"CLAUDE_CODE_ENTRYPOINT": "/usr/bin/claude"},
+			envVars:       map[string]string{"CLAUDE_CODE_ENTRYPOINT": "cli"},
 			expectedAgent: AgentTypeClaudeCode,
 			detected:      true,
 		},
@@ -144,6 +144,36 @@ func TestDetectFromEnvVars(t *testing.T) {
 			detected:      false,
 		},
 		{
+			name: "Codex takes precedence over inherited Claude marker",
+			envVars: map[string]string{
+				"CODEX_THREAD_ID":        "thread-id",
+				"CLAUDE_CODE_ENTRYPOINT": "cli",
+			},
+			expectedAgent: AgentTypeCodex,
+			detected:      true,
+		},
+		{
+			name: "Codex takes precedence over Cursor",
+			envVars: map[string]string{
+				"CODEX_THREAD_ID": "thread-id",
+				"CURSOR_AGENT":    "1",
+			},
+			expectedAgent: AgentTypeCodex,
+			detected:      true,
+		},
+		{
+			name:          "Empty Codex thread ID is ignored",
+			envVars:       map[string]string{"CODEX_THREAD_ID": ""},
+			expectedAgent: AgentTypeUnknown,
+			detected:      false,
+		},
+		{
+			name:          "Empty Codex session ID is ignored",
+			envVars:       map[string]string{"CODEX_SESSION_ID": ""},
+			expectedAgent: AgentTypeUnknown,
+			detected:      false,
+		},
+		{
 			name:          "Cursor via CURSOR_AGENT",
 			envVars:       map[string]string{"CURSOR_AGENT": "1"},
 			expectedAgent: AgentTypeCursor,
@@ -158,6 +188,21 @@ func TestDetectFromEnvVars(t *testing.T) {
 		{
 			name:          "CURSOR_AGENT requires exact value",
 			envVars:       map[string]string{"CURSOR_AGENT": "true"},
+			expectedAgent: AgentTypeUnknown,
+			detected:      false,
+		},
+		{
+			name: "Cursor takes precedence over inherited Claude marker",
+			envVars: map[string]string{
+				"CURSOR_AGENT":           "1",
+				"CLAUDE_CODE_ENTRYPOINT": "cli",
+			},
+			expectedAgent: AgentTypeCursor,
+			detected:      true,
+		},
+		{
+			name:          "Empty Cursor conversation ID is ignored",
+			envVars:       map[string]string{"CURSOR_CONVERSATION_ID": ""},
 			expectedAgent: AgentTypeUnknown,
 			detected:      false,
 		},
@@ -321,6 +366,13 @@ func TestMatchProcessToAgent(t *testing.T) {
 			expectedAgent: AgentTypeClaudeCode,
 		},
 		{
+			name: "Codex process name",
+			processInfo: parentProcessInfo{
+				Name: "codex",
+			},
+			expectedAgent: AgentTypeCodex,
+		},
+		{
 			name: "GitHub Copilot CLI process name",
 			processInfo: parentProcessInfo{
 				Name: "gh-copilot",
@@ -372,6 +424,14 @@ func TestMatchProcessToAgent(t *testing.T) {
 			expectedAgent: AgentTypeUnknown,
 		},
 		{
+			name: "Cursor desktop app is not Cursor agent",
+			processInfo: parentProcessInfo{
+				Name:       "Cursor.exe",
+				Executable: `C:\Users\example\AppData\Local\Programs\Cursor\Cursor.exe`,
+			},
+			expectedAgent: AgentTypeUnknown,
+		},
+		{
 			name: "Copilot name in host path does not match",
 			processInfo: parentProcessInfo{
 				Name:       "pwsh.exe",
@@ -383,6 +443,13 @@ func TestMatchProcessToAgent(t *testing.T) {
 			name: "Copilot name substring does not match",
 			processInfo: parentProcessInfo{
 				Name: "my-copilot-wrapper",
+			},
+			expectedAgent: AgentTypeUnknown,
+		},
+		{
+			name: "Codex name substring does not match",
+			processInfo: parentProcessInfo{
+				Name: "codex-wrapper",
 			},
 			expectedAgent: AgentTypeUnknown,
 		},
@@ -435,6 +502,7 @@ func TestMatchProcessToAgent_ExactExecutableNames(t *testing.T) {
 	}{
 		{"claude", AgentTypeClaudeCode},
 		{"claude-code", AgentTypeClaudeCode},
+		{"codex", AgentTypeCodex},
 		{"copilot", AgentTypeGitHubCopilotCLI},
 		{"copilot-cli", AgentTypeGitHubCopilotCLI},
 		{"gh-copilot", AgentTypeGitHubCopilotCLI},

--- a/docs/reference/telemetry-data.md
+++ b/docs/reference/telemetry-data.md
@@ -646,7 +646,7 @@ The `execution.environment` field identifies where azd is running. Format: `<env
 | `GitHub Actions` | GitHub Actions CI |
 | `Azure Pipelines` | Azure Pipelines CI |
 | `GitHub Codespaces` | GitHub Codespaces |
-| Other CI systems | `AppVeyor`, `Bamboo`, `BitBucket Pipelines`, `Travis CI`, `Circle CI`, `GitLab CI`, `Jenkins`, `AWS CodeBuild`, `Google Cloud Build`, `TeamCity`, `JetBrains Space` |
+| Other CI systems | `UnknownCI`, `AppVeyor`, `Bamboo`, `BitBucket Pipelines`, `Travis CI`, `Circle CI`, `GitLab CI`, `Jenkins`, `AWS CodeBuild`, `TeamCity`, `JetBrains Space` |
 
 **Modifiers:** `Azure App Spaces Portal` and `Microsoft Foundry Skill` may be appended as modifiers (`;` separated).
 

--- a/docs/specs/metrics-audit/telemetry-schema.md
+++ b/docs/specs/metrics-audit/telemetry-schema.md
@@ -60,8 +60,21 @@ These are set once at process startup via `resource.New()` and attached to every
 | Runtime version | `process.runtime.version` | SystemMetadata | PerformanceAndHealth | Go version |
 | Machine ID | `machine.id` | EndUserPseudonymizedInformation | BusinessInsight | MAC address hash |
 | Dev Device ID | `machine.devdeviceid` | EndUserPseudonymizedInformation | BusinessInsight | SQM User ID |
-| Execution environment | `execution.environment` | SystemMetadata | BusinessInsight | CI system detection |
+| Execution environment | `execution.environment` | SystemMetadata | BusinessInsight | Bounded execution-context value; see allowed values below |
 | Installer | `service.installer` | SystemMetadata | FeatureInsight | How azd was installed |
+
+#### Execution environment allowed values
+
+`execution.environment` contains one base environment and may include semicolon-separated modifiers:
+
+- Local and hosted environments: `Desktop`, `Visual Studio`, `Visual Studio Code`,
+  `VS Code Azure GitHub Copilot`, `Azure CloudShell`, `GitHub Codespaces`.
+- AI coding agents: `Claude Code`, `Codex`, `Cursor`, `GitHub Copilot CLI`, `GitHub Copilot App`,
+  `GitHub Copilot VSCode`, `Gemini`, `OpenCode`.
+- CI environments: `UnknownCI`, `Azure Pipelines`, `GitHub Actions`, `AppVeyor`, `Bamboo`,
+  `BitBucket Pipelines`, `Travis CI`, `Circle CI`, `GitLab CI`, `Jenkins`, `AWS CodeBuild`,
+  `TeamCity`, `JetBrains Space`.
+- Optional modifiers: `Azure App Spaces Portal`, `Microsoft Foundry Skill`.
 
 ### Experimentation
 


### PR DESCRIPTION
## Summary

- complete the telemetry and environment-variable documentation follow-up for Codex and Cursor detection
- document all AI agent markers that `azd` reads and clarify that marker values are not added to telemetry
- ignore empty agent markers and prioritize active Codex/Cursor markers over inherited Claude markers
- add safe Codex parent-process detection without treating the Cursor desktop IDE as an agent
- align the documented `execution.environment` values with the environments azd actually emits

## Context

This is a follow-up to https://github.com/Azure/azure-dev/issues/9699 and PR #9698. PR #9698 added Codex and Cursor recognition, but the authoritative telemetry schema and environment-variable reference were not updated alongside the implementation.

The identifier variables are used only as agent-presence signals. Their values are not included in `execution.environment` or otherwise added to telemetry by the agent-detection path.

## Validation

- targeted agent detection, terminal, telemetry resource, and no-prompt tests
- documentation spell check
- `git diff --check`