### PR TITLE
test: harden GitHub auth for AI agents live E2E

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/tests/e2e-live/README.md
+++ b/cli/azd/extensions/azure.ai.agents/tests/e2e-live/README.md
@@ -70,8 +70,10 @@ Pipeline: `eng/pipelines/ext-azure-ai-agents-live.yml` (ADO). The Tier 2 step
 builds `azd` + the extension and runs `go test -run TestTier2Live` inside an
 `AzureCLI@2` task (so the federated az session stays valid for the whole run).
 
+- **On demand (per PR):** comment `/azp run ext-azure-ai-agents-live` on the PR.
+  Requires write permission on the repo.
 - **Scheduled:** weekly, Monday 07:00 UTC against `main`.
-- **Manual:** queue the Azure DevOps pipeline and pick `deployModes` = `both` / `code` /
+- **Manual:** queue the pipeline and pick `deployModes` = `both` / `code` /
   `container`.
 
 Logs for each run are published as the `tier2-live-logs-<BuildId>` artifact.
@@ -79,7 +81,8 @@ Logs for each run are published as the `tier2-live-logs-<BuildId>` artifact.
 ### One-time admin setup
 
 1. **Register the pipeline** in Azure DevOps pointing at
-   `eng/pipelines/ext-azure-ai-agents-live.yml`, named `ext-azure-ai-agents-live`.
+   `eng/pipelines/ext-azure-ai-agents-live.yml`, named `ext-azure-ai-agents-live`
+   (the name used by `/azp run`).
 2. **Service connection** — the `serviceConnection` parameter (default
    `azure-sdk-tests`) must map to the shared **TME test subscription** via OIDC /
    workload-identity federation. The federated identity needs enough RBAC to

--- a/cli/azd/extensions/azure.ai.agents/tests/e2e-live/README.md
+++ b/cli/azd/extensions/azure.ai.agents/tests/e2e-live/README.md
@@ -70,10 +70,8 @@ Pipeline: `eng/pipelines/ext-azure-ai-agents-live.yml` (ADO). The Tier 2 step
 builds `azd` + the extension and runs `go test -run TestTier2Live` inside an
 `AzureCLI@2` task (so the federated az session stays valid for the whole run).
 
-- **On demand (per PR):** comment `/azp run ext-azure-ai-agents-live` on the PR.
-  Requires write permission on the repo.
 - **Scheduled:** weekly, Monday 07:00 UTC against `main`.
-- **Manual:** queue the pipeline and pick `deployModes` = `both` / `code` /
+- **Manual:** queue the Azure DevOps pipeline and pick `deployModes` = `both` / `code` /
   `container`.
 
 Logs for each run are published as the `tier2-live-logs-<BuildId>` artifact.
@@ -81,8 +79,7 @@ Logs for each run are published as the `tier2-live-logs-<BuildId>` artifact.
 ### One-time admin setup
 
 1. **Register the pipeline** in Azure DevOps pointing at
-   `eng/pipelines/ext-azure-ai-agents-live.yml`, named `ext-azure-ai-agents-live`
-   (the name used by `/azp run`).
+   `eng/pipelines/ext-azure-ai-agents-live.yml`, named `ext-azure-ai-agents-live`.
 2. **Service connection** — the `serviceConnection` parameter (default
    `azure-sdk-tests`) must map to the shared **TME test subscription** via OIDC /
    workload-identity federation. The federated identity needs enough RBAC to

