### PR TITLE
fix(deps): require patched OpenTelemetry core

### DIFF
--- a/cli/azd/test/evals/package-lock.json
+++ b/cli/azd/test/evals/package-lock.json
@@ -153,21 +153,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/resources": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",

--- a/cli/azd/test/evals/package.json
+++ b/cli/azd/test/evals/package.json
@@ -27,5 +27,8 @@
     "@microsoft/vally": "^0.11.0",
     "@types/node": "^24.13.3",
     "typescript": "^7.0.2"
+  },
+  "overrides": {
+    "@opentelemetry/core": "2.9.0"
   }
 }


### PR DESCRIPTION
## Summary

- override transitive `@opentelemetry/core` to 2.9.0 in the azd eval tooling
- remove the vulnerable nested 2.0.0 lockfile entry selected by Azure Monitor Exporter
- resolve GHSA-8988-4f7v-96qf

The direct dependency graph already selected 2.9.0, but the exporter retained a nested vulnerable copy; the override ensures all consumers use the patched release.

## Validation

- `npm ci` passes
- npm audit reports zero vulnerabilities