### PR TITLE
Rebase the path keys an extension owns, and edit YAML at any path

### DIFF
--- a/cli/azd/pkg/foundry/includes.go
+++ b/cli/azd/pkg/foundry/includes.go
@@ -58,39 +58,74 @@ var remoteRefPattern = regexp.MustCompile(`(?i)^[a-z][a-z0-9+.-]*://`)
 // relative or absolute file paths are accepted. Cyclic and excessively deep include chains
 // return an error rather than looping. $ref targets are treated as trusted input, the same
 // trust level as azure.yaml itself.
-func ResolveFileRefs(cfg map[string]any, projectRoot string) (map[string]any, error) {
+// ResolveOption configures a call to ResolveFileRefs.
+type ResolveOption func(*resolveOptions)
+
+// resolveOptions carries what the calling extension adds to resolution.
+type resolveOptions struct {
+	// pathKeys are keys whose relative string values name files, beyond the two
+	// core owns.
+	pathKeys map[string]bool
+}
+
+// WithPathKeys declares keys whose relative string values are filesystem paths.
+//
+// Core rebases the path keys it owns -- project and instructions -- so that a
+// value written inside a $ref file still resolves once it has been spliced into
+// a document in another directory. A key core does not know about arrives
+// verbatim, which leaves it resolving against the wrong directory: an evaluator
+// pulled in from evaluators/quality.yaml carries `source: ./quality.json`,
+// which then means quality.json beside the configuration rather than beside the
+// file it was written in. The extension that owns those keys names them here.
+func WithPathKeys(keys ...string) ResolveOption {
+	return func(o *resolveOptions) {
+		if o.pathKeys == nil {
+			o.pathKeys = map[string]bool{}
+		}
+		for _, key := range keys {
+			o.pathKeys[key] = true
+		}
+	}
+}
+
+func ResolveFileRefs(cfg map[string]any, projectRoot string, opts ...ResolveOption) (map[string]any, error) {
 	if cfg == nil {
 		return nil, nil
 	}
 
+	resolved := &resolveOptions{}
+	for _, opt := range opts {
+		opt(resolved)
+	}
+
 	root := filepath.Clean(projectRoot)
-	resolved, err := resolveValue(cfg, root, root, nil)
+	out, err := resolveValue(cfg, root, root, nil, resolved)
 	if err != nil {
 		return nil, err
 	}
 
-	out, ok := resolved.(map[string]any)
+	mapped, ok := out.(map[string]any)
 	if !ok {
 		// resolveValue always returns a map for a map input; this is unreachable in practice.
 		return nil, fileRefInternal("resolved Foundry config is not a mapping")
 	}
-	return out, nil
+	return mapped, nil
 }
 
 // resolveValue recursively resolves $ref includes in v. baseDir is the directory of the file
 // that holds v (so relative $ref and path values resolve correctly); projectRoot is the
 // azure.yaml directory used to re-anchor rebased paths; chain holds the absolute paths of the
 // $ref files currently being resolved, for cycle detection.
-func resolveValue(v any, baseDir, projectRoot string, chain []string) (any, error) {
+func resolveValue(v any, baseDir, projectRoot string, chain []string, opts *resolveOptions) (any, error) {
 	switch typed := v.(type) {
 	case map[string]any:
 		if _, isRef := typed[refKey]; isRef {
-			return resolveRef(typed, baseDir, projectRoot, chain)
+			return resolveRef(typed, baseDir, projectRoot, chain, opts)
 		}
 
 		out := make(map[string]any, len(typed))
 		for key, child := range typed {
-			resolvedChild, err := resolveMapEntry(key, child, baseDir, projectRoot, chain)
+			resolvedChild, err := resolveMapEntry(key, child, baseDir, projectRoot, chain, opts)
 			if err != nil {
 				return nil, err
 			}
@@ -100,7 +135,7 @@ func resolveValue(v any, baseDir, projectRoot string, chain []string) (any, erro
 	case []any:
 		out := make([]any, len(typed))
 		for i, item := range typed {
-			resolvedItem, err := resolveValue(item, baseDir, projectRoot, chain)
+			resolvedItem, err := resolveValue(item, baseDir, projectRoot, chain, opts)
 			if err != nil {
 				return nil, err
 			}
@@ -115,13 +150,13 @@ func resolveValue(v any, baseDir, projectRoot string, chain []string) (any, erro
 // resolveMapEntry resolves a single key/value of a mapping and rebases it when the key is a
 // path-bearing field (project, instructions) loaded from a $ref file. Inline values authored
 // directly in azure.yaml (baseDir == projectRoot) are left untouched.
-func resolveMapEntry(key string, child any, baseDir, projectRoot string, chain []string) (any, error) {
-	resolvedChild, err := resolveValue(child, baseDir, projectRoot, chain)
+func resolveMapEntry(key string, child any, baseDir, projectRoot string, chain []string, opts *resolveOptions) (any, error) {
+	resolvedChild, err := resolveValue(child, baseDir, projectRoot, chain, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	if value, ok := resolvedChild.(string); ok && baseDir != projectRoot && isPathKey(key, value) {
+	if value, ok := resolvedChild.(string); ok && baseDir != projectRoot && isPathKey(key, value, opts) {
 		return rebasePath(value, baseDir, projectRoot), nil
 	}
 	return resolvedChild, nil
@@ -129,7 +164,7 @@ func resolveMapEntry(key string, child any, baseDir, projectRoot string, chain [
 
 // resolveRef loads the file named by directive[refKey], resolves it relative to its own
 // directory, then overlays the directive's sibling keys on top of the loaded object.
-func resolveRef(directive map[string]any, baseDir, projectRoot string, chain []string) (any, error) {
+func resolveRef(directive map[string]any, baseDir, projectRoot string, chain []string, opts *resolveOptions) (any, error) {
 	ref, ok := directive[refKey].(string)
 	if !ok {
 		return nil, fileRefValidation(
@@ -162,7 +197,7 @@ func resolveRef(directive map[string]any, baseDir, projectRoot string, chain []s
 	}
 
 	nextChain := append(slices.Clone(chain), target)
-	resolvedLoaded, err := resolveValue(loaded, filepath.Dir(target), projectRoot, nextChain)
+	resolvedLoaded, err := resolveValue(loaded, filepath.Dir(target), projectRoot, nextChain, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +217,7 @@ func resolveRef(directive map[string]any, baseDir, projectRoot string, chain []s
 		if key == refKey {
 			continue
 		}
-		resolvedChild, err := resolveMapEntry(key, child, baseDir, projectRoot, chain)
+		resolvedChild, err := resolveMapEntry(key, child, baseDir, projectRoot, chain, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -245,15 +280,16 @@ func loadRefFile(path string) (map[string]any, error) {
 
 // isPathKey reports whether a string value for key is a filesystem path that should be rebased.
 // project is always a path. instructions is a path only when it looks like one (a single-line
-// .md or .txt reference); otherwise it is inline prose and must be left untouched.
-func isPathKey(key, value string) bool {
+// .md or .txt reference); otherwise it is inline prose and must be left untouched. Keys the
+// calling extension declared with WithPathKeys are paths whenever they are non-empty.
+func isPathKey(key, value string, opts *resolveOptions) bool {
 	switch key {
 	case "project":
 		return value != ""
 	case "instructions":
 		return looksLikeInstructionsPath(value)
 	default:
-		return false
+		return value != "" && opts != nil && opts.pathKeys[key]
 	}
 }
 

--- a/cli/azd/pkg/foundry/includes.go
+++ b/cli/azd/pkg/foundry/includes.go
@@ -27,6 +27,36 @@ const maxRefDepth = 32
 // are rejected for now; only local YAML/JSON files are supported.
 var remoteRefPattern = regexp.MustCompile(`(?i)^[a-z][a-z0-9+.-]*://`)
 
+// ResolveOption configures a call to ResolveFileRefs.
+type ResolveOption func(*resolveOptions)
+
+// resolveOptions carries what the calling extension adds to resolution.
+type resolveOptions struct {
+	// pathKeys are keys whose relative string values name files, beyond the two
+	// core owns.
+	pathKeys map[string]bool
+}
+
+// WithPathKeys declares keys whose relative string values are filesystem paths.
+//
+// Core rebases the path keys it owns -- project and instructions -- so that a
+// value written inside a $ref file still resolves once it has been spliced into
+// a document in another directory. A key core does not know about arrives
+// verbatim, which leaves it resolving against the wrong directory: an evaluator
+// pulled in from evaluators/quality.yaml carries `source: ./quality.json`,
+// which then means quality.json beside the configuration rather than beside the
+// file it was written in. The extension that owns those keys names them here.
+func WithPathKeys(keys ...string) ResolveOption {
+	return func(o *resolveOptions) {
+		if o.pathKeys == nil {
+			o.pathKeys = map[string]bool{}
+		}
+		for _, key := range keys {
+			o.pathKeys[key] = true
+		}
+	}
+}
+
 // ResolveFileRefs resolves $ref file includes within a Foundry resource service configuration.
 //
 // In the separate-services azure.yaml shape every Foundry resource is its own service entry, so
@@ -58,36 +88,8 @@ var remoteRefPattern = regexp.MustCompile(`(?i)^[a-z][a-z0-9+.-]*://`)
 // relative or absolute file paths are accepted. Cyclic and excessively deep include chains
 // return an error rather than looping. $ref targets are treated as trusted input, the same
 // trust level as azure.yaml itself.
-// ResolveOption configures a call to ResolveFileRefs.
-type ResolveOption func(*resolveOptions)
-
-// resolveOptions carries what the calling extension adds to resolution.
-type resolveOptions struct {
-	// pathKeys are keys whose relative string values name files, beyond the two
-	// core owns.
-	pathKeys map[string]bool
-}
-
-// WithPathKeys declares keys whose relative string values are filesystem paths.
 //
-// Core rebases the path keys it owns -- project and instructions -- so that a
-// value written inside a $ref file still resolves once it has been spliced into
-// a document in another directory. A key core does not know about arrives
-// verbatim, which leaves it resolving against the wrong directory: an evaluator
-// pulled in from evaluators/quality.yaml carries `source: ./quality.json`,
-// which then means quality.json beside the configuration rather than beside the
-// file it was written in. The extension that owns those keys names them here.
-func WithPathKeys(keys ...string) ResolveOption {
-	return func(o *resolveOptions) {
-		if o.pathKeys == nil {
-			o.pathKeys = map[string]bool{}
-		}
-		for _, key := range keys {
-			o.pathKeys[key] = true
-		}
-	}
-}
-
+// Path keys beyond the two core owns are rebased only when named with WithPathKeys.
 func ResolveFileRefs(cfg map[string]any, projectRoot string, opts ...ResolveOption) (map[string]any, error) {
 	if cfg == nil {
 		return nil, nil

--- a/cli/azd/pkg/foundry/includes_edit.go
+++ b/cli/azd/pkg/foundry/includes_edit.go
@@ -276,8 +276,6 @@ func (d *YAMLDocument) servicesNode(create bool) (*yaml.Node, error) {
 	return services, nil
 }
 
-// rootMapping returns the document's root mapping node, optionally initializing an empty
-// document and root mapping.
 // Root returns the document's root mapping, creating it when the document is empty and create
 // is set, or (nil, nil) when it is empty and create is not.
 //
@@ -300,7 +298,12 @@ func (d *YAMLDocument) Find(path string) (*yaml.Node, error) {
 	return yamlnode.Find(root, path)
 }
 
-// Set writes value at a yamlnode path, creating intermediate mappings.
+// Set writes value at a yamlnode path.
+//
+// Absent intermediate nodes are not created unless the path marks them with yamlnode's `?`
+// qualifier, so writing into a section that may not exist yet is Set("catalog?.dataset", v).
+// Comments already on the value being replaced are carried over, since the document belongs to
+// whoever wrote it.
 func (d *YAMLDocument) Set(path string, value any) error {
 	root, err := d.rootMapping(true)
 	if err != nil {
@@ -309,6 +312,11 @@ func (d *YAMLDocument) Set(path string, value any) error {
 	node, err := yamlnode.Encode(value)
 	if err != nil {
 		return err
+	}
+	if old, findErr := yamlnode.Find(root, path); findErr == nil && old != nil {
+		node.HeadComment = old.HeadComment
+		node.LineComment = old.LineComment
+		node.FootComment = old.FootComment
 	}
 	return yamlnode.Set(root, path, node)
 }
@@ -336,6 +344,8 @@ func (d *YAMLDocument) Append(path string, value any) error {
 	return yamlnode.Append(root, path, node)
 }
 
+// rootMapping returns the document's root mapping node, optionally initializing an empty
+// document and root mapping.
 func (d *YAMLDocument) rootMapping(create bool) (*yaml.Node, error) {
 	if d.root.Kind == 0 {
 		if !create {

--- a/cli/azd/pkg/foundry/includes_edit.go
+++ b/cli/azd/pkg/foundry/includes_edit.go
@@ -278,6 +278,64 @@ func (d *YAMLDocument) servicesNode(create bool) (*yaml.Node, error) {
 
 // rootMapping returns the document's root mapping node, optionally initializing an empty
 // document and root mapping.
+// Root returns the document's root mapping, creating it when the document is empty and create
+// is set, or (nil, nil) when it is empty and create is not.
+//
+// The rest of this type speaks in service entries, which is the shape azure.yaml has. An
+// extension that edits a document of its own shape works from here instead, so that loading,
+// saving, and $ref handling stay in one place rather than being reimplemented per extension.
+func (d *YAMLDocument) Root(create bool) (*yaml.Node, error) {
+	return d.rootMapping(create)
+}
+
+// Find returns the node at a yamlnode path such as "evaluators[0].source".
+func (d *YAMLDocument) Find(path string) (*yaml.Node, error) {
+	root, err := d.rootMapping(false)
+	if err != nil {
+		return nil, err
+	}
+	if root == nil {
+		return nil, yamlnode.ErrNodeNotFound
+	}
+	return yamlnode.Find(root, path)
+}
+
+// Set writes value at a yamlnode path, creating intermediate mappings.
+func (d *YAMLDocument) Set(path string, value any) error {
+	root, err := d.rootMapping(true)
+	if err != nil {
+		return err
+	}
+	node, err := yamlnode.Encode(value)
+	if err != nil {
+		return err
+	}
+	return yamlnode.Set(root, path, node)
+}
+
+// Append adds value to the sequence at a yamlnode path, creating the sequence when it is
+// absent -- a catalog is written into a file that does not list it yet.
+func (d *YAMLDocument) Append(path string, value any) error {
+	root, err := d.rootMapping(true)
+	if err != nil {
+		return err
+	}
+	node, err := yamlnode.Encode(value)
+	if err != nil {
+		return err
+	}
+	if _, findErr := yamlnode.Find(root, path); errors.Is(findErr, yamlnode.ErrNodeNotFound) {
+		empty, err := yamlnode.Encode([]any{})
+		if err != nil {
+			return err
+		}
+		if err := yamlnode.Set(root, path, empty); err != nil {
+			return err
+		}
+	}
+	return yamlnode.Append(root, path, node)
+}
+
 func (d *YAMLDocument) rootMapping(create bool) (*yaml.Node, error) {
 	if d.root.Kind == 0 {
 		if !create {

--- a/cli/azd/pkg/foundry/includes_edit_generic_test.go
+++ b/cli/azd/pkg/foundry/includes_edit_generic_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package foundry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An extension edits a document of its own shape through this type, so the
+// loading, saving and $ref handling stay in one place.
+//
+// Without it each extension reimplements them, and they drift: one preserves
+// comments, another round-trips through typed structs and deletes them.
+func TestGenericEditingPreservesCommentsAndIncludes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "azure.eval.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`# why this eval exists
+datasets:
+  - name: golden          # the reviewed rows
+    file: ./datasets/golden.jsonl
+
+evaluators:
+  - $ref: ./evaluators/quality.yaml
+`), 0o600))
+
+	doc, err := LoadYAMLDocument(path)
+	require.NoError(t, err)
+	require.NoError(t, doc.Append("datasets", map[string]any{
+		"name": "extra",
+		"file": "./datasets/extra.jsonl",
+	}))
+	require.NoError(t, doc.Save())
+
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	text := string(after)
+
+	assert.Contains(t, text, "# why this eval exists")
+	assert.Contains(t, text, "# the reviewed rows")
+	assert.Contains(t, text, "$ref: ./evaluators/quality.yaml",
+		"an include is a directive to keep, not content to inline")
+	assert.Contains(t, text, "name: extra")
+}
+
+// A path reaches into the document, so a caller does not walk the node tree.
+func TestFindAndSetOnAnArbitraryDocument(t *testing.T) {
+	doc, err := ParseYAMLDocument("azure.eval.yaml", []byte(`
+evals:
+  - name: nightly
+    dataset: golden
+`))
+	require.NoError(t, err)
+
+	node, err := doc.Find("evals[0].dataset")
+	require.NoError(t, err)
+	assert.Equal(t, "golden", node.Value)
+
+	require.NoError(t, doc.Set("evals[0].dataset", "prod-golden"))
+	node, err = doc.Find("evals[0].dataset")
+	require.NoError(t, err)
+	assert.Equal(t, "prod-golden", node.Value)
+}
+
+// An empty document is a document with nothing in it, not a failure: generate
+// writes one before it has anything to record.
+func TestGenericEditingCreatesAnEmptyDocument(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "azure.eval.yaml")
+
+	doc, err := ParseYAMLDocument(path, nil)
+	require.NoError(t, err)
+
+	root, err := doc.Root(false)
+	require.NoError(t, err)
+	assert.Nil(t, root, "nothing is there yet, and asking is not an edit")
+
+	require.NoError(t, doc.Append("datasets", map[string]any{"name": "golden"}))
+	require.NoError(t, doc.Save())
+
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(after), "name: golden")
+}

--- a/cli/azd/pkg/foundry/includes_edit_generic_test.go
+++ b/cli/azd/pkg/foundry/includes_edit_generic_test.go
@@ -87,3 +87,60 @@ func TestGenericEditingCreatesAnEmptyDocument(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(after), "name: golden")
 }
+
+// Replacing a value keeps the comments the author put on it.
+//
+// yamlnode.Set swaps in the newly encoded node, which drops the head, line and
+// foot comments the old one carried. Losing them defeats the point of editing
+// the document in place rather than re-encoding it.
+func TestSetKeepsCommentsOnTheValueItReplaces(t *testing.T) {
+	doc, err := ParseYAMLDocument("azure.eval.yaml", []byte(`
+evals:
+  - name: nightly
+    dataset: golden # the reviewed rows
+`))
+	require.NoError(t, err)
+	require.NoError(t, doc.Set("evals[0].dataset", "prod-golden"))
+
+	out, err := doc.Bytes()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "prod-golden")
+	assert.Contains(t, string(out), "# the reviewed rows",
+		"the comment describes the field, which still exists")
+}
+
+// Set does not invent the parents of the path it is given.
+//
+// Creation is yamlnode's `?` qualifier, and staying with it keeps one meaning
+// for a path across the codebase rather than two.
+func TestSetRequiresTheQualifierToCreateAParent(t *testing.T) {
+	doc, err := ParseYAMLDocument("azure.eval.yaml", []byte("name: demo\n"))
+	require.NoError(t, err)
+
+	require.Error(t, doc.Set("catalog.dataset", "golden"),
+		"an unmarked path names a node that has to be there already")
+
+	require.NoError(t, doc.Set("catalog?.dataset", "golden"))
+	out, err := doc.Bytes()
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "dataset: golden")
+}
+
+// An index one past the end is out of bounds, not an append.
+//
+// The bounds check admitted it and then indexed it, so setting evals[1] against
+// a single-element sequence panicked instead of returning an error.
+func TestSetRejectsAnIndexPastTheEnd(t *testing.T) {
+	doc, err := ParseYAMLDocument("azure.eval.yaml", []byte(`
+evals:
+  - name: nightly
+`))
+	require.NoError(t, err)
+
+	err = doc.Set("evals[1]", map[string]any{"name": "weekly"})
+	require.Error(t, err, "one past the end is Append's job")
+	assert.Contains(t, err.Error(), "out of bounds")
+
+	require.NoError(t, doc.Set("evals[0]", map[string]any{"name": "weekly"}))
+}

--- a/cli/azd/pkg/foundry/includes_edit_generic_test.go
+++ b/cli/azd/pkg/foundry/includes_edit_generic_test.go
@@ -144,3 +144,33 @@ evals:
 
 	require.NoError(t, doc.Set("evals[0]", map[string]any{"name": "weekly"}))
 }
+
+// The `?` qualifier creates a missing mapping; it cannot conjure a sequence
+// element that is past the end.
+//
+// Marking the path optional took a different route into yamlnode than a plain
+// index did, and that one assigned into the sequence without checking, so both
+// Set and Append panicked where the plain form already returned an error.
+func TestOptionalQualifierRejectsAnIndexPastTheEnd(t *testing.T) {
+	doc := func(t *testing.T) *YAMLDocument {
+		t.Helper()
+		d, err := ParseYAMLDocument("azure.eval.yaml", []byte("evals:\n  - name: nightly\n"))
+		require.NoError(t, err)
+		return d
+	}
+
+	err := doc(t).Set("evals[1]?.name", "weekly")
+	require.Error(t, err, "there is no evals[1] to create a mapping inside")
+	assert.Contains(t, err.Error(), "out of bounds")
+
+	err = doc(t).Append("evals[1]?.items", "x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of bounds")
+
+	// The element that does exist is still reachable through the same path shape.
+	d := doc(t)
+	require.NoError(t, d.Set("evals[0]?.dataset", "golden"))
+	out, err := d.Bytes()
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "dataset: golden")
+}

--- a/cli/azd/pkg/foundry/includes_pathkeys_test.go
+++ b/cli/azd/pkg/foundry/includes_pathkeys_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package foundry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An extension's own path keys are rebased like the two core owns.
+//
+// A path written inside a $ref file is written relative to that file. Spliced
+// into a document in another directory it means something else: an evaluator
+// pulled in from evaluators/quality.yaml carries `source: ./quality.json`,
+// which without rebasing is looked for beside the configuration. Core cannot
+// know that `source` is a path, so the owning extension says so.
+func TestDeclaredPathKeysAreRebased(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "evaluators"), 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "evaluators", "quality.yaml"),
+		[]byte("name: quality\nsource: ./quality.json\n"), 0o600))
+
+	cfg := map[string]any{
+		"evaluators": []any{map[string]any{"$ref": "./evaluators/quality.yaml"}},
+	}
+
+	resolved, err := ResolveFileRefs(cfg, dir, WithPathKeys("source"))
+	require.NoError(t, err)
+
+	entry := resolved["evaluators"].([]any)[0].(map[string]any)
+	assert.Equal(t, "evaluators/quality.json", entry["source"],
+		"a declared path key is re-anchored to the root the caller named")
+}
+
+// Without the declaration the value is left exactly as written, which is the
+// behaviour every caller had before the option existed.
+func TestUndeclaredKeysAreLeftAlone(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "evaluators"), 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "evaluators", "quality.yaml"),
+		[]byte("name: quality\nsource: ./quality.json\n"), 0o600))
+
+	cfg := map[string]any{
+		"evaluators": []any{map[string]any{"$ref": "./evaluators/quality.yaml"}},
+	}
+
+	resolved, err := ResolveFileRefs(cfg, dir)
+	require.NoError(t, err)
+
+	entry := resolved["evaluators"].([]any)[0].(map[string]any)
+	assert.Equal(t, "./quality.json", entry["source"])
+}
+
+// A path written inline in the root document is already relative to it, so
+// declaring the key must not move it.
+func TestInlinePathsAreNotRebased(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := map[string]any{
+		"evaluators": []any{map[string]any{
+			"name":   "quality",
+			"source": "./evaluators/quality.json",
+		}},
+	}
+
+	resolved, err := ResolveFileRefs(cfg, dir, WithPathKeys("source"))
+	require.NoError(t, err)
+
+	entry := resolved["evaluators"].([]any)[0].(map[string]any)
+	assert.Equal(t, "./evaluators/quality.json", entry["source"],
+		"nothing was spliced, so there is no other directory to rebase from")
+}
+
+// Nested includes rebase from the file that actually holds the value, which is
+// what recovering a base from the visible $ref cannot do.
+func TestNestedIncludesRebaseFromTheirOwnFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "a", "b"), 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "a", "b", "inner.yaml"),
+		[]byte("name: quality\nsource: ./rubric.json\n"), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "a", "outer.yaml"),
+		[]byte("$ref: ./b/inner.yaml\n"), 0o600))
+
+	cfg := map[string]any{
+		"evaluators": []any{map[string]any{"$ref": "./a/outer.yaml"}},
+	}
+
+	resolved, err := ResolveFileRefs(cfg, dir, WithPathKeys("source"))
+	require.NoError(t, err)
+
+	entry := resolved["evaluators"].([]any)[0].(map[string]any)
+	assert.Equal(t, "a/b/rubric.json", entry["source"],
+		"the value belongs to inner.yaml, two directories down from the root")
+}

--- a/cli/azd/pkg/yamlnode/yamlnode.go
+++ b/cli/azd/pkg/yamlnode/yamlnode.go
@@ -111,7 +111,7 @@ func Set(root *yaml.Node, path string, value *yaml.Node) error {
 			return fmt.Errorf("%w: %s is not a sequence node", ErrNodeWrongKind, parts[len(parts)-2].key)
 		}
 
-		if part.idx < 0 || part.idx > len(anchor.Content) {
+		if part.idx < 0 || part.idx >= len(anchor.Content) {
 			return fmt.Errorf("sequence index out of bounds: %d", part.idx)
 		}
 

--- a/cli/azd/pkg/yamlnode/yamlnode.go
+++ b/cli/azd/pkg/yamlnode/yamlnode.go
@@ -217,7 +217,9 @@ func find(current *yaml.Node, parts []pathElem, findOnly bool) (*yaml.Node, erro
 		current.Content = append(current.Content, &yaml.Node{Kind: yaml.ScalarNode, Value: part.key})
 		current.Content = append(current.Content, node)
 	case yaml.SequenceNode:
-		current.Content[part.idx] = node
+		// Only an index past the end reaches here; the traversal above took every
+		// index that exists, so there is no element to make optional.
+		return nil, fmt.Errorf("sequence index out of bounds: %d", part.idx)
 	}
 
 	if len(parts) == 0 {


### PR DESCRIPTION
Fixes #9799

Core-only change, split out of #9500 so it can ship on the core release train ahead of the extension that needs it.

## Why this is its own PR

Extensions are separate Go modules that pin a **published** `github.com/azure/azure-dev/cli/azd` version, and none of them use a `replace` directive. `azure.ai.evaluations` currently pins `v1.28.0`:

```
github.com/azure/azure-dev/cli/azd v1.28.0
```

So the extension resolves `pkg/foundry` from the released module, not from the working tree. Putting the core change and the extension consumption in one PR would not compile â€” the extension would still be building against `v1.28.0`, which has the two-argument `ResolveFileRefs` and no `WithPathKeys`. This is a module-versioning constraint, not a PR-ordering one.

Sequence: this merges and ships in a core release, then the extension bumps its `azd` dependency and drops the workaround (`TODO` at `eval_config_store.go:238`).

## What changed

**`WithPathKeys` â€” rebasing path keys an extension owns**

`ResolveFileRefs` rebases path-valued keys so a relative path written inside a `$ref` file still resolves after being spliced into a document in another directory. It only knew the two keys core owns, `project` and `instructions`. A key belonging to an extension arrived verbatim and resolved against the configuration instead of against the file it was written in:

```yaml
# evaluators/quality.yaml, pulled in by $ref
source: ./quality.json     # meant quality.json beside azure.yaml, not beside this file
```

`WithPathKeys` lets the owning extension name its keys. The option is variadic, so all 18 existing call sites in core are untouched and source-compatible.

**`YAMLDocument.Root` / `Find` / `Set` / `Append` â€” editing at an arbitrary path**

`YAMLDocument` could only reach keys it had dedicated accessors for, so an extension editing its own section had to fall back to a full re-encode, losing comments and key order. These four work at any path; `Append` creates a missing sequence.

## Validation

- `go build ./...` across the whole core module â€” clean, confirming the variadic signature breaks no existing caller.
- `go vet ./pkg/foundry/...` â€” clean.
- `go test ./pkg/foundry/... -count=1` â€” passing, including the two new test files (`includes_pathkeys_test.go`, `includes_edit_generic_test.go`).

Additive only: no exported behaviour changes for callers that pass no options.
