### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/vally-eval/action.yml
+++ b/.github/actions/vally-eval/action.yml
@@ -74,13 +74,13 @@ runs:
 
     - name: Set up Node.js
       if: steps.copilot.outputs.enabled == 'true'
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
 
     - name: Set up Go
       if: steps.copilot.outputs.enabled == 'true'
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version-file: ${{ inputs.working-directory }}/go.mod
 
@@ -219,7 +219,7 @@ runs:
 
     - name: Upload vally results
       if: always() && steps.copilot.outputs.enabled == 'true' && steps.run.outputs.vally-run-dir != ''
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ steps.run.outputs.vally-run-dir }}/**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           sparse-checkout: |
             .github

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -28,8 +28,8 @@ jobs:
   cspell-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "20"
       - run: npm install -g cspell@8.13.1
@@ -40,7 +40,7 @@ jobs:
   Copyright-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Copyright check
         run: ./eng/scripts/copyright-check.sh ./cli/azd
 
@@ -52,7 +52,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Run Pester tests for engineering scripts
         shell: pwsh
         run: |
@@ -73,8 +73,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: cli/azd/go.mod
       - name: Run mage helper tests

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           # Fetch full history for writing changelogs
           fetch-depth: 0
@@ -41,12 +41,12 @@ jobs:
           version: v0.74.4
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: cli/azd/go.mod
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "20"
 
@@ -57,4 +57,4 @@ jobs:
         run: npm install -g cspell@8.13.1
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2

--- a/.github/workflows/cspell-ext.yml
+++ b/.github/workflows/cspell-ext.yml
@@ -22,8 +22,8 @@ jobs:
   cspell-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "20"
       - run: npm install -g cspell@8.13.1

--- a/.github/workflows/cspell-misc.yml
+++ b/.github/workflows/cspell-misc.yml
@@ -19,8 +19,8 @@ jobs:
   cspell-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "20"
       - run: npm install -g cspell@8.13.1

--- a/.github/workflows/devcontainer-feature-release.yml
+++ b/.github/workflows/devcontainer-feature-release.yml
@@ -23,10 +23,10 @@ jobs:
     environment:
       name: deploy-devcontainer-feature
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: "Publish Features"
-        uses: devcontainers/action@v1
+        uses: devcontainers/action@1082abd5d2bf3a11abccba70eef98df068277772 # v1.4.3
         with:
           publish-features: "true"
           base-path-to-features: "./ext/devcontainer/src"

--- a/.github/workflows/devcontainer-feature-test.yml
+++ b/.github/workflows/devcontainer-feature-test.yml
@@ -25,7 +25,7 @@ jobs:
             "mcr.microsoft.com/devcontainers/base:debian",
           ]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: "Install latest devcontainer CLI"
         run: npm install -g @devcontainers/cli
@@ -37,7 +37,7 @@ jobs:
   test-scenarios:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: "Install latest devcontainer CLI"
         run: npm install -g @devcontainers/cli
@@ -49,7 +49,7 @@ jobs:
   test-global:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: "Install latest devcontainer CLI"
         run: npm install -g @devcontainers/cli

--- a/.github/workflows/devops-ext-ci.yml
+++ b/.github/workflows/devops-ext-ci.yml
@@ -21,8 +21,8 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "20"
       - name: Install dependencies

--- a/.github/workflows/ext-registry-check.yml
+++ b/.github/workflows/ext-registry-check.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Check if an extension registry changed
         id: changed
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -61,13 +61,13 @@ jobs:
 
       - name: Checkout
         if: steps.changed.outputs.registry_changed == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Check extension registry update
         if: steps.changed.outputs.registry_changed == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const script = require('./.github/scripts/src/ext-registry-check.js');

--- a/.github/workflows/ext-registry-ci.yml
+++ b/.github/workflows/ext-registry-ci.yml
@@ -23,10 +23,10 @@ jobs:
       run:
         working-directory: cli/azd
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: cli/azd/go.mod
           cache-dependency-path: |

--- a/.github/workflows/lint-bicep.yml
+++ b/.github/workflows/lint-bicep.yml
@@ -13,7 +13,7 @@ jobs:
   bicep-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Upgrade bicep
         run: |
           which bicep

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -29,12 +29,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: ${{ inputs.golangci-lint-version }}
           args: -v --timeout 10m0s
@@ -43,8 +43,8 @@ jobs:
   go-fix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
       - name: Check for go fix suggestions

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -21,11 +21,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Check linked issue
         id: issue-check
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const script = require('./.github/scripts/pr-governance-issue-check.js');
@@ -33,7 +33,7 @@ jobs:
 
       - name: Check issue priority
         if: steps.issue-check.outputs.skipped != 'true' && steps.issue-check.outcome == 'success'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PROJECT_TOKEN: ${{ secrets.PROJECT_READ_TOKEN }}
           ISSUE_NUMBERS: ${{ steps.issue-check.outputs.issue_numbers }}

--- a/.github/workflows/schema-ci.yml
+++ b/.github/workflows/schema-ci.yml
@@ -13,8 +13,8 @@ jobs:
   schema-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "20"
       - run: npm install -g jsonlint
@@ -22,7 +22,7 @@ jobs:
         run: jsonlint schemas/**/*.json -c
 # NOTE: Using jsonschema2md here to ensure the schemas are valid for documentation generation.
 #       Since we use jsonschema2md for CI pipelines, any changes to the schemas should make sure to keep the tool happy.
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.x'
       - run: pip install jsonschema2md==1.5.2

