### PR TITLE
refactor: support telemetry for ai agent related extensions

### DIFF
--- a/cli/azd/docs/extensions/extension-sdk-reference.md
+++ b/cli/azd/docs/extensions/extension-sdk-reference.md
@@ -581,6 +581,34 @@ behavior. Report an event immediately after the fact it represents is known,
 rather than waiting until the command completes, so a later unrelated failure
 does not lose the signal.
 
+#### Foundry telemetry reporter
+
+Microsoft Foundry extensions should use the shared reporter from
+`pkg/foundry/telemetry` instead of repeating generated-client error handling in
+each independently released extension:
+
+```go
+import "github.com/azure/azure-dev/cli/azd/pkg/foundry/telemetry"
+
+reporter := telemetry.NewReporter(client.Telemetry(), nil)
+reporter.Report(ctx, telemetry.Event{
+    Name: "deploy.completed",
+    Attributes: map[string]string{
+        "deploy.mode": "container",
+    },
+})
+```
+
+The reporter applies a one-second timeout, never retries, and never returns an
+error to product code. Rejected reports, unavailable hosts, and transport
+failures cannot change command behavior. Debug diagnostics contain only the
+event name and gRPC status code, never attribute values or raw transport error
+details.
+
+The shared reporter owns transport behavior only. Event names, attribute keys,
+and bounded values remain owned and reviewed by each Foundry extension. Use
+`telemetry.Options` to provide a shorter timeout or an `azdext.Logger` in tests.
+
 ### ConfigHelper
 
 ```go

--- a/cli/azd/docs/extensions/extension-telemetry.md
+++ b/cli/azd/docs/extensions/extension-telemetry.md
@@ -63,6 +63,32 @@ identity fields — a key of `extension.id` is recorded as `ext.extension.id`.
 
 ## Reporting an event
 
+Microsoft Foundry extensions should use the shared reporter in
+`pkg/foundry/telemetry` instead of calling the generated gRPC client directly:
+
+```go
+import "github.com/azure/azure-dev/cli/azd/pkg/foundry/telemetry"
+
+reporter := telemetry.NewReporter(client.Telemetry(), nil)
+reporter.Report(ctx, telemetry.Event{
+  Name: "deploy.completed",
+  Attributes: map[string]string{
+    "deploy.mode": "container",
+    "retries":     "2",
+  },
+})
+```
+
+`Report` is best effort and has no return value. It applies a one-second
+timeout, does not retry, treats `Accepted: false` as a normal result, and writes
+only the event name and gRPC status code to the debug log when reporting fails.
+It never logs attribute values or raw transport error details. Each Foundry
+extension should keep its approved event builders and bounded value types in
+the extension that owns those product semantics.
+
+Other extension families can call the generated client directly until they
+have an appropriate shared package:
+
 ```go
 if _, err := client.Telemetry().ReportUsage(
     ctx,

--- a/cli/azd/pkg/foundry/telemetry/reporter.go
+++ b/cli/azd/pkg/foundry/telemetry/reporter.go
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Package telemetry reports best-effort usage events from Microsoft Foundry extensions.
+package telemetry
+
+import (
+	"context"
+	"maps"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+)
+
+const defaultReportTimeout = time.Second
+
+// Event is an extension-owned usage event.
+type Event struct {
+	Name       string
+	Attributes map[string]string
+}
+
+// Reporter records usage events without affecting the caller's command result.
+type Reporter interface {
+	Report(ctx context.Context, event Event)
+}
+
+// Client is the telemetry RPC used by Reporter.
+type Client interface {
+	ReportUsage(
+		ctx context.Context,
+		request *azdext.ReportUsageRequest,
+		options ...grpc.CallOption,
+	) (*azdext.ReportUsageResponse, error)
+}
+
+// Options configures a Reporter.
+type Options struct {
+	Timeout time.Duration
+	Logger  *azdext.Logger
+}
+
+type reporter struct {
+	client  Client
+	timeout time.Duration
+	logger  *azdext.Logger
+}
+
+// NewReporter creates a best-effort usage reporter backed by the azd host.
+func NewReporter(client Client, options *Options) Reporter {
+	timeout := defaultReportTimeout
+	logger := azdext.NewLogger("foundry.telemetry")
+	if options != nil {
+		if options.Timeout > 0 {
+			timeout = options.Timeout
+		}
+		if options.Logger != nil {
+			logger = options.Logger
+		}
+	}
+
+	return &reporter{client: client, timeout: timeout, logger: logger}
+}
+
+func (r *reporter) Report(ctx context.Context, event Event) {
+	if r.client == nil {
+		return
+	}
+
+	reportCtx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+
+	response, err := r.client.ReportUsage(reportCtx, &azdext.ReportUsageRequest{
+		EventName:  event.Name,
+		Attributes: maps.Clone(event.Attributes),
+	})
+	if err != nil {
+		r.logger.Debug(
+			"telemetry event was not reported",
+			"event", event.Name,
+			"code", status.Code(err).String(),
+		)
+		return
+	}
+	if response == nil {
+		r.logger.Debug("telemetry event returned an empty response", "event", event.Name)
+	}
+}

--- a/cli/azd/pkg/foundry/telemetry/reporter_test.go
+++ b/cli/azd/pkg/foundry/telemetry/reporter_test.go
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type recordingClient struct {
+	ctx      context.Context
+	request  *azdext.ReportUsageRequest
+	response *azdext.ReportUsageResponse
+	err      error
+	calls    atomic.Int64
+}
+
+func (c *recordingClient) ReportUsage(
+	ctx context.Context,
+	request *azdext.ReportUsageRequest,
+	_ ...grpc.CallOption,
+) (*azdext.ReportUsageResponse, error) {
+	c.ctx = ctx
+	c.request = request
+	c.calls.Add(1)
+	return c.response, c.err
+}
+
+func TestReporterForwardsEvent(t *testing.T) {
+	t.Parallel()
+
+	client := &recordingClient{response: &azdext.ReportUsageResponse{Accepted: true}}
+	reporter := NewReporter(client, nil)
+	attributes := map[string]string{"mode": "declarative"}
+	reporter.Report(t.Context(), Event{Name: "resource.created", Attributes: attributes})
+	attributes["mode"] = "changed"
+
+	require.NotNil(t, client.request)
+	assert.Equal(t, "resource.created", client.request.EventName)
+	assert.Equal(t, map[string]string{"mode": "declarative"}, client.request.Attributes)
+	assert.Equal(t, int64(1), client.calls.Load())
+	_, hasDeadline := client.ctx.Deadline()
+	assert.True(t, hasDeadline)
+}
+
+func TestReporterIsBestEffort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		client   Client
+		wantLogs bool
+	}{
+		{name: "not accepted", client: &recordingClient{response: &azdext.ReportUsageResponse{}}},
+		{name: "empty response", client: &recordingClient{}, wantLogs: true},
+		{name: "RPC error", client: &recordingClient{err: errors.New("secret transport detail")}, wantLogs: true},
+		{name: "no client"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logs bytes.Buffer
+			reporter := NewReporter(test.client, &Options{Logger: azdext.NewLogger(
+				"test",
+				azdext.LoggerOptions{Debug: true, Writer: &logs},
+			)})
+			reporter.Report(t.Context(), Event{
+				Name:       "resource.created",
+				Attributes: map[string]string{"credential": "customer-secret"},
+			})
+
+			assert.Equal(t, test.wantLogs, logs.Len() > 0)
+			assert.NotContains(t, logs.String(), "customer-secret")
+			assert.NotContains(t, logs.String(), "secret transport detail")
+		})
+	}
+}
+
+func TestReporterHonorsTimeoutWithoutRetry(t *testing.T) {
+	t.Parallel()
+
+	client := &blockingClient{}
+	reporter := NewReporter(client, &Options{Timeout: time.Millisecond})
+	reporter.Report(t.Context(), Event{Name: "resource.created"})
+
+	assert.Equal(t, int64(1), client.calls.Load())
+	assert.ErrorIs(t, client.err, context.DeadlineExceeded)
+}
+
+func TestReporterHonorsCallerCancellation(t *testing.T) {
+	t.Parallel()
+
+	client := &blockingClient{}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	NewReporter(client, nil).Report(ctx, Event{Name: "resource.created"})
+
+	assert.Equal(t, int64(1), client.calls.Load())
+	assert.ErrorIs(t, client.err, context.Canceled)
+}
+
+func TestReporterSupportsConcurrentCalls(t *testing.T) {
+	t.Parallel()
+
+	client := &concurrentClient{}
+	reporter := NewReporter(client, nil)
+	var waitGroup sync.WaitGroup
+	for range 20 {
+		waitGroup.Go(func() {
+			reporter.Report(t.Context(), Event{Name: "resource.created"})
+		})
+	}
+	waitGroup.Wait()
+
+	assert.Equal(t, int64(20), client.calls.Load())
+}
+
+type blockingClient struct {
+	calls atomic.Int64
+	err   error
+}
+
+type concurrentClient struct {
+	calls atomic.Int64
+}
+
+func (c *concurrentClient) ReportUsage(
+	_ context.Context,
+	_ *azdext.ReportUsageRequest,
+	_ ...grpc.CallOption,
+) (*azdext.ReportUsageResponse, error) {
+	c.calls.Add(1)
+	return &azdext.ReportUsageResponse{Accepted: true}, nil
+}
+
+func (c *blockingClient) ReportUsage(
+	ctx context.Context,
+	_ *azdext.ReportUsageRequest,
+	_ ...grpc.CallOption,
+) (*azdext.ReportUsageResponse, error) {
+	c.calls.Add(1)
+	<-ctx.Done()
+	c.err = ctx.Err()
+	return nil, c.err
+}
+
+func TestReporterLogsStatusWithoutSensitiveDetails(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	client := &recordingClient{err: errors.New("secret transport detail")}
+	reporter := NewReporter(client, &Options{Logger: azdext.NewLogger(
+		"test",
+		azdext.LoggerOptions{Debug: true, Writer: &logs},
+	)})
+	reporter.Report(t.Context(), Event{
+		Name:       "resource.created",
+		Attributes: map[string]string{"credential": "customer-secret"},
+	})
+
+	assert.True(t, strings.Contains(logs.String(), "resource.created"))
+	assert.NotContains(t, logs.String(), "customer-secret")
+	assert.NotContains(t, logs.String(), "secret transport detail")
+}


### PR DESCRIPTION
Based on the comment from this PR https://github.com/Azure/azure-dev/pull/9841
Move telemetry related logic in azd/pkg/foundry package