### PR TITLE
feat(azure.ai.agents): update digital worker contracts

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 
+- [[#9776]](https://github.com/Azure/azure-dev/pull/9776) Update Digital Worker agent and Microsoft 365 publish contracts with service-side type detection, optional permission scopes, and access boundaries.
 - [[#9586]](https://github.com/Azure/azure-dev/pull/9586) Add support for private non-ACR registry connections when authoring and deploying hosted agents.
 - [[#9634]](https://github.com/Azure/azure-dev/pull/9634) Update prompt voice agents to use the unified Agents API with versioned voice endpoints.
 - [[#9655]](https://github.com/Azure/azure-dev/pull/9655) Add advanced prompt voice settings for audio, turn detection, modalities, tools, and service features.

--- a/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
+++ b/cli/azd/extensions/azure.ai.agents/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Features Added
 
-- [[#9776]](https://github.com/Azure/azure-dev/pull/9776) Update Digital Worker agent and Microsoft 365 publish contracts with service-side type detection, optional permission scopes, and access boundaries.
 - [[#9586]](https://github.com/Azure/azure-dev/pull/9586) Add support for private non-ACR registry connections when authoring and deploying hosted agents.
 - [[#9634]](https://github.com/Azure/azure-dev/pull/9634) Update prompt voice agents to use the unified Agents API with versioned voice endpoints.
 - [[#9655]](https://github.com/Azure/azure-dev/pull/9655) Add advanced prompt voice settings for audio, turn detection, modalities, tools, and service features.

--- a/cli/azd/extensions/azure.ai.agents/README.md
+++ b/cli/azd/extensions/azure.ai.agents/README.md
@@ -31,7 +31,7 @@ services:
       - protocol: activity
         version: 2.0.0
     activity:
-      useCase: digital_worker
+      digitalWorkerType: m365
       publish:
         publishScope: tenant
         agentDisplayName: My Digital Worker
@@ -46,8 +46,9 @@ services:
 ```
 
 The `activity.publish` block is shared Microsoft 365 app publish metadata for
-Activity use cases (including `simple`). For `digital_worker`, azd enforces
-tenant scope and sends `digital_worker_type: m365` when creating the agent.
+Activity agents. When `digitalWorkerType` is `m365`, azd enforces tenant scope
+and sends `digital_worker_type: m365` when creating the agent. Omit
+`digitalWorkerType` for simple mode.
 After deployment, the service-returned Digital Worker type controls pack and
 publish behavior. The publish request sets `publishAsAutopilot` automatically;
 the publish block itself is optional.
@@ -64,8 +65,8 @@ azd deploy
 azd ai agent publish
 ```
 
-For `simple` Activity agents, `publishScope` accepts `shared` or `tenant`. For
-`digital_worker`, `publishScope` is always `tenant`.
+For simple Activity agents, `publishScope` accepts `shared` or `tenant`. For an
+`m365` Digital Worker, `publishScope` is always `tenant`.
 An explicit `azd ai agent publish --scope <scope>` overrides the configured
 value where allowed by the use case. Use `--display-name` and `--app-version`
 to override the corresponding configured publish metadata for one command

--- a/cli/azd/extensions/azure.ai.agents/README.md
+++ b/cli/azd/extensions/azure.ai.agents/README.md
@@ -35,21 +35,29 @@ services:
       publish:
         publishScope: tenant
         agentDisplayName: My Digital Worker
-        agenticUserTemplate:
-          id: digitalWorkerTemplate
-          file: agenticUserTemplateManifest.json
-          schemaVersion: 0.1.0-preview
-          communicationProtocol: activityProtocol
+        optionalPermissionScopes:
+          - resourceAppId: ea9ffc3e-8a23-4a7d-836d-234d7c7565c1
+            scopes:
+              - McpServers.Mail.All
+              - McpServers.Calendar.All
+        accessBoundaries:
+          - read.1on1.developers
+          - write.1on1.developers
 ```
 
 The `activity.publish` block is shared Microsoft 365 app publish metadata for
 Activity use cases (including `simple`). For `digital_worker`, azd enforces
-additional constraints: `publish` must be present, `publishScope` must be
-`tenant`, and `agenticUserTemplate` must include `id`, `file`,
-`schemaVersion`, and `communicationProtocol`. The publish request sets
-`publishAsAutopilot` automatically to `true` for this use case; users do not
-need to declare it in YAML. The Agent Identity Blueprint ID is generated during
-deployment and added to the publish request automatically.
+tenant scope and sends `digital_worker_type: m365` when creating the agent.
+After deployment, the service-returned Digital Worker type controls pack and
+publish behavior. The publish request sets `publishAsAutopilot` automatically;
+the publish block itself is optional.
+
+`optionalPermissionScopes` selects additional Microsoft 365 permissions such as
+WorkIQ MCP scopes. `accessBoundaries` accepts the supported
+`read.1on1.developers`, `write.1on1.developers`,
+`read.group.developers`, and `write.group.developers` values. Omitting
+`accessBoundaries` preserves the current service configuration; an explicit
+empty array clears it.
 
 ```bash
 azd deploy
@@ -61,7 +69,10 @@ For `simple` Activity agents, `publishScope` accepts `shared` or `tenant`. For
 An explicit `azd ai agent publish --scope <scope>` overrides the configured
 value where allowed by the use case. Use `--display-name` and `--app-version`
 to override the corresponding configured publish metadata for one command
-invocation.
+invocation. Repeat `--optional-permission-scope <resource-app-id>=<scope>` or
+`--access-boundary <boundary>` to replace the configured values for one
+publication. Use `--clear-access-boundaries` to send an explicit empty array and
+clear existing boundaries.
 
 The Agent Inspector UI binds port `8087` by default. Use `--inspector-port` to
 move it, which is what you need when running two agents side by side or when a

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_agent_status.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_agent_status.go
@@ -825,7 +825,7 @@ func makeRealProbeAgentStatus(
 
 		client := agent_api.NewAgentClient(endpoint, cred)
 		v, err := client.GetAgentVersion(
-			ctx, agentName, agentVersion, apiVersion)
+			ctx, agentName, agentVersion, apiVersion, false)
 		if err != nil {
 			if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
 				return agentStatusProbeResult{

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/endpoint_show.go
@@ -102,7 +102,7 @@ func runEndpointShow(
 		return err
 	}
 
-	agent, err := agentClient.GetAgent(ctx, agentDef.Name, DefaultAgentAPIVersion)
+	agent, err := agentClient.GetAgent(ctx, agentDef.Name, DefaultAgentAPIVersion, false)
 	if err != nil {
 		return fmt.Errorf("failed to get agent %q: %w", agentDef.Name, err)
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_test.go
@@ -1028,6 +1028,7 @@ func (f *fakeConflictAgentChecker) GetAgent(
 	_ context.Context,
 	agentName string,
 	_ string,
+	_ bool,
 ) (*agent_api.AgentObject, error) {
 	f.calls = append(f.calls, agentName)
 	if f.err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_activity.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_activity.go
@@ -79,7 +79,7 @@ func writeTeamsAppPackage(
 		DeveloperWebsiteURL:      "https://learn.microsoft.com/azure/ai-foundry/",
 		PrivacyURL:               "https://learn.microsoft.com/azure/ai-foundry/",
 		TermsOfUseURL:            "https://learn.microsoft.com/azure/ai-foundry/",
-		CanRespondWithoutMention: true,
+		CanRespondWithoutMention: new(true),
 	}
 
 	zipBytes, err := agentClient.DownloadTeamsAppPackage(

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_activity_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_activity_test.go
@@ -66,7 +66,7 @@ func TestActivityBotTeardownTarget(t *testing.T) {
 	}
 }
 
-func TestResolveServiceActivityProfileUsesConfiguredUseCase(t *testing.T) {
+func TestResolveServiceActivityProfileUsesConfiguredDigitalWorkerType(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -81,7 +81,7 @@ func TestResolveServiceActivityProfileUsesConfiguredUseCase(t *testing.T) {
 		{
 			name: "digital worker skips simple flow",
 			activity: map[string]any{
-				"useCase": "digital_worker",
+				"digitalWorkerType": "m365",
 				"publish": map[string]any{
 					"publishScope": "tenant",
 				},
@@ -119,7 +119,7 @@ func TestResolveServiceActivityProfileUsesConfiguredUseCase(t *testing.T) {
 	}
 }
 
-func TestResolveServiceActivityProfileUsesConfiguredUseCaseFromFileRef(t *testing.T) {
+func TestResolveServiceActivityProfileUsesConfiguredDigitalWorkerTypeFromFileRef(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -131,7 +131,7 @@ func TestResolveServiceActivityProfileUsesConfiguredUseCaseFromFileRef(t *testin
 		"  - protocol: activity",
 		"    version: 2.0.0",
 		"activity:",
-		"  useCase: digital_worker",
+		"  digitalWorkerType: m365",
 		"  publish:",
 		"    publishScope: tenant",
 	}, "\n")
@@ -181,7 +181,7 @@ func TestShouldProvisionActivityBotUsesCanonicalUseCaseResolution(t *testing.T) 
 			"  - protocol: activity",
 			"    version: 2.0.0",
 			"activity:",
-			"  useCase: digital_worker",
+			"  digitalWorkerType: m365",
 			"  publish:",
 			"    publishScope: tenant",
 		}, "\n")

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_activity_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/listen_activity_test.go
@@ -84,12 +84,6 @@ func TestResolveServiceActivityProfileUsesConfiguredUseCase(t *testing.T) {
 				"useCase": "digital_worker",
 				"publish": map[string]any{
 					"publishScope": "tenant",
-					"agenticUserTemplate": map[string]any{
-						"id":                    "digitalWorkerTemplate",
-						"file":                  "agenticUserTemplateManifest.json",
-						"schemaVersion":         "0.1.0-preview",
-						"communicationProtocol": "activityProtocol",
-					},
 				},
 			},
 			want: project.ActivityUseCaseDigitalWorker,
@@ -140,11 +134,6 @@ func TestResolveServiceActivityProfileUsesConfiguredUseCaseFromFileRef(t *testin
 		"  useCase: digital_worker",
 		"  publish:",
 		"    publishScope: tenant",
-		"    agenticUserTemplate:",
-		"      id: digitalWorkerTemplate",
-		"      file: agenticUserTemplateManifest.json",
-		"      schemaVersion: 0.1.0-preview",
-		"      communicationProtocol: activityProtocol",
 	}, "\n")
 	require.NoError(t, os.WriteFile(definitionPath, []byte(referenced), 0600))
 
@@ -195,11 +184,6 @@ func TestShouldProvisionActivityBotUsesCanonicalUseCaseResolution(t *testing.T) 
 			"  useCase: digital_worker",
 			"  publish:",
 			"    publishScope: tenant",
-			"    agenticUserTemplate:",
-			"      id: digitalWorkerTemplate",
-			"      file: agenticUserTemplateManifest.json",
-			"      schemaVersion: 0.1.0-preview",
-			"      communicationProtocol: activityProtocol",
 		}, "\n")
 		require.NoError(t, os.WriteFile(definitionPath, []byte(definition), 0600))
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/optimize_deploy.go
@@ -139,7 +139,7 @@ func (a *OptimizeDeployAction) runDirect(
 	fmt.Fprintf(out, "  Fetching current agent definition...\n")
 	agentClient := agent_api.NewAgentClient(projectEndpoint, credential)
 
-	agentObj, err := agentClient.GetAgent(ctx, agentName, DefaultAgentAPIVersion)
+	agentObj, err := agentClient.GetAgent(ctx, agentName, DefaultAgentAPIVersion, false)
 	if err != nil {
 		return fmt.Errorf("failed to get agent %q: %w", agentName, err)
 	}
@@ -407,7 +407,7 @@ func pollVersionActive(
 			return fmt.Errorf("timed out waiting for version %s to become active after %s", versionNum, timeout)
 		}
 
-		version, err := client.GetAgentVersion(ctx, agentName, versionNum, DefaultAgentAPIVersion)
+		version, err := client.GetAgentVersion(ctx, agentName, versionNum, DefaultAgentAPIVersion, false)
 		if err != nil {
 			return fmt.Errorf("failed to poll version status: %w", err)
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
@@ -243,8 +243,14 @@ func resolveDigitalWorkerPublishInputs(
 	}
 	if flags.accessBoundariesSet {
 		values := make([]string, 0, len(flags.accessBoundaries))
+		seen := make(map[string]struct{}, len(flags.accessBoundaries))
 		for _, boundary := range flags.accessBoundaries {
-			values = append(values, strings.TrimSpace(boundary))
+			boundary = strings.TrimSpace(boundary)
+			if _, ok := seen[boundary]; ok {
+				continue
+			}
+			seen[boundary] = struct{}{}
+			values = append(values, boundary)
 		}
 		if err := project.ValidateDigitalWorkerAccessBoundaries(values); err != nil {
 			return nil, nil, exterrors.Validation(

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
@@ -222,8 +222,10 @@ func resolveDigitalWorkerPublishInputs(
 			})
 		}
 		if publish.AccessBoundaries != nil {
-			values := make([]string, len(*publish.AccessBoundaries))
-			copy(values, *publish.AccessBoundaries)
+			values := make([]string, 0, len(*publish.AccessBoundaries))
+			for _, boundary := range *publish.AccessBoundaries {
+				values = append(values, strings.TrimSpace(boundary))
+			}
 			boundaries = &values
 		}
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
@@ -200,7 +200,8 @@ func resolveDigitalWorkerPublishInputs(
 			return nil, nil, exterrors.Validation(
 				exterrors.CodeInvalidServiceConfig,
 				"Digital Worker permission scopes and access boundaries cannot be used for a simple Activity agent",
-				"remove --optional-permission-scope and --access-boundary, or publish a Digital Worker",
+				"remove --optional-permission-scope, --access-boundary, and --clear-access-boundaries, "+
+					"or publish a Digital Worker",
 			)
 		}
 		return nil, nil, nil

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
@@ -210,13 +210,6 @@ func resolveDigitalWorkerPublishInputs(
 	var permissions []agent_api.Microsoft365PermissionScopes
 	var boundaries *[]string
 	if publish != nil {
-		if err := project.ValidateDigitalWorkerPublishConfig(publish); err != nil {
-			return nil, nil, exterrors.Validation(
-				exterrors.CodeInvalidServiceConfig,
-				fmt.Sprintf("invalid Digital Worker publish configuration: %s", err),
-				"fix activity.publish in azure.yaml",
-			)
-		}
 		permissions = make([]agent_api.Microsoft365PermissionScopes, 0, len(publish.OptionalPermissionScopes))
 		for _, permission := range publish.OptionalPermissionScopes {
 			scopes := make([]string, 0, len(permission.Scopes))
@@ -264,7 +257,51 @@ func resolveDigitalWorkerPublishInputs(
 		values := []string{}
 		boundaries = &values
 	}
+
+	effectivePublish := effectiveDigitalWorkerPublishConfig(publish, flags, permissions, boundaries)
+	if effectivePublish != nil {
+		if err := project.ValidateDigitalWorkerPublishConfig(effectivePublish); err != nil {
+			return nil, nil, exterrors.Validation(
+				exterrors.CodeInvalidServiceConfig,
+				fmt.Sprintf("invalid Digital Worker publish configuration: %s", err),
+				"fix activity.publish in azure.yaml or pass valid publish override flags",
+			)
+		}
+	}
 	return permissions, boundaries, nil
+}
+
+func effectiveDigitalWorkerPublishConfig(
+	publish *project.ActivityPublishConfig,
+	flags *publishFlags,
+	permissions []agent_api.Microsoft365PermissionScopes,
+	boundaries *[]string,
+) *project.ActivityPublishConfig {
+	if publish == nil && len(permissions) == 0 && boundaries == nil {
+		return nil
+	}
+
+	effective := &project.ActivityPublishConfig{}
+	if publish != nil {
+		*effective = *publish
+	}
+	if flags.scopeSet {
+		effective.PublishScope = ""
+	}
+	if flags.optionalPermissionScopesSet {
+		effective.OptionalPermissionScopes = make([]project.Microsoft365PermissionScopes, 0, len(permissions))
+		for _, permission := range permissions {
+			effective.OptionalPermissionScopes = append(effective.OptionalPermissionScopes, project.Microsoft365PermissionScopes{
+				ResourceAppID: permission.ResourceAppID,
+				Scopes:        append([]string(nil), permission.Scopes...),
+			})
+		}
+	}
+	if flags.accessBoundariesSet || flags.clearAccessBoundaries {
+		effective.AccessBoundaries = boundaries
+	}
+
+	return effective
 }
 
 func parseOptionalPermissionScopeFlags(values []string) ([]agent_api.Microsoft365PermissionScopes, error) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
@@ -292,10 +292,13 @@ func effectiveDigitalWorkerPublishConfig(
 	if flags.optionalPermissionScopesSet {
 		effective.OptionalPermissionScopes = make([]project.Microsoft365PermissionScopes, 0, len(permissions))
 		for _, permission := range permissions {
-			effective.OptionalPermissionScopes = append(effective.OptionalPermissionScopes, project.Microsoft365PermissionScopes{
-				ResourceAppID: permission.ResourceAppID,
-				Scopes:        append([]string(nil), permission.Scopes...),
-			})
+			effective.OptionalPermissionScopes = append(
+				effective.OptionalPermissionScopes,
+				project.Microsoft365PermissionScopes{
+					ResourceAppID: permission.ResourceAppID,
+					Scopes:        append([]string(nil), permission.Scopes...),
+				},
+			)
 		}
 	}
 	if flags.accessBoundariesSet || flags.clearAccessBoundaries {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
@@ -194,7 +194,7 @@ func resolveDigitalWorkerPublishInputs(
 	publish := activityPublishConfig(packCtx)
 	if !isDigitalWorker {
 		hasDigitalWorkerConfig := publish != nil &&
-			(len(publish.OptionalPermissionScopes) > 0 || publish.AccessBoundaries != nil)
+			(publish.OptionalPermissionScopes != nil || publish.AccessBoundaries != nil)
 		if flags.optionalPermissionScopesSet || flags.accessBoundariesSet ||
 			flags.clearAccessBoundaries || hasDigitalWorkerConfig {
 			return nil, nil, exterrors.Validation(

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
@@ -222,7 +222,8 @@ func resolveDigitalWorkerPublishInputs(
 			})
 		}
 		if publish.AccessBoundaries != nil {
-			values := append([]string(nil), (*publish.AccessBoundaries)...)
+			values := make([]string, len(*publish.AccessBoundaries))
+			copy(values, *publish.AccessBoundaries)
 			boundaries = &values
 		}
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish.go
@@ -27,13 +27,18 @@ var teamsPublishScopes = []teamsPackScope{
 }
 
 type publishFlags struct {
-	name        string
-	scope       string
-	scopeSet    bool
-	displayName string
-	appVersion  string
-	output      string
-	noPrompt    bool
+	name                        string
+	scope                       string
+	scopeSet                    bool
+	displayName                 string
+	appVersion                  string
+	optionalPermissionScopes    []string
+	optionalPermissionScopesSet bool
+	accessBoundaries            []string
+	accessBoundariesSet         bool
+	clearAccessBoundaries       bool
+	output                      string
+	noPrompt                    bool
 }
 
 func newPublishCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
@@ -72,6 +77,8 @@ func newPublishCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 				flags.name = args[0]
 			}
 			flags.scopeSet = cmd.Flags().Changed("scope")
+			flags.optionalPermissionScopesSet = cmd.Flags().Changed("optional-permission-scope")
+			flags.accessBoundariesSet = cmd.Flags().Changed("access-boundary")
 			flags.output = extCtx.OutputFormat
 			flags.noPrompt = extCtx.NoPrompt
 
@@ -89,6 +96,25 @@ func newPublishCommand(extCtx *azdext.ExtensionContext) *cobra.Command {
 	cmd.Flags().StringVar(&flags.appVersion, "app-version", "",
 		"Version stamped into the Teams app manifest. If specified, it overrides activity.publish.appVersion "+
 			"in azure.yaml; otherwise azd uses the azure.yaml value, and falls back to 1.0.0.")
+	cmd.Flags().StringArrayVar(
+		&flags.optionalPermissionScopes,
+		"optional-permission-scope",
+		nil,
+		"Digital Worker permission in <resource-app-id>=<scope> form. Repeat to select multiple scopes.",
+	)
+	cmd.Flags().StringArrayVar(
+		&flags.accessBoundaries,
+		"access-boundary",
+		nil,
+		"Digital Worker access boundary. Repeat to select multiple developer boundaries.",
+	)
+	cmd.Flags().BoolVar(
+		&flags.clearAccessBoundaries,
+		"clear-access-boundaries",
+		false,
+		"Clear all existing Digital Worker access boundaries.",
+	)
+	cmd.MarkFlagsMutuallyExclusive("access-boundary", "clear-access-boundaries")
 
 	azdext.RegisterFlagOptions(cmd, azdext.FlagOptions{
 		Name:          "output",
@@ -120,15 +146,20 @@ func (a *PublishAction) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	optionalPermissionScopes, accessBoundaries, err := resolveDigitalWorkerPublishInputs(a.flags, packCtx)
+	if err != nil {
+		return err
+	}
 
 	request := buildTeamsAppPackageRequest(packCtx.botArmID, teamsAppRequestOptions{
-		scope:             scope,
-		agentName:         packCtx.agentName,
-		useCase:           packCtx.activityProfile.UseCase,
-		displayName:       a.flags.displayName,
-		appVersion:        a.flags.appVersion,
-		blueprintClientID: packCtx.blueprintClientID,
-		publish:           activityPublishConfig(packCtx),
+		scope:                    scope,
+		agentName:                packCtx.agentName,
+		useCase:                  packCtx.activityProfile.UseCase,
+		displayName:              a.flags.displayName,
+		appVersion:               a.flags.appVersion,
+		publish:                  activityPublishConfig(packCtx),
+		optionalPermissionScopes: optionalPermissionScopes,
+		accessBoundaries:         accessBoundaries,
 	})
 
 	if a.flags.output != "json" {
@@ -153,6 +184,113 @@ func (a *PublishAction) Run(ctx context.Context) error {
 	return writePublishResult(
 		os.Stdout, a.flags.output, result, scope, request.AgentDisplayName, packCtx.agentName, deepLink, isDigitalWorker,
 	)
+}
+
+func resolveDigitalWorkerPublishInputs(
+	flags *publishFlags,
+	packCtx *teamsPackContext,
+) ([]agent_api.Microsoft365PermissionScopes, *[]string, error) {
+	isDigitalWorker := packCtx.activityProfile.UseCase == project.ActivityUseCaseDigitalWorker
+	publish := activityPublishConfig(packCtx)
+	if !isDigitalWorker {
+		hasDigitalWorkerConfig := publish != nil &&
+			(len(publish.OptionalPermissionScopes) > 0 || publish.AccessBoundaries != nil)
+		if flags.optionalPermissionScopesSet || flags.accessBoundariesSet ||
+			flags.clearAccessBoundaries || hasDigitalWorkerConfig {
+			return nil, nil, exterrors.Validation(
+				exterrors.CodeInvalidServiceConfig,
+				"Digital Worker permission scopes and access boundaries cannot be used for a simple Activity agent",
+				"remove --optional-permission-scope and --access-boundary, or publish a Digital Worker",
+			)
+		}
+		return nil, nil, nil
+	}
+
+	var permissions []agent_api.Microsoft365PermissionScopes
+	var boundaries *[]string
+	if publish != nil {
+		if err := project.ValidateDigitalWorkerPublishConfig(publish); err != nil {
+			return nil, nil, exterrors.Validation(
+				exterrors.CodeInvalidServiceConfig,
+				fmt.Sprintf("invalid Digital Worker publish configuration: %s", err),
+				"fix activity.publish in azure.yaml",
+			)
+		}
+		permissions = make([]agent_api.Microsoft365PermissionScopes, 0, len(publish.OptionalPermissionScopes))
+		for _, permission := range publish.OptionalPermissionScopes {
+			scopes := make([]string, 0, len(permission.Scopes))
+			for _, scope := range permission.Scopes {
+				scopes = append(scopes, strings.TrimSpace(scope))
+			}
+			permissions = append(permissions, agent_api.Microsoft365PermissionScopes{
+				ResourceAppID: strings.TrimSpace(permission.ResourceAppID),
+				Scopes:        scopes,
+			})
+		}
+		if publish.AccessBoundaries != nil {
+			values := append([]string(nil), (*publish.AccessBoundaries)...)
+			boundaries = &values
+		}
+	}
+
+	if flags.optionalPermissionScopesSet {
+		var err error
+		permissions, err = parseOptionalPermissionScopeFlags(flags.optionalPermissionScopes)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	if flags.accessBoundariesSet {
+		values := make([]string, 0, len(flags.accessBoundaries))
+		for _, boundary := range flags.accessBoundaries {
+			values = append(values, strings.TrimSpace(boundary))
+		}
+		if err := project.ValidateDigitalWorkerAccessBoundaries(values); err != nil {
+			return nil, nil, exterrors.Validation(
+				exterrors.CodeInvalidServiceConfig,
+				fmt.Sprintf("invalid --access-boundary: %s", err),
+				"use a supported *.developers access boundary",
+			)
+		}
+		boundaries = &values
+	} else if flags.clearAccessBoundaries {
+		values := []string{}
+		boundaries = &values
+	}
+	return permissions, boundaries, nil
+}
+
+func parseOptionalPermissionScopeFlags(values []string) ([]agent_api.Microsoft365PermissionScopes, error) {
+	permissions := make([]agent_api.Microsoft365PermissionScopes, 0)
+	resourceIndexes := make(map[string]int)
+	seen := make(map[string]struct{})
+	for _, value := range values {
+		resourceAppID, scope, found := strings.Cut(value, "=")
+		resourceAppID = strings.TrimSpace(resourceAppID)
+		scope = strings.TrimSpace(scope)
+		if !found || resourceAppID == "" || scope == "" {
+			return nil, exterrors.Validation(
+				exterrors.CodeInvalidServiceConfig,
+				fmt.Sprintf("invalid optional permission scope %q", value),
+				"use --optional-permission-scope <resource-app-id>=<scope>",
+			)
+		}
+		key := resourceAppID + "\x00" + scope
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		index, ok := resourceIndexes[resourceAppID]
+		if !ok {
+			index = len(permissions)
+			resourceIndexes[resourceAppID] = index
+			permissions = append(permissions, agent_api.Microsoft365PermissionScopes{
+				ResourceAppID: resourceAppID,
+			})
+		}
+		permissions[index].Scopes = append(permissions[index].Scopes, scope)
+	}
+	return permissions, nil
 }
 
 func resolvePublishScope(flags *publishFlags, packCtx *teamsPackContext) (teamsPackScope, error) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish_test.go
@@ -252,8 +252,8 @@ func TestBuildTeamsAppPackageRequestUsesPublishMetadataForSimpleActivity(t *test
 	require.Equal(t, "Configured Activity agent", configured.AgentDisplayName)
 	require.Equal(t, "Shared", configured.PublishScope)
 	require.False(t, configured.PublishAsAutopilot)
-	require.False(t, configured.UseAgenticUserTemplate)
-	require.Nil(t, configured.AgenticUserTemplate)
+	require.Empty(t, configured.OptionalPermissionScopes)
+	require.Nil(t, configured.AccessBoundaries)
 
 	explicit := buildTeamsAppPackageRequest("", teamsAppRequestOptions{
 		displayName: "CLI Activity agent",
@@ -265,8 +265,74 @@ func TestBuildTeamsAppPackageRequestUsesPublishMetadataForSimpleActivity(t *test
 	require.Equal(t, "CLI Activity agent", explicit.AgentDisplayName)
 	require.Equal(t, "Tenant", explicit.PublishScope)
 	require.False(t, explicit.PublishAsAutopilot)
-	require.False(t, explicit.UseAgenticUserTemplate)
-	require.Nil(t, explicit.AgenticUserTemplate)
+	require.Empty(t, explicit.OptionalPermissionScopes)
+	require.Nil(t, explicit.AccessBoundaries)
+}
+
+func TestParseOptionalPermissionScopeFlags(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseOptionalPermissionScopeFlags([]string{
+		"resource-a=McpServers.Mail.All",
+		"resource-b=Ado.Mcp.Tools",
+		"resource-a=McpServers.Calendar.All",
+		"resource-a=McpServers.Mail.All",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []agent_api.Microsoft365PermissionScopes{
+		{ResourceAppID: "resource-a", Scopes: []string{"McpServers.Mail.All", "McpServers.Calendar.All"}},
+		{ResourceAppID: "resource-b", Scopes: []string{"Ado.Mcp.Tools"}},
+	}, got)
+}
+
+func TestParseOptionalPermissionScopeFlagsRejectsInvalidValue(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseOptionalPermissionScopeFlags([]string{"McpServers.Mail.All"})
+	require.ErrorContains(t, err, "invalid optional permission scope")
+}
+
+func TestResolveDigitalWorkerPublishInputs(t *testing.T) {
+	t.Parallel()
+
+	configBoundaries := []string{"read.1on1.developers"}
+	packCtx := digitalWorkerPackContext("tenant")
+	packCtx.activitySettings.Publish.OptionalPermissionScopes = []project.Microsoft365PermissionScopes{
+		{ResourceAppID: "configured-app", Scopes: []string{"Configured.Scope"}},
+	}
+	packCtx.activitySettings.Publish.AccessBoundaries = &configBoundaries
+
+	permissions, boundaries, err := resolveDigitalWorkerPublishInputs(&publishFlags{}, packCtx)
+	require.NoError(t, err)
+	require.Equal(t, "configured-app", permissions[0].ResourceAppID)
+	require.Equal(t, configBoundaries, *boundaries)
+
+	permissions, boundaries, err = resolveDigitalWorkerPublishInputs(&publishFlags{
+		optionalPermissionScopes:    []string{"flag-app=Flag.Scope"},
+		optionalPermissionScopesSet: true,
+		accessBoundaries:            []string{"write.group.developers"},
+		accessBoundariesSet:         true,
+	}, packCtx)
+	require.NoError(t, err)
+	require.Equal(t, "flag-app", permissions[0].ResourceAppID)
+	require.Equal(t, []string{"write.group.developers"}, *boundaries)
+
+	_, boundaries, err = resolveDigitalWorkerPublishInputs(&publishFlags{
+		clearAccessBoundaries: true,
+	}, packCtx)
+	require.NoError(t, err)
+	require.NotNil(t, boundaries)
+	require.Empty(t, *boundaries)
+}
+
+func TestResolveDigitalWorkerPublishInputsRejectsSimpleAgentFlags(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := resolveDigitalWorkerPublishInputs(&publishFlags{
+		accessBoundaries:    []string{"read.1on1.developers"},
+		accessBoundariesSet: true,
+	}, activityPackContext(project.ActivityUseCaseSimple, "shared"))
+	require.ErrorContains(t, err, "cannot be used for a simple Activity agent")
 }
 
 func digitalWorkerPackContext(publishScope string) *teamsPackContext {
@@ -278,16 +344,9 @@ func activityPackContext(useCase project.ActivityUseCase, publishScope string) *
 		activityProfile: project.ActivityProfile{UseCase: useCase},
 		activitySettings: &project.ActivitySettings{
 			Publish: &project.ActivityPublishConfig{
-				PublishAsAutopilot: true,
-				PublishScope:       publishScope,
-				AppVersion:         "2.3.4",
-				AgentDisplayName:   "Configured Activity agent",
-				AgenticUserTemplate: &project.AgenticUserTemplateConfig{
-					ID:                    "digitalWorkerTemplate",
-					File:                  "agenticUserTemplateManifest.json",
-					SchemaVersion:         "0.1.0-preview",
-					CommunicationProtocol: "activityProtocol",
-				},
+				PublishScope:     publishScope,
+				AppVersion:       "2.3.4",
+				AgentDisplayName: "Configured Activity agent",
 			},
 		},
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish_test.go
@@ -325,6 +325,35 @@ func TestResolveDigitalWorkerPublishInputs(t *testing.T) {
 	require.Empty(t, *boundaries)
 }
 
+func TestResolveDigitalWorkerPublishInputsValidatesAfterFlagOverrides(t *testing.T) {
+	t.Parallel()
+
+	configBoundaries := []string{"invalid.boundary"}
+	packCtx := digitalWorkerPackContext("shared")
+	packCtx.activitySettings.Publish.OptionalPermissionScopes = []project.Microsoft365PermissionScopes{
+		{ResourceAppID: "", Scopes: []string{""}},
+	}
+	packCtx.activitySettings.Publish.AccessBoundaries = &configBoundaries
+
+	permissions, boundaries, err := resolveDigitalWorkerPublishInputs(&publishFlags{
+		scope:                       "tenant",
+		scopeSet:                    true,
+		optionalPermissionScopes:    []string{"flag-app=Flag.Scope"},
+		optionalPermissionScopesSet: true,
+		clearAccessBoundaries:       true,
+	}, packCtx)
+
+	require.NoError(t, err)
+	require.Equal(t, []agent_api.Microsoft365PermissionScopes{
+		{ResourceAppID: "flag-app", Scopes: []string{"Flag.Scope"}},
+	}, permissions)
+	require.NotNil(t, boundaries)
+	require.Empty(t, *boundaries)
+
+	_, _, err = resolveDigitalWorkerPublishInputs(&publishFlags{}, packCtx)
+	require.ErrorContains(t, err, "publishScope must be tenant")
+}
+
 func TestResolveDigitalWorkerPublishInputsRejectsSimpleAgentFlags(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"azureaiagent/internal/pkg/agents/agent_api"
+	"azureaiagent/internal/pkg/agents/agent_yaml"
 	"azureaiagent/internal/project"
 
 	"github.com/stretchr/testify/require"
@@ -350,19 +351,37 @@ func TestResolveDigitalWorkerPublishInputsValidatesAfterFlagOverrides(t *testing
 	t.Parallel()
 
 	configBoundaries := []string{"invalid.boundary"}
-	packCtx := digitalWorkerPackContext("shared")
-	packCtx.activitySettings.Publish.OptionalPermissionScopes = []project.Microsoft365PermissionScopes{
+	activitySettings := &project.ActivitySettings{
+		DigitalWorkerType: agent_api.DigitalWorkerTypeM365,
+		Publish: &project.ActivityPublishConfig{
+			PublishScope: "shared",
+		},
+	}
+	activitySettings.Publish.OptionalPermissionScopes = []project.Microsoft365PermissionScopes{
 		{ResourceAppID: "", Scopes: []string{""}},
 	}
-	packCtx.activitySettings.Publish.AccessBoundaries = &configBoundaries
-
-	permissions, boundaries, err := resolveDigitalWorkerPublishInputs(&publishFlags{
+	activitySettings.Publish.AccessBoundaries = &configBoundaries
+	profile, err := resolveTeamsPackActivityProfile(agent_yaml.ContainerAgent{
+		Protocols: []agent_yaml.ProtocolVersionRecord{{Protocol: "activity", Version: "2.0.0"}},
+	}, activitySettings)
+	require.NoError(t, err)
+	packCtx := &teamsPackContext{
+		activityProfile:  profile,
+		activitySettings: activitySettings,
+	}
+	flags := &publishFlags{
 		scope:                       "tenant",
 		scopeSet:                    true,
 		optionalPermissionScopes:    []string{"flag-app=Flag.Scope"},
 		optionalPermissionScopesSet: true,
 		clearAccessBoundaries:       true,
-	}, packCtx)
+	}
+
+	scope, err := resolvePublishScope(flags, packCtx)
+	require.NoError(t, err)
+	require.Equal(t, "tenant", scope.flag)
+
+	permissions, boundaries, err := resolveDigitalWorkerPublishInputs(flags, packCtx)
 
 	require.NoError(t, err)
 	require.Equal(t, []agent_api.Microsoft365PermissionScopes{

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish_test.go
@@ -295,7 +295,7 @@ func TestParseOptionalPermissionScopeFlagsRejectsInvalidValue(t *testing.T) {
 func TestResolveDigitalWorkerPublishInputs(t *testing.T) {
 	t.Parallel()
 
-	configBoundaries := []string{"read.1on1.developers"}
+	configBoundaries := []string{" read.1on1.developers "}
 	packCtx := digitalWorkerPackContext("tenant")
 	packCtx.activitySettings.Publish.OptionalPermissionScopes = []project.Microsoft365PermissionScopes{
 		{ResourceAppID: "configured-app", Scopes: []string{"Configured.Scope"}},
@@ -305,7 +305,7 @@ func TestResolveDigitalWorkerPublishInputs(t *testing.T) {
 	permissions, boundaries, err := resolveDigitalWorkerPublishInputs(&publishFlags{}, packCtx)
 	require.NoError(t, err)
 	require.Equal(t, "configured-app", permissions[0].ResourceAppID)
-	require.Equal(t, configBoundaries, *boundaries)
+	require.Equal(t, []string{"read.1on1.developers"}, *boundaries)
 
 	permissions, boundaries, err = resolveDigitalWorkerPublishInputs(&publishFlags{
 		optionalPermissionScopes:    []string{"flag-app=Flag.Scope"},

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish_test.go
@@ -310,7 +310,7 @@ func TestResolveDigitalWorkerPublishInputs(t *testing.T) {
 	permissions, boundaries, err = resolveDigitalWorkerPublishInputs(&publishFlags{
 		optionalPermissionScopes:    []string{"flag-app=Flag.Scope"},
 		optionalPermissionScopesSet: true,
-		accessBoundaries:            []string{"write.group.developers"},
+		accessBoundaries:            []string{" write.group.developers ", "write.group.developers"},
 		accessBoundariesSet:         true,
 	}, packCtx)
 	require.NoError(t, err)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/publish_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/publish_test.go
@@ -325,6 +325,27 @@ func TestResolveDigitalWorkerPublishInputs(t *testing.T) {
 	require.Empty(t, *boundaries)
 }
 
+func TestResolveDigitalWorkerPublishInputsPreservesConfiguredEmptyBoundaries(t *testing.T) {
+	t.Parallel()
+
+	configuredBoundaries := []string{}
+	packCtx := digitalWorkerPackContext("tenant")
+	packCtx.activitySettings.Publish.AccessBoundaries = &configuredBoundaries
+
+	_, boundaries, err := resolveDigitalWorkerPublishInputs(&publishFlags{}, packCtx)
+
+	require.NoError(t, err)
+	require.NotNil(t, boundaries)
+	require.NotNil(t, *boundaries)
+	require.Empty(t, *boundaries)
+
+	payload, err := json.Marshal(struct {
+		AccessBoundaries *[]string `json:"accessBoundaries,omitempty"`
+	}{AccessBoundaries: boundaries})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"accessBoundaries":[]}`, string(payload))
+}
+
 func TestResolveDigitalWorkerPublishInputsValidatesAfterFlagOverrides(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/show.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/show.go
@@ -171,7 +171,7 @@ func (a *ShowAction) Run(ctx context.Context) error {
 	}
 
 	version, err := agentClient.GetAgentVersion(
-		ctx, a.Name, a.Version, DefaultAgentAPIVersion,
+		ctx, a.Name, a.Version, DefaultAgentAPIVersion, false,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to get agent version: %w", err)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
@@ -199,7 +199,8 @@ func resolveTeamsPackContext(
 		return nil, exterrors.Validation(
 			exterrors.CodeInvalidServiceConfig,
 			err.Error(),
-			"delete and recreate the agent so its immutable digital_worker_type matches activity.useCase",
+			"delete and recreate the agent so its immutable digital_worker_type matches "+
+				"activity.digitalWorkerType",
 		)
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
@@ -199,7 +199,7 @@ func resolveTeamsPackContext(
 		return nil, exterrors.Validation(
 			exterrors.CodeInvalidServiceConfig,
 			err.Error(),
-			"redeploy the agent so its service-side digital_worker_type matches activity.useCase",
+			"delete and recreate the agent so its immutable digital_worker_type matches activity.useCase",
 		)
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
@@ -311,17 +311,16 @@ func buildTeamsAppPackageRequest(
 	}
 
 	request := agent_api.TeamsAppPackageRequest{
-		BotServiceArmID:          botArmID,
-		PublishScope:             opts.scope.api,
-		AgentDisplayName:         displayName,
-		AppVersion:               appVersion,
-		ShortDescription:         fmt.Sprintf("%s agent", displayName),
-		FullDescription:          fmt.Sprintf("%s agent on Microsoft Teams (activity protocol)", displayName),
-		DeveloperName:            "Azure AI Foundry",
-		DeveloperWebsiteURL:      "https://learn.microsoft.com/azure/ai-foundry/",
-		PrivacyURL:               "https://learn.microsoft.com/azure/ai-foundry/",
-		TermsOfUseURL:            "https://learn.microsoft.com/azure/ai-foundry/",
-		CanRespondWithoutMention: true,
+		BotServiceArmID:     botArmID,
+		PublishScope:        opts.scope.api,
+		AgentDisplayName:    displayName,
+		AppVersion:          appVersion,
+		ShortDescription:    fmt.Sprintf("%s agent", displayName),
+		FullDescription:     fmt.Sprintf("%s agent on Microsoft Teams (activity protocol)", displayName),
+		DeveloperName:       "Azure AI Foundry",
+		DeveloperWebsiteURL: "https://learn.microsoft.com/azure/ai-foundry/",
+		PrivacyURL:          "https://learn.microsoft.com/azure/ai-foundry/",
+		TermsOfUseURL:       "https://learn.microsoft.com/azure/ai-foundry/",
 	}
 	if opts.useCase == project.ActivityUseCaseDigitalWorker {
 		request.PublishAsAutopilot = true
@@ -351,7 +350,7 @@ func buildTeamsAppPackageRequest(
 			request.TermsOfUseURL = publish.TermsOfUseURL
 		}
 		if publish.CanRespondWithoutMention != nil {
-			request.CanRespondWithoutMention = *publish.CanRespondWithoutMention
+			request.CanRespondWithoutMention = publish.CanRespondWithoutMention
 		}
 	}
 	return request

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
@@ -188,7 +188,7 @@ func resolveTeamsPackContext(
 		return nil, err
 	}
 	agentClient := agent_api.NewAgentClient(endpoint, credential)
-	remoteVersion, err := agentClient.GetAgentVersion(
+	remoteVersion, err := agentClient.GetAgentVersionWithDigitalWorkerType(
 		ctx, agentName, version, agent_api.AgentEndpointAPIVersion,
 	)
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
@@ -84,14 +84,13 @@ func teamsPackScopeFlags() []string {
 // loudly when the agent is missing, is not an activity agent, or has not been
 // deployed yet.
 type teamsPackContext struct {
-	proj              *azdext.ProjectConfig
-	svc               *azdext.ServiceConfig
-	agentName         string
-	botArmID          string
-	blueprintClientID string
-	agentClient       *agent_api.AgentClient
-	activityProfile   project.ActivityProfile
-	activitySettings  *project.ActivitySettings
+	proj             *azdext.ProjectConfig
+	svc              *azdext.ServiceConfig
+	agentName        string
+	botArmID         string
+	agentClient      *agent_api.AgentClient
+	activityProfile  project.ActivityProfile
+	activitySettings *project.ActivitySettings
 }
 
 // resolveTeamsPackContext resolves the target activity agent and derives the Azure
@@ -180,21 +179,32 @@ func resolveTeamsPackContext(
 		)
 	}
 
-	botArmID := ""
-	blueprintClientID := ""
-	if activityProfile.UseCase == project.ActivityUseCaseDigitalWorker {
-		blueprintClientID, err = readEnvValue(
-			ctx, azdClient, envName, envkey.AgentBlueprintClientID(svc.Name),
+	endpoint, err := resolveAgentEndpoint(ctx, "", "")
+	if err != nil {
+		return nil, err
+	}
+	credential, err := newAgentCredential()
+	if err != nil {
+		return nil, err
+	}
+	agentClient := agent_api.NewAgentClient(endpoint, credential)
+	remoteVersion, err := agentClient.GetAgentVersion(
+		ctx, agentName, version, agent_api.AgentEndpointAPIVersion,
+	)
+	if err != nil {
+		return nil, exterrors.ServiceFromAzure(err, exterrors.OpGetAgent)
+	}
+	activityProfile, err = project.ResolveDeployedActivityProfile(activityProfile, remoteVersion.DigitalWorkerType)
+	if err != nil {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			err.Error(),
+			"redeploy the agent so its service-side digital_worker_type matches activity.useCase",
 		)
-		if err != nil {
-			return nil, exterrors.Dependency(
-				exterrors.CodeAgentNotDeployed,
-				fmt.Sprintf("agent %q has no recorded blueprint client ID in environment %q", agentName, envName),
-				"run 'azd deploy' first; the blueprint client ID is required before "+
-					"publishing a digital_worker agent",
-			)
-		}
-	} else {
+	}
+
+	botArmID := ""
+	if activityProfile.UseCase != project.ActivityUseCaseDigitalWorker {
 		subscriptionID, readErr := readEnvValue(ctx, azdClient, envName, "AZURE_SUBSCRIPTION_ID")
 		if readErr != nil {
 			return nil, readErr
@@ -221,24 +231,14 @@ func resolveTeamsPackContext(
 		}
 	}
 
-	endpoint, err := resolveAgentEndpoint(ctx, "", "")
-	if err != nil {
-		return nil, err
-	}
-	credential, err := newAgentCredential()
-	if err != nil {
-		return nil, err
-	}
-
 	return &teamsPackContext{
-		proj:              proj,
-		svc:               svc,
-		agentName:         agentName,
-		botArmID:          botArmID,
-		blueprintClientID: blueprintClientID,
-		agentClient:       agent_api.NewAgentClient(endpoint, credential),
-		activityProfile:   activityProfile,
-		activitySettings:  serviceTargetConfig.Activity,
+		proj:             proj,
+		svc:              svc,
+		agentName:        agentName,
+		botArmID:         botArmID,
+		agentClient:      agentClient,
+		activityProfile:  activityProfile,
+		activitySettings: serviceTargetConfig.Activity,
 	}, nil
 }
 
@@ -263,13 +263,14 @@ func teamsBotArmID(subscriptionID, defaultResourceGroup, botName, botResourceGro
 // app package/publish request. Zero-value fields fall back to sensible defaults
 // derived from the agent name.
 type teamsAppRequestOptions struct {
-	scope             teamsPackScope
-	agentName         string
-	useCase           project.ActivityUseCase
-	displayName       string
-	appVersion        string
-	blueprintClientID string
-	publish           *project.ActivityPublishConfig
+	scope                    teamsPackScope
+	agentName                string
+	useCase                  project.ActivityUseCase
+	displayName              string
+	appVersion               string
+	publish                  *project.ActivityPublishConfig
+	optionalPermissionScopes []agent_api.Microsoft365PermissionScopes
+	accessBoundaries         *[]string
 }
 
 // buildTeamsAppPackageRequest assembles the Microsoft 365 request body shared by
@@ -322,20 +323,12 @@ func buildTeamsAppPackageRequest(
 		TermsOfUseURL:            "https://learn.microsoft.com/azure/ai-foundry/",
 		CanRespondWithoutMention: true,
 	}
+	if opts.useCase == project.ActivityUseCaseDigitalWorker {
+		request.PublishAsAutopilot = true
+		request.OptionalPermissionScopes = opts.optionalPermissionScopes
+		request.AccessBoundaries = opts.accessBoundaries
+	}
 	if publish != nil {
-		if opts.useCase == project.ActivityUseCaseDigitalWorker {
-			request.PublishAsAutopilot = publish.PublishAsAutopilot
-			request.UseAgenticUserTemplate = publish.AgenticUserTemplate != nil
-		}
-		if opts.useCase == project.ActivityUseCaseDigitalWorker && publish.AgenticUserTemplate != nil {
-			request.AgenticUserTemplate = &agent_api.AgenticUserTemplate{
-				ID:                       publish.AgenticUserTemplate.ID,
-				File:                     publish.AgenticUserTemplate.File,
-				SchemaVersion:            publish.AgenticUserTemplate.SchemaVersion,
-				AgentIdentityBlueprintID: opts.blueprintClientID,
-				CommunicationProtocol:    publish.AgenticUserTemplate.CommunicationProtocol,
-			}
-		}
 		if request.AgentDisplayName == "" && strings.TrimSpace(publish.AgentDisplayName) != "" {
 			request.AgentDisplayName = publish.AgentDisplayName
 		}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
@@ -12,6 +12,7 @@ import (
 
 	"azureaiagent/internal/exterrors"
 	"azureaiagent/internal/pkg/agents/agent_api"
+	"azureaiagent/internal/pkg/agents/agent_yaml"
 	"azureaiagent/internal/pkg/botservice"
 	"azureaiagent/internal/pkg/envkey"
 	"azureaiagent/internal/project"
@@ -93,6 +94,13 @@ type teamsPackContext struct {
 	activitySettings *project.ActivitySettings
 }
 
+func resolveTeamsPackActivityProfile(
+	ca agent_yaml.ContainerAgent,
+	settings *project.ActivitySettings,
+) (project.ActivityProfile, error) {
+	return project.ResolveActivityProfileWithSettings(ca, settings)
+}
+
 // resolveTeamsPackContext resolves the target activity agent and derives the Azure
 // Bot ARM id, credential, and Microsoft 365 client shared by the pack and publish
 // commands. It enforces the preconditions loudly:
@@ -136,7 +144,7 @@ func resolveTeamsPackContext(
 			"check the activity configuration in azure.yaml",
 		)
 	}
-	activityProfile, err := project.ResolveActivityProfileWithSettings(ca, serviceTargetConfig.Activity)
+	activityProfile, err := resolveTeamsPackActivityProfile(ca, serviceTargetConfig.Activity)
 	if err != nil {
 		return nil, exterrors.Validation(
 			exterrors.CodeInvalidServiceConfig,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack.go
@@ -188,8 +188,8 @@ func resolveTeamsPackContext(
 		return nil, err
 	}
 	agentClient := agent_api.NewAgentClient(endpoint, credential)
-	remoteVersion, err := agentClient.GetAgentVersionWithDigitalWorkerType(
-		ctx, agentName, version, agent_api.AgentEndpointAPIVersion,
+	remoteVersion, err := agentClient.GetAgentVersion(
+		ctx, agentName, version, agent_api.AgentEndpointAPIVersion, true,
 	)
 	if err != nil {
 		return nil, exterrors.ServiceFromAzure(err, exterrors.OpGetAgent)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack_test.go
@@ -12,6 +12,7 @@ import (
 	"azureaiagent/internal/project"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolveTeamsPackScope(t *testing.T) {
@@ -84,8 +85,11 @@ func TestBuildTeamsAppPackageRequest_DigitalWorkerUsesPublishMetadata(t *testing
 		t.Fatal(err)
 	}
 	canRespond := true
+	boundaries := []string{"read.1on1.developers", "write.group.developers"}
+	permissions := []agent_api.Microsoft365PermissionScopes{
+		{ResourceAppID: "resource-app", Scopes: []string{"McpServers.Mail.All"}},
+	}
 	publish := &project.ActivityPublishConfig{
-		PublishAsAutopilot:       true,
 		PublishScope:             "tenant",
 		CanRespondWithoutMention: &canRespond,
 		AppVersion:               "2.3.4",
@@ -96,39 +100,25 @@ func TestBuildTeamsAppPackageRequest_DigitalWorkerUsesPublishMetadata(t *testing
 		DeveloperWebsiteURL:      "https://contoso.example",
 		PrivacyURL:               "https://contoso.example/privacy",
 		TermsOfUseURL:            "https://contoso.example/terms",
-		AgenticUserTemplate: &project.AgenticUserTemplateConfig{
-			ID:                    "dw-template",
-			File:                  "agenticUserTemplateManifest.json",
-			SchemaVersion:         "0.1.0-preview",
-			CommunicationProtocol: "activityProtocol",
-		},
 	}
 	req := buildTeamsAppPackageRequest("/subscriptions/s/bot", teamsAppRequestOptions{
-		scope:             scope,
-		displayName:       "CLI Overridden",
-		useCase:           project.ActivityUseCaseDigitalWorker,
-		appVersion:        "",
-		blueprintClientID: "blueprint-client-id",
-		publish:           publish,
+		scope:                    scope,
+		displayName:              "CLI Overridden",
+		useCase:                  project.ActivityUseCaseDigitalWorker,
+		appVersion:               "",
+		publish:                  publish,
+		optionalPermissionScopes: permissions,
+		accessBoundaries:         &boundaries,
 	})
 	if !req.PublishAsAutopilot {
 		t.Fatal("PublishAsAutopilot = false, want true")
 	}
-	if !req.UseAgenticUserTemplate {
-		t.Fatal("UseAgenticUserTemplate = false, want true")
-	}
-	if req.AgenticUserTemplate == nil {
-		t.Fatal("AgenticUserTemplate = nil, want template")
-	}
-	if req.AgenticUserTemplate.AgentIdentityBlueprintID != "blueprint-client-id" {
-		t.Errorf(
-			"AgentIdentityBlueprintID = %q, want blueprint-client-id",
-			req.AgenticUserTemplate.AgentIdentityBlueprintID,
-		)
-	}
+	require.Equal(t, permissions, req.OptionalPermissionScopes)
+	require.Equal(t, boundaries, *req.AccessBoundaries)
 	if req.PublishScope != "Shared" {
 		t.Errorf("PublishScope = %q, want Shared", req.PublishScope)
 	}
+
 	if req.AgentDisplayName != "CLI Overridden" {
 		t.Errorf("AgentDisplayName = %q, want CLI Overridden", req.AgentDisplayName)
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/teams_pack_test.go
@@ -74,8 +74,8 @@ func TestBuildTeamsAppPackageRequest(t *testing.T) {
 	if req.AppVersion != "1.0.0" {
 		t.Errorf("AppVersion = %q, want default 1.0.0", req.AppVersion)
 	}
-	if !req.CanRespondWithoutMention {
-		t.Error("CanRespondWithoutMention = false, want true")
+	if req.CanRespondWithoutMention != nil {
+		t.Error("CanRespondWithoutMention must be omitted when not configured")
 	}
 }
 
@@ -113,6 +113,8 @@ func TestBuildTeamsAppPackageRequest_DigitalWorkerUsesPublishMetadata(t *testing
 	if !req.PublishAsAutopilot {
 		t.Fatal("PublishAsAutopilot = false, want true")
 	}
+	require.NotNil(t, req.CanRespondWithoutMention)
+	require.True(t, *req.CanRespondWithoutMention)
 	require.Equal(t, permissions, req.OptionalPermissionScopes)
 	require.Equal(t, boundaries, *req.AccessBoundaries)
 	if req.PublishScope != "Shared" {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/update.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/update.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"slices"
 
 	"azureaiagent/internal/pkg/agents/agent_api"
 	"azureaiagent/internal/pkg/agents/agent_yaml"
@@ -116,6 +117,15 @@ func runEndpointUpdate(
 		return fmt.Errorf("failed to map endpoint/card fields: %w", err)
 	}
 
+	serviceConfig, err := project.LoadServiceTargetAgentConfig(svc)
+	if err != nil {
+		return fmt.Errorf("failed to parse service activity settings: %w", err)
+	}
+	activityProfile, err := project.ResolveActivityProfileWithSettings(agentDef, serviceConfig.Activity)
+	if err != nil {
+		return fmt.Errorf("failed to resolve activity profile: %w", err)
+	}
+
 	// Resolve endpoint and create client.
 	agentContext, err := newAgentContext(ctx, "", "", agentDef.Name, "")
 	if err != nil {
@@ -124,6 +134,17 @@ func runEndpointUpdate(
 
 	agentClient, err := agentContext.NewClient()
 	if err != nil {
+		return err
+	}
+
+	if err := normalizeEndpointAuthSchemesForDeployedProfile(
+		ctx,
+		agentClient,
+		agentDef.Name,
+		activityProfile,
+		apiEndpoint,
+		DefaultAgentAPIVersion,
+	); err != nil {
 		return err
 	}
 
@@ -162,8 +183,8 @@ func warnIfAuthChange(
 	current, err := client.GetAgent(ctx, agentName, DefaultAgentAPIVersion)
 	if err != nil {
 		// Only ignore 404 (agent doesn't exist yet). Other errors should propagate.
-		var respErr *azcore.ResponseError
-		if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+		if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok &&
+			respErr.StatusCode == http.StatusNotFound {
 			return nil
 		}
 		return fmt.Errorf("failed to check current agent state: %w", err)
@@ -229,4 +250,84 @@ func getIsolationKindFromSchemes(schemes []agent_api.AgentEndpointAuthorizationS
 		}
 	}
 	return ""
+}
+
+func normalizeEndpointAuthSchemesForDeployedProfile(
+	ctx context.Context,
+	client *agent_api.AgentClient,
+	agentName string,
+	localProfile project.ActivityProfile,
+	endpoint *agent_api.AgentEndpoint,
+	apiVersion string,
+) error {
+	if endpoint == nil {
+		return nil
+	}
+
+	deployedAgent, err := client.GetAgentWithDigitalWorkerType(ctx, agentName, apiVersion)
+	if err != nil {
+		if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok &&
+			respErr.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return fmt.Errorf("failed to read deployed agent profile: %w", err)
+	}
+
+	resolvedProfile, err := project.ResolveDeployedActivityProfile(localProfile, deployedAgent.DigitalWorkerType)
+	if err != nil {
+		return fmt.Errorf("failed to reconcile activity.useCase with deployed digital_worker_type: %w", err)
+	}
+
+	ensureEndpointAuthSchemeForProfile(endpoint, resolvedProfile)
+	return nil
+}
+
+func ensureEndpointAuthSchemeForProfile(
+	endpoint *agent_api.AgentEndpoint,
+	profile project.ActivityProfile,
+) {
+	if endpoint == nil || !profile.IsActivity {
+		return
+	}
+
+	if profile.UseCase == project.ActivityUseCaseDigitalWorker {
+		ensureEndpointAuthScheme(endpoint, agent_api.AgentEndpointAuthSchemeBotServiceTenant)
+		return
+	}
+
+	ensureEndpointAuthScheme(endpoint, agent_api.AgentEndpointAuthSchemeBotServiceRbac)
+}
+
+func ensureEndpointAuthScheme(
+	endpoint *agent_api.AgentEndpoint,
+	schemeType agent_api.AgentEndpointAuthorizationSchemeType,
+) {
+	if !slices.Contains(endpoint.Protocols, agent_api.AgentEndpointProtocolActivity) {
+		endpoint.Protocols = append(endpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
+	}
+
+	schemes := endpoint.AuthorizationSchemes[:0]
+	hasTarget := false
+	for _, scheme := range endpoint.AuthorizationSchemes {
+		if scheme.Type == agent_api.AgentEndpointAuthSchemeBotService ||
+			scheme.Type == agent_api.AgentEndpointAuthSchemeBotServiceRbac ||
+			scheme.Type == agent_api.AgentEndpointAuthSchemeBotServiceTenant {
+			if scheme.Type == schemeType && !hasTarget {
+				schemes = append(schemes, scheme)
+				hasTarget = true
+			}
+			continue
+		}
+
+		if scheme.Type == schemeType {
+			hasTarget = true
+		}
+		schemes = append(schemes, scheme)
+	}
+
+	if !hasTarget {
+		schemes = append(schemes, agent_api.AgentEndpointAuthorizationScheme{Type: schemeType})
+	}
+
+	endpoint.AuthorizationSchemes = schemes
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/update.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/update.go
@@ -90,6 +90,9 @@ func runEndpointUpdate(
 	if err != nil {
 		return err
 	}
+	if err := project.ResolveServiceConfigInPlace(svc, proj.Path); err != nil {
+		return fmt.Errorf("failed to resolve service config: %w", err)
+	}
 
 	// Resolve the agent definition (inline on the service entry, or a legacy
 	// agent.yaml on disk).

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/update.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/update.go
@@ -277,7 +277,10 @@ func normalizeEndpointAuthSchemesForDeployedProfile(
 
 	resolvedProfile, err := project.ResolveDeployedActivityProfile(localProfile, deployedAgent.DigitalWorkerType)
 	if err != nil {
-		return fmt.Errorf("failed to reconcile activity.useCase with deployed digital_worker_type: %w", err)
+		return fmt.Errorf(
+			"failed to reconcile activity.digitalWorkerType with deployed digital_worker_type: %w",
+			err,
+		)
 	}
 
 	project.EnsureActivityEndpointAuthSchemeForProfile(endpoint, resolvedProfile)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/update.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/update.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"slices"
 
 	"azureaiagent/internal/pkg/agents/agent_api"
 	"azureaiagent/internal/pkg/agents/agent_yaml"
@@ -278,56 +277,6 @@ func normalizeEndpointAuthSchemesForDeployedProfile(
 		return fmt.Errorf("failed to reconcile activity.useCase with deployed digital_worker_type: %w", err)
 	}
 
-	ensureEndpointAuthSchemeForProfile(endpoint, resolvedProfile)
+	project.EnsureActivityEndpointAuthSchemeForProfile(endpoint, resolvedProfile)
 	return nil
-}
-
-func ensureEndpointAuthSchemeForProfile(
-	endpoint *agent_api.AgentEndpoint,
-	profile project.ActivityProfile,
-) {
-	if endpoint == nil || !profile.IsActivity {
-		return
-	}
-
-	if profile.UseCase == project.ActivityUseCaseDigitalWorker {
-		ensureEndpointAuthScheme(endpoint, agent_api.AgentEndpointAuthSchemeBotServiceTenant)
-		return
-	}
-
-	ensureEndpointAuthScheme(endpoint, agent_api.AgentEndpointAuthSchemeBotServiceRbac)
-}
-
-func ensureEndpointAuthScheme(
-	endpoint *agent_api.AgentEndpoint,
-	schemeType agent_api.AgentEndpointAuthorizationSchemeType,
-) {
-	if !slices.Contains(endpoint.Protocols, agent_api.AgentEndpointProtocolActivity) {
-		endpoint.Protocols = append(endpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
-	}
-
-	schemes := endpoint.AuthorizationSchemes[:0]
-	hasTarget := false
-	for _, scheme := range endpoint.AuthorizationSchemes {
-		if scheme.Type == agent_api.AgentEndpointAuthSchemeBotService ||
-			scheme.Type == agent_api.AgentEndpointAuthSchemeBotServiceRbac ||
-			scheme.Type == agent_api.AgentEndpointAuthSchemeBotServiceTenant {
-			if scheme.Type == schemeType && !hasTarget {
-				schemes = append(schemes, scheme)
-				hasTarget = true
-			}
-			continue
-		}
-
-		if scheme.Type == schemeType {
-			hasTarget = true
-		}
-		schemes = append(schemes, scheme)
-	}
-
-	if !hasTarget {
-		schemes = append(schemes, agent_api.AgentEndpointAuthorizationScheme{Type: schemeType})
-	}
-
-	endpoint.AuthorizationSchemes = schemes
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/update.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/update.go
@@ -182,7 +182,7 @@ func warnIfAuthChange(
 	noPrompt bool,
 ) error {
 	// Fetch current agent to compare auth config.
-	current, err := client.GetAgent(ctx, agentName, DefaultAgentAPIVersion)
+	current, err := client.GetAgent(ctx, agentName, DefaultAgentAPIVersion, false)
 	if err != nil {
 		// Only ignore 404 (agent doesn't exist yet). Other errors should propagate.
 		if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok &&
@@ -266,7 +266,7 @@ func normalizeEndpointAuthSchemesForDeployedProfile(
 		return nil
 	}
 
-	deployedAgent, err := client.GetAgentWithDigitalWorkerType(ctx, agentName, apiVersion)
+	deployedAgent, err := client.GetAgent(ctx, agentName, apiVersion, true)
 	if err != nil {
 		if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok &&
 			respErr.StatusCode == http.StatusNotFound {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/update_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/update_test.go
@@ -35,7 +35,7 @@ func TestEndpointUpdateResolvesActivitySettingsFromServiceRef(t *testing.T) {
 				"  protocols:\n"+
 				"    - activity\n"+
 				"activity:\n"+
-				"  useCase: digital_worker\n",
+				"  digitalWorkerType: m365\n",
 		),
 		0o600,
 	))

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/update_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/update_test.go
@@ -4,14 +4,60 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"azureaiagent/internal/pkg/agents/agent_api"
 	"azureaiagent/internal/project"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 )
+
+func TestEndpointUpdateResolvesActivitySettingsFromServiceRef(t *testing.T) {
+	t.Parallel()
+
+	projectRoot := t.TempDir()
+	definitionsDir := filepath.Join(projectRoot, "definitions")
+	require.NoError(t, os.MkdirAll(definitionsDir, 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(definitionsDir, "agent.yaml"),
+		[]byte(
+			"kind: hosted\n"+
+				"name: referenced-agent\n"+
+				"protocols:\n"+
+				"  - protocol: activity\n"+
+				"    version: \"2.0.0\"\n"+
+				"agentEndpoint:\n"+
+				"  protocols:\n"+
+				"    - activity\n"+
+				"activity:\n"+
+				"  useCase: digital_worker\n",
+		),
+		0o600,
+	))
+
+	props, err := structpb.NewStruct(map[string]any{"$ref": "./definitions/agent.yaml"})
+	require.NoError(t, err)
+	svc := &azdext.ServiceConfig{
+		Name:                 "agent-service",
+		Host:                 AiAgentHost,
+		AdditionalProperties: props,
+	}
+
+	require.NoError(t, project.ResolveServiceConfigInPlace(svc, projectRoot))
+	agentDef, _, _, err := project.LoadAgentDefinition(svc, projectRoot)
+	require.NoError(t, err)
+	serviceConfig, err := project.LoadServiceTargetAgentConfig(svc)
+	require.NoError(t, err)
+
+	profile, err := project.ResolveActivityProfileWithSettings(agentDef, serviceConfig.Activity)
+	require.NoError(t, err)
+	require.Equal(t, project.ActivityUseCaseDigitalWorker, profile.UseCase)
+}
 
 func TestEnsureEndpointAuthSchemeForProfile_DigitalWorker(t *testing.T) {
 	endpoint := &agent_api.AgentEndpoint{

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/update_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/update_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"testing"
+
+	"azureaiagent/internal/pkg/agents/agent_api"
+	"azureaiagent/internal/project"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureEndpointAuthSchemeForProfile_DigitalWorker(t *testing.T) {
+	endpoint := &agent_api.AgentEndpoint{
+		Protocols: []agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolResponses},
+		AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
+			{Type: agent_api.AgentEndpointAuthSchemeEntra},
+			{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
+			{Type: agent_api.AgentEndpointAuthSchemeBotService},
+		},
+	}
+
+	ensureEndpointAuthSchemeForProfile(endpoint, project.ActivityProfile{
+		IsActivity: true,
+		UseCase:    project.ActivityUseCaseDigitalWorker,
+	})
+
+	require.Contains(t, endpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
+	assert.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
+		{Type: agent_api.AgentEndpointAuthSchemeEntra},
+		{Type: agent_api.AgentEndpointAuthSchemeBotServiceTenant},
+	}, endpoint.AuthorizationSchemes)
+}
+
+func TestEnsureEndpointAuthSchemeForProfile_Simple(t *testing.T) {
+	endpoint := &agent_api.AgentEndpoint{
+		Protocols: []agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolResponses},
+		AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
+			{Type: agent_api.AgentEndpointAuthSchemeEntra},
+			{Type: agent_api.AgentEndpointAuthSchemeBotServiceTenant},
+		},
+	}
+
+	ensureEndpointAuthSchemeForProfile(endpoint, project.ActivityProfile{
+		IsActivity: true,
+		UseCase:    project.ActivityUseCaseSimple,
+	})
+
+	require.Contains(t, endpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
+	assert.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
+		{Type: agent_api.AgentEndpointAuthSchemeEntra},
+		{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
+	}, endpoint.AuthorizationSchemes)
+}
+
+func TestEnsureEndpointAuthSchemeForProfile_NonActivityNoop(t *testing.T) {
+	endpoint := &agent_api.AgentEndpoint{
+		Protocols: []agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolResponses},
+		AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
+			{Type: agent_api.AgentEndpointAuthSchemeEntra},
+		},
+	}
+
+	ensureEndpointAuthSchemeForProfile(endpoint, project.ActivityProfile{})
+
+	assert.Equal(t, []agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolResponses}, endpoint.Protocols)
+	assert.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{{Type: agent_api.AgentEndpointAuthSchemeEntra}}, endpoint.AuthorizationSchemes)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/update_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/update_test.go
@@ -23,7 +23,7 @@ func TestEnsureEndpointAuthSchemeForProfile_DigitalWorker(t *testing.T) {
 		},
 	}
 
-	ensureEndpointAuthSchemeForProfile(endpoint, project.ActivityProfile{
+	project.EnsureActivityEndpointAuthSchemeForProfile(endpoint, project.ActivityProfile{
 		IsActivity: true,
 		UseCase:    project.ActivityUseCaseDigitalWorker,
 	})
@@ -44,7 +44,7 @@ func TestEnsureEndpointAuthSchemeForProfile_Simple(t *testing.T) {
 		},
 	}
 
-	ensureEndpointAuthSchemeForProfile(endpoint, project.ActivityProfile{
+	project.EnsureActivityEndpointAuthSchemeForProfile(endpoint, project.ActivityProfile{
 		IsActivity: true,
 		UseCase:    project.ActivityUseCaseSimple,
 	})
@@ -64,8 +64,12 @@ func TestEnsureEndpointAuthSchemeForProfile_NonActivityNoop(t *testing.T) {
 		},
 	}
 
-	ensureEndpointAuthSchemeForProfile(endpoint, project.ActivityProfile{})
+	project.EnsureActivityEndpointAuthSchemeForProfile(endpoint, project.ActivityProfile{})
 
 	assert.Equal(t, []agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolResponses}, endpoint.Protocols)
-	assert.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{{Type: agent_api.AgentEndpointAuthSchemeEntra}}, endpoint.AuthorizationSchemes)
+	assert.Equal(
+		t,
+		[]agent_api.AgentEndpointAuthorizationScheme{{Type: agent_api.AgentEndpointAuthSchemeEntra}},
+		endpoint.AuthorizationSchemes,
+	)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/microsoft365.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/microsoft365.go
@@ -23,14 +23,19 @@ const Microsoft365APIVersion = "v1"
 // used by the Digital Worker publish flow.
 const Microsoft365DigitalWorkerAPIVersion = "2025-11-15-preview"
 
-// AgenticUserTemplate identifies the agentic-user manifest embedded in a
-// Digital Worker Teams app package.
-type AgenticUserTemplate struct {
-	ID                       string `json:"Id"`
-	File                     string `json:"File"`
-	SchemaVersion            string `json:"SchemaVersion"`
-	AgentIdentityBlueprintID string `json:"AgentIdentityBlueprintId"`
-	CommunicationProtocol    string `json:"CommunicationProtocol"`
+const microsoft365FeatureHeader = "HostedAgents=V1Preview,AgentEndpoints=V1Preview"
+
+func microsoft365Features(request TeamsAppPackageRequest) string {
+	if request.PublishAsAutopilot {
+		return microsoft365FeatureHeader + "," + DigitalWorkerPreviewFeature
+	}
+	return microsoft365FeatureHeader
+}
+
+// Microsoft365PermissionScopes selects optional permissions from one resource application.
+type Microsoft365PermissionScopes struct {
+	ResourceAppID string   `json:"resourceAppId"`
+	Scopes        []string `json:"scopes"`
 }
 
 // TeamsAppPackageRequest is the body for the Microsoft 365 "zip" endpoint. The
@@ -39,24 +44,24 @@ type AgenticUserTemplate struct {
 // server contract (Microsoft365PublishRequestV3).
 //
 // For the simple activity-agent case the package is a custom engine agent backed
-// by the agent's own instance identity, so PublishAsAutopilot and
-// UseAgenticUserTemplate are false. PublishScope "Personal" produces a package
-// intended for per-user sideload (no Teams admin required).
+// by the agent's own instance identity, so PublishAsAutopilot is false.
+// PublishScope "Personal" produces a package intended for per-user sideload
+// (no Teams admin required).
 type TeamsAppPackageRequest struct {
-	PublishAsAutopilot       bool                 `json:"PublishAsAutopilot"`
-	BotServiceArmID          string               `json:"BotServiceArmId"`
-	UseAgenticUserTemplate   bool                 `json:"useAgenticUserTemplate"`
-	AgenticUserTemplate      *AgenticUserTemplate `json:"agenticUserTemplate,omitempty"`
-	PublishScope             string               `json:"PublishScope"`
-	AgentDisplayName         string               `json:"AgentDisplayName"`
-	AppVersion               string               `json:"AppVersion"`
-	ShortDescription         string               `json:"ShortDescription"`
-	FullDescription          string               `json:"FullDescription"`
-	DeveloperName            string               `json:"DeveloperName"`
-	DeveloperWebsiteURL      string               `json:"DeveloperWebsiteUrl"`
-	PrivacyURL               string               `json:"PrivacyUrl"`
-	TermsOfUseURL            string               `json:"TermsOfUseUrl"`
-	CanRespondWithoutMention bool                 `json:"CanRespondWithoutMention"`
+	PublishAsAutopilot       bool                           `json:"PublishAsAutopilot"`
+	BotServiceArmID          string                         `json:"BotServiceArmId"`
+	PublishScope             string                         `json:"PublishScope"`
+	AgentDisplayName         string                         `json:"AgentDisplayName"`
+	AppVersion               string                         `json:"AppVersion"`
+	ShortDescription         string                         `json:"ShortDescription"`
+	FullDescription          string                         `json:"FullDescription"`
+	DeveloperName            string                         `json:"DeveloperName"`
+	DeveloperWebsiteURL      string                         `json:"DeveloperWebsiteUrl"`
+	PrivacyURL               string                         `json:"PrivacyUrl"`
+	TermsOfUseURL            string                         `json:"TermsOfUseUrl"`
+	CanRespondWithoutMention bool                           `json:"CanRespondWithoutMention"`
+	OptionalPermissionScopes []Microsoft365PermissionScopes `json:"optionalPermissionScopes,omitempty"`
+	AccessBoundaries         *[]string                      `json:"accessBoundaries,omitempty"`
 }
 
 // DownloadTeamsAppPackage calls the Microsoft 365 "zip" endpoint and returns the
@@ -92,7 +97,7 @@ func (c *AgentClient) DownloadTeamsAppPackage(
 		return nil, fmt.Errorf("failed to marshal Teams app package request: %w", err)
 	}
 	req.Raw().Header.Set("Accept", "application/zip")
-	req.Raw().Header.Set("Foundry-Features", "HostedAgents=V1Preview,AgentEndpoints=V1Preview")
+	req.Raw().Header.Set("Foundry-Features", microsoft365Features(request))
 
 	resp, err := c.pipeline.Do(req)
 	if err != nil {
@@ -155,7 +160,7 @@ func (c *AgentClient) PublishTeamsApp(
 	if err := runtime.MarshalAsJSON(req, request); err != nil {
 		return nil, fmt.Errorf("failed to marshal Teams app publish request: %w", err)
 	}
-	req.Raw().Header.Set("Foundry-Features", "HostedAgents=V1Preview,AgentEndpoints=V1Preview")
+	req.Raw().Header.Set("Foundry-Features", microsoft365Features(request))
 
 	resp, err := c.pipeline.Do(req)
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/microsoft365.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/microsoft365.go
@@ -59,7 +59,7 @@ type TeamsAppPackageRequest struct {
 	DeveloperWebsiteURL      string                         `json:"DeveloperWebsiteUrl"`
 	PrivacyURL               string                         `json:"PrivacyUrl"`
 	TermsOfUseURL            string                         `json:"TermsOfUseUrl"`
-	CanRespondWithoutMention bool                           `json:"CanRespondWithoutMention"`
+	CanRespondWithoutMention *bool                          `json:"CanRespondWithoutMention,omitempty"`
 	OptionalPermissionScopes []Microsoft365PermissionScopes `json:"optionalPermissionScopes,omitempty"`
 	AccessBoundaries         *[]string                      `json:"accessBoundaries,omitempty"`
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/microsoft365_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/microsoft365_test.go
@@ -43,7 +43,6 @@ func TestDownloadTeamsAppPackage_Success(t *testing.T) {
 	require.NoError(t, json.Unmarshal(bodyBytes, &sent))
 	require.Equal(t, request, sent)
 	require.False(t, sent.PublishAsAutopilot)
-	require.False(t, sent.UseAgenticUserTemplate)
 }
 
 func TestDownloadTeamsAppPackage_ErrorStatus(t *testing.T) {
@@ -106,16 +105,13 @@ func TestPublishTeamsApp_DigitalWorkerRequest(t *testing.T) {
 		http.StatusOK,
 		`{"titleId":"T_123","teamsAppId":"app-456"}`,
 	)
+	boundaries := []string{"read.1on1.developers", "write.group.developers"}
 	request := TeamsAppPackageRequest{
-		PublishAsAutopilot:     true,
-		UseAgenticUserTemplate: true,
-		AgenticUserTemplate: &AgenticUserTemplate{
-			ID:                       "digitalWorkerTemplate",
-			File:                     "agenticUserTemplateManifest.json",
-			SchemaVersion:            "0.1.0-preview",
-			AgentIdentityBlueprintID: "blueprint-client-id",
-			CommunicationProtocol:    "activityProtocol",
+		PublishAsAutopilot: true,
+		OptionalPermissionScopes: []Microsoft365PermissionScopes{
+			{ResourceAppID: "resource-app", Scopes: []string{"McpServers.Mail.All"}},
 		},
+		AccessBoundaries: &boundaries,
 		PublishScope:     "Tenant",
 		AgentDisplayName: "my-agent",
 		AppVersion:       "1.0.0",
@@ -128,6 +124,11 @@ func TestPublishTeamsApp_DigitalWorkerRequest(t *testing.T) {
 	require.Len(t, transport.requests, 1)
 	got := transport.requests[0]
 	require.Equal(t, Microsoft365DigitalWorkerAPIVersion, got.URL.Query().Get("api-version"))
+	require.Equal(
+		t,
+		microsoft365FeatureHeader+","+DigitalWorkerPreviewFeature,
+		got.Header.Get("Foundry-Features"),
+	)
 
 	bodyBytes, err := io.ReadAll(got.Body)
 	require.NoError(t, err)
@@ -135,7 +136,20 @@ func TestPublishTeamsApp_DigitalWorkerRequest(t *testing.T) {
 	require.NoError(t, json.Unmarshal(bodyBytes, &sent))
 	require.Equal(t, request, sent)
 	require.Empty(t, sent.BotServiceArmID)
-	require.Equal(t, "blueprint-client-id", sent.AgenticUserTemplate.AgentIdentityBlueprintID)
+	require.Equal(t, boundaries, *sent.AccessBoundaries)
+	require.NotContains(t, string(bodyBytes), "useAgenticUserTemplate")
+	require.NotContains(t, string(bodyBytes), "agenticUserTemplate")
+}
+
+func TestTeamsAppPackageRequest_AccessBoundaryTriState(t *testing.T) {
+	omitted, err := json.Marshal(TeamsAppPackageRequest{})
+	require.NoError(t, err)
+	require.NotContains(t, string(omitted), "accessBoundaries")
+
+	empty := []string{}
+	cleared, err := json.Marshal(TeamsAppPackageRequest{AccessBoundaries: &empty})
+	require.NoError(t, err)
+	require.Contains(t, string(cleared), `"accessBoundaries":[]`)
 }
 
 func TestPublishTeamsApp_ErrorStatus(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/microsoft365_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/microsoft365_test.go
@@ -21,7 +21,7 @@ func TestDownloadTeamsAppPackage_Success(t *testing.T) {
 		PublishScope:             "Personal",
 		AgentDisplayName:         "my-agent",
 		AppVersion:               "1.0.0",
-		CanRespondWithoutMention: true,
+		CanRespondWithoutMention: new(true),
 	}
 
 	zipBytes, err := client.DownloadTeamsAppPackage(t.Context(), "my-agent", request, Microsoft365APIVersion)
@@ -77,7 +77,7 @@ func TestPublishTeamsApp_Success(t *testing.T) {
 		PublishScope:             "Shared",
 		AgentDisplayName:         "my-agent",
 		AppVersion:               "1.0.0",
-		CanRespondWithoutMention: true,
+		CanRespondWithoutMention: new(true),
 	}
 
 	result, err := client.PublishTeamsApp(t.Context(), "my-agent", request, Microsoft365APIVersion)
@@ -150,6 +150,17 @@ func TestTeamsAppPackageRequest_AccessBoundaryTriState(t *testing.T) {
 	cleared, err := json.Marshal(TeamsAppPackageRequest{AccessBoundaries: &empty})
 	require.NoError(t, err)
 	require.Contains(t, string(cleared), `"accessBoundaries":[]`)
+}
+
+func TestTeamsAppPackageRequest_CanRespondWithoutMentionTriState(t *testing.T) {
+	omitted, err := json.Marshal(TeamsAppPackageRequest{})
+	require.NoError(t, err)
+	require.NotContains(t, string(omitted), "CanRespondWithoutMention")
+
+	disabled := false
+	configured, err := json.Marshal(TeamsAppPackageRequest{CanRespondWithoutMention: &disabled})
+	require.NoError(t, err)
+	require.Contains(t, string(configured), `"CanRespondWithoutMention":false`)
 }
 
 func TestPublishTeamsApp_ErrorStatus(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models.go
@@ -75,6 +75,14 @@ const (
 	AgentKindVoice AgentKind = "voice"
 )
 
+// DigitalWorkerType identifies the service-side Digital Worker classification.
+type DigitalWorkerType string
+
+const (
+	// DigitalWorkerTypeM365 is a Microsoft 365 Digital Worker.
+	DigitalWorkerTypeM365 DigitalWorkerType = "m365"
+)
+
 // AgentEventType represents the types of events that can be handled
 type AgentEventType string
 
@@ -457,9 +465,10 @@ type VoiceAgentDefinition struct {
 
 // CreateAgentVersionRequest represents a request to create an agent version
 type CreateAgentVersionRequest struct {
-	Description *string           `json:"description,omitempty"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
-	Definition  any               `json:"definition"` // Can be any of the agent definition types
+	Description       *string           `json:"description,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+	Definition        any               `json:"definition"` // Can be any of the agent definition types
+	DigitalWorkerType DigitalWorkerType `json:"digital_worker_type,omitempty"`
 }
 
 // CreateAgentRequest represents a request to create an agent
@@ -472,7 +481,9 @@ type CreateAgentRequest struct {
 
 // UpdateAgentRequest represents a request to update an agent
 type UpdateAgentRequest struct {
-	CreateAgentVersionRequest
+	Description *string           `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	Definition  any               `json:"definition"` // Can be any of the agent definition types
 }
 
 // PatchAgentRequest represents a partial update to agent-level fields.
@@ -517,6 +528,7 @@ type AgentVersionObject struct {
 	Blueprint          *BlueprintInfo      `json:"blueprint,omitempty"`
 	BlueprintReference *BlueprintReference `json:"blueprint_reference,omitempty"`
 	AgentGUID          string              `json:"agent_guid,omitempty"`
+	DigitalWorkerType  DigitalWorkerType   `json:"digital_worker_type,omitempty"`
 	// RequestID is populated from the x-request-id response header (not from JSON).
 	RequestID string `json:"-"`
 }
@@ -538,6 +550,7 @@ type AgentObject struct {
 	InstanceIdentity   *AgentIdentityInfo  `json:"instance_identity,omitempty"`
 	Blueprint          *BlueprintInfo      `json:"blueprint,omitempty"`
 	BlueprintReference *BlueprintReference `json:"blueprint_reference,omitempty"`
+	DigitalWorkerType  DigitalWorkerType   `json:"digital_worker_type,omitempty"`
 	Versions           struct {
 		Latest AgentVersionObject `json:"latest"`
 	} `json:"versions"`

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/models_test.go
@@ -15,8 +15,9 @@ func TestCreateAgentRequest_RoundTrip(t *testing.T) {
 	original := CreateAgentRequest{
 		Name: "test-agent",
 		CreateAgentVersionRequest: CreateAgentVersionRequest{
-			Description: new("A test agent"),
-			Metadata:    map[string]string{"env": "test"},
+			Description:       new("A test agent"),
+			Metadata:          map[string]string{"env": "test"},
+			DigitalWorkerType: DigitalWorkerTypeM365,
 			Definition: HostedAgentDefinition{
 				AgentDefinition: AgentDefinition{
 					Kind:      AgentKindHosted,
@@ -35,7 +36,9 @@ func TestCreateAgentRequest_RoundTrip(t *testing.T) {
 
 	// Verify JSON tag names
 	s := string(data)
-	for _, field := range []string{`"name"`, `"description"`, `"metadata"`, `"definition"`} {
+	for _, field := range []string{
+		`"name"`, `"description"`, `"metadata"`, `"definition"`, `"digital_worker_type":"m365"`,
+	} {
 		if !strings.Contains(s, field) {
 			t.Errorf("expected JSON to contain %s, got: %s", field, s)
 		}
@@ -55,15 +58,19 @@ func TestCreateAgentRequest_RoundTrip(t *testing.T) {
 	if got.Metadata["env"] != "test" {
 		t.Errorf("Metadata[env] = %q, want %q", got.Metadata["env"], "test")
 	}
+	if got.DigitalWorkerType != DigitalWorkerTypeM365 {
+		t.Errorf("DigitalWorkerType = %q, want %q", got.DigitalWorkerType, DigitalWorkerTypeM365)
+	}
 }
 
 func TestAgentObject_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	original := AgentObject{
-		Object: "agent",
-		ID:     "agent-123",
-		Name:   "my-agent",
+		Object:            "agent",
+		ID:                "agent-123",
+		Name:              "my-agent",
+		DigitalWorkerType: DigitalWorkerTypeM365,
 		Versions: struct {
 			Latest AgentVersionObject `json:"latest"`
 		}{
@@ -85,7 +92,9 @@ func TestAgentObject_RoundTrip(t *testing.T) {
 	}
 
 	s := string(data)
-	for _, field := range []string{`"object"`, `"id"`, `"name"`, `"versions"`, `"latest"`} {
+	for _, field := range []string{
+		`"object"`, `"id"`, `"name"`, `"versions"`, `"latest"`, `"digital_worker_type":"m365"`,
+	} {
 		if !strings.Contains(s, field) {
 			t.Errorf("expected JSON to contain %s", field)
 		}
@@ -104,6 +113,30 @@ func TestAgentObject_RoundTrip(t *testing.T) {
 	}
 	if got.Versions.Latest.CreatedAt != 1700000000 {
 		t.Errorf("Latest.CreatedAt = %d, want %d", got.Versions.Latest.CreatedAt, int64(1700000000))
+	}
+}
+
+func TestCreateAgentVersionRequest_OmitsEmptyDigitalWorkerType(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(CreateAgentVersionRequest{Definition: map[string]any{"kind": "hosted"}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "digital_worker_type") {
+		t.Fatalf("simple agent request must omit digital_worker_type: %s", data)
+	}
+}
+
+func TestUpdateAgentRequest_HasNoDigitalWorkerType(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(UpdateAgentRequest{Definition: map[string]any{"kind": "voice"}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "digital_worker_type") {
+		t.Fatalf("update request must omit immutable digital_worker_type: %s", data)
 	}
 }
 
@@ -297,7 +330,8 @@ func TestAgentVersionObject_RoundTrip(t *testing.T) {
 			Type:        "ManagedAgentIdentityBlueprint",
 			BlueprintID: "my-agent-abc12",
 		},
-		AgentGUID: "abc12345-0000-1111-2222-333344445555",
+		AgentGUID:         "abc12345-0000-1111-2222-333344445555",
+		DigitalWorkerType: DigitalWorkerTypeM365,
 	}
 
 	data, err := json.Marshal(original)
@@ -309,7 +343,7 @@ func TestAgentVersionObject_RoundTrip(t *testing.T) {
 	for _, field := range []string{
 		`"object"`, `"id"`, `"version"`, `"created_at"`,
 		`"status"`, `"instance_identity"`, `"blueprint"`,
-		`"blueprint_reference"`, `"agent_guid"`,
+		`"blueprint_reference"`, `"agent_guid"`, `"digital_worker_type"`,
 	} {
 		if !strings.Contains(s, field) {
 			t.Errorf("expected JSON to contain %s", field)
@@ -335,6 +369,9 @@ func TestAgentVersionObject_RoundTrip(t *testing.T) {
 	}
 	if got.AgentGUID != "abc12345-0000-1111-2222-333344445555" {
 		t.Errorf("AgentGUID = %q, want %q", got.AgentGUID, "abc12345-0000-1111-2222-333344445555")
+	}
+	if got.DigitalWorkerType != DigitalWorkerTypeM365 {
+		t.Errorf("DigitalWorkerType = %q, want %q", got.DigitalWorkerType, DigitalWorkerTypeM365)
 	}
 	if got.InstanceIdentity == nil || got.InstanceIdentity.PrincipalID != "inst-principal-id" {
 		t.Errorf("InstanceIdentity.PrincipalID mismatch")

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
@@ -108,22 +108,8 @@ func hasDigitalWorkerType(request any) bool {
 	}
 }
 
-// GetAgent retrieves a specific agent by name using the standard contract.
-func (c *AgentClient) GetAgent(ctx context.Context, agentName, apiVersion string) (*AgentObject, error) {
-	return c.getAgent(ctx, agentName, apiVersion, false)
-}
-
-// GetAgentWithDigitalWorkerType retrieves a specific agent and opts into the
-// preview contract that returns digital_worker_type.
-func (c *AgentClient) GetAgentWithDigitalWorkerType(
-	ctx context.Context,
-	agentName string,
-	apiVersion string,
-) (*AgentObject, error) {
-	return c.getAgent(ctx, agentName, apiVersion, true)
-}
-
-func (c *AgentClient) getAgent(
+// GetAgent retrieves a specific agent by name.
+func (c *AgentClient) GetAgent(
 	ctx context.Context,
 	agentName string,
 	apiVersion string,
@@ -676,23 +662,8 @@ func (c *AgentClient) zipDeployRequest(
 	return &agentObj, nil
 }
 
-// GetAgentVersion retrieves a specific version of an agent using the standard contract.
-func (c *AgentClient) GetAgentVersion(ctx context.Context, agentName, agentVersion, apiVersion string) (*AgentVersionObject, error) {
-	return c.getAgentVersion(ctx, agentName, agentVersion, apiVersion, false)
-}
-
-// GetAgentVersionWithDigitalWorkerType retrieves a specific version and opts
-// into the preview contract that returns digital_worker_type.
-func (c *AgentClient) GetAgentVersionWithDigitalWorkerType(
-	ctx context.Context,
-	agentName string,
-	agentVersion string,
-	apiVersion string,
-) (*AgentVersionObject, error) {
-	return c.getAgentVersion(ctx, agentName, agentVersion, apiVersion, true)
-}
-
-func (c *AgentClient) getAgentVersion(
+// GetAgentVersion retrieves a specific version of an agent.
+func (c *AgentClient) GetAgentVersion(
 	ctx context.Context,
 	agentName string,
 	agentVersion string,

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
@@ -89,6 +89,14 @@ func NewAgentClient(endpoint string, cred azcore.TokenCredential) *AgentClient {
 	}
 }
 
+// DigitalWorkerPreviewFeature opts agent definition operations into the
+// preview Digital Worker contract.
+const DigitalWorkerPreviewFeature = "DigitalWorker=V1Preview"
+
+func setDigitalWorkerPreviewFeature(req *policy.Request) {
+	req.Raw().Header.Set("Foundry-Features", DigitalWorkerPreviewFeature)
+}
+
 // GetAgent retrieves a specific agent by name
 func (c *AgentClient) GetAgent(ctx context.Context, agentName, apiVersion string) (*AgentObject, error) {
 	url := fmt.Sprintf("%s/agents/%s?api-version=%s", c.endpoint, agentName, apiVersion)
@@ -97,6 +105,7 @@ func (c *AgentClient) GetAgent(ctx context.Context, agentName, apiVersion string
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+	setDigitalWorkerPreviewFeature(req)
 
 	resp, err := c.pipeline.Do(req)
 	if err != nil {
@@ -134,6 +143,7 @@ func (c *AgentClient) CreateAgent(ctx context.Context, request *CreateAgentReque
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+	setDigitalWorkerPreviewFeature(req)
 
 	if err := req.SetBody(streaming.NopCloser(bytes.NewReader(payload)), "application/json"); err != nil {
 		return nil, fmt.Errorf("failed to set request body: %w", err)
@@ -296,6 +306,7 @@ func (c *AgentClient) UpdateAgent(ctx context.Context, agentName string, request
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+	setDigitalWorkerPreviewFeature(req)
 
 	if err := req.SetBody(streaming.NopCloser(bytes.NewReader(payload)), "application/json"); err != nil {
 		return nil, fmt.Errorf("failed to set request body: %w", err)
@@ -481,6 +492,7 @@ func (c *AgentClient) CreateAgentVersion(ctx context.Context, agentName string, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+	setDigitalWorkerPreviewFeature(req)
 
 	if err := req.SetBody(streaming.NopCloser(bytes.NewReader(payload)), "application/json"); err != nil {
 		return nil, fmt.Errorf("failed to set request body: %w", err)
@@ -599,6 +611,7 @@ func (c *AgentClient) zipDeployRequest(
 
 	// Required headers
 	req.Raw().Header.Set("x-ms-code-zip-sha256", sha256Hex)
+	setDigitalWorkerPreviewFeature(req)
 	if agentName != "" {
 		req.Raw().Header.Set("x-ms-agent-name", agentName)
 	}
@@ -634,6 +647,7 @@ func (c *AgentClient) GetAgentVersion(ctx context.Context, agentName, agentVersi
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
+	setDigitalWorkerPreviewFeature(req)
 
 	resp, err := c.pipeline.Do(req)
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
@@ -108,13 +108,35 @@ func hasDigitalWorkerType(request any) bool {
 	}
 }
 
-// GetAgent retrieves a specific agent by name
+// GetAgent retrieves a specific agent by name using the standard contract.
 func (c *AgentClient) GetAgent(ctx context.Context, agentName, apiVersion string) (*AgentObject, error) {
+	return c.getAgent(ctx, agentName, apiVersion, false)
+}
+
+// GetAgentWithDigitalWorkerType retrieves a specific agent and opts into the
+// preview contract that returns digital_worker_type.
+func (c *AgentClient) GetAgentWithDigitalWorkerType(
+	ctx context.Context,
+	agentName string,
+	apiVersion string,
+) (*AgentObject, error) {
+	return c.getAgent(ctx, agentName, apiVersion, true)
+}
+
+func (c *AgentClient) getAgent(
+	ctx context.Context,
+	agentName string,
+	apiVersion string,
+	includeDigitalWorkerType bool,
+) (*AgentObject, error) {
 	url := fmt.Sprintf("%s/agents/%s?api-version=%s", c.endpoint, agentName, apiVersion)
 
 	req, err := runtime.NewRequest(ctx, http.MethodGet, url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	if includeDigitalWorkerType {
+		setDigitalWorkerPreviewFeature(req)
 	}
 
 	resp, err := c.pipeline.Do(req)

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
@@ -116,7 +116,6 @@ func (c *AgentClient) GetAgent(ctx context.Context, agentName, apiVersion string
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	setDigitalWorkerPreviewFeature(req)
 
 	resp, err := c.pipeline.Do(req)
 	if err != nil {
@@ -655,15 +654,38 @@ func (c *AgentClient) zipDeployRequest(
 	return &agentObj, nil
 }
 
-// GetAgentVersion retrieves a specific version of an agent
+// GetAgentVersion retrieves a specific version of an agent using the standard contract.
 func (c *AgentClient) GetAgentVersion(ctx context.Context, agentName, agentVersion, apiVersion string) (*AgentVersionObject, error) {
+	return c.getAgentVersion(ctx, agentName, agentVersion, apiVersion, false)
+}
+
+// GetAgentVersionWithDigitalWorkerType retrieves a specific version and opts
+// into the preview contract that returns digital_worker_type.
+func (c *AgentClient) GetAgentVersionWithDigitalWorkerType(
+	ctx context.Context,
+	agentName string,
+	agentVersion string,
+	apiVersion string,
+) (*AgentVersionObject, error) {
+	return c.getAgentVersion(ctx, agentName, agentVersion, apiVersion, true)
+}
+
+func (c *AgentClient) getAgentVersion(
+	ctx context.Context,
+	agentName string,
+	agentVersion string,
+	apiVersion string,
+	includeDigitalWorkerType bool,
+) (*AgentVersionObject, error) {
 	url := fmt.Sprintf("%s/agents/%s/versions/%s?api-version=%s", c.endpoint, agentName, agentVersion, apiVersion)
 
 	req, err := runtime.NewRequest(ctx, http.MethodGet, url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	setDigitalWorkerPreviewFeature(req)
+	if includeDigitalWorkerType {
+		setDigitalWorkerPreviewFeature(req)
+	}
 
 	resp, err := c.pipeline.Do(req)
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations.go
@@ -97,6 +97,17 @@ func setDigitalWorkerPreviewFeature(req *policy.Request) {
 	req.Raw().Header.Set("Foundry-Features", DigitalWorkerPreviewFeature)
 }
 
+func hasDigitalWorkerType(request any) bool {
+	switch request := request.(type) {
+	case *CreateAgentRequest:
+		return request != nil && request.DigitalWorkerType != ""
+	case *CreateAgentVersionRequest:
+		return request != nil && request.DigitalWorkerType != ""
+	default:
+		return false
+	}
+}
+
 // GetAgent retrieves a specific agent by name
 func (c *AgentClient) GetAgent(ctx context.Context, agentName, apiVersion string) (*AgentObject, error) {
 	url := fmt.Sprintf("%s/agents/%s?api-version=%s", c.endpoint, agentName, apiVersion)
@@ -143,7 +154,9 @@ func (c *AgentClient) CreateAgent(ctx context.Context, request *CreateAgentReque
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	setDigitalWorkerPreviewFeature(req)
+	if hasDigitalWorkerType(request) {
+		setDigitalWorkerPreviewFeature(req)
+	}
 
 	if err := req.SetBody(streaming.NopCloser(bytes.NewReader(payload)), "application/json"); err != nil {
 		return nil, fmt.Errorf("failed to set request body: %w", err)
@@ -306,7 +319,6 @@ func (c *AgentClient) UpdateAgent(ctx context.Context, agentName string, request
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	setDigitalWorkerPreviewFeature(req)
 
 	if err := req.SetBody(streaming.NopCloser(bytes.NewReader(payload)), "application/json"); err != nil {
 		return nil, fmt.Errorf("failed to set request body: %w", err)
@@ -492,7 +504,9 @@ func (c *AgentClient) CreateAgentVersion(ctx context.Context, agentName string, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	setDigitalWorkerPreviewFeature(req)
+	if hasDigitalWorkerType(request) {
+		setDigitalWorkerPreviewFeature(req)
+	}
 
 	if err := req.SetBody(streaming.NopCloser(bytes.NewReader(payload)), "application/json"); err != nil {
 		return nil, fmt.Errorf("failed to set request body: %w", err)
@@ -611,7 +625,9 @@ func (c *AgentClient) zipDeployRequest(
 
 	// Required headers
 	req.Raw().Header.Set("x-ms-code-zip-sha256", sha256Hex)
-	setDigitalWorkerPreviewFeature(req)
+	if agentName != "" && hasDigitalWorkerType(metadata) {
+		setDigitalWorkerPreviewFeature(req)
+	}
 	if agentName != "" {
 		req.Raw().Header.Set("x-ms-agent-name", agentName)
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
@@ -747,7 +747,8 @@ func TestZipDeployRequest_MultipartFormat(t *testing.T) {
 
 	desc := "test desc"
 	metadata := &CreateAgentVersionRequest{
-		Description: &desc,
+		Description:       &desc,
+		DigitalWorkerType: DigitalWorkerTypeM365,
 	}
 	zipData := []byte("PK\x03\x04fake-zip-content")
 	sha256Hex := "abcdef1234567890"
@@ -765,6 +766,7 @@ func TestZipDeployRequest_MultipartFormat(t *testing.T) {
 	// Verify required headers
 	require.Equal(t, sha256Hex, transport.lastReq.Header.Get("x-ms-code-zip-sha256"))
 	require.Equal(t, "test-agent", transport.lastReq.Header.Get("x-ms-agent-name"))
+	require.Equal(t, DigitalWorkerPreviewFeature, transport.lastReq.Header.Get("Foundry-Features"))
 
 	// Verify multipart content type with boundary
 	contentType := transport.lastReq.Header.Get("Content-Type")
@@ -785,6 +787,7 @@ func TestZipDeployRequest_MultipartFormat(t *testing.T) {
 	var parsedMeta map[string]any
 	require.NoError(t, json.Unmarshal(part1Data, &parsedMeta))
 	require.Equal(t, "test desc", parsedMeta["description"])
+	require.Equal(t, "m365", parsedMeta["digital_worker_type"])
 
 	// Part 2: code ZIP
 	part2, err := reader.NextPart()
@@ -793,6 +796,41 @@ func TestZipDeployRequest_MultipartFormat(t *testing.T) {
 	require.Equal(t, "agent.zip", part2.FileName())
 	part2Data, _ := io.ReadAll(part2)
 	require.Equal(t, zipData, part2Data)
+}
+
+func TestCreateAgentVersion_DigitalWorkerContract(t *testing.T) {
+	transport := &capturingTransport{
+		statusCode: http.StatusCreated,
+		respBody:   `{"name":"worker","version":"1","digital_worker_type":"m365"}`,
+	}
+	client := newTestClient("https://test.example.com/api/projects/proj", transport)
+
+	got, err := client.CreateAgentVersion(
+		t.Context(),
+		"worker",
+		&CreateAgentVersionRequest{
+			Definition:        map[string]any{"kind": "hosted"},
+			DigitalWorkerType: DigitalWorkerTypeM365,
+		},
+		"v1",
+	)
+	require.NoError(t, err)
+	require.Equal(t, DigitalWorkerTypeM365, got.DigitalWorkerType)
+	require.Equal(t, DigitalWorkerPreviewFeature, transport.lastReq.Header.Get("Foundry-Features"))
+	require.Contains(t, string(transport.lastBody), `"digital_worker_type":"m365"`)
+}
+
+func TestGetAgentVersion_DigitalWorkerContract(t *testing.T) {
+	transport := &capturingTransport{
+		statusCode: http.StatusOK,
+		respBody:   `{"name":"worker","version":"1","digital_worker_type":"m365"}`,
+	}
+	client := newTestClient("https://test.example.com/api/projects/proj", transport)
+
+	got, err := client.GetAgentVersion(t.Context(), "worker", "1", "v1")
+	require.NoError(t, err)
+	require.Equal(t, DigitalWorkerTypeM365, got.DigitalWorkerType)
+	require.Equal(t, DigitalWorkerPreviewFeature, transport.lastReq.Header.Get("Foundry-Features"))
 }
 
 func TestZipDeployRequest_NoAgentNameHeader_OnUpdate(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
@@ -845,7 +845,7 @@ func TestGetAgent_StandardContractOmitsDigitalWorkerPreview(t *testing.T) {
 	}
 	client := newTestClient("https://test.example.com/api/projects/proj", transport)
 
-	_, err := client.GetAgent(t.Context(), "simple-agent", "v1")
+	_, err := client.GetAgent(t.Context(), "simple-agent", "v1", false)
 	require.NoError(t, err)
 	require.Empty(t, transport.lastReq.Header.Get("Foundry-Features"))
 }
@@ -857,7 +857,7 @@ func TestGetAgent_DigitalWorkerContract(t *testing.T) {
 	}
 	client := newTestClient("https://test.example.com/api/projects/proj", transport)
 
-	got, err := client.GetAgentWithDigitalWorkerType(t.Context(), "worker", "v1")
+	got, err := client.GetAgent(t.Context(), "worker", "v1", true)
 	require.NoError(t, err)
 	require.Equal(t, DigitalWorkerTypeM365, got.DigitalWorkerType)
 	require.Equal(t, DigitalWorkerPreviewFeature, transport.lastReq.Header.Get("Foundry-Features"))
@@ -887,7 +887,7 @@ func TestGetAgentVersion_DigitalWorkerContract(t *testing.T) {
 	}
 	client := newTestClient("https://test.example.com/api/projects/proj", transport)
 
-	got, err := client.GetAgentVersionWithDigitalWorkerType(t.Context(), "worker", "1", "v1")
+	got, err := client.GetAgentVersion(t.Context(), "worker", "1", "v1", true)
 	require.NoError(t, err)
 	require.Equal(t, DigitalWorkerTypeM365, got.DigitalWorkerType)
 	require.Equal(t, DigitalWorkerPreviewFeature, transport.lastReq.Header.Get("Foundry-Features"))
@@ -900,7 +900,7 @@ func TestGetAgentVersion_StandardContractOmitsDigitalWorkerPreview(t *testing.T)
 	}
 	client := newTestClient("https://test.example.com/api/projects/proj", transport)
 
-	_, err := client.GetAgentVersion(t.Context(), "simple-agent", "1", "v1")
+	_, err := client.GetAgentVersion(t.Context(), "simple-agent", "1", "v1", false)
 	require.NoError(t, err)
 	require.Empty(t, transport.lastReq.Header.Get("Foundry-Features"))
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
@@ -838,6 +838,18 @@ func TestCreateAgentVersion_SimpleContractOmitsDigitalWorkerPreview(t *testing.T
 	require.NotContains(t, string(transport.lastBody), "digital_worker_type")
 }
 
+func TestGetAgent_StandardContractOmitsDigitalWorkerPreview(t *testing.T) {
+	transport := &capturingTransport{
+		statusCode: http.StatusOK,
+		respBody:   `{"name":"simple-agent","versions":{"latest":{"version":"1"}}}`,
+	}
+	client := newTestClient("https://test.example.com/api/projects/proj", transport)
+
+	_, err := client.GetAgent(t.Context(), "simple-agent", "v1")
+	require.NoError(t, err)
+	require.Empty(t, transport.lastReq.Header.Get("Foundry-Features"))
+}
+
 func TestUpdateAgent_OmitsDigitalWorkerPreview(t *testing.T) {
 	transport := &capturingTransport{
 		statusCode: http.StatusOK,
@@ -862,10 +874,22 @@ func TestGetAgentVersion_DigitalWorkerContract(t *testing.T) {
 	}
 	client := newTestClient("https://test.example.com/api/projects/proj", transport)
 
-	got, err := client.GetAgentVersion(t.Context(), "worker", "1", "v1")
+	got, err := client.GetAgentVersionWithDigitalWorkerType(t.Context(), "worker", "1", "v1")
 	require.NoError(t, err)
 	require.Equal(t, DigitalWorkerTypeM365, got.DigitalWorkerType)
 	require.Equal(t, DigitalWorkerPreviewFeature, transport.lastReq.Header.Get("Foundry-Features"))
+}
+
+func TestGetAgentVersion_StandardContractOmitsDigitalWorkerPreview(t *testing.T) {
+	transport := &capturingTransport{
+		statusCode: http.StatusOK,
+		respBody:   `{"name":"simple-agent","version":"1"}`,
+	}
+	client := newTestClient("https://test.example.com/api/projects/proj", transport)
+
+	_, err := client.GetAgentVersion(t.Context(), "simple-agent", "1", "v1")
+	require.NoError(t, err)
+	require.Empty(t, transport.lastReq.Header.Get("Foundry-Features"))
 }
 
 func TestZipDeployRequest_NoAgentNameHeader_OnUpdate(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
@@ -850,6 +850,19 @@ func TestGetAgent_StandardContractOmitsDigitalWorkerPreview(t *testing.T) {
 	require.Empty(t, transport.lastReq.Header.Get("Foundry-Features"))
 }
 
+func TestGetAgent_DigitalWorkerContract(t *testing.T) {
+	transport := &capturingTransport{
+		statusCode: http.StatusOK,
+		respBody:   `{"name":"worker","digital_worker_type":"m365","versions":{"latest":{"version":"1"}}}`,
+	}
+	client := newTestClient("https://test.example.com/api/projects/proj", transport)
+
+	got, err := client.GetAgentWithDigitalWorkerType(t.Context(), "worker", "v1")
+	require.NoError(t, err)
+	require.Equal(t, DigitalWorkerTypeM365, got.DigitalWorkerType)
+	require.Equal(t, DigitalWorkerPreviewFeature, transport.lastReq.Header.Get("Foundry-Features"))
+}
+
 func TestUpdateAgent_OmitsDigitalWorkerPreview(t *testing.T) {
 	transport := &capturingTransport{
 		statusCode: http.StatusOK,

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/agent_api/operations_test.go
@@ -820,6 +820,41 @@ func TestCreateAgentVersion_DigitalWorkerContract(t *testing.T) {
 	require.Contains(t, string(transport.lastBody), `"digital_worker_type":"m365"`)
 }
 
+func TestCreateAgentVersion_SimpleContractOmitsDigitalWorkerPreview(t *testing.T) {
+	transport := &capturingTransport{
+		statusCode: http.StatusCreated,
+		respBody:   `{"name":"simple-agent","version":"1"}`,
+	}
+	client := newTestClient("https://test.example.com/api/projects/proj", transport)
+
+	_, err := client.CreateAgentVersion(
+		t.Context(),
+		"simple-agent",
+		&CreateAgentVersionRequest{Definition: map[string]any{"kind": "hosted"}},
+		"v1",
+	)
+	require.NoError(t, err)
+	require.Empty(t, transport.lastReq.Header.Get("Foundry-Features"))
+	require.NotContains(t, string(transport.lastBody), "digital_worker_type")
+}
+
+func TestUpdateAgent_OmitsDigitalWorkerPreview(t *testing.T) {
+	transport := &capturingTransport{
+		statusCode: http.StatusOK,
+		respBody:   `{"name":"simple-agent","versions":{"latest":{"version":"2"}}}`,
+	}
+	client := newTestClient("https://test.example.com/api/projects/proj", transport)
+
+	_, err := client.UpdateAgent(
+		t.Context(),
+		"simple-agent",
+		&UpdateAgentRequest{Definition: map[string]any{"kind": "hosted"}},
+		"v1",
+	)
+	require.NoError(t, err)
+	require.Empty(t, transport.lastReq.Header.Get("Foundry-Features"))
+}
+
 func TestGetAgentVersion_DigitalWorkerContract(t *testing.T) {
 	transport := &capturingTransport{
 		statusCode: http.StatusOK,
@@ -852,6 +887,7 @@ func TestZipDeployRequest_NoAgentNameHeader_OnUpdate(t *testing.T) {
 	require.Empty(t, transport.lastReq.Header.Get("x-ms-agent-name"))
 	// But other required headers should still be present
 	require.Equal(t, "sha", transport.lastReq.Header.Get("x-ms-code-zip-sha256"))
+	require.Empty(t, transport.lastReq.Header.Get("Foundry-Features"))
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/existence.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/existence.go
@@ -16,13 +16,18 @@ import (
 
 // AgentChecker can look up a named agent in a Foundry project.
 type AgentChecker interface {
-	GetAgent(ctx context.Context, agentName, apiVersion string) (*agent_api.AgentObject, error)
+	GetAgent(
+		ctx context.Context,
+		agentName string,
+		apiVersion string,
+		includeDigitalWorkerType bool,
+	) (*agent_api.AgentObject, error)
 }
 
 // AgentExists reports whether an agent with the given name exists in the Foundry project.
 // It returns false (without error) when the API returns 404, and an error for any other failure.
 func AgentExists(ctx context.Context, client AgentChecker, agentName, apiVersion string) (bool, error) {
-	_, err := client.GetAgent(ctx, agentName, apiVersion)
+	_, err := client.GetAgent(ctx, agentName, apiVersion, false)
 	if err == nil {
 		return true, nil
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/existence_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/agents/existence_test.go
@@ -18,7 +18,7 @@ type fakeAgentGetter struct {
 	err error
 }
 
-func (f fakeAgentGetter) GetAgent(context.Context, string, string) (*agent_api.AgentObject, error) {
+func (f fakeAgentGetter) GetAgent(context.Context, string, string, bool) (*agent_api.AgentObject, error) {
 	if f.err != nil {
 		return nil, f.err
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
@@ -5,6 +5,7 @@ package project
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"azureaiagent/internal/pkg/agents/agent_api"
@@ -65,6 +66,60 @@ func ResolveDeployedActivityProfile(
 			"deployed agent has unsupported digital_worker_type %q", digitalWorkerType,
 		)
 	}
+}
+
+// EnsureActivityEndpointAuthSchemeForProfile aligns an Activity endpoint's BotService
+// authorization scheme with the resolved Activity use case.
+func EnsureActivityEndpointAuthSchemeForProfile(
+	endpoint *agent_api.AgentEndpoint,
+	profile ActivityProfile,
+) {
+	if endpoint == nil || !profile.IsActivity {
+		return
+	}
+
+	if profile.UseCase == ActivityUseCaseDigitalWorker {
+		EnsureActivityEndpointAuthScheme(endpoint, agent_api.AgentEndpointAuthSchemeBotServiceTenant)
+		return
+	}
+
+	EnsureActivityEndpointAuthScheme(endpoint, agent_api.AgentEndpointAuthSchemeBotServiceRbac)
+}
+
+// EnsureActivityEndpointAuthScheme ensures the Activity protocol is advertised
+// and keeps exactly one BotService-family authorization scheme on the endpoint.
+func EnsureActivityEndpointAuthScheme(
+	endpoint *agent_api.AgentEndpoint,
+	schemeType agent_api.AgentEndpointAuthorizationSchemeType,
+) {
+	if !slices.Contains(endpoint.Protocols, agent_api.AgentEndpointProtocolActivity) {
+		endpoint.Protocols = append(endpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
+	}
+
+	schemes := endpoint.AuthorizationSchemes[:0]
+	hasTarget := false
+	for _, scheme := range endpoint.AuthorizationSchemes {
+		if scheme.Type == agent_api.AgentEndpointAuthSchemeBotService ||
+			scheme.Type == agent_api.AgentEndpointAuthSchemeBotServiceRbac ||
+			scheme.Type == agent_api.AgentEndpointAuthSchemeBotServiceTenant {
+			if scheme.Type == schemeType && !hasTarget {
+				schemes = append(schemes, scheme)
+				hasTarget = true
+			}
+			continue
+		}
+
+		if scheme.Type == schemeType {
+			hasTarget = true
+		}
+		schemes = append(schemes, scheme)
+	}
+
+	if !hasTarget {
+		schemes = append(schemes, agent_api.AgentEndpointAuthorizationScheme{Type: schemeType})
+	}
+
+	endpoint.AuthorizationSchemes = schemes
 }
 
 // IsActivityProtocol reports whether a hosted agent definition opts into the

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
@@ -151,9 +151,9 @@ func ResolveActivityProfile(ca agent_yaml.ContainerAgent) ActivityProfile {
 	return ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseSimple}
 }
 
-// ResolveActivityProfileWithSettings derives and validates the Digital Worker
-// type configured on the azd service. A missing type preserves the existing
-// simple Activity behavior.
+// ResolveActivityProfileWithSettings derives the Digital Worker type configured
+// on the azd service. A missing type preserves the existing simple Activity
+// behavior. Publish fields are validated after command-line overrides are applied.
 func ResolveActivityProfileWithSettings(
 	ca agent_yaml.ContainerAgent,
 	settings *ActivitySettings,
@@ -163,13 +163,6 @@ func ResolveActivityProfileWithSettings(
 		return profile, nil
 	}
 	if strings.TrimSpace(string(settings.DigitalWorkerType)) == "" {
-		if settings.Publish != nil &&
-			(settings.Publish.OptionalPermissionScopes != nil || settings.Publish.AccessBoundaries != nil) {
-			return ActivityProfile{}, fmt.Errorf(
-				"activity.publish.optionalPermissionScopes and activity.publish.accessBoundaries require " +
-					"activity.digitalWorkerType=m365",
-			)
-		}
 		return profile, nil
 	}
 
@@ -181,17 +174,39 @@ func ResolveActivityProfileWithSettings(
 
 	switch settings.DigitalWorkerType {
 	case agent_api.DigitalWorkerTypeM365:
-		if settings.Publish != nil {
-			if err := ValidateDigitalWorkerPublishConfig(settings.Publish); err != nil {
-				return ActivityProfile{}, err
-			}
-		}
 		return ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseDigitalWorker}, nil
 	default:
 		return ActivityProfile{}, fmt.Errorf(
 			"activity.digitalWorkerType must be %q when specified", agent_api.DigitalWorkerTypeM365,
 		)
 	}
+}
+
+// ResolveActivityProfileForDeploy derives the Activity profile and eagerly
+// validates publish settings when deploying an agent from azure.yaml.
+func ResolveActivityProfileForDeploy(
+	ca agent_yaml.ContainerAgent,
+	settings *ActivitySettings,
+) (ActivityProfile, error) {
+	profile, err := ResolveActivityProfileWithSettings(ca, settings)
+	if err != nil || settings == nil || settings.Publish == nil {
+		return profile, err
+	}
+
+	if profile.UseCase != ActivityUseCaseDigitalWorker {
+		if settings.Publish.OptionalPermissionScopes != nil || settings.Publish.AccessBoundaries != nil {
+			return ActivityProfile{}, fmt.Errorf(
+				"activity.publish.optionalPermissionScopes and activity.publish.accessBoundaries require " +
+					"activity.digitalWorkerType=m365",
+			)
+		}
+		return profile, nil
+	}
+
+	if err := ValidateDigitalWorkerPublishConfig(settings.Publish); err != nil {
+		return ActivityProfile{}, err
+	}
+	return profile, nil
 }
 
 // ValidateDigitalWorkerPublishConfig validates fields that are sent only for

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
@@ -57,7 +57,8 @@ func ResolveDeployedActivityProfile(
 	case "":
 		if local.UseCase == ActivityUseCaseDigitalWorker {
 			return ActivityProfile{}, fmt.Errorf(
-				"agent is configured as digital_worker but the deployed version has no digital_worker_type",
+				"agent is configured with activity.digitalWorkerType=m365 but the deployed version " +
+					"has no digital_worker_type",
 			)
 		}
 		return local, nil
@@ -150,26 +151,26 @@ func ResolveActivityProfile(ca agent_yaml.ContainerAgent) ActivityProfile {
 	return ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseSimple}
 }
 
-// ResolveActivityProfileWithSettings derives and validates the Activity use
-// case configured on the azd service. A missing setting preserves the existing
+// ResolveActivityProfileWithSettings derives and validates the Digital Worker
+// type configured on the azd service. A missing type preserves the existing
 // simple Activity behavior.
 func ResolveActivityProfileWithSettings(
 	ca agent_yaml.ContainerAgent,
 	settings *ActivitySettings,
 ) (ActivityProfile, error) {
 	profile := ResolveActivityProfile(ca)
-	if settings == nil || strings.TrimSpace(string(settings.UseCase)) == "" {
+	if settings == nil || strings.TrimSpace(string(settings.DigitalWorkerType)) == "" {
 		return profile, nil
 	}
 
 	if !profile.IsActivity {
-		return ActivityProfile{}, fmt.Errorf("activity.useCase requires an Activity-protocol hosted agent")
+		return ActivityProfile{}, fmt.Errorf(
+			"activity.digitalWorkerType requires an Activity-protocol hosted agent",
+		)
 	}
 
-	switch settings.UseCase {
-	case ActivityUseCaseSimple:
-		return profile, nil
-	case ActivityUseCaseDigitalWorker:
+	switch settings.DigitalWorkerType {
+	case agent_api.DigitalWorkerTypeM365:
 		if settings.Publish != nil {
 			if err := ValidateDigitalWorkerPublishConfig(settings.Publish); err != nil {
 				return ActivityProfile{}, err
@@ -178,7 +179,7 @@ func ResolveActivityProfileWithSettings(
 		return ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseDigitalWorker}, nil
 	default:
 		return ActivityProfile{}, fmt.Errorf(
-			"activity.useCase must be %q or %q", ActivityUseCaseSimple, ActivityUseCaseDigitalWorker,
+			"activity.digitalWorkerType must be %q when specified", agent_api.DigitalWorkerTypeM365,
 		)
 	}
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
@@ -24,6 +24,13 @@ const (
 	ActivityUseCaseDigitalWorker ActivityUseCase = "digital_worker"
 )
 
+var supportedDigitalWorkerAccessBoundaries = map[string]struct{}{
+	"read.1on1.developers":   {},
+	"write.1on1.developers":  {},
+	"read.group.developers":  {},
+	"write.group.developers": {},
+}
+
 // ActivityProfile summarizes the activity-protocol characteristics of a hosted
 // agent definition. It is the single gate that keeps all Teams/bot-specific
 // behavior off the path of non-activity agents: when IsActivity is false the
@@ -34,6 +41,30 @@ type ActivityProfile struct {
 	// UseCase is the resolved Teams hosting model. Only meaningful when
 	// IsActivity is true. Phase 1 always resolves ActivityUseCaseSimple.
 	UseCase ActivityUseCase
+}
+
+// ResolveDeployedActivityProfile reconciles local authoring intent with the
+// service-side Digital Worker classification, which is authoritative after
+// deployment.
+func ResolveDeployedActivityProfile(
+	local ActivityProfile,
+	digitalWorkerType agent_api.DigitalWorkerType,
+) (ActivityProfile, error) {
+	switch digitalWorkerType {
+	case agent_api.DigitalWorkerTypeM365:
+		return ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseDigitalWorker}, nil
+	case "":
+		if local.UseCase == ActivityUseCaseDigitalWorker {
+			return ActivityProfile{}, fmt.Errorf(
+				"agent is configured as digital_worker but the deployed version has no digital_worker_type",
+			)
+		}
+		return local, nil
+	default:
+		return ActivityProfile{}, fmt.Errorf(
+			"deployed agent has unsupported digital_worker_type %q", digitalWorkerType,
+		)
+	}
 }
 
 // IsActivityProtocol reports whether a hosted agent definition opts into the
@@ -84,38 +115,9 @@ func ResolveActivityProfileWithSettings(
 	case ActivityUseCaseSimple:
 		return profile, nil
 	case ActivityUseCaseDigitalWorker:
-		if settings.Publish == nil {
-			return ActivityProfile{}, fmt.Errorf("activity.publish is required for digital_worker")
-		}
-		// publishAsAutopilot is a derived runtime requirement for the digital_worker
-		// use case. It is inferred automatically and should not be treated as a
-		// user-configurable Azure YAML knob.
-		settings.Publish.PublishAsAutopilot = true
-		publishScope := strings.TrimSpace(settings.Publish.PublishScope)
-		if publishScope != "" && !strings.EqualFold(publishScope, "tenant") {
-			return ActivityProfile{}, fmt.Errorf(
-				"activity.publish.publishScope must be tenant for digital_worker (shared is not supported)",
-			)
-		}
-		template := settings.Publish.AgenticUserTemplate
-		if template == nil {
-			return ActivityProfile{}, fmt.Errorf("activity.publish.agenticUserTemplate is required for digital_worker")
-		}
-		requiredTemplateFields := []struct {
-			name  string
-			value string
-		}{
-			{name: "id", value: template.ID},
-			{name: "file", value: template.File},
-			{name: "schemaVersion", value: template.SchemaVersion},
-			{name: "communicationProtocol", value: template.CommunicationProtocol},
-		}
-		for _, field := range requiredTemplateFields {
-			value := field.value
-			if strings.TrimSpace(value) == "" {
-				return ActivityProfile{}, fmt.Errorf(
-					"activity.publish.agenticUserTemplate.%s is required for digital_worker", field.name,
-				)
+		if settings.Publish != nil {
+			if err := ValidateDigitalWorkerPublishConfig(settings.Publish); err != nil {
+				return ActivityProfile{}, err
 			}
 		}
 		return ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseDigitalWorker}, nil
@@ -124,6 +126,53 @@ func ResolveActivityProfileWithSettings(
 			"activity.useCase must be %q or %q", ActivityUseCaseSimple, ActivityUseCaseDigitalWorker,
 		)
 	}
+}
+
+// ValidateDigitalWorkerPublishConfig validates fields that are sent only for
+// Microsoft 365 Digital Worker publication.
+func ValidateDigitalWorkerPublishConfig(publish *ActivityPublishConfig) error {
+	publishScope := strings.TrimSpace(publish.PublishScope)
+	if publishScope != "" && !strings.EqualFold(publishScope, "tenant") {
+		return fmt.Errorf(
+			"activity.publish.publishScope must be tenant for digital_worker (shared is not supported)",
+		)
+	}
+	for i, permission := range publish.OptionalPermissionScopes {
+		if strings.TrimSpace(permission.ResourceAppID) == "" {
+			return fmt.Errorf("activity.publish.optionalPermissionScopes[%d].resourceAppId is required", i)
+		}
+		if len(permission.Scopes) == 0 {
+			return fmt.Errorf("activity.publish.optionalPermissionScopes[%d].scopes must not be empty", i)
+		}
+		for j, scope := range permission.Scopes {
+			if strings.TrimSpace(scope) == "" {
+				return fmt.Errorf(
+					"activity.publish.optionalPermissionScopes[%d].scopes[%d] must not be empty", i, j,
+				)
+			}
+		}
+	}
+	if publish.AccessBoundaries != nil {
+		if err := ValidateDigitalWorkerAccessBoundaries(*publish.AccessBoundaries); err != nil {
+			return fmt.Errorf("activity.publish.accessBoundaries: %w", err)
+		}
+	}
+	return nil
+}
+
+// ValidateDigitalWorkerAccessBoundaries validates the initial azd-supported
+// developer-only boundary set.
+func ValidateDigitalWorkerAccessBoundaries(boundaries []string) error {
+	for _, boundary := range boundaries {
+		if _, ok := supportedDigitalWorkerAccessBoundaries[strings.TrimSpace(boundary)]; !ok {
+			return fmt.Errorf(
+				"unsupported value %q; supported values are read.1on1.developers, "+
+					"write.1on1.developers, read.group.developers, and write.group.developers",
+				boundary,
+			)
+		}
+	}
+	return nil
 }
 
 // ComposeActivityAgentEndpoint folds the Activity endpoint requirements into an

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
@@ -159,7 +159,17 @@ func ResolveActivityProfileWithSettings(
 	settings *ActivitySettings,
 ) (ActivityProfile, error) {
 	profile := ResolveActivityProfile(ca)
-	if settings == nil || strings.TrimSpace(string(settings.DigitalWorkerType)) == "" {
+	if settings == nil {
+		return profile, nil
+	}
+	if strings.TrimSpace(string(settings.DigitalWorkerType)) == "" {
+		if settings.Publish != nil &&
+			(settings.Publish.OptionalPermissionScopes != nil || settings.Publish.AccessBoundaries != nil) {
+			return ActivityProfile{}, fmt.Errorf(
+				"activity.publish.optionalPermissionScopes and activity.publish.accessBoundaries require " +
+					"activity.digitalWorkerType=m365",
+			)
+		}
 		return profile, nil
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
@@ -69,6 +69,11 @@ func ResolveDeployedActivityProfile(
 	}
 }
 
+func digitalWorkerTypeMismatchSuggestion() string {
+	return "delete and recreate the agent so its immutable digital_worker_type matches " +
+		"activity.digitalWorkerType"
+}
+
 // EnsureActivityEndpointAuthSchemeForProfile aligns an Activity endpoint's BotService
 // authorization scheme with the resolved Activity use case.
 func EnsureActivityEndpointAuthSchemeForProfile(

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile_test.go
@@ -114,7 +114,7 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 
 	t.Run("digital worker resolves", func(t *testing.T) {
 		profile, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
-			UseCase: ActivityUseCaseDigitalWorker,
+			DigitalWorkerType: agent_api.DigitalWorkerTypeM365,
 			Publish: &ActivityPublishConfig{
 				PublishScope: "tenant",
 			},
@@ -126,7 +126,7 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 
 	t.Run("digital worker allows omitted publish block", func(t *testing.T) {
 		profile, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
-			UseCase: ActivityUseCaseDigitalWorker,
+			DigitalWorkerType: agent_api.DigitalWorkerTypeM365,
 		})
 		require.NoError(t, err)
 		require.Equal(t, ActivityUseCaseDigitalWorker, profile.UseCase)
@@ -135,7 +135,7 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 	t.Run("digital worker accepts optional permissions and boundaries", func(t *testing.T) {
 		boundaries := []string{"read.1on1.developers", "write.group.developers"}
 		profile, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
-			UseCase: ActivityUseCaseDigitalWorker,
+			DigitalWorkerType: agent_api.DigitalWorkerTypeM365,
 			Publish: &ActivityPublishConfig{
 				OptionalPermissionScopes: []Microsoft365PermissionScopes{
 					{ResourceAppID: "resource-app", Scopes: []string{"McpServers.Mail.All"}},
@@ -150,7 +150,7 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 
 	t.Run("digital worker rejects missing resource app id", func(t *testing.T) {
 		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
-			UseCase: ActivityUseCaseDigitalWorker,
+			DigitalWorkerType: agent_api.DigitalWorkerTypeM365,
 			Publish: &ActivityPublishConfig{
 				OptionalPermissionScopes: []Microsoft365PermissionScopes{
 					{Scopes: []string{"McpServers.Mail.All"}},
@@ -162,7 +162,7 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 
 	t.Run("digital worker rejects empty permission scopes", func(t *testing.T) {
 		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
-			UseCase: ActivityUseCaseDigitalWorker,
+			DigitalWorkerType: agent_api.DigitalWorkerTypeM365,
 			Publish: &ActivityPublishConfig{
 				OptionalPermissionScopes: []Microsoft365PermissionScopes{
 					{ResourceAppID: "resource-app"},
@@ -174,7 +174,7 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 
 	t.Run("digital worker requires tenant publish scope", func(t *testing.T) {
 		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
-			UseCase: ActivityUseCaseDigitalWorker,
+			DigitalWorkerType: agent_api.DigitalWorkerTypeM365,
 			Publish: &ActivityPublishConfig{
 				PublishScope: "shared",
 			},
@@ -185,17 +185,24 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 	t.Run("digital worker rejects unsupported access boundary", func(t *testing.T) {
 		boundaries := []string{"read.1on1.tenant"}
 		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
-			UseCase: ActivityUseCaseDigitalWorker,
-			Publish: &ActivityPublishConfig{AccessBoundaries: &boundaries},
+			DigitalWorkerType: agent_api.DigitalWorkerTypeM365,
+			Publish:           &ActivityPublishConfig{AccessBoundaries: &boundaries},
 		})
 		require.ErrorContains(t, err, "unsupported value")
 	})
 
 	t.Run("digital worker requires activity protocol", func(t *testing.T) {
 		_, err := ResolveActivityProfileWithSettings(agent_yaml.ContainerAgent{}, &ActivitySettings{
-			UseCase: ActivityUseCaseDigitalWorker,
+			DigitalWorkerType: agent_api.DigitalWorkerTypeM365,
 		})
 		require.ErrorContains(t, err, "Activity-protocol")
+	})
+
+	t.Run("unsupported digital worker type rejected", func(t *testing.T) {
+		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+			DigitalWorkerType: agent_api.DigitalWorkerType("slack"),
+		})
+		require.ErrorContains(t, err, `activity.digitalWorkerType must be "m365" when specified`)
 	})
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile_test.go
@@ -198,6 +198,21 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 		require.ErrorContains(t, err, "Activity-protocol")
 	})
 
+	t.Run("simple rejects optional permission scopes", func(t *testing.T) {
+		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+			Publish: &ActivityPublishConfig{OptionalPermissionScopes: []Microsoft365PermissionScopes{}},
+		})
+		require.ErrorContains(t, err, "activity.digitalWorkerType=m365")
+	})
+
+	t.Run("simple rejects access boundaries", func(t *testing.T) {
+		boundaries := []string{}
+		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+			Publish: &ActivityPublishConfig{AccessBoundaries: &boundaries},
+		})
+		require.ErrorContains(t, err, "activity.digitalWorkerType=m365")
+	})
+
 	t.Run("unsupported digital worker type rejected", func(t *testing.T) {
 		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
 			DigitalWorkerType: agent_api.DigitalWorkerType("slack"),

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile_test.go
@@ -132,6 +132,22 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 		require.Equal(t, ActivityUseCaseDigitalWorker, profile.UseCase)
 	})
 
+	t.Run("classification allows publish fields to be overridden later", func(t *testing.T) {
+		boundaries := []string{"invalid.boundary"}
+		profile, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+			DigitalWorkerType: agent_api.DigitalWorkerTypeM365,
+			Publish: &ActivityPublishConfig{
+				PublishScope: "shared",
+				OptionalPermissionScopes: []Microsoft365PermissionScopes{
+					{Scopes: []string{""}},
+				},
+				AccessBoundaries: &boundaries,
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, ActivityUseCaseDigitalWorker, profile.UseCase)
+	})
+
 	t.Run("digital worker accepts optional permissions and boundaries", func(t *testing.T) {
 		boundaries := []string{"read.1on1.developers", "write.group.developers"}
 		profile, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
@@ -149,7 +165,7 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 	})
 
 	t.Run("digital worker rejects missing resource app id", func(t *testing.T) {
-		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+		_, err := ResolveActivityProfileForDeploy(activityAgent, &ActivitySettings{
 			DigitalWorkerType: agent_api.DigitalWorkerTypeM365,
 			Publish: &ActivityPublishConfig{
 				OptionalPermissionScopes: []Microsoft365PermissionScopes{
@@ -161,7 +177,7 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 	})
 
 	t.Run("digital worker rejects empty permission scopes", func(t *testing.T) {
-		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+		_, err := ResolveActivityProfileForDeploy(activityAgent, &ActivitySettings{
 			DigitalWorkerType: agent_api.DigitalWorkerTypeM365,
 			Publish: &ActivityPublishConfig{
 				OptionalPermissionScopes: []Microsoft365PermissionScopes{
@@ -173,7 +189,7 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 	})
 
 	t.Run("digital worker requires tenant publish scope", func(t *testing.T) {
-		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+		_, err := ResolveActivityProfileForDeploy(activityAgent, &ActivitySettings{
 			DigitalWorkerType: agent_api.DigitalWorkerTypeM365,
 			Publish: &ActivityPublishConfig{
 				PublishScope: "shared",
@@ -184,7 +200,7 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 
 	t.Run("digital worker rejects unsupported access boundary", func(t *testing.T) {
 		boundaries := []string{"read.1on1.tenant"}
-		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+		_, err := ResolveActivityProfileForDeploy(activityAgent, &ActivitySettings{
 			DigitalWorkerType: agent_api.DigitalWorkerTypeM365,
 			Publish:           &ActivityPublishConfig{AccessBoundaries: &boundaries},
 		})
@@ -199,7 +215,7 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 	})
 
 	t.Run("simple rejects optional permission scopes", func(t *testing.T) {
-		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+		_, err := ResolveActivityProfileForDeploy(activityAgent, &ActivitySettings{
 			Publish: &ActivityPublishConfig{OptionalPermissionScopes: []Microsoft365PermissionScopes{}},
 		})
 		require.ErrorContains(t, err, "activity.digitalWorkerType=m365")
@@ -207,7 +223,7 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 
 	t.Run("simple rejects access boundaries", func(t *testing.T) {
 		boundaries := []string{}
-		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+		_, err := ResolveActivityProfileForDeploy(activityAgent, &ActivitySettings{
 			Publish: &ActivityPublishConfig{AccessBoundaries: &boundaries},
 		})
 		require.ErrorContains(t, err, "activity.digitalWorkerType=m365")

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile_test.go
@@ -6,6 +6,7 @@ package project
 import (
 	"testing"
 
+	"azureaiagent/internal/pkg/agents/agent_api"
 	"azureaiagent/internal/pkg/agents/agent_yaml"
 	"azureaiagent/internal/pkg/envkey"
 
@@ -115,49 +116,31 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 		profile, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
 			UseCase: ActivityUseCaseDigitalWorker,
 			Publish: &ActivityPublishConfig{
-				PublishAsAutopilot: true,
-				PublishScope:       "tenant",
-				AgenticUserTemplate: &AgenticUserTemplateConfig{
-					ID:                    "digitalWorkerTemplate",
-					File:                  "agenticUserTemplateManifest.json",
-					SchemaVersion:         "0.1.0-preview",
-					CommunicationProtocol: "activityProtocol",
-				},
-			},
-		})
-		require.NoError(t, err)
-		require.True(t, profile.IsActivity)
-		require.Equal(t, ActivityUseCaseDigitalWorker, profile.UseCase)
-	})
-
-	t.Run("digital worker defaults omitted publish scope", func(t *testing.T) {
-		profile, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
-			UseCase: ActivityUseCaseDigitalWorker,
-			Publish: &ActivityPublishConfig{
-				PublishAsAutopilot: true,
-				AgenticUserTemplate: &AgenticUserTemplateConfig{
-					ID:                    "digitalWorkerTemplate",
-					File:                  "agenticUserTemplateManifest.json",
-					SchemaVersion:         "0.1.0-preview",
-					CommunicationProtocol: "activityProtocol",
-				},
-			},
-		})
-		require.NoError(t, err)
-		require.Equal(t, ActivityUseCaseDigitalWorker, profile.UseCase)
-	})
-
-	t.Run("digital worker infers autopilot publish", func(t *testing.T) {
-		profile, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
-			UseCase: ActivityUseCaseDigitalWorker,
-			Publish: &ActivityPublishConfig{
 				PublishScope: "tenant",
-				AgenticUserTemplate: &AgenticUserTemplateConfig{
-					ID:                    "digitalWorkerTemplate",
-					File:                  "agenticUserTemplateManifest.json",
-					SchemaVersion:         "0.1.0-preview",
-					CommunicationProtocol: "activityProtocol",
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, profile.IsActivity)
+		require.Equal(t, ActivityUseCaseDigitalWorker, profile.UseCase)
+	})
+
+	t.Run("digital worker allows omitted publish block", func(t *testing.T) {
+		profile, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+			UseCase: ActivityUseCaseDigitalWorker,
+		})
+		require.NoError(t, err)
+		require.Equal(t, ActivityUseCaseDigitalWorker, profile.UseCase)
+	})
+
+	t.Run("digital worker accepts optional permissions and boundaries", func(t *testing.T) {
+		boundaries := []string{"read.1on1.developers", "write.group.developers"}
+		profile, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+			UseCase: ActivityUseCaseDigitalWorker,
+			Publish: &ActivityPublishConfig{
+				OptionalPermissionScopes: []Microsoft365PermissionScopes{
+					{ResourceAppID: "resource-app", Scopes: []string{"McpServers.Mail.All"}},
 				},
+				AccessBoundaries: &boundaries,
 			},
 		})
 		require.NoError(t, err)
@@ -165,61 +148,81 @@ func TestResolveActivityProfileWithSettings(t *testing.T) {
 		require.True(t, profile.IsActivity)
 	})
 
-	t.Run("digital worker requires agentic user template", func(t *testing.T) {
+	t.Run("digital worker rejects missing resource app id", func(t *testing.T) {
 		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
 			UseCase: ActivityUseCaseDigitalWorker,
 			Publish: &ActivityPublishConfig{
-				PublishAsAutopilot: true,
-				PublishScope:       "tenant",
+				OptionalPermissionScopes: []Microsoft365PermissionScopes{
+					{Scopes: []string{"McpServers.Mail.All"}},
+				},
 			},
 		})
-		require.ErrorContains(t, err, "agenticUserTemplate")
+		require.ErrorContains(t, err, "resourceAppId is required")
 	})
 
-	t.Run("digital worker missing template fields reports first field deterministically", func(t *testing.T) {
+	t.Run("digital worker rejects empty permission scopes", func(t *testing.T) {
 		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
 			UseCase: ActivityUseCaseDigitalWorker,
 			Publish: &ActivityPublishConfig{
-				PublishAsAutopilot:  true,
-				PublishScope:        "tenant",
-				AgenticUserTemplate: &AgenticUserTemplateConfig{},
+				OptionalPermissionScopes: []Microsoft365PermissionScopes{
+					{ResourceAppID: "resource-app"},
+				},
 			},
 		})
-		require.ErrorContains(t, err, "activity.publish.agenticUserTemplate.id")
+		require.ErrorContains(t, err, "scopes must not be empty")
 	})
 
 	t.Run("digital worker requires tenant publish scope", func(t *testing.T) {
 		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
 			UseCase: ActivityUseCaseDigitalWorker,
 			Publish: &ActivityPublishConfig{
-				PublishAsAutopilot: true,
-				PublishScope:       "shared",
-				AgenticUserTemplate: &AgenticUserTemplateConfig{
-					ID:                    "digitalWorkerTemplate",
-					File:                  "agenticUserTemplateManifest.json",
-					SchemaVersion:         "0.1.0-preview",
-					CommunicationProtocol: "activityProtocol",
-				},
+				PublishScope: "shared",
 			},
 		})
 		require.ErrorContains(t, err, "publishScope must be tenant")
 	})
 
+	t.Run("digital worker rejects unsupported access boundary", func(t *testing.T) {
+		boundaries := []string{"read.1on1.tenant"}
+		_, err := ResolveActivityProfileWithSettings(activityAgent, &ActivitySettings{
+			UseCase: ActivityUseCaseDigitalWorker,
+			Publish: &ActivityPublishConfig{AccessBoundaries: &boundaries},
+		})
+		require.ErrorContains(t, err, "unsupported value")
+	})
+
 	t.Run("digital worker requires activity protocol", func(t *testing.T) {
 		_, err := ResolveActivityProfileWithSettings(agent_yaml.ContainerAgent{}, &ActivitySettings{
 			UseCase: ActivityUseCaseDigitalWorker,
-			Publish: &ActivityPublishConfig{
-				PublishAsAutopilot: true,
-				PublishScope:       "tenant",
-				AgenticUserTemplate: &AgenticUserTemplateConfig{
-					ID:                    "digitalWorkerTemplate",
-					File:                  "agenticUserTemplateManifest.json",
-					SchemaVersion:         "0.1.0-preview",
-					CommunicationProtocol: "activityProtocol",
-				},
-			},
 		})
 		require.ErrorContains(t, err, "Activity-protocol")
+	})
+}
+
+func TestResolveDeployedActivityProfile(t *testing.T) {
+	t.Run("service m365 overrides local simple", func(t *testing.T) {
+		got, err := ResolveDeployedActivityProfile(
+			ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseSimple},
+			agent_api.DigitalWorkerTypeM365,
+		)
+		require.NoError(t, err)
+		require.Equal(t, ActivityUseCaseDigitalWorker, got.UseCase)
+	})
+
+	t.Run("configured digital worker requires service classification", func(t *testing.T) {
+		_, err := ResolveDeployedActivityProfile(
+			ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseDigitalWorker},
+			"",
+		)
+		require.ErrorContains(t, err, "no digital_worker_type")
+	})
+
+	t.Run("unknown service classification is rejected", func(t *testing.T) {
+		_, err := ResolveDeployedActivityProfile(
+			ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseSimple},
+			"future-worker",
+		)
+		require.ErrorContains(t, err, "unsupported digital_worker_type")
 	})
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile_test.go
@@ -264,6 +264,14 @@ func TestResolveDeployedActivityProfile(t *testing.T) {
 	})
 }
 
+func TestDigitalWorkerTypeMismatchSuggestionRequiresRecreation(t *testing.T) {
+	t.Parallel()
+
+	suggestion := digitalWorkerTypeMismatchSuggestion()
+	require.Contains(t, suggestion, "delete and recreate")
+	require.NotContains(t, suggestion, "redeploy")
+}
+
 func TestDigitalWorkerBotTransitionWarning(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agent_definition.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agent_definition.go
@@ -514,6 +514,12 @@ func LoadServiceTargetAgentConfig(svc *azdext.ServiceConfig) (*ServiceTargetAgen
 	if s == nil {
 		return cfg, nil
 	}
+	if activity := s.GetFields()["activity"].GetStructValue(); activity.GetFields()["useCase"] != nil {
+		return nil, fmt.Errorf(
+			"activity.useCase is not supported; use activity.digitalWorkerType: m365 for a Digital Worker " +
+				"or omit digitalWorkerType for simple mode",
+		)
+	}
 	if err := UnmarshalStruct(s, &cfg); err != nil {
 		return nil, err
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/agent_definition_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/agent_definition_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"azureaiagent/internal/pkg/agents/agent_api"
 	"azureaiagent/internal/pkg/agents/agent_yaml"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -102,6 +103,32 @@ func TestAgentDefinitionRoundTrip(t *testing.T) {
 	require.NotNil(t, cfg.Container)
 	require.NotNil(t, cfg.Container.Resources)
 	require.Equal(t, "1", cfg.Container.Resources.Cpu)
+}
+
+func TestLoadServiceTargetAgentConfigDigitalWorkerType(t *testing.T) {
+	t.Parallel()
+
+	props, err := structpb.NewStruct(map[string]any{
+		"activity": map[string]any{"digitalWorkerType": "m365"},
+	})
+	require.NoError(t, err)
+
+	cfg, err := LoadServiceTargetAgentConfig(&azdext.ServiceConfig{AdditionalProperties: props})
+	require.NoError(t, err)
+	require.Equal(t, agent_api.DigitalWorkerTypeM365, cfg.Activity.DigitalWorkerType)
+}
+
+func TestLoadServiceTargetAgentConfigRejectsUseCase(t *testing.T) {
+	t.Parallel()
+
+	props, err := structpb.NewStruct(map[string]any{
+		"activity": map[string]any{"useCase": "digital_worker"},
+	})
+	require.NoError(t, err)
+
+	_, err = LoadServiceTargetAgentConfig(&azdext.ServiceConfig{AdditionalProperties: props})
+	require.ErrorContains(t, err, "activity.useCase is not supported")
+	require.ErrorContains(t, err, "activity.digitalWorkerType: m365")
 }
 
 // TestAgentDefinitionRoundTrip_SessionConfiguration verifies the optional

--- a/cli/azd/extensions/azure.ai.agents/internal/project/config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/config.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"azureaiagent/internal/pkg/agents/agent_api"
+
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -58,8 +60,8 @@ type ServiceTargetAgentConfig struct {
 
 // ActivitySettings configures the Teams hosting model for an Activity-protocol agent.
 type ActivitySettings struct {
-	UseCase ActivityUseCase        `json:"useCase,omitempty"`
-	Publish *ActivityPublishConfig `json:"publish,omitempty"`
+	DigitalWorkerType agent_api.DigitalWorkerType `json:"digitalWorkerType,omitempty"`
+	Publish           *ActivityPublishConfig      `json:"publish,omitempty"`
 }
 
 // ActivityPublishConfig carries Activity-protocol Teams package/publish metadata.

--- a/cli/azd/extensions/azure.ai.agents/internal/project/config.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/config.go
@@ -66,26 +66,24 @@ type ActivitySettings struct {
 // Digital Worker-only fields are applied only when the resolved use case is
 // digital_worker.
 type ActivityPublishConfig struct {
-	PublishAsAutopilot       bool                       `json:"publishAsAutopilot,omitempty"`
-	PublishScope             string                     `json:"publishScope,omitempty"`
-	CanRespondWithoutMention *bool                      `json:"canRespondWithoutMention,omitempty"`
-	AppVersion               string                     `json:"appVersion,omitempty"`
-	AgentDisplayName         string                     `json:"agentDisplayName,omitempty"`
-	ShortDescription         string                     `json:"shortDescription,omitempty"`
-	FullDescription          string                     `json:"fullDescription,omitempty"`
-	DeveloperName            string                     `json:"developerName,omitempty"`
-	DeveloperWebsiteURL      string                     `json:"developerWebsiteUrl,omitempty"`
-	PrivacyURL               string                     `json:"privacyUrl,omitempty"`
-	TermsOfUseURL            string                     `json:"termsOfUseUrl,omitempty"`
-	AgenticUserTemplate      *AgenticUserTemplateConfig `json:"agenticUserTemplate,omitempty"`
+	PublishScope             string                         `json:"publishScope,omitempty"`
+	CanRespondWithoutMention *bool                          `json:"canRespondWithoutMention,omitempty"`
+	AppVersion               string                         `json:"appVersion,omitempty"`
+	AgentDisplayName         string                         `json:"agentDisplayName,omitempty"`
+	ShortDescription         string                         `json:"shortDescription,omitempty"`
+	FullDescription          string                         `json:"fullDescription,omitempty"`
+	DeveloperName            string                         `json:"developerName,omitempty"`
+	DeveloperWebsiteURL      string                         `json:"developerWebsiteUrl,omitempty"`
+	PrivacyURL               string                         `json:"privacyUrl,omitempty"`
+	TermsOfUseURL            string                         `json:"termsOfUseUrl,omitempty"`
+	OptionalPermissionScopes []Microsoft365PermissionScopes `json:"optionalPermissionScopes,omitempty"`
+	AccessBoundaries         *[]string                      `json:"accessBoundaries,omitempty"`
 }
 
-// AgenticUserTemplateConfig identifies the template embedded in a Digital Worker Teams package.
-type AgenticUserTemplateConfig struct {
-	ID                    string `json:"id,omitempty"`
-	File                  string `json:"file,omitempty"`
-	SchemaVersion         string `json:"schemaVersion,omitempty"`
-	CommunicationProtocol string `json:"communicationProtocol,omitempty"`
+// Microsoft365PermissionScopes selects optional permissions from one resource application.
+type Microsoft365PermissionScopes struct {
+	ResourceAppID string   `json:"resourceAppId"`
+	Scopes        []string `json:"scopes"`
 }
 
 // ContainerSettings provides container configuration for the Azure AI Service target

--- a/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy.go
@@ -202,7 +202,7 @@ func DeployPreparedStandaloneHostedAgent(
 	}
 
 	prepared.progress("Checking existing agent")
-	_, getErr := agentClient.GetAgent(ctx, prepared.definition.Name, agent_api.AgentEndpointAPIVersion)
+	_, getErr := agentClient.GetAgent(ctx, prepared.definition.Name, agent_api.AgentEndpointAPIVersion, false)
 	var agentObject *agent_api.AgentObject
 	if getErr != nil {
 		if responseError, ok := errors.AsType[*azcore.ResponseError](getErr); !ok ||

--- a/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy.go
@@ -202,7 +202,12 @@ func DeployPreparedStandaloneHostedAgent(
 	}
 
 	prepared.progress("Checking existing agent")
-	_, getErr := agentClient.GetAgent(ctx, prepared.definition.Name, agent_api.AgentEndpointAPIVersion, false)
+	existingAgent, getErr := agentClient.GetAgent(
+		ctx,
+		prepared.definition.Name,
+		agent_api.AgentEndpointAPIVersion,
+		true,
+	)
 	var agentObject *agent_api.AgentObject
 	if getErr != nil {
 		if responseError, ok := errors.AsType[*azcore.ResponseError](getErr); !ok ||
@@ -219,6 +224,13 @@ func DeployPreparedStandaloneHostedAgent(
 			agent_api.AgentEndpointAPIVersion,
 		)
 	} else {
+		if err := reconcileStandaloneEndpointWithDeployedAgent(
+			request,
+			prepared.definition,
+			existingAgent,
+		); err != nil {
+			return nil, err
+		}
 		prepared.progress("Creating a new agent version from code package")
 		writeExistingAgentVersionWarning(prepared.definition.Name)
 		agentObject, err = agentClient.UpdateAgentFromZip(
@@ -275,6 +287,27 @@ func DeployPreparedStandaloneHostedAgent(
 		State:    version.Status,
 		Endpoint: endpoint,
 	}, nil
+}
+
+func reconcileStandaloneEndpointWithDeployedAgent(
+	request *agent_api.CreateAgentRequest,
+	definition agent_yaml.ContainerAgent,
+	existingAgent *agent_api.AgentObject,
+) error {
+	resolvedProfile, err := ResolveDeployedActivityProfile(
+		ResolveActivityProfile(definition),
+		existingAgent.DigitalWorkerType,
+	)
+	if err != nil {
+		return exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			err.Error(),
+			"delete and recreate the agent so its immutable digital_worker_type matches the local agent definition",
+		)
+	}
+
+	EnsureActivityEndpointAuthSchemeForProfile(request.AgentEndpoint, resolvedProfile)
+	return nil
 }
 
 func newStandaloneCredential() (azcore.TokenCredential, error) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy.go
@@ -202,11 +202,12 @@ func DeployPreparedStandaloneHostedAgent(
 	}
 
 	prepared.progress("Checking existing agent")
+	localProfile := ResolveActivityProfile(prepared.definition)
 	existingAgent, getErr := agentClient.GetAgent(
 		ctx,
 		prepared.definition.Name,
 		agent_api.AgentEndpointAPIVersion,
-		true,
+		localProfile.IsActivity,
 	)
 	var agentObject *agent_api.AgentObject
 	if getErr != nil {
@@ -224,12 +225,10 @@ func DeployPreparedStandaloneHostedAgent(
 			agent_api.AgentEndpointAPIVersion,
 		)
 	} else {
-		if err := reconcileStandaloneEndpointWithDeployedAgent(
-			request,
-			prepared.definition,
-			existingAgent,
-		); err != nil {
-			return nil, err
+		if localProfile.IsActivity {
+			if err := reconcileStandaloneEndpointWithDeployedAgent(request, localProfile, existingAgent); err != nil {
+				return nil, err
+			}
 		}
 		prepared.progress("Creating a new agent version from code package")
 		writeExistingAgentVersionWarning(prepared.definition.Name)
@@ -291,11 +290,11 @@ func DeployPreparedStandaloneHostedAgent(
 
 func reconcileStandaloneEndpointWithDeployedAgent(
 	request *agent_api.CreateAgentRequest,
-	definition agent_yaml.ContainerAgent,
+	localProfile ActivityProfile,
 	existingAgent *agent_api.AgentObject,
 ) error {
 	resolvedProfile, err := ResolveDeployedActivityProfile(
-		ResolveActivityProfile(definition),
+		localProfile,
 		existingAgent.DigitalWorkerType,
 	)
 	if err != nil {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy.go
@@ -299,10 +299,13 @@ func reconcileStandaloneEndpointWithDeployedAgent(
 		return exterrors.Validation(
 			exterrors.CodeInvalidServiceConfig,
 			err.Error(),
-			"delete and recreate the agent so its immutable digital_worker_type matches the local agent definition",
+			digitalWorkerTypeMismatchSuggestion(),
 		)
 	}
 
+	if resolvedProfile.IsActivity && request.AgentEndpoint == nil {
+		request.AgentEndpoint = &agent_api.AgentEndpoint{}
+	}
 	EnsureActivityEndpointAuthSchemeForProfile(request.AgentEndpoint, resolvedProfile)
 	return nil
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy.go
@@ -207,7 +207,7 @@ func DeployPreparedStandaloneHostedAgent(
 		ctx,
 		prepared.definition.Name,
 		agent_api.AgentEndpointAPIVersion,
-		localProfile.IsActivity,
+		true,
 	)
 	var agentObject *agent_api.AgentObject
 	if getErr != nil {
@@ -225,10 +225,8 @@ func DeployPreparedStandaloneHostedAgent(
 			agent_api.AgentEndpointAPIVersion,
 		)
 	} else {
-		if localProfile.IsActivity {
-			if err := reconcileStandaloneEndpointWithDeployedAgent(request, localProfile, existingAgent); err != nil {
-				return nil, err
-			}
+		if err := reconcileStandaloneEndpointWithDeployedAgent(request, localProfile, existingAgent); err != nil {
+			return nil, err
 		}
 		prepared.progress("Creating a new agent version from code package")
 		writeExistingAgentVersionWarning(prepared.definition.Name)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy_test.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"azureaiagent/internal/pkg/agents/agent_api"
+	"azureaiagent/internal/pkg/agents/agent_yaml"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -89,4 +92,28 @@ language: python
 	assert.NotEmpty(t, prepared.zipData)
 	assert.NotEmpty(t, prepared.sha256Hex)
 	assert.NotNil(t, prepared.credential)
+}
+
+func TestReconcileStandaloneEndpointWithDeployedDigitalWorker(t *testing.T) {
+	t.Parallel()
+
+	definition := agent_yaml.ContainerAgent{
+		Protocols: []agent_yaml.ProtocolVersionRecord{{Protocol: "activity", Version: "2.0.0"}},
+	}
+	request := &agent_api.CreateAgentRequest{
+		AgentEndpoint: &agent_api.AgentEndpoint{
+			Protocols: []agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolActivity},
+			AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
+				{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
+			},
+		},
+	}
+	existingAgent := &agent_api.AgentObject{DigitalWorkerType: agent_api.DigitalWorkerTypeM365}
+
+	err := reconcileStandaloneEndpointWithDeployedAgent(request, definition, existingAgent)
+
+	require.NoError(t, err)
+	require.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
+		{Type: agent_api.AgentEndpointAuthSchemeBotServiceTenant},
+	}, request.AgentEndpoint.AuthorizationSchemes)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy_test.go
@@ -118,6 +118,24 @@ func TestReconcileStandaloneEndpointWithDeployedDigitalWorker(t *testing.T) {
 	}, request.AgentEndpoint.AuthorizationSchemes)
 }
 
+func TestReconcileStandaloneEndpointCreatesEndpointForDeployedDigitalWorker(t *testing.T) {
+	t.Parallel()
+
+	request := &agent_api.CreateAgentRequest{}
+	existingAgent := &agent_api.AgentObject{DigitalWorkerType: agent_api.DigitalWorkerTypeM365}
+
+	err := reconcileStandaloneEndpointWithDeployedAgent(request, ActivityProfile{}, existingAgent)
+
+	require.NoError(t, err)
+	require.NotNil(t, request.AgentEndpoint)
+	require.Equal(t, []agent_api.AgentEndpointProtocol{
+		agent_api.AgentEndpointProtocolActivity,
+	}, request.AgentEndpoint.Protocols)
+	require.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
+		{Type: agent_api.AgentEndpointAuthSchemeBotServiceTenant},
+	}, request.AgentEndpoint.AuthorizationSchemes)
+}
+
 func TestReconcileStandaloneEndpointPromotesNonActivityDefinitionForDeployedDigitalWorker(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy_test.go
@@ -110,7 +110,7 @@ func TestReconcileStandaloneEndpointWithDeployedDigitalWorker(t *testing.T) {
 	}
 	existingAgent := &agent_api.AgentObject{DigitalWorkerType: agent_api.DigitalWorkerTypeM365}
 
-	err := reconcileStandaloneEndpointWithDeployedAgent(request, definition, existingAgent)
+	err := reconcileStandaloneEndpointWithDeployedAgent(request, ResolveActivityProfile(definition), existingAgent)
 
 	require.NoError(t, err)
 	require.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{

--- a/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy_test.go
@@ -117,3 +117,29 @@ func TestReconcileStandaloneEndpointWithDeployedDigitalWorker(t *testing.T) {
 		{Type: agent_api.AgentEndpointAuthSchemeBotServiceTenant},
 	}, request.AgentEndpoint.AuthorizationSchemes)
 }
+
+func TestReconcileStandaloneEndpointPromotesNonActivityDefinitionForDeployedDigitalWorker(t *testing.T) {
+	t.Parallel()
+
+	request := &agent_api.CreateAgentRequest{
+		AgentEndpoint: &agent_api.AgentEndpoint{
+			Protocols: []agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolResponses},
+			AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
+				{Type: agent_api.AgentEndpointAuthSchemeEntra},
+			},
+		},
+	}
+	existingAgent := &agent_api.AgentObject{DigitalWorkerType: agent_api.DigitalWorkerTypeM365}
+
+	err := reconcileStandaloneEndpointWithDeployedAgent(request, ActivityProfile{}, existingAgent)
+
+	require.NoError(t, err)
+	require.Equal(t, []agent_api.AgentEndpointProtocol{
+		agent_api.AgentEndpointProtocolResponses,
+		agent_api.AgentEndpointProtocolActivity,
+	}, request.AgentEndpoint.Protocols)
+	require.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
+		{Type: agent_api.AgentEndpointAuthSchemeEntra},
+		{Type: agent_api.AgentEndpointAuthSchemeBotServiceTenant},
+	}, request.AgentEndpoint.AuthorizationSchemes)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/doc_examples_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/doc_examples_test.go
@@ -896,6 +896,48 @@ func TestDocSchemaPromptVoiceRejectsToolbox(t *testing.T) {
 	}))
 }
 
+func TestDocSchemaDigitalWorkerPublishFields(t *testing.T) {
+	t.Parallel()
+
+	schema := loadDocSchema(t, extensionRoot(t))
+	digitalWorkerPublish := map[string]any{
+		"optionalPermissionScopes": []any{
+			map[string]any{
+				"resourceAppId": "resource-app-id",
+				"scopes":        []any{"McpServers.Mail.All"},
+			},
+		},
+		"accessBoundaries": []any{"read.1on1.developers"},
+	}
+
+	require.NoError(t, schema.validate(map[string]any{
+		"activity": map[string]any{
+			"useCase": "digital_worker",
+			"publish": digitalWorkerPublish,
+		},
+	}))
+	require.Error(t, schema.validate(map[string]any{
+		"activity": map[string]any{
+			"useCase": "simple",
+			"publish": digitalWorkerPublish,
+		},
+	}))
+	require.Error(t, schema.validate(map[string]any{
+		"activity": map[string]any{
+			"publish": digitalWorkerPublish,
+		},
+	}))
+	require.NoError(t, schema.validate(map[string]any{
+		"activity": map[string]any{
+			"useCase": "simple",
+			"publish": map[string]any{
+				"publishScope":     "shared",
+				"agentDisplayName": "Simple Activity agent",
+			},
+		},
+	}))
+}
+
 func TestActiveDocAgentConfig(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/doc_examples_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/doc_examples_test.go
@@ -912,14 +912,19 @@ func TestDocSchemaDigitalWorkerPublishFields(t *testing.T) {
 
 	require.NoError(t, schema.validate(map[string]any{
 		"activity": map[string]any{
-			"useCase": "digital_worker",
-			"publish": digitalWorkerPublish,
+			"digitalWorkerType": "m365",
+			"publish":           digitalWorkerPublish,
 		},
 	}))
 	require.Error(t, schema.validate(map[string]any{
 		"activity": map[string]any{
-			"useCase": "simple",
-			"publish": digitalWorkerPublish,
+			"digitalWorkerType": "other",
+			"publish":           digitalWorkerPublish,
+		},
+	}))
+	require.Error(t, schema.validate(map[string]any{
+		"activity": map[string]any{
+			"useCase": "digital_worker",
 		},
 	}))
 	require.Error(t, schema.validate(map[string]any{
@@ -929,7 +934,6 @@ func TestDocSchemaDigitalWorkerPublishFields(t *testing.T) {
 	}))
 	require.NoError(t, schema.validate(map[string]any{
 		"activity": map[string]any{
-			"useCase": "simple",
 			"publish": map[string]any{
 				"publishScope":     "shared",
 				"agentDisplayName": "Simple Activity agent",

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -3060,7 +3060,11 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 
 	// Check if agent already exists (GET /agents/{name})
 	progress("Checking existing agent")
-	_, getErr := agentClient.GetAgent(ctx, agentDef.Name, agent_api.AgentEndpointAPIVersion)
+	existingAgent, getErr := agentClient.GetAgentWithDigitalWorkerType(
+		ctx,
+		agentDef.Name,
+		agent_api.AgentEndpointAPIVersion,
+	)
 	var agentResp *agent_api.AgentObject
 
 	if getErr != nil {
@@ -3078,6 +3082,17 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 			return nil, exterrors.ServiceFromAzure(err, exterrors.OpCreateAgent)
 		}
 	} else {
+		localProfile := ResolveActivityProfile(agentDef)
+		if versionRequest.DigitalWorkerType == agent_api.DigitalWorkerTypeM365 {
+			localProfile = ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseDigitalWorker}
+		}
+		if _, err := ResolveDeployedActivityProfile(localProfile, existingAgent.DigitalWorkerType); err != nil {
+			return nil, exterrors.Validation(
+				exterrors.CodeInvalidServiceConfig,
+				err.Error(),
+				"delete and recreate the agent so its immutable digital_worker_type matches activity.useCase",
+			)
+		}
 		// Agent exists — update
 		progress("Updating existing agent from code package")
 		writeExistingAgentVersionWarning(agentDef.Name)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -2228,6 +2228,9 @@ func ensureActivityEndpointAuthSchemeForProfile(
 	request *agent_api.CreateAgentRequest,
 	profile ActivityProfile,
 ) {
+	if !profile.IsActivity {
+		return
+	}
 	if request.AgentEndpoint == nil {
 		request.AgentEndpoint = &agent_api.AgentEndpoint{}
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1528,14 +1528,15 @@ func (p *AgentServiceTargetProvider) Deploy(
 		return nil, err
 	}
 
+	projectEndpoint := azdEnv["FOUNDRY_PROJECT_ENDPOINT"]
+	agentClient := agent_api.NewAgentClient(
+		projectEndpoint,
+		p.credential,
+	)
+
 	// Poll until agent version is active
 	if result.agentVersion.Status != "active" {
 		progress("Agent version created; waiting for activation")
-		projectEndpoint := azdEnv["FOUNDRY_PROJECT_ENDPOINT"]
-		agentClient := agent_api.NewAgentClient(
-			projectEndpoint,
-			p.credential,
-		)
 		polledVersion, pollErr := p.waitForAgentActive(
 			ctx,
 			agentClient,
@@ -1550,6 +1551,27 @@ func (p *AgentServiceTargetProvider) Deploy(
 		result.agentVersion = polledVersion
 	} else {
 		fmt.Fprintf(os.Stderr, "Agent version %s is already active.\n", result.agentVersion.Version)
+	}
+
+	// Read the deployed version so post-deploy behavior uses the service-side
+	// Digital Worker classification rather than only the local authoring intent.
+	deployedVersion, err := agentClient.GetAgentVersion(
+		ctx,
+		result.agentName,
+		result.agentVersion.Version,
+		agent_api.AgentEndpointAPIVersion,
+	)
+	if err != nil {
+		return nil, exterrors.ServiceFromAzure(err, exterrors.OpGetAgent)
+	}
+	result.agentVersion = deployedVersion
+	activityProfile, err = ResolveDeployedActivityProfile(activityProfile, deployedVersion.DigitalWorkerType)
+	if err != nil {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			err.Error(),
+			"redeploy the agent so its service-side digital_worker_type matches activity.useCase",
+		)
 	}
 
 	// Patch agent-level endpoint/card fields
@@ -2166,6 +2188,11 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 	}
 
 	applyAgentMetadata(request)
+	if foundryAgentConfig != nil &&
+		foundryAgentConfig.Activity != nil &&
+		foundryAgentConfig.Activity.UseCase == ActivityUseCaseDigitalWorker {
+		request.DigitalWorkerType = agent_api.DigitalWorkerTypeM365
+	}
 
 	// Default to "responses" protocol when none specified in agent.yaml.
 	protocols := agentDef.Protocols
@@ -2490,7 +2517,9 @@ func (p *AgentServiceTargetProvider) deployVoiceAgentRemote(
 	if shouldUpdate {
 		progress("Updating voice agent using unified API")
 		updateRequest := &agent_api.UpdateAgentRequest{
-			CreateAgentVersionRequest: request.CreateAgentVersionRequest,
+			Description: request.Description,
+			Metadata:    request.Metadata,
+			Definition:  request.Definition,
 		}
 		agentObject, err := agentClient.UpdateVoiceAgent(
 			ctx, request.Name, updateRequest, agent_api.AgentEndpointAPIVersion, overriddenHost,
@@ -2948,9 +2977,10 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 
 	// Build the metadata for multipart upload
 	versionRequest := &agent_api.CreateAgentVersionRequest{
-		Description: prep.request.Description,
-		Metadata:    prep.request.Metadata,
-		Definition:  prep.request.Definition,
+		Description:       prep.request.Description,
+		Metadata:          prep.request.Metadata,
+		Definition:        prep.request.Definition,
+		DigitalWorkerType: prep.request.DigitalWorkerType,
 	}
 
 	// Create agent client
@@ -2982,8 +3012,10 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 		// Agent exists — update
 		progress("Updating existing agent from code package")
 		writeExistingAgentVersionWarning(agentDef.Name)
+		updateVersionRequest := *versionRequest
+		updateVersionRequest.DigitalWorkerType = ""
 		agentResp, err = agentClient.UpdateAgentFromZip(
-			ctx, agentDef.Name, versionRequest, zipData, sha256Hex, agent_api.AgentEndpointAPIVersion,
+			ctx, agentDef.Name, &updateVersionRequest, zipData, sha256Hex, agent_api.AgentEndpointAPIVersion,
 		)
 		if err != nil {
 			return nil, exterrors.ServiceFromAzure(err, exterrors.OpCreateAgent)
@@ -3405,9 +3437,10 @@ func (p *AgentServiceTargetProvider) createAgent(
 
 	// Extract CreateAgentVersionRequest from CreateAgentRequest
 	versionRequest := &agent_api.CreateAgentVersionRequest{
-		Description: request.Description,
-		Metadata:    request.Metadata,
-		Definition:  request.Definition,
+		Description:       request.Description,
+		Metadata:          request.Metadata,
+		Definition:        request.Definition,
+		DigitalWorkerType: request.DigitalWorkerType,
 	}
 
 	// Create agent version
@@ -3527,19 +3560,14 @@ func (p *AgentServiceTargetProvider) registerAgentEnvironmentVariables(
 		)
 	}
 	if activityProfile.UseCase == ActivityUseCaseDigitalWorker {
-		if activitySettings == nil || activitySettings.Publish == nil {
-			return fmt.Errorf("Digital Worker publish configuration is missing")
-		}
 		blueprint := agentVersionResponse.Blueprint
-		if blueprint == nil || strings.TrimSpace(blueprint.ClientID) == "" {
-			return fmt.Errorf("Digital Worker agent version is missing Blueprint client ID")
+		if blueprint != nil && strings.TrimSpace(blueprint.ClientID) != "" {
+			envVars = append(envVars, azdext.SetEnvRequest{
+				EnvName: p.env.Name,
+				Key:     envkey.AgentBlueprintClientID(serviceConfig.Name),
+				Value:   blueprint.ClientID,
+			})
 		}
-
-		envVars = append(envVars, azdext.SetEnvRequest{
-			EnvName: p.env.Name,
-			Key:     envkey.AgentBlueprintClientID(serviceConfig.Name),
-			Value:   blueprint.ClientID,
-		})
 	}
 
 	for i := range envVars {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -2257,7 +2257,8 @@ func ensureActivityEndpointAuthScheme(
 	schemes := request.AgentEndpoint.AuthorizationSchemes[:0]
 	hasTarget := false
 	for _, scheme := range request.AgentEndpoint.AuthorizationSchemes {
-		if scheme.Type == agent_api.AgentEndpointAuthSchemeBotServiceRbac ||
+		if scheme.Type == agent_api.AgentEndpointAuthSchemeBotService ||
+			scheme.Type == agent_api.AgentEndpointAuthSchemeBotServiceRbac ||
 			scheme.Type == agent_api.AgentEndpointAuthSchemeBotServiceTenant {
 			if scheme.Type == schemeType && !hasTarget {
 				schemes = append(schemes, scheme)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1475,7 +1475,7 @@ func (p *AgentServiceTargetProvider) Deploy(
 		fmt.Println("Loaded custom service target configuration")
 	}
 	addAgentToolboxDependency(serviceTargetConfig, agentDef.Toolbox)
-	activityProfile, err := ResolveActivityProfileWithSettings(agentDef, serviceTargetConfig.Activity)
+	activityProfile, err := ResolveActivityProfileForDeploy(agentDef, serviceTargetConfig.Activity)
 	if err != nil {
 		return nil, exterrors.Validation(
 			exterrors.CodeInvalidServiceConfig,
@@ -2202,7 +2202,7 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 		foundryAgentConfig.Activity.DigitalWorkerType == agent_api.DigitalWorkerTypeM365 {
 		request.DigitalWorkerType = agent_api.DigitalWorkerTypeM365
 	}
-	activityProfile, err := ResolveActivityProfileWithSettings(agentDef, foundryAgentConfig.Activity)
+	activityProfile, err := ResolveActivityProfileForDeploy(agentDef, foundryAgentConfig.Activity)
 	if err != nil {
 		return nil, exterrors.Validation(
 			exterrors.CodeInvalidAgentRequest,

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1569,9 +1569,11 @@ func (p *AgentServiceTargetProvider) Deploy(
 	result.agentVersion = deployedVersion
 	activityProfile, err = ResolveDeployedActivityProfile(activityProfile, deployedVersion.DigitalWorkerType)
 	if err != nil {
-		suggestion := "redeploy the agent so its service-side digital_worker_type matches activity.useCase"
+		suggestion := "redeploy the agent so its service-side digital_worker_type matches " +
+			"activity.digitalWorkerType"
 		if agentDef.CodeConfiguration != nil {
-			suggestion = "delete and recreate the agent so its immutable digital_worker_type matches activity.useCase"
+			suggestion = "delete and recreate the agent so its immutable digital_worker_type matches " +
+				"activity.digitalWorkerType"
 		}
 		return nil, exterrors.Validation(
 			exterrors.CodeInvalidServiceConfig,
@@ -2197,7 +2199,7 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 	applyAgentMetadata(request)
 	if foundryAgentConfig != nil &&
 		foundryAgentConfig.Activity != nil &&
-		foundryAgentConfig.Activity.UseCase == ActivityUseCaseDigitalWorker {
+		foundryAgentConfig.Activity.DigitalWorkerType == agent_api.DigitalWorkerTypeM365 {
 		request.DigitalWorkerType = agent_api.DigitalWorkerTypeM365
 	}
 	activityProfile, err := ResolveActivityProfileWithSettings(agentDef, foundryAgentConfig.Activity)
@@ -3052,7 +3054,8 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 				return nil, exterrors.Validation(
 					exterrors.CodeInvalidServiceConfig,
 					err.Error(),
-					"delete and recreate the agent so its immutable digital_worker_type matches activity.useCase",
+					"delete and recreate the agent so its immutable digital_worker_type matches "+
+						"activity.digitalWorkerType",
 				)
 			}
 		}
@@ -3535,7 +3538,8 @@ func reconcileCreateRequestWithDeployedDigitalWorkerType(
 			return true, exterrors.Validation(
 				exterrors.CodeInvalidServiceConfig,
 				err.Error(),
-				"delete and recreate the agent so its immutable digital_worker_type matches activity.useCase",
+				"delete and recreate the agent so its immutable digital_worker_type matches "+
+					"activity.digitalWorkerType",
 			)
 		}
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -3020,11 +3020,15 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 
 	// Check if agent already exists (GET /agents/{name})
 	progress("Checking existing agent")
+	localProfile := ResolveActivityProfile(agentDef)
+	if versionRequest.DigitalWorkerType == agent_api.DigitalWorkerTypeM365 {
+		localProfile = ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseDigitalWorker}
+	}
 	existingAgent, getErr := agentClient.GetAgent(
 		ctx,
 		agentDef.Name,
 		agent_api.AgentEndpointAPIVersion,
-		true,
+		localProfile.IsActivity,
 	)
 	var agentResp *agent_api.AgentObject
 
@@ -3043,16 +3047,14 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 			return nil, exterrors.ServiceFromAzure(err, exterrors.OpCreateAgent)
 		}
 	} else {
-		localProfile := ResolveActivityProfile(agentDef)
-		if versionRequest.DigitalWorkerType == agent_api.DigitalWorkerTypeM365 {
-			localProfile = ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseDigitalWorker}
-		}
-		if _, err := ResolveDeployedActivityProfile(localProfile, existingAgent.DigitalWorkerType); err != nil {
-			return nil, exterrors.Validation(
-				exterrors.CodeInvalidServiceConfig,
-				err.Error(),
-				"delete and recreate the agent so its immutable digital_worker_type matches activity.useCase",
-			)
+		if localProfile.IsActivity {
+			if _, err := ResolveDeployedActivityProfile(localProfile, existingAgent.DigitalWorkerType); err != nil {
+				return nil, exterrors.Validation(
+					exterrors.CodeInvalidServiceConfig,
+					err.Error(),
+					"delete and recreate the agent so its immutable digital_worker_type matches activity.useCase",
+				)
+			}
 		}
 		// Agent exists — update
 		progress("Updating existing agent from code package")
@@ -3518,7 +3520,8 @@ func reconcileCreateRequestWithDeployedDigitalWorkerType(
 	request *agent_api.CreateAgentRequest,
 	apiVersion string,
 ) (bool, error) {
-	existingAgent, getErr := agentClient.GetAgent(ctx, request.Name, apiVersion, true)
+	localProfile := activityProfileFromCreateRequest(request)
+	existingAgent, getErr := agentClient.GetAgent(ctx, request.Name, apiVersion, localProfile.IsActivity)
 	if getErr != nil {
 		if respErr, ok := errors.AsType[*azcore.ResponseError](getErr); !ok ||
 			respErr.StatusCode != http.StatusNotFound {
@@ -3527,15 +3530,14 @@ func reconcileCreateRequestWithDeployedDigitalWorkerType(
 		return false, nil
 	}
 
-	if _, err := ResolveDeployedActivityProfile(
-		activityProfileFromCreateRequest(request),
-		existingAgent.DigitalWorkerType,
-	); err != nil {
-		return true, exterrors.Validation(
-			exterrors.CodeInvalidServiceConfig,
-			err.Error(),
-			"delete and recreate the agent so its immutable digital_worker_type matches activity.useCase",
-		)
+	if localProfile.IsActivity {
+		if _, err := ResolveDeployedActivityProfile(localProfile, existingAgent.DigitalWorkerType); err != nil {
+			return true, exterrors.Validation(
+				exterrors.CodeInvalidServiceConfig,
+				err.Error(),
+				"delete and recreate the agent so its immutable digital_worker_type matches activity.useCase",
+			)
+		}
 	}
 
 	request.DigitalWorkerType = ""

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -2228,55 +2228,10 @@ func ensureActivityEndpointAuthSchemeForProfile(
 	request *agent_api.CreateAgentRequest,
 	profile ActivityProfile,
 ) {
-	if !profile.IsActivity {
-		return
-	}
-	if profile.UseCase == ActivityUseCaseDigitalWorker {
-		ensureActivityEndpointAuthScheme(request, agent_api.AgentEndpointAuthSchemeBotServiceTenant)
-		return
-	}
-	ensureActivityEndpointAuthScheme(request, agent_api.AgentEndpointAuthSchemeBotServiceRbac)
-}
-
-func ensureActivityEndpointAuthScheme(
-	request *agent_api.CreateAgentRequest,
-	schemeType agent_api.AgentEndpointAuthorizationSchemeType,
-) {
 	if request.AgentEndpoint == nil {
 		request.AgentEndpoint = &agent_api.AgentEndpoint{}
 	}
-
-	hasActivity := slices.Contains(request.AgentEndpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
-	if !hasActivity {
-		request.AgentEndpoint.Protocols = append(
-			request.AgentEndpoint.Protocols,
-			agent_api.AgentEndpointProtocolActivity,
-		)
-	}
-
-	schemes := request.AgentEndpoint.AuthorizationSchemes[:0]
-	hasTarget := false
-	for _, scheme := range request.AgentEndpoint.AuthorizationSchemes {
-		if scheme.Type == agent_api.AgentEndpointAuthSchemeBotService ||
-			scheme.Type == agent_api.AgentEndpointAuthSchemeBotServiceRbac ||
-			scheme.Type == agent_api.AgentEndpointAuthSchemeBotServiceTenant {
-			if scheme.Type == schemeType && !hasTarget {
-				schemes = append(schemes, scheme)
-				hasTarget = true
-			}
-			continue
-		}
-		if scheme.Type == schemeType {
-			hasTarget = true
-		}
-		schemes = append(schemes, scheme)
-	}
-	if !hasTarget {
-		schemes = append(schemes, agent_api.AgentEndpointAuthorizationScheme{
-			Type: schemeType,
-		})
-	}
-	request.AgentEndpoint.AuthorizationSchemes = schemes
+	EnsureActivityEndpointAuthSchemeForProfile(request.AgentEndpoint, profile)
 }
 
 // deployResult holds the intermediate results from a deploy method (code or container)
@@ -3518,7 +3473,18 @@ func (p *AgentServiceTargetProvider) createAgent(
 		p.credential,
 	)
 
-	writeExistingAgentVersionWarningIfPresent(ctx, agentClient, request.Name)
+	updatingExisting, err := reconcileCreateRequestWithDeployedDigitalWorkerType(
+		ctx,
+		agentClient,
+		request,
+		agent_api.AgentEndpointAPIVersion,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if updatingExisting {
+		writeExistingAgentVersionWarning(request.Name)
+	}
 
 	// Extract CreateAgentVersionRequest from CreateAgentRequest
 	versionRequest := &agent_api.CreateAgentVersionRequest{
@@ -3539,6 +3505,47 @@ func (p *AgentServiceTargetProvider) createAgent(
 	fmt.Fprintf(os.Stderr, "Agent version '%s' created successfully!\n", agentVersionResponse.Name)
 
 	return agentVersionResponse, nil
+}
+
+func reconcileCreateRequestWithDeployedDigitalWorkerType(
+	ctx context.Context,
+	agentClient *agent_api.AgentClient,
+	request *agent_api.CreateAgentRequest,
+	apiVersion string,
+) (bool, error) {
+	existingAgent, getErr := agentClient.GetAgentWithDigitalWorkerType(ctx, request.Name, apiVersion)
+	if getErr != nil {
+		if respErr, ok := errors.AsType[*azcore.ResponseError](getErr); !ok ||
+			respErr.StatusCode != http.StatusNotFound {
+			return false, exterrors.ServiceFromAzure(getErr, exterrors.OpCreateAgent)
+		}
+		return false, nil
+	}
+
+	if _, err := ResolveDeployedActivityProfile(
+		activityProfileFromCreateRequest(request),
+		existingAgent.DigitalWorkerType,
+	); err != nil {
+		return true, exterrors.Validation(
+			exterrors.CodeInvalidServiceConfig,
+			err.Error(),
+			"delete and recreate the agent so its immutable digital_worker_type matches activity.useCase",
+		)
+	}
+
+	request.DigitalWorkerType = ""
+	return true, nil
+}
+
+func activityProfileFromCreateRequest(request *agent_api.CreateAgentRequest) ActivityProfile {
+	if request.DigitalWorkerType == agent_api.DigitalWorkerTypeM365 {
+		return ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseDigitalWorker}
+	}
+	if request.AgentEndpoint != nil &&
+		slices.Contains(request.AgentEndpoint.Protocols, agent_api.AgentEndpointProtocolActivity) {
+		return ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseSimple}
+	}
+	return ActivityProfile{}
 }
 
 // displayAgentInfo displays information about the agent being deployed

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1569,16 +1569,10 @@ func (p *AgentServiceTargetProvider) Deploy(
 	result.agentVersion = deployedVersion
 	activityProfile, err = ResolveDeployedActivityProfile(activityProfile, deployedVersion.DigitalWorkerType)
 	if err != nil {
-		suggestion := "redeploy the agent so its service-side digital_worker_type matches " +
-			"activity.digitalWorkerType"
-		if agentDef.CodeConfiguration != nil {
-			suggestion = "delete and recreate the agent so its immutable digital_worker_type matches " +
-				"activity.digitalWorkerType"
-		}
 		return nil, exterrors.Validation(
 			exterrors.CodeInvalidServiceConfig,
 			err.Error(),
-			suggestion,
+			digitalWorkerTypeMismatchSuggestion(),
 		)
 	}
 	ensureActivityEndpointAuthSchemeForProfile(result.request, activityProfile)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -2192,6 +2192,9 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 		foundryAgentConfig.Activity != nil &&
 		foundryAgentConfig.Activity.UseCase == ActivityUseCaseDigitalWorker {
 		request.DigitalWorkerType = agent_api.DigitalWorkerTypeM365
+		ensureActivityEndpointAuthScheme(request, agent_api.AgentEndpointAuthSchemeBotServiceTenant)
+	} else if IsActivityProtocol(agentDef) {
+		ensureActivityEndpointAuthScheme(request, agent_api.AgentEndpointAuthSchemeBotServiceRbac)
 	}
 
 	// Default to "responses" protocol when none specified in agent.yaml.
@@ -2207,6 +2210,52 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 		request:         request,
 		protocols:       protocols,
 	}, nil
+}
+
+func ensureActivityEndpointAuthScheme(
+	request *agent_api.CreateAgentRequest,
+	schemeType agent_api.AgentEndpointAuthorizationSchemeType,
+) {
+	if request.AgentEndpoint == nil {
+		request.AgentEndpoint = &agent_api.AgentEndpoint{}
+	}
+
+	hasActivity := false
+	for _, protocol := range request.AgentEndpoint.Protocols {
+		if protocol == agent_api.AgentEndpointProtocolActivity {
+			hasActivity = true
+			break
+		}
+	}
+	if !hasActivity {
+		request.AgentEndpoint.Protocols = append(
+			request.AgentEndpoint.Protocols,
+			agent_api.AgentEndpointProtocolActivity,
+		)
+	}
+
+	schemes := request.AgentEndpoint.AuthorizationSchemes[:0]
+	hasTarget := false
+	for _, scheme := range request.AgentEndpoint.AuthorizationSchemes {
+		if scheme.Type == agent_api.AgentEndpointAuthSchemeBotServiceRbac ||
+			scheme.Type == agent_api.AgentEndpointAuthSchemeBotServiceTenant {
+			if scheme.Type == schemeType && !hasTarget {
+				schemes = append(schemes, scheme)
+				hasTarget = true
+			}
+			continue
+		}
+		if scheme.Type == schemeType {
+			hasTarget = true
+		}
+		schemes = append(schemes, scheme)
+	}
+	if !hasTarget {
+		schemes = append(schemes, agent_api.AgentEndpointAuthorizationScheme{
+			Type: schemeType,
+		})
+	}
+	request.AgentEndpoint.AuthorizationSchemes = schemes
 }
 
 // deployResult holds the intermediate results from a deploy method (code or container)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1568,12 +1568,17 @@ func (p *AgentServiceTargetProvider) Deploy(
 	result.agentVersion = deployedVersion
 	activityProfile, err = ResolveDeployedActivityProfile(activityProfile, deployedVersion.DigitalWorkerType)
 	if err != nil {
+		suggestion := "redeploy the agent so its service-side digital_worker_type matches activity.useCase"
+		if agentDef.CodeConfiguration != nil {
+			suggestion = "delete and recreate the agent so its immutable digital_worker_type matches activity.useCase"
+		}
 		return nil, exterrors.Validation(
 			exterrors.CodeInvalidServiceConfig,
 			err.Error(),
-			"redeploy the agent so its service-side digital_worker_type matches activity.useCase",
+			suggestion,
 		)
 	}
+	ensureActivityEndpointAuthSchemeForProfile(result.request, activityProfile)
 
 	// Patch agent-level endpoint/card fields
 	if result.request.AgentEndpoint != nil || result.request.AgentCard != nil {
@@ -2193,10 +2198,16 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 		foundryAgentConfig.Activity != nil &&
 		foundryAgentConfig.Activity.UseCase == ActivityUseCaseDigitalWorker {
 		request.DigitalWorkerType = agent_api.DigitalWorkerTypeM365
-		ensureActivityEndpointAuthScheme(request, agent_api.AgentEndpointAuthSchemeBotServiceTenant)
-	} else if IsActivityProtocol(agentDef) {
-		ensureActivityEndpointAuthScheme(request, agent_api.AgentEndpointAuthSchemeBotServiceRbac)
 	}
+	activityProfile, err := ResolveActivityProfileWithSettings(agentDef, foundryAgentConfig.Activity)
+	if err != nil {
+		return nil, exterrors.Validation(
+			exterrors.CodeInvalidAgentRequest,
+			fmt.Sprintf("failed to resolve Activity configuration: %s", err),
+			"check the activity configuration in azure.yaml",
+		)
+	}
+	ensureActivityEndpointAuthSchemeForProfile(request, activityProfile)
 
 	// Default to "responses" protocol when none specified in agent.yaml.
 	protocols := agentDef.Protocols
@@ -2211,6 +2222,20 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 		request:         request,
 		protocols:       protocols,
 	}, nil
+}
+
+func ensureActivityEndpointAuthSchemeForProfile(
+	request *agent_api.CreateAgentRequest,
+	profile ActivityProfile,
+) {
+	if !profile.IsActivity {
+		return
+	}
+	if profile.UseCase == ActivityUseCaseDigitalWorker {
+		ensureActivityEndpointAuthScheme(request, agent_api.AgentEndpointAuthSchemeBotServiceTenant)
+		return
+	}
+	ensureActivityEndpointAuthScheme(request, agent_api.AgentEndpointAuthSchemeBotServiceRbac)
 }
 
 func ensureActivityEndpointAuthScheme(

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1556,7 +1556,7 @@ func (p *AgentServiceTargetProvider) Deploy(
 
 	// Read the deployed version so post-deploy behavior uses the service-side
 	// Digital Worker classification rather than only the local authoring intent.
-	deployedVersion, err := agentClient.GetAgentVersion(
+	deployedVersion, err := agentClient.GetAgentVersionWithDigitalWorkerType(
 		ctx,
 		result.agentName,
 		result.agentVersion.Version,

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -2220,13 +2221,7 @@ func ensureActivityEndpointAuthScheme(
 		request.AgentEndpoint = &agent_api.AgentEndpoint{}
 	}
 
-	hasActivity := false
-	for _, protocol := range request.AgentEndpoint.Protocols {
-		if protocol == agent_api.AgentEndpointProtocolActivity {
-			hasActivity = true
-			break
-		}
-	}
+	hasActivity := slices.Contains(request.AgentEndpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
 	if !hasActivity {
 		request.AgentEndpoint.Protocols = append(
 			request.AgentEndpoint.Protocols,

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -1556,11 +1556,12 @@ func (p *AgentServiceTargetProvider) Deploy(
 
 	// Read the deployed version so post-deploy behavior uses the service-side
 	// Digital Worker classification rather than only the local authoring intent.
-	deployedVersion, err := agentClient.GetAgentVersionWithDigitalWorkerType(
+	deployedVersion, err := agentClient.GetAgentVersion(
 		ctx,
 		result.agentName,
 		result.agentVersion.Version,
 		agent_api.AgentEndpointAPIVersion,
+		true,
 	)
 	if err != nil {
 		return nil, exterrors.ServiceFromAzure(err, exterrors.OpGetAgent)
@@ -3019,10 +3020,11 @@ func (p *AgentServiceTargetProvider) deployHostedCodeAgent(
 
 	// Check if agent already exists (GET /agents/{name})
 	progress("Checking existing agent")
-	existingAgent, getErr := agentClient.GetAgentWithDigitalWorkerType(
+	existingAgent, getErr := agentClient.GetAgent(
 		ctx,
 		agentDef.Name,
 		agent_api.AgentEndpointAPIVersion,
+		true,
 	)
 	var agentResp *agent_api.AgentObject
 
@@ -3394,7 +3396,7 @@ func (p *AgentServiceTargetProvider) waitForAgentActive(
 		attempt++
 		progress(fmt.Sprintf("Polling agent status (%d/%d)", attempt, maxAttempts))
 
-		versionResp, err := agentClient.GetAgentVersion(ctx, agentName, version, agent_api.AgentEndpointAPIVersion)
+		versionResp, err := agentClient.GetAgentVersion(ctx, agentName, version, agent_api.AgentEndpointAPIVersion, false)
 		if err != nil {
 			lastPollErr = err
 			fmt.Fprintf(os.Stderr, "  Warning: poll failed: %s\n", err)
@@ -3516,7 +3518,7 @@ func reconcileCreateRequestWithDeployedDigitalWorkerType(
 	request *agent_api.CreateAgentRequest,
 	apiVersion string,
 ) (bool, error) {
-	existingAgent, getErr := agentClient.GetAgentWithDigitalWorkerType(ctx, request.Name, apiVersion)
+	existingAgent, getErr := agentClient.GetAgent(ctx, request.Name, apiVersion, true)
 	if getErr != nil {
 		if respErr, ok := errors.AsType[*azcore.ResponseError](getErr); !ok ||
 			respErr.StatusCode != http.StatusNotFound {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -2028,6 +2028,30 @@ func TestPrepareDeployUsesRbacForSimpleActivityEndpoint(t *testing.T) {
 	)
 }
 
+func TestEnsureActivityEndpointAuthSchemeForPromotedDigitalWorker(t *testing.T) {
+	t.Parallel()
+
+	request := &agent_api.CreateAgentRequest{
+		AgentEndpoint: &agent_api.AgentEndpoint{
+			Protocols: []agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolActivity},
+			AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
+				{Type: agent_api.AgentEndpointAuthSchemeEntra},
+				{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
+			},
+		},
+	}
+
+	ensureActivityEndpointAuthSchemeForProfile(request, ActivityProfile{
+		IsActivity: true,
+		UseCase:    ActivityUseCaseDigitalWorker,
+	})
+
+	require.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
+		{Type: agent_api.AgentEndpointAuthSchemeEntra},
+		{Type: agent_api.AgentEndpointAuthSchemeBotServiceTenant},
+	}, request.AgentEndpoint.AuthorizationSchemes)
+}
+
 func TestValidateRegistryConnectionDefinition(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -1949,6 +1949,13 @@ func TestPrepareDeploySetsDigitalWorkerType(t *testing.T) {
 	t.Parallel()
 
 	agentDef := sampleContainerAgent()
+	agentDef.Protocols = []agent_yaml.ProtocolVersionRecord{{Protocol: "activity", Version: "2.0.0"}}
+	agentDef.AgentEndpoint = &agent_yaml.AgentEndpoint{
+		Protocols: []string{"activity"},
+		AuthorizationSchemes: []agent_yaml.AuthorizationScheme{
+			{Type: string(agent_api.AgentEndpointAuthSchemeBotServiceRbac)},
+		},
+	}
 	props, err := AgentDefinitionToServiceProperties(agentDef, &ServiceTargetAgentConfig{
 		Activity: &ActivitySettings{UseCase: ActivityUseCaseDigitalWorker},
 	})
@@ -1969,6 +1976,56 @@ func TestPrepareDeploySetsDigitalWorkerType(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, agent_api.DigitalWorkerTypeM365, prep.request.DigitalWorkerType)
+	require.NotNil(t, prep.request.AgentEndpoint)
+	require.Equal(
+		t,
+		[]agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolActivity},
+		prep.request.AgentEndpoint.Protocols,
+	)
+	require.Len(t, prep.request.AgentEndpoint.AuthorizationSchemes, 1)
+	require.Equal(
+		t,
+		agent_api.AgentEndpointAuthSchemeBotServiceTenant,
+		prep.request.AgentEndpoint.AuthorizationSchemes[0].Type,
+	)
+}
+
+func TestPrepareDeployUsesRbacForSimpleActivityEndpoint(t *testing.T) {
+	t.Parallel()
+
+	agentDef := sampleContainerAgent()
+	agentDef.Protocols = []agent_yaml.ProtocolVersionRecord{{Protocol: "activity", Version: "2.0.0"}}
+	agentDef.AgentEndpoint = &agent_yaml.AgentEndpoint{Protocols: []string{"activity"}}
+	props, err := AgentDefinitionToServiceProperties(agentDef, nil)
+	require.NoError(t, err)
+	svc := &azdext.ServiceConfig{
+		Name:                 "simple-activity",
+		AdditionalProperties: props,
+	}
+
+	prep, err := (&AgentServiceTargetProvider{}).prepareDeploy(
+		svc,
+		agentDef,
+		map[string]string{"FOUNDRY_PROJECT_ENDPOINT": "https://example"},
+		[]agent_yaml.AgentBuildOption{
+			agent_yaml.WithImageURL("registry.example/activity:v1"),
+		},
+	)
+
+	require.NoError(t, err)
+	require.Empty(t, prep.request.DigitalWorkerType)
+	require.NotNil(t, prep.request.AgentEndpoint)
+	require.Equal(
+		t,
+		[]agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolActivity},
+		prep.request.AgentEndpoint.Protocols,
+	)
+	require.Len(t, prep.request.AgentEndpoint.AuthorizationSchemes, 1)
+	require.Equal(
+		t,
+		agent_api.AgentEndpointAuthSchemeBotServiceRbac,
+		prep.request.AgentEndpoint.AuthorizationSchemes[0].Type,
+	)
 }
 
 func TestValidateRegistryConnectionDefinition(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -1325,7 +1325,7 @@ func TestRegisterAgentEnvironmentVariables_PersistsDigitalWorkerBlueprintClientI
 		"",
 		false,
 		ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseDigitalWorker},
-		&ActivitySettings{UseCase: ActivityUseCaseDigitalWorker, Publish: publish},
+		&ActivitySettings{DigitalWorkerType: agent_api.DigitalWorkerTypeM365, Publish: publish},
 	)
 	require.NoError(t, err)
 	require.Equal(t, "blueprint-client-id", envStub.values[envkey.AgentBlueprintClientID("my-svc")])
@@ -1958,7 +1958,7 @@ func TestPrepareDeploySetsDigitalWorkerType(t *testing.T) {
 		},
 	}
 	props, err := AgentDefinitionToServiceProperties(agentDef, &ServiceTargetAgentConfig{
-		Activity: &ActivitySettings{UseCase: ActivityUseCaseDigitalWorker},
+		Activity: &ActivitySettings{DigitalWorkerType: agent_api.DigitalWorkerTypeM365},
 	})
 	require.NoError(t, err)
 	svc := &azdext.ServiceConfig{

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -119,6 +119,7 @@ func (f fakeProjectAgentChecker) GetAgent(
 	context.Context,
 	string,
 	string,
+	bool,
 ) (*agent_api.AgentObject, error) {
 	if f.err != nil {
 		return nil, f.err

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -2094,6 +2094,48 @@ func TestEnsureActivityEndpointAuthSchemeReplacesLegacyBotService(t *testing.T) 
 	}
 }
 
+func TestActivityProfileFromCreateRequest(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name    string
+		request *agent_api.CreateAgentRequest
+		want    ActivityProfile
+	}{
+		{
+			name: "digital worker",
+			request: &agent_api.CreateAgentRequest{
+				CreateAgentVersionRequest: agent_api.CreateAgentVersionRequest{
+					DigitalWorkerType: agent_api.DigitalWorkerTypeM365,
+				},
+			},
+			want: ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseDigitalWorker},
+		},
+		{
+			name: "simple activity",
+			request: &agent_api.CreateAgentRequest{
+				AgentEndpoint: &agent_api.AgentEndpoint{
+					Protocols: []agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolActivity},
+				},
+			},
+			want: ActivityProfile{IsActivity: true, UseCase: ActivityUseCaseSimple},
+		},
+		{
+			name: "non activity",
+			request: &agent_api.CreateAgentRequest{
+				AgentEndpoint: &agent_api.AgentEndpoint{
+					Protocols: []agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolResponses},
+				},
+			},
+			want: ActivityProfile{},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, activityProfileFromCreateRequest(test.request))
+		})
+	}
+}
+
 func TestValidateRegistryConnectionDefinition(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -2094,6 +2094,16 @@ func TestEnsureActivityEndpointAuthSchemeReplacesLegacyBotService(t *testing.T) 
 	}
 }
 
+func TestEnsureActivityEndpointAuthSchemeForNonActivityDoesNotCreateEndpoint(t *testing.T) {
+	t.Parallel()
+
+	request := &agent_api.CreateAgentRequest{}
+
+	ensureActivityEndpointAuthSchemeForProfile(request, ActivityProfile{})
+
+	require.Nil(t, request.AgentEndpoint)
+}
+
 func TestActivityProfileFromCreateRequest(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -1306,10 +1306,7 @@ func TestRegisterAgentEnvironmentVariables_PersistsDigitalWorkerBlueprintClientI
 		azdClient: newEnvTestClient(t, envStub),
 		env:       &azdext.Environment{Name: "test-env"},
 	}
-	publish := &ActivityPublishConfig{
-		PublishAsAutopilot: true,
-		PublishScope:       "tenant",
-	}
+	publish := &ActivityPublishConfig{PublishScope: "tenant"}
 
 	err := provider.registerAgentEnvironmentVariables(
 		t.Context(),
@@ -1927,6 +1924,7 @@ func TestPrepareDeployAppliesDefaultResources(t *testing.T) {
 		Name:                 "basic-agent",
 		AdditionalProperties: props,
 	}
+
 	provider := &AgentServiceTargetProvider{}
 
 	prep, err := provider.prepareDeploy(
@@ -1945,6 +1943,32 @@ func TestPrepareDeployAppliesDefaultResources(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, DefaultCpu, definition.CPU)
 	require.Equal(t, DefaultMemory, definition.Memory)
+}
+
+func TestPrepareDeploySetsDigitalWorkerType(t *testing.T) {
+	t.Parallel()
+
+	agentDef := sampleContainerAgent()
+	props, err := AgentDefinitionToServiceProperties(agentDef, &ServiceTargetAgentConfig{
+		Activity: &ActivitySettings{UseCase: ActivityUseCaseDigitalWorker},
+	})
+	require.NoError(t, err)
+	svc := &azdext.ServiceConfig{
+		Name:                 "digital-worker",
+		AdditionalProperties: props,
+	}
+
+	prep, err := (&AgentServiceTargetProvider{}).prepareDeploy(
+		svc,
+		agentDef,
+		map[string]string{"FOUNDRY_PROJECT_ENDPOINT": "https://example"},
+		[]agent_yaml.AgentBuildOption{
+			agent_yaml.WithImageURL("registry.example/worker:v1"),
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, agent_api.DigitalWorkerTypeM365, prep.request.DigitalWorkerType)
 }
 
 func TestValidateRegistryConnectionDefinition(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -2052,6 +2052,48 @@ func TestEnsureActivityEndpointAuthSchemeForPromotedDigitalWorker(t *testing.T) 
 	}, request.AgentEndpoint.AuthorizationSchemes)
 }
 
+func TestEnsureActivityEndpointAuthSchemeReplacesLegacyBotService(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name    string
+		useCase ActivityUseCase
+		want    agent_api.AgentEndpointAuthorizationSchemeType
+	}{
+		{
+			name:    "digital worker",
+			useCase: ActivityUseCaseDigitalWorker,
+			want:    agent_api.AgentEndpointAuthSchemeBotServiceTenant,
+		},
+		{
+			name:    "simple activity",
+			useCase: ActivityUseCaseSimple,
+			want:    agent_api.AgentEndpointAuthSchemeBotServiceRbac,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := &agent_api.CreateAgentRequest{
+				AgentEndpoint: &agent_api.AgentEndpoint{
+					AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
+						{Type: agent_api.AgentEndpointAuthSchemeEntra},
+						{Type: agent_api.AgentEndpointAuthSchemeBotService},
+					},
+				},
+			}
+
+			ensureActivityEndpointAuthSchemeForProfile(request, ActivityProfile{
+				IsActivity: true,
+				UseCase:    test.useCase,
+			})
+
+			require.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
+				{Type: agent_api.AgentEndpointAuthSchemeEntra},
+				{Type: test.want},
+			}, request.AgentEndpoint.AuthorizationSchemes)
+		})
+	}
+}
+
 func TestValidateRegistryConnectionDefinition(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
@@ -221,14 +221,14 @@
       }
     },
     {
-      "$comment": "The activity.publish block is shared publish metadata for Activity use cases (including simple). Digital Worker publish is tenant-only; permission scopes and access boundaries are optional.",
+      "$comment": "The activity.publish block is shared publish metadata for Activity agents. Microsoft 365 Digital Worker publish is tenant-only; permission scopes and access boundaries are optional.",
       "if": {
         "properties": {
           "activity": {
             "properties": {
-              "useCase": { "const": "digital_worker" }
+              "digitalWorkerType": { "const": "m365" }
             },
-            "required": ["useCase"]
+            "required": ["digitalWorkerType"]
           }
         },
         "required": ["activity"]
@@ -248,23 +248,13 @@
       }
     },
     {
-      "$comment": "Optional permission scopes and access boundaries apply only to Digital Workers. An omitted activity.useCase defaults to simple.",
+      "$comment": "Optional permission scopes and access boundaries apply only to Digital Workers. An omitted activity.digitalWorkerType selects simple mode.",
       "if": {
         "properties": {
           "activity": {
-            "anyOf": [
-              {
-                "properties": {
-                  "useCase": { "const": "simple" }
-                },
-                "required": ["useCase"]
-              },
-              {
-                "not": {
-                  "required": ["useCase"]
-                }
-              }
-            ]
+            "not": {
+              "required": ["digitalWorkerType"]
+            }
           }
         },
         "required": ["activity"]
@@ -305,9 +295,9 @@
   "definitions": {
     "ActivitySettings": {
       "type": "object",
-      "description": "Activity-protocol Teams configuration. The publish block is shared metadata for Activity use cases; digital_worker applies additional constraints via allOf.",
+      "description": "Activity-protocol Teams configuration. Omit digitalWorkerType for simple mode; m365 applies Digital Worker constraints via allOf.",
       "properties": {
-        "useCase": { "type": "string", "enum": ["simple", "digital_worker"] },
+        "digitalWorkerType": { "type": "string", "enum": ["m365"] },
         "publish": {
           "$ref": "#/definitions/ActivityPublishConfig",
           "description": "Shared Microsoft 365 app publish metadata used by Activity use cases. Digital Worker publication is tenant-only."

--- a/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
@@ -248,6 +248,45 @@
       }
     },
     {
+      "$comment": "Optional permission scopes and access boundaries apply only to Digital Workers. An omitted activity.useCase defaults to simple.",
+      "if": {
+        "properties": {
+          "activity": {
+            "anyOf": [
+              {
+                "properties": {
+                  "useCase": { "const": "simple" }
+                },
+                "required": ["useCase"]
+              },
+              {
+                "not": {
+                  "required": ["useCase"]
+                }
+              }
+            ]
+          }
+        },
+        "required": ["activity"]
+      },
+      "then": {
+        "properties": {
+          "activity": {
+            "properties": {
+              "publish": {
+                "not": {
+                  "anyOf": [
+                    { "required": ["optionalPermissionScopes"] },
+                    { "required": ["accessBoundaries"] }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "$comment": "A registry connection applies only to a hosted container agent, not code or managed voice deploy.",
       "if": {
         "required": ["registryConnectionId"]

--- a/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
+++ b/cli/azd/extensions/azure.ai.agents/schemas/azure.ai.agent.json
@@ -221,7 +221,7 @@
       }
     },
     {
-      "$comment": "The activity.publish block is shared publish metadata for Activity use cases (including simple). Digital Worker adds stricter requirements: publish must exist, publishScope must be tenant, and agenticUserTemplate is required to carry the persisted blueprint identity.",
+      "$comment": "The activity.publish block is shared publish metadata for Activity use cases (including simple). Digital Worker publish is tenant-only; permission scopes and access boundaries are optional.",
       "if": {
         "properties": {
           "activity": {
@@ -236,13 +236,11 @@
       "then": {
         "properties": {
           "activity": {
-            "required": ["publish"],
             "properties": {
               "publish": {
                 "properties": {
                   "publishScope": { "const": "tenant" }
-                },
-                "required": ["agenticUserTemplate"]
+                }
               }
             }
           }
@@ -273,7 +271,7 @@
         "useCase": { "type": "string", "enum": ["simple", "digital_worker"] },
         "publish": {
           "$ref": "#/definitions/ActivityPublishConfig",
-          "description": "Shared Microsoft 365 app publish metadata used by Activity use cases. For digital_worker, publishScope=tenant and agenticUserTemplate are required."
+          "description": "Shared Microsoft 365 app publish metadata used by Activity use cases. Digital Worker publication is tenant-only."
         }
       },
       "additionalProperties": false
@@ -291,19 +289,40 @@
         "developerWebsiteUrl": { "type": "string", "format": "uri" },
         "privacyUrl": { "type": "string", "format": "uri" },
         "termsOfUseUrl": { "type": "string", "format": "uri" },
-        "agenticUserTemplate": { "$ref": "#/definitions/AgenticUserTemplateConfig" }
+        "optionalPermissionScopes": {
+          "type": "array",
+          "description": "Optional Microsoft 365 permission selections for a Digital Worker.",
+          "items": { "$ref": "#/definitions/Microsoft365PermissionScopes" }
+        },
+        "accessBoundaries": {
+          "type": "array",
+          "description": "Optional Digital Worker access boundaries. An explicit empty array clears existing boundaries.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "read.1on1.developers",
+              "write.1on1.developers",
+              "read.group.developers",
+              "write.group.developers"
+            ]
+          },
+          "uniqueItems": true
+        }
       },
       "additionalProperties": false
     },
-    "AgenticUserTemplateConfig": {
+    "Microsoft365PermissionScopes": {
       "type": "object",
       "properties": {
-        "id": { "type": "string", "minLength": 1 },
-        "file": { "type": "string", "minLength": 1 },
-        "schemaVersion": { "type": "string", "minLength": 1 },
-        "communicationProtocol": { "type": "string", "minLength": 1 }
+        "resourceAppId": { "type": "string", "minLength": 1 },
+        "scopes": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "uniqueItems": true
+        }
       },
-      "required": ["id", "file", "schemaVersion", "communicationProtocol"],
+      "required": ["resourceAppId", "scopes"],
       "additionalProperties": false
     },
     "ProtocolVersionRecord": {


### PR DESCRIPTION
## Summary

Updates the `azure.ai.agents` extension to support the latest Digital Worker agent and Microsoft 365 publish contracts.

- Declares Digital Workers through `activity.digitalWorkerType: m365` in `azure.yaml`, mapped to the service-side `digital_worker_type=m365` contract, and reconciles it with the deployed immutable type.
- Applies the `DigitalWorker=V1Preview` feature to the agent operations that require the Digital Worker contract.
- Replaces legacy agentic-user-template publish fields with `optionalPermissionScopes` and `accessBoundaries`.
- Adds `azure.yaml` schema/runtime validation and `azd ai agent publish` flags for permission scopes, access boundaries, and explicit boundary clearing.
- Restricts Digital Worker publication to tenant scope and prevents Digital Worker-only options on simple Activity agents.
- Uses `BotServiceTenant` for Digital Worker Activity endpoints while preserving `BotServiceRbac` for simple Activity agents.
- Updates documentation and regression coverage for the new behavior.

## Why

The previous flow relied on the legacy Microsoft 365 publish payload (`publishAsAutopilot` and agentic-user-template fields) to identify and configure a Digital Worker. The updated service contract moves Digital Worker classification to the agent resource and exposes permission scopes and access boundaries directly in the publish request.

The extension must treat that classification consistently throughout the lifecycle. In particular, leaving the Activity endpoint on the simple-agent `BotServiceRbac` scheme after declaring `digital_worker_type=m365` causes Agent 365 conversations to enter the Azure RBAC `checkaccess` path and fail with `MISE12042 / AzureAuthorizationModule / BadRequest`. A live sample confirmed that changing the endpoint to `BotServiceTenant` restores conversations.

## Contract changes

### Agent deploy and discovery

- Serialize and deserialize `digital_worker_type` on agent/version models.
- Map `activity.digitalWorkerType: m365` from `azure.yaml` to the service-side `digital_worker_type=m365` contract.
- Reconcile the local Digital Worker type with the deployed service-side type.
- Preserve immutable type semantics for update paths and provide delete/recreate guidance when migration is required.
- Select `BotServiceTenant` for Digital Workers and `BotServiceRbac` for simple Activity agents.

### Microsoft 365 publish

- Remove legacy `useAgenticUserTemplate` and `agenticUserTemplate` fields.
- Send optional permission scopes grouped by resource application.
- Support tri-state access boundaries: omit, set, or explicitly clear.
- Resolve command-line values over `azure.yaml` values.

### Configuration schema

For a Microsoft 365 Digital Worker, set `activity.digitalWorkerType` to `m365`:

```yaml
activity:
  digitalWorkerType: m365
  publish:
    publishScope: tenant
    optionalPermissionScopes:
      - resourceAppId: <resource-app-id>
        scopes:
          - <scope>
    accessBoundaries:
      - read.1on1.developers
```

For a simple Activity agent, omit `digitalWorkerType`:

```yaml
activity:
  publish:
    publishScope: shared
```

The schema accepts only `m365` when `digitalWorkerType` is present. An omitted value selects simple mode. The removed `activity.useCase` field is rejected by both schema and runtime validation so an existing Digital Worker configuration cannot silently fall back to simple mode.

## Validation

```powershell
go test ./...
go fix -diff ./...
azd x build
```

The endpoint authorization behavior was also validated with a deployed Digital Worker sample: `BotServiceRbac` reproduced the conversation-time Azure Authorization failure, while `BotServiceTenant` allowed conversations to proceed.

Fixes #9790