### PR TITLE
fix(ai-skills): prefer canonical project endpoint

### DIFF
--- a/cli/azd/extensions/azure.ai.skills/README.md
+++ b/cli/azd/extensions/azure.ai.skills/README.md
@@ -98,14 +98,16 @@ the skill service in `uses:` so azd deploys it first. Removing the service from
 The Foundry project endpoint is resolved in this order:
 
 1. `-p` / `--project-endpoint` flag on the command.
-2. Active azd env value `AZURE_AI_PROJECT_ENDPOINT`.
+2. Active azd env value `FOUNDRY_PROJECT_ENDPOINT`, falling back to legacy
+   `AZURE_AI_PROJECT_ENDPOINT`.
 3. Global config `extensions.ai-projects.context.endpoint` (written by
    `azd ai project set`). Falls back to the legacy
    `extensions.ai-skills.project.context.endpoint` and
    `extensions.ai-agents.project.context.endpoint` keys so users who
    configured the endpoint via earlier extensions are not forced to re-run
    `set`.
-4. Host environment variable `FOUNDRY_PROJECT_ENDPOINT`.
+4. Host environment variable `FOUNDRY_PROJECT_ENDPOINT`, falling back to legacy
+   `AZURE_AI_PROJECT_ENDPOINT`.
 5. Structured error with an actionable suggestion.
 
 ## Local Development

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/endpoint.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/endpoint.go
@@ -43,15 +43,17 @@ const (
 	// projectsContextPath the first time any `azd ai project` command runs;
 	// the fallback exists for the window in between.
 	agentsContextEndpointKey = "extensions.ai-agents.project.context.endpoint"
-	azdEnvKey                = "AZURE_AI_PROJECT_ENDPOINT"
 	foundryEnvKey            = "FOUNDRY_PROJECT_ENDPOINT"
+	legacyAzdEnvKey          = "AZURE_AI_PROJECT_ENDPOINT"
 )
 
 // azdProjectSources holds the values read from azd-managed sources
 // (levels 2 and 3 of resolveProjectEndpoint).
 type azdProjectSources struct {
-	// EnvValue is AZURE_AI_PROJECT_ENDPOINT from the active azd env, or "".
+	// EnvValue is FOUNDRY_PROJECT_ENDPOINT from the active azd env, or "".
 	EnvValue string
+	// LegacyEnvValue is AZURE_AI_PROJECT_ENDPOINT from the active azd env, or "".
+	LegacyEnvValue string
 	// CfgEndpoint is the endpoint persisted at projectsContextPath in global
 	// config, or "". Source of truth for `azd ai project set`.
 	CfgEndpoint string
@@ -77,7 +79,8 @@ type azdProjectSources struct {
 var readAzdProjectSourcesFunc = readAzdProjectSources
 
 // readAzdProjectSources dials the azd daemon (if reachable) and reads the
-// active env's AZURE_AI_PROJECT_ENDPOINT and the three candidate global-config
+// active env's FOUNDRY_PROJECT_ENDPOINT (falling back to
+// AZURE_AI_PROJECT_ENDPOINT) and the three candidate global-config
 // keys in a single client lifetime. Errors talking to the daemon are silently
 // ignored (treated as "no daemon"); the caller falls through to the
 // FOUNDRY_PROJECT_ENDPOINT host env var.
@@ -90,13 +93,22 @@ func readAzdProjectSources(ctx context.Context) (azdProjectSources, error) {
 	}
 	defer azdClient.Close()
 
-	// Level 2: active azd env → AZURE_AI_PROJECT_ENDPOINT.
+	// Level 2: active azd env → FOUNDRY_PROJECT_ENDPOINT, then the legacy
+	// AZURE_AI_PROJECT_ENDPOINT compatibility fallback.
 	if envResp, err := azdClient.Environment().GetCurrent(ctx, &azdext.EmptyRequest{}); err == nil {
-		if valResp, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
-			EnvName: envResp.Environment.Name,
-			Key:     azdEnvKey,
-		}); err == nil && valResp.Value != "" {
-			out.EnvValue = valResp.Value
+		for _, value := range []struct {
+			key string
+			dst *string
+		}{
+			{foundryEnvKey, &out.EnvValue},
+			{legacyAzdEnvKey, &out.LegacyEnvValue},
+		} {
+			if valResp, err := azdClient.Environment().GetValue(ctx, &azdext.GetEnvRequest{
+				EnvName: envResp.Environment.Name,
+				Key:     value.key,
+			}); err == nil && valResp.Value != "" {
+				*value.dst = valResp.Value
+			}
 		}
 	}
 
@@ -129,9 +141,9 @@ func readAzdProjectSources(ctx context.Context) (azdProjectSources, error) {
 	return out, nil
 }
 
-// resolveProjectEndpoint implements the 5-level cascade from the design spec:
-// flag, azd env, global config (ai-projects then legacy ai-skills then legacy
-// ai-agents), host env, error.
+// resolveProjectEndpoint implements the endpoint cascade: flag, active azd env
+// (canonical then legacy), global config, host env (canonical then legacy),
+// then error.
 func resolveProjectEndpoint(ctx context.Context, flagEndpoint string) (string, endpointSource, error) {
 	if flagEndpoint != "" {
 		if err := validateEndpoint(flagEndpoint); err != nil {
@@ -150,6 +162,14 @@ func resolveProjectEndpoint(ctx context.Context, flagEndpoint string) (string, e
 			return "", "", err
 		}
 		return sources.EnvValue, sourceAzdEnv, nil
+	}
+	if sources.LegacyEnvValue != "" {
+		if err := validateEndpoint(sources.LegacyEnvValue); err != nil {
+			return "", "", err
+		}
+		log.Printf("resolveProjectEndpoint: using fallback active environment key %q; "+
+			"set %s to migrate", legacyAzdEnvKey, foundryEnvKey)
+		return sources.LegacyEnvValue, sourceAzdEnv, nil
 	}
 
 	if sources.CfgFound && sources.CfgEndpoint != "" {
@@ -183,11 +203,19 @@ func resolveProjectEndpoint(ctx context.Context, flagEndpoint string) (string, e
 		}
 		return ep, sourceFoundryEnv, nil
 	}
+	if ep := os.Getenv(legacyAzdEnvKey); ep != "" {
+		if err := validateEndpoint(ep); err != nil {
+			return "", "", err
+		}
+		log.Printf("resolveProjectEndpoint: using fallback host environment variable %q; "+
+			"export %s to migrate", legacyAzdEnvKey, foundryEnvKey)
+		return ep, sourceFoundryEnv, nil
+	}
 
 	return "", "", exterrors.Dependency(
 		exterrors.CodeMissingProjectEndpoint,
 		"no Foundry project endpoint resolved",
-		"pass --project-endpoint, set "+azdEnvKey+" in the active azd environment, "+
+		"pass --project-endpoint, set "+foundryEnvKey+" in the active azd environment, "+
 			"persist a workspace default with `azd ai project set <endpoint>`, "+
 			"or export "+foundryEnvKey+" in your shell",
 	)

--- a/cli/azd/extensions/azure.ai.skills/internal/cmd/endpoint_test.go
+++ b/cli/azd/extensions/azure.ai.skills/internal/cmd/endpoint_test.go
@@ -31,6 +31,8 @@ func stubAzdProjectSources(t *testing.T, sources azdProjectSources, err error) {
 func isolateFromAzdDaemon(t *testing.T) {
 	t.Helper()
 	t.Setenv("AZD_SERVER", "")
+	t.Setenv(foundryEnvKey, "")
+	t.Setenv(legacyAzdEnvKey, "")
 	stubAzdProjectSources(t, azdProjectSources{}, nil)
 }
 
@@ -62,6 +64,33 @@ func TestResolveProjectEndpoint_AzdEnvBeatsGlobalConfig(t *testing.T) {
 	ep, src, err := resolveProjectEndpoint(t.Context(), "")
 	require.NoError(t, err)
 	assert.Equal(t, "https://envaccount.example.com", ep)
+	assert.Equal(t, sourceAzdEnv, src)
+}
+
+func TestResolveProjectEndpoint_AzdEnvCanonicalBeatsLegacy(t *testing.T) {
+	isolateFromAzdDaemon(t)
+	stubAzdProjectSources(t, azdProjectSources{
+		EnvValue:       "https://canonical.example.com",
+		LegacyEnvValue: "https://legacy.example.com",
+	}, nil)
+
+	ep, src, err := resolveProjectEndpoint(t.Context(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://canonical.example.com", ep)
+	assert.Equal(t, sourceAzdEnv, src)
+}
+
+func TestResolveProjectEndpoint_AzdEnvFallsBackToLegacy(t *testing.T) {
+	isolateFromAzdDaemon(t)
+	stubAzdProjectSources(t, azdProjectSources{
+		LegacyEnvValue: "https://legacy.example.com",
+		CfgEndpoint:    "https://config.example.com",
+		CfgFound:       true,
+	}, nil)
+
+	ep, src, err := resolveProjectEndpoint(t.Context(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://legacy.example.com", ep)
 	assert.Equal(t, sourceAzdEnv, src)
 }
 
@@ -122,6 +151,28 @@ func TestResolveProjectEndpoint_HostEnvVar(t *testing.T) {
 	assert.Equal(t, sourceFoundryEnv, src)
 }
 
+func TestResolveProjectEndpoint_HostEnvCanonicalBeatsLegacy(t *testing.T) {
+	isolateFromAzdDaemon(t)
+	t.Setenv(foundryEnvKey, "https://canonical.example.com")
+	t.Setenv(legacyAzdEnvKey, "https://legacy.example.com")
+
+	ep, src, err := resolveProjectEndpoint(t.Context(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://canonical.example.com", ep)
+	assert.Equal(t, sourceFoundryEnv, src)
+}
+
+func TestResolveProjectEndpoint_HostEnvFallsBackToLegacy(t *testing.T) {
+	isolateFromAzdDaemon(t)
+	t.Setenv(foundryEnvKey, "")
+	t.Setenv(legacyAzdEnvKey, "https://legacy.example.com")
+
+	ep, src, err := resolveProjectEndpoint(t.Context(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://legacy.example.com", ep)
+	assert.Equal(t, sourceFoundryEnv, src)
+}
+
 func TestResolveProjectEndpoint_InvalidScheme(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -144,7 +195,8 @@ func TestResolveProjectEndpoint_InvalidScheme(t *testing.T) {
 
 func TestResolveProjectEndpoint_MissingAll(t *testing.T) {
 	isolateFromAzdDaemon(t)
-	t.Setenv("FOUNDRY_PROJECT_ENDPOINT", "")
+	t.Setenv(foundryEnvKey, "")
+	t.Setenv(legacyAzdEnvKey, "")
 
 	_, _, err := resolveProjectEndpoint(t.Context(), "")
 	require.Error(t, err)


### PR DESCRIPTION
## Summary

Skill commands can fail to resolve projects created by current Foundry provisioning because the active azd environment is checked only for the legacy `AZURE_AI_PROJECT_ENDPOINT` key.

## Changes

- **Endpoint resolution**: prefer active and process `FOUNDRY_PROJECT_ENDPOINT`, while retaining `AZURE_AI_PROJECT_ENDPOINT` as a compatibility fallback.
- **Documentation and tests**: document the canonical-first cascade and cover precedence plus legacy-only environments.

## Breaking Changes

- `FOUNDRY_PROJECT_ENDPOINT` now takes precedence over `AZURE_AI_PROJECT_ENDPOINT`; environments that set both may resolve a different project. The legacy fallback remains for now and is planned for removal before GA.

## Manual Validation

- Built and installed the updated `azure.ai.skills` extension, cleared `AZURE_AI_PROJECT_ENDPOINT` in an existing azd environment, and confirmed `azd ai skill list --output json` resolved the project using only active `FOUNDRY_PROJECT_ENDPOINT`.
