### PR TITLE
feat: prompt for Foundry project names

### DIFF
--- a/cli/azd/extensions/ai-non-interactive.md
+++ b/cli/azd/extensions/ai-non-interactive.md
@@ -16,7 +16,7 @@ no non-interactive equivalent is a bug.
 | `ai agent init` | Source, template, or manifest | `--manifest`, `--src`, `--image`, or the hidden automation-only `--kind` | Infers the flow from supplied inputs; otherwise returns actionable missing-input guidance. |
 | `ai agent init` | Reuse or overwrite an existing agent definition | Reuse the detected definition, or pass `--force` to overwrite | Refuses to overwrite unless `--force` is present. |
 | `ai agent init` | Copy a large local manifest directory | `--manifest` and `--src` identify the exact source and destination | Copies the selected directory without an additional prompt. |
-| `ai agent init` | Foundry project: existing or new | `--project-id` selects an existing project; `AZURE_AI_PROJECT_NAME` supplies the new project name | Prompts for a new project name interactively; in no-prompt mode, uses a supplied name or keeps the existing derived-name fallback without prompting. |
+| `ai agent init` | Foundry project: existing or new | `--project-id` selects an existing project | Creates or defers a new project configuration when no project ID is supplied. |
 | `ai agent init` | Azure subscription | `AZURE_SUBSCRIPTION_ID`, or the subscription embedded in `--project-id` | Defers Azure setup with actionable guidance when the value cannot be resolved. |
 | `ai agent init` | Azure location | `AZURE_LOCATION`, `AZURE_AI_DEPLOYMENTS_LOCATION`, or the location of `--project-id` | Uses the configured value or defers Azure setup with actionable guidance. |
 | `ai agent init` | Agent name | `--agent-name`, manifest name, or adopted service name | Uses the supplied/inferred name; errors when a name is required and cannot be inferred. |

--- a/cli/azd/extensions/ai-non-interactive.md
+++ b/cli/azd/extensions/ai-non-interactive.md
@@ -16,7 +16,7 @@ no non-interactive equivalent is a bug.
 | `ai agent init` | Source, template, or manifest | `--manifest`, `--src`, `--image`, or the hidden automation-only `--kind` | Infers the flow from supplied inputs; otherwise returns actionable missing-input guidance. |
 | `ai agent init` | Reuse or overwrite an existing agent definition | Reuse the detected definition, or pass `--force` to overwrite | Refuses to overwrite unless `--force` is present. |
 | `ai agent init` | Copy a large local manifest directory | `--manifest` and `--src` identify the exact source and destination | Copies the selected directory without an additional prompt. |
-| `ai agent init` | Foundry project: existing or new | `--project-id` selects an existing project | Creates or defers a new project configuration when no project ID is supplied. |
+| `ai agent init` | Foundry project: existing or new | `--project-id` selects an existing project; `AZURE_AI_PROJECT_NAME` supplies the new project name | Prompts for a new project name interactively; in no-prompt mode, uses a supplied name or keeps the existing derived-name fallback without prompting. |
 | `ai agent init` | Azure subscription | `AZURE_SUBSCRIPTION_ID`, or the subscription embedded in `--project-id` | Defers Azure setup with actionable guidance when the value cannot be resolved. |
 | `ai agent init` | Azure location | `AZURE_LOCATION`, `AZURE_AI_DEPLOYMENTS_LOCATION`, or the location of `--project-id` | Uses the configured value or defers Azure setup with actionable guidance. |
 | `ai agent init` | Agent name | `--agent-name`, manifest name, or adopted service name | Uses the supplied/inferred name; errors when a name is required and cannot be inferred. |

--- a/cli/azd/extensions/azure.ai.agents/README.md
+++ b/cli/azd/extensions/azure.ai.agents/README.md
@@ -14,7 +14,7 @@ the generated infrastructure, it is offered as the default. The name must be
 3-32 characters, start with a letter or number, and contain only letters,
 numbers, or hyphens.
 
