### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/vally-eval/action.yml
+++ b/.github/actions/vally-eval/action.yml
@@ -74,13 +74,13 @@ runs:
 
     - name: Set up Node.js
       if: steps.copilot.outputs.enabled == 'true'
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
 
     - name: Set up Go
       if: steps.copilot.outputs.enabled == 'true'
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
       with:
         go-version-file: ${{ inputs.working-directory }}/go.mod
 
@@ -219,7 +219,7 @@ runs:
 
     - name: Upload vally results
       if: always() && steps.copilot.outputs.enabled == 'true' && steps.run.outputs.vally-run-dir != ''
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ steps.run.outputs.vally-run-dir }}/**

--- a/.github/actions/vally-eval/action.yml
+++ b/.github/actions/vally-eval/action.yml
@@ -80,7 +80,7 @@ runs:
 
     - name: Set up Go
       if: steps.copilot.outputs.enabled == 'true'
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
       with:
         go-version-file: ${{ inputs.working-directory }}/go.mod
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
       - "/"
       - "/.github/actions/vally-eval"
       - "/cli/azd/extensions/azure.coding-agent/internal/cmd/templates"
+      - "/cli/azd/resources/pipeline/.github/workflows"
     schedule:
       interval: "daily"
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/vally-eval"
+      - "/cli/azd/extensions/azure.coding-agent/internal/cmd/templates"
     schedule:
       interval: "daily"
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,20 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]
+  - package-ecosystem: "npm"
+    directories:
+      - "/.github/scripts"
+      - "/eng/common/tsp-client"
+      - "/eng/common/spelling"
+      - "/ext/vscode"
+      - "/ext/azuredevops/setupAzd"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]

--- a/.github/skills/azd-preflight/SKILL.md
+++ b/.github/skills/azd-preflight/SKILL.md
@@ -2,11 +2,11 @@
 name: azd-preflight
 license: MIT
 metadata:
-  version: "1.2"
+  version: "1.3"
   # Bump major on breaking prompt/trigger changes; bump minor on new references or fix strategies.
 description: >-
   **WORKFLOW SKILL** — Runs `mage preflight` from `cli/azd/` and auto-fixes failures.
-  Covers linting, formatting, copyright, spelling, build, and tests.
+  Covers linting, formatting, copyright, spelling, build, tests, and generated pipeline action pins.
   Iterates fix-then-rerun cycles until all checks pass.
 
   INVOKES: mage CLI, go CLI, golangci-lint, cspell, gh CLI, bash/sh, ask_user.
@@ -38,5 +38,6 @@ and re-runs until all checks pass — or escalates to the user when a fix requir
 
 - All 9 preflight checks pass (or user explicitly chose to skip specific checks)
 - Every changed `CHANGELOG.md` passes its targeted spell check
+- When the generated pipeline action manifest changes, `azure-dev.ymlt` and its snapshots are synchronized
 - All auto-applied fixes are saved to disk (not staged or committed — the user decides when to commit)
 - A clear summary of what passed, what was fixed, and what was skipped is displayed

--- a/.github/skills/azd-preflight/references/fix-strategies.md
+++ b/.github/skills/azd-preflight/references/fix-strategies.md
@@ -98,6 +98,24 @@ For each unknown word:
    file-scoped `overrides` entry in the resolved owning cspell config.
 4. **If uncertain**: Ask the user via `ask_user` whether to fix the spelling or update a dictionary.
 
+## Generated Pipeline Action Pins — Auto-fix
+
+When `cli/azd/resources/pipeline/.github/workflows/azure-dev-actions.yml` changes:
+
+1. Read the `uses:` value and trailing release-version comment for the `checkout`, `setup-azd`,
+   `setup-terraform`, and `setup-dotnet` step IDs.
+2. Validate that each ID maps to its expected action repository and uses a full 40-character SHA.
+3. Update the matching action repository's literal `uses:` line in
+   `cli/azd/resources/pipeline/.github/azure-dev.ymlt`. Do not match by line number or copy a SHA
+   between different action repositories.
+4. Regenerate the pipeline snapshots from `cli/azd/`:
+
+   ```bash
+   UPDATE_SNAPSHOTS=true go test ./pkg/pipeline -run '^Test_promptForCiFiles$'
+   ```
+
+5. Remove `UPDATE_SNAPSHOTS` from the environment and rerun the same test without update mode.
+
 ## Build (`go build`) — Analyze and Fix
 
 Re-run the build:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           sparse-checkout: |
             .github

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
           sparse-checkout: |
             .github

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -28,8 +28,8 @@ jobs:
   cspell-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           node-version: "20"
       - run: npm install -g cspell@8.13.1
@@ -40,7 +40,7 @@ jobs:
   Copyright-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
       - name: Copyright check
         run: ./eng/scripts/copyright-check.sh ./cli/azd
 
@@ -52,7 +52,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
       - name: Run Pester tests for engineering scripts
         shell: pwsh
         run: |
@@ -73,8 +73,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: cli/azd/go.mod
       - name: Run mage helper tests

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -28,8 +28,8 @@ jobs:
   cspell-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: "20"
       - run: npm install -g cspell@8.13.1
@@ -40,7 +40,7 @@ jobs:
   Copyright-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Copyright check
         run: ./eng/scripts/copyright-check.sh ./cli/azd
 
@@ -52,7 +52,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Run Pester tests for engineering scripts
         shell: pwsh
         run: |
@@ -73,8 +73,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: cli/azd/go.mod
       - name: Run mage helper tests

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           # Fetch full history for writing changelogs
           fetch-depth: 0
@@ -41,12 +41,12 @@ jobs:
           version: v0.74.4
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: cli/azd/go.mod
 
       - name: Set up Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: "20"
 
@@ -57,4 +57,4 @@ jobs:
         run: npm install -g cspell@8.13.1
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3.1.2
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
           # Fetch full history for writing changelogs
           fetch-depth: 0
@@ -41,12 +41,12 @@ jobs:
           version: v0.74.4
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: cli/azd/go.mod
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           node-version: "20"
 
@@ -57,4 +57,4 @@ jobs:
         run: npm install -g cspell@8.13.1
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3.1.2

--- a/.github/workflows/cspell-ext.yml
+++ b/.github/workflows/cspell-ext.yml
@@ -22,8 +22,8 @@ jobs:
   cspell-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: "20"
       - run: npm install -g cspell@8.13.1

--- a/.github/workflows/cspell-ext.yml
+++ b/.github/workflows/cspell-ext.yml
@@ -22,8 +22,8 @@ jobs:
   cspell-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           node-version: "20"
       - run: npm install -g cspell@8.13.1

--- a/.github/workflows/cspell-misc.yml
+++ b/.github/workflows/cspell-misc.yml
@@ -19,8 +19,8 @@ jobs:
   cspell-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: "20"
       - run: npm install -g cspell@8.13.1

--- a/.github/workflows/cspell-misc.yml
+++ b/.github/workflows/cspell-misc.yml
@@ -19,8 +19,8 @@ jobs:
   cspell-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           node-version: "20"
       - run: npm install -g cspell@8.13.1

--- a/.github/workflows/devcontainer-feature-release.yml
+++ b/.github/workflows/devcontainer-feature-release.yml
@@ -23,7 +23,7 @@ jobs:
     environment:
       name: deploy-devcontainer-feature
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: "Publish Features"
         uses: devcontainers/action@1082abd5d2bf3a11abccba70eef98df068277772  # v1.4.3

--- a/.github/workflows/devcontainer-feature-release.yml
+++ b/.github/workflows/devcontainer-feature-release.yml
@@ -23,10 +23,10 @@ jobs:
     environment:
       name: deploy-devcontainer-feature
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: "Publish Features"
-        uses: devcontainers/action@v1
+        uses: devcontainers/action@1082abd5d2bf3a11abccba70eef98df068277772  # v1.4.3
         with:
           publish-features: "true"
           base-path-to-features: "./ext/devcontainer/src"

--- a/.github/workflows/devcontainer-feature-test.yml
+++ b/.github/workflows/devcontainer-feature-test.yml
@@ -25,7 +25,7 @@ jobs:
             "mcr.microsoft.com/devcontainers/base:debian",
           ]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: "Install latest devcontainer CLI"
         run: npm install -g @devcontainers/cli
@@ -37,7 +37,7 @@ jobs:
   test-scenarios:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: "Install latest devcontainer CLI"
         run: npm install -g @devcontainers/cli
@@ -49,7 +49,7 @@ jobs:
   test-global:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: "Install latest devcontainer CLI"
         run: npm install -g @devcontainers/cli

--- a/.github/workflows/devcontainer-feature-test.yml
+++ b/.github/workflows/devcontainer-feature-test.yml
@@ -25,7 +25,7 @@ jobs:
             "mcr.microsoft.com/devcontainers/base:debian",
           ]
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: "Install latest devcontainer CLI"
         run: npm install -g @devcontainers/cli
@@ -37,7 +37,7 @@ jobs:
   test-scenarios:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: "Install latest devcontainer CLI"
         run: npm install -g @devcontainers/cli
@@ -49,7 +49,7 @@ jobs:
   test-global:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: "Install latest devcontainer CLI"
         run: npm install -g @devcontainers/cli

--- a/.github/workflows/devops-ext-ci.yml
+++ b/.github/workflows/devops-ext-ci.yml
@@ -21,8 +21,8 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: "20"
       - name: Install dependencies

--- a/.github/workflows/devops-ext-ci.yml
+++ b/.github/workflows/devops-ext-ci.yml
@@ -21,8 +21,8 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           node-version: "20"
       - name: Install dependencies

--- a/.github/workflows/event.yml
+++ b/.github/workflows/event.yml
@@ -25,6 +25,6 @@ jobs:
     name: Handle ${{ github.event_name }} ${{ github.event.action }} event
     runs-on: ubuntu-latest
     steps:
-      - uses: azure/azure-sdk-actions@main
+      - uses: azure/azure-sdk-actions@6a2d61414e790705ab24370421c0a5b04b65de53  # main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ext-registry-check.yml
+++ b/.github/workflows/ext-registry-check.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Check if an extension registry changed
         id: changed
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -61,13 +61,13 @@ jobs:
 
       - name: Checkout
         if: steps.changed.outputs.registry_changed == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Check extension registry update
         if: steps.changed.outputs.registry_changed == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const script = require('./.github/scripts/src/ext-registry-check.js');

--- a/.github/workflows/ext-registry-check.yml
+++ b/.github/workflows/ext-registry-check.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Checkout
         if: steps.changed.outputs.registry_changed == 'true'
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 

--- a/.github/workflows/ext-registry-ci.yml
+++ b/.github/workflows/ext-registry-ci.yml
@@ -23,10 +23,10 @@ jobs:
       run:
         working-directory: cli/azd
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: cli/azd/go.mod
           cache-dependency-path: |

--- a/.github/workflows/ext-registry-ci.yml
+++ b/.github/workflows/ext-registry-ci.yml
@@ -23,10 +23,10 @@ jobs:
       run:
         working-directory: cli/azd
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: cli/azd/go.mod
           cache-dependency-path: |

--- a/.github/workflows/lint-bicep.yml
+++ b/.github/workflows/lint-bicep.yml
@@ -13,7 +13,7 @@ jobs:
   bicep-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Upgrade bicep
         run: |
           which bicep

--- a/.github/workflows/lint-bicep.yml
+++ b/.github/workflows/lint-bicep.yml
@@ -13,7 +13,7 @@ jobs:
   bicep-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
       - name: Upgrade bicep
         run: |
           which bicep

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -29,8 +29,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
       - name: golangci-lint
@@ -43,8 +43,8 @@ jobs:
   go-fix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
       - name: Check for go fix suggestions

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -29,12 +29,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a  # v9.3.0
         with:
           version: ${{ inputs.golangci-lint-version }}
           args: -v --timeout 10m0s
@@ -43,8 +43,8 @@ jobs:
   go-fix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
       - name: Check for go fix suggestions

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Check linked issue
         id: issue-check

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -21,11 +21,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Check linked issue
         id: issue-check
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const script = require('./.github/scripts/pr-governance-issue-check.js');
@@ -33,7 +33,7 @@ jobs:
 
       - name: Check issue priority
         if: steps.issue-check.outputs.skipped != 'true' && steps.issue-check.outcome == 'success'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           PROJECT_TOKEN: ${{ secrets.PROJECT_READ_TOKEN }}
           ISSUE_NUMBERS: ${{ steps.issue-check.outputs.issue_numbers }}

--- a/.github/workflows/schema-ci.yml
+++ b/.github/workflows/schema-ci.yml
@@ -13,8 +13,8 @@ jobs:
   schema-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           node-version: "20"
       - run: npm install -g jsonlint
@@ -22,7 +22,7 @@ jobs:
         run: jsonlint schemas/**/*.json -c
 # NOTE: Using jsonschema2md here to ensure the schemas are valid for documentation generation.
 #       Since we use jsonschema2md for CI pipelines, any changes to the schemas should make sure to keep the tool happy.
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.x'
       - run: pip install jsonschema2md==1.5.2

