### PR TITLE
fix: add unified toolbox diagnostics

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/README.md
+++ b/cli/azd/extensions/azure.ai.agents/README.md
@@ -16,9 +16,12 @@ lifecycle behavior remain owned by the `azure.ai.toolboxes` and
 `azure.ai.connections` extensions.
 
 If a toolbox is declared inline on an agent, move its definition to an
-independent `azure.ai.toolbox` service before deployment, attach that service
-with the command above, and then run `azd deploy`. The add command only updates
-the agent's `uses` list; it does not create or deploy the toolbox service.
+independent `azure.ai.toolbox` service before deployment. If the new service key
+differs from the original toolbox name (for example, `My Tools` becomes
+`MyTools`), replace the inline entry in the agent's `toolboxes` list with the
+new service key. Then attach that service with the command above and run `azd deploy`.
+The add command only updates the agent's `uses` list; it does not rewrite
+`toolboxes`, create the service, or deploy it.
 
 ## Running Local Agents
 

--- a/cli/azd/extensions/azure.ai.agents/README.md
+++ b/cli/azd/extensions/azure.ai.agents/README.md
@@ -15,6 +15,11 @@ do not create or deploy the dependency. Toolbox and Connection configuration and
 lifecycle behavior remain owned by the `azure.ai.toolboxes` and
 `azure.ai.connections` extensions.
 
+If a toolbox is declared inline on an agent, move its definition to an
+independent `azure.ai.toolbox` service before deployment, attach that service
+with the command above, and then run `azd deploy`. The add command only updates
+the agent's `uses` list; it does not create or deploy the toolbox service.
+
 ## Running Local Agents
 
 `azd ai agent run` starts the selected agent locally and, by default, opens the

--- a/cli/azd/extensions/azure.ai.agents/cspell.yaml
+++ b/cli/azd/extensions/azure.ai.agents/cspell.yaml
@@ -85,6 +85,7 @@ words:
   - protocolversionrecord
   - Qdrant
   - schedulerun
+  - servicekey
   - Toolsets
   - underscoped
   - unparseable

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_toolboxes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_toolboxes.go
@@ -180,14 +180,8 @@ func classifyToolboxState(
 	toolboxes, missing []nextstep.ResourceRef,
 ) Result {
 	missingKeys := make(map[string]struct{}, len(missing))
-	missingUnique := make([]nextstep.ResourceRef, 0, len(missing))
 	for _, toolbox := range missing {
-		key := envkey.ToolboxMCPEndpoint(toolbox.Name)
-		if _, duplicate := missingKeys[key]; duplicate {
-			continue
-		}
-		missingKeys[key] = struct{}{}
-		missingUnique = append(missingUnique, toolbox)
+		missingKeys[envkey.ToolboxMCPEndpoint(toolbox.Name)] = struct{}{}
 	}
 	seen := make(map[string]struct{}, len(toolboxes))
 	matched := 0
@@ -201,14 +195,15 @@ func classifyToolboxState(
 			matched++
 		}
 	}