-To preconfigure the name, set it in the active azd environment before running
+To configure the name, set it in the active azd environment before running
 init:
 
 ```bash

--- a/cli/azd/extensions/azure.ai.agents/README.md
+++ b/cli/azd/extensions/azure.ai.agents/README.md
@@ -6,6 +6,25 @@ See the shared [AI extension non-interactive input reference](../ai-non-interact
 for every prompt's flag, environment/configuration input, or deterministic
 no-prompt behavior.
 
+## Choosing a Foundry project name
+
+During interactive `azd ai agent init`, azd prompts for the name of a new
+Microsoft Foundry project. If the current azd environment name is valid for
+the generated infrastructure, it is offered as the default. The name must be
+3-32 characters, start with a letter or number, and contain only letters,
+numbers, or hyphens.
+
+To preconfigure the name, set it in the active azd environment before running
+init:
+
+```bash
+azd env set AZURE_AI_PROJECT_NAME my-foundry-project
+```
+
+An existing `AZURE_AI_PROJECT_NAME` value is offered as the default during
+interactive new-project setup. `--no-prompt` remains non-interactive and keeps
+its existing automatic environment-name fallback.
+
 ## Composing Agent Dependencies
 
 Use the Agent command surface to attach existing Toolbox or Connection services

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init.go
@@ -2748,13 +2748,18 @@ func (a *InitAction) configureModelChoice(
 				if err := validateAcrConnectionInput(a.flags.acrConnection, false, true); err != nil {
 					return nil, err
 				}
+				if err := ensureLocation(ctx, a.azdClient, a.azureContext, a.environment.Name); err != nil {
+					return nil, err
+				}
+				if err := ensureNewFoundryProjectName(
+					ctx, a.azdClient, a.environment.Name,
+				); err != nil {
+					return nil, err
+				}
 				if err := setEnvValue(
 					ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false",
 				); err != nil {
 					return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
-				}
-				if err := ensureLocation(ctx, a.azdClient, a.azureContext, a.environment.Name); err != nil {
-					return nil, err
 				}
 			} else {
 				if err := setEnvValue(
@@ -2776,6 +2781,11 @@ func (a *InitAction) configureModelChoice(
 			}
 			a.credential = newCred
 
+			if err := ensureNewFoundryProjectName(
+				ctx, a.azdClient, a.environment.Name,
+			); err != nil {
+				return nil, err
+			}
 			// Creating new resources — clear any stale existing-project flag
 			if err := setEnvValue(
 				ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false",

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_project_setup.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_project_setup.go
@@ -198,14 +198,17 @@ func configureFoundryProject(
 				if err := validateAcrConnectionInput(acrConnection, false, true); err != nil {
 					return nil, err
 				}
+				if err := ensureLocation(ctx, azdClient, azureContext, envName); err != nil {
+					return nil, err
+				}
+				if err := ensureNewFoundryProjectName(ctx, azdClient, envName); err != nil {
+					return nil, err
+				}
 				if err := setEnvValue(ctx, azdClient, envName, "USE_EXISTING_AI_PROJECT", "false"); err != nil {
 					return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 				}
 				if err := updatePendingProjectSignal(ctx, azdClient, envName, false); err != nil {
 					log.Printf("warning: failed to update project provision signal: %v", err)
-				}
-				if err := ensureLocation(ctx, azdClient, azureContext, envName); err != nil {
-					return nil, err
 				}
 			} else {
 				if err := setEnvValue(ctx, azdClient, envName, "USE_EXISTING_AI_PROJECT", "true"); err != nil {
@@ -228,6 +231,9 @@ func configureFoundryProject(
 			}
 			result.Credential = newCred
 
+			if err := ensureNewFoundryProjectName(ctx, azdClient, envName); err != nil {
+				return nil, err
+			}
 			if err := setEnvValue(ctx, azdClient, envName, "USE_EXISTING_AI_PROJECT", "false"); err != nil {
 				return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 			}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -172,7 +172,7 @@ func ensureNewFoundryProjectName(
 		defaultName = envName
 	}
 
-	response, err := azdClient.Prompt().Prompt(ctx, &azdext.PromptRequest{
+	request := &azdext.PromptRequest{
 		Options: &azdext.PromptOptions{
 			Message: "Enter a name for the new Foundry project",
 			HelpMessage: "Use 3-32 letters, numbers, or hyphens. " +
@@ -183,19 +183,32 @@ func ensureNewFoundryProjectName(
 				"starting with a letter or number.",
 			DefaultValue: defaultName,
 		},
-	})
-	if err != nil {
-		if exterrors.IsCancellation(err) {
-			return exterrors.Cancelled("Foundry project name prompt was cancelled")
+	}
+
+	for {
+		response, err := azdClient.Prompt().Prompt(ctx, request)
+		if err != nil {
+			if exterrors.IsCancellation(err) {
+				return exterrors.Cancelled("Foundry project name prompt was cancelled")
+			}
+			return exterrors.FromPrompt(err, "failed to prompt for Foundry project name")
 		}
-		return exterrors.FromPrompt(err, "failed to prompt for Foundry project name")
-	}
 
-	if err := validateNewFoundryProjectName(response.Value); err != nil {
-		return err
-	}
+		if err := validateNewFoundryProjectName(response.Value); err == nil {
+			return setEnvValue(
+				ctx,
+				azdClient,
+				envName,
+				foundryProjectNameEnvKey,
+				response.Value,
+			)
+		} else {
+			writeValidationRetryError(err)
+		}
 
-	return setEnvValue(ctx, azdClient, envName, foundryProjectNameEnvKey, response.Value)
+		request.Options.DefaultValue = ""
+		request.Options.Message = "Enter a valid name for the new Foundry project"
+	}
 }
 
 // projectResourceIdRegex is the precompiled regex for parsing Foundry project ARM resource IDs.

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers.go
@@ -104,6 +104,8 @@ type FoundryDeploymentInfo struct {
 
 const foundryProjectResourceType = "Microsoft.CognitiveServices/accounts/projects"
 
+const foundryProjectNameEnvKey = "AZURE_AI_PROJECT_NAME"
+
 // setEnvValue sets a single environment variable in the azd environment.
 func setEnvValue(ctx context.Context, azdClient *azdext.AzdClient, envName, key, value string) error {
 	_, err := azdClient.Environment().SetValue(ctx, &azdext.SetEnvRequest{
@@ -133,6 +135,67 @@ func getEnvValue(ctx context.Context, azdClient *azdext.AzdClient, envName, key 
 		}
 	}
 	return "", nil
+}
+
+var foundryProjectNameRegex = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9-]{2,31}$`)
+
+func validateNewFoundryProjectName(name string) error {
+	if foundryProjectNameRegex.MatchString(name) {
+		return nil
+	}
+
+	return exterrors.Validation(
+		exterrors.CodeInvalidParameter,
+		fmt.Sprintf(
+			"invalid Foundry project name %q: use 3-32 letters, "+
+				"numbers, or hyphens, starting with a letter or number",
+			name,
+		),
+		"enter a valid Foundry project name and retry",
+	)
+}
+
+func ensureNewFoundryProjectName(
+	ctx context.Context,
+	azdClient *azdext.AzdClient,
+	envName string,
+) error {
+	configuredName, err := getEnvValue(ctx, azdClient, envName, foundryProjectNameEnvKey)
+	if err != nil {
+		return err
+	}
+
+	defaultName := ""
+	if foundryProjectNameRegex.MatchString(configuredName) {
+		defaultName = configuredName
+	} else if foundryProjectNameRegex.MatchString(envName) {
+		defaultName = envName
+	}
+
+	response, err := azdClient.Prompt().Prompt(ctx, &azdext.PromptRequest{
+		Options: &azdext.PromptOptions{
+			Message: "Enter a name for the new Foundry project",
+			HelpMessage: "Use 3-32 letters, numbers, or hyphens. " +
+				"The name must start with a letter or number.",
+			Required:        true,
+			RequiredMessage: "A Foundry project name is required.",
+			ValidationMessage: "Use 3-32 letters, numbers, or hyphens, " +
+				"starting with a letter or number.",
+			DefaultValue: defaultName,
+		},
+	})
+	if err != nil {
+		if exterrors.IsCancellation(err) {
+			return exterrors.Cancelled("Foundry project name prompt was cancelled")
+		}
+		return exterrors.FromPrompt(err, "failed to prompt for Foundry project name")
+	}
+
+	if err := validateNewFoundryProjectName(response.Value); err != nil {
+		return err
+	}
+
+	return setEnvValue(ctx, azdClient, envName, foundryProjectNameEnvKey, response.Value)
 }
 
 // projectResourceIdRegex is the precompiled regex for parsing Foundry project ARM resource IDs.
