### PR TITLE
test: cache AI agents live sample download

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -896,13 +896,16 @@ func readManifestContentForInitDetection(
 		return content, true
 	}
 	cachedContent, cached := readCachedTemplateManifest(manifestPointer)
+	if cached {
+		return cachedContent, true
+	}
 	if azdClient == nil || !strings.Contains(manifestPointer, "://") {
-		return cachedContent, cached
+		return nil, false
 	}
 
 	parsedURL, err := url.Parse(manifestPointer)
 	if err != nil || !strings.Contains(parsedURL.Hostname(), "github") {
-		return cachedContent, cached
+		return nil, false
 	}
 
 	commandRunner := exec.NewCommandRunner(&exec.RunnerOptions{
@@ -924,13 +927,13 @@ func readManifestContentForInitDetection(
 	ghCli := github.NewGitHubCli(console, commandRunner)
 	if err := ghCli.EnsureInstalled(ctx); err != nil {
 		log.Printf("detect unified azure.yaml: ensuring gh is installed: %v", err)
-		return cachedContent, cached
+		return nil, false
 	}
 
 	urlInfo, err := parseGitHubUrlForAdopt(ctx, azdClient, manifestPointer)
 	if err != nil {
 		log.Printf("detect unified azure.yaml: parsing GitHub URL: %v", err)
-		return cachedContent, cached
+		return nil, false
 	}
 
 	apiPath := fmt.Sprintf("/repos/%s/contents/%s", urlInfo.RepoSlug, urlInfo.FilePath)
@@ -940,7 +943,7 @@ func readManifestContentForInitDetection(
 	content, err := downloadGithubManifest(ctx, urlInfo, apiPath, ghCli)
 	if err != nil {
 		log.Printf("detect unified azure.yaml: downloading GitHub file: %v", err)
-		return cachedContent, cached
+		return nil, false
 	}
 
 	return []byte(content), true
@@ -1417,6 +1420,7 @@ func stageRemoteAzureYaml(
 	fmt.Println(output.WithGrayFormat("Downloading sample from GitHub..."))
 
 	triedPublicDownload := false
+	var publicDownloadErr error
 	if urlInfo := parseGitHubUrlNaive(pointer); urlInfo != nil {
 		triedPublicDownload = true
 		dirPath := parentDirOf(urlInfo.FilePath)
@@ -1434,12 +1438,25 @@ func stageRemoteAzureYaml(
 				}
 				return nil
 			}
+			publicDownloadErr = errors.New("downloaded sample did not contain azure.yaml")
+		} else {
+			publicDownloadErr = err
 		}
 	}
 
 	if triedPublicDownload {
 		if err := clearStagingDirectory(staging); err != nil {
 			return err
+		}
+		if publicDownloadErr != nil {
+			restored, cacheErr := restoreCachedTemplate(pointer, staging)
+			if cacheErr != nil {
+				return fmt.Errorf("%w; cached sample fallback also failed: %v", publicDownloadErr, cacheErr)
+			}
+			if restored {
+				emitTemplateCacheWarning(templateCacheFallbackMessage(pointer, publicDownloadErr))
+				return nil
+			}
 		}
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -1475,28 +1475,26 @@ func stageRemoteAzureYaml(
 	)
 	ghCli := github.NewGitHubCli(console, commandRunner)
 	if err := ghCli.EnsureInstalled(ctx); err != nil {
-		downloadErr := exterrors.Dependency(
+		return exterrors.Dependency(
 			exterrors.CodeGitHubDownloadFailed,
 			fmt.Sprintf("ensuring gh is installed: %s", err),
 			"install the GitHub CLI (gh) from https://cli.github.com",
 		)
-		return useCachedTemplateOnDownloadError(pointer, staging, downloadErr)
 	}
 
 	urlInfo, err := parseGitHubUrlForAdopt(ctx, azdClient, pointer)
 	if err != nil {
-		return useCachedTemplateOnDownloadError(pointer, staging, err)
+		return err
 	}
 	dirPath := parentDirOf(urlInfo.FilePath)
 	if err := downloadDirectoryContents(
 		ctx, urlInfo.Hostname, urlInfo.RepoSlug, dirPath, dirPath, urlInfo.Branch, staging, ghCli, console,
 	); err != nil {
-		downloadErr := exterrors.Dependency(
+		return exterrors.Dependency(
 			exterrors.CodeGitHubDownloadFailed,
 			fmt.Sprintf("downloading sample directory: %s", err),
 			"verify the URL points to a valid azure.yaml in the repository and you have access",
 		)
-		return useCachedTemplateOnDownloadError(pointer, staging, downloadErr)
 	}
 
 	hasAzureYaml, err := ensureStagedAzureYaml(staging)
@@ -1509,9 +1507,6 @@ func stageRemoteAzureYaml(
 			"no azure.yaml was found in the downloaded sample directory",
 			"verify the URL points to a directory that contains an azure.yaml",
 		)
-	}
-	if cacheErr := refreshTemplateCache(pointer, staging); cacheErr != nil {
-		emitTemplateCacheWarning(fmt.Sprintf("Unable to refresh the sample cache: %s", cacheErr))
 	}
 	return nil
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -899,7 +899,7 @@ func readManifestContentForInitDetection(
 	if cached {
 		return cachedContent, true
 	}
-	if templateCacheDir() != "" {
+	if templateCacheRoot() != "" {
 		return nil, false
 	}
 	if azdClient == nil || !strings.Contains(manifestPointer, "://") {
@@ -1451,7 +1451,7 @@ func stageRemoteAzureYaml(
 		if err := clearStagingDirectory(staging); err != nil {
 			return err
 		}
-		if publicDownloadErr != nil && templateCacheDir() != "" {
+		if publicDownloadErr != nil && templateCacheRoot() != "" {
 			return useCachedTemplateOnDownloadError(pointer, staging, publicDownloadErr)
 		}
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -899,6 +899,9 @@ func readManifestContentForInitDetection(
 	if cached {
 		return cachedContent, true
 	}
+	if templateCacheDir() != "" {
+		return nil, false
+	}
 	if azdClient == nil || !strings.Contains(manifestPointer, "://") {
 		return nil, false
 	}
@@ -1448,15 +1451,8 @@ func stageRemoteAzureYaml(
 		if err := clearStagingDirectory(staging); err != nil {
 			return err
 		}
-		if publicDownloadErr != nil {
-			restored, cacheErr := restoreCachedTemplate(pointer, staging)
-			if cacheErr != nil {
-				return fmt.Errorf("%w; cached sample fallback also failed: %v", publicDownloadErr, cacheErr)
-			}
-			if restored {
-				emitTemplateCacheWarning(templateCacheFallbackMessage(pointer, publicDownloadErr))
-				return nil
-			}
+		if publicDownloadErr != nil && templateCacheDir() != "" {
+			return useCachedTemplateOnDownloadError(pointer, staging, publicDownloadErr)
 		}
 	}
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/init_adopt.go
@@ -895,13 +895,14 @@ func readManifestContentForInitDetection(
 	if content, ok := readManifestContentForPeek(ctx, manifestPointer, httpClient); ok {
 		return content, true
 	}
+	cachedContent, cached := readCachedTemplateManifest(manifestPointer)
 	if azdClient == nil || !strings.Contains(manifestPointer, "://") {
-		return nil, false
+		return cachedContent, cached
 	}
 
 	parsedURL, err := url.Parse(manifestPointer)
 	if err != nil || !strings.Contains(parsedURL.Hostname(), "github") {
-		return nil, false
+		return cachedContent, cached
 	}
 
 	commandRunner := exec.NewCommandRunner(&exec.RunnerOptions{
@@ -923,13 +924,13 @@ func readManifestContentForInitDetection(
 	ghCli := github.NewGitHubCli(console, commandRunner)
 	if err := ghCli.EnsureInstalled(ctx); err != nil {
 		log.Printf("detect unified azure.yaml: ensuring gh is installed: %v", err)
-		return nil, false
+		return cachedContent, cached
 	}
 
 	urlInfo, err := parseGitHubUrlForAdopt(ctx, azdClient, manifestPointer)
 	if err != nil {
 		log.Printf("detect unified azure.yaml: parsing GitHub URL: %v", err)
-		return nil, false
+		return cachedContent, cached
 	}
 
 	apiPath := fmt.Sprintf("/repos/%s/contents/%s", urlInfo.RepoSlug, urlInfo.FilePath)
@@ -939,7 +940,7 @@ func readManifestContentForInitDetection(
 	content, err := downloadGithubManifest(ctx, urlInfo, apiPath, ghCli)
 	if err != nil {
 		log.Printf("detect unified azure.yaml: downloading GitHub file: %v", err)
-		return nil, false
+		return cachedContent, cached
 	}
 
 	return []byte(content), true
@@ -1428,6 +1429,9 @@ func stageRemoteAzureYaml(
 				return normalizeErr
 			}
 			if hasAzureYaml {
+				if cacheErr := refreshTemplateCache(pointer, staging); cacheErr != nil {
+					emitTemplateCacheWarning(fmt.Sprintf("Unable to refresh the sample cache: %s", cacheErr))
+				}
 				return nil
 			}
 		}
@@ -1458,26 +1462,28 @@ func stageRemoteAzureYaml(
 	)
 	ghCli := github.NewGitHubCli(console, commandRunner)
 	if err := ghCli.EnsureInstalled(ctx); err != nil {
-		return exterrors.Dependency(
+		downloadErr := exterrors.Dependency(
 			exterrors.CodeGitHubDownloadFailed,
 			fmt.Sprintf("ensuring gh is installed: %s", err),
 			"install the GitHub CLI (gh) from https://cli.github.com",
 		)
+		return useCachedTemplateOnDownloadError(pointer, staging, downloadErr)
 	}
 
 	urlInfo, err := parseGitHubUrlForAdopt(ctx, azdClient, pointer)
 	if err != nil {
-		return err
+		return useCachedTemplateOnDownloadError(pointer, staging, err)
 	}
 	dirPath := parentDirOf(urlInfo.FilePath)
 	if err := downloadDirectoryContents(
 		ctx, urlInfo.Hostname, urlInfo.RepoSlug, dirPath, dirPath, urlInfo.Branch, staging, ghCli, console,
 	); err != nil {
-		return exterrors.Dependency(
+		downloadErr := exterrors.Dependency(
 			exterrors.CodeGitHubDownloadFailed,
 			fmt.Sprintf("downloading sample directory: %s", err),
 			"verify the URL points to a valid azure.yaml in the repository and you have access",
 		)
+		return useCachedTemplateOnDownloadError(pointer, staging, downloadErr)
 	}
 
 	hasAzureYaml, err := ensureStagedAzureYaml(staging)
@@ -1490,6 +1496,9 @@ func stageRemoteAzureYaml(
 			"no azure.yaml was found in the downloaded sample directory",
 			"verify the URL points to a directory that contains an azure.yaml",
 		)
+	}
+	if cacheErr := refreshTemplateCache(pointer, staging); cacheErr != nil {
+		emitTemplateCacheWarning(fmt.Sprintf("Unable to refresh the sample cache: %s", cacheErr))
 	}
 	return nil
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
@@ -77,7 +77,7 @@ func refreshTemplateCache(pointer, staging string) error {
 func useCachedTemplateOnDownloadError(pointer, staging string, downloadErr error) error {
 	restored, err := restoreCachedTemplate(pointer, staging)
 	if err != nil {
-		return fmt.Errorf("%w; cached sample fallback also failed: %v", downloadErr, err)
+		return fmt.Errorf("%w; cached sample fallback also failed: %w", downloadErr, err)
 	}
 	if !restored {
 		return downloadErr

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
@@ -19,6 +19,8 @@ import (
 const templateCacheDirEnv = "AZURE_AI_AGENTS_E2E_TEMPLATE_CACHE_DIR"
 const templateCacheRefreshedMarker = ".refreshed"
 
+var renameTemplateCachePath = os.Rename
+
 func templateCacheRoot() string {
 	return strings.TrimSpace(os.Getenv(templateCacheDirEnv))
 }
@@ -68,11 +70,30 @@ func refreshTemplateCache(pointer, staging string) error {
 	if err := copyDirectory(staging, tempDir); err != nil {
 		return fmt.Errorf("stage sample cache: %w", err)
 	}
-	if err := os.RemoveAll(cacheDir); err != nil {
-		return fmt.Errorf("replace sample cache: %w", err)
+
+	previousDir := cacheDir + ".previous"
+	if err := os.RemoveAll(previousDir); err != nil {
+		return fmt.Errorf("clear previous sample cache: %w", err)
 	}
-	if err := os.Rename(tempDir, cacheDir); err != nil {
+	hadPrevious := fileExists(filepath.Join(cacheDir, "azure.yaml"))
+	if hadPrevious {
+		if err := renameTemplateCachePath(cacheDir, previousDir); err != nil {
+			return fmt.Errorf("preserve previous sample cache: %w", err)
+		}
+	}
+	if err := renameTemplateCachePath(tempDir, cacheDir); err != nil {
+		if hadPrevious {
+			if restoreErr := renameTemplateCachePath(previousDir, cacheDir); restoreErr != nil {
+				return fmt.Errorf(
+					"activate sample cache and restore previous cache: %w",
+					errors.Join(err, restoreErr),
+				)
+			}
+		}
 		return fmt.Errorf("activate sample cache: %w", err)
+	}
+	if err := os.RemoveAll(previousDir); err != nil {
+		return fmt.Errorf("remove previous sample cache: %w", err)
 	}
 	if err := os.WriteFile(
 		filepath.Join(templateCacheRoot(), templateCacheRefreshedMarker),

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"context"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -106,10 +107,12 @@ func refreshTemplateCache(pointer, staging string) error {
 }
 
 func useCachedTemplateOnDownloadError(pointer, staging string, downloadErr error) error {
+	if errors.Is(downloadErr, context.Canceled) || errors.Is(downloadErr, context.DeadlineExceeded) {
+		return downloadErr
+	}
 	restored, err := restoreCachedTemplate(pointer, staging)
 	if err != nil {
-		var localErr *azdext.LocalError
-		if errors.As(downloadErr, &localErr) {
+		if localErr, ok := errors.AsType[*azdext.LocalError](downloadErr); ok {
 			combinedErr := *localErr
 			combinedErr.Message = fmt.Sprintf("%s; cached sample fallback also failed: %s", localErr.Message, err)
 			return &combinedErr

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,12 +16,20 @@ import (
 
 const templateCacheDirEnv = "AZURE_AI_AGENTS_E2E_TEMPLATE_CACHE_DIR"
 
-func templateCacheDir() string {
+func templateCacheRoot() string {
 	return strings.TrimSpace(os.Getenv(templateCacheDirEnv))
 }
 
-func readCachedTemplateManifest(_ string) ([]byte, bool) {
-	cacheDir := templateCacheDir()
+func templateCacheDir(pointer string) string {
+	root := templateCacheRoot()
+	if root == "" {
+		return ""
+	}
+	return filepath.Join(root, fmt.Sprintf("%x", sha256.Sum256([]byte(pointer))))
+}
+
+func readCachedTemplateManifest(pointer string) ([]byte, bool) {
+	cacheDir := templateCacheDir(pointer)
 	if cacheDir == "" {
 		return nil, false
 	}
@@ -29,8 +38,8 @@ func readCachedTemplateManifest(_ string) ([]byte, bool) {
 	return content, err == nil
 }
 
-func restoreCachedTemplate(_ string, staging string) (bool, error) {
-	cacheDir := templateCacheDir()
+func restoreCachedTemplate(pointer, staging string) (bool, error) {
+	cacheDir := templateCacheDir(pointer)
 	if cacheDir == "" || !fileExists(filepath.Join(cacheDir, "azure.yaml")) {
 		return false, nil
 	}
@@ -43,8 +52,8 @@ func restoreCachedTemplate(_ string, staging string) (bool, error) {
 	return true, nil
 }
 
-func refreshTemplateCache(_ string, staging string) error {
-	cacheDir := templateCacheDir()
+func refreshTemplateCache(pointer, staging string) error {
+	cacheDir := templateCacheDir(pointer)
 	if cacheDir == "" {
 		return nil
 	}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
+	"github.com/azure/azure-dev/cli/azd/pkg/output"
+)
+
+const templateCacheDirEnv = "AZURE_AI_AGENTS_E2E_TEMPLATE_CACHE_DIR"
+
+func templateCachePath(pointer string) (string, bool) {
+	root := strings.TrimSpace(os.Getenv(templateCacheDirEnv))
+	if root == "" {
+		return "", false
+	}
+
+	key := fmt.Sprintf("%x", sha256.Sum256([]byte(pointer)))
+	return filepath.Join(root, key), true
+}
+
+func readCachedTemplateManifest(pointer string) ([]byte, bool) {
+	cachePath, ok := templateCachePath(pointer)
+	if !ok {
+		return nil, false
+	}
+
+	//nolint:gosec // cachePath is rooted in a CI-controlled directory and keyed by a SHA-256 digest.
+	content, err := os.ReadFile(filepath.Join(cachePath, "azure.yaml"))
+	return content, err == nil
+}
+
+func restoreCachedTemplate(pointer, staging string) (bool, error) {
+	cachePath, ok := templateCachePath(pointer)
+	if !ok || !fileExists(filepath.Join(cachePath, "azure.yaml")) {
+		return false, nil
+	}
+
+	if err := clearStagingDirectory(staging); err != nil {
+		return false, fmt.Errorf("prepare staging directory for cached sample: %w", err)
+	}
+	if err := copyDirectory(cachePath, staging); err != nil {
+		return false, fmt.Errorf("restore cached sample: %w", err)
+	}
+	return true, nil
+}
+
+func refreshTemplateCache(pointer, staging string) error {
+	cachePath, ok := templateCachePath(pointer)
+	if !ok {
+		return nil
+	}
+
+	root := filepath.Dir(cachePath)
+	if err := os.MkdirAll(root, osutil.PermissionDirectory); err != nil {
+		return fmt.Errorf("create template cache directory: %w", err)
+	}
+	tempPath, err := os.MkdirTemp(root, ".refresh-*")
+	if err != nil {
+		return fmt.Errorf("create temporary template cache: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tempPath) }()
+
+	if err := copyDirectory(staging, tempPath); err != nil {
+		return fmt.Errorf("copy sample into template cache: %w", err)
+	}
+	if !fileExists(filepath.Join(tempPath, "azure.yaml")) {
+		return fmt.Errorf("downloaded sample cache does not contain azure.yaml")
+	}
+	backupPath := cachePath + ".previous"
+	if err := os.RemoveAll(backupPath); err != nil {
+		return fmt.Errorf("prepare template cache backup: %w", err)
+	}
+	hadCache := fileExists(cachePath)
+	if hadCache {
+		if err := os.Rename(cachePath, backupPath); err != nil {
+			return fmt.Errorf("back up template cache: %w", err)
+		}
+	}
+	if err := os.Rename(tempPath, cachePath); err != nil {
+		if hadCache {
+			_ = os.Rename(backupPath, cachePath)
+		}
+		return fmt.Errorf("activate template cache: %w", err)
+	}
+	if err := os.RemoveAll(backupPath); err != nil {
+		return fmt.Errorf("remove previous template cache: %w", err)
+	}
+	return nil
+}
+
+func useCachedTemplateOnDownloadError(pointer, staging string, downloadErr error) error {
+	restored, cacheErr := restoreCachedTemplate(pointer, staging)
+	if cacheErr != nil {
+		return fmt.Errorf("%w; cached sample fallback also failed: %v", downloadErr, cacheErr)
+	}
+	if !restored {
+		return downloadErr
+	}
+
+	emitTemplateCacheWarning(templateCacheFallbackMessage(pointer, downloadErr))
+	return nil
+}
+
+func templateCacheFallbackMessage(pointer string, downloadErr error) string {
+	detail := downloadErr.Error()
+	if redacted := redactTemplatePointer(pointer); redacted != pointer {
+		detail = strings.ReplaceAll(detail, pointer, redacted)
+	}
+	return fmt.Sprintf("GitHub sample download failed; using the last cached sample. Details: %s", detail)
+}
+
+func redactTemplatePointer(pointer string) string {
+	parsed, err := url.Parse(pointer)
+	if err != nil {
+		return pointer
+	}
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.ForceQuery = false
+	parsed.Fragment = ""
+	parsed.RawFragment = ""
+	return parsed.String()
+}
+
+func emitTemplateCacheWarning(message string) {
+	if os.Getenv("TF_BUILD") != "" {
+		fmt.Printf("##vso[task.logissue type=warning]%s\n", escapeAzurePipelinesMessage(message))
+		return
+	}
+	fmt.Println(output.WithWarningFormat("WARNING: %s", message))
+}
+
+func escapeAzurePipelinesMessage(message string) string {
+	replacer := strings.NewReplacer(
+		"%", "%AZP25",
+		"\r", "%0D",
+		"\n", "%0A",
+		"]", "%5D",
+	)
+	return replacer.Replace(message)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+// cspell:ignore logissue
 
 package cmd
 

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
@@ -6,15 +6,18 @@ package cmd
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/azure/azure-dev/cli/azd/pkg/azdext"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
 const templateCacheDirEnv = "AZURE_AI_AGENTS_E2E_TEMPLATE_CACHE_DIR"
+const templateCacheRefreshedMarker = ".refreshed"
 
 func templateCacheRoot() string {
 	return strings.TrimSpace(os.Getenv(templateCacheDirEnv))
@@ -71,12 +74,25 @@ func refreshTemplateCache(pointer, staging string) error {
 	if err := os.Rename(tempDir, cacheDir); err != nil {
 		return fmt.Errorf("activate sample cache: %w", err)
 	}
+	if err := os.WriteFile(
+		filepath.Join(templateCacheRoot(), templateCacheRefreshedMarker),
+		[]byte("refreshed\n"),
+		0600,
+	); err != nil {
+		return fmt.Errorf("mark refreshed sample cache: %w", err)
+	}
 	return nil
 }
 
 func useCachedTemplateOnDownloadError(pointer, staging string, downloadErr error) error {
 	restored, err := restoreCachedTemplate(pointer, staging)
 	if err != nil {
+		var localErr *azdext.LocalError
+		if errors.As(downloadErr, &localErr) {
+			combinedErr := *localErr
+			combinedErr.Message = fmt.Sprintf("%s; cached sample fallback also failed: %s", localErr.Message, err)
+			return &combinedErr
+		}
 		return fmt.Errorf("%w; cached sample fallback also failed: %w", downloadErr, err)
 	}
 	if !restored {

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
@@ -5,147 +5,85 @@
 package cmd
 
 import (
-	"crypto/sha256"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/azure/azure-dev/cli/azd/pkg/osutil"
 	"github.com/azure/azure-dev/cli/azd/pkg/output"
 )
 
 const templateCacheDirEnv = "AZURE_AI_AGENTS_E2E_TEMPLATE_CACHE_DIR"
 
-func templateCachePath(pointer string) (string, bool) {
-	root := strings.TrimSpace(os.Getenv(templateCacheDirEnv))
-	if root == "" {
-		return "", false
-	}
-
-	key := fmt.Sprintf("%x", sha256.Sum256([]byte(pointer)))
-	return filepath.Join(root, key), true
+func templateCacheDir() string {
+	return strings.TrimSpace(os.Getenv(templateCacheDirEnv))
 }
 
-func readCachedTemplateManifest(pointer string) ([]byte, bool) {
-	cachePath, ok := templateCachePath(pointer)
-	if !ok {
+func readCachedTemplateManifest(_ string) ([]byte, bool) {
+	cacheDir := templateCacheDir()
+	if cacheDir == "" {
 		return nil, false
 	}
-
-	//nolint:gosec // cachePath is rooted in a CI-controlled directory and keyed by a SHA-256 digest.
-	content, err := os.ReadFile(filepath.Join(cachePath, "azure.yaml"))
+	//nolint:gosec // cacheDir is set by the live-test pipeline.
+	content, err := os.ReadFile(filepath.Join(cacheDir, "azure.yaml"))
 	return content, err == nil
 }
 
-func restoreCachedTemplate(pointer, staging string) (bool, error) {
-	cachePath, ok := templateCachePath(pointer)
-	if !ok || !fileExists(filepath.Join(cachePath, "azure.yaml")) {
+func restoreCachedTemplate(_ string, staging string) (bool, error) {
+	cacheDir := templateCacheDir()
+	if cacheDir == "" || !fileExists(filepath.Join(cacheDir, "azure.yaml")) {
 		return false, nil
 	}
-
 	if err := clearStagingDirectory(staging); err != nil {
-		return false, fmt.Errorf("prepare staging directory for cached sample: %w", err)
+		return false, err
 	}
-	if err := copyDirectory(cachePath, staging); err != nil {
+	if err := copyDirectory(cacheDir, staging); err != nil {
 		return false, fmt.Errorf("restore cached sample: %w", err)
 	}
 	return true, nil
 }
 
-func refreshTemplateCache(pointer, staging string) error {
-	cachePath, ok := templateCachePath(pointer)
-	if !ok {
+func refreshTemplateCache(_ string, staging string) error {
+	cacheDir := templateCacheDir()
+	if cacheDir == "" {
 		return nil
 	}
 
-	root := filepath.Dir(cachePath)
-	if err := os.MkdirAll(root, osutil.PermissionDirectory); err != nil {
-		return fmt.Errorf("create template cache directory: %w", err)
+	tempDir := cacheDir + ".new"
+	if err := os.RemoveAll(tempDir); err != nil {
+		return err
 	}
-	tempPath, err := os.MkdirTemp(root, ".refresh-*")
-	if err != nil {
-		return fmt.Errorf("create temporary template cache: %w", err)
+	if err := copyDirectory(staging, tempDir); err != nil {
+		return fmt.Errorf("stage sample cache: %w", err)
 	}
-	defer func() { _ = os.RemoveAll(tempPath) }()
-
-	if err := copyDirectory(staging, tempPath); err != nil {
-		return fmt.Errorf("copy sample into template cache: %w", err)
+	if err := os.RemoveAll(cacheDir); err != nil {
+		return fmt.Errorf("replace sample cache: %w", err)
 	}
-	if !fileExists(filepath.Join(tempPath, "azure.yaml")) {
-		return fmt.Errorf("downloaded sample cache does not contain azure.yaml")
-	}
-	backupPath := cachePath + ".previous"
-	if err := os.RemoveAll(backupPath); err != nil {
-		return fmt.Errorf("prepare template cache backup: %w", err)
-	}
-	hadCache := fileExists(cachePath)
-	if hadCache {
-		if err := os.Rename(cachePath, backupPath); err != nil {
-			return fmt.Errorf("back up template cache: %w", err)
-		}
-	}
-	if err := os.Rename(tempPath, cachePath); err != nil {
-		if hadCache {
-			_ = os.Rename(backupPath, cachePath)
-		}
-		return fmt.Errorf("activate template cache: %w", err)
-	}
-	if err := os.RemoveAll(backupPath); err != nil {
-		return fmt.Errorf("remove previous template cache: %w", err)
+	if err := os.Rename(tempDir, cacheDir); err != nil {
+		return fmt.Errorf("activate sample cache: %w", err)
 	}
 	return nil
 }
 
 func useCachedTemplateOnDownloadError(pointer, staging string, downloadErr error) error {
-	restored, cacheErr := restoreCachedTemplate(pointer, staging)
-	if cacheErr != nil {
-		return fmt.Errorf("%w; cached sample fallback also failed: %v", downloadErr, cacheErr)
+	restored, err := restoreCachedTemplate(pointer, staging)
+	if err != nil {
+		return fmt.Errorf("%w; cached sample fallback also failed: %v", downloadErr, err)
 	}
 	if !restored {
 		return downloadErr
 	}
-
-	emitTemplateCacheWarning(templateCacheFallbackMessage(pointer, downloadErr))
+	emitTemplateCacheWarning(
+		fmt.Sprintf("GitHub sample download failed; using the cached sample. Details: %s", downloadErr),
+	)
 	return nil
-}
-
-func templateCacheFallbackMessage(pointer string, downloadErr error) string {
-	detail := downloadErr.Error()
-	if redacted := redactTemplatePointer(pointer); redacted != pointer {
-		detail = strings.ReplaceAll(detail, pointer, redacted)
-	}
-	return fmt.Sprintf("GitHub sample download failed; using the last cached sample. Details: %s", detail)
-}
-
-func redactTemplatePointer(pointer string) string {
-	parsed, err := url.Parse(pointer)
-	if err != nil {
-		return pointer
-	}
-	parsed.User = nil
-	parsed.RawQuery = ""
-	parsed.ForceQuery = false
-	parsed.Fragment = ""
-	parsed.RawFragment = ""
-	return parsed.String()
 }
 
 func emitTemplateCacheWarning(message string) {
 	if os.Getenv("TF_BUILD") != "" {
-		fmt.Printf("##vso[task.logissue type=warning]%s\n", escapeAzurePipelinesMessage(message))
+		message = strings.NewReplacer("%", "%AZP25", "\r", "%0D", "\n", "%0A", "]", "%5D").Replace(message)
+		fmt.Printf("##vso[task.logissue type=warning]%s\n", message)
 		return
 	}
 	fmt.Println(output.WithWarningFormat("WARNING: %s", message))
-}
-
-func escapeAzurePipelinesMessage(message string) string {
-	replacer := strings.NewReplacer(
-		"%", "%AZP25",
-		"\r", "%0D",
-		"\n", "%0A",
-		"]", "%5D",
-	)
-	return replacer.Replace(message)
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,9 +12,8 @@ import (
 )
 
 func TestTemplateCacheRoundTrip(t *testing.T) {
-	cacheRoot := t.TempDir()
-	t.Setenv(templateCacheDirEnv, cacheRoot)
-	pointer := "https://github.com/example/samples/blob/main/basic/azure.yaml"
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	t.Setenv(templateCacheDirEnv, cacheDir)
 
 	downloaded := t.TempDir()
 	require.NoError(t, os.WriteFile(
@@ -26,51 +24,15 @@ func TestTemplateCacheRoundTrip(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(downloaded, "src"), 0750))
 	require.NoError(t, os.WriteFile(filepath.Join(downloaded, "src", "main.py"), []byte("print('ok')\n"), 0600))
 
-	require.NoError(t, refreshTemplateCache(pointer, downloaded))
+	require.NoError(t, refreshTemplateCache("", downloaded))
 
-	content, ok := readCachedTemplateManifest(pointer)
+	content, ok := readCachedTemplateManifest("")
 	require.True(t, ok)
 	require.Contains(t, string(content), "cached-sample")
 
-	updated := t.TempDir()
-	require.NoError(t, os.WriteFile(
-		filepath.Join(updated, "azure.yaml"),
-		[]byte("name: updated-sample\nservices: {}\n"),
-		0600,
-	))
-	require.NoError(t, refreshTemplateCache(pointer, updated))
-
-	content, ok = readCachedTemplateManifest(pointer)
-	require.True(t, ok)
-	require.Contains(t, string(content), "updated-sample")
-
 	staging := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(staging, "partial.txt"), []byte("partial"), 0600))
-	restored, err := restoreCachedTemplate(pointer, staging)
+	restored, err := restoreCachedTemplate("", staging)
 	require.NoError(t, err)
 	require.True(t, restored)
-	require.False(t, fileExists(filepath.Join(staging, "partial.txt")))
-	require.Contains(t, mustReadFile(t, filepath.Join(staging, "azure.yaml")), "updated-sample")
-}
-
-func TestTemplateCacheFallbackMessageRedactsCredentials(t *testing.T) {
-	pointer := "https://user:secret@github.com/example/samples/blob/main/azure.yaml?sig=token#fragment"
-	message := templateCacheFallbackMessage(pointer, errors.New("download failed: "+pointer))
-
-	require.NotContains(t, message, "user")
-	require.NotContains(t, message, "secret")
-	require.NotContains(t, message, "sig=token")
-	require.NotContains(t, message, "fragment")
-	require.Contains(t, message, "https://github.com/example/samples/blob/main/azure.yaml")
-}
-
-func TestEscapeAzurePipelinesMessage(t *testing.T) {
-	require.Equal(t, "failure%AZP25%0D%0Adetail%5D", escapeAzurePipelinesMessage("failure%\r\ndetail]"))
-}
-
-func mustReadFile(t *testing.T, path string) string {
-	t.Helper()
-	content, err := os.ReadFile(path)
-	require.NoError(t, err)
-	return string(content)
+	require.True(t, fileExists(filepath.Join(staging, "src", "main.py")))
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateCacheRoundTrip(t *testing.T) {
+	cacheRoot := t.TempDir()
+	t.Setenv(templateCacheDirEnv, cacheRoot)
+	pointer := "https://github.com/example/samples/blob/main/basic/azure.yaml"
+
+	downloaded := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(downloaded, "azure.yaml"),
+		[]byte("name: cached-sample\nservices: {}\n"),
+		0600,
+	))
+	require.NoError(t, os.MkdirAll(filepath.Join(downloaded, "src"), 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(downloaded, "src", "main.py"), []byte("print('ok')\n"), 0600))
+
+	require.NoError(t, refreshTemplateCache(pointer, downloaded))
+
+	content, ok := readCachedTemplateManifest(pointer)
+	require.True(t, ok)
+	require.Contains(t, string(content), "cached-sample")
+
+	updated := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(updated, "azure.yaml"),
+		[]byte("name: updated-sample\nservices: {}\n"),
+		0600,
+	))
+	require.NoError(t, refreshTemplateCache(pointer, updated))
+
+	content, ok = readCachedTemplateManifest(pointer)
+	require.True(t, ok)
+	require.Contains(t, string(content), "updated-sample")
+
+	staging := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(staging, "partial.txt"), []byte("partial"), 0600))
+	restored, err := restoreCachedTemplate(pointer, staging)
+	require.NoError(t, err)
+	require.True(t, restored)
+	require.False(t, fileExists(filepath.Join(staging, "partial.txt")))
+	require.Contains(t, mustReadFile(t, filepath.Join(staging, "azure.yaml")), "updated-sample")
+}
+
+func TestTemplateCacheFallbackMessageRedactsCredentials(t *testing.T) {
+	pointer := "https://user:secret@github.com/example/samples/blob/main/azure.yaml?sig=token#fragment"
+	message := templateCacheFallbackMessage(pointer, errors.New("download failed: "+pointer))
+
+	require.NotContains(t, message, "user")
+	require.NotContains(t, message, "secret")
+	require.NotContains(t, message, "sig=token")
+	require.NotContains(t, message, "fragment")
+	require.Contains(t, message, "https://github.com/example/samples/blob/main/azure.yaml")
+}
+
+func TestEscapeAzurePipelinesMessage(t *testing.T) {
+	require.Equal(t, "failure%AZP25%0D%0Adetail%5D", escapeAzurePipelinesMessage("failure%\r\ndetail]"))
+}
+
+func mustReadFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(content)
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
@@ -66,3 +66,30 @@ func TestUseCachedTemplateOnDownloadError(t *testing.T) {
 		require.ErrorIs(t, err, downloadErr)
 	})
 }
+
+func TestRefreshTemplateCachePreservesPreviousCacheOnActivationFailure(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	t.Setenv(templateCacheDirEnv, cacheDir)
+	pointer := "https://github.com/example/samples/blob/main/basic/azure.yaml"
+
+	previous := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(previous, "azure.yaml"), []byte("name: previous\n"), 0600))
+	require.NoError(t, refreshTemplateCache(pointer, previous))
+
+	originalRename := renameTemplateCachePath
+	renameTemplateCachePath = func(oldPath, newPath string) error {
+		if oldPath == templateCacheDir(pointer)+".new" {
+			return errors.New("simulated activation failure")
+		}
+		return os.Rename(oldPath, newPath)
+	}
+	t.Cleanup(func() { renameTemplateCachePath = originalRename })
+
+	replacement := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(replacement, "azure.yaml"), []byte("name: replacement\n"), 0600))
+	require.Error(t, refreshTemplateCache(pointer, replacement))
+
+	content, ok := readCachedTemplateManifest(pointer)
+	require.True(t, ok)
+	require.Contains(t, string(content), "previous")
+}

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
@@ -26,6 +26,10 @@ func TestTemplateCacheRoundTrip(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(downloaded, "src", "main.py"), []byte("print('ok')\n"), 0600))
 
 	require.NoError(t, refreshTemplateCache(pointer, downloaded))
+	otherPointer := "https://github.com/example/samples/blob/main/other/azure.yaml"
+	require.NotEqual(t, templateCacheDir(pointer), templateCacheDir(otherPointer))
+	_, ok := readCachedTemplateManifest(otherPointer)
+	require.False(t, ok)
 
 	content, ok := readCachedTemplateManifest(pointer)
 	require.True(t, ok)

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,6 +27,7 @@ func TestTemplateCacheRoundTrip(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(downloaded, "src", "main.py"), []byte("print('ok')\n"), 0600))
 
 	require.NoError(t, refreshTemplateCache(pointer, downloaded))
+	require.FileExists(t, filepath.Join(cacheDir, templateCacheRefreshedMarker))
 	otherPointer := "https://github.com/example/samples/blob/main/other/azure.yaml"
 	require.NotEqual(t, templateCacheDir(pointer), templateCacheDir(otherPointer))
 	_, ok := readCachedTemplateManifest(otherPointer)
@@ -40,4 +42,27 @@ func TestTemplateCacheRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, restored)
 	require.True(t, fileExists(filepath.Join(staging, "src", "main.py")))
+}
+
+func TestUseCachedTemplateOnDownloadError(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	t.Setenv(templateCacheDirEnv, cacheDir)
+	pointer := "https://github.com/example/samples/blob/main/basic/azure.yaml"
+	downloadErr := errors.New("GitHub unavailable")
+
+	t.Run("cache hit", func(t *testing.T) {
+		downloaded := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(downloaded, "azure.yaml"), []byte("name: cached\n"), 0600))
+		require.NoError(t, refreshTemplateCache(pointer, downloaded))
+
+		staging := t.TempDir()
+		require.NoError(t, useCachedTemplateOnDownloadError(pointer, staging, downloadErr))
+		require.FileExists(t, filepath.Join(staging, "azure.yaml"))
+	})
+
+	t.Run("cache miss", func(t *testing.T) {
+		missingPointer := "https://github.com/example/samples/blob/main/missing/azure.yaml"
+		err := useCachedTemplateOnDownloadError(missingPointer, t.TempDir(), downloadErr)
+		require.ErrorIs(t, err, downloadErr)
+	})
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
@@ -14,6 +14,7 @@ import (
 func TestTemplateCacheRoundTrip(t *testing.T) {
 	cacheDir := filepath.Join(t.TempDir(), "cache")
 	t.Setenv(templateCacheDirEnv, cacheDir)
+	pointer := "https://github.com/example/samples/blob/main/basic/azure.yaml"
 
 	downloaded := t.TempDir()
 	require.NoError(t, os.WriteFile(
@@ -24,14 +25,14 @@ func TestTemplateCacheRoundTrip(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(downloaded, "src"), 0750))
 	require.NoError(t, os.WriteFile(filepath.Join(downloaded, "src", "main.py"), []byte("print('ok')\n"), 0600))
 
-	require.NoError(t, refreshTemplateCache("", downloaded))
+	require.NoError(t, refreshTemplateCache(pointer, downloaded))
 
-	content, ok := readCachedTemplateManifest("")
+	content, ok := readCachedTemplateManifest(pointer)
 	require.True(t, ok)
 	require.Contains(t, string(content), "cached-sample")
 
 	staging := t.TempDir()
-	restored, err := restoreCachedTemplate("", staging)
+	restored, err := restoreCachedTemplate(pointer, staging)
 	require.NoError(t, err)
 	require.True(t, restored)
 	require.True(t, fileExists(filepath.Join(staging, "src", "main.py")))

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -64,6 +65,13 @@ func TestUseCachedTemplateOnDownloadError(t *testing.T) {
 		missingPointer := "https://github.com/example/samples/blob/main/missing/azure.yaml"
 		err := useCachedTemplateOnDownloadError(missingPointer, t.TempDir(), downloadErr)
 		require.ErrorIs(t, err, downloadErr)
+	})
+
+	t.Run("cancellation is not replaced by cache", func(t *testing.T) {
+		staging := t.TempDir()
+		err := useCachedTemplateOnDownloadError(pointer, staging, context.Canceled)
+		require.ErrorIs(t, err, context.Canceled)
+		require.NoFileExists(t, filepath.Join(staging, "azure.yaml"))
 	})
 }
 

--- a/cli/azd/extensions/azure.ai.agents/tests/e2e-live/README.md
+++ b/cli/azd/extensions/azure.ai.agents/tests/e2e-live/README.md
@@ -135,6 +135,7 @@ safe to include in a normal `go test ./...`.
 | `E2E_USE_AZ_CLI_AUTH`      | —                              | `true` → set `auth.useAzCliAuth` (CI; auto-on under ADO/GHA) |
 | `E2E_TESTDIR`              | `/tmp/e2e-tests/tier2-<mode>`  | Scratch dir for the scaffolded project                      |
 | `E2E_KEEP_ARTIFACTS`       | —                              | `true` → keep the per-run `AZD_CONFIG_DIR` copy for debugging |
+| `AZURE_AI_AGENTS_E2E_TEMPLATE_CACHE_DIR` | —                 | CI cache for the last successfully downloaded sample         |
 | `GH_TOKEN`                 | —                              | GitHub token for template clone (optional)                  |
 
 In CI the driver auto-detects GitHub Actions (`GITHUB_ACTIONS`) and Azure DevOps

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -104,6 +104,7 @@ extends:
                   artifact: azure-ai-agents-template-cache
                   condition: and(
                     always(),
+                    eq(variables['PublishTemplateCache'], 'true'),
                     eq(variables['System.JobAttempt'], '1')
                     )
                   displayName: Publish last-known-good sample cache
@@ -214,6 +215,9 @@ extends:
                   project: $(System.TeamProjectId)
                   definition: $(System.DefinitionId)
                   buildVersionToDownload: latest
+                  tags: azure-ai-agents-template-cache
+                  allowPartiallySucceededBuilds: true
+                  allowFailedBuilds: true
                   artifactName: azure-ai-agents-template-cache
                   targetPath: $(Pipeline.Workspace)/azure-ai-agents-template-cache
 
@@ -272,6 +276,20 @@ extends:
                   # azure-sdk org PAT (ambient in the ADO project) used only to
                   # avoid anonymous GitHub rate limits when cloning the template.
                   GH_TOKEN: $(azuresdk-github-pat)
+
+              # Cache publication is independent of provision/deploy success.
+              # The extension writes only a complete downloaded sample here.
+              - bash: |
+                  cache_dir="$(Pipeline.Workspace)/azure-ai-agents-template-cache"
+                  if find "$cache_dir" -name azure.yaml -print -quit | grep -q .; then
+                    echo "##vso[task.setvariable variable=PublishTemplateCache]true"
+                    echo "##vso[build.addbuildtag]azure-ai-agents-template-cache"
+                    echo "Valid sample cache will be published from this run."
+                  else
+                    echo "No valid sample cache was produced by this run."
+                  fi
+                condition: always()
+                displayName: Mark valid sample cache
 
               # Safety net for hard crashes / step timeout: the in-test teardown
               # runs `azd down` already, but if the run died mid-way, force-purge

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -99,6 +99,15 @@ extends:
                   artifact: tier2-live-logs-$(Build.BuildId)-$(System.JobAttempt)
                   condition: always()
                   displayName: Publish test logs
+                - output: pipelineArtifact
+                  path: $(Pipeline.Workspace)/azure-ai-agents-template-cache
+                  artifact: azure-ai-agents-template-cache
+                  condition: and(
+                    always(),
+                    eq(variables['Build.SourceBranch'], 'refs/heads/main'),
+                    eq(variables['System.JobAttempt'], '1')
+                    )
+                  displayName: Publish last-known-good sample cache
             steps:
               - checkout: self
 
@@ -196,16 +205,20 @@ extends:
               - bash: mkdir -p "$(Pipeline.Workspace)/azure-ai-agents-template-cache"
                 displayName: Prepare sample cache directory
 
-              # Use a unique exact key so a successful download can refresh the
-              # immutable cache after every run. restoreKeys selects the most
-              # recent sample saved by this pipeline when GitHub is unavailable.
-              - task: Cache@2
-                displayName: Restore AI agents sample cache
+              # Every PR, scheduled, and manual run reads the same last-known-good
+              # sample published by a successful main run. Only main can update it,
+              # so untrusted PR content cannot poison the shared fallback.
+              - task: DownloadPipelineArtifact@2
+                displayName: Restore last-known-good sample cache
+                continueOnError: true
                 inputs:
-                  key: '"azure-ai-agents-template-v1" | "$(Agent.OS)" | "$(Build.BuildId)"'
-                  restoreKeys: |
-                    "azure-ai-agents-template-v1" | "$(Agent.OS)"
-                  path: $(Pipeline.Workspace)/azure-ai-agents-template-cache
+                  buildType: specific
+                  project: $(System.TeamProjectId)
+                  definition: $(System.DefinitionId)
+                  buildVersionToDownload: latestFromBranch
+                  branchName: refs/heads/main
+                  artifactName: azure-ai-agents-template-cache
+                  targetPath: $(Pipeline.Workspace)/azure-ai-agents-template-cache
 
               # Run the live golden path INSIDE the AzureCLI@2 task so the az CLI
               # session (consumed by azd via auth.useAzCliAuth) stays valid for the

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -206,7 +206,7 @@ extends:
                 displayName: Prepare sample cache directory
 
               # Every PR, scheduled, and manual run reads the same last-known-good
-              # sample published by the latest successful run of this pipeline.
+              # sample published by the latest tagged run of this pipeline.
               - task: DownloadPipelineArtifact@2
                 displayName: Restore last-known-good sample cache
                 continueOnError: true
@@ -271,8 +271,6 @@ extends:
                   E2E_LOCATION: eastus2
                   E2E_USE_AZ_CLI_AUTH: "true"
                   AZURE_AI_AGENTS_E2E_TEMPLATE_CACHE_DIR: $(Pipeline.Workspace)/azure-ai-agents-template-cache
-                  GH_PROMPT_DISABLED: "1"
-                  GIT_TERMINAL_PROMPT: "0"
                   # azure-sdk org PAT (ambient in the ADO project) used only to
                   # avoid anonymous GitHub rate limits when cloning the template.
                   GH_TOKEN: $(azuresdk-github-pat)

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -104,7 +104,6 @@ extends:
                   artifact: azure-ai-agents-template-cache
                   condition: and(
                     always(),
-                    eq(variables['Build.SourceBranch'], 'refs/heads/main'),
                     eq(variables['System.JobAttempt'], '1')
                     )
                   displayName: Publish last-known-good sample cache
@@ -206,8 +205,7 @@ extends:
                 displayName: Prepare sample cache directory
 
               # Every PR, scheduled, and manual run reads the same last-known-good
-              # sample published by a successful main run. Only main can update it,
-              # so untrusted PR content cannot poison the shared fallback.
+              # sample published by the latest successful run of this pipeline.
               - task: DownloadPipelineArtifact@2
                 displayName: Restore last-known-good sample cache
                 continueOnError: true
@@ -215,8 +213,7 @@ extends:
                   buildType: specific
                   project: $(System.TeamProjectId)
                   definition: $(System.DefinitionId)
-                  buildVersionToDownload: latestFromBranch
-                  branchName: refs/heads/main
+                  buildVersionToDownload: latest
                   artifactName: azure-ai-agents-template-cache
                   targetPath: $(Pipeline.Workspace)/azure-ai-agents-template-cache
 

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -207,28 +207,40 @@ extends:
               - bash: |
                   set -euo pipefail
                   api="$(System.CollectionUri)$(System.TeamProjectId)/_apis/build"
-                  if ! builds=$(curl -fsS \
-                      -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" \
-                      "$api/builds?definitions=$(System.DefinitionId)&statusFilter=completed&queryOrder=finishTimeDescending&%24top=50&api-version=7.1"); then
-                    echo "##vso[task.logissue type=warning]Unable to query previous sample cache builds; continuing uncached."
-                    exit 0
-                  fi
-                  for build_id in $(echo "$builds" | jq -r '.value[].id'); do
-                    if ! artifacts=$(curl -fsS \
-                        -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" \
-                        "$api/builds/$build_id/artifacts?api-version=7.1"); then
-                      echo "##vso[task.logissue type=warning]Unable to inspect sample cache artifacts for build $build_id; trying an older build."
-                      continue
+                  continuation_token=""
+                  headers=$(mktemp)
+                  trap 'rm -f "$headers"' EXIT
+                  while true; do
+                    url="$api/builds?definitions=$(System.DefinitionId)&statusFilter=completed&queryOrder=finishTimeDescending&%24top=100&api-version=7.1"
+                    if [ -n "$continuation_token" ]; then
+                      url="$url&continuationToken=$continuation_token"
                     fi
-                    artifact_name=$(echo "$artifacts" | jq -r '
-                      [.value[].name |
-                        select(. == "azure-ai-agents-template-cache" or
-                          startswith("azure-ai-agents-template-cache-"))][0] // empty')
-                    if [ -n "$artifact_name" ]; then
-                      echo "##vso[task.setvariable variable=SampleCacheBuildId]$build_id"
-                      echo "##vso[task.setvariable variable=SampleCacheArtifactName]$artifact_name"
-                      echo "Using sample cache from build $build_id."
+                    if ! builds=$(curl -fsS -D "$headers" \
+                        -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" "$url"); then
+                      echo "##vso[task.logissue type=warning]Unable to query previous sample cache builds; continuing uncached."
                       exit 0
+                    fi
+                    for build_id in $(echo "$builds" | jq -r '.value[].id'); do
+                      if ! artifacts=$(curl -fsS \
+                          -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" \
+                          "$api/builds/$build_id/artifacts?api-version=7.1"); then
+                        echo "##vso[task.logissue type=warning]Unable to inspect sample cache artifacts for build $build_id; trying an older build."
+                        continue
+                      fi
+                      artifact_name=$(echo "$artifacts" | jq -r '
+                        [.value[].name |
+                          select(. == "azure-ai-agents-template-cache" or
+                            startswith("azure-ai-agents-template-cache-"))][0] // empty')
+                      if [ -n "$artifact_name" ]; then
+                        echo "##vso[task.setvariable variable=SampleCacheBuildId]$build_id"
+                        echo "##vso[task.setvariable variable=SampleCacheArtifactName]$artifact_name"
+                        echo "Using sample cache from build $build_id."
+                        exit 0
+                      fi
+                    done
+                    continuation_token=$(awk 'tolower($1) == "x-ms-continuationtoken:" {gsub("\r", "", $2); print $2}' "$headers")
+                    if [ -z "$continuation_token" ]; then
+                      break
                     fi
                   done
                   echo "No previous sample cache artifact was found."

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -193,6 +193,20 @@ extends:
                     }' > "$HOME/.azd/config.json"
                 displayName: Install azure.ai.agents and azure.ai.projects extensions
 
+              - bash: mkdir -p "$(Pipeline.Workspace)/azure-ai-agents-template-cache"
+                displayName: Prepare sample cache directory
+
+              # Use a unique exact key so a successful download can refresh the
+              # immutable cache after every run. restoreKeys selects the most
+              # recent sample saved by this pipeline when GitHub is unavailable.
+              - task: Cache@2
+                displayName: Restore AI agents sample cache
+                inputs:
+                  key: '"azure-ai-agents-template-v1" | "$(Agent.OS)" | "$(Build.BuildId)"'
+                  restoreKeys: |
+                    "azure-ai-agents-template-v1" | "$(Agent.OS)"
+                  path: $(Pipeline.Workspace)/azure-ai-agents-template-cache
+
               # Run the live golden path INSIDE the AzureCLI@2 task so the az CLI
               # session (consumed by azd via auth.useAzCliAuth) stays valid for the
               # whole run. keepAzSessionActive is REQUIRED: the service connection
@@ -242,6 +256,9 @@ extends:
                   E2E_CREATE_PROJECT: "true"
                   E2E_LOCATION: eastus2
                   E2E_USE_AZ_CLI_AUTH: "true"
+                  AZURE_AI_AGENTS_E2E_TEMPLATE_CACHE_DIR: $(Pipeline.Workspace)/azure-ai-agents-template-cache
+                  GH_PROMPT_DISABLED: "1"
+                  GIT_TERMINAL_PROMPT: "0"
                   # azure-sdk org PAT (ambient in the ADO project) used only to
                   # avoid anonymous GitHub rate limits when cloning the template.
                   GH_TOKEN: $(azuresdk-github-pat)

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -101,11 +101,10 @@ extends:
                   displayName: Publish test logs
                 - output: pipelineArtifact
                   path: $(Pipeline.Workspace)/azure-ai-agents-template-cache
-                  artifact: azure-ai-agents-template-cache
+                  artifact: azure-ai-agents-template-cache-$(System.JobAttempt)
                   condition: and(
                     always(),
-                    eq(variables['PublishTemplateCache'], 'true'),
-                    eq(variables['System.JobAttempt'], '1')
+                    eq(variables['PublishTemplateCache'], 'true')
                     )
                   displayName: Publish last-known-good sample cache
             steps:
@@ -205,21 +204,49 @@ extends:
               - bash: mkdir -p "$(Pipeline.Workspace)/azure-ai-agents-template-cache"
                 displayName: Prepare sample cache directory
 
+              - bash: |
+                  set -euo pipefail
+                  api="$(System.CollectionUri)$(System.TeamProjectId)/_apis/build"
+                  builds=$(curl -fsS \
+                    -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" \
+                    "$api/builds?definitions=$(System.DefinitionId)&statusFilter=completed&queryOrder=finishTimeDescending&%24top=50&api-version=7.1")
+                  for build_id in $(echo "$builds" | jq -r '.value[].id'); do
+                    artifacts=$(curl -fsS \
+                      -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" \
+                      "$api/builds/$build_id/artifacts?api-version=7.1")
+                    artifact_name=$(echo "$artifacts" | jq -r '
+                      [.value[].name |
+                        select(. == "azure-ai-agents-template-cache" or
+                          startswith("azure-ai-agents-template-cache-"))][0] // empty')
+                    if [ -n "$artifact_name" ]; then
+                      echo "##vso[task.setvariable variable=SampleCacheBuildId]$build_id"
+                      echo "##vso[task.setvariable variable=SampleCacheArtifactName]$artifact_name"
+                      echo "Using sample cache from build $build_id."
+                      exit 0
+                    fi
+                  done
+                  echo "No previous sample cache artifact was found."
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                displayName: Find latest sample cache artifact
+
               # Every PR, scheduled, and manual run reads the same last-known-good
-              # sample published by the latest tagged run of this pipeline.
+              # sample artifact produced by this pipeline, regardless of branch.
               - task: DownloadPipelineArtifact@2
                 displayName: Restore last-known-good sample cache
+                condition: ne(variables['SampleCacheBuildId'], '')
                 continueOnError: true
                 inputs:
                   buildType: specific
                   project: $(System.TeamProjectId)
                   definition: $(System.DefinitionId)
-                  buildVersionToDownload: latest
-                  tags: azure-ai-agents-template-cache
-                  allowPartiallySucceededBuilds: true
-                  allowFailedBuilds: true
-                  artifactName: azure-ai-agents-template-cache
+                  buildVersionToDownload: specific
+                  pipelineId: $(SampleCacheBuildId)
+                  artifactName: $(SampleCacheArtifactName)
                   targetPath: $(Pipeline.Workspace)/azure-ai-agents-template-cache
+
+              - bash: rm -f "$(Pipeline.Workspace)/azure-ai-agents-template-cache/.refreshed"
+                displayName: Reset sample cache refresh marker
 
               # Run the live golden path INSIDE the AzureCLI@2 task so the az CLI
               # session (consumed by azd via auth.useAzCliAuth) stays valid for the
@@ -279,15 +306,15 @@ extends:
               # The extension writes only a complete downloaded sample here.
               - bash: |
                   cache_dir="$(Pipeline.Workspace)/azure-ai-agents-template-cache"
-                  if find "$cache_dir" -name azure.yaml -print -quit | grep -q .; then
+                  if [ -f "$cache_dir/.refreshed" ]; then
                     echo "##vso[task.setvariable variable=PublishTemplateCache]true"
-                    echo "##vso[build.addbuildtag]azure-ai-agents-template-cache"
-                    echo "Valid sample cache will be published from this run."
+                    rm -f "$cache_dir/.refreshed"
+                    echo "Refreshed sample cache will be published from this run."
                   else
-                    echo "No valid sample cache was produced by this run."
+                    echo "No sample cache was refreshed by this run."
                   fi
                 condition: always()
-                displayName: Mark valid sample cache
+                displayName: Mark refreshed sample cache
 
               # Safety net for hard crashes / step timeout: the in-test teardown
               # runs `azd down` already, but if the run died mid-way, force-purge

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -207,13 +207,19 @@ extends:
               - bash: |
                   set -euo pipefail
                   api="$(System.CollectionUri)$(System.TeamProjectId)/_apis/build"
-                  builds=$(curl -fsS \
-                    -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" \
-                    "$api/builds?definitions=$(System.DefinitionId)&statusFilter=completed&queryOrder=finishTimeDescending&%24top=50&api-version=7.1")
-                  for build_id in $(echo "$builds" | jq -r '.value[].id'); do
-                    artifacts=$(curl -fsS \
+                  if ! builds=$(curl -fsS \
                       -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" \
-                      "$api/builds/$build_id/artifacts?api-version=7.1")
+                      "$api/builds?definitions=$(System.DefinitionId)&statusFilter=completed&queryOrder=finishTimeDescending&%24top=50&api-version=7.1"); then
+                    echo "##vso[task.logissue type=warning]Unable to query previous sample cache builds; continuing uncached."
+                    exit 0
+                  fi
+                  for build_id in $(echo "$builds" | jq -r '.value[].id'); do
+                    if ! artifacts=$(curl -fsS \
+                        -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" \
+                        "$api/builds/$build_id/artifacts?api-version=7.1"); then
+                      echo "##vso[task.logissue type=warning]Unable to inspect sample cache artifacts for build $build_id; trying an older build."
+                      continue
+                    fi
                     artifact_name=$(echo "$artifacts" | jq -r '
                       [.value[].name |
                         select(. == "azure-ai-agents-template-cache" or


### PR DESCRIPTION
## Problem

The Azure AI Agents Tier 2 live test downloads the same public Foundry sample on every run. GitHub availability and anonymous rate limits can intermittently make `azd ai agent init` fail even though the agent lifecycle itself is healthy.

## Fix

The cache identity is simply:

```text
pipeline definition ID + sample source link
```

- The pipeline ID scopes the shared artifact to this live pipeline.
- The sample link is hashed only to give each sample its own directory.
- PR number, branch, trigger type, run ID, provision, and deploy results are not part of the cache identity.
- Every PR, automatic, scheduled, and manual run reads and updates the same cache for a given sample link.

The existing anonymous GitHub download still runs first. A successful download refreshes the cached sample and the existing flow continues. A failed download restores the cached sample, emits an Azure Pipelines warning with the failure detail, and the existing flow continues without entering GitHub CLI/device login. If no cache exists yet, the download failure remains a failure.

Cache publication is independent of later provision/deploy success. This adds no secret, Key Vault group, protected ADO resource dependency, or trigger change.

## Validation plan

1. Confirm one run publishes the shared cache.
2. Run three additional live validations sequentially.
3. Confirm none fail because of sample download or GitHub device login.

Fixes #9925