-	return classifyToolboxResults(missingUnique, matched)
+	return classifyToolboxResults(missing, matched)
 }
 
 func classifyToolboxResults(
 	missing []nextstep.ResourceRef,
 	matched int,
 ) Result {
-	if len(missing) == 0 {
+	uniqueMissing := uniqueToolboxRefs(missing)
+	if len(uniqueMissing) == 0 {
 		return Result{
 			Status:  StatusPass,
 			Message: fmt.Sprintf("all %d declared toolbox(es) have an MCP endpoint set.", matched),
@@ -216,19 +211,17 @@ func classifyToolboxResults(
 		}
 	}
 
-	slices.SortFunc(missing, func(a, b nextstep.ResourceRef) int {
-		if a.Name != b.Name {
-			return strings.Compare(a.Name, b.Name)
-		}
-		return strings.Compare(a.ServiceName, b.ServiceName)
-	})
+	slices.SortFunc(uniqueMissing, compareToolboxRefs)
+	slices.SortFunc(missing, compareToolboxRefs)
 	var names []string
+	for _, toolbox := range uniqueMissing {
+		names = append(names, fmt.Sprintf("%s (env %s, service %s)",
+			toolbox.Name, envkey.ToolboxMCPEndpoint(toolbox.Name), toolbox.ServiceName))
+	}
 	hasSplit := false
 	hasBundled := false
 	hasLegacy := false
 	for _, toolbox := range missing {
-		names = append(names, fmt.Sprintf("%s (env %s, service %s)",
-			toolbox.Name, envkey.ToolboxMCPEndpoint(toolbox.Name), toolbox.ServiceName))
 		hasSplit = hasSplit || toolbox.ToolboxSource == nextstep.ToolboxSourceSplit
 		hasBundled = hasBundled || toolbox.ToolboxSource == nextstep.ToolboxSourceBundled
 		hasLegacy = hasLegacy ||
@@ -257,13 +250,34 @@ func classifyToolboxResults(
 	return Result{
 		Status: StatusFail,
 		Message: fmt.Sprintf("%d declared toolbox(es) have no MCP endpoint set in the azd environment: %s",
-			len(missing), strings.Join(names, ", ")),
+			len(uniqueMissing), strings.Join(names, ", ")),
 		Suggestion: suggestion,
 		Details: map[string]any{
-			"missingToolboxes": toolboxLookupDetails(missing),
+			"missingToolboxes": toolboxLookupDetails(uniqueMissing),
 			"matchedCount":     matched,
 		},
 	}
+}
+
+func compareToolboxRefs(a, b nextstep.ResourceRef) int {
+	if a.Name != b.Name {
+		return strings.Compare(a.Name, b.Name)
+	}
+	return strings.Compare(a.ServiceName, b.ServiceName)
+}
+
+func uniqueToolboxRefs(refs []nextstep.ResourceRef) []nextstep.ResourceRef {
+	seen := make(map[string]struct{}, len(refs))
+	unique := make([]nextstep.ResourceRef, 0, len(refs))
+	for _, ref := range refs {
+		key := envkey.ToolboxMCPEndpoint(ref.Name)
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, ref)
+	}
+	return unique
 }
 
 func bundledToolboxMigrationSuggestion(
@@ -324,42 +338,44 @@ func toolboxLookupDetails(toolboxes []nextstep.ResourceRef) []toolboxLookup {
 // surface instead of a quiet pass-through.
 //
 // Dedup is on the canonical env key, not the toolbox name: the
-// manifest walker deduplicates on (ServiceName, Name) so the same toolbox
-// referenced by two services surfaces twice in state.Toolboxes.
-// Without dedup here the doctor would issue two gRPC reads for the
-// same key and report the same toolbox twice in the missing list.
+// manifest walker keeps one ref per (ServiceName, Name), so the same
+// toolbox used by two services surfaces twice in state.Toolboxes.
+// Env reads stay unique; missing owners are kept for attach guidance.
 func classifyToolboxEndpoints(
 	ctx context.Context,
 	toolboxes []nextstep.ResourceRef,
 	lookup toolboxEnvLookupFn,
 ) Result {
 	seen := make(map[string]struct{}, len(toolboxes))
+	missingKeys := make(map[string]struct{}, len(toolboxes))
 	var missing []nextstep.ResourceRef
 	matched := 0
 
 	for _, t := range toolboxes {
 		key := envkey.ToolboxMCPEndpoint(t.Name)
-		if _, dup := seen[key]; dup {
-			continue
-		}
-		seen[key] = struct{}{}
+		if _, dup := seen[key]; !dup {
+			seen[key] = struct{}{}
 
-		value, err := lookup(ctx, key)
-		if err != nil {
-			return Result{
-				Status: StatusFail,
-				Message: fmt.Sprintf(
-					"could not read toolbox endpoint env vars from the azd environment: %s",
-					err),
-				Suggestion: "Verify the azd extension is healthy and the active environment is accessible. " +
-					"Try `azd env list` and `azd env get-values`.",
+			value, err := lookup(ctx, key)
+			if err != nil {
+				return Result{
+					Status: StatusFail,
+					Message: fmt.Sprintf(
+						"could not read toolbox endpoint env vars from the azd environment: %s",
+						err),
+					Suggestion: "Verify the azd extension is healthy and the active environment is accessible. " +
+						"Try `azd env list` and `azd env get-values`.",
+				}
+			}
+			if strings.TrimSpace(value) == "" {
+				missingKeys[key] = struct{}{}
+			} else {
+				matched++
 			}
 		}
-		if strings.TrimSpace(value) == "" {
+		if _, ok := missingKeys[key]; ok {
 			missing = append(missing, t)
-			continue
 		}
-		matched++
 	}
 
 	result := classifyToolboxResults(missing, matched)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_toolboxes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_toolboxes.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 
 	"azureaiagent/internal/cmd/nextstep"
@@ -107,6 +106,21 @@ func newCheckToolboxes(deps Dependencies) Check {
 					Status:     StatusFail,
 					Message:    fmt.Sprintf("failed to assemble agent state: %s", cause),
 					Suggestion: "Re-run `azd ai agent doctor`; the state assembly returned nil unexpectedly.",
+				}
+			}
+			if len(state.ToolboxLoadErrors) > 0 {
+				issues := slices.Clone(state.ToolboxLoadErrors)
+				slices.Sort(issues)
+				return Result{
+					Status: StatusFail,
+					Message: fmt.Sprintf(
+						"could not load configured toolboxes: %s",
+						strings.Join(issues, "; ")),
+					Suggestion: "Repair azure.yaml and any referenced toolbox files, then " +
+						"re-run `azd ai agent doctor`.",
+					Details: map[string]any{
+						"toolboxLoadErrors": issues,
+					},
 				}
 			}
 			if len(state.ToolboxDependencyErrors) > 0 {
@@ -209,16 +223,36 @@ func classifyToolboxResults(
 	})
 	var names []string
 	hasSplit := false
+	hasBundled := false
 	hasLegacy := false
 	for _, toolbox := range missing {
 		names = append(names, fmt.Sprintf("%s (env %s, service %s)",
 			toolbox.Name, envkey.ToolboxMCPEndpoint(toolbox.Name), toolbox.ServiceName))
 		hasSplit = hasSplit || toolbox.ToolboxSource == nextstep.ToolboxSourceSplit
-		hasLegacy = hasLegacy || toolbox.ToolboxSource != nextstep.ToolboxSourceSplit
+		hasBundled = hasBundled || toolbox.ToolboxSource == nextstep.ToolboxSourceBundled
+		hasLegacy = hasLegacy ||
+			toolbox.ToolboxSource == nextstep.ToolboxSourceLegacyManifest ||
+			toolbox.ToolboxSource == nextstep.ToolboxSourceUnknown
 	}
 	suggestion := "Run `azd provision` to materialize toolbox infrastructure, or " +
 		"`azd env set <ENV_VAR> <endpoint>` to point at an existing toolbox."
 	switch {
+	case hasBundled && hasSplit && hasLegacy:
+		suggestion = "Move bundled toolboxes to independent azure.ai.toolbox services, " +
+			"run `azd ai agent add toolbox <service> --agent <agent>`, then run " +
+			"`azd deploy`; run `azd provision` for legacy toolbox resources."
+	case hasBundled && hasSplit:
+		suggestion = "Move bundled toolboxes to independent azure.ai.toolbox services, " +
+			"run `azd ai agent add toolbox <service> --agent <agent>`, then run " +
+			"`azd deploy`."
+	case hasBundled && hasLegacy:
+		suggestion = "Move bundled toolboxes to independent azure.ai.toolbox services, " +
+			"run `azd ai agent add toolbox <service> --agent <agent>`, then run " +
+			"`azd deploy`; run `azd provision` for legacy toolbox resources."
+	case hasBundled:
+		suggestion = "Move bundled toolboxes to independent azure.ai.toolbox services, " +
+			"run `azd ai agent add toolbox <service> --agent <agent>`, then run " +
+			"`azd deploy`."
 	case hasSplit && hasLegacy:
 		suggestion = "Run `azd deploy` for split toolbox services and `azd provision` " +
 			"for legacy toolbox resources, or set an existing endpoint."
@@ -275,7 +309,7 @@ func classifyToolboxEndpoints(
 	lookup toolboxEnvLookupFn,
 ) Result {
 	seen := make(map[string]struct{}, len(toolboxes))
-	var missing []toolboxLookup
+	var missing []nextstep.ResourceRef
 	matched := 0
 
 	for _, t := range toolboxes {
@@ -297,51 +331,22 @@ func classifyToolboxEndpoints(
 			}
 		}
 		if strings.TrimSpace(value) == "" {
-			missing = append(missing, toolboxLookup{
-				Name: t.Name, ServiceName: t.ServiceName, EnvVar: key,
-			})
+			missing = append(missing, t)
 			continue
 		}
 		matched++
 	}
 
-	sort.Slice(missing, func(i, j int) bool {
-		if missing[i].Name != missing[j].Name {
-			return missing[i].Name < missing[j].Name
-		}
-		return missing[i].ServiceName < missing[j].ServiceName
-	})
-
-	if len(missing) == 0 {
-		return Result{
-			Status:  StatusPass,
-			Message: fmt.Sprintf("all %d declared toolbox(es) have an MCP endpoint set.", matched),
-			Details: map[string]any{
-				"matchedCount": matched,
-			},
-		}
+	result := classifyToolboxResults(missing, matched)
+	if result.Status == StatusFail {
+		result.Message = strings.Replace(
+			result.Message,
+			"declared toolbox(es)",
+			"toolbox(es)",
+			1,
+		)
 	}
-
-	var sb strings.Builder
-	for i, m := range missing {
-		if i > 0 {
-			sb.WriteString(", ")
-		}
-		sb.WriteString(fmt.Sprintf("%s (env %s, service %s)", m.Name, m.EnvVar, m.ServiceName))
-	}
-
-	return Result{
-		Status: StatusFail,
-		Message: fmt.Sprintf(
-			"%d toolbox(es) declared in agent.manifest.yaml have no MCP endpoint set in the azd environment: %s",
-			len(missing), sb.String()),
-		Suggestion: "Run `azd provision` to materialize toolbox infrastructure, or " +
-			"`azd env set <ENV_VAR> <endpoint>` to point at an existing toolbox.",
-		Details: map[string]any{
-			"missingToolboxes": missing,
-			"matchedCount":     matched,
-		},
-	}
+	return result
 }
 
 // makeRealToolboxEnvLookup binds an `azdext.AzdClient` to a one-key

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_toolboxes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_toolboxes.go
@@ -11,6 +11,7 @@ import (
 
 	"azureaiagent/internal/cmd/nextstep"
 	"azureaiagent/internal/pkg/envkey"
+	"azureaiagent/internal/pkg/servicekey"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 )
@@ -238,21 +239,15 @@ func classifyToolboxResults(
 		"`azd env set <ENV_VAR> <endpoint>` to point at an existing toolbox."
 	switch {
 	case hasBundled && hasSplit && hasLegacy:
-		suggestion = "Move bundled toolboxes to independent azure.ai.toolbox services, " +
-			"run `azd ai agent add toolbox <service> --agent <agent>`, then run " +
-			"`azd deploy`; run `azd provision` for legacy toolbox resources."
+		suggestion = bundledToolboxMigrationSuggestion(missing) +
+			" Run `azd provision` for legacy toolbox resources."
 	case hasBundled && hasSplit:
-		suggestion = "Move bundled toolboxes to independent azure.ai.toolbox services, " +
-			"run `azd ai agent add toolbox <service> --agent <agent>`, then run " +
-			"`azd deploy`."
+		suggestion = bundledToolboxMigrationSuggestion(missing)
 	case hasBundled && hasLegacy:
-		suggestion = "Move bundled toolboxes to independent azure.ai.toolbox services, " +
-			"run `azd ai agent add toolbox <service> --agent <agent>`, then run " +
-			"`azd deploy`; run `azd provision` for legacy toolbox resources."
+		suggestion = bundledToolboxMigrationSuggestion(missing) +
+			" Run `azd provision` for legacy toolbox resources."
 	case hasBundled:
-		suggestion = "Move bundled toolboxes to independent azure.ai.toolbox services, " +
-			"run `azd ai agent add toolbox <service> --agent <agent>`, then run " +
-			"`azd deploy`."
+		suggestion = bundledToolboxMigrationSuggestion(missing)
 	case hasSplit && hasLegacy:
 		suggestion = "Run `azd deploy` for split toolbox services and `azd provision` " +
 			"for legacy toolbox resources, or set an existing endpoint."
@@ -269,6 +264,36 @@ func classifyToolboxResults(
 			"matchedCount":     matched,
 		},
 	}
+}
+
+func bundledToolboxMigrationSuggestion(
+	missing []nextstep.ResourceRef,
+) string {
+	replacements := make([]string, 0)
+	for _, toolbox := range missing {
+		if toolbox.ToolboxSource != nextstep.ToolboxSourceBundled {
+			continue
+		}
+		serviceKey := servicekey.SanitizeServiceName(toolbox.Name)
+		if serviceKey == toolbox.Name {
+			continue
+		}
+		replacements = append(replacements, fmt.Sprintf(
+			"%q in agent %q -> service key %q",
+			toolbox.Name,
+			toolbox.ServiceName,
+			serviceKey,
+		))
+	}
+
+	suggestion := "Move bundled toolboxes to independent " +
+		"azure.ai.toolbox services"
+	if len(replacements) > 0 {
+		suggestion += ", then replace the changed agent `toolboxes` " +
+			"entries (" + strings.Join(replacements, "; ") + ")"
+	}
+	return suggestion + ", run `azd ai agent add toolbox <service> --agent " +
+		"<agent>`, then run `azd deploy`."
 }
 
 type toolboxLookup struct {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_toolboxes_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_toolboxes_test.go
@@ -409,6 +409,35 @@ func TestCheckToolboxes_BundledSourceAvoidsManualEndpointGuidance(t *testing.T) 
 	require.NotContains(t, res.Suggestion, "azd provision")
 }
 
+func TestCheckToolboxes_BundledOwnersKeepAttachGuidance(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithToolboxes(
+		nextstep.ResourceRef{
+			Name:          "My Tools",
+			ServiceName:   "agent-a",
+			ToolboxSource: nextstep.ToolboxSourceBundled,
+		},
+		nextstep.ResourceRef{
+			Name:          "My Tools",
+			ServiceName:   "agent-b",
+			ToolboxSource: nextstep.ToolboxSourceBundled,
+		},
+	)
+	state.ToolboxEndpointsChecked = true
+	state.MissingToolboxEndpoints = state.Toolboxes
+
+	res := runToolboxesCheck(t, Dependencies{
+		AzdClient:     &azdext.AzdClient{},
+		assembleState: fixedAssembler(state),
+	}, nil)
+	require.Equal(t, StatusFail, res.Status)
+	require.Contains(t, res.Message, "1 declared toolbox(es)")
+	require.Contains(t, res.Suggestion, `"My Tools" in agent "agent-a"`)
+	require.Contains(t, res.Suggestion, `"My Tools" in agent "agent-b"`)
+	require.Equal(t, 0, res.Details["matchedCount"])
+}
+
 func TestCheckToolboxes_BundledSpacedNameExplainsReferenceMigration(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_toolboxes_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_toolboxes_test.go
@@ -404,8 +404,31 @@ func TestCheckToolboxes_BundledSourceAvoidsManualEndpointGuidance(t *testing.T) 
 	require.Equal(t, StatusFail, res.Status)
 	require.Contains(t, res.Suggestion, "azd ai agent add toolbox")
 	require.Contains(t, res.Suggestion, "azd deploy")
+	require.NotContains(t, res.Suggestion, "replace the changed agent")
 	require.NotContains(t, res.Suggestion, "azd env set")
 	require.NotContains(t, res.Suggestion, "azd provision")
+}
+
+func TestCheckToolboxes_BundledSpacedNameExplainsReferenceMigration(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithToolboxes(nextstep.ResourceRef{
+		Name:          "My Tools",
+		ServiceName:   "My Agent",
+		ToolboxSource: nextstep.ToolboxSourceBundled,
+	})
+	state.ToolboxEndpointsChecked = true
+	state.MissingToolboxEndpoints = state.Toolboxes
+
+	res := runToolboxesCheck(t, Dependencies{
+		AzdClient:     &azdext.AzdClient{},
+		assembleState: fixedAssembler(state),
+	}, nil)
+	require.Equal(t, StatusFail, res.Status)
+	require.Contains(t, res.Suggestion, `"My Tools" in agent "My Agent"`)
+	require.Contains(t, res.Suggestion, `service key "MyTools"`)
+	require.Contains(t, res.Suggestion, "replace the changed agent `toolboxes` entries")
+	require.Contains(t, res.Suggestion, "azd ai agent add toolbox")
 }
 
 // ---- Dedup on canonical env key ----

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_toolboxes_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/doctor/checks_toolboxes_test.go
@@ -142,6 +142,34 @@ func TestCheckToolboxes_FailsOnToolboxDependencyError(t *testing.T) {
 		res.Details["toolboxDependencyErrors"])
 }
 
+func TestCheckToolboxes_FailsOnToolboxLoadErrorBeforeLookup(t *testing.T) {
+	t.Parallel()
+
+	state := &nextstep.State{
+		ToolboxLoadErrors: []string{
+			`agent service "agent": resolve $ref: file not found`,
+		},
+		Toolboxes: []nextstep.ResourceRef{{
+			Name: "broken-tools",
+		}},
+		HasToolboxes: true,
+	}
+	res := runToolboxesCheck(t, Dependencies{
+		AzdClient:     &azdext.AzdClient{},
+		assembleState: fixedAssembler(state),
+		lookupToolboxEnv: func(context.Context, string) (string, error) {
+			t.Fatal("load errors must be reported before endpoint lookup")
+			return "", nil
+		},
+	}, nil)
+
+	require.Equal(t, StatusFail, res.Status)
+	require.Contains(t, res.Message, "could not load configured toolboxes")
+	require.Contains(t, res.Suggestion, "referenced toolbox files")
+	require.Equal(t, state.ToolboxLoadErrors,
+		res.Details["toolboxLoadErrors"])
+}
+
 func TestCheckToolboxes_FailsWhenAssemblerReturnsNilState(t *testing.T) {
 	t.Parallel()
 	deps := Dependencies{
@@ -356,6 +384,28 @@ func TestCheckToolboxes_MixedSourcesShowBothRemediations(t *testing.T) {
 	require.Equal(t, StatusFail, res.Status)
 	require.Contains(t, res.Suggestion, "azd deploy")
 	require.Contains(t, res.Suggestion, "azd provision")
+}
+
+func TestCheckToolboxes_BundledSourceAvoidsManualEndpointGuidance(t *testing.T) {
+	t.Parallel()
+
+	state := stateWithToolboxes(nextstep.ResourceRef{
+		Name:          "bundled-tools",
+		ServiceName:   "agent",
+		ToolboxSource: nextstep.ToolboxSourceBundled,
+	})
+	state.ToolboxEndpointsChecked = true
+	state.MissingToolboxEndpoints = state.Toolboxes
+
+	res := runToolboxesCheck(t, Dependencies{
+		AzdClient:     &azdext.AzdClient{},
+		assembleState: fixedAssembler(state),
+	}, nil)
+	require.Equal(t, StatusFail, res.Status)
+	require.Contains(t, res.Suggestion, "azd ai agent add toolbox")
+	require.Contains(t, res.Suggestion, "azd deploy")
+	require.NotContains(t, res.Suggestion, "azd env set")
+	require.NotContains(t, res.Suggestion, "azd provision")
 }
 
 // ---- Dedup on canonical env key ----

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/connections.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/connections.go
@@ -357,6 +357,12 @@ func resolveAgentConnectionConfig(
 	if err != nil {
 		return nil, err
 	}
+	if mapHasConnectionKind(inline) {
+		if _, found := inline["connections"]; !found {
+			return nil, nil
+		}
+		return inline, nil
+	}
 	legacy, err := resolveAgentConnectionProperties(
 		svc.GetConfig(),
 		projectRoot,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/manifest.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/manifest.go
@@ -35,8 +35,10 @@ var manifestFileNames = []string{
 }
 
 // populateManifestResources walks each service's agent.manifest.yaml
-// (when present) and aggregates the declared model/toolbox/connection
-// resources onto state. The walker is strictly best-effort: missing
+// (when present) and aggregates the declared model resources onto
+// state. Toolbox resources are collected by populateToolboxes so
+// unified configuration can control legacy fallback. The walker is
+// strictly best-effort: missing
 // files, unreadable bytes, malformed YAML, and unknown resource kinds
 // are all silently skipped so an in-flight `azd ai agent init` (which
 // rewrites the manifest mid-flight) or a template with no manifest
@@ -46,12 +48,10 @@ var manifestFileNames = []string{
 //
 //   - Has* flags are true when at least one resource of the matching
 //     kind is found across all services.
-//   - Slices are sorted by Name (ties broken by ServiceName) and the
-//     pair (ServiceName, Name) is the de-duplication key — the same
-//     name appearing under two services surfaces twice; the same name
-//     listed twice in one service collapses to one entry. This
-//     matches the doctor-check expectation that per-service failures
-//     remain individually addressable.
+//   - ModelRefs are sorted by Name (ties broken by ServiceName) and
+//     the pair (ServiceName, Name) is the de-duplication key — the
+//     same name appearing under two services surfaces twice; the same
+//     name listed twice in one service collapses to one entry.
 //   - The Detail field carries a kind-specific summary (model id,
 //     connection target/category, empty for toolboxes) so doctor
 //     remediation lines have enough context to be actionable without
@@ -67,7 +67,6 @@ func populateManifestResources(projectPath string, state *State) {
 	}
 
 	models := map[resourceKey]ResourceRef{}
-	toolboxes := map[resourceKey]ResourceRef{}
 
 	for _, svc := range state.Services {
 		data := readManifestBytes(projectPath, svc.RelativePath)
@@ -93,27 +92,12 @@ func populateManifestResources(projectPath string, state *State) {
 					ServiceName: svc.Name,
 					Detail:      r.Id,
 				}
-			case agent_yaml.ToolboxResource:
-				if r.Name == "" {
-					continue
-				}
-				k := resourceKey{service: svc.Name, name: r.Name}
-				if _, dup := toolboxes[k]; dup {
-					continue
-				}
-				toolboxes[k] = ResourceRef{
-					Name:          r.Name,
-					ServiceName:   svc.Name,
-					ToolboxSource: ToolboxSourceLegacyManifest,
-				}
 			}
 		}
 	}
 
 	state.ModelRefs = sortedResourceRefs(models)
-	state.Toolboxes = sortedResourceRefs(toolboxes)
 	state.HasModels = len(state.ModelRefs) > 0
-	state.HasToolboxes = len(state.Toolboxes) > 0
 }
 
 // populateSplitToolboxes adds active toolbox dependencies to state.
@@ -129,7 +113,7 @@ func populateSplitToolboxes(
 		return splitToolboxResult{}
 	}
 
-	candidates, excludedAgents := splitToolboxDependencies(
+	candidates, excludedAgents, checkedAgents := splitToolboxDependencies(
 		ctx,
 		src,
 		envName,
@@ -143,9 +127,12 @@ func populateSplitToolboxes(
 	}
 	if len(candidates) == 0 {
 		slices.Sort(state.ToolboxDependencyErrors)
+		slices.Sort(state.ToolboxLoadErrors)
 		return splitToolboxResult{
 			excludedAgents: excludedAgents,
+			checkedAgents:  checkedAgents,
 			endpointKeys:   endpointKeys,
+			reservedKeys:   make(map[string]struct{}),
 		}
 	}
 
@@ -160,6 +147,7 @@ func populateSplitToolboxes(
 	for _, key := range keys {
 		candidate := candidates[key]
 		reserved[key] = struct{}{}
+
 		enabled, err := isServiceEnabled(
 			ctx,
 			src,
@@ -185,6 +173,7 @@ func populateSplitToolboxes(
 					err,
 				),
 			)
+			recordToolboxLoadIssue(state, issue)
 			continue
 		}
 		if !enabled {
@@ -197,14 +186,41 @@ func populateSplitToolboxes(
 				state.ToolboxDependencyErrors,
 				issue,
 			)
-			*errs = append(
-				*errs,
-				errors.New(issue),
-			)
+			*errs = append(*errs, errors.New(issue))
 			continue
 		}
 
-		split[key] = candidate.ref
+		svc := projectCfg.Services[candidate.configName]
+		resolved, err := resolveToolboxServiceProperties(
+			svc,
+			projectCfg.Path,
+		)
+		if err != nil {
+			recordToolboxLoadError(
+				state,
+				errs,
+				fmt.Sprintf(
+					"toolbox service %q: %v",
+					candidate.ref.ServiceName,
+					err,
+				),
+			)
+			continue
+		}
+		if resolvedToolboxConditionError(
+			state,
+			errs,
+			"toolbox service",
+			candidate.ref.ServiceName,
+			resolved,
+		) {
+			continue
+		}
+
+		if existing, found := split[key]; !found ||
+			candidate.ref.ServiceName < existing.ServiceName {
+			split[key] = candidate.ref
+		}
 	}
 
 	merged := make([]ResourceRef, 0, len(state.Toolboxes)+len(split))
@@ -228,13 +244,17 @@ func populateSplitToolboxes(
 	slices.Sort(state.ToolboxDependencyErrors)
 	return splitToolboxResult{
 		excludedAgents: excludedAgents,
+		checkedAgents:  checkedAgents,
 		endpointKeys:   endpointKeys,
+		reservedKeys:   reserved,
 	}
 }
 
 type splitToolboxResult struct {
 	excludedAgents map[string]struct{}
+	checkedAgents  map[string]struct{}
 	endpointKeys   map[string]struct{}
+	reservedKeys   map[string]struct{}
 }
 
 type splitToolboxCandidate struct {
@@ -255,15 +275,16 @@ func splitToolboxDependencies(
 	projectCfg *azdext.ProjectConfig,
 	state *State,
 	errs *[]error,
-) (map[string]splitToolboxCandidate, map[string]struct{}) {
+) (map[string]splitToolboxCandidate, map[string]struct{}, map[string]struct{}) {
 	services := make(map[string]splitToolboxService)
-	for serviceName, svc := range projectCfg.Services {
+	for _, serviceName := range sortedServiceKeys(projectCfg) {
+		svc := projectCfg.Services[serviceName]
 		if svc == nil || svc.GetHost() != toolboxHost {
 			continue
 		}
-		name := svc.GetName()
+		name := strings.TrimSpace(serviceName)
 		if name == "" {
-			name = serviceName
+			name = strings.TrimSpace(svc.GetName())
 		}
 		if name == "" {
 			continue
@@ -278,18 +299,22 @@ func splitToolboxDependencies(
 			configName: serviceName,
 		}
 		services[serviceName] = service
-		services[name] = service
+		if name != serviceName {
+			services[name] = service
+		}
 	}
 
 	candidates := make(map[string]splitToolboxCandidate)
 	excludedAgents := make(map[string]struct{})
-	for serviceName, svc := range projectCfg.Services {
+	checkedAgents := make(map[string]struct{})
+	for _, serviceName := range sortedServiceKeys(projectCfg) {
+		svc := projectCfg.Services[serviceName]
 		if svc == nil || svc.GetHost() != agentHost {
 			continue
 		}
-		agentName := svc.GetName()
+		agentName := strings.TrimSpace(serviceName)
 		if agentName == "" {
-			agentName = serviceName
+			agentName = strings.TrimSpace(svc.GetName())
 		}
 		dependencies := make([]splitToolboxService, 0)
 		for _, dependencyName := range svc.GetUses() {
@@ -300,21 +325,12 @@ func splitToolboxDependencies(
 			dependencies = append(dependencies, service)
 		}
 
+		if len(dependencies) == 0 {
+			continue
+		}
+		checkedAgents[serviceName] = struct{}{}
 		enabled, err := isServiceEnabled(ctx, src, envName, serviceName)
 		if err != nil {
-			if len(dependencies) == 0 {
-				*errs = append(
-					*errs,
-					fmt.Errorf(
-						"agent service %q deployment condition: %w",
-						agentName,
-						err,
-					),
-				)
-				excludedAgents[agentName] = struct{}{}
-				excludedAgents[serviceName] = struct{}{}
-				continue
-			}
 			names := make([]string, 0, len(dependencies))
 			for _, service := range dependencies {
 				names = appendUnique(names, service.ref.ServiceName)
@@ -330,6 +346,7 @@ func splitToolboxDependencies(
 				state.ToolboxDependencyErrors,
 				issue,
 			)
+			recordToolboxLoadIssue(state, issue)
 			*errs = append(
 				*errs,
 				fmt.Errorf(
@@ -345,9 +362,6 @@ func splitToolboxDependencies(
 		if !enabled {
 			excludedAgents[agentName] = struct{}{}
 			excludedAgents[serviceName] = struct{}{}
-			continue
-		}
-		if len(dependencies) == 0 {
 			continue
 		}
 
@@ -368,7 +382,7 @@ func splitToolboxDependencies(
 		slices.Sort(candidate.agents)
 		candidates[key] = candidate
 	}
-	return candidates, excludedAgents
+	return candidates, excludedAgents, checkedAgents
 }
 
 func appendUnique(values []string, value string) []string {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
@@ -447,9 +447,10 @@ func appendBundledToolboxGuidance(
 		return strings.Compare(a.ServiceName, b.ServiceName)
 	})
 
-	limit := min(len(bundled), maxFixupLines)
-	for _, toolbox := range bundled[:limit] {
-		serviceKey := servicekey.SanitizeServiceName(toolbox.Name)
+	groups := groupBundledToolboxes(bundled)
+	limit := min(len(groups), maxFixupLines)
+	for _, group := range groups[:limit] {
+		serviceKey := servicekey.SanitizeServiceName(group[0].Name)
 		*out = append(*out, Suggestion{
 			Command: fmt.Sprintf(
 				"edit azure.yaml: create azure.ai.toolbox service %q",
@@ -459,28 +460,30 @@ func appendBundledToolboxGuidance(
 			Priority:    priority,
 		})
 		priority++
-		if serviceKey != toolbox.Name {
+		for _, toolbox := range group {
+			if serviceKey != toolbox.Name {
+				*out = append(*out, Suggestion{
+					Command: fmt.Sprintf(
+						"edit agent configuration: replace toolbox %q with service key %q",
+						toolbox.Name,
+						serviceKey,
+					),
+					Description: "update the agent's toolboxes reference to the new service key",
+					Priority:    priority,
+				})
+				priority++
+			}
 			*out = append(*out, Suggestion{
 				Command: fmt.Sprintf(
-					"edit agent configuration: replace toolbox %q with service key %q",
-					toolbox.Name,
-					serviceKey,
+					"azd ai agent add toolbox %s --agent %s",
+					shellEscapeSingleQuoted(serviceKey),
+					shellEscapeSingleQuoted(toolbox.ServiceName),
 				),
-				Description: "update the agent's toolboxes reference to the new service key",
+				Description: "attach the independent toolbox service to the agent",
 				Priority:    priority,
 			})
 			priority++
 		}
-		*out = append(*out, Suggestion{
-			Command: fmt.Sprintf(
-				"azd ai agent add toolbox %s --agent %s",
-				shellEscapeSingleQuoted(serviceKey),
-				shellEscapeSingleQuoted(toolbox.ServiceName),
-			),
-			Description: "attach the independent toolbox service to the agent",
-			Priority:    priority,
-		})
-		priority++
 	}
 	if len(bundled) > 0 {
 		*out = append(*out, Suggestion{
@@ -491,6 +494,32 @@ func appendBundledToolboxGuidance(
 		priority++
 	}
 	return priority
+}
+
+// groupBundledToolboxes collapses equal names so the service is
+// created once, while each owning agent stays in the group.
+func groupBundledToolboxes(toolboxes []ResourceRef) [][]ResourceRef {
+	groups := make([][]ResourceRef, 0)
+	index := make(map[string]int, len(toolboxes))
+	for _, toolbox := range toolboxes {
+		i, found := index[toolbox.Name]
+		if !found {
+			index[toolbox.Name] = len(groups)
+			groups = append(groups, []ResourceRef{toolbox})
+			continue
+		}
+		duplicate := false
+		for _, existing := range groups[i] {
+			if existing.ServiceName == toolbox.ServiceName {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			groups[i] = append(groups[i], toolbox)
+		}
+	}
+	return groups
 }
 
 func hasMissingToolboxSource(toolboxes []ResourceRef, source ToolboxSource) bool {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
@@ -90,18 +90,13 @@ const (
 //     and still emit `azd ai agent run`, leaving the user to discover
 //     the unset manual var when the agent crashes.
 //
-//     Toolbox sub-branch: emits `azd provision` (with an
-//     `azd ai agent doctor` follow-up so the user can verify whether
-//     the toolbox already exists in their Foundry project before
-//     publishing a fresh version). Toolbox-derived endpoint vars
-//     (`TOOLBOX_<NAME>_MCP_ENDPOINT`) are azd-managed outputs of
-//     provision (see listen.go::registerToolboxEnvVars), not operator-
-//     supplied; suggesting `azd env set` for them would be misleading
-//     because the value is the URL of a Foundry resource that doesn't
-//     yet exist at this point in the lifecycle. The actual live
-//     existence check requires a Foundry API call and lives in
-//     `azd ai agent doctor`'s local.toolboxes check, not here —
-//     ResolveAfterInit is offline by contract.
+//     Toolbox sub-branch: emits source-specific repair steps.
+//     Toolbox-derived endpoint vars
+//     (`TOOLBOX_<NAME>_MCP_ENDPOINT`) are azd-managed outputs, not
+//     operator-supplied; suggesting `azd env set` for them would be
+//     misleading. The actual live existence check requires a Foundry
+//     API call and lives in `azd ai agent doctor`'s local.toolboxes
+//     check, not here — ResolveAfterInit is offline by contract.
 //
 //     Manual-vars sub-branch: one `azd env set <KEY> <value>` per
 //     missing operator-supplied var (up to maxFixupLines). Matches
@@ -181,8 +176,11 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 	hasManualVars := len(state.MissingManualVars) > 0
 	hasToolboxEndpointErrors := len(state.ToolboxEndpointErrors) > 0
 	hasToolboxDependencyErrors := len(state.ToolboxDependencyErrors) > 0
+	hasToolboxLoadErrors := len(state.ToolboxLoadErrors) > 0
 	hasSplitToolboxEndpoints := hasMissingToolboxSource(
 		state.MissingToolboxEndpoints, ToolboxSourceSplit)
+	hasBundledToolboxEndpoints := hasMissingToolboxSource(
+		state.MissingToolboxEndpoints, ToolboxSourceBundled)
 	hasLegacyToolboxEndpoints := hasMissingLegacyToolbox(
 		state.MissingToolboxEndpoints)
 
@@ -211,8 +209,20 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 			state.ToolboxDependencyErrors,
 			priority,
 		)
+		priority = appendToolboxLoadGuidance(
+			&out,
+			state.ToolboxLoadErrors,
+			priority,
+		)
+		if hasBundledToolboxEndpoints {
+			priority = appendBundledToolboxGuidance(
+				&out,
+				state.MissingToolboxEndpoints,
+				priority,
+			)
+		}
 	case hasToolboxEndpoints || hasToolboxEndpointErrors ||
-		hasToolboxDependencyErrors || hasManualVars:
+		hasToolboxDependencyErrors || hasToolboxLoadErrors || hasManualVars:
 		// Combined branch for the two "things the user has to fix before
 		// running locally" categories. They are intentionally additive
 		// (not mutually exclusive) so a manifest that declares a
@@ -222,6 +232,11 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 		// still emit `azd ai agent run`, leaving the user to discover
 		// the unset manual var when the agent crashes.
 		//
+		priority = appendToolboxLoadGuidance(
+			&out,
+			state.ToolboxLoadErrors,
+			priority,
+		)
 		priority = appendToolboxDependencyGuidance(
 			&out,
 			state.ToolboxDependencyErrors,
@@ -240,21 +255,26 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 		// belongs in doctor's local.toolboxes (one HTTP GET per
 		// toolbox); ResolveAfterInit is offline by contract and must
 		// not initiate Foundry API calls.
-		if hasToolboxEndpoints {
-			if hasLegacyToolboxEndpoints {
-				out = append(out, Suggestion{
-					Command:     "azd provision",
-					Description: "create your toolbox(es) in Foundry",
-					Priority:    priority,
-				})
-				priority++
-				out = append(out, Suggestion{
-					Command:     "azd ai agent doctor",
-					Description: "(optional) check whether your toolbox(es) already exist in Foundry",
-					Priority:    priority,
-				})
-				priority++
-			}
+		if hasToolboxEndpoints && hasBundledToolboxEndpoints {
+			priority = appendBundledToolboxGuidance(
+				&out,
+				state.MissingToolboxEndpoints,
+				priority,
+			)
+		}
+		if hasToolboxEndpoints && hasLegacyToolboxEndpoints {
+			out = append(out, Suggestion{
+				Command:     "azd provision",
+				Description: "create your legacy toolbox(es) in Foundry",
+				Priority:    priority,
+			})
+			priority++
+			out = append(out, Suggestion{
+				Command:     "azd ai agent doctor",
+				Description: "(optional) check whether your legacy toolbox(es) already exist in Foundry",
+				Priority:    priority,
+			})
+			priority++
 		}
 		if hasToolboxEndpointErrors {
 			out = append(out, Suggestion{
@@ -283,7 +303,10 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 		}
 		// A split toolbox deploys the whole project, so add this step
 		// after the required agent values are set.
-		if hasSplitToolboxEndpoints {
+		if hasSplitToolboxEndpoints &&
+			!slices.ContainsFunc(out, func(s Suggestion) bool {
+				return strings.TrimSpace(s.Command) == "azd deploy"
+			}) {
 			out = append(out, Suggestion{
 				Command:     "azd deploy",
 				Description: "deploy split toolbox services",
@@ -300,7 +323,8 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 		// fix-ups first; the trailing `azd deploy` reminder still applies.
 		if !hasPlaceholders &&
 			!hasToolboxEndpointErrors &&
-			!hasToolboxDependencyErrors {
+			!hasToolboxDependencyErrors &&
+			!hasToolboxLoadErrors {
 			out = append(out, Suggestion{
 				Command: "azd ai agent run",
 				Description: runFollowUpDescription(
@@ -309,6 +333,7 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 					hasSplitToolboxEndpoints,
 					hasLegacyToolboxEndpoints,
 					hasToolboxEndpointErrors,
+					hasBundledToolboxEndpoints,
 				),
 				Priority: priority,
 			})
@@ -335,6 +360,7 @@ func ResolveAfterInit(state *State, readmeExists func(relativePath string) bool)
 	}
 
 	if !hasToolboxDependencyErrors &&
+		!hasToolboxLoadErrors &&
 		!slices.ContainsFunc(out, func(s Suggestion) bool {
 			return strings.TrimSpace(s.Command) == "azd deploy"
 		}) {
@@ -378,6 +404,80 @@ func appendToolboxDependencyGuidance(
 	return priority
 }
 
+func appendToolboxLoadGuidance(
+	out *[]Suggestion,
+	issues []string,
+	priority int,
+) int {
+	if len(issues) == 0 {
+		return priority
+	}
+
+	sorted := slices.Clone(issues)
+	slices.Sort(sorted)
+	limit := min(len(sorted), maxFixupLines)
+	for _, issue := range sorted[:limit] {
+		*out = append(*out, Suggestion{
+			Command:     "edit azure.yaml or its referenced toolbox files",
+			Description: issue,
+			Priority:    priority,
+		})
+		priority++
+	}
+	return priority
+}
+
+func appendBundledToolboxGuidance(
+	out *[]Suggestion,
+	toolboxes []ResourceRef,
+	priority int,
+) int {
+	bundled := make([]ResourceRef, 0, len(toolboxes))
+	for _, toolbox := range toolboxes {
+		if toolbox.ToolboxSource == ToolboxSourceBundled {
+			bundled = append(bundled, toolbox)
+		}
+	}
+	slices.SortFunc(bundled, func(a, b ResourceRef) int {
+		if a.Name != b.Name {
+			return strings.Compare(a.Name, b.Name)
+		}
+		return strings.Compare(a.ServiceName, b.ServiceName)
+	})
+
+	limit := min(len(bundled), maxFixupLines)
+	for _, toolbox := range bundled[:limit] {
+		*out = append(*out, Suggestion{
+			Command: fmt.Sprintf(
+				"edit azure.yaml: create azure.ai.toolbox service %q",
+				toolbox.Name,
+			),
+			Description: "move the bundled toolbox definition to an independent service",
+			Priority:    priority,
+		})
+		priority++
+		*out = append(*out, Suggestion{
+			Command: fmt.Sprintf(
+				"azd ai agent add toolbox %s --agent %s",
+				toolbox.Name,
+				toolbox.ServiceName,
+			),
+			Description: "attach the independent toolbox service to the agent",
+			Priority:    priority,
+		})
+		priority++
+	}
+	if len(bundled) > 0 {
+		*out = append(*out, Suggestion{
+			Command:     "azd deploy",
+			Description: "deploy the resulting toolbox service graph",
+			Priority:    priority,
+		})
+		priority++
+	}
+	return priority
+}
+
 func hasMissingToolboxSource(toolboxes []ResourceRef, source ToolboxSource) bool {
 	for _, toolbox := range toolboxes {
 		if toolbox.ToolboxSource == source {
@@ -389,7 +489,8 @@ func hasMissingToolboxSource(toolboxes []ResourceRef, source ToolboxSource) bool
 
 func hasMissingLegacyToolbox(toolboxes []ResourceRef) bool {
 	for _, toolbox := range toolboxes {
-		if toolbox.ToolboxSource != ToolboxSourceSplit {
+		if toolbox.ToolboxSource == ToolboxSourceLegacyManifest ||
+			toolbox.ToolboxSource == ToolboxSourceUnknown {
 			return true
 		}
 	}
@@ -413,7 +514,10 @@ func qualifyCommandEnvironment(command, environmentName string) string {
 func runFollowUpDescription(
 	hasToolboxEndpoints, hasManualVars, hasSplitToolboxEndpoints,
 	hasLegacyToolboxEndpoints, hasToolboxEndpointErrors bool,
+	bundledToolboxEndpoints ...bool,
 ) string {
+	hasBundledToolboxEndpoints := len(bundledToolboxEndpoints) > 0 &&
+		bundledToolboxEndpoints[0]
 	switch {
 	case hasToolboxEndpointErrors:
 		return "start the agent locally once toolbox endpoint checks pass"
@@ -427,6 +531,8 @@ func runFollowUpDescription(
 		return "start the agent locally once the steps above are complete"
 	case hasSplitToolboxEndpoints && hasToolboxEndpoints:
 		return "start the agent locally once deployment completes"
+	case hasBundledToolboxEndpoints && hasToolboxEndpoints:
+		return "start the agent locally once toolbox migration and deployment complete"
 	case hasToolboxEndpoints:
 		return "start the agent locally once provision completes"
 	case hasManualVars:

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
@@ -449,10 +449,11 @@ func appendBundledToolboxGuidance(
 
 	limit := min(len(bundled), maxFixupLines)
 	for _, toolbox := range bundled[:limit] {
+		serviceKey := servicekey.SanitizeServiceName(toolbox.Name)
 		*out = append(*out, Suggestion{
 			Command: fmt.Sprintf(
 				"edit azure.yaml: create azure.ai.toolbox service %q",
-				toolbox.Name,
+				serviceKey,
 			),
 			Description: "move the bundled toolbox definition to an independent service",
 			Priority:    priority,
@@ -461,7 +462,7 @@ func appendBundledToolboxGuidance(
 		*out = append(*out, Suggestion{
 			Command: fmt.Sprintf(
 				"azd ai agent add toolbox %s --agent %s",
-				shellEscapeSingleQuoted(servicekey.SanitizeServiceName(toolbox.Name)),
+				shellEscapeSingleQuoted(serviceKey),
 				shellEscapeSingleQuoted(toolbox.ServiceName),
 			),
 			Description: "attach the independent toolbox service to the agent",

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
@@ -8,6 +8,8 @@ import (
 	"path"
 	"slices"
 	"strings"
+
+	"azureaiagent/internal/pkg/servicekey"
 )
 
 const (
@@ -459,8 +461,8 @@ func appendBundledToolboxGuidance(
 		*out = append(*out, Suggestion{
 			Command: fmt.Sprintf(
 				"azd ai agent add toolbox %s --agent %s",
-				toolbox.Name,
-				toolbox.ServiceName,
+				shellEscapeSingleQuoted(servicekey.SanitizeServiceName(toolbox.Name)),
+				shellEscapeSingleQuoted(toolbox.ServiceName),
 			),
 			Description: "attach the independent toolbox service to the agent",
 			Priority:    priority,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver.go
@@ -459,6 +459,18 @@ func appendBundledToolboxGuidance(
 			Priority:    priority,
 		})
 		priority++
+		if serviceKey != toolbox.Name {
+			*out = append(*out, Suggestion{
+				Command: fmt.Sprintf(
+					"edit agent configuration: replace toolbox %q with service key %q",
+					toolbox.Name,
+					serviceKey,
+				),
+				Description: "update the agent's toolboxes reference to the new service key",
+				Priority:    priority,
+			})
+			priority++
+		}
 		*out = append(*out, Suggestion{
 			Command: fmt.Sprintf(
 				"azd ai agent add toolbox %s --agent %s",

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
@@ -615,7 +615,7 @@ func TestResolveAfterInit_BundledToolboxGuidanceQuotesSpacedNames(t *testing.T) 
 	suggestions := ResolveAfterInit(state, nil)
 	require.GreaterOrEqual(t, len(suggestions), 2)
 	assert.Equal(t,
-		"edit azure.yaml: create azure.ai.toolbox service \"My Tools\"",
+		"edit azure.yaml: create azure.ai.toolbox service \"MyTools\"",
 		suggestions[0].Command)
 	assert.Equal(t,
 		"azd ai agent add toolbox 'MyTools' --agent 'My Agent'",

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
@@ -583,7 +583,7 @@ func TestResolveAfterInit_BundledToolboxGuidanceMigratesInOrder(t *testing.T) {
 		"edit azure.yaml: create azure.ai.toolbox service \"bundled-tools\"",
 		suggestions[0].Command)
 	assert.Equal(t,
-		"azd ai agent add toolbox bundled-tools --agent agent",
+		"azd ai agent add toolbox 'bundled-tools' --agent 'agent'",
 		suggestions[1].Command)
 	assert.Equal(t, "azd deploy", suggestions[2].Command)
 	assert.Equal(t, "azd ai agent run", suggestions[3].Command)
@@ -598,6 +598,28 @@ func TestResolveAfterInit_BundledToolboxGuidanceMigratesInOrder(t *testing.T) {
 		assert.NotContains(t, suggestion.Command, "azd provision")
 	}
 	assert.Equal(t, 1, deployCount)
+}
+
+func TestResolveAfterInit_BundledToolboxGuidanceQuotesSpacedNames(t *testing.T) {
+	t.Parallel()
+
+	state := &State{
+		HasProjectEndpoint: true,
+		MissingToolboxEndpoints: []ResourceRef{{
+			Name:          "My Tools",
+			ServiceName:   "My Agent",
+			ToolboxSource: ToolboxSourceBundled,
+		}},
+	}
+
+	suggestions := ResolveAfterInit(state, nil)
+	require.GreaterOrEqual(t, len(suggestions), 2)
+	assert.Equal(t,
+		"edit azure.yaml: create azure.ai.toolbox service \"My Tools\"",
+		suggestions[0].Command)
+	assert.Equal(t,
+		"azd ai agent add toolbox 'MyTools' --agent 'My Agent'",
+		suggestions[1].Command)
 }
 
 func TestResolveAfterInit_BundledToolboxGuidanceSurvivesProvisioning(t *testing.T) {
@@ -618,7 +640,7 @@ func TestResolveAfterInit_BundledToolboxGuidanceSurvivesProvisioning(t *testing.
 		"edit azure.yaml: create azure.ai.toolbox service \"bundled-tools\"",
 		suggestions[1].Command)
 	assert.Equal(t,
-		"azd ai agent add toolbox bundled-tools --agent agent",
+		"azd ai agent add toolbox 'bundled-tools' --agent 'agent'",
 		suggestions[2].Command)
 	assert.Equal(t, "azd deploy", suggestions[3].Command)
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
@@ -565,6 +565,91 @@ func TestResolveAfterInit_SplitToolboxUsesDeployOnce(t *testing.T) {
 	assert.Equal(t, 1, deployCount)
 }
 
+func TestResolveAfterInit_BundledToolboxGuidanceMigratesInOrder(t *testing.T) {
+	t.Parallel()
+
+	state := &State{
+		HasProjectEndpoint: true,
+		MissingToolboxEndpoints: []ResourceRef{{
+			Name:          "bundled-tools",
+			ServiceName:   "agent",
+			ToolboxSource: ToolboxSourceBundled,
+		}},
+	}
+
+	suggestions := ResolveAfterInit(state, nil)
+	require.GreaterOrEqual(t, len(suggestions), 4)
+	assert.Equal(t,
+		"edit azure.yaml: create azure.ai.toolbox service \"bundled-tools\"",
+		suggestions[0].Command)
+	assert.Equal(t,
+		"azd ai agent add toolbox bundled-tools --agent agent",
+		suggestions[1].Command)
+	assert.Equal(t, "azd deploy", suggestions[2].Command)
+	assert.Equal(t, "azd ai agent run", suggestions[3].Command)
+
+	var deployCount int
+	for _, suggestion := range suggestions {
+		if suggestion.Command == "azd deploy" {
+			deployCount++
+		}
+		assert.NotContains(t, suggestion.Command,
+			"azd env set TOOLBOX_BUNDLED_TOOLS_MCP_ENDPOINT")
+		assert.NotContains(t, suggestion.Command, "azd provision")
+	}
+	assert.Equal(t, 1, deployCount)
+}
+
+func TestResolveAfterInit_BundledToolboxGuidanceSurvivesProvisioning(t *testing.T) {
+	t.Parallel()
+
+	state := &State{
+		MissingToolboxEndpoints: []ResourceRef{{
+			Name:          "bundled-tools",
+			ServiceName:   "agent",
+			ToolboxSource: ToolboxSourceBundled,
+		}},
+	}
+
+	suggestions := ResolveAfterInit(state, nil)
+	require.GreaterOrEqual(t, len(suggestions), 4)
+	assert.Equal(t, "azd provision", suggestions[0].Command)
+	assert.Equal(t,
+		"edit azure.yaml: create azure.ai.toolbox service \"bundled-tools\"",
+		suggestions[1].Command)
+	assert.Equal(t,
+		"azd ai agent add toolbox bundled-tools --agent agent",
+		suggestions[2].Command)
+	assert.Equal(t, "azd deploy", suggestions[3].Command)
+
+	var deployCount int
+	for _, suggestion := range suggestions {
+		if suggestion.Command == "azd deploy" {
+			deployCount++
+		}
+	}
+	assert.Equal(t, 1, deployCount)
+}
+
+func TestResolveAfterInit_ToolboxLoadErrorBlocksLocalRun(t *testing.T) {
+	t.Parallel()
+
+	state := &State{
+		HasProjectEndpoint: true,
+		ToolboxLoadErrors: []string{
+			`agent service "agent": resolve service-level properties: missing $ref`,
+		},
+	}
+
+	suggestions := ResolveAfterInit(state, nil)
+	require.NotEmpty(t, suggestions)
+	assert.Contains(t, suggestions[0].Command, "edit azure.yaml")
+	for _, suggestion := range suggestions {
+		assert.NotEqual(t, "azd ai agent run", suggestion.Command)
+		assert.NotEqual(t, "azd deploy", suggestion.Command)
+	}
+}
+
 func TestResolveAfterInit_SplitToolboxDeployFollowsManualVars(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
@@ -593,6 +593,7 @@ func TestResolveAfterInit_BundledToolboxGuidanceMigratesInOrder(t *testing.T) {
 		if suggestion.Command == "azd deploy" {
 			deployCount++
 		}
+		assert.NotContains(t, suggestion.Command, "replace toolbox")
 		assert.NotContains(t, suggestion.Command,
 			"azd env set TOOLBOX_BUNDLED_TOOLS_MCP_ENDPOINT")
 		assert.NotContains(t, suggestion.Command, "azd provision")
@@ -613,13 +614,16 @@ func TestResolveAfterInit_BundledToolboxGuidanceQuotesSpacedNames(t *testing.T) 
 	}
 
 	suggestions := ResolveAfterInit(state, nil)
-	require.GreaterOrEqual(t, len(suggestions), 2)
+	require.GreaterOrEqual(t, len(suggestions), 3)
 	assert.Equal(t,
 		"edit azure.yaml: create azure.ai.toolbox service \"MyTools\"",
 		suggestions[0].Command)
 	assert.Equal(t,
-		"azd ai agent add toolbox 'MyTools' --agent 'My Agent'",
+		"edit agent configuration: replace toolbox \"My Tools\" with service key \"MyTools\"",
 		suggestions[1].Command)
+	assert.Equal(t,
+		"azd ai agent add toolbox 'MyTools' --agent 'My Agent'",
+		suggestions[2].Command)
 }
 
 func TestResolveAfterInit_BundledToolboxGuidanceSurvivesProvisioning(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/resolver_test.go
@@ -601,6 +601,85 @@ func TestResolveAfterInit_BundledToolboxGuidanceMigratesInOrder(t *testing.T) {
 	assert.Equal(t, 1, deployCount)
 }
 
+func TestResolveAfterInit_BundledToolboxGuidanceAttachesEveryOwner(t *testing.T) {
+	t.Parallel()
+
+	state := &State{
+		HasProjectEndpoint: true,
+		MissingToolboxEndpoints: []ResourceRef{
+			{
+				Name:          "bundled-tools",
+				ServiceName:   "agent-a",
+				ToolboxSource: ToolboxSourceBundled,
+			},
+			{
+				Name:          "bundled-tools",
+				ServiceName:   "agent-b",
+				ToolboxSource: ToolboxSourceBundled,
+			},
+		},
+	}
+
+	suggestions := ResolveAfterInit(state, nil)
+	require.GreaterOrEqual(t, len(suggestions), 5)
+	assert.Equal(t,
+		"edit azure.yaml: create azure.ai.toolbox service \"bundled-tools\"",
+		suggestions[0].Command)
+	assert.Equal(t,
+		"azd ai agent add toolbox 'bundled-tools' --agent 'agent-a'",
+		suggestions[1].Command)
+	assert.Equal(t,
+		"azd ai agent add toolbox 'bundled-tools' --agent 'agent-b'",
+		suggestions[2].Command)
+	assert.Equal(t, "azd deploy", suggestions[3].Command)
+
+	var createCount int
+	for _, suggestion := range suggestions {
+		if strings.Contains(suggestion.Command, "create azure.ai.toolbox service") {
+			createCount++
+		}
+	}
+	assert.Equal(t, 1, createCount)
+}
+
+func TestResolveAfterInit_BundledToolboxGuidanceReplacesEveryOwner(t *testing.T) {
+	t.Parallel()
+
+	state := &State{
+		HasProjectEndpoint: true,
+		MissingToolboxEndpoints: []ResourceRef{
+			{
+				Name:          "My Tools",
+				ServiceName:   "agent-a",
+				ToolboxSource: ToolboxSourceBundled,
+			},
+			{
+				Name:          "My Tools",
+				ServiceName:   "agent-b",
+				ToolboxSource: ToolboxSourceBundled,
+			},
+		},
+	}
+
+	suggestions := ResolveAfterInit(state, nil)
+	require.GreaterOrEqual(t, len(suggestions), 6)
+	assert.Equal(t,
+		"edit azure.yaml: create azure.ai.toolbox service \"MyTools\"",
+		suggestions[0].Command)
+	assert.Equal(t,
+		"edit agent configuration: replace toolbox \"My Tools\" with service key \"MyTools\"",
+		suggestions[1].Command)
+	assert.Equal(t,
+		"azd ai agent add toolbox 'MyTools' --agent 'agent-a'",
+		suggestions[2].Command)
+	assert.Equal(t,
+		"edit agent configuration: replace toolbox \"My Tools\" with service key \"MyTools\"",
+		suggestions[3].Command)
+	assert.Equal(t,
+		"azd ai agent add toolbox 'MyTools' --agent 'agent-b'",
+		suggestions[4].Command)
+}
+
 func TestResolveAfterInit_BundledToolboxGuidanceQuotesSpacedNames(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state.go
@@ -335,7 +335,7 @@ func assembleState(ctx context.Context, src Source, opts ...Option) (*State, []e
 		if len(state.Services) > 0 {
 			populateManifestResources(project.Path, state)
 		}
-		splitToolboxState = populateSplitToolboxes(
+		splitToolboxState = populateToolboxes(
 			ctx,
 			src,
 			envName,
@@ -354,6 +354,17 @@ func assembleState(ctx context.Context, src Source, opts ...Option) (*State, []e
 	}
 
 	if project != nil && envName != "" {
+		collectAgentConditionsForMissingVars(
+			ctx,
+			src,
+			envName,
+			project,
+			state.Services,
+			splitToolboxState.excludedAgents,
+			splitToolboxState.checkedAgents,
+			&errs,
+			state,
+		)
 		state.MissingInfraVars, state.MissingManualVars, state.UnresolvedPlaceholders =
 			detectMissingVars(
 				ctx,
@@ -369,13 +380,100 @@ func assembleState(ctx context.Context, src Source, opts ...Option) (*State, []e
 		populateOpenAPIPayload(ctx, cfg, project.Path, envName, state)
 	}
 
-	if envName != "" && len(state.Toolboxes) > 0 {
+	if envName != "" && len(state.Toolboxes) > 0 &&
+		len(state.ToolboxLoadErrors) == 0 {
 		state.MissingToolboxEndpoints = probeToolboxEndpoints(
 			ctx, src, envName, state.Toolboxes, &state.ToolboxEndpointErrors, &errs)
 		state.ToolboxEndpointsChecked = true
 	}
 
 	return state, errs
+}
+
+func collectAgentConditionsForMissingVars(
+	ctx context.Context,
+	src Source,
+	envName string,
+	projectCfg *azdext.ProjectConfig,
+	services []ServiceState,
+	excludedAgents map[string]struct{},
+	checkedAgents map[string]struct{},
+	errs *[]error,
+	state *State,
+) {
+	if projectCfg == nil {
+		return
+	}
+	if excludedAgents == nil {
+		excludedAgents = make(map[string]struct{})
+	}
+	if checkedAgents == nil {
+		checkedAgents = make(map[string]struct{})
+	}
+
+	serviceStates := make(map[string]ServiceState, len(services))
+	for _, service := range services {
+		serviceStates[service.Name] = service
+	}
+
+	for _, serviceName := range sortedServiceKeys(projectCfg) {
+		svc := projectCfg.Services[serviceName]
+		if svc == nil || svc.GetHost() != agentHost {
+			continue
+		}
+		if _, excluded := excludedAgents[serviceName]; excluded {
+			continue
+		}
+
+		serviceState, found := serviceStates[serviceName]
+		if !found {
+			serviceState, found = serviceStates[svc.GetName()]
+		}
+		if !found {
+			continue
+		}
+		refs, placeholders := extractEnvironmentRefs(serviceState.EnvironmentValues)
+		if len(refs) == 0 && len(placeholders) == 0 {
+			continue
+		}
+
+		agentName := serviceName
+		if strings.TrimSpace(svc.GetName()) != "" {
+			agentName = svc.GetName()
+		}
+		enabled, err := ensureAgentServiceEnabled(
+			ctx,
+			src,
+			envName,
+			serviceName,
+			checkedAgents,
+		)
+		if err != nil {
+			issue := fmt.Sprintf(
+				"agent service %q deployment condition: %v",
+				agentName,
+				err,
+			)
+			state.EnvironmentLoadErrors = append(
+				state.EnvironmentLoadErrors,
+				issue,
+			)
+			*errs = append(
+				*errs,
+				fmt.Errorf(
+					"agent service %q deployment condition: %w",
+					agentName,
+					err,
+				),
+			)
+			addExcludedAgent(excludedAgents, serviceName)
+			continue
+		}
+		if !enabled {
+			addExcludedAgent(excludedAgents, serviceName)
+		}
+	}
+	slices.Sort(state.EnvironmentLoadErrors)
 }
 
 func detectMissingAzureContextVars(ctx context.Context, src Source, envName string, errs *[]error) []string {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state.go
@@ -494,8 +494,8 @@ func detectMissingAzureContextVars(ctx context.Context, src Source, envName stri
 }
 
 // probeToolboxEndpoints reads each canonical toolbox endpoint once.
-// azd produces these values, so the probe does not depend on agent
-// environment references.
+// Missing results keep every owning agent so attach guidance is
+// complete; only the env-var read is deduplicated.
 func probeToolboxEndpoints(
 	ctx context.Context,
 	src Source,
@@ -505,21 +505,24 @@ func probeToolboxEndpoints(
 	errs *[]error,
 ) []ResourceRef {
 	seen := make(map[string]struct{}, len(toolboxes))
+	missingKeys := make(map[string]struct{}, len(toolboxes))
 	var missing []ResourceRef
 	for _, toolbox := range toolboxes {
 		key := envkey.ToolboxMCPEndpoint(toolbox.Name)
-		if _, ok := seen[key]; ok {
-			continue
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			value, err := src.EnvValue(ctx, envName, key)
+			if err != nil {
+				probeErr := fmt.Errorf("read toolbox endpoint %s: %w", key, err)
+				*endpointErrors = append(*endpointErrors, probeErr.Error())
+				*errs = append(*errs, probeErr)
+				continue
+			}
+			if strings.TrimSpace(value) == "" {
+				missingKeys[key] = struct{}{}
+			}
 		}
-		seen[key] = struct{}{}
-		value, err := src.EnvValue(ctx, envName, key)
-		if err != nil {
-			probeErr := fmt.Errorf("read toolbox endpoint %s: %w", key, err)
-			*endpointErrors = append(*endpointErrors, probeErr.Error())
-			*errs = append(*errs, probeErr)
-			continue
-		}
-		if strings.TrimSpace(value) == "" {
+		if _, ok := missingKeys[key]; ok {
 			missing = append(missing, toolbox)
 		}
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state_test.go
@@ -436,6 +436,48 @@ func TestAssembleState_CollectsBundledToolboxes(t *testing.T) {
 	}, toolboxSources(state.Toolboxes))
 }
 
+func TestAssembleState_KeepsBundledToolboxOwners(t *testing.T) {
+	t.Parallel()
+
+	src := &fakeSource{
+		envName: "dev",
+		calls:   make(map[string]int),
+		project: &azdext.ProjectConfig{
+			Path: t.TempDir(),
+			Services: map[string]*azdext.ServiceConfig{
+				"agent-a": newAgentService(t, map[string]any{
+					"kind":      "hostedAgent",
+					"toolboxes": []any{"shared"},
+				}),
+				"agent-b": newAgentService(t, map[string]any{
+					"kind":      "hostedAgent",
+					"toolboxes": []any{"shared"},
+				}),
+			},
+		},
+	}
+
+	state, errs := assembleState(t.Context(), src)
+	require.Empty(t, errs)
+	require.Equal(t, []string{"shared", "shared"}, toolboxNames(state.Toolboxes))
+	require.Equal(t, []string{"agent-a", "agent-b"}, toolboxServiceNames(state.Toolboxes))
+	require.Equal(t, []ToolboxSource{
+		ToolboxSourceBundled,
+		ToolboxSourceBundled,
+	}, toolboxSources(state.Toolboxes))
+	require.Equal(
+		t,
+		[]string{"shared", "shared"},
+		toolboxNames(state.MissingToolboxEndpoints),
+	)
+	require.Equal(
+		t,
+		[]string{"agent-a", "agent-b"},
+		toolboxServiceNames(state.MissingToolboxEndpoints),
+	)
+	require.Equal(t, 1, src.calls["dev/TOOLBOX_SHARED_MCP_ENDPOINT"])
+}
+
 func TestAssembleState_MixedShapeToolboxesPreferKindedNestedConfig(t *testing.T) {
 	t.Parallel()
 
@@ -864,6 +906,14 @@ func toolboxSources(refs []ResourceRef) []ToolboxSource {
 		sources = append(sources, ref.ToolboxSource)
 	}
 	return sources
+}
+
+func toolboxServiceNames(refs []ResourceRef) []string {
+	names := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		names = append(names, ref.ServiceName)
+	}
+	return names
 }
 
 func TestAssembleState_SplitToolboxConditionUsesEnvironment(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state_test.go
@@ -682,6 +682,78 @@ func TestAssembleState_InlineToolboxSkipsUnusedLegacyRef(t *testing.T) {
 	assert.Equal(t, 1, src.calls["dev/TOOLBOX_INLINE_TOOLS_MCP_ENDPOINT"])
 }
 
+func TestAssembleState_ToolboxCollectionIgnoresUnrelatedRefs(t *testing.T) {
+	t.Parallel()
+
+	projectRoot := t.TempDir()
+	writeManifest(t, projectRoot, "src/agent", `
+resources:
+  - name: valid-tools
+    kind: toolbox
+`)
+	agent := newAgentService(t, map[string]any{
+		"kind": "hostedAgent",
+		"connections": []any{
+			map[string]any{"$ref": "missing-connection.yaml"},
+		},
+	})
+	agent.RelativePath = "src/agent"
+
+	src := &fakeSource{
+		envName: "dev",
+		calls:   make(map[string]int),
+		project: &azdext.ProjectConfig{
+			Path: projectRoot,
+			Services: map[string]*azdext.ServiceConfig{
+				"agent": agent,
+			},
+		},
+	}
+
+	state, errs := assembleState(t.Context(), src)
+	require.NotEmpty(t, errs)
+	require.Len(t, state.ConnectionLoadErrors, 1)
+	require.Empty(t, state.ToolboxLoadErrors)
+	require.True(t, state.ToolboxEndpointsChecked)
+	require.Equal(t, []string{"valid-tools"}, toolboxNames(state.Toolboxes))
+	require.Equal(t, 1, src.calls["dev/TOOLBOX_VALID_TOOLS_MCP_ENDPOINT"])
+}
+
+func TestAssembleState_DisabledAgentIgnoresUnrelatedRefs(t *testing.T) {
+	t.Parallel()
+
+	agent := newAgentService(t, map[string]any{
+		"kind":      "hostedAgent",
+		"toolboxes": []any{"disabled-tools"},
+		"connections": []any{
+			map[string]any{"$ref": "missing-connection.yaml"},
+		},
+	})
+	agent.Name = "disabled-agent"
+
+	src := &fakeSource{
+		envName: "dev",
+		configValues: map[string]*structpb.Value{
+			"disabled-agent/condition": structpb.NewBoolValue(false),
+		},
+		calls: make(map[string]int),
+		project: &azdext.ProjectConfig{
+			Path: t.TempDir(),
+			Services: map[string]*azdext.ServiceConfig{
+				"disabled-agent": agent,
+			},
+		},
+	}
+
+	state, errs := assembleState(t.Context(), src)
+	require.NotEmpty(t, errs)
+	require.Empty(t, state.Toolboxes)
+	require.Empty(t, state.ToolboxLoadErrors)
+	require.Empty(t, state.ConnectionLoadErrors)
+	require.False(t, state.ToolboxEndpointsChecked)
+	require.Equal(t, 0, src.calls["dev/TOOLBOX_DISABLED_TOOLS_MCP_ENDPOINT"])
+}
+
 func TestAssembleState_InvalidBundledToolboxIsReported(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state_test.go
@@ -406,6 +406,330 @@ func TestAssembleState_InactiveSplitToolboxEndpointIsNotManual(t *testing.T) {
 	}
 }
 
+func TestAssembleState_CollectsBundledToolboxes(t *testing.T) {
+	t.Parallel()
+
+	agent := newAgentService(t, map[string]any{
+		"kind": "hostedAgent",
+		"toolboxes": []any{
+			"alpha",
+			map[string]any{"name": "beta", "tools": []any{}},
+		},
+	})
+
+	src := &fakeSource{
+		envName: "dev",
+		project: &azdext.ProjectConfig{
+			Path: t.TempDir(),
+			Services: map[string]*azdext.ServiceConfig{
+				"agent": agent,
+			},
+		},
+	}
+
+	state, errs := assembleState(t.Context(), src)
+	require.Empty(t, errs)
+	require.Equal(t, []string{"alpha", "beta"}, toolboxNames(state.Toolboxes))
+	require.Equal(t, []ToolboxSource{
+		ToolboxSourceBundled,
+		ToolboxSourceBundled,
+	}, toolboxSources(state.Toolboxes))
+}
+
+func TestAssembleState_ExplicitEmptyToolboxesSuppressLegacyManifest(t *testing.T) {
+	t.Parallel()
+
+	projectRoot := t.TempDir()
+	writeManifest(t, projectRoot, "src/agent", `
+resources:
+  - name: legacy-tools
+    kind: toolbox
+`)
+	agent := newAgentService(t, map[string]any{
+		"kind":      "hostedAgent",
+		"toolboxes": []any{},
+	})
+	agent.RelativePath = "src/agent"
+
+	src := &fakeSource{
+		envName: "dev",
+		project: &azdext.ProjectConfig{
+			Path: projectRoot,
+			Services: map[string]*azdext.ServiceConfig{
+				"agent": agent,
+			},
+		},
+	}
+
+	state, errs := assembleState(t.Context(), src)
+	require.Empty(t, errs)
+	assert.Empty(t, state.Toolboxes)
+	assert.False(t, state.HasToolboxes)
+}
+
+func TestAssembleState_AbsentToolboxesFallsBackToLegacyManifest(t *testing.T) {
+	t.Parallel()
+
+	projectRoot := t.TempDir()
+	writeManifest(t, projectRoot, "src/agent", `
+resources:
+  - name: legacy-tools
+    kind: toolbox
+`)
+	agent := newAgentService(t, map[string]any{"kind": "hostedAgent"})
+	agent.RelativePath = "src/agent"
+
+	src := &fakeSource{
+		envName: "dev",
+		project: &azdext.ProjectConfig{
+			Path: projectRoot,
+			Services: map[string]*azdext.ServiceConfig{
+				"agent": agent,
+			},
+		},
+	}
+
+	state, errs := assembleState(t.Context(), src)
+	require.Empty(t, errs)
+	require.Len(t, state.Toolboxes, 1)
+	assert.Equal(t, "legacy-tools", state.Toolboxes[0].Name)
+	assert.Equal(t, ToolboxSourceLegacyManifest, state.Toolboxes[0].ToolboxSource)
+}
+
+func TestAssembleState_ToolboxSourcePrecedence(t *testing.T) {
+	t.Parallel()
+
+	projectRoot := t.TempDir()
+	writeManifest(t, projectRoot, "src/b", `
+resources:
+  - name: legacy-only
+    kind: toolbox
+`)
+	writeManifest(t, projectRoot, "src/a", `
+resources:
+  - name: same
+    kind: toolbox
+`)
+
+	agentA := newAgentService(t, map[string]any{
+		"kind": "hostedAgent",
+		"toolboxes": []any{
+			map[string]any{"name": "same"},
+			"bundled-only",
+		},
+	})
+	agentA.Name = "a"
+	agentA.RelativePath = "src/a"
+	agentA.Uses = []string{"same"}
+
+	agentB := &azdext.ServiceConfig{
+		Name:         "b",
+		Host:         agentHost,
+		RelativePath: "src/b",
+	}
+
+	src := &fakeSource{
+		envName: "dev",
+		project: &azdext.ProjectConfig{
+			Path: projectRoot,
+			Services: map[string]*azdext.ServiceConfig{
+				"same": {
+					Name:                 "payload-name",
+					Host:                 toolboxHost,
+					AdditionalProperties: mustStruct(t, map[string]any{"name": "ignored"}),
+				},
+				"a": agentA,
+				"b": agentB,
+			},
+		},
+	}
+
+	state, errs := assembleState(t.Context(), src)
+	require.Empty(t, errs)
+	require.Equal(t, []string{"bundled-only", "legacy-only", "same"},
+		toolboxNames(state.Toolboxes))
+	assert.Equal(t, ToolboxSourceBundled, state.Toolboxes[0].ToolboxSource)
+	assert.Equal(t, ToolboxSourceLegacyManifest, state.Toolboxes[1].ToolboxSource)
+	assert.Equal(t, ToolboxSourceSplit, state.Toolboxes[2].ToolboxSource)
+	assert.Equal(t, "same", state.Toolboxes[2].ServiceName)
+}
+
+func TestAssembleState_ResolvesToolboxRefs(t *testing.T) {
+	t.Parallel()
+
+	projectRoot := t.TempDir()
+	writeProjectFile(t, projectRoot, "agent.yaml", `
+kind: hostedAgent
+toolboxes:
+  - $ref: toolbox-entry.yaml
+`)
+	writeProjectFile(t, projectRoot, "toolbox-entry.yaml", `
+name: nested-toolbox
+`)
+
+	agent := newAgentService(t, map[string]any{
+		"$ref": "agent.yaml",
+	})
+
+	src := &fakeSource{
+		envName: "dev",
+		project: &azdext.ProjectConfig{
+			Path: projectRoot,
+			Services: map[string]*azdext.ServiceConfig{
+				"agent": agent,
+			},
+		},
+	}
+
+	state, errs := assembleState(t.Context(), src)
+	require.Empty(t, errs)
+	require.Len(t, state.Toolboxes, 1)
+	assert.Equal(t, "nested-toolbox", state.Toolboxes[0].Name)
+	assert.Equal(t, ToolboxSourceBundled, state.Toolboxes[0].ToolboxSource)
+}
+
+func TestAssembleState_InlineToolboxSkipsUnusedLegacyRef(t *testing.T) {
+	t.Parallel()
+
+	agent := newAgentService(t, map[string]any{
+		"kind":      "hostedAgent",
+		"toolboxes": []any{"inline-tools"},
+	})
+	agent.Config = mustStruct(t, map[string]any{
+		"$ref": "missing-legacy-agent.yaml",
+	})
+
+	src := &fakeSource{
+		envName: "dev",
+		calls:   make(map[string]int),
+		project: &azdext.ProjectConfig{
+			Path: t.TempDir(),
+			Services: map[string]*azdext.ServiceConfig{
+				"agent": agent,
+			},
+		},
+	}
+
+	state, errs := assembleState(t.Context(), src)
+	require.Empty(t, errs)
+	require.Len(t, state.Toolboxes, 1)
+	assert.Equal(t, "inline-tools", state.Toolboxes[0].Name)
+	assert.Empty(t, state.ToolboxLoadErrors)
+	assert.Equal(t, 1, src.calls["dev/TOOLBOX_INLINE_TOOLS_MCP_ENDPOINT"])
+}
+
+func TestAssembleState_InvalidBundledToolboxIsReported(t *testing.T) {
+	t.Parallel()
+
+	agent := newAgentService(t, map[string]any{
+		"kind": "hostedAgent",
+		"toolboxes": []any{
+			map[string]any{"tools": []any{}},
+		},
+	})
+	src := &fakeSource{
+		envName: "dev",
+		calls:   make(map[string]int),
+		project: &azdext.ProjectConfig{
+			Path: t.TempDir(),
+			Services: map[string]*azdext.ServiceConfig{
+				"agent": agent,
+			},
+		},
+	}
+
+	state, errs := assembleState(t.Context(), src)
+	require.Len(t, errs, 1)
+	require.Len(t, state.ToolboxLoadErrors, 1)
+	assert.Contains(t, state.ToolboxLoadErrors[0], "must include a non-empty name")
+	assert.Empty(t, state.Toolboxes)
+	assert.Equal(t, 0, src.calls["dev/TOOLBOX__MCP_ENDPOINT"])
+	assert.False(t, state.ToolboxEndpointsChecked)
+}
+
+func TestAssembleState_ResolvedAgentConditionIsReported(t *testing.T) {
+	t.Parallel()
+
+	projectRoot := t.TempDir()
+	writeProjectFile(t, projectRoot, "agent.yaml", `
+kind: hostedAgent
+condition: false
+toolboxes:
+  - referenced-tools
+`)
+	agent := newAgentService(t, map[string]any{
+		"$ref": "agent.yaml",
+	})
+
+	src := &fakeSource{
+		envName: "dev",
+		calls:   make(map[string]int),
+		project: &azdext.ProjectConfig{
+			Path: projectRoot,
+			Services: map[string]*azdext.ServiceConfig{
+				"agent": agent,
+			},
+		},
+	}
+
+	state, errs := assembleState(t.Context(), src)
+	require.Len(t, errs, 1)
+	require.Len(t, state.ToolboxLoadErrors, 1)
+	assert.Contains(t, state.ToolboxLoadErrors[0], "condition in its resolved $ref")
+	assert.Empty(t, state.Toolboxes)
+	assert.Equal(t, 0, src.calls["dev/TOOLBOX_REFERENCED_TOOLS_MCP_ENDPOINT"])
+}
+
+func TestAssembleState_ToolboxLoadErrorSuppressesLegacyAndProbe(t *testing.T) {
+	t.Parallel()
+
+	projectRoot := t.TempDir()
+	writeManifest(t, projectRoot, "src/agent", `
+resources:
+  - name: stale-tools
+    kind: toolbox
+`)
+	agent := newAgentService(t, map[string]any{
+		"$ref":      "missing-toolbox.yaml",
+		"toolboxes": []any{},
+	})
+	agent.RelativePath = "src/agent"
+
+	src := &fakeSource{
+		envName: "dev",
+		calls:   make(map[string]int),
+		project: &azdext.ProjectConfig{
+			Path: projectRoot,
+			Services: map[string]*azdext.ServiceConfig{
+				"agent": agent,
+			},
+		},
+	}
+
+	state, errs := assembleState(t.Context(), src)
+	require.NotEmpty(t, errs)
+	require.Len(t, state.ToolboxLoadErrors, 1)
+	assert.Contains(t, state.ToolboxLoadErrors[0], "$ref")
+	assert.Empty(t, state.Toolboxes)
+	assert.Equal(t, 0, src.calls["dev/TOOLBOX_STALE_TOOLS_MCP_ENDPOINT"])
+}
+
+func toolboxNames(refs []ResourceRef) []string {
+	names := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		names = append(names, ref.Name)
+	}
+	return names
+}
+
+func toolboxSources(refs []ResourceRef) []ToolboxSource {
+	sources := make([]ToolboxSource, 0, len(refs))
+	for _, ref := range refs {
+		sources = append(sources, ref.ToolboxSource)
+	}
+	return sources
+}
+
 func TestAssembleState_SplitToolboxConditionUsesEnvironment(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/state_test.go
@@ -436,6 +436,70 @@ func TestAssembleState_CollectsBundledToolboxes(t *testing.T) {
 	}, toolboxSources(state.Toolboxes))
 }
 
+func TestAssembleState_MixedShapeToolboxesPreferKindedNestedConfig(t *testing.T) {
+	t.Parallel()
+
+	agent := newAgentService(t, map[string]any{
+		"toolboxes": []any{"inline-tools"},
+	})
+	agent.Config = mustStruct(t, map[string]any{
+		"kind":      "hostedAgent",
+		"toolboxes": []any{"nested-tools"},
+	})
+
+	src := &fakeSource{
+		envName: "dev",
+		project: &azdext.ProjectConfig{
+			Path: t.TempDir(),
+			Services: map[string]*azdext.ServiceConfig{
+				"agent": agent,
+			},
+		},
+	}
+
+	state, errs := assembleState(t.Context(), src)
+	require.Empty(t, errs)
+	require.True(t, state.HasToolboxes)
+	require.True(t, state.ToolboxEndpointsChecked)
+	require.Equal(t, []string{"nested-tools"}, toolboxNames(state.Toolboxes))
+	require.Equal(t, []string{"nested-tools"}, toolboxNames(state.MissingToolboxEndpoints))
+}
+
+func TestAssembleState_MixedShapeEmptyInlineFallsBackToManifest(t *testing.T) {
+	t.Parallel()
+
+	projectRoot := t.TempDir()
+	writeManifest(t, projectRoot, "src/agent", `
+resources:
+  - name: legacy-tools
+    kind: toolbox
+`)
+	agent := newAgentService(t, map[string]any{
+		"toolboxes": []any{},
+	})
+	agent.Config = mustStruct(t, map[string]any{
+		"kind": "hostedAgent",
+	})
+	agent.RelativePath = "src/agent"
+
+	src := &fakeSource{
+		envName: "dev",
+		project: &azdext.ProjectConfig{
+			Path: projectRoot,
+			Services: map[string]*azdext.ServiceConfig{
+				"agent": agent,
+			},
+		},
+	}
+
+	state, errs := assembleState(t.Context(), src)
+	require.Empty(t, errs)
+	require.True(t, state.HasToolboxes)
+	require.True(t, state.ToolboxEndpointsChecked)
+	require.Equal(t, []string{"legacy-tools"}, toolboxNames(state.Toolboxes))
+	require.Equal(t, []string{"legacy-tools"}, toolboxNames(state.MissingToolboxEndpoints))
+}
+
 func TestAssembleState_ExplicitEmptyToolboxesSuppressLegacyManifest(t *testing.T) {
 	t.Parallel()
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/toolboxes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/toolboxes.go
@@ -94,8 +94,8 @@ func collectBundledAndLegacyToolboxes(
 	excludedAgents map[string]struct{},
 	checkedAgents map[string]struct{},
 	errs *[]error,
-) map[string]ResourceRef {
-	collected := make(map[string]ResourceRef)
+) map[string][]ResourceRef {
+	collected := make(map[string][]ResourceRef)
 	if excludedAgents == nil {
 		excludedAgents = make(map[string]struct{})
 	}
@@ -233,7 +233,7 @@ func collectBundledAndLegacyToolboxes(
 		}
 
 		for _, toolbox := range bundled {
-			addToolboxIfHigherPriority(
+			addCollectedToolbox(
 				collected,
 				ResourceRef{
 					Name:          toolbox.Name,
@@ -243,7 +243,7 @@ func collectBundledAndLegacyToolboxes(
 			)
 		}
 		for _, name := range legacy {
-			addToolboxIfHigherPriority(
+			addCollectedToolbox(
 				collected,
 				ResourceRef{
 					Name:          name,
@@ -455,16 +455,30 @@ func mapHasToolboxKind(values map[string]any) bool {
 	return ok && strings.TrimSpace(kind) != ""
 }
 
-func addToolboxIfHigherPriority(
-	collected map[string]ResourceRef,
+// addCollectedToolbox keeps highest-priority refs per endpoint.
+// Equal-priority owners are preserved so each agent can attach.
+func addCollectedToolbox(
+	collected map[string][]ResourceRef,
 	ref ResourceRef,
 ) {
 	key := envkey.ToolboxMCPEndpoint(ref.Name)
-	existing, found := collected[key]
-	if !found || toolboxSourcePriority(ref.ToolboxSource) >
-		toolboxSourcePriority(existing.ToolboxSource) {
-		collected[key] = ref
+	existing := collected[key]
+	if len(existing) == 0 ||
+		toolboxSourcePriority(ref.ToolboxSource) >
+			toolboxSourcePriority(existing[0].ToolboxSource) {
+		collected[key] = []ResourceRef{ref}
+		return
 	}
+	if toolboxSourcePriority(ref.ToolboxSource) <
+		toolboxSourcePriority(existing[0].ToolboxSource) {
+		return
+	}
+	for _, current := range existing {
+		if current.ServiceName == ref.ServiceName {
+			return
+		}
+	}
+	collected[key] = append(existing, ref)
 }
 
 func toolboxSourcePriority(source ToolboxSource) int {
@@ -482,28 +496,33 @@ func toolboxSourcePriority(source ToolboxSource) int {
 
 func mergeToolboxFallbacks(
 	state *State,
-	fallbacks map[string]ResourceRef,
+	fallbacks map[string][]ResourceRef,
 	reservedKeys map[string]struct{},
 ) {
-	merged := make(map[string]ResourceRef, len(state.Toolboxes)+len(fallbacks))
+	merged := make(map[string][]ResourceRef, len(state.Toolboxes)+len(fallbacks))
 	for _, ref := range state.Toolboxes {
-		merged[envkey.ToolboxMCPEndpoint(ref.Name)] = ref
+		key := envkey.ToolboxMCPEndpoint(ref.Name)
+		merged[key] = append(merged[key], ref)
 	}
-	for key, ref := range fallbacks {
+	for key, refs := range fallbacks {
+		if len(refs) == 0 {
+			continue
+		}
 		if _, reserved := reservedKeys[key]; reserved {
 			continue
 		}
-		if existing, found := merged[key]; found &&
-			toolboxSourcePriority(existing.ToolboxSource) >=
-				toolboxSourcePriority(ref.ToolboxSource) {
+		existing := merged[key]
+		if len(existing) > 0 &&
+			toolboxSourcePriority(existing[0].ToolboxSource) >=
+				toolboxSourcePriority(refs[0].ToolboxSource) {
 			continue
 		}
-		merged[key] = ref
+		merged[key] = refs
 	}
 
 	state.Toolboxes = state.Toolboxes[:0]
-	for _, ref := range merged {
-		state.Toolboxes = append(state.Toolboxes, ref)
+	for _, refs := range merged {
+		state.Toolboxes = append(state.Toolboxes, refs...)
 	}
 }
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/toolboxes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/toolboxes.go
@@ -15,6 +15,7 @@ import (
 	"azureaiagent/internal/pkg/envkey"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/azure/azure-dev/cli/azd/pkg/foundry"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -389,7 +390,29 @@ func resolveAgentToolboxProperties(
 	projectRoot string,
 	source string,
 ) (map[string]any, error) {
-	return resolveAgentConnectionProperties(props, projectRoot, source)
+	if props == nil || len(props.GetFields()) == 0 {
+		return nil, nil
+	}
+
+	raw := props.AsMap()
+	if _, hasRootRef := raw["$ref"]; hasRootRef {
+		return resolveAgentConnectionProperties(props, projectRoot, source)
+	}
+
+	toolboxes, hasToolboxes := raw["toolboxes"]
+	if !hasToolboxes {
+		return raw, nil
+	}
+
+	resolved, err := foundry.ResolveFileRefs(
+		map[string]any{"toolboxes": toolboxes},
+		projectRoot,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s: %w", source, err)
+	}
+	raw["toolboxes"] = resolved["toolboxes"]
+	return raw, nil
 }
 
 func resolveToolboxServiceProperties(

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/toolboxes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/toolboxes.go
@@ -362,8 +362,7 @@ func resolveAgentToolboxConfig(
 	if err != nil {
 		return nil, false, err
 	}
-	if len(inline) > 0 &&
-		(hasToolboxField(inline) || mapHasToolboxKind(inline)) {
+	if mapHasToolboxKind(inline) {
 		_, explicit := inline["toolboxes"]
 		return inline, explicit, nil
 	}
@@ -383,11 +382,6 @@ func resolveAgentToolboxConfig(
 	}
 	_, explicit := resolved["toolboxes"]
 	return resolved, explicit, nil
-}
-
-func hasToolboxField(values map[string]any) bool {
-	_, found := values["toolboxes"]
-	return found
 }
 
 func resolveAgentToolboxProperties(
@@ -425,9 +419,6 @@ func selectAgentToolboxProperties(
 ) map[string]any {
 	if len(inline) == 0 {
 		return legacy
-	}
-	if _, found := inline["toolboxes"]; found {
-		return inline
 	}
 	if !mapHasToolboxKind(inline) &&
 		mapHasToolboxKind(legacy) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/toolboxes.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/toolboxes.go
@@ -1,0 +1,532 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package nextstep
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"azureaiagent/internal/pkg/agents/agent_yaml"
+	"azureaiagent/internal/pkg/envkey"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type bundledToolbox struct {
+	Name string `json:"name"`
+}
+
+// UnmarshalJSON accepts both a toolbox name and a toolbox object.
+func (t *bundledToolbox) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err == nil {
+		t.Name = name
+		return nil
+	}
+
+	type toolbox bundledToolbox
+	var value toolbox
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = bundledToolbox(value)
+	return nil
+}
+
+// populateToolboxes assembles split, bundled, and legacy toolboxes.
+// Split services have precedence over bundled definitions, which have
+// precedence over legacy manifests.
+func populateToolboxes(
+	ctx context.Context,
+	src Source,
+	envName string,
+	projectCfg *azdext.ProjectConfig,
+	state *State,
+	errs *[]error,
+) splitToolboxResult {
+	splitState := populateSplitToolboxes(
+		ctx,
+		src,
+		envName,
+		projectCfg,
+		state,
+		errs,
+	)
+	if projectCfg == nil || state == nil {
+		return splitState
+	}
+
+	fallbacks := collectBundledAndLegacyToolboxes(
+		ctx,
+		src,
+		envName,
+		projectCfg,
+		state,
+		splitState.excludedAgents,
+		splitState.checkedAgents,
+		errs,
+	)
+	mergeToolboxFallbacks(state, fallbacks, splitState.reservedKeys)
+	slices.SortFunc(state.Toolboxes, func(a, b ResourceRef) int {
+		if c := strings.Compare(a.Name, b.Name); c != 0 {
+			return c
+		}
+		return strings.Compare(a.ServiceName, b.ServiceName)
+	})
+	slices.Sort(state.ToolboxLoadErrors)
+	state.HasToolboxes = len(state.Toolboxes) > 0
+	return splitState
+}
+
+func collectBundledAndLegacyToolboxes(
+	ctx context.Context,
+	src Source,
+	envName string,
+	projectCfg *azdext.ProjectConfig,
+	state *State,
+	excludedAgents map[string]struct{},
+	checkedAgents map[string]struct{},
+	errs *[]error,
+) map[string]ResourceRef {
+	collected := make(map[string]ResourceRef)
+	if excludedAgents == nil {
+		excludedAgents = make(map[string]struct{})
+	}
+	if checkedAgents == nil {
+		checkedAgents = make(map[string]struct{})
+	}
+
+	for _, serviceName := range sortedServiceKeys(projectCfg) {
+		svc := projectCfg.Services[serviceName]
+		if svc == nil || svc.GetHost() != agentHost {
+			continue
+		}
+		agentName := serviceName
+		if strings.TrimSpace(agentName) == "" {
+			agentName = strings.TrimSpace(svc.GetName())
+		}
+		if _, excluded := excludedAgents[serviceName]; excluded {
+			continue
+		}
+		if _, excluded := excludedAgents[agentName]; excluded {
+			continue
+		}
+
+		resolved, explicit, err := resolveAgentToolboxConfig(
+			svc,
+			projectCfg.Path,
+		)
+		if err != nil {
+			if agentServiceMayContainToolboxes(svc) {
+				enabled, conditionErr := ensureAgentServiceEnabled(
+					ctx,
+					src,
+					envName,
+					serviceName,
+					checkedAgents,
+				)
+				if conditionErr != nil {
+					recordToolboxLoadError(
+						state,
+						errs,
+						fmt.Sprintf(
+							"agent service %q deployment condition: %v",
+							agentName,
+							conditionErr,
+						),
+					)
+					addExcludedAgent(excludedAgents, serviceName)
+					continue
+				}
+				if !enabled {
+					addExcludedAgent(excludedAgents, serviceName)
+					continue
+				}
+			}
+			recordToolboxLoadError(
+				state,
+				errs,
+				fmt.Sprintf("agent service %q: %v", agentName, err),
+			)
+			continue
+		}
+		if resolvedToolboxConditionError(
+			state,
+			errs,
+			"agent service",
+			agentName,
+			resolved,
+		) {
+			continue
+		}
+
+		var bundled []bundledToolbox
+		var decodeErr error
+		if explicit {
+			bundled, decodeErr = decodeBundledToolboxes(resolved)
+		}
+
+		var legacy []string
+		if !explicit {
+			data := readManifestBytes(projectCfg.Path, svc.GetRelativePath())
+			if data != nil {
+				resources, err := agent_yaml.ExtractResourceDefinitions(data)
+				if err == nil {
+					for _, resource := range resources {
+						toolbox, ok := resource.(agent_yaml.ToolboxResource)
+						if ok && strings.TrimSpace(toolbox.Name) != "" {
+							legacy = append(legacy, toolbox.Name)
+						}
+					}
+				}
+			}
+		}
+
+		hasBundled := explicit && hasBundledToolboxEntries(resolved)
+		if !hasBundled && len(legacy) == 0 {
+			continue
+		}
+
+		enabled, conditionErr := ensureAgentServiceEnabled(
+			ctx,
+			src,
+			envName,
+			serviceName,
+			checkedAgents,
+		)
+		if conditionErr != nil {
+			recordToolboxLoadError(
+				state,
+				errs,
+				fmt.Sprintf(
+					"agent service %q deployment condition: %v",
+					agentName,
+					conditionErr,
+				),
+			)
+			addExcludedAgent(excludedAgents, serviceName)
+			continue
+		}
+		if !enabled {
+			addExcludedAgent(excludedAgents, serviceName)
+			continue
+		}
+
+		if decodeErr != nil {
+			recordToolboxLoadError(
+				state,
+				errs,
+				fmt.Sprintf(
+					"agent service %q: decode toolboxes: %v",
+					agentName,
+					decodeErr,
+				),
+			)
+			continue
+		}
+
+		for _, toolbox := range bundled {
+			addToolboxIfHigherPriority(
+				collected,
+				ResourceRef{
+					Name:          toolbox.Name,
+					ServiceName:   agentName,
+					ToolboxSource: ToolboxSourceBundled,
+				},
+			)
+		}
+		for _, name := range legacy {
+			addToolboxIfHigherPriority(
+				collected,
+				ResourceRef{
+					Name:          name,
+					ServiceName:   agentName,
+					ToolboxSource: ToolboxSourceLegacyManifest,
+				},
+			)
+		}
+	}
+	return collected
+}
+
+func decodeBundledToolboxes(
+	resolved map[string]any,
+) ([]bundledToolbox, error) {
+	raw, found := resolved["toolboxes"]
+	if !found {
+		return nil, nil
+	}
+
+	entries, ok := raw.([]any)
+	if !ok {
+		return nil, errors.New("toolboxes must be an array")
+	}
+
+	decoded := make([]bundledToolbox, 0, len(entries))
+	for i, entry := range entries {
+		if entry == nil {
+			return nil, fmt.Errorf(
+				"toolboxes[%d] must be a named toolbox string or object",
+				i,
+			)
+		}
+
+		data, err := json.Marshal(entry)
+		if err != nil {
+			return nil, fmt.Errorf("toolboxes[%d]: %w", i, err)
+		}
+
+		var toolbox bundledToolbox
+		if err := json.Unmarshal(data, &toolbox); err != nil {
+			return nil, fmt.Errorf("toolboxes[%d]: %w", i, err)
+		}
+		if strings.TrimSpace(toolbox.Name) == "" {
+			return nil, fmt.Errorf(
+				"toolboxes[%d] must include a non-empty name",
+				i,
+			)
+		}
+		decoded = append(decoded, toolbox)
+	}
+	return decoded, nil
+}
+
+func hasBundledToolboxEntries(resolved map[string]any) bool {
+	raw, found := resolved["toolboxes"]
+	if !found {
+		return false
+	}
+	entries, ok := raw.([]any)
+	return !ok || len(entries) > 0
+}
+
+func agentServiceMayContainToolboxes(svc *azdext.ServiceConfig) bool {
+	if svc == nil {
+		return false
+	}
+	for _, props := range []*structpb.Struct{
+		svc.GetAdditionalProperties(),
+		svc.GetConfig(),
+	} {
+		if props == nil {
+			continue
+		}
+		fields := props.GetFields()
+		if _, found := fields["toolboxes"]; found {
+			return true
+		}
+		if _, found := fields["$ref"]; found {
+			return true
+		}
+	}
+	return false
+}
+
+func ensureAgentServiceEnabled(
+	ctx context.Context,
+	src Source,
+	envName string,
+	serviceName string,
+	checkedAgents map[string]struct{},
+) (bool, error) {
+	if _, checked := checkedAgents[serviceName]; checked {
+		return true, nil
+	}
+	enabled, err := isServiceEnabled(ctx, src, envName, serviceName)
+	checkedAgents[serviceName] = struct{}{}
+	return enabled, err
+}
+
+func addExcludedAgent(
+	excludedAgents map[string]struct{},
+	serviceName string,
+) {
+	excludedAgents[serviceName] = struct{}{}
+}
+
+func resolveAgentToolboxConfig(
+	svc *azdext.ServiceConfig,
+	projectRoot string,
+) (map[string]any, bool, error) {
+	inline, err := resolveAgentToolboxProperties(
+		svc.GetAdditionalProperties(),
+		projectRoot,
+		"service-level properties",
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(inline) > 0 &&
+		(hasToolboxField(inline) || mapHasToolboxKind(inline)) {
+		_, explicit := inline["toolboxes"]
+		return inline, explicit, nil
+	}
+
+	legacy, err := resolveAgentToolboxProperties(
+		svc.GetConfig(),
+		projectRoot,
+		"deprecated config",
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	resolved := selectAgentToolboxProperties(inline, legacy)
+	if len(resolved) == 0 {
+		return nil, false, nil
+	}
+	_, explicit := resolved["toolboxes"]
+	return resolved, explicit, nil
+}
+
+func hasToolboxField(values map[string]any) bool {
+	_, found := values["toolboxes"]
+	return found
+}
+
+func resolveAgentToolboxProperties(
+	props *structpb.Struct,
+	projectRoot string,
+	source string,
+) (map[string]any, error) {
+	return resolveAgentConnectionProperties(props, projectRoot, source)
+}
+
+func resolveToolboxServiceProperties(
+	svc *azdext.ServiceConfig,
+	projectRoot string,
+) (map[string]any, error) {
+	if svc == nil {
+		return nil, errors.New("service configuration is nil")
+	}
+	if props := svc.GetAdditionalProperties(); props != nil &&
+		len(props.GetFields()) > 0 {
+		return resolveServiceProperties(svc, projectRoot)
+	}
+	if props := svc.GetConfig(); props != nil &&
+		len(props.GetFields()) > 0 {
+		return resolveAgentToolboxProperties(
+			props,
+			projectRoot,
+			"deprecated config",
+		)
+	}
+	return map[string]any{}, nil
+}
+
+func selectAgentToolboxProperties(
+	inline, legacy map[string]any,
+) map[string]any {
+	if len(inline) == 0 {
+		return legacy
+	}
+	if _, found := inline["toolboxes"]; found {
+		return inline
+	}
+	if !mapHasToolboxKind(inline) &&
+		mapHasToolboxKind(legacy) {
+		return legacy
+	}
+	return inline
+}
+
+func mapHasToolboxKind(values map[string]any) bool {
+	kind, ok := values["kind"].(string)
+	return ok && strings.TrimSpace(kind) != ""
+}
+
+func addToolboxIfHigherPriority(
+	collected map[string]ResourceRef,
+	ref ResourceRef,
+) {
+	key := envkey.ToolboxMCPEndpoint(ref.Name)
+	existing, found := collected[key]
+	if !found || toolboxSourcePriority(ref.ToolboxSource) >
+		toolboxSourcePriority(existing.ToolboxSource) {
+		collected[key] = ref
+	}
+}
+
+func toolboxSourcePriority(source ToolboxSource) int {
+	switch source {
+	case ToolboxSourceBundled:
+		return 2
+	case ToolboxSourceLegacyManifest:
+		return 1
+	case ToolboxSourceSplit:
+		return 3
+	default:
+		return 0
+	}
+}
+
+func mergeToolboxFallbacks(
+	state *State,
+	fallbacks map[string]ResourceRef,
+	reservedKeys map[string]struct{},
+) {
+	merged := make(map[string]ResourceRef, len(state.Toolboxes)+len(fallbacks))
+	for _, ref := range state.Toolboxes {
+		merged[envkey.ToolboxMCPEndpoint(ref.Name)] = ref
+	}
+	for key, ref := range fallbacks {
+		if _, reserved := reservedKeys[key]; reserved {
+			continue
+		}
+		if existing, found := merged[key]; found &&
+			toolboxSourcePriority(existing.ToolboxSource) >=
+				toolboxSourcePriority(ref.ToolboxSource) {
+			continue
+		}
+		merged[key] = ref
+	}
+
+	state.Toolboxes = state.Toolboxes[:0]
+	for _, ref := range merged {
+		state.Toolboxes = append(state.Toolboxes, ref)
+	}
+}
+
+func recordToolboxLoadError(
+	state *State,
+	errs *[]error,
+	issue string,
+) {
+	if recordToolboxLoadIssue(state, issue) {
+		*errs = append(*errs, errors.New(issue))
+	}
+}
+
+func recordToolboxLoadIssue(state *State, issue string) bool {
+	if slices.Contains(state.ToolboxLoadErrors, issue) {
+		return false
+	}
+	state.ToolboxLoadErrors = append(state.ToolboxLoadErrors, issue)
+	return true
+}
+
+func resolvedToolboxConditionError(
+	state *State,
+	errs *[]error,
+	serviceType string,
+	serviceName string,
+	resolved map[string]any,
+) bool {
+	if _, found := resolved["condition"]; !found {
+		return false
+	}
+	issue := fmt.Sprintf(
+		"%s %q has condition in its resolved $ref; "+
+			"put condition beside host in azure.yaml",
+		serviceType,
+		serviceName,
+	)
+	recordToolboxLoadError(state, errs, issue)
+	return true
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/types.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/nextstep/types.go
@@ -114,6 +114,11 @@ type State struct {
 	// dependency conditions.
 	ToolboxDependencyErrors []string
 
+	// ToolboxLoadErrors contains failures loading unified toolbox
+	// configuration or referenced files. These errors block local-run
+	// guidance because the assembled toolbox state is incomplete.
+	ToolboxLoadErrors []string
+
 	// ToolboxEndpointsChecked is true after assembly probes every
 	// active toolbox endpoint.
 	ToolboxEndpointsChecked bool
@@ -160,7 +165,8 @@ type State struct {
 
 	// HasModels, HasToolboxes, and HasConnections are aggregate flags.
 	// They describe resources. Models still come from agent manifests.
-	// Toolboxes include split services and manifest resources.
+	// Toolboxes include split services, bundled definitions, and
+	// legacy manifest resources.
 	// Connections prefer enabled azure.ai.connection services.
 	// Bundled agent config and legacy manifest resources are fallback
 	// sources. Doctor checks skip when no matching resource exists,

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"azureaiagent/internal/pkg/servicekey"
 	"azureaiagent/internal/project"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -113,7 +114,7 @@ func emitResourceServices(
 
 	for i := range connections {
 		conn := connections[i]
-		connName := sanitizeServiceName(conn.Name)
+		connName := servicekey.SanitizeServiceName(conn.Name)
 		if connName == "" {
 			fmt.Fprintf(os.Stderr,
 				"warning: connection %q has no characters usable as an azure.yaml service key; "+
@@ -138,7 +139,7 @@ func emitResourceServices(
 
 	for i := range toolboxes {
 		toolbox := toolboxes[i]
-		toolboxName := sanitizeServiceName(toolbox.Name)
+		toolboxName := servicekey.SanitizeServiceName(toolbox.Name)
 		if toolboxName == "" {
 			fmt.Fprintf(os.Stderr,
 				"warning: toolbox %q has no characters usable as an azure.yaml service key; "+
@@ -226,7 +227,7 @@ func resolveProjectServiceKey(
 	if existing := existingProjectServiceKey(ctx, azdClient); existing != "" {
 		return existing
 	}
-	if key := sanitizeServiceName(projectName); key != "" && key != agentServiceName {
+	if key := servicekey.SanitizeServiceName(projectName); key != "" && key != agentServiceName {
 		return key
 	}
 	return aiProjectServiceName
@@ -483,16 +484,6 @@ func setServiceUses(ctx context.Context, azdClient *azdext.AzdClient, serviceNam
 	}
 
 	return nil
-}
-
-// sanitizeServiceName converts a resource name into an azure.yaml service key by
-// trimming surrounding whitespace and removing interior spaces, matching how the
-// agent service name is derived from the agent name. Only spaces are stripped, so
-// the name is expected to otherwise consist of characters valid in a YAML map key
-// (letters, digits, '-', '_', '.'); Foundry resource names already meet this. A
-// name that reduces to an empty string is skipped by the caller with a warning.
-func sanitizeServiceName(name string) string {
-	return strings.ReplaceAll(strings.TrimSpace(name), " ", "")
 }
 
 // reserveServiceName records an azure.yaml service key derived from a Foundry

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/resource_services_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 
+	"azureaiagent/internal/pkg/servicekey"
 	"azureaiagent/internal/project"
 
 	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
@@ -65,9 +66,9 @@ func agentService(t *testing.T, name string, toolConnections ...project.ToolConn
 func TestSanitizeServiceName(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "MyAgent", sanitizeServiceName("  My Agent  "))
-	assert.Equal(t, "gpt4o", sanitizeServiceName("gpt 4 o"))
-	assert.Equal(t, "", sanitizeServiceName("   "))
+	assert.Equal(t, "MyAgent", servicekey.SanitizeServiceName("  My Agent  "))
+	assert.Equal(t, "gpt4o", servicekey.SanitizeServiceName("gpt 4 o"))
+	assert.Equal(t, "", servicekey.SanitizeServiceName("   "))
 }
 
 // TestReserveServiceName verifies distinct service keys are accepted and that

--- a/cli/azd/extensions/azure.ai.agents/internal/pkg/servicekey/servicekey.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/pkg/servicekey/servicekey.go
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Package servicekey contains helpers for azure.yaml service keys.
+package servicekey
+
+import "strings"
+
+// SanitizeServiceName converts a resource name into an azure.yaml service key
+// by trimming surrounding whitespace and removing interior spaces. Resource
+// names are expected to otherwise consist of characters valid in a YAML map
+// key (letters, digits, '-', '_', '.').
+func SanitizeServiceName(name string) string {
+	return strings.ReplaceAll(strings.TrimSpace(name), " ", "")
+}


### PR DESCRIPTION
## Why this change is needed

Agents can declare bundled toolboxes in unified `azure.yaml`, while older projects still use `agent.manifest.yaml`. Next-step and Doctor previously did not represent those sources consistently, so missing endpoints and broken references could produce incomplete guidance or an incorrect legacy fallback.

## Approach

- Collect split, bundled, and legacy toolbox declarations into one source-aware state model.
- Deduplicate by canonical endpoint environment key with precedence `split > bundled > legacy`.
- Treat explicit empty declarations as authoritative and surface unified configuration or `$ref` errors.
- Provide source-specific Next-step and Doctor remediation while preserving legacy compatibility.
- Add regression coverage and bundled-toolbox migration documentation.

## Validation

- `go test ./...`
- `go build ./...`
- Targeted `golangci-lint` checks

## End-to-end validation

| Command | Result |
| --- | --- |
| `azd ai agent doctor --local-only --no-prompt` (bundled toolbox, missing endpoint) | **PASS** — reported the missing `TOOLBOX_RESEARCH_TOOLS_MCP_ENDPOINT` and provided bundled-toolbox migration guidance. |
| `azd ai agent doctor --local-only --no-prompt` (endpoint configured) | **PASS** — reported `local.toolboxes` as passing. |
| `azd ai agent doctor --local-only --no-prompt` (invalid `$ref`) | **PASS** — surfaced the toolbox load error and repair guidance. |

Fixes #9565