@@ -491,7 +554,7 @@ func configureFoundryProjectEnv(
 		return err
 	}
 
-	if err := setEnvValue(ctx, azdClient, envName, "AZURE_AI_PROJECT_NAME", project.ProjectName); err != nil {
+	if err := setEnvValue(ctx, azdClient, envName, foundryProjectNameEnvKey, project.ProjectName); err != nil {
 		return err
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
@@ -8,8 +8,10 @@ import (
 	"errors"
 	"net"
 	"strconv"
+	"strings"
 	"testing"
 
+	"azureaiagent/internal/exterrors"
 	"azureaiagent/internal/pkg/azure"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -21,6 +23,175 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+func TestValidateNewFoundryProjectName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		valid bool
+	}{
+		{name: "minimum length", value: "abc", valid: true},
+		{name: "maximum length", value: strings.Repeat("a", 32), valid: true},
+		{name: "uppercase is preserved", value: "My-Project", valid: true},
+		{name: "too short", value: "ab"},
+		{name: "too long", value: strings.Repeat("a", 33)},
+		{name: "leading hyphen", value: "-my-project"},
+		{name: "spaces", value: "my project"},
+		{name: "underscore", value: "my_project"},
+		{name: "dot", value: "my.project"},
+		{name: "unicode", value: "my-projéct"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNewFoundryProjectName(tt.value)
+			if tt.valid {
+				require.NoError(t, err)
+				return
+			}
+
+			localErr, ok := errors.AsType[*azdext.LocalError](err)
+			require.True(t, ok)
+			require.Equal(t, exterrors.CodeInvalidParameter, localErr.Code)
+		})
+	}
+}
+
+func TestEnsureNewFoundryProjectName_PromptsAndPersists(t *testing.T) {
+	const envName = "agent-dev"
+	const projectName = "my-foundry-project"
+
+	envServer := &testEnvironmentServiceServer{
+		environments: map[string]*azdext.Environment{
+			envName: {Name: envName},
+		},
+		values: map[string]map[string]string{},
+	}
+	promptServer := &testPromptServiceServer{
+		promptResponses: []string{projectName},
+	}
+	azdClient := newTestAzdClient(
+		t,
+		envServer,
+		&testWorkflowServiceServer{},
+		promptServer,
+	)
+
+	require.NoError(t, ensureNewFoundryProjectName(t.Context(), azdClient, envName))
+	require.Equal(t, projectName, envServer.values[envName][foundryProjectNameEnvKey])
+	require.Len(t, promptServer.promptRequests, 1)
+	require.Equal(t, envName, promptServer.promptRequests[0].Options.DefaultValue)
+	require.True(t, promptServer.promptRequests[0].Options.Required)
+	require.Equal(
+		t,
+		"Enter a name for the new Foundry project",
+		promptServer.promptRequests[0].Options.Message,
+	)
+}
+
+func TestEnsureNewFoundryProjectName_InvalidEnvironmentNameHasNoDefault(t *testing.T) {
+	const envName = "agent_dev"
+
+	envServer := &testEnvironmentServiceServer{
+		environments: map[string]*azdext.Environment{
+			envName: {Name: envName},
+		},
+		values: map[string]map[string]string{},
+	}
+	promptServer := &testPromptServiceServer{
+		promptResponses: []string{"my-foundry-project"},
+	}
+	azdClient := newTestAzdClient(
+		t,
+		envServer,
+		&testWorkflowServiceServer{},
+		promptServer,
+	)
+
+	require.NoError(t, ensureNewFoundryProjectName(t.Context(), azdClient, envName))
+	require.Empty(t, promptServer.promptRequests[0].Options.DefaultValue)
+	require.Equal(
+		t,
+		"my-foundry-project",
+		envServer.values[envName][foundryProjectNameEnvKey],
+	)
+}
+
+func TestEnsureNewFoundryProjectName_UsesConfiguredNameAsDefault(t *testing.T) {
+	const envName = "agent-dev"
+	const projectName = "configured-project"
+	const newProjectName = "new-project"
+
+	envServer := &testEnvironmentServiceServer{
+		environments: map[string]*azdext.Environment{
+			envName: {Name: envName},
+		},
+		values: map[string]map[string]string{
+			envName: {foundryProjectNameEnvKey: projectName},
+		},
+	}
+	promptServer := &testPromptServiceServer{
+		promptResponses: []string{newProjectName},
+	}
+	azdClient := newTestAzdClient(
+		t,
+		envServer,
+		&testWorkflowServiceServer{},
+		promptServer,
+	)
+
+	require.NoError(t, ensureNewFoundryProjectName(t.Context(), azdClient, envName))
+	require.Len(t, promptServer.promptRequests, 1)
+	require.Equal(t, projectName, promptServer.promptRequests[0].Options.DefaultValue)
+	require.Equal(t, newProjectName, envServer.values[envName][foundryProjectNameEnvKey])
+}
+
+func TestEnsureNewFoundryProjectName_InvalidResponseDoesNotPersist(t *testing.T) {
+	const envName = "agent-dev"
+
+	envServer := &testEnvironmentServiceServer{
+		environments: map[string]*azdext.Environment{
+			envName: {Name: envName},
+		},
+		values: map[string]map[string]string{},
+	}
+	promptServer := &testPromptServiceServer{
+		promptResponses: []string{"invalid name"},
+	}
+	azdClient := newTestAzdClient(
+		t,
+		envServer,
+		&testWorkflowServiceServer{},
+		promptServer,
+	)
+
+	err := ensureNewFoundryProjectName(t.Context(), azdClient, envName)
+	require.Error(t, err)
+	require.NotContains(t, envServer.values[envName], foundryProjectNameEnvKey)
+}
+
+func TestEnsureNewFoundryProjectName_PromptFailure(t *testing.T) {
+	const envName = "agent-dev"
+
+	envServer := &testEnvironmentServiceServer{
+		environments: map[string]*azdext.Environment{
+			envName: {Name: envName},
+		},
+		values: map[string]map[string]string{},
+	}
+	azdClient := newTestAzdClient(
+		t,
+		envServer,
+		&testWorkflowServiceServer{},
+		&testPromptServiceServer{},
+	)
+
+	err := ensureNewFoundryProjectName(t.Context(), azdClient, envName)
+	require.Error(t, err)
+	require.NotContains(t, envServer.values[envName], foundryProjectNameEnvKey)
+}
 
 func TestFoundryProjectInfo_Endpoint(t *testing.T) {
 	t.Parallel()

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_foundry_resources_helpers_test.go
@@ -148,8 +148,9 @@ func TestEnsureNewFoundryProjectName_UsesConfiguredNameAsDefault(t *testing.T) {
 	require.Equal(t, newProjectName, envServer.values[envName][foundryProjectNameEnvKey])
 }
 
-func TestEnsureNewFoundryProjectName_InvalidResponseDoesNotPersist(t *testing.T) {
+func TestEnsureNewFoundryProjectName_InvalidResponseReprompts(t *testing.T) {
 	const envName = "agent-dev"
+	const projectName = "my-foundry-project"
 
 	envServer := &testEnvironmentServiceServer{
 		environments: map[string]*azdext.Environment{
@@ -158,7 +159,7 @@ func TestEnsureNewFoundryProjectName_InvalidResponseDoesNotPersist(t *testing.T)
 		values: map[string]map[string]string{},
 	}
 	promptServer := &testPromptServiceServer{
-		promptResponses: []string{"invalid name"},
+		promptResponses: []string{"invalid name", projectName},
 	}
 	azdClient := newTestAzdClient(
 		t,
@@ -167,9 +168,19 @@ func TestEnsureNewFoundryProjectName_InvalidResponseDoesNotPersist(t *testing.T)
 		promptServer,
 	)
 
-	err := ensureNewFoundryProjectName(t.Context(), azdClient, envName)
-	require.Error(t, err)
-	require.NotContains(t, envServer.values[envName], foundryProjectNameEnvKey)
+	require.NoError(t, ensureNewFoundryProjectName(t.Context(), azdClient, envName))
+	require.Equal(t, projectName, envServer.values[envName][foundryProjectNameEnvKey])
+	require.Len(t, promptServer.promptRequests, 2)
+	require.Equal(
+		t,
+		"",
+		promptServer.promptRequests[1].Options.DefaultValue,
+	)
+	require.Equal(
+		t,
+		"Enter a valid name for the new Foundry project",
+		promptServer.promptRequests[1].Options.Message,
+	)
 }
 
 func TestEnsureNewFoundryProjectName_PromptFailure(t *testing.T) {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_from_code.go
@@ -454,11 +454,16 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 				if err := validateAcrConnectionInput(a.flags.acrConnection, false, true); err != nil {
 					return nil, err
 				}
-				if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false"); err != nil {
-					return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
-				}
 				if err := ensureLocation(ctx, a.azdClient, a.azureContext, a.environment.Name); err != nil {
 					return nil, err
+				}
+				if err := ensureNewFoundryProjectName(
+					ctx, a.azdClient, a.environment.Name,
+				); err != nil {
+					return nil, err
+				}
+				if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false"); err != nil {
+					return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 				}
 			} else {
 				selectedProject = proj
@@ -479,6 +484,11 @@ func (a *InitFromCodeAction) createDefinitionFromLocalAgent(ctx context.Context)
 			}
 			a.credential = newCred
 
+			if err := ensureNewFoundryProjectName(
+				ctx, a.azdClient, a.environment.Name,
+			); err != nil {
+				return nil, err
+			}
 			if err := setEnvValue(ctx, a.azdClient, a.environment.Name, "USE_EXISTING_AI_PROJECT", "false"); err != nil {
 				return nil, fmt.Errorf("failed to set USE_EXISTING_AI_PROJECT: %w", err)
 			}


### PR DESCRIPTION
## Why

During `azd ai agent init`, a new Foundry project gets its name from the azd environment. Users cannot choose a name during setup, and separate projects can end up sharing an unintended name.

## What changed

- Prompt for a name when creating a new Foundry project from the agent initialization flows.
- Use a valid `AZURE_AI_PROJECT_NAME` as the default, then fall back to the azd environment name.
- Validate the name and save it to the active azd environment.
- Keep existing-project selection, explicit `--project-id`, deferred initialization, and `--no-prompt` behavior unchanged.
- Document the interactive and non-interactive inputs.

## Approach

A shared helper handles default selection, validation, and persistence. It runs only after the user chooses to create a new project, so existing-project setup and headless flows keep their current behavior.

## Validation

| Command | Scenario | Result |
|---|---|---|
| `azd ai agent init` | Interactive new-project flow on the PR build | PASS |
| `azd ai agent init --src <dir>` | Interactive local-source flow on the PR build | PASS |
| `azd ai agent init` | Invalid name, retry, then persist the valid name | PASS |
| `azd ai agent init --no-prompt` | New-project path with `AZURE_AI_PROJECT_NAME` configured | PASS |
| `azd ai agent init --project-id <id>` | Existing Foundry project path without the new name prompt | PASS |

No Azure resources were created or modified during testing.

Fixes: #7833