### PR TITLE
Expose live cache fallback warnings in pipeline logs

### DIFF
--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache.go
@@ -18,6 +18,7 @@ import (
 )
 
 const templateCacheDirEnv = "AZURE_AI_AGENTS_E2E_TEMPLATE_CACHE_DIR"
+const templateCacheWarningsFileEnv = "AZURE_AI_AGENTS_E2E_TEMPLATE_CACHE_WARNINGS_FILE"
 const templateCacheRefreshedMarker = ".refreshed"
 
 var renameTemplateCachePath = os.Rename
@@ -122,17 +123,36 @@ func useCachedTemplateOnDownloadError(pointer, staging string, downloadErr error
 	if !restored {
 		return downloadErr
 	}
-	emitTemplateCacheWarning(
-		fmt.Sprintf("GitHub sample download failed; using the cached sample. Details: %s", downloadErr),
-	)
+	message := fmt.Sprintf("GitHub sample download failed; using the cached sample. Details: %s", downloadErr)
+	emitTemplateCacheWarning(message)
+	if path := os.Getenv(templateCacheWarningsFileEnv); path != "" && os.Getenv("TF_BUILD") != "" {
+		if err := appendTemplateCacheWarning(path, templateCacheWarningCommand(message)); err != nil {
+			fmt.Println(output.WithWarningFormat("Unable to persist sample cache fallback warning: %s", err))
+		}
+	}
 	return nil
 }
 
 func emitTemplateCacheWarning(message string) {
 	if os.Getenv("TF_BUILD") != "" {
-		message = strings.NewReplacer("%", "%AZP25", "\r", "%0D", "\n", "%0A", "]", "%5D").Replace(message)
-		fmt.Printf("##vso[task.logissue type=warning]%s\n", message)
+		fmt.Print(templateCacheWarningCommand(message))
 		return
 	}
+
 	fmt.Println(output.WithWarningFormat("WARNING: %s", message))
+}
+
+func templateCacheWarningCommand(message string) string {
+	message = strings.NewReplacer("%", "%AZP25", "\r", "%0D", "\n", "%0A", "]", "%5D").Replace(message)
+	return fmt.Sprintf("##vso[task.logissue type=warning]%s\n", message)
+}
+
+func appendTemplateCacheWarning(path, line string) error {
+	//nolint:gosec // The live-test pipeline supplies this per-job diagnostic path.
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		return err
+	}
+	_, writeErr := file.WriteString(line)
+	return errors.Join(writeErr, file.Close())
 }

