### PR TITLE
feat(azure.ai.agents): update digital worker contracts

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 
+- [[#9776]](https://github.com/Azure/azure-dev/pull/9776) Update Digital Worker agent and Microsoft 365 publish contracts with service-side type detection, optional permission scopes, and access boundaries.
 - [[#9586]](https://github.com/Azure/azure-dev/pull/9586) Add support for private non-ACR registry connections when authoring and deploying hosted agents.
 - [[#9634]](https://github.com/Azure/azure-dev/pull/9634) Update prompt voice agents to use the unified Agents API with versioned voice endpoints.
 - [[#9655]](https://github.com/Azure/azure-dev/pull/9655) Add advanced prompt voice settings for audio, turn detection, modalities, tools, and service features.

--- a/cli/azd/extensions/azure.ai.agents/README.md
+++ b/cli/azd/extensions/azure.ai.agents/README.md
@@ -35,21 +35,29 @@ services:
       publish:
         publishScope: tenant
         agentDisplayName: My Digital Worker
-        agenticUserTemplate:
-          id: digitalWorkerTemplate
-          file: agenticUserTemplateManifest.json
-          schemaVersion: 0.1.0-preview
-          communicationProtocol: activityProtocol
+        optionalPermissionScopes:
+          - resourceAppId: ea9ffc3e-8a23-4a7d-836d-234d7c7565c1
+            scopes:
+              - McpServers.Mail.All
+              - McpServers.Calendar.All
+        accessBoundaries:
+          - read.1on1.developers
+          - write.1on1.developers
 ```
 
 The `activity.publish` block is shared Microsoft 365 app publish metadata for
 Activity use cases (including `simple`). For `digital_worker`, azd enforces
-additional constraints: `publish` must be present, `publishScope` must be
-`tenant`, and `agenticUserTemplate` must include `id`, `file`,
-`schemaVersion`, and `communicationProtocol`. The publish request sets
-`publishAsAutopilot` automatically to `true` for this use case; users do not
-need to declare it in YAML. The Agent Identity Blueprint ID is generated during
-deployment and added to the publish request automatically.
+tenant scope and sends `digital_worker_type: m365` when creating the agent.
+After deployment, the service-returned Digital Worker type controls pack and
+publish behavior. The publish request sets `publishAsAutopilot` automatically;
+the publish block itself is optional.
+
+`optionalPermissionScopes` selects additional Microsoft 365 permissions such as
+WorkIQ MCP scopes. `accessBoundaries` accepts the supported
+`read.1on1.developers`, `write.1on1.developers`,
+`read.group.developers`, and `write.group.developers` values. Omitting
+`accessBoundaries` preserves the current service configuration; an explicit
+empty array clears it.
 
 ```bash
 azd deploy
@@ -61,7 +69,10 @@ For `simple` Activity agents, `publishScope` accepts `shared` or `tenant`. For
 An explicit `azd ai agent publish --scope <scope>` overrides the configured
 value where allowed by the use case. Use `--display-name` and `--app-version`
 to override the corresponding configured publish metadata for one command
-invocation.
+invocation. Repeat `--optional-permission-scope <resource-app-id>=<scope>` or
+`--access-boundary <boundary>` to replace the configured values for one
+publication. Use `--clear-access-boundaries` to send an explicit empty array and
+clear existing boundaries.
 
 The Agent Inspector UI binds port `8087` by default. Use `--inspector-port` to
 move it, which is what you need when running two agents side by side or when a

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_activity_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_activity_test.go
@@ -84,12 +84,6 @@ func TestResolveServiceActivityProfileUsesConfiguredUseCase(t *testing.T) {
 				"useCase": "digital_worker",
 				"publish": map[string]any{
 					"publishScope": "tenant",
-					"agenticUserTemplate": map[string]any{
-						"id":                    "digitalWorkerTemplate",
-						"file":                  "agenticUserTemplateManifest.json",
-						"schemaVersion":         "0.1.0-preview",
-						"communicationProtocol": "activityProtocol",
-					},
 				},
 			},
 			want: project.ActivityUseCaseDigitalWorker,
@@ -140,11 +134,6 @@ func TestResolveServiceActivityProfileUsesConfiguredUseCaseFromFileRef(t *testin
 		"  useCase: digital_worker",
 		"  publish:",
 		"    publishScope: tenant",
-		"    agenticUserTemplate:",
-		"      id: digitalWorkerTemplate",
-		"      file: agenticUserTemplateManifest.json",
-		"      schemaVersion: 0.1.0-preview",
-		"      communicationProtocol: activityProtocol",
 	}, "\n")
 	require.NoError(t, os.WriteFile(definitionPath, []byte(referenced), 0600))
 
@@ -195,11 +184,6 @@ func TestShouldProvisionActivityBotUsesCanonicalUseCaseResolution(t *testing.T) 
 			"  useCase: digital_worker",
 			"  publish:",
 			"    publishScope: tenant",
-			"    agenticUserTemplate:",
-			"      id: digitalWorkerTemplate",
-			"      file: agenticUserTemplateManifest.json",
-			"      schemaVersion: 0.1.0-preview",
-			"      communicationProtocol: activityProtocol",
 		}, "\n")
 		require.NoError(t, os.WriteFile(definitionPath, []byte(definition), 0600))
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
@@ -27,13 +27,18 @@ var teamsPublishScopes = []teamsPackScope{
 }
 
 type publishFlags struct {
-	name        string
-	scope       string
-	scopeSet    bool
-	displayName string
-	appVersion  string
-	output      string
-	noPrompt    bool
+	name                        string
+	scope                       string
+	scopeSet                    bool
+	displayName                 string
+	appVersion                  string
+	optionalPermissionScopes    []string
+	optionalPermissionScopesSet bool
+	accessBoundaries            []string
+	accessBoundariesSet         bool
+	clearAccessBoundaries       bool
+	output                      string
+	noPrompt                    bool
 }
 
 func newPublishCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
@@ -72,6 +77,8 @@ func newPublishCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 				flags.name = args[0]
 			}
 			flags.scopeSet = cmd.Flags().Changed("scope")
+			flags.optionalPermissionScopesSet = cmd.Flags().Changed("optional-permission-scope")
+			flags.accessBoundariesSet = cmd.Flags().Changed("access-boundary")
 			flags.output = extCtx.OutputFormat
 			flags.noPrompt = extCtx.NoPrompt
 
@@ -89,6 +96,25 @@ func newPublishCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 	cmd.Flags().StringVar(&flags.appVersion, "app-version", "",
 		"Version stamped into the Teams app manifest. If specified, it overrides activity.publish.appVersion "+
 			"in azure.yaml; otherwise azd uses the azure.yaml value, and falls back to 1.0.0.")
+	cmd.Flags().StringArrayVar(
+		&flags.optionalPermissionScopes,
+		"optional-permission-scope",
+		nil,
+		"Digital Worker permission in <resource-app-id>=<scope> form. Repeat to select multiple scopes.",
+	)
+	cmd.Flags().StringArrayVar(
+		&flags.accessBoundaries,
+		"access-boundary",
+		nil,
+		"Digital Worker access boundary. Repeat to select multiple developer boundaries.",
+	)
+	cmd.Flags().BoolVar(
+		&flags.clearAccessBoundaries,
+		"clear-access-boundaries",
+		false,
+		"Clear all existing Digital Worker access boundaries.",
+	)
+	cmd.MarkFlagsMutuallyExclusive("access-boundary", "clear-access-boundaries")
 
 	azdext.RegisterFlagOptions(cmd, azdext.FlagOptions{
 		Name:          "output",
@@ -120,15 +146,20 @@ func (a *PublishAction) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	optionalPermissionScopes, accessBoundaries, err := resolveDigitalWorkerPublishInputs(a.flags, packCtx)
+	if err != nil {
+		return err
+	}
 
 	request := buildTeamsAppPackageRequest(packCtx.botArmID, teamsAppRequestOptions{
-		scope:             scope,
-		agentName:         packCtx.agentName,
-		useCase:           packCtx.activityProfile.UseCase,
-		displayName:       a.flags.displayName,
-		appVersion:        a.flags.appVersion,
-		blueprintClientID: packCtx.blueprintClientID,
-		publish:           activityPublishConfig(packCtx),
+		scope:                    scope,
+		agentName:                packCtx.agentName,
+		useCase:                  packCtx.activityProfile.UseCase,
+		displayName:              a.flags.displayName,
+		appVersion:               a.flags.appVersion,
+		publish:                  activityPublishConfig(packCtx),
+		optionalPermissionScopes: optionalPermissionScopes,
+		accessBoundaries:         accessBoundaries,
 	})
 
 	if a.flags.output != "json" {
@@ -153,6 +184,113 @@ func (a *PublishAction) Run(ctx context.Context) error {
 	return writePublishResult(
 		os.Stdout, a.flags.output, result, scope, request.AgentDisplayName, packCtx.agentName, deepLink, isDigitalWorker,
 	)
+}
+
+func resolveDigitalWorkerPublishInputs(
+	flags *publishFlags,
+	packCtx *teamsPackContext,
+) ([]agent_api.Microsoft365PermissionScopes, *[]string, error) {
+	isDigitalWorker := packCtx.activityProfile.UseCase == project.ActivityUseCaseDigitalWorker
+	publish := activityPublishConfig(packCtx)
+	if !isDigitalWorker {
+		hasDigitalWorkerConfig := publish != nil &&
+			(len(publish.OptionalPermissionScopes) > 0 || publish.AccessBoundaries != nil)
+		if flags.optionalPermissionScopesSet || flags.accessBoundariesSet ||
+			flags.clearAccessBoundaries || hasDigitalWorkerConfig {
+			return nil, nil, exterrors.Validation(
+				exterrors.CodeInvalidServiceConfig,
+				"Digital Worker permission scopes and access boundaries cannot be used for a simple Activity agent",
+				"remove --optional-permission-scope and --access-boundary, or publish a Digital Worker",
+			)
+		}
+		return nil, nil, nil
+	}
+
+	var permissions []agent_api.Microsoft365PermissionScopes
+	var boundaries *[]string
+	if publish != nil {
+		if err := project.ValidateDigitalWorkerPublishConfig(publish); err != nil {
+			return nil, nil, exterrors.Validation(
+				exterrors.CodeInvalidServiceConfig,
+				fmt.Sprintf("invalid Digital Worker publish configuration: %s", err),
+				"fix activity.publish in azure.yaml",
+			)
+		}
+		permissions = make([]agent_api.Microsoft365PermissionScopes, 0, len(publish.OptionalPermissionScopes))
+		for _, permission := range publish.OptionalPermissionScopes {
+			scopes := make([]string, 0, len(permission.Scopes))
+			for _, scope := range permission.Scopes {
+				scopes = append(scopes, strings.TrimSpace(scope))
+			}
+			permissions = append(permissions, agent_api.Microsoft365PermissionScopes{
+				ResourceAppID: strings.TrimSpace(permission.ResourceAppID),
+				Scopes:        scopes,
+			})
+		}
+		if publish.AccessBoundaries != nil {
+			values := append([]string(nil), (*publish.AccessBoundaries)...)
+			boundaries = &values
+		}
+	}
+
+	if flags.optionalPermissionScopesSet {
+		var err error
+		permissions, err = parseOptionalPermissionScopeFlags(flags.optionalPermissionScopes)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	if flags.accessBoundariesSet {
+		values := make([]string, 0, len(flags.accessBoundaries))
+		for _, boundary := range flags.accessBoundaries {
+			values = append(values, strings.TrimSpace(boundary))
+		}
+		if err := project.ValidateDigitalWorkerAccessBoundaries(values); err != nil {
+			return nil, nil, exterrors.Validation(
+				exterrors.CodeInvalidServiceConfig,
+				fmt.Sprintf("invalid --access-boundary: %s", err),
+				"use a supported *.developers access boundary",
+			)
+		}
+		boundaries = &values
+	} else if flags.clearAccessBoundaries {
+		values := []string{}
+		boundaries = &values
+	}
+	return permissions, boundaries, nil
+}
+
+func parseOptionalPermissionScopeFlags(values []string) ([]agent_api.Microsoft365PermissionScopes, error) {
+	permissions := make([]agent_api.Microsoft365PermissionScopes, 0)
+	resourceIndexes := make(map[string]int)
+	seen := make(map[string]struct{})
+	for _, value := range values {
+		resourceAppID, scope, found := strings.Cut(value, "=")
+		resourceAppID = strings.TrimSpace(resourceAppID)
+		scope = strings.TrimSpace(scope)
+		if !found || resourceAppID == "" || scope == "" {
+			return nil, exterrors.Validation(
+				exterrors.CodeInvalidServiceConfig,
+				fmt.Sprintf("invalid optional permission scope %q", value),
+				"use --optional-permission-scope <resource-app-id>=<scope>",
+			)
+		}
+		key := resourceAppID + "\x00" + scope
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		index, ok := resourceIndexes[resourceAppID]
+		if !ok {
+			index = len(permissions)
+			resourceIndexes[resourceAppID] = index
+			permissions = append(permissions, agent_api.Microsoft365PermissionScopes{
+				ResourceAppID: resourceAppID,
+			})
+		}
+		permissions[index].Scopes = append(permissions[index].Scopes, scope)
+	}
+	return permissions, nil
 }
 
 func resolvePublishScope(flags *publishFlags, packCtx *teamsPackContext) (teamsPackScope, error) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish_test.go
@@ -252,8 +252,8 @@ func TestBuildTeamsAppPackageRequestUsesPublishMetadataForSimpleActivity(t *test
 	require.Equal(t, "Configured Activity agent", configured.AgentDisplayName)
 	require.Equal(t, "Shared", configured.PublishScope)
 	require.False(t, configured.PublishAsAutopilot)
-	require.False(t, configured.UseAgenticUserTemplate)
-	require.Nil(t, configured.AgenticUserTemplate)
+	require.Empty(t, configured.OptionalPermissionScopes)
+	require.Nil(t, configured.AccessBoundaries)
 
 	explicit := buildTeamsAppPackageRequest("", teamsAppRequestOptions{
 		displayName: "CLI Activity agent",
@@ -265,8 +265,74 @@ func TestBuildTeamsAppPackageRequestUsesPublishMetadataForSimpleActivity(t *test
 	require.Equal(t, "CLI Activity agent", explicit.AgentDisplayName)
 	require.Equal(t, "Tenant", explicit.PublishScope)
 	require.False(t, explicit.PublishAsAutopilot)
-	require.False(t, explicit.UseAgenticUserTemplate)
-	require.Nil(t, explicit.AgenticUserTemplate)
+	require.Empty(t, explicit.OptionalPermissionScopes)
+	require.Nil(t, explicit.AccessBoundaries)
+}
+
+func TestParseOptionalPermissionScopeFlags(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseOptionalPermissionScopeFlags([]string{
+		"resource-a=McpServers.Mail.All",
+		"resource-b=Ado.Mcp.Tools",
+		"resource-a=McpServers.Calendar.All",
+		"resource-a=McpServers.Mail.All",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []agent_api.Microsoft365PermissionScopes{
+		{ResourceAppID: "resource-a", Scopes: []string{"McpServers.Mail.All", "McpServers.Calendar.All"}},
+		{ResourceAppID: "resource-b", Scopes: []string{"Ado.Mcp.Tools"}},
+	}, got)
+}
+
+func TestParseOptionalPermissionScopeFlagsRejectsInvalidValue(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseOptionalPermissionScopeFlags([]string{"McpServers.Mail.All"})
+	require.ErrorContains(t, err, "invalid optional permission scope")
+}
+
+func TestResolveDigitalWorkerPublishInputs(t *testing.T) {
+	t.Parallel()
+
+	configBoundaries := []string{"read.1on1.developers"}
+	packCtx := digitalWorkerPackContext("tenant")
+	packCtx.activitySettings.Publish.OptionalPermissionScopes = []project.Microsoft365PermissionScopes{
+		{ResourceAppID: "configured-app", Scopes: []string{"Configured.Scope"}},
+	}
+	packCtx.activitySettings.Publish.AccessBoundaries = &configBoundaries
+
+	permissions, boundaries, err := resolveDigitalWorkerPublishInputs(&publishFlags{}, packCtx)
+	require.NoError(t, err)
+	require.Equal(t, "configured-app", permissions[0].ResourceAppID)
+	require.Equal(t, configBoundaries, *boundaries)
+
+	permissions, boundaries, err = resolveDigitalWorkerPublishInputs(&publishFlags{
+		optionalPermissionScopes:    []string{"flag-app=Flag.Scope"},
+		optionalPermissionScopesSet: true,
+		accessBoundaries:            []string{"write.group.developers"},
+		accessBoundariesSet:         true,
+	}, packCtx)
+	require.NoError(t, err)
+	require.Equal(t, "flag-app", permissions[0].ResourceAppID)
+	require.Equal(t, []string{"write.group.developers"}, *boundaries)
+
+	_, boundaries, err = resolveDigitalWorkerPublishInputs(&publishFlags{
+		clearAccessBoundaries: true,
+	}, packCtx)
+	require.NoError(t, err)
+	require.NotNil(t, boundaries)
+	require.Empty(t, *boundaries)
+}
+
+func TestResolveDigitalWorkerPublishInputsRejectsSimpleAgentFlags(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := resolveDigitalWorkerPublishInputs(&publishFlags{
+		accessBoundaries:    []string{"read.1on1.developers"},
+		accessBoundariesSet: true,
+	}, activityPackContext(project.ActivityUseCaseSimple, "shared"))
+	require.ErrorContains(t, err, "cannot be used for a simple Activity agent")
 }
 
 func digitalWorkerPackContext(publishScope string) *teamsPackContext {
@@ -278,16 +344,9 @@ func activityPackContext(useCase project.ActivityUseCase, publishScope string) *
 		activityProfile: project.ActivityProfile{UseCase: useCase},
 		activitySettings: &project.ActivitySettings{
 			Publish: &project.ActivityPublishConfig{
-				PublishAsAutopilot: true,
-				PublishScope:       publishScope,
-				AppVersion:         "2.3.4",
-				AgentDisplayName:   "Configured Activity agent",
-				AgenticUserTemplate: &project.AgenticUserTemplateConfig{
-					ID:                    "digitalWorkerTemplate",
-					File:                  "agenticUserTemplateManifest.json",
-					SchemaVersion:         "0.1.0-preview",
-					CommunicationProtocol: "activityProtocol",
-				},
+				PublishScope:     publishScope,
+				AppVersion:       "2.3.4",
+				AgentDisplayName: "Configured Activity agent",
 			},
 		},
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
@@ -84,14 +84,13 @@ func teamsPackScopeFlags() []string {
 // loudly when the agent is missing, is not an activity agent, or has not been
 // deployed yet.
 type teamsPackContext struct {
-	proj              *azdext.ProjectConfig
-	svc               *azdext.ServiceConfig
-	agentName         string
-	botArmID          string
-	blueprintClientID string
-	agentClient       *agent_api.AgentClient
-	activityProfile   project.ActivityProfile
-	activitySettings  *project.ActivitySettings
+	proj             *azdext.ProjectConfig
+	svc              *azdext.ServiceConfig
+	agentName        string
+	botArmID         string
+	agentClient      *agent_api.AgentClient
+	activityProfile  project.ActivityProfile
+	activitySettings *project.ActivitySettings
 }
 
 // resolveTeamsPackContext resolves the target activity agent and derives the Azure
@@ -180,21 +179,32 @@ func resolveTeamsPackContext(
 		)
 	}
 
-	botArmID := ""
-	blueprintClientID := ""
-	if activityProfile.UseCase == project.ActivityUseCaseDigitalWorker {
-		blueprintClientID, err = readEnvValue(
-			ctx, azdClient, envName, envkey.AgentBlueprintClientID(svc.Name),
+	endpoint, err := resolveAgentEndpoint(ctx, "", "")
+	if err != nil {
+		return nil, err
+	}
+	credential, err := newAgentCredential()
+	if err != nil {
+		return nil, err
+	}
+	agentClient := agent_api.NewAgentClient(endpoint, credential)
+	remoteVersion, err := agentClient.GetAgentVersion(
+		ctx, agentName, version, agent_api.AgentEndpointAPIVersion,
+	)
+	if err != nil {
+		return nil, exterrors.ServiceFromAzure(err, exterrors.OpGetAgent)
+	}
+	activityProfile, err = project.ResolveDeployedActivityProfile(activityProfile, remoteVersion.DigitalWorkerType)
+	if err != nil {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			err.Error(),
+			"redeploy the agent so its service-side digital_worker_type matches activity.useCase",
 		)
-		if err != nil {
-			return nil, exterrors.Dependency(
-				exterrors.CodeAgentNotDeployed,
-				fmt.Sprintf("agent %q has no recorded blueprint client ID in environment %q", agentName, envName),
-				"run 'azd deploy' first; the blueprint client ID is required before "+
-					"publishing a digital_worker agent",
-			)
-		}
-	} else {
+	}
+
+	botArmID := ""
+	if activityProfile.UseCase != project.ActivityUseCaseDigitalWorker {
 		subscriptionID, readErr := readEnvValue(ctx, azdClient, envName, "AZURE_SUBSCRIPTION_ID")
 		if readErr != nil {
 			return nil, readErr
@@ -221,24 +231,14 @@ func resolveTeamsPackContext(
 		}
 	}
 
-	endpoint, err := resolveAgentEndpoint(ctx, "", "")
-	if err != nil {
-		return nil, err
-	}
-	credential, err := newAgentCredential()
-	if err != nil {
-		return nil, err
-	}
-
 	return &teamsPackContext{
-		proj:              proj,
-		svc:               svc,
-		agentName:         agentName,
-		botArmID:          botArmID,
-		blueprintClientID: blueprintClientID,
-		agentClient:       agent_api.NewAgentClient(endpoint, credential),
-		activityProfile:   activityProfile,
-		activitySettings:  serviceTargetConfig.Activity,
+		proj:             proj,
+		svc:              svc,
+		agentName:        agentName,
+		botArmID:         botArmID,
+		agentClient:      agentClient,
+		activityProfile:  activityProfile,
+		activitySettings: serviceTargetConfig.Activity,
 	}, nil
 }
 
@@ -263,13 +263,14 @@ func teamsBotArmID(subscriptionID, defaultResourceGroup, botName, botResourceGro
 // app package/publish request. Zero-value fields fall back to sensible defaults
 // derived from the agent name.
 type teamsAppRequestOptions struct {
-	scope             teamsPackScope
-	agentName         string
-	useCase           project.ActivityUseCase
-	displayName       string
-	appVersion        string
-	blueprintClientID string
-	publish           *project.ActivityPublishConfig
+	scope                    teamsPackScope
+	agentName                string
+	useCase                  project.ActivityUseCase
+	displayName              string
+	appVersion               string
+	publish                  *project.ActivityPublishConfig
+	optionalPermissionScopes []agent_api.Microsoft365PermissionScopes
+	accessBoundaries         *[]string
 }
 
 // buildTeamsAppPackageRequest assembles the Microsoft 365 request body shared by
@@ -322,20 +323,12 @@ func buildTeamsAppPackageRequest(
 		TermsOfUseURL:            "https://learn.microsoft.com/azure/ai-foundry/",
 		CanRespondWithoutMention: true,
 	}
+	if opts.useCase == project.ActivityUseCaseDigitalWorker {
+		request.PublishAsAutopilot = true
+		request.OptionalPermissionScopes = opts.optionalPermissionScopes
+		request.AccessBoundaries = opts.accessBoundaries
+	}
 	if publish != nil {
-		if opts.useCase == project.ActivityUseCaseDigitalWorker {
-			request.PublishAsAutopilot = publish.PublishAsAutopilot
-			request.UseAgenticUserTemplate = publish.AgenticUserTemplate != nil
-		}
-		if opts.useCase == project.ActivityUseCaseDigitalWorker && publish.AgenticUserTemplate != nil {
-			request.AgenticUserTemplate = &agent_api.AgenticUserTemplate{
-				ID:                       publish.AgenticUserTemplate.ID,
-				File:                     publish.AgenticUserTemplate.File,
-				SchemaVersion:            publish.AgenticUserTemplate.SchemaVersion,
-				AgentIdentityBlueprintID: opts.blueprintClientID,
-				CommunicationProtocol:    publish.AgenticUserTemplate.CommunicationProtocol,
-			}
-		}
 		if request.AgentDisplayName == "" && strings.TrimSpace(publish.AgentDisplayName) != "" {
 			request.AgentDisplayName = publish.AgentDisplayName
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack_test.go
@@ -12,6 +12,7 @@ import (
 	"azureaiagent/internal/project"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolveTeamsPackScope(t *testing.T) {
@@ -84,8 +85,11 @@ func TestBuildTeamsAppPackageRequest_DigitalWorkerUsesPublishMetadata(t *testing
 		t.Fatal(err)
 	}
 	canRespond := true
+	boundaries := []string{"read.1on1.developers", "write.group.developers"}
+	permissions := []agent_api.Microsoft365PermissionScopes{
+		{ResourceAppID: "resource-app", Scopes: []string{"McpServers.Mail.All"}},
+	}
 	publish := &project.ActivityPublishConfig{
-		PublishAsAutopilot:       true,
 		PublishScope:             "tenant",
 		CanRespondWithoutMention: &canRespond,
 		AppVersion:               "2.3.4",
@@ -96,39 +100,25 @@ func TestBuildTeamsAppPackageRequest_DigitalWorkerUsesPublishMetadata(t *testing
 		DeveloperWebsiteURL:      "https://contoso.example",
 		PrivacyURL:               "https://contoso.example/privacy",
 		TermsOfUseURL:            "https://contoso.example/terms",
-		AgenticUserTemplate: &project.AgenticUserTemplateConfig{
-			ID:                    "dw-template",
-			File:                  "agenticUserTemplateManifest.json",
-			SchemaVersion:         "0.1.0-preview",
-			CommunicationProtocol: "activityProtocol",
-		},
 	}
 	req := buildTeamsAppPackageRequest("/subscriptions/s/bot", teamsAppRequestOptions{
-		scope:             scope,
-		displayName:       "CLI Overridden",
-		useCase:           project.ActivityUseCaseDigitalWorker,
-		appVersion:        "",
-		blueprintClientID: "blueprint-client-id",
-		publish:           publish,
+		scope:                    scope,
+		displayName:              "CLI Overridden",
+		useCase:                  project.ActivityUseCaseDigitalWorker,
+		appVersion:               "",
+		publish:                  publish,
+		optionalPermissionScopes: permissions,
+		accessBoundaries:         &boundaries,
 	})
 	if !req.PublishAsAutopilot {
 		t.Fatal("PublishAsAutopilot = false, want true")
 	}
-	if !req.UseAgenticUserTemplate {
-		t.Fatal("UseAgenticUserTemplate = false, want true")
-	}
-	if req.AgenticUserTemplate == nil {
-		t.Fatal("AgenticUserTemplate = nil, want template")
-	}
-	if req.AgenticUserTemplate.AgentIdentityBlueprintID != "blueprint-client-id" {
-		t.Errorf(
-			"AgentIdentityBlueprintID = %q, want blueprint-client-id",
-			req.AgenticUserTemplate.AgentIdentityBlueprintID,
-		)
-	}
+	require.Equal(t, permissions, req.OptionalPermissionScopes)
+	require.Equal(t, boundaries, *req.AccessBoundaries)
 	if req.PublishScope != "Shared" {
 		t.Errorf("PublishScope = %q, want Shared", req.PublishScope)
 	}
+
 	if req.AgentDisplayName != "CLI Overridden" {
 		t.Errorf("AgentDisplayName = %q, want CLI Overridden", req.AgentDisplayName)
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/microsoft365.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/microsoft365.go
@@ -23,14 +23,19 @@ const Microsoft365APIVersion = "v1"
 // used by the Digital Worker publish flow.
 const Microsoft365DigitalWorkerAPIVersion = "2025-11-15-preview"
 
-// AgenticUserTemplate identifies the agentic-user manifest embedded in a
-// Digital Worker Teams app package.
-type AgenticUserTemplate struct {
-	ID                       string `json:"Id"`
-	File                     string `json:"File"`
-	SchemaVersion            string `json:"SchemaVersion"`
-	AgentIdentityBlueprintID string `json:"AgentIdentityBlueprintId"`
-	CommunicationProtocol    string `json:"CommunicationProtocol"`
+const microsoft365FeatureHeader = "HostedAgents=V1Preview,AgentEndpoints=V1Preview"
+
+func microsoft365Features(request TeamsAppPackageRequest) string {
+	if request.PublishAsAutopilot {
+		return microsoft365FeatureHeader + "," + DigitalWorkerPreviewFeature
+	}
+	return microsoft365FeatureHeader
+}
+
+// Microsoft365PermissionScopes selects optional permissions from one resource application.
+type Microsoft365PermissionScopes struct {
+	ResourceAppID string   `json:"resourceAppId"`
+	Scopes        []string `json:"scopes"`
 }
 
 // TeamsAppPackageRequest is the body for the Microsoft 365 "zip" endpoint. The
@@ -39,24 +44,24 @@ type AgenticUserTemplate struct {
 // server contract (Microsoft365PublishRequestV3).
 //
 // For the simple activity-agent case the package is a custom engine agent backed
-// by the agent's own instance identity, so PublishAsAutopilot and
-// UseAgenticUserTemplate are false. PublishScope "Personal" produces a package
-// intended for per-user sideload (no Teams admin required).
+// by the agent's own instance identity, so PublishAsAutopilot is false.
+// PublishScope "Personal" produces a package intended for per-user sideload
+// (no Teams admin required).
 type TeamsAppPackageRequest struct {
-	PublishAsAutopilot       bool                 `json:"PublishAsAutopilot"`
-	BotServiceArmID          string               `json:"BotServiceArmId"`
-	UseAgenticUserTemplate   bool                 `json:"useAgenticUserTemplate"`
-	AgenticUserTemplate      *AgenticUserTemplate `json:"agenticUserTemplate,omitempty"`
-	PublishScope             string               `json:"PublishScope"`
-	AgentDisplayName         string               `json:"AgentDisplayName"`
-	AppVersion               string               `json:"AppVersion"`
-	ShortDescription         string               `json:"ShortDescription"`
-	FullDescription          string               `json:"FullDescription"`
-	DeveloperName            string               `json:"DeveloperName"`
-	DeveloperWebsiteURL      string               `json:"DeveloperWebsiteUrl"`
-	PrivacyURL               string               `json:"PrivacyUrl"`
-	TermsOfUseURL            string               `json:"TermsOfUseUrl"`
-	CanRespondWithoutMention bool                 `json:"CanRespondWithoutMention"`
+	PublishAsAutopilot       bool                           `json:"PublishAsAutopilot"`
+	BotServiceArmID          string                         `json:"BotServiceArmId"`
+	PublishScope             string                         `json:"PublishScope"`
+	AgentDisplayName         string                         `json:"AgentDisplayName"`
+	AppVersion               string                         `json:"AppVersion"`
+	ShortDescription         string                         `json:"ShortDescription"`
+	FullDescription          string                         `json:"FullDescription"`
+	DeveloperName            string                         `json:"DeveloperName"`
+	DeveloperWebsiteURL      string                         `json:"DeveloperWebsiteUrl"`
+	PrivacyURL               string                         `json:"PrivacyUrl"`
+	TermsOfUseURL            string                         `json:"TermsOfUseUrl"`
+	CanRespondWithoutMention bool                           `json:"CanRespondWithoutMention"`
+	OptionalPermissionScopes []Microsoft365PermissionScopes `json:"optionalPermissionScopes,omitempty"`
+	AccessBoundaries         *[]string                      `json:"accessBoundaries,omitempty"`
 }
 
 // DownloadTeamsAppPackage calls the Microsoft 365 "zip" endpoint and returns the
@@ -92,7 +97,7 @@ func (c *AgentClient) DownloadTeamsAppPackage(
 		return nil, fmt.Errorf("failed to marshal Teams app package request: %w", err)
 	}
 	req.Raw().Header.Set("Accept", "application/zip")
-	req.Raw().Header.Set("Foundry-Features", "HostedAgents=V1Preview,AgentEndpoints=V1Preview")
+	req.Raw().Header.Set("Foundry-Features", microsoft365Features(request))
 
 	resp, err := c.pipeline.Do(req)
 	if err != nil {
@@ -155,7 +160,7 @@ func (c *AgentClient) PublishTeamsApp(
 	if err := runtime.MarshalAsJSON(req, request); err != nil {
 		return nil, fmt.Errorf("failed to marshal Teams app publish request: %w", err)
 	}
-	req.Raw().Header.Set("Foundry-Features", "HostedAgents=V1Preview,AgentEndpoints=V1Preview")
+	req.Raw().Header.Set("Foundry-Features", microsoft365Features(request))
 
 	resp, err := c.pipeline.Do(req)
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/microsoft365_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/microsoft365_test.go
@@ -43,7 +43,6 @@ func TestDownloadTeamsAppPackage_Success(t *testing.T) {
 	require.NoError(t, json.Unmarshal(bodyBytes, &sent))
 	require.Equal(t, request, sent)
 	require.False(t, sent.PublishAsAutopilot)
-	require.False(t, sent.UseAgenticUserTemplate)
 }
 
 func TestDownloadTeamsAppPackage_ErrorStatus(t *testing.T) {
@@ -106,16 +105,13 @@ func TestPublishTeamsApp_DigitalWorkerRequest(t *testing.T) {
 		http.StatusOK,
 		`{"titleId":"T_123","teamsAppId":"app-456"}`,
 	)
+	boundaries := []string{"read.1on1.developers", "write.group.developers"}
 	request := TeamsAppPackageRequest{
-		PublishAsAutopilot:     true,
-		UseAgenticUserTemplate: true,
-		AgenticUserTemplate: &AgenticUserTemplate{
-			ID:                       "digitalWorkerTemplate",
-			File:                     "agenticUserTemplateManifest.json",
-			SchemaVersion:            "0.1.0-preview",
-			AgentIdentityBlueprintID: "blueprint-client-id",
-			CommunicationProtocol:    "activityProtocol",
+		PublishAsAutopilot: true,
+		OptionalPermissionScopes: []Microsoft365PermissionScopes{
+			{ResourceAppID: "resource-app", Scopes: []string{"McpServers.Mail.All"}},
 		},
+		AccessBoundaries: &boundaries,
 		PublishScope:     "Tenant",
 		AgentDisplayName: "my-agent",
 		AppVersion:       "1.0.0",
@@ -128,6 +124,11 @@ func TestPublishTeamsApp_DigitalWorkerRequest(t *testing.T) {
 	require.Len(t, transport.requests, 1)
 	got := transport.requests[0]
 	require.Equal(t, Microsoft365DigitalWorkerAPIVersion, got.URL.Query().Get("api-version"))
+	require.Equal(
+		t,
+		microsoft365FeatureHeader+","+DigitalWorkerPreviewFeature,
+		got.Header.Get("Foundry-Features"),
+	)
 
 	bodyBytes, err := io.ReadAll(got.Body)
 	require.NoError(t, err)
@@ -135,7 +136,20 @@ func TestPublishTeamsApp_DigitalWorkerRequest(t *testing.T) {
 	require.NoError(t, json.Unmarshal(bodyBytes, &sent))
 	require.Equal(t, request, sent)
 	require.Empty(t, sent.BotServiceArmID)
-	require.Equal(t, "blueprint-client-id", sent.AgenticUserTemplate.AgentIdentityBlueprintID)
+	require.Equal(t, boundaries, *sent.AccessBoundaries)
+	require.NotContains(t, string(bodyBytes), "useAgenticUserTemplate")
+	require.NotContains(t, string(bodyBytes), "agenticUserTemplate")
+}
+
+func TestTeamsAppPackageRequest_AccessBoundaryTriState(t *testing.T) {
+	omitted, err := json.Marshal(TeamsAppPackageRequest{})
+	require.NoError(t, err)
+	require.NotContains(t, string(omitted), "accessBoundaries")
+
+	empty := []string{}
+	cleared, err := json.Marshal(TeamsAppPackageRequest{AccessBoundaries: &empty})
+	require.NoError(t, err)
+	require.Contains(t, string(cleared), `"accessBoundaries":[]`)
 }
 
 func TestPublishTeamsApp_ErrorStatus(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
@@ -75,6 +75,14 @@ const (
 	AgentKindVoice AgentKind = "voice"
 )
 
+// DigitalWorkerType identifies the service-side Digital Worker classification.
+type DigitalWorkerType string
+
+const (
+	// DigitalWorkerTypeM365 is a Microsoft 365 Digital Worker.
+	DigitalWorkerTypeM365 DigitalWorkerType = "m365"
+)
+
 // AgentEventType represents the types of events that can be handled
 type AgentEventType string
 
@@ -457,9 +465,10 @@ type VoiceAgentDefinition struct {
 
 // CreateAgentVersionRequest represents a request to create an agent version
 type CreateAgentVersionRequest struct {
-	Description *string           `json:"description,omitempty"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
-	Definition  any               `json:"definition"` // Can be any of the agent definition types
+	Description       *string           `json:"description,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+	Definition        any               `json:"definition"` // Can be any of the agent definition types
+	DigitalWorkerType DigitalWorkerType `json:"digital_worker_type,omitempty"`
 }
 
 // CreateAgentRequest represents a request to create an agent
@@ -472,7 +481,9 @@ type CreateAgentRequest struct {
 
 // UpdateAgentRequest represents a request to update an agent
 type UpdateAgentRequest struct {
-	CreateAgentVersionRequest
+	Description *string           `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	Definition  any               `json:"definition"` // Can be any of the agent definition types
 }
 
 // PatchAgentRequest represents a partial update to agent-level fields.
@@ -517,6 +528,7 @@ type AgentVersionObject struct {
 	Blueprint          *BlueprintInfo      `json:"blueprint,omitempty"`
 	BlueprintReference *BlueprintReference `json:"blueprint_reference,omitempty"`
 	AgentGUID          string              `json:"agent_guid,omitempty"`
+	DigitalWorkerType  DigitalWorkerType   `json:"digital_worker_type,omitempty"`
 	// RequestID is populated from the x-request-id response header (not from JSON).
 	RequestID string `json:"-"`
 }
@@ -538,6 +550,7 @@ type AgentObject struct {
 	InstanceIdentity   *AgentIdentityInfo  `json:"instance_identity,omitempty"`
 	Blueprint          *BlueprintInfo      `json:"blueprint,omitempty"`
 	BlueprintReference *BlueprintReference `json:"blueprint_reference,omitempty"`
+	DigitalWorkerType  DigitalWorkerType   `json:"digital_worker_type,omitempty"`
 	Versions           struct {
 		Latest AgentVersionObject `json:"latest"`
 	} `json:"versions"`

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
@@ -15,8 +15,9 @@ func TestCreateAgentRequest_RoundTrip(t *testing.T) {
 	original := CreateAgentRequest{
 		Name: "test-agent",
 		CreateAgentVersionRequest: CreateAgentVersionRequest{
-			Description: new("A test agent"),
-			Metadata:    map[string]string{"env": "test"},
+			Description:       new("A test agent"),
+			Metadata:          map[string]string{"env": "test"},
+			DigitalWorkerType: DigitalWorkerTypeM365,
 			Definition: HostedAgentDefinition{
 				AgentDefinition: AgentDefinition{
 					Kind:      AgentKindHosted,
@@ -35,7 +36,9 @@ func TestCreateAgentRequest_RoundTrip(t *testing.T) {
 
 	// Verify JSON tag names
 	s := string(data)
-	for _, field := range []string{`"name"`, `"description"`, `"metadata"`, `"definition"`} {
+	for _, field := range []string{
+		`"name"`, `"description"`, `"metadata"`, `"definition"`, `"digital_worker_type":"m365"`,
+	} {
 		if !strings.Contains(s, field) {
 			t.Errorf("expected JSON to contain %s, got: %s", field, s)
 		}
@@ -55,15 +58,19 @@ func TestCreateAgentRequest_RoundTrip(t *testing.T) {
 	if got.Metadata["env"] != "test" {
 		t.Errorf("Metadata[env] = %q, want %q", got.Metadata["env"], "test")
 	}
+	if got.DigitalWorkerType != DigitalWorkerTypeM365 {
+		t.Errorf("DigitalWorkerType = %q, want %q", got.DigitalWorkerType, DigitalWorkerTypeM365)
+	}
 }
 
 func TestAgentObject_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	original := AgentObject{
-		Object: "agent",
-		ID:     "agent-123",
-		Name:   "my-agent",
+		Object:            "agent",
+		ID:                "agent-123",
+		Name:              "my-agent",
+		DigitalWorkerType: DigitalWorkerTypeM365,
 		Versions: struct {
 			Latest AgentVersionObject `json:"latest"`
 		}{
@@ -85,7 +92,9 @@ func TestAgentObject_RoundTrip(t *testing.T) {
 	}
 
 	s := string(data)
-	for _, field := range []string{`"object"`, `"id"`, `"name"`, `"versions"`, `"latest"`} {
+	for _, field := range []string{
+		`"object"`, `"id"`, `"name"`, `"versions"`, `"latest"`, `"digital_worker_type":"m365"`,
+	} {
 		if !strings.Contains(s, field) {
 			t.Errorf("expected JSON to contain %s", field)
 		}
@@ -104,6 +113,30 @@ func TestAgentObject_RoundTrip(t *testing.T) {
 	}
 	if got.Versions.Latest.CreatedAt != 1700000000 {
 		t.Errorf("Latest.CreatedAt = %d, want %d", got.Versions.Latest.CreatedAt, int64(1700000000))
+	}
+}
+
+func TestCreateAgentVersionRequest_OmitsEmptyDigitalWorkerType(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(CreateAgentVersionRequest{Definition: map[string]any{"kind": "hosted"}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "digital_worker_type") {
+		t.Fatalf("simple agent request must omit digital_worker_type: %s", data)
+	}
+}
+
+func TestUpdateAgentRequest_HasNoDigitalWorkerType(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(UpdateAgentRequest{Definition: map[string]any{"kind": "voice"}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "digital_worker_type") {
+		t.Fatalf("update request must omit immutable digital_worker_type: %s", data)
 	}
 }
 
@@ -297,7 +330,8 @@ func TestAgentVersionObject_RoundTrip(t *testing.T) {
 			Type:        "ManagedAgentIdentityBlueprint",
 			BlueprintID: "my-agent-abc12",
 		},
-		AgentGUID: "abc12345-0000-1111-2222-333344445555",
+		AgentGUID:         "abc12345-0000-1111-2222-333344445555",
+		DigitalWorkerType: DigitalWorkerTypeM365,
 	}
 
 	data, err := json.Marshal(original)
@@ -309,7 +343,7 @@ func TestAgentVersionObject_RoundTrip(t *testing.T) {
 	for _, field := range []string{
 		`"object"`, `"id"`, `"version"`, `"created_at"`,
 		`"status"`, `"instance_identity"`, `"blueprint"`,
-		`"blueprint_reference"`, `"agent_guid"`,
+		`"blueprint_reference"`, `"agent_guid"`, `"digital_worker_type"`,
 	} {
 		if !strings.Contains(s, field) {
 			t.Errorf("expected JSON to contain %s", field)
@@ -335,6 +369,9 @@ func TestAgentVersionObject_RoundTrip(t *testing.T) {
 	}
 	if got.AgentGUID != "abc12345-0000-1111-2222-333344445555" {
 		t.Errorf("AgentGUID = %q, want %q", got.AgentGUID, "abc12345-0000-1111-2222-333344445555")
+	}
+	if got.DigitalWorkerType != DigitalWorkerTypeM365 {
+		t.Errorf("DigitalWorkerType = %q, want %q", got.DigitalWorkerType, DigitalWorkerTypeM365)
 	}
 	if got.InstanceIdentity == nil || got.InstanceIdentity.PrincipalID != "inst-principal-id" {
 		t.Errorf("InstanceIdentity.PrincipalID mismatch")

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
@@ -89,6 +89,14 @@ func NewAgentClient(endpoint string, cred azcore.TokenCredential) *AgentClient {
 	}
 }
 
+// DigitalWorkerPreviewFeature opts agent definition operations into the
+// preview Digital Worker contract.
+const DigitalWorkerPreviewFeature = "DigitalWorker=V1Preview"
+
+func setDigitalWorkerPreviewFeature(req *policy.Request) {
+	req.Raw().Header.Set("Foundry-Features", DigitalWorkerPreviewFeature)
+}
+
 // GetAgent retrieves a specific agent by name
 func (c *AgentClient) GetAgent(ctx context.Context, agentName, apiVersion string) (*AgentObject, error) {
 	url := fmt.Sprintf("%s/agents/%s?api-version=%s", c.endpoint, agentName, apiVersion)
@@ -97,6 +105,7 @@ func (c *AgentClient) GetAgent(ctx context.Context, agentName, apiVersion string
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+	setDigitalWorkerPreviewFeature(req)
 
 	resp, err := c.pipeline.Do(req)
 	if err != nil {
@@ -134,6 +143,7 @@ func (c *AgentClient) CreateAgent(ctx context.Context, request *CreateAgentReque
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+	setDigitalWorkerPreviewFeature(req)
 
 	if err := req.SetBody(streaming.NopCloser(bytes.NewReader(payload)), "application/json"); err != nil {
 		return nil, fmt.Errorf("failed to set request body: %w", err)
@@ -296,6 +306,7 @@ func (c *AgentClient) UpdateAgent(ctx context.Context, agentName string, request
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+	setDigitalWorkerPreviewFeature(req)
 
 	if err := req.SetBody(streaming.NopCloser(bytes.NewReader(payload)), "application/json"); err != nil {
 		return nil, fmt.Errorf("failed to set request body: %w", err)
@@ -481,6 +492,7 @@ func (c *AgentClient) CreateAgentVersion(ctx context.Context, agentName string, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+	setDigitalWorkerPreviewFeature(req)
 
 	if err := req.SetBody(streaming.NopCloser(bytes.NewReader(payload)), "application/json"); err != nil {
 		return nil, fmt.Errorf("failed to set request body: %w", err)
@@ -599,6 +611,7 @@ func (c *AgentClient) zipDeployRequest(
 
 	// Required headers
 	req.Raw().Header.Set("x-ms-code-zip-sha256", sha256Hex)
+	setDigitalWorkerPreviewFeature(req)
 	if agentName != "" {
 		req.Raw().Header.Set("x-ms-agent-name", agentName)
 	}
@@ -634,6 +647,7 @@ func (c *AgentClient) GetAgentVersion(ctx context.Context, agentName, agentVersi
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+	setDigitalWorkerPreviewFeature(req)
 
 	resp, err := c.pipeline.Do(req)
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
@@ -747,7 +747,8 @@ func TestZipDeployRequest_MultipartFormat(t *testing.T) {
 
 	desc := "test desc"
 	metadata := &CreateAgentVersionRequest{
-		Description: &desc,
+		Description:       &desc,
+		DigitalWorkerType: DigitalWorkerTypeM365,
 	}
 	zipData := []byte("PK\x03\x04fake-zip-content")
 	sha256Hex := "abcdef1234567890"
@@ -765,6 +766,7 @@ func TestZipDeployRequest_MultipartFormat(t *testing.T) {
 	// Verify required headers
 	require.Equal(t, sha256Hex, transport.lastReq.Header.Get("x-ms-code-zip-sha256"))
 	require.Equal(t, "test-agent", transport.lastReq.Header.Get("x-ms-agent-name"))
+	require.Equal(t, DigitalWorkerPreviewFeature, transport.lastReq.Header.Get("Foundry-Features"))
 
 	// Verify multipart content type with boundary
 	contentType := transport.lastReq.Header.Get("Content-Type")
@@ -785,6 +787,7 @@ func TestZipDeployRequest_MultipartFormat(t *testing.T) {
 	var parsedMeta map[string]any
 	require.NoError(t, json.Unmarshal(part1Data, &parsedMeta))
 	require.Equal(t, "test desc", parsedMeta["description"])
+	require.Equal(t, "m365", parsedMeta["digital_worker_type"])
 
 	// Part 2: code ZIP
 	part2, err := reader.NextPart()
@@ -793,6 +796,41 @@ func TestZipDeployRequest_MultipartFormat(t *testing.T) {
 	require.Equal(t, "agent.zip", part2.FileName())
 	part2Data, _ := io.ReadAll(part2)
 	require.Equal(t, zipData, part2Data)
+}
+
+func TestCreateAgentVersion_DigitalWorkerContract(t *testing.T) {
+	transport := &capturingTransport{
+		statusCode: http.StatusCreated,
+		respBody:   `{"name":"worker","version":"1","digital_worker_type":"m365"}`,
+	}
+	client := newTestClient("https://test.example.com/api/projects/proj", transport)
+
+	got, err := client.CreateAgentVersion(
+		t.Context(),
+		"worker",
+		&CreateAgentVersionRequest{
+			Definition:        map[string]any{"kind": "hosted"},
+			DigitalWorkerType: DigitalWorkerTypeM365,
+		},
+		"v1",
+	)
+	require.NoError(t, err)
+	require.Equal(t, DigitalWorkerTypeM365, got.DigitalWorkerType)
+	require.Equal(t, DigitalWorkerPreviewFeature, transport.lastReq.Header.Get("Foundry-Features"))
+	require.Contains(t, string(transport.lastBody), `"digital_worker_type":"m365"`)
+}
+
+func TestGetAgentVersion_DigitalWorkerContract(t *testing.T) {
+	transport := &capturingTransport{
+		statusCode: http.StatusOK,
+		respBody:   `{"name":"worker","version":"1","digital_worker_type":"m365"}`,
+	}
+	client := newTestClient("https://test.example.com/api/projects/proj", transport)
+
+	got, err := client.GetAgentVersion(t.Context(), "worker", "1", "v1")
+	require.NoError(t, err)
+	require.Equal(t, DigitalWorkerTypeM365, got.DigitalWorkerType)
+	require.Equal(t, DigitalWorkerPreviewFeature, transport.lastReq.Header.Get("Foundry-Features"))
 }
 
 func TestZipDeployRequest_NoAgentNameHeader_OnUpdate(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
@@ -24,6 +24,13 @@ const (
 	ActivityUseCaseDigitalWorker ActivityUseCase = "digital_worker"
 )
 
+var supportedDigitalWorkerAccessBoundaries = map[string]struct{}{
+	"read.1on1.developers":   {},
+	"write.1on1.developers":  {},
+	"read.group.developers":  {},
+	"write.group.developers": {},
+}
+
 // ActivityProfile summarizes the activity-protocol characteristics of a hosted
 // agent definition. It is the single gate that keeps all Teams/bot-specific
 // behavior off the path of non-activity agents: when IsActivity is false the
@@ -34,6 +41,30 @@ type ActivityProfile struct {
 	// UseCase is the resolved Teams hosting model. Only meaningful when
 	// IsActivity is true. Phase 1 always resolves ActivityUseCaseSimple.
 	UseCase ActivityUseCase
+}
+
+// ResolveDeployedActivityProfile reconciles local authoring intent with the
+// service-side Digital Worker classification, which is authoritative after
+// deployment.
+func ResolveDeployedActivityProfile(
+	local ActivityProfile,
+	digitalWorkerType agent_api.DigitalWorkerType,
+) (ActivityProfile, error) {
+	switch digitalWorkerType {
+	case agent_api.DigitalWorkerTypeM365:
+		return ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseDigitalWorker}, nil
+	case "":
+		if local.UseCase == ActivityUseCaseDigitalWorker {
+			return ActivityProfile{}, fmt.Errorf(
+				"agent is configured as digital_worker but the deployed version has no digital_worker_type",
+			)
+		}
+		return local, nil
+	default:
+		return ActivityProfile{}, fmt.Errorf(
+			"deployed agent has unsupported digital_worker_type %q", digitalWorkerType,
+		)
+	}
 }
 
 // IsActivityProtocol reports whether a hosted agent definition opts into the
@@ -84,38 +115,9 @@ func ResolveActivityProfileWithSettings(
 	case ActivityUseCaseSimple:
 		return profile, nil
 	case ActivityUseCaseDigitalWorker:
-		if settings.Publish == nil {
-			return ActivityProfile{}, fmt.Errorf("activity.publish is required for digital_worker")
-		}
-		// publishAsAutopilot is a derived runtime requirement for the digital_worker
-		// use case. It is inferred automatically and should not be treated as a
-		// user-configurable Azure YAML knob.
-		settings.Publish.PublishAsAutopilot = true
-		publishScope := strings.TrimSpace(settings.Publish.PublishScope)
-		if publishScope != "" && !strings.EqualFold(publishScope, "tenant") {
-			return ActivityProfile{}, fmt.Errorf(
-				"activity.publish.publishScope must be tenant for digital_worker (shared is not supported)",
-			)
-		}
-		template := settings.Publish.AgenticUserTemplate
-		if template == nil {
-			return ActivityProfile{}, fmt.Errorf("activity.publish.agenticUserTemplate is required for digital_worker")
-		}
-		requiredTemplateFields := []struct {
-			name  string
-			value string
-		}{
-			{name: "id", value: template.ID},
-			{name: "file", value: template.File},
-			{name: "schemaVersion", value: template.SchemaVersion},
-			{name: "communicationProtocol", value: template.CommunicationProtocol},
-		}
-		for _, field := range requiredTemplateFields {
-			value := field.value
-			if strings.TrimSpace(value) == "" {
-				return ActivityProfile{}, fmt.Errorf(
-					"activity.publish.agenticUserTemplate.%s is required for digital_worker", field.name,
-				)
+		if settings.Publish != nil {
+			if err := ValidateDigitalWorkerPublishConfig(settings.Publish); err != nil {
+				return ActivityProfile{}, err
 			}
 		}
 		return ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseDigitalWorker}, nil
@@ -124,6 +126,53 @@ func ResolveActivityProfileWithSettings(
 			"activity.useCase must be %q or %q", ActivityUseCaseSimple, ActivityUseCaseDigitalWorker,
 		)
 	}
+}
+
+// ValidateDigitalWorkerPublishConfig validates fields that are sent only for
+// Microsoft 365 Digital Worker publication.
+func ValidateDigitalWorkerPublishConfig(publish *ActivityPublishConfig) error {
+	publishScope := strings.TrimSpace(publish.PublishScope)
+	if publishScope != "" && !strings.EqualFold(publishScope, "tenant") {
+		return fmt.Errorf(
+			"activity.publish.publishScope must be tenant for digital_worker (shared is not supported)",
+		)
+	}
+	for i, permission := range publish.OptionalPermissionScopes {
+		if strings.TrimSpace(permission.ResourceAppID) == "" {
+			return fmt.Errorf("activity.publish.optionalPermissionScopes[%d].resourceAppId is required", i)
+		}
+		if len(permission.Scopes) == 0 {
+			return fmt.Errorf("activity.publish.optionalPermissionScopes[%d].scopes must not be empty", i)
+		}
+		for j, scope := range permission.Scopes {
+			if strings.TrimSpace(scope) == "" {
+				return fmt.Errorf(
+					"activity.publish.optionalPermissionScopes[%d].scopes[%d] must not be empty", i, j,
+				)
+			}
+		}
+	}
+	if publish.AccessBoundaries != nil {
+		if err := ValidateDigitalWorkerAccessBoundaries(*publish.AccessBoundaries); err != nil {
+			return fmt.Errorf("activity.publish.accessBoundaries: %w", err)
+		}
+	}
+	return nil
+}
+
+// ValidateDigitalWorkerAccessBoundaries validates the initial azd-supported
+// developer-only boundary set.
+func ValidateDigitalWorkerAccessBoundaries(boundaries []string) error {
+	for _, boundary := range boundaries {
+		if _, ok := supportedDigitalWorkerAccessBoundaries[strings.TrimSpace(boundary)]; !ok {
+			return fmt.Errorf(
+				"unsupported value %q; supported values are read.1on1.developers, "+
+					"write.1on1.developers, read.group.developers, and write.group.developers",
+				boundary,
+			)
+		}
+	}
+	return nil
 }
 
 // ComposeActivityAgentEndpoint folds the Activity endpoint requirements into an

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile_test.go
@@ -6,6 +6,7 @@ package project
 import (
 	"testing"
 
+	"azureaiagent/internal/pkg/agents/agent_api"
 	"azureaiagent/internal/pkg/agents/agent_yaml"
 	"azureaiagent/internal/pkg/envkey"
 
@@ -115,49 +116,31 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 		profile, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
 			UseCase: ActivityUseCaseDigitalWorker,
 			Publish: &ActivityPublishConfig{
-				PublishAsAutopilot: true,
-				PublishScope:       "tenant",
-				AgenticUserTemplate: &AgenticUserTemplateConfig{
-					ID:                    "digitalWorkerTemplate",
-					File:                  "agenticUserTemplateManifest.json",
-					SchemaVersion:         "0.1.0-preview",
-					CommunicationProtocol: "activityProtocol",
-				},
-			},
-		})
-		require.NoError(t, err)
-		require.True(t, profile.IsActivity)
-		require.Equal(t, ActivityUseCaseDigitalWorker, profile.UseCase)
-	})
-
-	t.Run("digital worker defaults omitted publish scope", func(t *testing.T) {
-		profile, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
-			UseCase: ActivityUseCaseDigitalWorker,
-			Publish: &ActivityPublishConfig{
-				PublishAsAutopilot: true,
-				AgenticUserTemplate: &AgenticUserTemplateConfig{
-					ID:                    "digitalWorkerTemplate",
-					File:                  "agenticUserTemplateManifest.json",
-					SchemaVersion:         "0.1.0-preview",
-					CommunicationProtocol: "activityProtocol",
-				},
-			},
-		})
-		require.NoError(t, err)
-		require.Equal(t, ActivityUseCaseDigitalWorker, profile.UseCase)
-	})
-
-	t.Run("digital worker infers autopilot publish", func(t *testing.T) {
-		profile, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
-			UseCase: ActivityUseCaseDigitalWorker,
-			Publish: &ActivityPublishConfig{
 				PublishScope: "tenant",
-				AgenticUserTemplate: &AgenticUserTemplateConfig{
-					ID:                    "digitalWorkerTemplate",
-					File:                  "agenticUserTemplateManifest.json",
-					SchemaVersion:         "0.1.0-preview",
-					CommunicationProtocol: "activityProtocol",
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, profile.IsActivity)
+		require.Equal(t, ActivityUseCaseDigitalWorker, profile.UseCase)
+	})
+
+	t.Run("digital worker allows omitted publish block", func(t *testing.T) {
+		profile, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+			UseCase: ActivityUseCaseDigitalWorker,
+		})
+		require.NoError(t, err)
+		require.Equal(t, ActivityUseCaseDigitalWorker, profile.UseCase)
+	})
+
+	t.Run("digital worker accepts optional permissions and boundaries", func(t *testing.T) {
+		boundaries := []string{"read.1on1.developers", "write.group.developers"}
+		profile, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+			UseCase: ActivityUseCaseDigitalWorker,
+			Publish: &ActivityPublishConfig{
+				OptionalPermissionScopes: []Microsoft365PermissionScopes{
+					{ResourceAppID: "resource-app", Scopes: []string{"McpServers.Mail.All"}},
 				},
+				AccessBoundaries: &boundaries,
 			},
 		})
 		require.NoError(t, err)
@@ -165,61 +148,81 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 		require.True(t, profile.IsActivity)
 	})
 
-	t.Run("digital worker requires agentic user template", func(t *testing.T) {
+	t.Run("digital worker rejects missing resource app id", func(t *testing.T) {
 		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
 			UseCase: ActivityUseCaseDigitalWorker,
 			Publish: &ActivityPublishConfig{
-				PublishAsAutopilot: true,
-				PublishScope:       "tenant",
+				OptionalPermissionScopes: []Microsoft365PermissionScopes{
+					{Scopes: []string{"McpServers.Mail.All"}},
+				},
 			},
 		})
-		require.ErrorContains(t, err, "agenticUserTemplate")
+		require.ErrorContains(t, err, "resourceAppId is required")
 	})
 
-	t.Run("digital worker missing template fields reports first field deterministically", func(t *testing.T) {
+	t.Run("digital worker rejects empty permission scopes", func(t *testing.T) {
 		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
 			UseCase: ActivityUseCaseDigitalWorker,
 			Publish: &ActivityPublishConfig{
-				PublishAsAutopilot:  true,
-				PublishScope:        "tenant",
-				AgenticUserTemplate: &AgenticUserTemplateConfig{},
+				OptionalPermissionScopes: []Microsoft365PermissionScopes{
+					{ResourceAppID: "resource-app"},
+				},
 			},
 		})
-		require.ErrorContains(t, err, "activity.publish.agenticUserTemplate.id")
+		require.ErrorContains(t, err, "scopes must not be empty")
 	})
 
 	t.Run("digital worker requires tenant publish scope", func(t *testing.T) {
 		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
 			UseCase: ActivityUseCaseDigitalWorker,
 			Publish: &ActivityPublishConfig{
-				PublishAsAutopilot: true,
-				PublishScope:       "shared",
-				AgenticUserTemplate: &AgenticUserTemplateConfig{
-					ID:                    "digitalWorkerTemplate",
-					File:                  "agenticUserTemplateManifest.json",
-					SchemaVersion:         "0.1.0-preview",
-					CommunicationProtocol: "activityProtocol",
-				},
+				PublishScope: "shared",
 			},
 		})
 		require.ErrorContains(t, err, "publishScope must be tenant")
 	})
 
+	t.Run("digital worker rejects unsupported access boundary", func(t *testing.T) {
+		boundaries := []string{"read.1on1.tenant"}
+		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+			UseCase: ActivityUseCaseDigitalWorker,
+			Publish: &ActivityPublishConfig{AccessBoundaries: &boundaries},
+		})
+		require.ErrorContains(t, err, "unsupported value")
+	})
+
 	t.Run("digital worker requires activity protocol", func(t *testing.T) {
 		_, err := ResolveActivityProfileWithSettings(agent_yaml.ContainerAgent{}, &ActivitySettings{
 			UseCase: ActivityUseCaseDigitalWorker,
-			Publish: &ActivityPublishConfig{
-				PublishAsAutopilot: true,
-				PublishScope:       "tenant",
-				AgenticUserTemplate: &AgenticUserTemplateConfig{
-					ID:                    "digitalWorkerTemplate",
-					File:                  "agenticUserTemplateManifest.json",
-					SchemaVersion:         "0.1.0-preview",
-					CommunicationProtocol: "activityProtocol",
-				},
-			},
 		})
 		require.ErrorContains(t, err, "Activity-protocol")
+	})
+}
+
+func TestResolveDeployedActivityProfile(t *testing.T) {
+	t.Run("service m365 overrides local simple", func(t *testing.T) {
+		got, err := ResolveDeployedActivityProfile(
+			ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseSimple},
+			agent_api.DigitalWorkerTypeM365,
+		)
+		require.NoError(t, err)
+		require.Equal(t, ActivityUseCaseDigitalWorker, got.UseCase)
+	})
+
+	t.Run("configured digital worker requires service classification", func(t *testing.T) {
+		_, err := ResolveDeployedActivityProfile(
+			ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseDigitalWorker},
+			"",
+		)
+		require.ErrorContains(t, err, "no digital_worker_type")
+	})
+
+	t.Run("unknown service classification is rejected", func(t *testing.T) {
+		_, err := ResolveDeployedActivityProfile(
+			ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseSimple},
+			"future-worker",
+		)
+		require.ErrorContains(t, err, "unsupported digital_worker_type")
 	})
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/config.go
@@ -66,26 +66,24 @@ type ActivitySettings struct {
 // Digital Worker-only fields are applied only when the resolved use case is
 // digital_worker.
 type ActivityPublishConfig struct {
-	PublishAsAutopilot       bool                       `json:"publishAsAutopilot,omitempty"`
-	PublishScope             string                     `json:"publishScope,omitempty"`
-	CanRespondWithoutMention *bool                      `json:"canRespondWithoutMention,omitempty"`
-	AppVersion               string                     `json:"appVersion,omitempty"`
-	AgentDisplayName         string                     `json:"agentDisplayName,omitempty"`
-	ShortDescription         string                     `json:"shortDescription,omitempty"`
-	FullDescription          string                     `json:"fullDescription,omitempty"`
-	DeveloperName            string                     `json:"developerName,omitempty"`
-	DeveloperWebsiteURL      string                     `json:"developerWebsiteUrl,omitempty"`
-	PrivacyURL               string                     `json:"privacyUrl,omitempty"`
-	TermsOfUseURL            string                     `json:"termsOfUseUrl,omitempty"`
-	AgenticUserTemplate      *AgenticUserTemplateConfig `json:"agenticUserTemplate,omitempty"`
+	PublishScope             string                         `json:"publishScope,omitempty"`
+	CanRespondWithoutMention *bool                          `json:"canRespondWithoutMention,omitempty"`
+	AppVersion               string                         `json:"appVersion,omitempty"`
+	AgentDisplayName         string                         `json:"agentDisplayName,omitempty"`
+	ShortDescription         string                         `json:"shortDescription,omitempty"`
+	FullDescription          string                         `json:"fullDescription,omitempty"`
+	DeveloperName            string                         `json:"developerName,omitempty"`
+	DeveloperWebsiteURL      string                         `json:"developerWebsiteUrl,omitempty"`
+	PrivacyURL               string                         `json:"privacyUrl,omitempty"`
+	TermsOfUseURL            string                         `json:"termsOfUseUrl,omitempty"`
+	OptionalPermissionScopes []Microsoft365PermissionScopes `json:"optionalPermissionScopes,omitempty"`
+	AccessBoundaries         *[]string                      `json:"accessBoundaries,omitempty"`
 }
 
-// AgenticUserTemplateConfig identifies the template embedded in a Digital Worker Teams package.
-type AgenticUserTemplateConfig struct {
-	ID                    string `json:"id,omitempty"`
-	File                  string `json:"file,omitempty"`
-	SchemaVersion         string `json:"schemaVersion,omitempty"`
-	CommunicationProtocol string `json:"communicationProtocol,omitempty"`
+// Microsoft365PermissionScopes selects optional permissions from one resource application.
+type Microsoft365PermissionScopes struct {
+	ResourceAppID string   `json:"resourceAppId"`
+	Scopes        []string `json:"scopes"`
 }
 
 // ContainerSettings provides container configuration for the Azure AI Service target

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1528,14 +1528,15 @@ func (p *AgentServiceTargetProvider) Deploy(
 		return nil, err
 	}
 
+	projectEndpoint := azdEnv["FOUNDRY_PROJECT_ENDPOINT"]
+	agentClient := agent_api.NewAgentClient(
+		projectEndpoint,
+		p.credential,
+	)
+
 	// Poll until agent version is active
 	if result.agentVersion.Status != "active" {
 		progress("Agent version created; waiting for activation")
-		projectEndpoint := azdEnv["FOUNDRY_PROJECT_ENDPOINT"]
-		agentClient := agent_api.NewAgentClient(
-			projectEndpoint,
-			p.credential,
-		)
 		polledVersion, pollErr := p.waitForAgentActive(
 			ctx,
 			agentClient,
@@ -1550,6 +1551,27 @@ func (p *AgentServiceTargetProvider) Deploy(
 		result.agentVersion = polledVersion
 	} else {
 		fmt.Fprintf(os.Stderr, "Agent version %s is already active.\n", result.agentVersion.Version)
+	}
+
+	// Read the deployed version so post-deploy behavior uses the service-side
+	// Digital Worker classification rather than only the local authoring intent.
+	deployedVersion, err := agentClient.GetAgentVersion(
+		ctx,
+		result.agentName,
+		result.agentVersion.Version,
+		agent_api.AgentEndpointAPIVersion,
+	)
+	if err != nil {
+		return nil, exterrors.ServiceFromAzure(err, exterrors.OpGetAgent)
+	}
+	result.agentVersion = deployedVersion
+	activityProfile, err = ResolveDeployedActivityProfile(activityProfile, deployedVersion.DigitalWorkerType)
+	if err != nil {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			err.Error(),
+			"redeploy the agent so its service-side digital_worker_type matches activity.useCase",
+		)
 	}
 
 	// Patch agent-level endpoint/card fields
@@ -2166,6 +2188,11 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 	}
 
 	applyAgentMetadata(request)
+	if foundryAgentConfig != nil &&
+		foundryAgentConfig.Activity != nil &&
+		foundryAgentConfig.Activity.UseCase == ActivityUseCaseDigitalWorker {
+		request.DigitalWorkerType = agent_api.DigitalWorkerTypeM365
+	}
 
 	// Default to "responses" protocol when none specified in agent.yaml.
 	protocols := agentDef.Protocols
@@ -2490,7 +2517,9 @@ func (p *AgentServiceTargetProvider) deployVoiceAgentRemote(
 	if shouldUpdate {
 		progress("Updating voice agent using unified API")
 		updateRequest := &agent_api.UpdateAgentRequest{
-			CreateAgentVersionRequest: request.CreateAgentVersionRequest,
+			Description: request.Description,
+			Metadata:    request.Metadata,
+			Definition:  request.Definition,
 		}
 		agentObject, err := agentClient.UpdateVoiceAgent(
 			ctx, request.Name, updateRequest, agent_api.AgentEndpointAPIVersion, overriddenHost,
@@ -2948,9 +2977,10 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 
 	// Build the metadata for multipart upload
 	versionRequest := &agent_api.CreateAgentVersionRequest{
-		Description: prep.request.Description,
-		Metadata:    prep.request.Metadata,
-		Definition:  prep.request.Definition,
+		Description:       prep.request.Description,
+		Metadata:          prep.request.Metadata,
+		Definition:        prep.request.Definition,
+		DigitalWorkerType: prep.request.DigitalWorkerType,
 	}
 
 	// Create agent client
@@ -2982,8 +3012,10 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 		// Agent exists — update
 		progress("Updating existing agent from code package")
 		writeExistingAgentVersionWarning(agentDef.Name)
+		updateVersionRequest := *versionRequest
+		updateVersionRequest.DigitalWorkerType = ""
 		agentResp, err = agentClient.UpdateAgentFromZip(
-			ctx, agentDef.Name, versionRequest, zipData, sha256Hex, agent_api.AgentEndpointAPIVersion,
+			ctx, agentDef.Name, &updateVersionRequest, zipData, sha256Hex, agent_api.AgentEndpointAPIVersion,
 		)
 		if err != nil {
 			return nil, exterrors.ServiceFromAzure(err, exterrors.OpCreateAgent)
@@ -3405,9 +3437,10 @@ func (p *AgentServiceTargetProvider) createAgent(
 
 	// Extract CreateAgentVersionRequest from CreateAgentRequest
 	versionRequest := &agent_api.CreateAgentVersionRequest{
-		Description: request.Description,
-		Metadata:    request.Metadata,
-		Definition:  request.Definition,
+		Description:       request.Description,
+		Metadata:          request.Metadata,
+		Definition:        request.Definition,
+		DigitalWorkerType: request.DigitalWorkerType,
 	}
 
 	// Create agent version
@@ -3527,19 +3560,14 @@ func (p *AgentServiceTargetProvider) registerAgentEnvironmentVariables(
 		)
 	}
 	if activityProfile.UseCase == ActivityUseCaseDigitalWorker {
-		if activitySettings == nil || activitySettings.Publish == nil {
-			return fmt.Errorf("Digital Worker publish configuration is missing")
-		}
 		blueprint := agentVersionResponse.Blueprint
-		if blueprint == nil || strings.TrimSpace(blueprint.ClientID) == "" {
-			return fmt.Errorf("Digital Worker agent version is missing Blueprint client ID")
+		if blueprint != nil && strings.TrimSpace(blueprint.ClientID) != "" {
+			envVars = append(envVars, azdext.SetEnvRequest{
+				EnvName: p.env.Name,
+				Key:     envkey.AgentBlueprintClientID(serviceConfig.Name),
+				Value:   blueprint.ClientID,
+			})
 		}
-
-		envVars = append(envVars, azdext.SetEnvRequest{
-			EnvName: p.env.Name,
-			Key:     envkey.AgentBlueprintClientID(serviceConfig.Name),
-			Value:   blueprint.ClientID,
-		})
 	}
 
 	for i := range envVars {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -1306,10 +1306,7 @@ func TestRegisterAgentEnvironmentVariables_PersistsDigitalWorkerBlueprintClientI
 		azdClient: newEnvTestClient(t, envStub),
 		env:       &azdext.Environment{Name: "test-env"},
 	}
-	publish := &ActivityPublishConfig{
-		PublishAsAutopilot: true,
-		PublishScope:       "tenant",
-	}
+	publish := &ActivityPublishConfig{PublishScope: "tenant"}
 
 	err := provider.registerAgentEnvironmentVariables(
 		t.Context(),
@@ -1927,6 +1924,7 @@ func TestPrepareDeployAppliesDefaultResources(t *testing.T) {
 		Name:                 "basic-agent",
 		AdditionalProperties: props,
 	}
+
 	provider := &AgentServiceTargetProvider{}
 
 	prep, err := provider.prepareDeploy(
@@ -1945,6 +1943,32 @@ func TestPrepareDeployAppliesDefaultResources(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, DefaultCpu, definition.CPU)
 	require.Equal(t, DefaultMemory, definition.Memory)
+}
+
+func TestPrepareDeploySetsDigitalWorkerType(t *testing.T) {
+	t.Parallel()
+
+	agentDef := sampleContainerAgent()
+	props, err := AgentDefinitionToServiceProperties(agentDef, &ServiceTargetAgentConfig{
+		Activity: &ActivitySettings{UseCase: ActivityUseCaseDigitalWorker},
+	})
+	require.NoError(t, err)
+	svc := &azdext.ServiceConfig{
+		Name:                 "digital-worker",
+		AdditionalProperties: props,
+	}
+
+	prep, err := (&AgentServiceTargetProvider{}).prepareDeploy(
+		svc,
+		agentDef,
+		map[string]string{"FOUNDRY_PROJECT_ENDPOINT": "https://example"},
+		[]agent_yaml.AgentBuildOption{
+			agent_yaml.WithImageURL("registry.example/worker:v1"),
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, agent_api.DigitalWorkerTypeM365, prep.request.DigitalWorkerType)
 }
 
 func TestValidateRegistryConnectionDefinition(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
@@ -221,7 +221,7 @@
       }
     },
     {
-      "$comment": "The activity.publish block is shared publish metadata for Activity use cases (including simple). Digital Worker adds stricter requirements: publish must exist, publishScope must be tenant, and agenticUserTemplate is required to carry the persisted blueprint identity.",
+      "$comment": "The activity.publish block is shared publish metadata for Activity use cases (including simple). Digital Worker publish is tenant-only; permission scopes and access boundaries are optional.",
       "if": {
         "properties": {
           "activity": {
@@ -236,13 +236,11 @@
       "then": {
         "properties": {
           "activity": {
-            "required": ["publish"],
             "properties": {
               "publish": {
                 "properties": {
                   "publishScope": { "const": "tenant" }
-                },
-                "required": ["agenticUserTemplate"]
+                }
               }
             }
           }
@@ -273,7 +271,7 @@
         "useCase": { "type": "string", "enum": ["simple", "digital_worker"] },
         "publish": {
           "$ref": "#/definitions/ActivityPublishConfig",
-          "description": "Shared Microsoft 365 app publish metadata used by Activity use cases. For digital_worker, publishScope=tenant and agenticUserTemplate are required."
+          "description": "Shared Microsoft 365 app publish metadata used by Activity use cases. Digital Worker publication is tenant-only."
         }
       },
       "additionalProperties": false
@@ -291,19 +289,40 @@
         "developerWebsiteUrl": { "type": "string", "format": "uri" },
         "privacyUrl": { "type": "string", "format": "uri" },
         "termsOfUseUrl": { "type": "string", "format": "uri" },
-        "agenticUserTemplate": { "$ref": "#/definitions/AgenticUserTemplateConfig" }
+        "optionalPermissionScopes": {
+          "type": "array",
+          "description": "Optional Microsoft 365 permission selections for a Digital Worker.",
+          "items": { "$ref": "#/definitions/Microsoft365PermissionScopes" }
+        },
+        "accessBoundaries": {
+          "type": "array",
+          "description": "Optional Digital Worker access boundaries. An explicit empty array clears existing boundaries.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "read.1on1.developers",
+              "write.1on1.developers",
+              "read.group.developers",
+              "write.group.developers"
+            ]
+          },
+          "uniqueItems": true
+        }
       },
       "additionalProperties": false
     },
-    "AgenticUserTemplateConfig": {
+    "Microsoft365PermissionScopes": {
       "type": "object",
       "properties": {
-        "id": { "type": "string", "minLength": 1 },
-        "file": { "type": "string", "minLength": 1 },
-        "schemaVersion": { "type": "string", "minLength": 1 },
-        "communicationProtocol": { "type": "string", "minLength": 1 }
+        "resourceAppId": { "type": "string", "minLength": 1 },
+        "scopes": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "uniqueItems": true
+        }
       },
-      "required": ["id", "file", "schemaVersion", "communicationProtocol"],
+      "required": ["resourceAppId", "scopes"],
       "additionalProperties": false
     },
     "ProtocolVersionRecord": {


### PR DESCRIPTION
## Summary

- send `digital_worker_type: m365` with `DigitalWorker=V1Preview` when deploying configured Digital Workers and use the service-returned type for post-deploy Bot routing, pack, and publish decisions
- update the Microsoft 365 publish request by removing agentic-user-template fields and adding `optionalPermissionScopes` plus tri-state `accessBoundaries`
- support Digital Worker publish inputs in `azure.yaml` and repeatable CLI flags while preserving the Simple Activity Bot/package flow

## Testing

- `go test ./internal/pkg/agents/agent_api ./internal/project ./internal/cmd ./internal/synthesis`
- `go test ./...`
- `go build ./...`
- `go test -count=1 ./internal/pkg/agents/agent_api ./internal/project ./internal/cmd ./internal/synthesis`

## Follow-up validation

- [ ] Run the provision/deploy/publish E2E against the updated service in `westus2`
- [ ] Confirm GET returns `digital_worker_type: m365`
- [ ] Confirm Microsoft 365 publish accepts explicit WorkIQ scopes and developer access boundaries
- [ ] Complete admin approval and Teams validation