--- a/.github/workflows/schema-ci.yml
+++ b/.github/workflows/schema-ci.yml
@@ -13,8 +13,8 @@ jobs:
   schema-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: "20"
       - run: npm install -g jsonlint
@@ -22,7 +22,7 @@ jobs:
         run: jsonlint schemas/**/*.json -c
 # NOTE: Using jsonschema2md here to ensure the schemas are valid for documentation generation.
 #       Since we use jsonschema2md for CI pipelines, any changes to the schemas should make sure to keep the tool happy.
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.x'
       - run: pip install jsonschema2md==1.5.2

--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -27,10 +27,10 @@ jobs:
         working-directory: .github/scripts
     steps:
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Node
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           # 24 is the version that the GitHub actions script I'm running should also be 
           # running under.

--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -27,10 +27,10 @@ jobs:
         working-directory: .github/scripts
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           # 24 is the version that the GitHub actions script I'm running should also be 
           # running under.

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -10,7 +10,7 @@ jobs:
   mark-stale-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629  # v10.4.0
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93  # v11.0.0
         with:
           days-before-issue-stale: 365        # Initial filter to stale yearly ignored issues
         #   only-issue-labels:                # Not enabled until we have a better idea for what to target

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -10,7 +10,7 @@ jobs:
   mark-stale-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629  # v10.4.0
         with:
           days-before-issue-stale: 365        # Initial filter to stale yearly ignored issues
         #   only-issue-labels:                # Not enabled until we have a better idea for what to target

