### PR TITLE
Add canary pipeline for azure-dev cli

### DIFF
--- a/cli/azd/AGENTS.md
+++ b/cli/azd/AGENTS.md
@@ -51,7 +51,7 @@ When investigating a pipeline:
 - Otherwise, locate the relevant pipeline in the folders above.
 - Correlate runs using the pull request number, commit SHA, and source branch.
 - Inspect the failed or running job logs first. Distinguish the root failure from secondary warnings, infrastructure noise, or downstream failures.
-- For releases, distinguish publishing from validation using the source branch and template parameters. For the core CLI pipeline, `DoPublish=true` identifies a publishing release run.
+- For releases, distinguish publishing from validation using the source branch and template parameters. For the core CLI pipeline, `ReleaseMode=Standard` identifies a production publication and `ReleaseMode=Canary` identifies canary validation.
 
 ## Development
 

--- a/eng/pipelines/release-cli.yml
+++ b/eng/pipelines/release-cli.yml
@@ -1,8 +1,11 @@
 parameters:
-  - name: DoPublish
-    displayName: Check to run a release build
-    type: boolean
-    default: false
+  - name: ReleaseMode
+    displayName: Release mode
+    type: string
+    default: Canary
+    values:
+      - Standard
+      - Canary
   - name: AzureRecordMode
     displayName: Azure Record Mode
     type: string
