### PR TITLE
ci: temporarily disable AI agents live PR trigger

### DIFF
--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -29,17 +29,7 @@
 #     project) to avoid anonymous rate limits — no extra secret setup required.
 
 trigger: none
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - eng/pipelines/ext-azure-ai-agents-live.yml
-      - cli/azd/go.mod
-      - cli/azd/go.sum
-      - cli/azd/extensions/azure.ai.agents/**
-      - cli/azd/extensions/azure.ai.projects/**
+pr: none
 
 schedules:
   # 7am UTC Monday (offset from other weekly E2E pipelines to reduce contention).


### PR DESCRIPTION
## Summary

Temporarily disables the Azure AI Agents Tier 2 live pipeline as a pull-request trigger by setting `pr: none`.

This is an emergency unblock for unrelated PRs while the live pipeline authentication issue is fixed separately in #9923.

## Scope

- Changes only `eng/pipelines/ext-azure-ai-agents-live.yml`.
- Does not change live-test, GitHub authentication, Key Vault, provisioning, deployment, or cleanup logic.
- Keeps the weekly schedule unchanged.
- Keeps direct Azure DevOps manual queueing available.
- Does not affect GitHub Actions, other Azure DevOps pipelines, or the Tier 0/1 static PR gate.

## Temporary limitation

PR comment triggering with `/azp run` is disabled while `pr: none` is present. After an Azure DevOps administrator restores definition 8268 to require comments from all internal PR authors, this commit can be reverted to restore comment-triggered runs without restoring automatic runs.

Related: #9925
