### PR TITLE
Fix concurrent Lazy get and set

### DIFF
--- a/cli/azd/pkg/lazy/lazy.go
+++ b/cli/azd/pkg/lazy/lazy.go
@@ -10,12 +10,11 @@ type InitializerFn[T comparable] func() (T, error)
 // A data structure that will lazily load an instance of the underlying type
 // from the specified initializer
 type Lazy[T comparable] struct {
-	initialized  bool
-	initializer  InitializerFn[T]
-	value        T
-	error        error
-	getValueLock sync.Mutex
-	setValueLock sync.Mutex
+	initialized bool
+	initializer InitializerFn[T]
+	value       T
+	error       error
+	valueLock   sync.RWMutex
 }
 
 // Creates a new Lazy[T]
@@ -33,29 +32,40 @@ func From[T comparable](value T) *Lazy[T] {
 // Gets the value of the configured initializer
 // Initializer will only run once on success
 func (l *Lazy[T]) GetValue() (T, error) {
-	// Only allow a single caller to get a value at one time.
-	// Additional calls will block until current call is complete
-	l.getValueLock.Lock()
-	defer l.getValueLock.Unlock()
+	// if we're initialized, we're just reading the value. Let other readers through.
+	l.valueLock.RLock()
+	initialized, value, err := l.initialized, l.value, l.error
+	l.valueLock.RUnlock()
 
-	if !l.initialized {
-		value, err := l.initializer()
-		if err == nil {
-			l.SetValue(value)
-		} else {
-			l.error = err
-		}
+	if initialized {
+		return value, err
+	}
+
+	// we weren't initialized when we checked. Grab the write lock and check again.
+	// (someone may have initialized us, or called SetValue, while we were waiting)
+	l.valueLock.Lock()
+	defer l.valueLock.Unlock()
+
+	if l.initialized {
+		return l.value, l.error
+	}
+
+	value, err = l.initializer()
+	if err == nil {
+		l.value = value
+		l.error = nil
+		l.initialized = true
+	} else {
+		l.error = err
 	}
 
 	return l.value, l.error
 }
 
-// Sets a value on the lazy type
+// Sets a value on the lazy type. Setting this bypasses the initializer.
 func (l *Lazy[T]) SetValue(value T) {
-	// Only allow a single caller to get a value at one time.
-	// Additional calls will block until current call is complete
-	l.setValueLock.Lock()
-	defer l.setValueLock.Unlock()
+	l.valueLock.Lock()
+	defer l.valueLock.Unlock()
 
 	l.value = value
 	l.error = nil

--- a/cli/azd/pkg/lazy/lazy_test.go
+++ b/cli/azd/pkg/lazy/lazy_test.go
@@ -5,6 +5,7 @@ package lazy
 
 import (
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,6 +29,38 @@ func Test_Lazy_Init(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 	require.True(t, ran)
+}
+
+func Test_Lazy_Init_BypassInitializer(t *testing.T) {
+	initFn := func() (string, error) {
+		require.Fail(t, "THIS SHOULD NEVER BE CALLED")
+		return "", errors.New("NEVER USED")
+	}
+
+	instance := NewLazy(initFn)
+	instance.SetValue("explicitly set!")
+	actualValue, err := instance.GetValue()
+	require.Equal(t, "explicitly set!", actualValue)
+	require.NoError(t, err)
+}
+
+func Test_Lazy_SetValueRecoversFromInitializationError(t *testing.T) {
+	initializerCalls := 0
+	instance := NewLazy(func() (string, error) {
+		initializerCalls++
+		return "", errors.New("FAIL ON PURPOSE")
+	})
+
+	value, err := instance.GetValue()
+	require.EqualError(t, err, "FAIL ON PURPOSE")
+	require.Empty(t, value)
+	require.Equal(t, 1, initializerCalls)
+
+	instance.SetValue("recovered")
+	value, err = instance.GetValue()
+	require.NoError(t, err)
+	require.Equal(t, "recovered", value)
+	require.Equal(t, 1, initializerCalls)
 }
 
 func Test_Lazy_GetValue(t *testing.T) {
@@ -105,6 +138,30 @@ func Test_Lazy_SetValue(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func Test_Lazy_GetValueAndSetValue_Concurrent(t *testing.T) {
+	instance := From(0)
+	start := make(chan struct{})
+	var waitGroup sync.WaitGroup
+
+	for writerValue := 1; writerValue <= 4; writerValue++ {
+		waitGroup.Go(func() {
+			<-start
+			for range 1_000 {
+				instance.SetValue(writerValue)
+			}
+		})
+		waitGroup.Go(func() {
+			<-start
+			for range 1_000 {
+				_, _ = instance.GetValue()
+			}
+		})
+	}
+
+	close(start)
+	waitGroup.Wait()
+}
+
 func Test_Lazy_GetValue_Concurrent(t *testing.T) {
 	expected := "test"
 	callCount := 0
@@ -119,25 +176,23 @@ func Test_Lazy_GetValue_Concurrent(t *testing.T) {
 
 	instance := NewLazy(initFn)
 
-	var actual string
-	var err error
+	type result struct {
+		value string
+		err   error
+	}
+	results := make(chan result, 2)
 
-	res := make(chan bool, 2)
+	for range 2 {
+		go func() {
+			actual, err := instance.GetValue()
+			results <- result{value: actual, err: err}
+		}()
+	}
 
-	go func() {
-		actual, err = instance.GetValue()
-		res <- true
-	}()
-
-	go func() {
-		actual, err = instance.GetValue()
-		res <- true
-	}()
-
-	done := <-res
-
-	require.True(t, done)
-	require.Equal(t, expected, actual)
-	require.NoError(t, err)
+	for range 2 {
+		actual := <-results
+		require.Equal(t, expected, actual.value)
+		require.NoError(t, actual.err)
+	}
 	require.Equal(t, 1, callCount)
 }


### PR DESCRIPTION
Make Lazy get/set operations safe under concurrent access and add regression coverage.