--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -27,10 +27,10 @@ jobs:
         working-directory: .github/scripts
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           # 24 is the version that the GitHub actions script I'm running should also be 
           # running under.

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -10,7 +10,7 @@ jobs:
   mark-stale-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           days-before-issue-stale: 365        # Initial filter to stale yearly ignored issues
         #   only-issue-labels:                # Not enabled until we have a better idea for what to target

--- a/.github/workflows/test-ext-azure-ai-agents.yml
+++ b/.github/workflows/test-ext-azure-ai-agents.yml
@@ -25,9 +25,9 @@ jobs:
       TIER_0_TEST_PATTERN: '^Test_AIAgent_(Version|Help|Init_NoPrompt_MissingFlags|Doctor_Help)$'
       TIER_1_TEST_PATTERN: '^Test_AIAgent_(Init_(NoPrompt_(Defer|WithProject)|NegativeControl_BadCassette)|SampleList_(Recorded|JSON_Recorded))$'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: cli/azd/go.mod
 

--- a/.github/workflows/validate-go-dependency-versions.yml
+++ b/.github/workflows/validate-go-dependency-versions.yml
@@ -19,8 +19,8 @@ jobs:
   check-dependency-version-consistency:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: cli/azd/go.mod
       - name: Validate dependency version consistency

--- a/.github/workflows/validate-go-version.yml
+++ b/.github/workflows/validate-go-version.yml
@@ -17,7 +17,7 @@ jobs:
   check-go-version-consistency:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Validate Go version consistency
         run: |

--- a/.github/workflows/verify-ext-providers.yml
+++ b/.github/workflows/verify-ext-providers.yml
@@ -36,8 +36,8 @@ jobs:
       run:
         working-directory: cli/azd
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: cli/azd/go.mod
       - name: Verify provider contract coverage
@@ -49,8 +49,8 @@ jobs:
     if: inputs.working-directory != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
       # go test -run exits 0 when nothing matches, so first require the

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -21,8 +21,8 @@ jobs:
   cspell-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "22"
       - run: npm install -g cspell@8.13.1
@@ -40,10 +40,10 @@ jobs:
             upload-artifact: true
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -51,7 +51,7 @@ jobs:
       # `azure-dev-<version>.vsix`
       - name: Set package additional arguments
         id: package-arguments
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           result-encoding: string
           script: |
@@ -78,7 +78,7 @@ jobs:
 
       - name: 'Upload azd binary to artifact store (upload-artifact: true only)'
         if: matrix.upload-artifact == true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: package
           path: ./ext/vscode/azure-dev*.vsix


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