--- a/.github/workflows/test-ext-azure-ai-agents.yml
+++ b/.github/workflows/test-ext-azure-ai-agents.yml
@@ -25,9 +25,9 @@ jobs:
       TIER_0_TEST_PATTERN: '^Test_AIAgent_(Version|Help|Init_NoPrompt_MissingFlags|Doctor_Help)$'
       TIER_1_TEST_PATTERN: '^Test_AIAgent_(Init_(NoPrompt_(Defer|WithProject)|NegativeControl_BadCassette)|SampleList_(Recorded|JSON_Recorded))$'
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: cli/azd/go.mod
 

--- a/.github/workflows/test-ext-azure-ai-agents.yml
+++ b/.github/workflows/test-ext-azure-ai-agents.yml
@@ -25,9 +25,9 @@ jobs:
       TIER_0_TEST_PATTERN: '^Test_AIAgent_(Version|Help|Init_NoPrompt_MissingFlags|Doctor_Help)$'
       TIER_1_TEST_PATTERN: '^Test_AIAgent_(Init_(NoPrompt_(Defer|WithProject)|NegativeControl_BadCassette)|SampleList_(Recorded|JSON_Recorded))$'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: cli/azd/go.mod
 

--- a/.github/workflows/validate-go-dependency-versions.yml
+++ b/.github/workflows/validate-go-dependency-versions.yml
@@ -19,8 +19,8 @@ jobs:
   check-dependency-version-consistency:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: cli/azd/go.mod
       - name: Validate dependency version consistency

