### PR TITLE
fix: preserve workflow errors and step flags

### DIFF
--- a/cli/azd/cmd/container.go
+++ b/cli/azd/cmd/container.go
@@ -1057,12 +1057,94 @@ func (w *workflowCmdAdapter) ExecuteContext(ctx context.Context, args []string) 
 	rootCmd := w.newCommand()
 	// Always set args explicitly to prevent Cobra from falling back to os.Args[1:].
 	// Cobra uses os.Args when cmd.args is nil (but not when it's an empty slice).
-	mergedArgs := append(slices.Clone(args), w.globalArgs...)
+	mergedArgs := mergeWorkflowArgs(args, w.globalArgs)
 	if mergedArgs == nil {
 		mergedArgs = []string{}
 	}
 	rootCmd.SetArgs(mergedArgs)
 	return rootCmd.ExecuteContext(childCtx)
+}
+
+func mergeWorkflowArgs(stepArgs, globalArgs []string) []string {
+	if len(globalArgs) == 0 {
+		return slices.Clone(stepArgs)
+	}
+
+	aliases := workflowFlagAliases()
+	stepFlags := make(map[string]struct{})
+	for _, arg := range stepArgs {
+		if arg == "--" {
+			break
+		}
+
+		if name := workflowFlagName(arg, aliases); name != "" {
+			stepFlags[name] = struct{}{}
+		}
+	}
+
+	mergedArgs := slices.Clone(stepArgs)
+	for _, arg := range globalArgs {
+		name := workflowFlagName(arg, aliases)
+		if _, ok := stepFlags[name]; ok {
+			continue
+		}
+		mergedArgs = append(mergedArgs, arg)
+	}
+
+	return mergedArgs
+}
+
+func workflowFlagAliases() map[string]string {
+	aliases := map[string]string{
+		"output":          "output",
+		"o":               "output",
+		"no-prompt":       "no-prompt",
+		"non-interactive": "no-prompt",
+	}
+
+	globalFlags := CreateGlobalFlagSet()
+	globalFlags.VisitAll(func(flag *pflag.Flag) {
+		name := flag.Name
+		if name == internal.EnvironmentNameFlagName {
+			return
+		}
+
+		canonicalName := name
+		if name == "non-interactive" {
+			canonicalName = "no-prompt"
+		}
+		aliases[name] = canonicalName
+		if flag.Shorthand != "" {
+			aliases[flag.Shorthand] = canonicalName
+		}
+	})
+
+	return aliases
+}
+
+func workflowFlagName(arg string, aliases map[string]string) string {
+	if !strings.HasPrefix(arg, "-") || arg == "-" {
+		return ""
+	}
+
+	name := strings.TrimLeft(arg, "-")
+	if name == "" {
+		return ""
+	}
+
+	if index := strings.IndexByte(name, '='); index >= 0 {
+		name = name[:index]
+	}
+
+	if !strings.HasPrefix(arg, "--") && len(name) > 1 {
+		name = name[:1]
+	}
+
+	if canonical, ok := aliases[name]; ok {
+		return canonical
+	}
+
+	return name
 }
 
 // extractGlobalArgs extracts global flag arguments from the process command line.

--- a/cli/azd/cmd/container_test.go
+++ b/cli/azd/cmd/container_test.go
@@ -367,6 +367,46 @@ func Test_workflowCmdAdapter_ContextPropagation(t *testing.T) {
 			"boolean global flag value should not leak into workflow step positional args")
 	})
 
