### PR TITLE
fix(deps): update fast-uri security release

### DIFF
--- a/ext/vscode/package-lock.json
+++ b/ext/vscode/package-lock.json
@@ -3647,8 +3647,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.4",
-            "integrity": "sha1-Oz2vnOaPQflW3wtQUTLAz86ex68=",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+            "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
## Summary

- update the VS Code extension lockfile from `fast-uri` 3.1.4 to 3.1.6
- resolve GHSA-7p8r-x3mc-p8w7

## Validation

- lint, spell check, TypeScript type-check, and bundle build pass
- targeted npm audit no longer reports `fast-uri`
- VS Code integration tests could not launch locally because the environment has no X server