--- a/.github/workflows/validate-go-dependency-versions.yml
+++ b/.github/workflows/validate-go-dependency-versions.yml
@@ -19,8 +19,8 @@ jobs:
   check-dependency-version-consistency:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: cli/azd/go.mod
       - name: Validate dependency version consistency

--- a/.github/workflows/validate-go-version.yml
+++ b/.github/workflows/validate-go-version.yml
@@ -17,7 +17,7 @@ jobs:
   check-go-version-consistency:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Validate Go version consistency
         run: |

--- a/.github/workflows/validate-go-version.yml
+++ b/.github/workflows/validate-go-version.yml
@@ -17,7 +17,7 @@ jobs:
   check-go-version-consistency:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Validate Go version consistency
         run: |

--- a/.github/workflows/verify-ext-providers.yml
+++ b/.github/workflows/verify-ext-providers.yml
@@ -36,8 +36,8 @@ jobs:
       run:
         working-directory: cli/azd
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: cli/azd/go.mod
       - name: Verify provider contract coverage
@@ -49,8 +49,8 @@ jobs:
     if: inputs.working-directory != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
       # go test -run exits 0 when nothing matches, so first require the

--- a/.github/workflows/verify-ext-providers.yml
+++ b/.github/workflows/verify-ext-providers.yml
@@ -36,8 +36,8 @@ jobs:
       run:
         working-directory: cli/azd
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: cli/azd/go.mod
       - name: Verify provider contract coverage
@@ -49,8 +49,8 @@ jobs:
     if: inputs.working-directory != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
       # go test -run exits 0 when nothing matches, so first require the

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -21,8 +21,8 @@ jobs:
   cspell-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           node-version: "22"
       - run: npm install -g cspell@8.13.1
@@ -40,10 +40,10 @@ jobs:
             upload-artifact: true
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -51,7 +51,7 @@ jobs:
       # `azure-dev-<version>.vsix`
       - name: Set package additional arguments
         id: package-arguments
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           result-encoding: string
           script: |
@@ -78,7 +78,7 @@ jobs:
 
       - name: 'Upload azd binary to artifact store (upload-artifact: true only)'
         if: matrix.upload-artifact == true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: package
           path: ./ext/vscode/azure-dev*.vsix

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -21,8 +21,8 @@ jobs:
   cspell-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: "22"
       - run: npm install -g cspell@8.13.1
@@ -40,10 +40,10 @@ jobs:
             upload-artifact: true
 
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: 'Upload azd binary to artifact store (upload-artifact: true only)'
         if: matrix.upload-artifact == true
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: package
           path: ./ext/vscode/azure-dev*.vsix

--- a/cli/azd/extensions/azure.coding-agent/internal/cmd/templates/copilot-setup-steps.yml
+++ b/cli/azd/extensions/azure.coding-agent/internal/cmd/templates/copilot-setup-steps.yml
@@ -12,7 +12,7 @@ jobs:
     environment: copilot
     steps:
       - name: Install azd
-        uses: Azure/setup-azd@v2
+        uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
       - name: Azure login
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
         with:

--- a/cli/azd/extensions/azure.coding-agent/internal/cmd/templates/copilot-setup-steps.yml
+++ b/cli/azd/extensions/azure.coding-agent/internal/cmd/templates/copilot-setup-steps.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install azd
         uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
       - name: Azure login
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c  # v3.0.2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -5,7 +5,6 @@ package pipeline
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"html/template"
@@ -40,7 +39,6 @@ import (
 	"github.com/azure/azure-dev/cli/azd/resources"
 	"github.com/google/uuid"
 	"github.com/sethvargo/go-retry"
-	"go.yaml.in/yaml/v3"
 )
 
 type PipelineAuthType string
