### PR TITLE
fix(deps): update js-yaml security release

### DIFF
--- a/ext/vscode/package-lock.json
+++ b/ext/vscode/package-lock.json
@@ -4439,8 +4439,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
## Summary

- update the VS Code extension lockfile from `js-yaml` 4.1.1 to 4.3.2
- resolve GHSA-5p4m-2wfm-xmqj

## Validation

- lint, spell check, TypeScript type-check, and bundle build pass
- targeted npm audit no longer reports `js-yaml`
- VS Code integration tests could not launch locally because the environment has no X server