--- a/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
+++ b/cli/azd/extensions/azure.ai.agents/internal/cmd/template_cache_test.go
@@ -8,10 +8,74 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestTemplateCacheWarningFile(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		tfBuild     string
+		cacheHit    bool
+		downloadErr error
+		wantWarning bool
+	}{
+		{"fallback", "True", true, errors.New("GitHub 503: 50%\r\nretry]"), true},
+		{"cache miss", "True", false, errors.New("GitHub unavailable"), false},
+		{"canceled", "True", true, context.Canceled, false},
+		{"deadline", "True", true, context.DeadlineExceeded, false},
+		{"outside ADO", "", true, errors.New("GitHub unavailable"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TF_BUILD", tc.tfBuild)
+			warningsFile := filepath.Join(t.TempDir(), "warnings.log")
+			t.Setenv(templateCacheWarningsFileEnv, warningsFile)
+			t.Setenv(templateCacheDirEnv, t.TempDir())
+			emitTemplateCacheWarning("Unable to refresh sample cache")
+			require.NoFileExists(t, warningsFile, "only successful fallback warnings should be persisted")
+			pointer := "https://github.com/example/samples/blob/main/basic/azure.yaml"
+			if tc.cacheHit {
+				downloaded := t.TempDir()
+				require.NoError(t, os.WriteFile(filepath.Join(downloaded, "azure.yaml"), []byte("name: cached\n"), 0600))
+				require.NoError(t, refreshTemplateCache(pointer, downloaded))
+				require.NoFileExists(t, warningsFile, "successful downloads should not emit fallback warnings")
+			}
+			for range 2 {
+				err := useCachedTemplateOnDownloadError(pointer, t.TempDir(), tc.downloadErr)
+				if tc.cacheHit && !errors.Is(tc.downloadErr, context.Canceled) &&
+					!errors.Is(tc.downloadErr, context.DeadlineExceeded) {
+					require.NoError(t, err)
+				} else {
+					require.ErrorIs(t, err, tc.downloadErr)
+				}
+			}
+			if !tc.wantWarning {
+				require.NoFileExists(t, warningsFile)
+				return
+			}
+			data, err := os.ReadFile(warningsFile)
+			require.NoError(t, err)
+			line := "##vso[task.logissue type=warning]GitHub sample download failed; " +
+				"using the cached sample. Details: GitHub 503: 50%AZP25%0D%0Aretry%5D\n"
+			require.Equal(t, strings.Repeat(line, 2), string(data))
+		})
+	}
+}
+
+func TestTemplateCacheWarningWriteFailureDoesNotFailFallback(t *testing.T) {
+	t.Setenv("TF_BUILD", "True")
+	t.Setenv(templateCacheWarningsFileEnv, t.TempDir()) // A directory cannot be opened as a warning file.
+	t.Setenv(templateCacheDirEnv, t.TempDir())
+	pointer := "https://github.com/example/samples/blob/main/basic/azure.yaml"
+	downloaded := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(downloaded, "azure.yaml"), []byte("name: cached\n"), 0600))
+	require.NoError(t, refreshTemplateCache(pointer, downloaded))
+	staging := t.TempDir()
+	require.NoError(t, useCachedTemplateOnDownloadError(pointer, staging, errors.New("GitHub unavailable")))
+	require.FileExists(t, filepath.Join(staging, "azure.yaml"))
+}
 
 func TestTemplateCacheRoundTrip(t *testing.T) {
 	cacheDir := filepath.Join(t.TempDir(), "cache")

--- a/cli/azd/extensions/azure.ai.agents/tests/e2e-live/README.md
+++ b/cli/azd/extensions/azure.ai.agents/tests/e2e-live/README.md
@@ -136,6 +136,7 @@ safe to include in a normal `go test ./...`.
 | `E2E_TESTDIR`              | `/tmp/e2e-tests/tier2-<mode>`  | Scratch dir for the scaffolded project                      |
 | `E2E_KEEP_ARTIFACTS`       | —                              | `true` → keep the per-run `AZD_CONFIG_DIR` copy for debugging |
 | `AZURE_AI_AGENTS_E2E_TEMPLATE_CACHE_DIR` | —                 | CI cache for the last successfully downloaded sample         |
+| `AZURE_AI_AGENTS_E2E_TEMPLATE_CACHE_WARNINGS_FILE` | —      | ADO-only per-job file for replaying successful cache fallback warnings outside the interactive PTY; keep outside the shared cache |
 | `GH_TOKEN`                 | —                              | GitHub token for template clone (optional)                  |
 
 In CI the driver auto-detects GitHub Actions (`GITHUB_ACTIONS`) and Azure DevOps
@@ -143,6 +144,13 @@ In CI the driver auto-detects GitHub Actions (`GITHUB_ACTIONS`) and Azure DevOps
 resources down interactively (answering the confirmation prompt), and a
 `t.Cleanup` force teardown (`azd down --force --purge`) always runs on top, even
 on failure.
+
+The live pipeline clears the warning file before testing and replays it from an
+always-run post-test step, even when no sample was refreshed. Only successful cache
+fallback warnings are appended as escaped Azure Pipelines logging commands so both
+deploy modes retain their diagnostics. The file is not part of the shared sample
+artifact; reporting failures do not turn a successful cache fallback into an init
+failure.
 
 ## Files
 

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -263,8 +263,14 @@ extends:
                   artifactName: $(SampleCacheArtifactName)
                   targetPath: $(Pipeline.Workspace)/azure-ai-agents-template-cache
 
-              - bash: rm -f "$(Pipeline.Workspace)/azure-ai-agents-template-cache/.refreshed"
-                displayName: Reset sample cache refresh marker
+              - bash: |
+                  rm -f "$(Pipeline.Workspace)/azure-ai-agents-template-cache/.refreshed"
+                  if ! (umask 077; : > "$CACHE_WARNINGS_FILE"); then
+                    echo "##vso[task.logissue type=warning]Unable to initialize sample cache warning file."
+                  fi
+                env:
+                  CACHE_WARNINGS_FILE: $(Agent.TempDirectory)/azure-ai-agents-cache-warnings-$(System.JobAttempt).log
+                displayName: Reset sample cache state
 
               # Run the live golden path INSIDE the AzureCLI@2 task so the az CLI
               # session (consumed by azd via auth.useAzCliAuth) stays valid for the
@@ -316,6 +322,7 @@ extends:
                   E2E_LOCATION: eastus2
                   E2E_USE_AZ_CLI_AUTH: "true"
                   AZURE_AI_AGENTS_E2E_TEMPLATE_CACHE_DIR: $(Pipeline.Workspace)/azure-ai-agents-template-cache
+                  AZURE_AI_AGENTS_E2E_TEMPLATE_CACHE_WARNINGS_FILE: $(Agent.TempDirectory)/azure-ai-agents-cache-warnings-$(System.JobAttempt).log
                   # azure-sdk org PAT (ambient in the ADO project) used only to
                   # avoid anonymous GitHub rate limits when cloning the template.
                   GH_TOKEN: $(azuresdk-github-pat)
@@ -331,8 +338,19 @@ extends:
                   else
                     echo "No sample cache was refreshed by this run."
                   fi
+                  # Interactive init output stays inside the PTY; replay only successful cache fallback warnings.
+                  if [ -f "$CACHE_WARNINGS_FILE" ]; then
+                    if ! cat "$CACHE_WARNINGS_FILE"; then
+                      echo "##vso[task.logissue type=warning]Unable to read sample cache warning file."
+                    fi
+                    if ! rm -f "$CACHE_WARNINGS_FILE"; then
+                      echo "##vso[task.logissue type=warning]Unable to remove sample cache warning file."
+                    fi
+                  fi
+                env:
+                  CACHE_WARNINGS_FILE: $(Agent.TempDirectory)/azure-ai-agents-cache-warnings-$(System.JobAttempt).log
                 condition: always()
-                displayName: Mark refreshed sample cache
+                displayName: Report and mark sample cache state
 
               # Safety net for hard crashes / step timeout: the in-test teardown
               # runs `azd down` already, but if the run died mid-way, force-purge

--- a/eng/pipelines/ext-azure-ai-agents-live.yml
+++ b/eng/pipelines/ext-azure-ai-agents-live.yml
@@ -264,6 +264,7 @@ extends:
                   targetPath: $(Pipeline.Workspace)/azure-ai-agents-template-cache
 
               - bash: |
+                  set -e
                   rm -f "$(Pipeline.Workspace)/azure-ai-agents-template-cache/.refreshed"
                   if ! (umask 077; : > "$CACHE_WARNINGS_FILE"); then
                     echo "##vso[task.logissue type=warning]Unable to initialize sample cache warning file."


### PR DESCRIPTION
## Summary

- persist only successful template-cache fallback warnings to a per-job file outside the shared cache
- replay the escaped Azure Pipelines logging commands from the existing always-run post-test step
- keep warning reporting failures non-blocking

This follows up on Rick Winter's post-merge review comment: https://github.com/Azure/azure-dev/pull/9929#discussion_r3971136539

The cache key and sharing scope, triggers, download ordering, authentication, and provision/deploy behavior from #9929 are unchanged.

## Validation

- `go test ./internal/cmd -count=1`
- `go build ./...`
- `golangci-lint v2.11.4`
- pipeline YAML parse
- `git diff --check`


Fixes #9946