@@ -143,6 +146,11 @@ extends:
 
     # Do not publish on scheduled builds, only release from Azure/azure-dev
     - ${{ if and(ne(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Repository.Name'], 'Azure/azure-dev')) }}:
-      # Only publish if build is manually triggered & DoPublish is true, or if it's a CI build (push to main)
-      - ${{ if or(and(eq('Manual', variables['Build.Reason']), eq('true', parameters.DoPublish)), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'PullRequest')) }}:
+      - ${{ if and(eq(parameters.ReleaseMode, 'Standard'), in(variables['Build.Reason'], 'Manual', 'IndividualCI', 'BatchedCI', 'PullRequest')) }}:
         - template: /eng/pipelines/templates/stages/publish.yml
+
+      # Canary publication is available only for manual runs.
+      - ${{ if and(eq(parameters.ReleaseMode, 'Canary'), eq(variables['Build.Reason'], 'Manual')) }}:
+        - template: /eng/pipelines/templates/stages/publish.yml
+          parameters:
+            ReleaseMode: Canary

--- a/eng/pipelines/templates/stages/publish.yml
+++ b/eng/pipelines/templates/stages/publish.yml
@@ -1,6 +1,17 @@
+parameters:
+  - name: ReleaseMode
+    type: string
+    default: Standard
+    values:
+      - Standard
+      - Canary
+
 stages:
   - stage: PublishCLI
-    dependsOn: Sign
+    dependsOn:
+      - Sign
+      - ${{ if eq(parameters.ReleaseMode, 'Canary') }}:
+        - Verify_Installers
     condition: >-
       and(
         succeeded(),
@@ -23,6 +34,7 @@ stages:
         condition: >-
           and(
             succeeded(),
+            eq('${{ parameters.ReleaseMode }}', 'Standard'),
             ne('true', variables['Skip.Publish'])
           )
         environment: package-publish
@@ -74,6 +86,7 @@ stages:
         condition: >-
           and(
             succeeded(),
+            eq('${{ parameters.ReleaseMode }}', 'Standard'),
             ne('true', variables['Skip.Publish'])
           )
         environment: package-publish
@@ -103,7 +116,9 @@ stages:
                 - template: /eng/pipelines/templates/steps/publish-cli-choco.yml
 
       - job: Publish_WinGet
-        dependsOn: Publish_Release
+        dependsOn:
+          - ${{ if eq(parameters.ReleaseMode, 'Standard') }}:
+            - Publish_Release
         condition: >-
           and(
             succeeded(),
@@ -115,20 +130,24 @@ stages:
           image: $(WINDOWSVMIMAGE)
           os: windows
 
-        templateContext:
-          outputs:
-            - output: pipelineArtifact
-              artifact: winget-manifest
-              targetPath: winget
+        ${{ if eq(parameters.ReleaseMode, 'Standard') }}:
+          templateContext:
+            outputs:
+              - output: pipelineArtifact
+                artifact: winget-manifest
+                targetPath: winget
 
         steps:
           - template: /eng/pipelines/templates/steps/publish-cli-winget.yml
+            parameters:
+              ValidationMode: ${{ eq(parameters.ReleaseMode, 'Canary') }}
 
       - job: Publish_Brew
         dependsOn: Publish_Release
         condition: >-
           and(
             succeeded(),
+            eq('${{ parameters.ReleaseMode }}', 'Standard'),
             ne('true', variables['Skip.Publish'])
           )
 
@@ -147,6 +166,7 @@ stages:
         condition: >-
           and(
             succeeded(),
+            eq('${{ parameters.ReleaseMode }}', 'Standard'),
             ne('true', variables['Skip.Publish'])
           )
 
@@ -169,6 +189,7 @@ stages:
         condition: >-
           and(
             succeeded(),
+            eq('${{ parameters.ReleaseMode }}', 'Standard'),
             ne('true', variables['Skip.IncrementVersion'])
           )
 
@@ -197,6 +218,7 @@ stages:
         condition: >-
           and(
             succeeded(),
+            eq('${{ parameters.ReleaseMode }}', 'Standard'),
             ne('true', variables['Skip.Publish'])
           )
 
@@ -216,6 +238,7 @@ stages:
     condition: >-
       and(
         succeeded(),
+        eq('${{ parameters.ReleaseMode }}', 'Standard'),
         ne(variables['Skip.Release'], 'true'),
         or(
           eq('Manual', variables['BuildReasonOverride']),
@@ -326,6 +349,11 @@ stages:
 
   - stage: PublishIntegration
     dependsOn: Sign
+    condition: >-
+      and(
+        succeeded(),
+        eq('${{ parameters.ReleaseMode }}', 'Standard')
+      )
 
     variables:
       - template: /eng/pipelines/templates/variables/image.yml
@@ -596,6 +624,7 @@ stages:
     condition: >-
       and(
         succeeded(),
+        eq('${{ parameters.ReleaseMode }}', 'Standard'),
         ne(variables['Skip.Release'], 'true'),
         or(
           eq('Manual', variables['BuildReasonOverride']),
@@ -655,3 +684,4 @@ stages:
                       }
                   env:
                     AZCOPY_AUTO_LOGIN_TYPE: 'PSCRED'
+

--- a/eng/pipelines/templates/steps/publish-cli-winget.yml
+++ b/eng/pipelines/templates/steps/publish-cli-winget.yml
@@ -24,21 +24,21 @@ steps:
       env:
         GH_TOKEN: ${{ parameters.GitHubToken }}
 
-  - ${{ else }}:
-    - pwsh: |
-        $PSNativeCommandArgumentPassing = 'Legacy'
-        Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-
-        $AdditionalArgs = ""
-        if ($$(SubmitWinGetPackage)) {
-          $AdditionalArgs = "--submit"
-        }
-
-        ./wingetcreate.exe update `
-          Microsoft.Azd `
-          --version '$(MSI_VERSION)' `
-          --urls "https://github.com/Azure/azure-dev/releases/download/azure-dev-cli_$(CLI_VERSION)/azd-windows-amd64.msi" `
-          --token ${{ parameters.GitHubToken }} `
-          --out winget `
-          $AdditionalArgs
-      displayName: Submit to WinGet
+#  - ${{ else }}:
+#    - pwsh: |
+#        $PSNativeCommandArgumentPassing = 'Legacy'
+#        Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+#
+#        $AdditionalArgs = ""
+#        if ($$(SubmitWinGetPackage)) {
+#          $AdditionalArgs = "--submit"
+#        }
+#
+#        ./wingetcreate.exe update `
+#          Microsoft.Azd `
+#          --version '$(MSI_VERSION)' `
+#          --urls "https://github.com/Azure/azure-dev/releases/download/azure-dev-cli_$(CLI_VERSION)/azd-windows-amd64.msi" `
+#          --token ${{ parameters.GitHubToken }} `
+#          --out winget `
+#          $AdditionalArgs
+#      displayName: Submit to WinGet

--- a/eng/pipelines/templates/steps/publish-cli-winget.yml
+++ b/eng/pipelines/templates/steps/publish-cli-winget.yml
@@ -3,24 +3,42 @@ parameters:
     type: string
     default: $(azuresdk-github-pat)
     displayName: GitHub token
+  - name: ValidationMode
+    type: boolean
+    default: false
+    displayName: Validate GitHub token without submitting
 
 steps:
   - template: /eng/pipelines/templates/steps/set-metadata-variables.yml
 
-  - pwsh: |
-      $PSNativeCommandArgumentPassing = 'Legacy'
-      Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+  - ${{ if parameters.ValidationMode }}:
+    - pwsh: |
+        $ErrorActionPreference = 'Stop'
+        $repository = gh api repos/microsoft/winget-pkgs --jq '.full_name'
+        if ($LASTEXITCODE -ne 0) {
+          throw "The GitHub token could not authenticate or cannot read microsoft/winget-pkgs."
+        }
 
-      $AdditionalArgs = ""
-      if ($$(SubmitWinGetPackage)) {
+        Write-Host "GitHub token authenticated and read '$repository'."
+      displayName: Validate GitHub token
+      env:
+        GH_TOKEN: ${{ parameters.GitHubToken }}
+
+  - ${{ else }}:
+    - pwsh: |
+        $PSNativeCommandArgumentPassing = 'Legacy'
+        Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+
+        $AdditionalArgs = ""
+        if ($$(SubmitWinGetPackage)) {
           $AdditionalArgs = "--submit"
-      }
+        }
 
-      ./wingetcreate.exe update `
+        ./wingetcreate.exe update `
           Microsoft.Azd `
           --version '$(MSI_VERSION)' `
           --urls "https://github.com/Azure/azure-dev/releases/download/azure-dev-cli_$(CLI_VERSION)/azd-windows-amd64.msi" `
           --token ${{ parameters.GitHubToken }} `
           --out winget `
           $AdditionalArgs
-    displayName: Submit to WinGet
+      displayName: Submit to WinGet


### PR DESCRIPTION
This pull request introduces a new "Canary" release mode to the CLI release pipeline, allowing for differentiated handling of standard and canary releases. The changes add parameters and conditional logic to the pipeline and publish templates, ensuring that canary builds are published only on manual runs, use different artifacts, and skip production publishing steps. Additionally, validation steps are added for canary releases.

**Release pipeline enhancements:**

* Added a `ReleaseMode` parameter (with values `Standard` and `Canary`) to `release-cli.yml` and `publish.yml`, enabling selection between standard and canary release workflows. [[1]](diffhunk://#diff-985a7123d32f7ffa1809cc7baa384727046681efedc9075497cfcd0081ec69a7R6-R12) [[2]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R1-R14)
* Updated pipeline triggers and publishing logic so that standard releases follow the existing flow, while canary releases are only allowed for manual runs and use a modified publishing process. [[1]](diffhunk://#diff-985a7123d32f7ffa1809cc7baa384727046681efedc9075497cfcd0081ec69a7L147-R161) [[2]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R39-R42) [[3]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R51-R73) [[4]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R100-R119)
* Canary releases now depend on the `Verify_Installers` job and publish to a separate location with a unique URL, while skipping production environments and outputs. [[1]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R1-R14) [[2]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R51-R73) [[3]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R82) [[4]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R100-R119)

**Step and artifact handling:**

* Canary releases fetch and publish installer artifacts instead of changelogs, and skip jobs and stages related to standard production publishing (e.g., Chocolatey, Brew, integration stages). [[1]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R51-R73) [[2]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R161) [[3]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R170-R178) [[4]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R197) [[5]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R220) [[6]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R249) [[7]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R269) [[8]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R380-R384) [[9]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R655)

**Validation improvements:**

* Added a `ValidationMode` parameter to the `publish-cli-winget.yml` template, allowing canary releases to validate the GitHub token without submitting to the production repository. [[1]](diffhunk://#diff-a027c26a19ab1c61040e38dd879eaf46dbfdb7fd1fd4286ee1a30b2338888415R6-R27) [[2]](diffhunk://#diff-2d900ca6e2f2dd499b0530b1857a7c1cbd362fc35b6b17ec1fc39afb862ec794R170-R178)

These changes provide a safe and isolated path for publishing canary builds, ensuring that only validated and intended releases reach production channels.