### PR TITLE
fix(extensions): initialize streams before startup

### DIFF
--- a/cli/azd/cmd/middleware/extensions.go
+++ b/cli/azd/cmd/middleware/extensions.go
@@ -341,6 +341,10 @@ func startAndWaitExtension(
 		return err
 	}
 
+	stdin := ext.StdIn()
+	stdout := ext.StdOut()
+	stderr := ext.StdErr()
+
 	// Start the extension process in a separate goroutine
 	go func() {
 		allEnv := []string{
@@ -365,9 +369,9 @@ func startAndWaitExtension(
 		invokeOptions := &extensions.InvokeOptions{
 			Args:        args,
 			Env:         allEnv,
-			StdIn:       ext.StdIn(),
-			StdOut:      ext.StdOut(),
-			StdErr:      ext.StdErr(),
+			StdIn:       stdin,
+			StdOut:      stdout,
+			StdErr:      stderr,
 			Debug:       opts.debug,
 			NoPrompt:    opts.noPrompt,
 			Cwd:         opts.cwd,


### PR DESCRIPTION
## Summary

- initialize extension I/O and readiness state before launching the `listen` goroutine
- ensure startup errors and readiness waits use the same initialized channel
- prevent intermittent extension startup timeouts caused by concurrent initialization

Fixes #9986

## Validation

- `go test -race ./cmd/middleware -run "^TestStartAndWaitExtension_PropagatesTraceContext$" -count=100`
- `go test ./cmd/middleware`