--- a/cli/azd/extensions/azure.ai.agents/tests/e2e-live/tier2_live_test.go
+++ b/cli/azd/extensions/azure.ai.agents/tests/e2e-live/tier2_live_test.go
@@ -131,11 +131,17 @@ func newRunner(t *testing.T, mode string) *runner {
 	env = append(env,
 		"AZD_CONFIG_DIR="+configDir,
 		"AZD_NON_INTERACTIVE=false",
+		"GH_PROMPT_DISABLED=1",
+		"GIT_TERMINAL_PROMPT=0",
 	)
 	if tenant := os.Getenv("E2E_TENANT"); tenant != "" {
 		env = append(env, "AZURE_TENANT_ID="+tenant)
 	}
-	if tok := ghToken(); tok != "" {
+	tok := ghToken()
+	if tok == "" && os.Getenv("TF_BUILD") != "" {
+		t.Fatal("GH_TOKEN/GITHUB_TOKEN is required for Azure DevOps live tests")
+	}
+	if tok != "" {
 		env = append(env, "GH_TOKEN="+tok, "GITHUB_TOKEN="+tok)
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/tests/e2e-live/tier2_live_test.go
+++ b/cli/azd/extensions/azure.ai.agents/tests/e2e-live/tier2_live_test.go
@@ -1154,13 +1154,13 @@ func exitCode(err error) int {
 	return -1
 }
 
-// ghToken resolves a usable GitHub token from the environment, falling back to `gh`.
+// ghToken resolves a GitHub token from the environment, falling back to `gh`.
+// The actual download validates the token; a separate network preflight can
+// incorrectly discard a valid token during a transient GitHub failure.
 func ghToken() string {
-	for _, k := range []string{"GITHUB_TOKEN", "GH_TOKEN"} {
-		if v := os.Getenv(k); v != "" {
-			if isUsableGitHubToken(v) {
-				return v
-			}
+	for _, k := range []string{"GH_TOKEN", "GITHUB_TOKEN"} {
+		if v := strings.TrimSpace(os.Getenv(k)); v != "" {
+			return v
 		}
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -1172,20 +1172,7 @@ func ghToken() string {
 	if err != nil {
 		return ""
 	}
-	token := strings.TrimSpace(string(out))
-	if token == "" || !isUsableGitHubToken(token) {
-		return ""
-	}
-	return token
-}
-
-func isUsableGitHubToken(token string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	//nolint:gosec // gh is a trusted fixed binary; no user input in args.
-	cmd := exec.CommandContext(ctx, "gh", "auth", "status", "--hostname", "github.com")
-	cmd.Env = append(withoutGitHubTokenEnv(os.Environ()), "GH_TOKEN="+token, "GITHUB_TOKEN="+token)
-	return cmd.Run() == nil
+	return strings.TrimSpace(string(out))
 }
 
 func isInvalidGitHubTokenError(err error) bool {

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -72,6 +72,8 @@ extends:
         displayName: AI Agents Live Golden Path
         variables:
           - template: /eng/pipelines/templates/variables/image.yml
+          # This Key Vault-backed group exposes only azuresdk-github-pat.
+          - group: Release Secrets for GitHub
         jobs:
           - job: Tier2
             displayName: Tier 2 — init/provision/deploy/invoke/down
@@ -216,7 +218,7 @@ extends:
                   workingDirectory: cli/azd/extensions/azure.ai.agents
                   inlineScript: |
                     set -euo pipefail
-                    if [ -z "${GH_TOKEN:-}" ]; then
+                    if [ -z "${GH_TOKEN:-}" ] || [ "$GH_TOKEN" = '$(azuresdk-github-pat)' ]; then
                       echo "ERROR: azuresdk-github-pat was not injected as GH_TOKEN" >&2
                       exit 1
                     fi

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -216,6 +216,32 @@ extends:
                   workingDirectory: cli/azd/extensions/azure.ai.agents
                   inlineScript: |
                     set -euo pipefail
+                    if [ -z "${GH_TOKEN:-}" ]; then
+                      echo "ERROR: azuresdk-github-pat was not injected as GH_TOKEN" >&2
+                      exit 1
+                    fi
+                    if ! command -v gh >/dev/null 2>&1; then
+                      echo "ERROR: GitHub CLI is required to validate GH_TOKEN" >&2
+                      exit 1
+                    fi
+                    github_auth_ok=false
+                    for attempt in 1 2 3; do
+                      if gh api rate_limit >/dev/null 2>&1; then
+                        github_auth_ok=true
+                        break
+                      fi
+                      if [ "$attempt" -lt 3 ]; then
+                        echo "GitHub token validation attempt $attempt failed; retrying..." >&2
+                        sleep 5
+                      fi
+                    done
+                    if [ "$github_auth_ok" != true ]; then
+                      echo "ERROR: GH_TOKEN is invalid or GitHub authentication is unavailable" >&2
+                      exit 1
+                    fi
+                    # GitHub CLI prefers GH_TOKEN, while other GitHub clients
+                    # commonly read GITHUB_TOKEN. Keep both child paths aligned.
+                    export GITHUB_TOKEN="$GH_TOKEN"
                     azd config set auth.useAzCliAuth true
                     # Assign first (not `export X=$(...)`, which hides command
                     # substitution failures from set -e), then verify non-empty.

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -8,9 +8,15 @@
 # This pipeline is the live counterpart to the PR-gate checks in
 # `.github/workflows/lint-ext-azure-ai-agents.yml` (Tier 0 offline + Tier 1
 # recording/playback). Live Azure access is intentionally kept OUT of the
-# automatic PR pipeline (per Azure SDK EngSys / SFI guidance).
+# automatic PR pipeline (per Azure SDK EngSys / SFI guidance). The PR trigger
+# below only associates this pipeline with relevant PRs targeting main so
+# `/azp run ext-azure-ai-agents-live` can queue it; the ADO pipeline definition
+# must be configured to require a team member comment before building PRs.
 # It runs only:
-#   - On demand by manually queuing the Azure DevOps pipeline.
+#   - On demand via the PR comment:
+#       /azp run azure-dev - live - ext - azure.ai.agents
+#     (or, if accepted by Azure Pipelines: /azp run ext-azure-ai-agents-live)
+#     (requires write permission on the repo)
 #   - On the weekly schedule below.
 #
 # Required ADO setup (one-time, admin) — see tests/e2e-live/README.md:
@@ -23,7 +29,17 @@
 #     project) to avoid anonymous rate limits — no extra secret setup required.
 
 trigger: none
-pr: none
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - eng/pipelines/ext-azure-ai-agents-live.yml
+      - cli/azd/go.mod
+      - cli/azd/go.sum
+      - cli/azd/extensions/azure.ai.agents/**
+      - cli/azd/extensions/azure.ai.projects/**
 
 schedules:
   # 7am UTC Monday (offset from other weekly E2E pipelines to reduce contention).

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -8,15 +8,9 @@
 # This pipeline is the live counterpart to the PR-gate checks in
 # `.github/workflows/lint-ext-azure-ai-agents.yml` (Tier 0 offline + Tier 1
 # recording/playback). Live Azure access is intentionally kept OUT of the
-# automatic PR pipeline (per Azure SDK EngSys / SFI guidance). The PR trigger
-# below only associates this pipeline with relevant PRs targeting main so
-# `/azp run ext-azure-ai-agents-live` can queue it; the ADO pipeline definition
-# must be configured to require a team member comment before building PRs.
+# automatic PR pipeline (per Azure SDK EngSys / SFI guidance).
 # It runs only:
-#   - On demand via the PR comment:
-#       /azp run azure-dev - live - ext - azure.ai.agents
-#     (or, if accepted by Azure Pipelines: /azp run ext-azure-ai-agents-live)
-#     (requires write permission on the repo)
+#   - On demand by manually queuing the Azure DevOps pipeline.
 #   - On the weekly schedule below.
 #
 # Required ADO setup (one-time, admin) — see tests/e2e-live/README.md:
@@ -29,17 +23,7 @@
 #     project) to avoid anonymous rate limits — no extra secret setup required.
 
 trigger: none
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - eng/pipelines/ext-azure-ai-agents-live.yml
-      - cli/azd/go.mod
-      - cli/azd/go.sum
-      - cli/azd/extensions/azure.ai.agents/**
-      - cli/azd/extensions/azure.ai.projects/**
+pr: none
 
 schedules:
   # 7am UTC Monday (offset from other weekly E2E pipelines to reduce contention).


### PR DESCRIPTION
## Problem

The Azure AI Agents Tier 2 live test intermittently fails while downloading a public GitHub starter template. The downloader first uses the anonymous GitHub Contents API and falls back to GitHub CLI authentication when anonymous access is unavailable or rate-limited.

Pipeline definition 8268 passed `$(azuresdk-github-pat)` without binding the Key Vault-backed variable group that exposes that secret. As a result, successful historical runs were relying on anonymous GitHub access, while fallback attempts could enter device login or fail template download.

## Changes

- Preserve non-empty `GH_TOKEN` / `GITHUB_TOKEN` values instead of prevalidating and silently discarding them.
- Prefer `GH_TOKEN` and pass it to the PTY child process.
- Set `GH_PROMPT_DISABLED=1` and `GIT_TERMINAL_PROMPT=0` to prevent unattended authentication prompts.
- Fail early in Azure DevOps when no usable token is available.
- Bind the least-privilege `Release Secrets for GitHub` variable group.
- Reject an unresolved `$(azuresdk-github-pat)` macro.
- Validate GitHub authentication with three retries before starting the live test.

## ADO authorization

An Azure SDK ADO administrator must grant pipeline 8268 one-time access to the `Release Secrets for GitHub` variable group and its `AzureSDKEngKeyVault Secrets` service connection.

The emergency removal of this live pipeline from PR triggers is intentionally handled separately in #9927.

Fixes #9925