@@ -1286,15 +1284,6 @@ func generatePipelineDefinition(path string, props projectProperties) error {
 	if err != nil {
 		return fmt.Errorf("parsing embedded file %s: %w", embedFilePath, err)
 	}
-
-	var actionVersions pipelineActionVersions
-	if props.CiProvider == ciProviderGitHubActions {
-		actionVersions, err = loadPipelineActionVersions()
-		if err != nil {
-			return fmt.Errorf("loading GitHub Actions versions: %w", err)
-		}
-	}
-
 	builder := strings.Builder{}
 	tmplContext := struct {
 		BranchName             string
@@ -1304,7 +1293,6 @@ func generatePipelineDefinition(path string, props projectProperties) error {
 		Secrets                []string
 		AlphaFeatures          []string
 		IsTerraform            bool
-		Actions                pipelineActionVersions
 	}{
 		BranchName:             props.BranchName,
 		FedCredLogIn:           props.AuthType == AuthTypeFederated,
@@ -1313,7 +1301,6 @@ func generatePipelineDefinition(path string, props projectProperties) error {
 		Secrets:                props.Secrets,
 		AlphaFeatures:          props.RequiredAlphaFeatures,
 		IsTerraform:            props.InfraProvider == infraProviderTerraform,
-		Actions:                actionVersions,
 	}
 
 	// Apply provider parameters
@@ -1347,109 +1334,6 @@ func generatePipelineDefinition(path string, props projectProperties) error {
 	if err := os.WriteFile(path, contents, osutil.PermissionFile); err != nil {
 		return fmt.Errorf("creating file %s: %w", path, err)
 	}
-	return nil
-}
-
-type pipelineActionVersions struct {
-	Checkout       string
-	SetupAzd       string
-	SetupTerraform string
-	SetupDotNet    string
-}
-
-type pipelineActionReference struct {
-	value   string
-	comment string
-}
-
-func (r *pipelineActionReference) UnmarshalYAML(node *yaml.Node) error {
-	if node.Kind != yaml.ScalarNode {
-		return fmt.Errorf("expected a scalar action reference")
-	}
-
-	r.value = node.Value
-	r.comment = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(node.LineComment), "#"))
-	return nil
-}
-
-func (r pipelineActionReference) String() string {
-	if r.comment == "" {
-		return r.value
-	}
-	return fmt.Sprintf("%s  # %s", r.value, r.comment)
-}
-
-func loadPipelineActionVersions() (pipelineActionVersions, error) {
-	const manifestPath = "pipeline/.github/workflows/azure-dev-actions.yml"
-
-	contents, err := resources.PipelineFiles.ReadFile(manifestPath)
-	if err != nil {
-		return pipelineActionVersions{}, fmt.Errorf("reading embedded file %s: %w", manifestPath, err)
-	}
-
-	var manifest struct {
-		Jobs map[string]struct {
-			Steps []struct {
-				ID   string                  `yaml:"id"`
-				Uses pipelineActionReference `yaml:"uses"`
-			} `yaml:"steps"`
-		} `yaml:"jobs"`
-	}
-	if err := yaml.Unmarshal(contents, &manifest); err != nil {
-		return pipelineActionVersions{}, fmt.Errorf("parsing embedded file %s: %w", manifestPath, err)
-	}
-
-	job, ok := manifest.Jobs["action-versions"]
-	if !ok {
-		return pipelineActionVersions{}, fmt.Errorf("job action-versions is missing from %s", manifestPath)
-	}
-
-	references := make(map[string]pipelineActionReference, len(job.Steps))
-	for _, step := range job.Steps {
-		references[step.ID] = step.Uses
-	}
-
-	required := []struct {
-		id     string
-		action string
-	}{
-		{id: "checkout", action: "actions/checkout"},
-		{id: "setup-azd", action: "Azure/setup-azd"},
-		{id: "setup-terraform", action: "hashicorp/setup-terraform"},
-		{id: "setup-dotnet", action: "actions/setup-dotnet"},
-	}
-	for _, requirement := range required {
-		reference, ok := references[requirement.id]
-		if !ok {
-			return pipelineActionVersions{}, fmt.Errorf("step %s is missing from %s", requirement.id, manifestPath)
-		}
-		if err := validatePipelineActionReference(reference.value, requirement.action); err != nil {
-			return pipelineActionVersions{}, fmt.Errorf("step %s in %s: %w", requirement.id, manifestPath, err)
-		}
-	}
-
-	return pipelineActionVersions{
-		Checkout:       references["checkout"].String(),
-		SetupAzd:       references["setup-azd"].String(),
-		SetupTerraform: references["setup-terraform"].String(),
-		SetupDotNet:    references["setup-dotnet"].String(),
-	}, nil
-}
-
-func validatePipelineActionReference(reference string, expectedAction string) error {
-	prefix := expectedAction + "@"
-	if !strings.HasPrefix(reference, prefix) {
-		return fmt.Errorf("expected action %s, got %s", expectedAction, reference)
-	}
-
-	sha := strings.TrimPrefix(reference, prefix)
-	if len(sha) != 40 {
-		return fmt.Errorf("expected a full 40-character commit SHA, got %s", reference)
-	}
-	if _, err := hex.DecodeString(sha); err != nil {
-		return fmt.Errorf("invalid commit SHA in %s: %w", reference, err)
-	}
-
 	return nil
 }
 

--- a/cli/azd/pkg/pipeline/pipeline_manager.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager.go
@@ -5,6 +5,7 @@ package pipeline
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"html/template"
@@ -39,6 +40,7 @@ import (
 	"github.com/azure/azure-dev/cli/azd/resources"
 	"github.com/google/uuid"
 	"github.com/sethvargo/go-retry"
+	"go.yaml.in/yaml/v3"
 )
 
 type PipelineAuthType string
@@ -1284,6 +1286,15 @@ func generatePipelineDefinition(path string, props projectProperties) error {
 	if err != nil {
 		return fmt.Errorf("parsing embedded file %s: %w", embedFilePath, err)
 	}
+
+	var actionVersions pipelineActionVersions
+	if props.CiProvider == ciProviderGitHubActions {
+		actionVersions, err = loadPipelineActionVersions()
+		if err != nil {
+			return fmt.Errorf("loading GitHub Actions versions: %w", err)
+		}
+	}
+
 	builder := strings.Builder{}
 	tmplContext := struct {
 		BranchName             string
@@ -1293,6 +1304,7 @@ func generatePipelineDefinition(path string, props projectProperties) error {
 		Secrets                []string
 		AlphaFeatures          []string
 		IsTerraform            bool
+		Actions                pipelineActionVersions
 	}{
 		BranchName:             props.BranchName,
 		FedCredLogIn:           props.AuthType == AuthTypeFederated,
@@ -1301,6 +1313,7 @@ func generatePipelineDefinition(path string, props projectProperties) error {
 		Secrets:                props.Secrets,
 		AlphaFeatures:          props.RequiredAlphaFeatures,
 		IsTerraform:            props.InfraProvider == infraProviderTerraform,
+		Actions:                actionVersions,
 	}
 
 	// Apply provider parameters
@@ -1334,6 +1347,109 @@ func generatePipelineDefinition(path string, props projectProperties) error {
 	if err := os.WriteFile(path, contents, osutil.PermissionFile); err != nil {
 		return fmt.Errorf("creating file %s: %w", path, err)
 	}
+	return nil
+}
+
+type pipelineActionVersions struct {
+	Checkout       string
+	SetupAzd       string
+	SetupTerraform string
+	SetupDotNet    string
+}
+
+type pipelineActionReference struct {
+	value   string
+	comment string
+}
+
+func (r *pipelineActionReference) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.ScalarNode {
+		return fmt.Errorf("expected a scalar action reference")
+	}
+
+	r.value = node.Value
+	r.comment = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(node.LineComment), "#"))
+	return nil
+}
+
+func (r pipelineActionReference) String() string {
+	if r.comment == "" {
+		return r.value
+	}
+	return fmt.Sprintf("%s  # %s", r.value, r.comment)
+}
+
+func loadPipelineActionVersions() (pipelineActionVersions, error) {
+	const manifestPath = "pipeline/.github/workflows/azure-dev-actions.yml"
+
+	contents, err := resources.PipelineFiles.ReadFile(manifestPath)
+	if err != nil {
+		return pipelineActionVersions{}, fmt.Errorf("reading embedded file %s: %w", manifestPath, err)
+	}
+
+	var manifest struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				ID   string                  `yaml:"id"`
+				Uses pipelineActionReference `yaml:"uses"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(contents, &manifest); err != nil {
+		return pipelineActionVersions{}, fmt.Errorf("parsing embedded file %s: %w", manifestPath, err)
+	}
+
+	job, ok := manifest.Jobs["action-versions"]
+	if !ok {
+		return pipelineActionVersions{}, fmt.Errorf("job action-versions is missing from %s", manifestPath)
+	}
+
+	references := make(map[string]pipelineActionReference, len(job.Steps))
+	for _, step := range job.Steps {
+		references[step.ID] = step.Uses
+	}
+
+	required := []struct {
+		id     string
+		action string
+	}{
+		{id: "checkout", action: "actions/checkout"},
+		{id: "setup-azd", action: "Azure/setup-azd"},
+		{id: "setup-terraform", action: "hashicorp/setup-terraform"},
+		{id: "setup-dotnet", action: "actions/setup-dotnet"},
+	}
+	for _, requirement := range required {
+		reference, ok := references[requirement.id]
+		if !ok {
+			return pipelineActionVersions{}, fmt.Errorf("step %s is missing from %s", requirement.id, manifestPath)
+		}
+		if err := validatePipelineActionReference(reference.value, requirement.action); err != nil {
+			return pipelineActionVersions{}, fmt.Errorf("step %s in %s: %w", requirement.id, manifestPath, err)
+		}
+	}
+
+	return pipelineActionVersions{
+		Checkout:       references["checkout"].String(),
+		SetupAzd:       references["setup-azd"].String(),
+		SetupTerraform: references["setup-terraform"].String(),
+		SetupDotNet:    references["setup-dotnet"].String(),
+	}, nil
+}
+
+func validatePipelineActionReference(reference string, expectedAction string) error {
+	prefix := expectedAction + "@"
+	if !strings.HasPrefix(reference, prefix) {
+		return fmt.Errorf("expected action %s, got %s", expectedAction, reference)
+	}
+
+	sha := strings.TrimPrefix(reference, prefix)
+	if len(sha) != 40 {
+		return fmt.Errorf("expected a full 40-character commit SHA, got %s", reference)
+	}
+	if _, err := hex.DecodeString(sha); err != nil {
+		return fmt.Errorf("invalid commit SHA in %s: %w", reference, err)
+	}
+
 	return nil
 }
 

--- a/cli/azd/pkg/pipeline/pipeline_manager_test.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager_test.go
@@ -801,6 +801,50 @@ func Test_promptForCiFiles(t *testing.T) {
 	})
 }
 
+func Test_validatePipelineActionReference(t *testing.T) {
+	tests := []struct {
+		name           string
+		reference      string
+		expectedAction string
+		errorContains  string
+	}{
+		{
+			name:           "Valid",
+			reference:      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+			expectedAction: "actions/checkout",
+		},
+		{
+			name:           "WrongAction",
+			reference:      "actions/setup-dotnet@3d3c42e5aac5ba805825da76410c181273ba90b1",
+			expectedAction: "actions/checkout",
+			errorContains:  "expected action actions/checkout",
+		},
+		{
+			name:           "VersionTag",
+			reference:      "actions/checkout@v7.0.1",
+			expectedAction: "actions/checkout",
+			errorContains:  "expected a full 40-character commit SHA",
+		},
+		{
+			name:           "InvalidSha",
+			reference:      "actions/checkout@zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+			expectedAction: "actions/checkout",
+			errorContains:  "invalid commit SHA",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validatePipelineActionReference(test.reference, test.expectedAction)
+			if test.errorContains == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, test.errorContains)
+			}
+		})
+	}
+}
+
 func Test_promptForCiFiles_azureDevOpsDirectory(t *testing.T) {
 	t.Run("no files - azdo selected - azuredevops dir - fed Cred", func(t *testing.T) {
 		tempDir := t.TempDir()

--- a/cli/azd/pkg/pipeline/pipeline_manager_test.go
+++ b/cli/azd/pkg/pipeline/pipeline_manager_test.go
@@ -801,50 +801,6 @@ func Test_promptForCiFiles(t *testing.T) {
 	})
 }
 
-func Test_validatePipelineActionReference(t *testing.T) {
-	tests := []struct {
-		name           string
-		reference      string
-		expectedAction string
-		errorContains  string
-	}{
-		{
-			name:           "Valid",
-			reference:      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
-			expectedAction: "actions/checkout",
-		},
-		{
-			name:           "WrongAction",
-			reference:      "actions/setup-dotnet@3d3c42e5aac5ba805825da76410c181273ba90b1",
-			expectedAction: "actions/checkout",
-			errorContains:  "expected action actions/checkout",
-		},
-		{
-			name:           "VersionTag",
-			reference:      "actions/checkout@v7.0.1",
-			expectedAction: "actions/checkout",
-			errorContains:  "expected a full 40-character commit SHA",
-		},
-		{
-			name:           "InvalidSha",
-			reference:      "actions/checkout@zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
-			expectedAction: "actions/checkout",
-			errorContains:  "invalid commit SHA",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			err := validatePipelineActionReference(test.reference, test.expectedAction)
-			if test.errorContains == "" {
-				assert.NoError(t, err)
-			} else {
-				assert.ErrorContains(t, err, test.errorContains)
-			}
-		})
-	}
-}
-
 func Test_promptForCiFiles_azureDevOpsDirectory(t *testing.T) {
 	t.Run("no files - azdo selected - azuredevops dir - fed Cred", func(t *testing.T) {
 		tempDir := t.TempDir()

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_App_host_-_fed_Cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_App_host_-_fed_Cred.snap
@@ -23,11 +23,11 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install azd
         uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
       - name: Setup .NET
-        uses: actions/setup-dotnet@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68  # v6.0.0
         with:
           dotnet-version: | 
             8.x

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_App_host_-_fed_Cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_App_host_-_fed_Cred.snap
@@ -23,11 +23,11 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
       - name: Install azd
-        uses: Azure/setup-azd@v2
+        uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           dotnet-version: | 
             8.x

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_Variables_and_Secrets.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_Variables_and_Secrets.snap
@@ -25,11 +25,11 @@ jobs:
       VAR_2: ${{ vars.VAR_2 }}
     steps:
       - name: Checkout
-        uses: actions/checkout@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install azd
         uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
       - name: Setup .NET
-        uses: actions/setup-dotnet@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68  # v6.0.0
         with:
           dotnet-version: | 
             8.x

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_Variables_and_Secrets.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_Variables_and_Secrets.snap
@@ -25,11 +25,11 @@ jobs:
       VAR_2: ${{ vars.VAR_2 }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
       - name: Install azd
-        uses: Azure/setup-azd@v2
+        uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           dotnet-version: | 
             8.x

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_branch_name.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_branch_name.snap
@@ -23,7 +23,7 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install azd
         uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
       - name: Log in with Azure (Federated Credentials)

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_branch_name.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_branch_name.snap
@@ -23,9 +23,9 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
       - name: Install azd
-        uses: Azure/setup-azd@v2
+        uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
       - name: Log in with Azure (Federated Credentials)
         run: |
           azd auth login `

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_no_app_host_-_client_cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_no_app_host_-_client_cred.snap
@@ -18,9 +18,9 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
       - name: Install azd
-        uses: Azure/setup-azd@v2
+        uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
       - name: Log in with Azure (Client Credentials)
         run: |
           $info = $Env:AZURE_CREDENTIALS | ConvertFrom-Json -AsHashtable;

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_no_app_host_-_client_cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_no_app_host_-_client_cred.snap
@@ -18,7 +18,7 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install azd
         uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
       - name: Log in with Azure (Client Credentials)

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_no_app_host_-_fed_Cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_no_app_host_-_fed_Cred.snap
@@ -23,7 +23,7 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install azd
         uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
       - name: Log in with Azure (Federated Credentials)

--- a/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_no_app_host_-_fed_Cred.snap
+++ b/cli/azd/pkg/pipeline/testdata/Test_promptForCiFiles-no_files_-_github_selected_-_no_app_host_-_fed_Cred.snap
@@ -23,9 +23,9 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
       - name: Install azd
-        uses: Azure/setup-azd@v2
+        uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
       - name: Log in with Azure (Federated Credentials)
         run: |
           azd auth login `

--- a/cli/azd/resources/pipeline/.github/azure-dev.ymlt
+++ b/cli/azd/resources/pipeline/.github/azure-dev.ymlt
@@ -39,18 +39,18 @@ jobs:
 {{- end }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
       - name: Install azd
-        uses: Azure/setup-azd@v2
+        uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
 {{- if .IsTerraform}}
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3.1.2
         with:
           terraform_version: 1.9.0
 {{ end }}
 {{- if .InstallDotNetForAspire}}
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           dotnet-version: | 
             8.x

--- a/cli/azd/resources/pipeline/.github/azure-dev.ymlt
+++ b/cli/azd/resources/pipeline/.github/azure-dev.ymlt
@@ -39,18 +39,18 @@ jobs:
 {{- end }}
     steps:
       - name: Checkout
-        uses: {{.Actions.Checkout}}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install azd
-        uses: {{.Actions.SetupAzd}}
+        uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
 {{- if .IsTerraform}}
       - name: Install Terraform
-        uses: {{.Actions.SetupTerraform}}
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
           terraform_version: 1.9.0
 {{ end }}
 {{- if .InstallDotNetForAspire}}
       - name: Setup .NET
-        uses: {{.Actions.SetupDotNet}}
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68  # v6.0.0
         with:
           dotnet-version: | 
             8.x

--- a/cli/azd/resources/pipeline/.github/azure-dev.ymlt
+++ b/cli/azd/resources/pipeline/.github/azure-dev.ymlt
@@ -39,18 +39,18 @@ jobs:
 {{- end }}
     steps:
       - name: Checkout
-        uses: actions/checkout@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
+        uses: {{.Actions.Checkout}}
       - name: Install azd
-        uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
+        uses: {{.Actions.SetupAzd}}
 {{- if .IsTerraform}}
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3.1.2
+        uses: {{.Actions.SetupTerraform}}
         with:
           terraform_version: 1.9.0
 {{ end }}
 {{- if .InstallDotNetForAspire}}
       - name: Setup .NET
-        uses: actions/setup-dotnet@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        uses: {{.Actions.SetupDotNet}}
         with:
           dotnet-version: | 
             8.x

--- a/cli/azd/resources/pipeline/.github/workflows/azure-dev-actions.yml
+++ b/cli/azd/resources/pipeline/.github/workflows/azure-dev-actions.yml
@@ -1,0 +1,19 @@
+name: azd generated pipeline action versions
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  action-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - id: setup-azd
+        uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553  # v2.4.0
+      - id: setup-terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
+      - id: setup-dotnet
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68  # v6.0.0


### PR DESCRIPTION
Fixes #9802

## Summary

- pin 66 mutable GitHub Action references to immutable commit SHAs, using each action's latest stable release where one is published
- use `actions/checkout@v7.0.1` and update the other changed actions to their latest stable releases
- cover repository workflows, the `vally-eval` composite action, the generated Copilot setup workflow, and the workflow emitted by `azd pipeline config`
- retain release-version comments beside each SHA for readability and future updates
- load generated pipeline action pins from a valid, Dependabot-managed workflow manifest and validate each action repository and full SHA before rendering
- configure daily Dependabot checks with a seven-day cooldown across the root workflows and nonstandard action/template directories

`Azure/azure-sdk-actions` does not publish releases or tags, so its current `main` commit is pinned directly.

## Validation

- `actionlint` v1.7.12 on all changed workflows and the generated-pipeline action manifest
- `go test ./internal/cmd/...` in `cli/azd/extensions/azure.coding-agent`
- `go test ./pkg/pipeline`
- repository-wide scan reports zero mutable action references in executable workflows, actions, and generated templates
- all changed released actions match their latest stable release commit SHA