### PR TITLE
Add mapper context and raw template support

### DIFF
--- a/cli/azd/internal/mapper/mapper.go
+++ b/cli/azd/internal/mapper/mapper.go
@@ -99,8 +99,10 @@ type Resolver func(key string) string
 type MapperFunc func(ctx context.Context, src any, dst any) error
 
 type resolverKeyType struct{}
+type envSubstKeyType struct{}
 
 var resolverKey = resolverKeyType{}
+var envSubstKey = envSubstKeyType{}
 
 var (
 	registry = make(map[[2]reflect.Type]MapperFunc)
@@ -126,6 +128,36 @@ type Mapper struct {
 
 // Default mapper instance for convenience functions
 var defaultMapper = &Mapper{ctx: context.Background()}
+
+// WithContext sets the context that will be passed to converters (ie, registered with
+// [MustRegister]). This allows you to set and pass converter-specific settings per mapping call.
+func WithContext(ctx context.Context) *Mapper {
+	return &Mapper{ctx: ctx}
+}
+
+// WithResolver returns a copy configured with an environment variable resolver.
+func (m *Mapper) WithResolver(resolver Resolver) *Mapper {
+	if resolver == nil {
+		return &Mapper{ctx: m.ctx}
+	}
+
+	ctx := context.WithValue(m.ctx, resolverKey, func(key string) string {
+		return resolver(key)
+	})
+	return &Mapper{ctx: ctx}
+}
+
+// WithEnvSubst returns a copy configured to enable or disable environment substitution.
+// Environment substitution is enabled by default.
+func (m *Mapper) WithEnvSubst(enabled bool) *Mapper {
+	return &Mapper{ctx: context.WithValue(m.ctx, envSubstKey, enabled)}
+}
+
+// EnvSubstEnabled reports whether environment substitution is enabled for a conversion.
+func EnvSubstEnabled(ctx context.Context) bool {
+	enabled, configured := ctx.Value(envSubstKey).(bool)
+	return !configured || enabled
+}
 
 // Register a type converter function that transforms type S to type T.
 //
@@ -280,14 +312,7 @@ func Convert(src any, dst any) error {
 //	    return &azdext.Service{Image: expandedImage}, nil
 //	}
 func WithResolver(resolver Resolver) *Mapper {
-	if resolver == nil {
-		return &Mapper{ctx: context.Background()}
-	}
-
-	ctx := context.WithValue(context.Background(), resolverKey, func(key string) string {
-		return resolver(key)
-	})
-	return &Mapper{ctx: ctx}
+	return WithContext(context.Background()).WithResolver(resolver)
 }
 
 // Convert performs type conversion using this mapper's context.

--- a/cli/azd/internal/mapper/mapper_test.go
+++ b/cli/azd/internal/mapper/mapper_test.go
@@ -194,6 +194,36 @@ func TestMappingWithoutResolver(t *testing.T) {
 	assert.True(t, result.Ready)
 }
 
+func TestMappingWithContext(t *testing.T) {
+	clearRegistry()
+
+	type conversionModeKey struct{}
+	Register(func(ctx context.Context, src string) (string, error) {
+		mode, _ := ctx.Value(conversionModeKey{}).(string)
+		return mode + ":" + src, nil
+	})
+
+	ctx := context.WithValue(t.Context(), conversionModeKey{}, "template")
+	var result string
+	err := WithContext(ctx).Convert("value", &result)
+
+	require.NoError(t, err)
+	assert.Equal(t, "template:value", result)
+}
+
+func TestMapperWithEnvSubst(t *testing.T) {
+	base := WithContext(t.Context())
+	require.True(t, EnvSubstEnabled(base.ctx))
+
+	disabled := base.WithResolver(func(key string) string {
+		return "resolved-" + key
+	}).WithEnvSubst(false)
+	require.False(t, EnvSubstEnabled(disabled.ctx))
+	require.Equal(t, "resolved-value", GetResolver(disabled.ctx)("value"))
+	require.True(t, EnvSubstEnabled(base.ctx))
+	require.Nil(t, GetResolver(base.ctx))
+}
+
 func TestMappingWithEnvironmentResolver(t *testing.T) {
 	clearRegistry()
 

--- a/cli/azd/pkg/config/config.go
+++ b/cli/azd/pkg/config/config.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -63,6 +64,98 @@ func NewConfig(data map[string]any) Config {
 
 	return &config{
 		data: data,
+	}
+}
+
+// Clone returns an independent copy of source, including its local vault state.
+// Vault references remain references; secret values are not materialized in the raw data.
+func Clone(source Config) Config {
+	if source == nil {
+		return NewEmptyConfig()
+	}
+
+	cloned := &config{data: cloneMap(source.Raw())}
+	if sourceConfig, ok := source.(*config); ok {
+		cloned.vaultId = sourceConfig.vaultId
+		if sourceConfig.vault != nil {
+			cloned.vault = Clone(sourceConfig.vault)
+		}
+	}
+	return cloned
+}
+
+// ApplyDelta applies changes made between initial and updated to destination.
+// Unchanged values do not replace values written to destination after initial was captured.
+func ApplyDelta(destination, initial, updated Config) {
+	applyMapDelta(destination.Raw(), initial.Raw(), updated.Raw())
+
+	destinationConfig, destinationOK := destination.(*config)
+	initialConfig, initialOK := initial.(*config)
+	updatedConfig, updatedOK := updated.(*config)
+	if !destinationOK || !initialOK || !updatedOK || updatedConfig.vault == nil {
+		return
+	}
+	if destinationConfig.vault == nil {
+		destinationConfig.vault = NewEmptyConfig()
+	}
+	if initialConfig.vault == nil {
+		initialConfig.vault = NewEmptyConfig()
+	}
+	ApplyDelta(destinationConfig.vault, initialConfig.vault, updatedConfig.vault)
+	destinationConfig.vaultId = updatedConfig.vaultId
+}
+
+func applyMapDelta(destination, initial, updated map[string]any) {
+	for key, initialValue := range initial {
+		updatedValue, hasUpdated := updated[key]
+		if !hasUpdated {
+			delete(destination, key)
+			continue
+		}
+
+		initialMap, initialIsMap := initialValue.(map[string]any)
+		updatedMap, updatedIsMap := updatedValue.(map[string]any)
+		if initialIsMap && updatedIsMap {
+			destinationMap, destinationIsMap := destination[key].(map[string]any)
+			if !destinationIsMap {
+				destinationMap = map[string]any{}
+				destination[key] = destinationMap
+			}
+			applyMapDelta(destinationMap, initialMap, updatedMap)
+			continue
+		}
+		if !reflect.DeepEqual(initialValue, updatedValue) {
+			destination[key] = cloneValue(updatedValue)
+		}
+	}
+
+	for key, updatedValue := range updated {
+		if _, existed := initial[key]; !existed {
+			destination[key] = cloneValue(updatedValue)
+		}
+	}
+}
+
+func cloneMap(source map[string]any) map[string]any {
+	cloned := make(map[string]any, len(source))
+	for key, value := range source {
+		cloned[key] = cloneValue(value)
+	}
+	return cloned
+}
+
+func cloneValue(value any) any {
+	switch value := value.(type) {
+	case map[string]any:
+		return cloneMap(value)
+	case []any:
+		cloned := make([]any, len(value))
+		for i, item := range value {
+			cloned[i] = cloneValue(item)
+		}
+		return cloned
+	default:
+		return value
 	}
 }
 

--- a/cli/azd/pkg/config/config.go
+++ b/cli/azd/pkg/config/config.go
@@ -116,6 +116,9 @@ func applyMapDelta(destination, initial, updated map[string]any) {
 		initialMap, initialIsMap := initialValue.(map[string]any)
 		updatedMap, updatedIsMap := updatedValue.(map[string]any)
 		if initialIsMap && updatedIsMap {
+			if reflect.DeepEqual(initialMap, updatedMap) {
+				continue
+			}
 			destinationMap, destinationIsMap := destination[key].(map[string]any)
 			if !destinationIsMap {
 				destinationMap = map[string]any{}

--- a/cli/azd/pkg/config/config_test.go
+++ b/cli/azd/pkg/config/config_test.go
@@ -10,6 +10,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCloneAndApplyDelta(t *testing.T) {
+	destination := NewConfig(map[string]any{
+		"shared": map[string]any{"unchanged": "initial", "removed": "old"},
+	})
+	initial := Clone(destination)
+	updated := Clone(initial)
+
+	require.NoError(t, updated.Set("shared.unchanged", "provider"))
+	require.NoError(t, updated.Unset("shared.removed"))
+	require.NoError(t, updated.Set("shared.added", "new"))
+	require.NoError(t, destination.Set("concurrent", "preserved"))
+
+	ApplyDelta(destination, initial, updated)
+
+	require.Equal(t, "provider", valueAt(t, destination, "shared.unchanged"))
+	_, hasRemoved := destination.Get("shared.removed")
+	require.False(t, hasRemoved)
+	require.Equal(t, "new", valueAt(t, destination, "shared.added"))
+	require.Equal(t, "preserved", valueAt(t, destination, "concurrent"))
+}
+
+func valueAt(t *testing.T, source Config, path string) any {
+	t.Helper()
+	value, has := source.Get(path)
+	require.True(t, has)
+	return value
+}
+
 func Test_SetGetUnsetWithValue(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/cli/azd/pkg/config/config_test.go
+++ b/cli/azd/pkg/config/config_test.go
@@ -31,6 +31,19 @@ func TestCloneAndApplyDelta(t *testing.T) {
 	require.Equal(t, "preserved", valueAt(t, destination, "concurrent"))
 }
 
+func TestApplyDeltaPreservesConcurrentNestedMapReplacement(t *testing.T) {
+	destination := NewConfig(map[string]any{
+		"shared": map[string]any{"unchanged": "initial"},
+	})
+	initial := Clone(destination)
+	updated := Clone(initial)
+	require.NoError(t, destination.Set("shared", "concurrent"))
+
+	ApplyDelta(destination, initial, updated)
+
+	require.Equal(t, "concurrent", valueAt(t, destination, "shared"))
+}
+
 func valueAt(t *testing.T, source Config, path string) any {
 	t.Helper()
 	value, has := source.Get(path)

--- a/cli/azd/pkg/osutil/expandable_map.go
+++ b/cli/azd/pkg/osutil/expandable_map.go
@@ -9,6 +9,15 @@ import "fmt"
 // It provides convenient methods for expanding all values in the map.
 type ExpandableMap map[string]ExpandableString
 
+// Raw returns all values without environment substitution.
+func (em ExpandableMap) Raw() map[string]string {
+	result := make(map[string]string, len(em))
+	for key, value := range em {
+		result[key] = value.Raw()
+	}
+	return result
+}
+
 // Expand evaluates all ExpandableString values in the map, substituting variables as [ExpandableString.Envsubst] would.
 // Returns a map[string]string with all values expanded, or an error if any expansion fails.
 // The mapping parameter is a function that returns the value for a given variable name.

--- a/cli/azd/pkg/osutil/expandable_map_test.go
+++ b/cli/azd/pkg/osutil/expandable_map_test.go
@@ -12,6 +12,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestExpandableMap_Raw(t *testing.T) {
+	values := ExpandableMap{
+		"TEMPLATE": NewExpandableString("${VALUE}"),
+		"STATIC":   NewExpandableString("static-value"),
+	}
+
+	assert.Equal(t, map[string]string{
+		"TEMPLATE": "${VALUE}",
+		"STATIC":   "static-value",
+	}, values.Raw())
+}
+
 func TestExpandableMap_Expand(t *testing.T) {
 	t.Run("EmptyMap", func(t *testing.T) {
 		em := ExpandableMap{}

--- a/cli/azd/pkg/osutil/expandable_string.go
+++ b/cli/azd/pkg/osutil/expandable_string.go
@@ -44,6 +44,11 @@ func (e ExpandableString) IsZero() bool {
 	return e.Empty()
 }
 
+// Raw returns the unexpanded template.
+func (e ExpandableString) Raw() string {
+	return e.template
+}
+
 // Envsubst evaluates the template, substituting values as [envsubst.Eval] would.
 func (e ExpandableString) Envsubst(mapping func(string) string) (string, error) {
 	return envsubst.Eval(e.template, mapping)

--- a/cli/azd/pkg/project/mapper_registry.go
+++ b/cli/azd/pkg/project/mapper_registry.go
@@ -103,32 +103,36 @@ func registerProjectMappings() {
 		resolver := mapper.GetResolver(ctx)
 		envResolver := getEnvResolver(resolver)
 
-		resourceGroupName, err := src.ResourceGroupName.Envsubst(envResolver)
+		resourceGroupName, err := envsubstIfEnabled(ctx, src.ResourceGroupName, envResolver)
 		if err != nil {
 			return nil, fmt.Errorf("envsubst service resource group name: %w", err)
 		}
 
-		resourceName, err := src.ResourceName.Envsubst(envResolver)
+		resourceName, err := envsubstIfEnabled(ctx, src.ResourceName, envResolver)
 		if err != nil {
 			return nil, fmt.Errorf("envsubst service resource name: %w", err)
 		}
 
-		image, err := src.Image.Envsubst(envResolver)
+		image, err := envsubstIfEnabled(ctx, src.Image, envResolver)
 		if err != nil {
 			return nil, fmt.Errorf("envsubst image: %w", err)
 		}
 
 		var serviceEnv map[string]string
 		if len(src.Environment) > 0 {
-			serviceEnv, err = src.Environment.Expand(envResolver)
-			if err != nil {
-				return nil, fmt.Errorf("envsubst service environment: %w", err)
+			if mapper.EnvSubstEnabled(ctx) {
+				serviceEnv, err = src.Environment.Expand(envResolver)
+				if err != nil {
+					return nil, fmt.Errorf("envsubst service environment: %w", err)
+				}
+			} else {
+				serviceEnv = src.Environment.Raw()
 			}
 		}
 
 		// Convert Docker options
 		var docker *azdext.DockerProjectOptions
-		err = mapper.WithResolver(resolver).Convert(src.Docker, &docker)
+		err = mapper.WithContext(ctx).Convert(src.Docker, &docker)
 		if err != nil {
 			return nil, fmt.Errorf("convert docker options: %w", err)
 		}
@@ -176,24 +180,24 @@ func registerProjectMappings() {
 		resolver := mapper.GetResolver(ctx)
 		envResolver := getEnvResolver(resolver)
 
-		registry, err := src.Registry.Envsubst(envResolver)
+		registry, err := envsubstIfEnabled(ctx, src.Registry, envResolver)
 		if err != nil {
 			return nil, fmt.Errorf("envsubst docker registry: %w", err)
 		}
 
-		image, err := src.Image.Envsubst(envResolver)
+		image, err := envsubstIfEnabled(ctx, src.Image, envResolver)
 		if err != nil {
 			return nil, fmt.Errorf("envsubst docker image: %w", err)
 		}
 
-		tag, err := src.Tag.Envsubst(envResolver)
+		tag, err := envsubstIfEnabled(ctx, src.Tag, envResolver)
 		if err != nil {
 			return nil, fmt.Errorf("envsubst docker tag: %w", err)
 		}
 
 		buildArgs := []string{}
 		for _, arg := range src.BuildArgs {
-			resolvedArg, err := arg.Envsubst(envResolver)
+			resolvedArg, err := envsubstIfEnabled(ctx, arg, envResolver)
 			if err != nil {
 				return nil, fmt.Errorf("envsubst docker build arg '%s': %w", arg, err)
 			}
@@ -393,7 +397,7 @@ func registerProjectMappings() {
 		// Convert Docker options if present
 		if src.Docker != nil {
 			var dockerOptions DockerProjectOptions
-			err := mapper.Convert(src.Docker, &dockerOptions)
+			err := mapper.WithContext(ctx).Convert(src.Docker, &dockerOptions)
 			if err != nil {
 				return nil, fmt.Errorf("convert docker options: %w", err)
 			}
@@ -410,11 +414,12 @@ func registerProjectMappings() {
 
 		if len(src.Environment) > 0 {
 			result.Environment = make(osutil.ExpandableMap, len(src.Environment))
+			newEnvironmentValue := osutil.NewLiteralExpandableString
+			if !mapper.EnvSubstEnabled(ctx) {
+				newEnvironmentValue = osutil.NewExpandableString
+			}
 			for key, value := range src.Environment {
-				// Incoming values are expanded literals, not templates: escape them so a
-				// later expansion (or a round trip back into azure.yaml) cannot reinterpret
-				// or corrupt values containing `$`.
-				result.Environment[key] = osutil.NewLiteralExpandableString(value)
+				result.Environment[key] = newEnvironmentValue(value)
 			}
 		}
 
@@ -714,7 +719,7 @@ func registerProjectMappings() {
 		resolver := mapper.GetResolver(ctx)
 		envResolver := getEnvResolver(resolver)
 
-		resourceGroupName, err := src.ResourceGroupName.Envsubst(envResolver)
+		resourceGroupName, err := envsubstIfEnabled(ctx, src.ResourceGroupName, envResolver)
 		if err != nil {
 			return nil, fmt.Errorf("failed resolving ResourceGroupName, %w", err)
 		}
@@ -722,7 +727,7 @@ func registerProjectMappings() {
 		services := make(map[string]*azdext.ServiceConfig, len(src.Services))
 		for i, svc := range src.Services {
 			var serviceConfig *azdext.ServiceConfig
-			if err := mapper.WithResolver(resolver).Convert(svc, &serviceConfig); err != nil {
+			if err := mapper.WithContext(ctx).Convert(svc, &serviceConfig); err != nil {
 				return nil, fmt.Errorf("converting service %q: %w", i, err)
 			}
 
@@ -770,7 +775,7 @@ func registerProjectMappings() {
 		services := make(map[string]*ServiceConfig, len(src.Services))
 		for name, protoSvc := range src.Services {
 			var serviceConfig *ServiceConfig
-			if err := mapper.Convert(protoSvc, &serviceConfig); err != nil {
+			if err := mapper.WithContext(ctx).Convert(protoSvc, &serviceConfig); err != nil {
 				return nil, fmt.Errorf("converting service %s: %w", name, err)
 			}
 			services[name] = serviceConfig
@@ -815,6 +820,17 @@ func getEnvResolver(resolver mapper.Resolver) func(string) string {
 		return func(key string) string { return resolver(key) }
 	}
 	return func(string) string { return "" }
+}
+
+func envsubstIfEnabled(
+	ctx context.Context,
+	value osutil.ExpandableString,
+	resolver func(string) string,
+) (string, error) {
+	if !mapper.EnvSubstEnabled(ctx) {
+		return value.Raw(), nil
+	}
+	return value.Envsubst(resolver)
 }
 
 // getResourceTypeKinds returns the kinds for a given resource type.

--- a/cli/azd/pkg/project/mapper_registry_test.go
+++ b/cli/azd/pkg/project/mapper_registry_test.go
@@ -110,6 +110,86 @@ func TestServiceConfigMappingWithResolver(t *testing.T) {
 	}, protoConfig.Environment)
 }
 
+func TestServiceConfigMappingWithoutEnvSubst(t *testing.T) {
+	serviceConfig := &ServiceConfig{
+		ResourceGroupName: osutil.NewExpandableString("rg-${ENV}"),
+		ResourceName:      osutil.NewExpandableString("app-${ENV}"),
+		Image:             osutil.NewExpandableString("${REGISTRY}/app:${TAG}"),
+		Environment: osutil.ExpandableMap{
+			"ENDPOINT": osutil.NewExpandableString("${API_ENDPOINT}"),
+		},
+		Docker: DockerProjectOptions{
+			Registry:  osutil.NewExpandableString("${REGISTRY}"),
+			Image:     osutil.NewExpandableString("app-${ENV}"),
+			Tag:       osutil.NewExpandableString("${TAG}"),
+			BuildArgs: []osutil.ExpandableString{osutil.NewExpandableString("ENV=${ENV}")},
+		},
+	}
+
+	var protoConfig *azdext.ServiceConfig
+	err := mapper.WithContext(t.Context()).WithEnvSubst(false).Convert(serviceConfig, &protoConfig)
+	require.NoError(t, err)
+
+	require.Equal(t, "rg-${ENV}", protoConfig.ResourceGroupName)
+	require.Equal(t, "app-${ENV}", protoConfig.ResourceName)
+	require.Equal(t, "${REGISTRY}/app:${TAG}", protoConfig.Image)
+	require.Equal(t, map[string]string{"ENDPOINT": "${API_ENDPOINT}"}, protoConfig.Environment)
+	require.Equal(t, "${REGISTRY}", protoConfig.Docker.Registry)
+	require.Equal(t, "app-${ENV}", protoConfig.Docker.Image)
+	require.Equal(t, "${TAG}", protoConfig.Docker.Tag)
+	require.Equal(t, []string{"ENV=${ENV}"}, protoConfig.Docker.BuildArgs)
+}
+
+func TestServiceConfigReverseMappingWithoutEnvSubst(t *testing.T) {
+	protoConfig := &azdext.ServiceConfig{
+		ResourceGroupName: "rg-${ENV}",
+		ResourceName:      "app-${ENV}",
+		Image:             "${REGISTRY}/app:${TAG}",
+		Environment: map[string]string{
+			"FROM_ENV":       "${ENV_VALUE}",
+			"LITERAL_DOLLAR": "cost: $5",
+		},
+		Docker: &azdext.DockerProjectOptions{
+			Registry:  "${REGISTRY}",
+			Image:     "app-${ENV}",
+			Tag:       "${TAG}",
+			BuildArgs: []string{"ENV=${ENV}"},
+		},
+	}
+
+	var serviceConfig *ServiceConfig
+	err := mapper.WithContext(t.Context()).WithEnvSubst(false).Convert(protoConfig, &serviceConfig)
+	require.NoError(t, err)
+
+	resolver := func(key string) string {
+		switch key {
+		case "ENV":
+			return "dev"
+		case "REGISTRY":
+			return "registry.example"
+		case "TAG":
+			return "latest"
+		case "ENV_VALUE":
+			return "resolved"
+		}
+		return ""
+	}
+	require.Equal(t, "rg-dev", serviceConfig.ResourceGroupName.MustEnvsubst(resolver))
+	require.Equal(t, "app-dev", serviceConfig.ResourceName.MustEnvsubst(resolver))
+	require.Equal(t, "registry.example/app:latest", serviceConfig.Image.MustEnvsubst(resolver))
+	require.Equal(t, "registry.example", serviceConfig.Docker.Registry.MustEnvsubst(resolver))
+	require.Equal(t, "app-dev", serviceConfig.Docker.Image.MustEnvsubst(resolver))
+	require.Equal(t, "latest", serviceConfig.Docker.Tag.MustEnvsubst(resolver))
+	require.Equal(t, "ENV=dev", serviceConfig.Docker.BuildArgs[0].MustEnvsubst(resolver))
+
+	expanded, err := serviceConfig.Environment.Expand(resolver)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"FROM_ENV":       "resolved",
+		"LITERAL_DOLLAR": "cost: $5",
+	}, expanded)
+}
+
 func TestServiceConfigMappingWithConfig(t *testing.T) {
 	// Test ServiceConfig with various Config field scenarios
 	tests := []struct {
@@ -1028,6 +1108,28 @@ func TestPublishOptionsMapping(t *testing.T) {
 }
 
 func TestProjectConfigMapping(t *testing.T) {
+	t.Run("environment substitution disabled", func(t *testing.T) {
+		projectConfig := &ProjectConfig{
+			ResourceGroupName: osutil.NewExpandableString("rg-${ENV}"),
+			Services: map[string]*ServiceConfig{
+				"api": {
+					Image: osutil.NewExpandableString("${REGISTRY}/api"),
+				},
+			},
+		}
+
+		var protoConfig *azdext.ProjectConfig
+		err := mapper.WithContext(t.Context()).WithEnvSubst(false).Convert(projectConfig, &protoConfig)
+		require.NoError(t, err)
+		require.Equal(t, "rg-${ENV}", protoConfig.ResourceGroupName)
+		require.Equal(t, "${REGISTRY}/api", protoConfig.Services["api"].Image)
+
+		var roundTrip *ProjectConfig
+		err = mapper.WithContext(t.Context()).WithEnvSubst(false).Convert(protoConfig, &roundTrip)
+		require.NoError(t, err)
+		require.Equal(t, "rg-dev", roundTrip.ResourceGroupName.MustEnvsubst(func(string) string { return "dev" }))
+	})
+
 	t.Run("ProjectConfig -> proto ProjectConfig", func(t *testing.T) {
 		projectConfig := &ProjectConfig{
 			Name:              "test-project",


### PR DESCRIPTION
`mapper` is basically a clearinghouse for `gRPC <-> in-memory-model` conversions. It's used by pretty much anything that's deserializing or working with gRPC. By default, it always assumes you want to envsubst certain strings, which meant trying to do a round-trip on a model (receive via RPC method, send back to save via RPC method) would be lossy - the env vars would be expanded in your strings, so you wouldn't be saving your template literal, you'd be saving the expanded string.

This PR adds two things:
- You can control the context that `mapper` stores, so you can create a new instance of mapper with specific flags enabled.
- There's a new WithEnvSubst() function that lets you disable/enable envsubst calls. By default, it's enabled, so you have the behavior most people expect. If you turn it off you get the config as it is, no expansions.