### PR TITLE
fix(ai-agents): defer endpoint authorization defaults to service

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/update_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/update_test.go
@@ -59,13 +59,12 @@ func TestEndpointUpdateResolvesActivitySettingsFromServiceRef(t *testing.T) {
 	require.Equal(t, project.ActivityUseCaseDigitalWorker, profile.UseCase)
 }
 
-func TestEnsureEndpointAuthSchemeForProfile_DigitalWorker(t *testing.T) {
+func TestEnsureEndpointAuthSchemeForProfile_DigitalWorkerPreservesExplicitRbac(t *testing.T) {
 	endpoint := &agent_api.AgentEndpoint{
 		Protocols: []agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolResponses},
 		AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
 			{Type: agent_api.AgentEndpointAuthSchemeEntra},
 			{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
-			{Type: agent_api.AgentEndpointAuthSchemeBotService},
 		},
 	}
 
@@ -77,11 +76,11 @@ func TestEnsureEndpointAuthSchemeForProfile_DigitalWorker(t *testing.T) {
 	require.Contains(t, endpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
 	assert.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
 		{Type: agent_api.AgentEndpointAuthSchemeEntra},
-		{Type: agent_api.AgentEndpointAuthSchemeBotServiceTenant},
+		{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
 	}, endpoint.AuthorizationSchemes)
 }
 
-func TestEnsureEndpointAuthSchemeForProfile_Simple(t *testing.T) {
+func TestEnsureEndpointAuthSchemeForProfile_SimplePreservesExplicitTenant(t *testing.T) {
 	endpoint := &agent_api.AgentEndpoint{
 		Protocols: []agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolResponses},
 		AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
@@ -98,6 +97,19 @@ func TestEnsureEndpointAuthSchemeForProfile_Simple(t *testing.T) {
 	require.Contains(t, endpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
 	assert.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
 		{Type: agent_api.AgentEndpointAuthSchemeEntra},
+		{Type: agent_api.AgentEndpointAuthSchemeBotServiceTenant},
+	}, endpoint.AuthorizationSchemes)
+}
+
+func TestEnsureEndpointAuthSchemeForProfile_DefaultsToRbacWhenOmitted(t *testing.T) {
+	endpoint := &agent_api.AgentEndpoint{}
+
+	project.EnsureActivityEndpointAuthSchemeForProfile(endpoint, project.ActivityProfile{
+		IsActivity: true,
+		UseCase:    project.ActivityUseCaseDigitalWorker,
+	})
+
+	assert.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
 		{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
 	}, endpoint.AuthorizationSchemes)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/update_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/update_test.go
@@ -113,7 +113,7 @@ func TestEnsureEndpointAuthSchemeForProfile_DigitalWorkerUsesServiceDefaultWhenO
 	assert.Empty(t, endpoint.AuthorizationSchemes)
 }
 
-func TestEnsureEndpointAuthSchemeForProfile_SimpleDefaultsToRbacWhenOmitted(t *testing.T) {
+func TestEnsureEndpointAuthSchemeForProfile_SimpleUsesServiceDefaultWhenOmitted(t *testing.T) {
 	endpoint := &agent_api.AgentEndpoint{}
 
 	project.EnsureActivityEndpointAuthSchemeForProfile(endpoint, project.ActivityProfile{
@@ -121,9 +121,8 @@ func TestEnsureEndpointAuthSchemeForProfile_SimpleDefaultsToRbacWhenOmitted(t *t
 		UseCase:    project.ActivityUseCaseSimple,
 	})
 
-	assert.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
-		{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
-	}, endpoint.AuthorizationSchemes)
+	assert.Contains(t, endpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
+	assert.Empty(t, endpoint.AuthorizationSchemes)
 }
 
 func TestEnsureEndpointAuthSchemeForProfile_NonActivityNoop(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/update_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/update_test.go
@@ -101,12 +101,24 @@ func TestEnsureEndpointAuthSchemeForProfile_SimplePreservesExplicitTenant(t *tes
 	}, endpoint.AuthorizationSchemes)
 }
 
-func TestEnsureEndpointAuthSchemeForProfile_DefaultsToRbacWhenOmitted(t *testing.T) {
+func TestEnsureEndpointAuthSchemeForProfile_DigitalWorkerUsesServiceDefaultWhenOmitted(t *testing.T) {
 	endpoint := &agent_api.AgentEndpoint{}
 
 	project.EnsureActivityEndpointAuthSchemeForProfile(endpoint, project.ActivityProfile{
 		IsActivity: true,
 		UseCase:    project.ActivityUseCaseDigitalWorker,
+	})
+
+	assert.Contains(t, endpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
+	assert.Empty(t, endpoint.AuthorizationSchemes)
+}
+
+func TestEnsureEndpointAuthSchemeForProfile_SimpleDefaultsToRbacWhenOmitted(t *testing.T) {
+	endpoint := &agent_api.AgentEndpoint{}
+
+	project.EnsureActivityEndpointAuthSchemeForProfile(endpoint, project.ActivityProfile{
+		IsActivity: true,
+		UseCase:    project.ActivityUseCaseSimple,
 	})
 
 	assert.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
@@ -74,19 +74,19 @@ func digitalWorkerTypeMismatchSuggestion() string {
 		"activity.digitalWorkerType"
 }
 
-// serviceDefaultsActivityAuthorizationScheme records whether the Agents service
-// applies BotServiceRbac when an Activity endpoint omits authorization schemes.
-// Keep this false until that service behavior is available for both simple
-// Activity agents and Digital Workers.
-const serviceDefaultsActivityAuthorizationScheme = false
-
 // EnsureActivityEndpointAuthSchemeForProfile preserves explicitly authored
-// authorization schemes and applies the Activity default only when none was supplied.
+// authorization schemes. Simple Activity agents receive BotServiceRbac when no
+// scheme is supplied, while Digital Workers rely on the service default.
 func EnsureActivityEndpointAuthSchemeForProfile(
 	endpoint *agent_api.AgentEndpoint,
 	profile ActivityProfile,
 ) {
 	if endpoint == nil || !profile.IsActivity {
+		return
+	}
+
+	ensureActivityEndpointProtocol(endpoint)
+	if profile.UseCase == ActivityUseCaseDigitalWorker {
 		return
 	}
 
@@ -99,15 +99,19 @@ func EnsureActivityEndpointAuthScheme(
 	endpoint *agent_api.AgentEndpoint,
 	schemeType agent_api.AgentEndpointAuthorizationSchemeType,
 ) {
-	if !slices.Contains(endpoint.Protocols, agent_api.AgentEndpointProtocolActivity) {
-		endpoint.Protocols = append(endpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
-	}
+	ensureActivityEndpointProtocol(endpoint)
 
-	if len(endpoint.AuthorizationSchemes) == 0 && !serviceDefaultsActivityAuthorizationScheme {
+	if len(endpoint.AuthorizationSchemes) == 0 {
 		endpoint.AuthorizationSchemes = append(
 			endpoint.AuthorizationSchemes,
 			agent_api.AgentEndpointAuthorizationScheme{Type: schemeType},
 		)
+	}
+}
+
+func ensureActivityEndpointProtocol(endpoint *agent_api.AgentEndpoint) {
+	if !slices.Contains(endpoint.Protocols, agent_api.AgentEndpointProtocolActivity) {
+		endpoint.Protocols = append(endpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
 	}
 }
 
@@ -252,9 +256,10 @@ func ValidateDigitalWorkerAccessBoundaries(boundaries []string) error {
 // endpoint carries a list of protocols and a list of authorization schemes. This
 // helper therefore advertises every selected protocol on the endpoint,
 // normalizing the legacy "activity_protocol" spelling to the canonical
-// "activity", and applies BotServiceRbac only when authorization schemes are
-// omitted and the service does not yet supply that default. No-op inputs (nil
-// existing endpoint) start fresh.
+// "activity", and applies BotServiceRbac when authorization schemes are omitted.
+// This init-time helper produces the Simple Activity shape; deploy-time Digital
+// Worker defaults are handled separately. No-op inputs (nil existing endpoint)
+// start fresh.
 func ComposeActivityAgentEndpoint(
 	existing *agent_yaml.AgentEndpoint,
 	protocols []agent_yaml.ProtocolVersionRecord,
@@ -286,7 +291,7 @@ func ComposeActivityAgentEndpoint(
 		seen[name] = true
 	}
 
-	if len(ep.AuthorizationSchemes) == 0 && !serviceDefaultsActivityAuthorizationScheme {
+	if len(ep.AuthorizationSchemes) == 0 {
 		ep.AuthorizationSchemes = append(ep.AuthorizationSchemes, agent_yaml.AuthorizationScheme{
 			Type: string(agent_api.AgentEndpointAuthSchemeBotServiceRbac),
 		})

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
@@ -75,8 +75,8 @@ func digitalWorkerTypeMismatchSuggestion() string {
 }
 
 // EnsureActivityEndpointAuthSchemeForProfile preserves explicitly authored
-// authorization schemes. Simple Activity agents receive BotServiceRbac when no
-// scheme is supplied, while Digital Workers rely on the service default.
+// authorization schemes and ensures an existing Activity endpoint advertises
+// the Activity protocol. The service owns defaults when schemes are omitted.
 func EnsureActivityEndpointAuthSchemeForProfile(
 	endpoint *agent_api.AgentEndpoint,
 	profile ActivityProfile,
@@ -86,27 +86,6 @@ func EnsureActivityEndpointAuthSchemeForProfile(
 	}
 
 	ensureActivityEndpointProtocol(endpoint)
-	if profile.UseCase == ActivityUseCaseDigitalWorker {
-		return
-	}
-
-	EnsureActivityEndpointAuthScheme(endpoint, agent_api.AgentEndpointAuthSchemeBotServiceRbac)
-}
-
-// EnsureActivityEndpointAuthScheme ensures the Activity protocol is advertised and
-// applies the supplied default authorization scheme only when the endpoint omits all schemes.
-func EnsureActivityEndpointAuthScheme(
-	endpoint *agent_api.AgentEndpoint,
-	schemeType agent_api.AgentEndpointAuthorizationSchemeType,
-) {
-	ensureActivityEndpointProtocol(endpoint)
-
-	if len(endpoint.AuthorizationSchemes) == 0 {
-		endpoint.AuthorizationSchemes = append(
-			endpoint.AuthorizationSchemes,
-			agent_api.AgentEndpointAuthorizationScheme{Type: schemeType},
-		)
-	}
 }
 
 func ensureActivityEndpointProtocol(endpoint *agent_api.AgentEndpoint) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile.go
@@ -74,8 +74,14 @@ func digitalWorkerTypeMismatchSuggestion() string {
 		"activity.digitalWorkerType"
 }
 
-// EnsureActivityEndpointAuthSchemeForProfile aligns an Activity endpoint's BotService
-// authorization scheme with the resolved Activity use case.
+// serviceDefaultsActivityAuthorizationScheme records whether the Agents service
+// applies BotServiceRbac when an Activity endpoint omits authorization schemes.
+// Keep this false until that service behavior is available for both simple
+// Activity agents and Digital Workers.
+const serviceDefaultsActivityAuthorizationScheme = false
+
+// EnsureActivityEndpointAuthSchemeForProfile preserves explicitly authored
+// authorization schemes and applies the Activity default only when none was supplied.
 func EnsureActivityEndpointAuthSchemeForProfile(
 	endpoint *agent_api.AgentEndpoint,
 	profile ActivityProfile,
@@ -84,16 +90,11 @@ func EnsureActivityEndpointAuthSchemeForProfile(
 		return
 	}
 
-	if profile.UseCase == ActivityUseCaseDigitalWorker {
-		EnsureActivityEndpointAuthScheme(endpoint, agent_api.AgentEndpointAuthSchemeBotServiceTenant)
-		return
-	}
-
 	EnsureActivityEndpointAuthScheme(endpoint, agent_api.AgentEndpointAuthSchemeBotServiceRbac)
 }
 
-// EnsureActivityEndpointAuthScheme ensures the Activity protocol is advertised
-// and keeps exactly one BotService-family authorization scheme on the endpoint.
+// EnsureActivityEndpointAuthScheme ensures the Activity protocol is advertised and
+// applies the supplied default authorization scheme only when the endpoint omits all schemes.
 func EnsureActivityEndpointAuthScheme(
 	endpoint *agent_api.AgentEndpoint,
 	schemeType agent_api.AgentEndpointAuthorizationSchemeType,
@@ -102,30 +103,12 @@ func EnsureActivityEndpointAuthScheme(
 		endpoint.Protocols = append(endpoint.Protocols, agent_api.AgentEndpointProtocolActivity)
 	}
 
-	schemes := endpoint.AuthorizationSchemes[:0]
-	hasTarget := false
-	for _, scheme := range endpoint.AuthorizationSchemes {
-		if scheme.Type == agent_api.AgentEndpointAuthSchemeBotService ||
-			scheme.Type == agent_api.AgentEndpointAuthSchemeBotServiceRbac ||
-			scheme.Type == agent_api.AgentEndpointAuthSchemeBotServiceTenant {
-			if scheme.Type == schemeType && !hasTarget {
-				schemes = append(schemes, scheme)
-				hasTarget = true
-			}
-			continue
-		}
-
-		if scheme.Type == schemeType {
-			hasTarget = true
-		}
-		schemes = append(schemes, scheme)
+	if len(endpoint.AuthorizationSchemes) == 0 && !serviceDefaultsActivityAuthorizationScheme {
+		endpoint.AuthorizationSchemes = append(
+			endpoint.AuthorizationSchemes,
+			agent_api.AgentEndpointAuthorizationScheme{Type: schemeType},
+		)
 	}
-
-	if !hasTarget {
-		schemes = append(schemes, agent_api.AgentEndpointAuthorizationScheme{Type: schemeType})
-	}
-
-	endpoint.AuthorizationSchemes = schemes
 }
 
 // IsActivityProtocol reports whether a hosted agent definition opts into the
@@ -267,12 +250,11 @@ func ValidateDigitalWorkerAccessBoundaries(boundaries []string) error {
 // (responses/invocations/...). Activity is not exclusive: the platform models
 // every protocol as a sibling per-protocol entry on the same endpoint, and the
 // endpoint carries a list of protocols and a list of authorization schemes. This
-// helper therefore (1) advertises every selected protocol on the endpoint,
+// helper therefore advertises every selected protocol on the endpoint,
 // normalizing the legacy "activity_protocol" spelling to the canonical
-// "activity", and (2) ensures the BotServiceRbac scheme Activity requires is
-// present without dropping any scheme already declared. For a pure-activity
-// agent the result is protocols=["activity"] guarded by BotServiceRbac — the same
-// declaration the manifest path emits. No-op inputs (nil existing endpoint) start fresh.
+// "activity", and applies BotServiceRbac only when authorization schemes are
+// omitted and the service does not yet supply that default. No-op inputs (nil
+// existing endpoint) start fresh.
 func ComposeActivityAgentEndpoint(
 	existing *agent_yaml.AgentEndpoint,
 	protocols []agent_yaml.ProtocolVersionRecord,
@@ -304,15 +286,10 @@ func ComposeActivityAgentEndpoint(
 		seen[name] = true
 	}
 
-	// Ensure the BotServiceRbac scheme Activity requires is present, keeping any
-	// scheme already declared for the other protocols.
-	for _, s := range ep.AuthorizationSchemes {
-		if s.Type == string(agent_api.AgentEndpointAuthSchemeBotServiceRbac) {
-			return ep
-		}
+	if len(ep.AuthorizationSchemes) == 0 && !serviceDefaultsActivityAuthorizationScheme {
+		ep.AuthorizationSchemes = append(ep.AuthorizationSchemes, agent_yaml.AuthorizationScheme{
+			Type: string(agent_api.AgentEndpointAuthSchemeBotServiceRbac),
+		})
 	}
-	ep.AuthorizationSchemes = append(ep.AuthorizationSchemes, agent_yaml.AuthorizationScheme{
-		Type: string(agent_api.AgentEndpointAuthSchemeBotServiceRbac),
-	})
 	return ep
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/activity_profile_test.go
@@ -428,4 +428,20 @@ func TestComposeActivityAgentEndpoint(t *testing.T) {
 		require.Equal(t, "EntraId", ep.AuthorizationSchemes[0].Type)
 		require.Equal(t, "BotServiceRbac", ep.AuthorizationSchemes[1].Type)
 	})
+
+	t.Run("explicit scheme without rbac is preserved", func(t *testing.T) {
+		existing := &agent_yaml.AgentEndpoint{
+			AuthorizationSchemes: []agent_yaml.AuthorizationScheme{
+				{Type: "BotServiceTenant"},
+			},
+		}
+
+		ep := ComposeActivityAgentEndpoint(existing, []agent_yaml.ProtocolVersionRecord{
+			{Protocol: "activity", Version: "2.0.0"},
+		})
+
+		require.Equal(t, []agent_yaml.AuthorizationScheme{
+			{Type: "BotServiceTenant"},
+		}, ep.AuthorizationSchemes)
+	})
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy.go
@@ -258,6 +258,11 @@ func DeployPreparedStandaloneHostedAgent(
 			return nil, err
 		}
 	}
+	if getErr != nil {
+		if err := reconcileStandaloneEndpointWithDeployedAgent(request, localProfile, agentObject); err != nil {
+			return nil, err
+		}
+	}
 	if err := provider.patchAgentEndpointFields(
 		ctx,
 		prepared.definition.Name,
@@ -303,7 +308,9 @@ func reconcileStandaloneEndpointWithDeployedAgent(
 		)
 	}
 
-	if resolvedProfile.IsActivity && request.AgentEndpoint == nil {
+	if resolvedProfile.IsActivity &&
+		resolvedProfile.UseCase != ActivityUseCaseDigitalWorker &&
+		request.AgentEndpoint == nil {
 		request.AgentEndpoint = &agent_api.AgentEndpoint{}
 	}
 	EnsureActivityEndpointAuthSchemeForProfile(request.AgentEndpoint, resolvedProfile)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy.go
@@ -308,11 +308,6 @@ func reconcileStandaloneEndpointWithDeployedAgent(
 		)
 	}
 
-	if resolvedProfile.IsActivity &&
-		resolvedProfile.UseCase != ActivityUseCaseDigitalWorker &&
-		request.AgentEndpoint == nil {
-		request.AgentEndpoint = &agent_api.AgentEndpoint{}
-	}
 	EnsureActivityEndpointAuthSchemeForProfile(request.AgentEndpoint, resolvedProfile)
 	return nil
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy_test.go
@@ -118,13 +118,28 @@ func TestReconcileStandaloneEndpointWithDeployedDigitalWorker(t *testing.T) {
 	}, request.AgentEndpoint.AuthorizationSchemes)
 }
 
-func TestReconcileStandaloneEndpointCreatesEndpointForDeployedDigitalWorker(t *testing.T) {
+func TestReconcileStandaloneEndpointUsesServiceDefaultForDeployedDigitalWorker(t *testing.T) {
 	t.Parallel()
 
 	request := &agent_api.CreateAgentRequest{}
 	existingAgent := &agent_api.AgentObject{DigitalWorkerType: agent_api.DigitalWorkerTypeM365}
 
 	err := reconcileStandaloneEndpointWithDeployedAgent(request, ActivityProfile{}, existingAgent)
+
+	require.NoError(t, err)
+	require.Nil(t, request.AgentEndpoint)
+}
+
+func TestReconcileStandaloneEndpointCreatesEndpointForSimpleActivity(t *testing.T) {
+	t.Parallel()
+
+	request := &agent_api.CreateAgentRequest{}
+	existingAgent := &agent_api.AgentObject{}
+
+	err := reconcileStandaloneEndpointWithDeployedAgent(request, ActivityProfile{
+		IsActivity: true,
+		UseCase:    ActivityUseCaseSimple,
+	}, existingAgent)
 
 	require.NoError(t, err)
 	require.NotNil(t, request.AgentEndpoint)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy_test.go
@@ -114,7 +114,7 @@ func TestReconcileStandaloneEndpointWithDeployedDigitalWorker(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
-		{Type: agent_api.AgentEndpointAuthSchemeBotServiceTenant},
+		{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
 	}, request.AgentEndpoint.AuthorizationSchemes)
 }
 
@@ -132,7 +132,7 @@ func TestReconcileStandaloneEndpointCreatesEndpointForDeployedDigitalWorker(t *t
 		agent_api.AgentEndpointProtocolActivity,
 	}, request.AgentEndpoint.Protocols)
 	require.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
-		{Type: agent_api.AgentEndpointAuthSchemeBotServiceTenant},
+		{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
 	}, request.AgentEndpoint.AuthorizationSchemes)
 }
 
@@ -158,6 +158,5 @@ func TestReconcileStandaloneEndpointPromotesNonActivityDefinitionForDeployedDigi
 	}, request.AgentEndpoint.Protocols)
 	require.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
 		{Type: agent_api.AgentEndpointAuthSchemeEntra},
-		{Type: agent_api.AgentEndpointAuthSchemeBotServiceTenant},
 	}, request.AgentEndpoint.AuthorizationSchemes)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/direct_deploy_test.go
@@ -130,7 +130,7 @@ func TestReconcileStandaloneEndpointUsesServiceDefaultForDeployedDigitalWorker(t
 	require.Nil(t, request.AgentEndpoint)
 }
 
-func TestReconcileStandaloneEndpointCreatesEndpointForSimpleActivity(t *testing.T) {
+func TestReconcileStandaloneEndpointUsesServiceDefaultForSimpleActivity(t *testing.T) {
 	t.Parallel()
 
 	request := &agent_api.CreateAgentRequest{}
@@ -142,13 +142,7 @@ func TestReconcileStandaloneEndpointCreatesEndpointForSimpleActivity(t *testing.
 	}, existingAgent)
 
 	require.NoError(t, err)
-	require.NotNil(t, request.AgentEndpoint)
-	require.Equal(t, []agent_api.AgentEndpointProtocol{
-		agent_api.AgentEndpointProtocolActivity,
-	}, request.AgentEndpoint.Protocols)
-	require.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
-		{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
-	}, request.AgentEndpoint.AuthorizationSchemes)
+	require.Nil(t, request.AgentEndpoint)
 }
 
 func TestReconcileStandaloneEndpointPromotesNonActivityDefinitionForDeployedDigitalWorker(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -2196,7 +2196,7 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 		foundryAgentConfig.Activity.DigitalWorkerType == agent_api.DigitalWorkerTypeM365 {
 		request.DigitalWorkerType = agent_api.DigitalWorkerTypeM365
 	}
-	activityProfile, err := ResolveActivityProfileForDeploy(agentDef, foundryAgentConfig.Activity)
+	_, err = ResolveActivityProfileForDeploy(agentDef, foundryAgentConfig.Activity)
 	if err != nil {
 		return nil, exterrors.Validation(
 			exterrors.CodeInvalidAgentRequest,
@@ -2204,7 +2204,6 @@ func (p *AgentServiceTargetProvider) prepareDeploy(
 			"check the activity configuration in azure.yaml",
 		)
 	}
-	ensureActivityEndpointAuthSchemeForProfile(request, activityProfile)
 
 	// Default to "responses" protocol when none specified in agent.yaml.
 	protocols := agentDef.Protocols
@@ -2229,6 +2228,9 @@ func ensureActivityEndpointAuthSchemeForProfile(
 		return
 	}
 	if request.AgentEndpoint == nil {
+		if profile.UseCase == ActivityUseCaseDigitalWorker {
+			return
+		}
 		request.AgentEndpoint = &agent_api.AgentEndpoint{}
 	}
 	EnsureActivityEndpointAuthSchemeForProfile(request.AgentEndpoint, profile)

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent.go
@@ -2228,10 +2228,7 @@ func ensureActivityEndpointAuthSchemeForProfile(
 		return
 	}
 	if request.AgentEndpoint == nil {
-		if profile.UseCase == ActivityUseCaseDigitalWorker {
-			return
-		}
-		request.AgentEndpoint = &agent_api.AgentEndpoint{}
+		return
 	}
 	EnsureActivityEndpointAuthSchemeForProfile(request.AgentEndpoint, profile)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -1984,11 +1984,7 @@ func TestPrepareDeploySetsDigitalWorkerType(t *testing.T) {
 		prep.request.AgentEndpoint.Protocols,
 	)
 	require.Len(t, prep.request.AgentEndpoint.AuthorizationSchemes, 1)
-	require.Equal(
-		t,
-		agent_api.AgentEndpointAuthSchemeBotServiceTenant,
-		prep.request.AgentEndpoint.AuthorizationSchemes[0].Type,
-	)
+	require.Equal(t, agent_api.AgentEndpointAuthSchemeBotServiceRbac, prep.request.AgentEndpoint.AuthorizationSchemes[0].Type)
 }
 
 func TestPrepareDeployUsesRbacForSimpleActivityEndpoint(t *testing.T) {
@@ -2029,7 +2025,7 @@ func TestPrepareDeployUsesRbacForSimpleActivityEndpoint(t *testing.T) {
 	)
 }
 
-func TestEnsureActivityEndpointAuthSchemeForPromotedDigitalWorker(t *testing.T) {
+func TestEnsureActivityEndpointAuthSchemeForPromotedDigitalWorkerPreservesExplicitScheme(t *testing.T) {
 	t.Parallel()
 
 	request := &agent_api.CreateAgentRequest{
@@ -2049,30 +2045,18 @@ func TestEnsureActivityEndpointAuthSchemeForPromotedDigitalWorker(t *testing.T) 
 
 	require.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
 		{Type: agent_api.AgentEndpointAuthSchemeEntra},
-		{Type: agent_api.AgentEndpointAuthSchemeBotServiceTenant},
+		{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
 	}, request.AgentEndpoint.AuthorizationSchemes)
 }
 
-func TestEnsureActivityEndpointAuthSchemeReplacesLegacyBotService(t *testing.T) {
+func TestEnsureActivityEndpointAuthSchemePreservesExplicitLegacyBotService(t *testing.T) {
 	t.Parallel()
 
-	for _, test := range []struct {
-		name    string
-		useCase ActivityUseCase
-		want    agent_api.AgentEndpointAuthorizationSchemeType
-	}{
-		{
-			name:    "digital worker",
-			useCase: ActivityUseCaseDigitalWorker,
-			want:    agent_api.AgentEndpointAuthSchemeBotServiceTenant,
-		},
-		{
-			name:    "simple activity",
-			useCase: ActivityUseCaseSimple,
-			want:    agent_api.AgentEndpointAuthSchemeBotServiceRbac,
-		},
+	for _, useCase := range []ActivityUseCase{
+		ActivityUseCaseDigitalWorker,
+		ActivityUseCaseSimple,
 	} {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(string(useCase), func(t *testing.T) {
 			request := &agent_api.CreateAgentRequest{
 				AgentEndpoint: &agent_api.AgentEndpoint{
 					AuthorizationSchemes: []agent_api.AgentEndpointAuthorizationScheme{
@@ -2084,12 +2068,12 @@ func TestEnsureActivityEndpointAuthSchemeReplacesLegacyBotService(t *testing.T) 
 
 			ensureActivityEndpointAuthSchemeForProfile(request, ActivityProfile{
 				IsActivity: true,
-				UseCase:    test.useCase,
+				UseCase:    useCase,
 			})
 
 			require.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
 				{Type: agent_api.AgentEndpointAuthSchemeEntra},
-				{Type: test.want},
+				{Type: agent_api.AgentEndpointAuthSchemeBotService},
 			}, request.AgentEndpoint.AuthorizationSchemes)
 		})
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -2018,7 +2018,7 @@ func TestPrepareDeployLeavesOmittedDigitalWorkerEndpointNil(t *testing.T) {
 	require.Nil(t, prep.request.AgentCard)
 }
 
-func TestPrepareDeployDefersRbacForSimpleActivityEndpointUntilProfileIsResolved(t *testing.T) {
+func TestPrepareDeployPreservesOmittedSimpleActivityAuthorizationSchemes(t *testing.T) {
 	t.Parallel()
 
 	agentDef := sampleContainerAgent()
@@ -2109,7 +2109,7 @@ func TestEnsureActivityEndpointAuthSchemeForDigitalWorkerPreservesEndpointWithou
 	require.Empty(t, request.AgentEndpoint.AuthorizationSchemes)
 }
 
-func TestEnsureActivityEndpointAuthSchemeForSimpleActivityCreatesRbacEndpoint(t *testing.T) {
+func TestEnsureActivityEndpointAuthSchemeForSimpleActivityUsesServiceDefault(t *testing.T) {
 	t.Parallel()
 
 	request := &agent_api.CreateAgentRequest{}
@@ -2119,13 +2119,7 @@ func TestEnsureActivityEndpointAuthSchemeForSimpleActivityCreatesRbacEndpoint(t 
 		UseCase:    ActivityUseCaseSimple,
 	})
 
-	require.NotNil(t, request.AgentEndpoint)
-	require.Equal(t, []agent_api.AgentEndpointProtocol{
-		agent_api.AgentEndpointProtocolActivity,
-	}, request.AgentEndpoint.Protocols)
-	require.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
-		{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
-	}, request.AgentEndpoint.AuthorizationSchemes)
+	require.Nil(t, request.AgentEndpoint)
 }
 
 func TestEnsureActivityEndpointAuthSchemePreservesExplicitLegacyBotService(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/project/service_target_agent_test.go
@@ -1987,7 +1987,38 @@ func TestPrepareDeploySetsDigitalWorkerType(t *testing.T) {
 	require.Equal(t, agent_api.AgentEndpointAuthSchemeBotServiceRbac, prep.request.AgentEndpoint.AuthorizationSchemes[0].Type)
 }
 
-func TestPrepareDeployUsesRbacForSimpleActivityEndpoint(t *testing.T) {
+func TestPrepareDeployLeavesOmittedDigitalWorkerEndpointNil(t *testing.T) {
+	t.Parallel()
+
+	agentDef := sampleContainerAgent()
+	agentDef.Protocols = []agent_yaml.ProtocolVersionRecord{{Protocol: "activity", Version: "2.0.0"}}
+	agentDef.AgentEndpoint = nil
+	agentDef.AgentCard = nil
+	props, err := AgentDefinitionToServiceProperties(agentDef, &ServiceTargetAgentConfig{
+		Activity: &ActivitySettings{DigitalWorkerType: agent_api.DigitalWorkerTypeM365},
+	})
+	require.NoError(t, err)
+	svc := &azdext.ServiceConfig{
+		Name:                 "digital-worker",
+		AdditionalProperties: props,
+	}
+
+	prep, err := (&AgentServiceTargetProvider{}).prepareDeploy(
+		svc,
+		agentDef,
+		map[string]string{"FOUNDRY_PROJECT_ENDPOINT": "https://example"},
+		[]agent_yaml.AgentBuildOption{
+			agent_yaml.WithImageURL("registry.example/worker:v1"),
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, agent_api.DigitalWorkerTypeM365, prep.request.DigitalWorkerType)
+	require.Nil(t, prep.request.AgentEndpoint)
+	require.Nil(t, prep.request.AgentCard)
+}
+
+func TestPrepareDeployDefersRbacForSimpleActivityEndpointUntilProfileIsResolved(t *testing.T) {
 	t.Parallel()
 
 	agentDef := sampleContainerAgent()
@@ -2017,12 +2048,7 @@ func TestPrepareDeployUsesRbacForSimpleActivityEndpoint(t *testing.T) {
 		[]agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolActivity},
 		prep.request.AgentEndpoint.Protocols,
 	)
-	require.Len(t, prep.request.AgentEndpoint.AuthorizationSchemes, 1)
-	require.Equal(
-		t,
-		agent_api.AgentEndpointAuthSchemeBotServiceRbac,
-		prep.request.AgentEndpoint.AuthorizationSchemes[0].Type,
-	)
+	require.Empty(t, prep.request.AgentEndpoint.AuthorizationSchemes)
 }
 
 func TestEnsureActivityEndpointAuthSchemeForPromotedDigitalWorkerPreservesExplicitScheme(t *testing.T) {
@@ -2045,6 +2071,59 @@ func TestEnsureActivityEndpointAuthSchemeForPromotedDigitalWorkerPreservesExplic
 
 	require.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
 		{Type: agent_api.AgentEndpointAuthSchemeEntra},
+		{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
+	}, request.AgentEndpoint.AuthorizationSchemes)
+}
+
+func TestEnsureActivityEndpointAuthSchemeForDigitalWorkerUsesServiceDefault(t *testing.T) {
+	t.Parallel()
+
+	request := &agent_api.CreateAgentRequest{}
+
+	ensureActivityEndpointAuthSchemeForProfile(request, ActivityProfile{
+		IsActivity: true,
+		UseCase:    ActivityUseCaseDigitalWorker,
+	})
+
+	require.Nil(t, request.AgentEndpoint)
+}
+
+func TestEnsureActivityEndpointAuthSchemeForDigitalWorkerPreservesEndpointWithoutAddingScheme(t *testing.T) {
+	t.Parallel()
+
+	request := &agent_api.CreateAgentRequest{
+		AgentEndpoint: &agent_api.AgentEndpoint{
+			Protocols: []agent_api.AgentEndpointProtocol{agent_api.AgentEndpointProtocolResponses},
+		},
+	}
+
+	ensureActivityEndpointAuthSchemeForProfile(request, ActivityProfile{
+		IsActivity: true,
+		UseCase:    ActivityUseCaseDigitalWorker,
+	})
+
+	require.Equal(t, []agent_api.AgentEndpointProtocol{
+		agent_api.AgentEndpointProtocolResponses,
+		agent_api.AgentEndpointProtocolActivity,
+	}, request.AgentEndpoint.Protocols)
+	require.Empty(t, request.AgentEndpoint.AuthorizationSchemes)
+}
+
+func TestEnsureActivityEndpointAuthSchemeForSimpleActivityCreatesRbacEndpoint(t *testing.T) {
+	t.Parallel()
+
+	request := &agent_api.CreateAgentRequest{}
+
+	ensureActivityEndpointAuthSchemeForProfile(request, ActivityProfile{
+		IsActivity: true,
+		UseCase:    ActivityUseCaseSimple,
+	})
+
+	require.NotNil(t, request.AgentEndpoint)
+	require.Equal(t, []agent_api.AgentEndpointProtocol{
+		agent_api.AgentEndpointProtocolActivity,
+	}, request.AgentEndpoint.Protocols)
+	require.Equal(t, []agent_api.AgentEndpointAuthorizationScheme{
 		{Type: agent_api.AgentEndpointAuthSchemeBotServiceRbac},
 	}, request.AgentEndpoint.AuthorizationSchemes)
 }


### PR DESCRIPTION
## Summary

- stop deploy and endpoint-update normalization from creating an `agentEndpoint` or injecting `agentEndpoint.authorizationSchemes` when they are omitted from `azure.yaml`, for both Simple Activity agents and Digital Workers
- defer omitted authorization defaults to the Agents service
- preserve explicitly configured authorization schemes and other endpoint/card fields
- continue adding the Activity protocol only when reconciling an existing Activity endpoint
- add regression coverage for omitted configuration and explicit non-RBAC schemes

This change is scoped to deploy/update behavior; it does not change init-time configuration authoring.

Fixes #9847

## Validation

- `go test ./internal/project/... ./internal/cmd/...`
- `go test ./...`
- `git diff --check`
- `azd x build` (built and installed locally)