### PR TITLE
test: avoid prevalidating GitHub tokens in AI agents live E2E

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/tests/e2e-live/tier2_live_test.go
+++ b/cli/azd/extensions/azure.ai.agents/tests/e2e-live/tier2_live_test.go
@@ -1154,13 +1154,13 @@ func exitCode(err error) int {
 	return -1
 }
 
-// ghToken resolves a usable GitHub token from the environment, falling back to `gh`.
+// ghToken resolves a GitHub token from the environment, falling back to `gh`.
+// The actual download validates the token; a separate network preflight can
+// incorrectly discard a valid token during a transient GitHub failure.
 func ghToken() string {
-	for _, k := range []string{"GITHUB_TOKEN", "GH_TOKEN"} {
-		if v := os.Getenv(k); v != "" {
-			if isUsableGitHubToken(v) {
-				return v
-			}
+	for _, k := range []string{"GH_TOKEN", "GITHUB_TOKEN"} {
+		if v := strings.TrimSpace(os.Getenv(k)); v != "" {
+			return v
 		}
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -1172,20 +1172,7 @@ func ghToken() string {
 	if err != nil {
 		return ""
 	}
-	token := strings.TrimSpace(string(out))
-	if token == "" || !isUsableGitHubToken(token) {
-		return ""
-	}
-	return token
-}
-
-func isUsableGitHubToken(token string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	//nolint:gosec // gh is a trusted fixed binary; no user input in args.
-	cmd := exec.CommandContext(ctx, "gh", "auth", "status", "--hostname", "github.com")
-	cmd.Env = append(withoutGitHubTokenEnv(os.Environ()), "GH_TOKEN="+token, "GITHUB_TOKEN="+token)
-	return cmd.Run() == nil
+	return strings.TrimSpace(string(out))
 }
 
 func isInvalidGitHubTokenError(err error) bool {


### PR DESCRIPTION
Removes GitHub token prevalidation from the Azure AI Agents Tier 2 live E2E test.

The test previously ran `gh auth status` before passing the pipeline token to the `azd` subprocess. Any nonzero result, including a transient network failure or timeout, caused the token to be discarded. If template download later fell back to the GitHub CLI, `gh` entered an interactive authentication flow and the test failed.

The test now:

- Uses `GH_TOKEN`, falling back to `GITHUB_TOKEN`.
- Passes the token directly to the `azd` subprocess.
- Lets the actual GitHub request validate the token.
- Preserves the existing explicit handling for invalid-token failures.