+	t.Run("StepFlagsOverrideInheritedGlobalFlags", func(t *testing.T) {
+		var (
+			debugEnabled bool
+			outputFormat string
+		)
+
+		newCommand := func() *cobra.Command {
+			rootCmd := &cobra.Command{Use: "root"}
+			rootCmd.PersistentFlags().AddFlagSet(CreateGlobalFlagSet())
+
+			stepCmd := &cobra.Command{
+				Use: "step",
+				RunE: func(cmd *cobra.Command, args []string) error {
+					var err error
+					debugEnabled, err = cmd.Flags().GetBool("debug")
+					require.NoError(t, err)
+					outputFormat, err = cmd.Flags().GetString("output")
+					require.NoError(t, err)
+					return nil
+				},
+			}
+			stepCmd.Flags().String("output", "json", "")
+			rootCmd.AddCommand(stepCmd)
+			return rootCmd
+		}
+
+		adapter := &workflowCmdAdapter{
+			newCommand: newCommand,
+			globalArgs: []string{"--debug=true", "--output=json"},
+		}
+
+		err := adapter.ExecuteContext(
+			context.WithoutCancel(t.Context()),
+			[]string{"step", "--debug=false", "--output", "none"},
+		)
+		require.NoError(t, err)
+		require.False(t, debugEnabled)
+		require.Equal(t, "none", outputFormat)
+	})
+
 	t.Run("NewRootCmdPreservesMiddlewareChain", func(t *testing.T) {
 		// Verify that building a real command tree via NewRootCmd preserves
 		// the full middleware chain (debug, ux, telemetry, error, loginGuard, etc.)

--- a/cli/azd/internal/grpcserver/workflow_service.go
+++ b/cli/azd/internal/grpcserver/workflow_service.go
@@ -41,10 +41,17 @@ func (s *workflowService) Run(ctx context.Context, request *azdext.RunWorkflowRe
 	}
 
 	if err := s.runner.Run(ctx, azdWorkflow); err != nil {
+		code := codes.Internal
 		if errors.Is(err, environment.ErrExists) {
-			return nil, status.Errorf(codes.AlreadyExists, "failed to run workflow: %v", err)
+			code = codes.AlreadyExists
 		}
-		return nil, status.Errorf(codes.Internal, "failed to run workflow: %v", err)
+
+		st := status.New(code, "failed to run workflow: "+err.Error())
+		if relayedErr := relayedExtensionError(err); relayedErr != nil {
+			st = withRelayedExtensionErrorDetail(st, relayedErr)
+		}
+
+		return nil, st.Err()
 	}
 
 	return &azdext.EmptyResponse{}, nil

--- a/cli/azd/internal/grpcserver/workflow_service_test.go
+++ b/cli/azd/internal/grpcserver/workflow_service_test.go
@@ -90,6 +90,46 @@ func Test_WorkflowService_Run_Success(t *testing.T) {
 		testRunner.AssertCalled(t, "ExecuteContext", contextType, []string{"provision"})
 	})
 
+	t.Run("StructuredFailure", func(t *testing.T) {
+		expectedErr := &azdext.LocalError{
+			Message:    "invalid project configuration",
+			Code:       "invalid_project",
+			Category:   azdext.LocalErrorCategoryValidation,
+			Suggestion: "Fix the project configuration and retry.",
+		}
+		testRunner := &TestWorkflowRunner{}
+		runner := workflow.NewRunner(testRunner, mockContext.Console)
+		testRunner.On("ExecuteContext", contextType, mock.Anything).Return(expectedErr)
+
+		service := NewWorkflowService(runner)
+		req := &azdext.RunWorkflowRequest{
+			Workflow: &azdext.Workflow{
+				Name: "testWorkflow",
+				Steps: []*azdext.WorkflowStep{
+					{
+						Command: &azdext.WorkflowCommand{
+							Args: []string{"provision"},
+						},
+					},
+				},
+			},
+		}
+
+		resp, err := service.Run(*mockContext.Context, req)
+
+		require.Error(t, err)
+		require.Equal(t, codes.Internal, status.Code(err))
+		require.Nil(t, resp)
+
+		extensionErr := azdext.ExtensionErrorFromStatus(status.Convert(err))
+		require.NotNil(t, extensionErr)
+		relayedErr := azdext.UnwrapError(extensionErr)
+		var localErr *azdext.LocalError
+		require.ErrorAs(t, relayedErr, &localErr)
+		require.Equal(t, expectedErr.Code, localErr.Code)
+		require.Equal(t, expectedErr.Suggestion, localErr.Suggestion)
+	})
+
 	t.Run("EnvironmentAlreadyExists", func(t *testing.T) {
 		envExistsErr := fmt.Errorf("creating environment 'myenv': %w", environment.ErrExists)
 		testRunner := &TestWorkflowRunner{}


### PR DESCRIPTION
## Why this change is needed

Nested workflow commands currently lose structured extension errors at the gRPC boundary, and inherited global flags can override flags explicitly supplied by a workflow step. This makes extension failures harder to classify and can change the requested behavior of nested commands.

## What changed

- Preserve structured extension errors in WorkflowService gRPC status details.
- Give workflow step flags precedence over inherited global flags.
- Add regression coverage for structured errors and flag precedence.

## Why this approach

The implementation reuses the existing extension error serialization and gRPC detail helpers, keeping the established error contract intact. Workflow argument merging filters only inherited flags that the step explicitly sets, while preserving propagation of other parent-level global flags.