### PR TITLE
Re-enable extension PR publishing for forks

### DIFF
--- a/eng/pipelines/templates/stages/publish-extension-pr.yml
+++ b/eng/pipelines/templates/stages/publish-extension-pr.yml
@@ -9,13 +9,11 @@ parameters:
 stages:
   - stage: PublishExtensionForPR
     dependsOn: BuildAndTest
-    # Fork builds cannot access the service connections required to publish bundles or comment on PRs.
     condition: >-
       and(
         succeeded(),
         ne(variables['Skip.Release'], 'true'),
-        eq(variables['Build.Reason'], 'PullRequest'),
-        ne(variables['System.PullRequest.IsFork'], 'True')
+        eq(variables['Build.Reason'], 'PullRequest')
       )
 
     variables:


### PR DESCRIPTION
Closes #9669

### Summary

This PR reverts #9670 and restores extension PR bundle publishing and installation comments for fork PRs. The Azure DevOps configuration now provides the required service connections for these builds, so the temporary fork guard is no longer needed.

### Testing

Confirmed the pipeline condition again allows all pull request builds to enter the `PublishExtensionForPR` stage.