### PR TITLE
Fix nil dereference in StopAsync when telemetry is disabled

### DIFF
--- a/cli/azd/internal/vsrpc/models_test.go
+++ b/cli/azd/internal/vsrpc/models_test.go
@@ -299,7 +299,7 @@ func TestAspireHost_Fields(t *testing.T) {
 func TestInitializeAsync_RootPath_NotExists(t *testing.T) {
 	t.Parallel()
 	s := newTestServer()
-	svc := newServerService(s)
+	svc := newServerService(s, nil)
 	_, err := svc.InitializeAsync(t.Context(), filepath.Join(t.TempDir(), "no-such-dir"), InitializeServerOptions{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid root path")
@@ -312,7 +312,7 @@ func TestInitializeAsync_RootPath_NotDirectory(t *testing.T) {
 	require.NoError(t, os.WriteFile(file, []byte("x"), 0o600))
 
 	s := newTestServer()
-	svc := newServerService(s)
+	svc := newServerService(s, nil)
 	_, err := svc.InitializeAsync(t.Context(), file, InitializeServerOptions{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not a directory")
@@ -321,7 +321,7 @@ func TestInitializeAsync_RootPath_NotDirectory(t *testing.T) {
 func TestInitializeAsync_WithInvalidCertificate(t *testing.T) {
 	t.Parallel()
 	s := newTestServer()
-	svc := newServerService(s)
+	svc := newServerService(s, nil)
 
 	badCert := "this-is-not-a-cert"
 	_, err := svc.InitializeAsync(t.Context(), t.TempDir(), InitializeServerOptions{
@@ -355,7 +355,7 @@ func TestInitializeAsync_CertWithNonHttpsEndpoint(t *testing.T) {
 	endpoint := "http://example.com"
 
 	s := newTestServer()
-	svc := newServerService(s)
+	svc := newServerService(s, nil)
 
 	_, err := svc.InitializeAsync(t.Context(), t.TempDir(), InitializeServerOptions{
 		AuthenticationEndpoint:    &endpoint,
@@ -372,7 +372,7 @@ func TestInitializeAsync_CertWithUnparseableEndpoint(t *testing.T) {
 	endpoint := "http://invalid\x7f/"
 
 	s := newTestServer()
-	svc := newServerService(s)
+	svc := newServerService(s, nil)
 
 	_, err := svc.InitializeAsync(t.Context(), t.TempDir(), InitializeServerOptions{
 		AuthenticationEndpoint:    &endpoint,
@@ -382,32 +382,60 @@ func TestInitializeAsync_CertWithUnparseableEndpoint(t *testing.T) {
 }
 
 func TestServe_ClosedListenerReturns(t *testing.T) {
-	t.Setenv("AZD_DEBUG_SERVER_DEBUG_ENDPOINTS", "false")
+	testServe := func(t *testing.T, s *Server) {
+		t.Helper()
+		t.Setenv("AZD_DEBUG_SERVER_DEBUG_ENDPOINTS", "false")
 
-	s := newTestServer()
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
 
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
+		done := make(chan error, 1)
+		go func() {
+			done <- s.Serve(l)
+		}()
 
-	done := make(chan error, 1)
-	go func() {
-		done <- s.Serve(l)
-	}()
+		// Close the listener immediately; Serve should return.
+		require.NoError(t, l.Close())
 
-	// Close the listener immediately; Serve should return.
-	require.NoError(t, l.Close())
+		select {
+		case err := <-done:
+			// Any error is fine; we're primarily verifying Serve returns.
+			require.Error(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Serve did not return after listener close")
+		}
 
-	select {
-	case err := <-done:
-		// Any error is fine; we're primarily verifying Serve returns.
-		require.Error(t, err)
-	case <-time.After(5 * time.Second):
-		t.Fatal("Serve did not return after listener close")
+		// cancelTelemetryUpload should have been installed.
+		require.NotNil(t, s.cancelTelemetryUpload)
+		s.cancelTelemetryUpload()
 	}
 
-	// cancelTelemetryUpload should have been installed.
-	require.NotNil(t, s.cancelTelemetryUpload)
-	s.cancelTelemetryUpload()
+	t.Run("WithTelemetrySystem", func(t *testing.T) {
+		ts := &testTelemetrySystem{
+			backgroundUploadCalled: make(chan struct{}),
+		}
+		s := newTestServer()
+		s.getTelemetrySystem = func() telemetrySystem {
+			return ts
+		}
+
+		testServe(t, s)
+
+		select {
+		case <-ts.backgroundUploadCalled:
+		case <-time.After(5 * time.Second):
+			t.Fatal("background telemetry upload was not started")
+		}
+	})
+
+	t.Run("WithoutTelemetrySystem", func(t *testing.T) {
+		s := newTestServer()
+		s.getTelemetrySystem = func() telemetrySystem {
+			return nil
+		}
+
+		testServe(t, s)
+	})
 }
 
 func TestValidateSession_EmptyId(t *testing.T) {
@@ -516,7 +544,7 @@ func TestEnvironmentService_ServeHTTP(t *testing.T) {
 
 func TestServerService_ServeHTTP(t *testing.T) {
 	s := newTestServer()
-	svc := newServerService(s)
+	svc := newServerService(s, nil)
 	rpcConn := connectRPC(t, svc)
 
 	_, err := rpcConn.Call(t.Context(), "InitializeAsync", "not-an-array", nil)
@@ -809,7 +837,7 @@ func TestAspireService_RenameAspireHostAsync_InvalidSession(t *testing.T) {
 
 func TestServerService_InitializeAsync_InvalidParams(t *testing.T) {
 	s := newTestServer()
-	svc := newServerService(s)
+	svc := newServerService(s, nil)
 	rpcConn := connectRPC(t, svc)
 
 	// InitializeAsync expects (rootPath string, options InitializeServerOptions)

--- a/cli/azd/internal/vsrpc/server.go
+++ b/cli/azd/internal/vsrpc/server.go
@@ -38,12 +38,33 @@ type Server struct {
 	rootContainer *ioc.NestedContainer
 	// cancelTelemetryUpload is a function that cancels the background telemetry upload goroutine.
 	cancelTelemetryUpload func()
+	// getTelemetrySystem resolves the optional process telemetry system when the server starts.
+	// (this is in here for testing)
+	getTelemetrySystem func() telemetrySystem
+}
+
+// telemetrySystem is an interface so we can mock the results of [telemetry.GetTelemetrySystem].
+type telemetrySystem interface {
+	RunBackgroundUpload(ctx context.Context, enableDebugLogging bool) error
+	Shutdown(ctx context.Context) error
+}
+
+func getTelemetrySystem() telemetrySystem {
+	// don't be tempted to avoid this explicit nil check/conversion :)
+	// https://go.dev/doc/faq#nil_error
+	ts := telemetry.GetTelemetrySystem()
+	if ts == nil {
+		return nil
+	}
+
+	return ts
 }
 
 func NewServer(rootContainer *ioc.NestedContainer) *Server {
 	return &Server{
-		sessions:      make(map[string]*serverSession),
-		rootContainer: rootContainer,
+		sessions:           make(map[string]*serverSession),
+		rootContainer:      rootContainer,
+		getTelemetrySystem: getTelemetrySystem,
 	}
 }
 
@@ -77,9 +98,10 @@ func checkLocalhostOrigin(r *http.Request) bool {
 // Serve calls http.Serve with the given listener and a handler that serves the VS RPC protocol.
 func (s *Server) Serve(l net.Listener) error {
 	mux := http.NewServeMux()
+	ts := s.getTelemetrySystem()
 
 	mux.Handle("/AspireService/v1.0", newAspireService(s))
-	mux.Handle("/ServerService/v1.0", newServerService(s))
+	mux.Handle("/ServerService/v1.0", newServerService(s, ts))
 	mux.Handle("/EnvironmentService/v1.0", newEnvironmentService(s))
 
 	// Expose a few special test endpoints that can be used to debug our special RPC behavior around cancellation and
@@ -92,7 +114,6 @@ func (s *Server) Serve(l net.Listener) error {
 	// Run upload periodically in the background while the server is running.
 	//nolint:gosec // G118: cancel is stored on the server and invoked later by StopAsync.
 	ctx, cancel := context.WithCancel(context.Background())
-	ts := telemetry.GetTelemetrySystem()
 	backgroundTelemetry := func() {
 		ticker := time.NewTicker(5 * time.Second)
 		for {

--- a/cli/azd/internal/vsrpc/server_service.go
+++ b/cli/azd/internal/vsrpc/server_service.go
@@ -11,20 +11,19 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
 	"github.com/azure/azure-dev/cli/azd/pkg/httputil"
 )
 
 // serverService is the RPC server for the '/ServerService/v1.0' endpoint.
 type serverService struct {
-	server             *Server
-	getTelemetrySystem func() *telemetry.TelemetrySystem
+	server          *Server
+	telemetrySystem telemetrySystem
 }
 
-func newServerService(server *Server) *serverService {
+func newServerService(server *Server, telemetrySystem telemetrySystem) *serverService {
 	return &serverService{
-		server:             server,
-		getTelemetrySystem: telemetry.GetTelemetrySystem,
+		server:          server,
+		telemetrySystem: telemetrySystem,
 	}
 }
 
@@ -94,10 +93,9 @@ func (s *serverService) StopAsync(ctx context.Context) error {
 	// client terminate `azd` once they know all outstanding RPCs have completed instead of trying to do a graceful
 	// shutdown on our end.
 
-	ts := s.getTelemetrySystem()
 	// Flush all in-memory telemetry data before stopping.
-	if ts != nil {
-		err := ts.Shutdown(ctx)
+	if s.telemetrySystem != nil {
+		err := s.telemetrySystem.Shutdown(ctx)
 		if err != nil {
 			log.Printf("error shutting down telemetry: %v", err)
 		}

--- a/cli/azd/internal/vsrpc/server_service.go
+++ b/cli/azd/internal/vsrpc/server_service.go
@@ -94,9 +94,11 @@ func (s *serverService) StopAsync(ctx context.Context) error {
 
 	ts := telemetry.GetTelemetrySystem()
 	// Flush all in-memory telemetry data before stopping.
-	err := ts.Shutdown(ctx)
-	if err != nil {
-		log.Printf("error shutting down telemetry: %v", err)
+	if ts != nil {
+		err := ts.Shutdown(ctx)
+		if err != nil {
+			log.Printf("error shutting down telemetry: %v", err)
+		}
 	}
 
 	// Graceful telemetry cancellation.

--- a/cli/azd/internal/vsrpc/server_service.go
+++ b/cli/azd/internal/vsrpc/server_service.go
@@ -17,12 +17,14 @@ import (
 
 // serverService is the RPC server for the '/ServerService/v1.0' endpoint.
 type serverService struct {
-	server *Server
+	server             *Server
+	getTelemetrySystem func() *telemetry.TelemetrySystem
 }
 
 func newServerService(server *Server) *serverService {
 	return &serverService{
-		server: server,
+		server:             server,
+		getTelemetrySystem: telemetry.GetTelemetrySystem,
 	}
 }
 
@@ -92,7 +94,7 @@ func (s *serverService) StopAsync(ctx context.Context) error {
 	// client terminate `azd` once they know all outstanding RPCs have completed instead of trying to do a graceful
 	// shutdown on our end.
 
-	ts := telemetry.GetTelemetrySystem()
+	ts := s.getTelemetrySystem()
 	// Flush all in-memory telemetry data before stopping.
 	if ts != nil {
 		err := ts.Shutdown(ctx)

--- a/cli/azd/internal/vsrpc/server_service_test.go
+++ b/cli/azd/internal/vsrpc/server_service_test.go
@@ -5,16 +5,37 @@ package vsrpc
 
 import (
 	"bytes"
+	"context"
+	"sync"
 	"testing"
 
-	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
 	"github.com/stretchr/testify/require"
 )
+
+type testTelemetrySystem struct {
+	shutdownCalled         bool
+	backgroundUploadCalled chan struct{}
+	backgroundUploadOnce   sync.Once
+}
+
+func (t *testTelemetrySystem) Shutdown(context.Context) error {
+	t.shutdownCalled = true
+	return nil
+}
+
+func (t *testTelemetrySystem) RunBackgroundUpload(context.Context, bool) error {
+	if t.backgroundUploadCalled != nil {
+		t.backgroundUploadOnce.Do(func() {
+			close(t.backgroundUploadCalled)
+		})
+	}
+	return nil
+}
 
 func TestInitializeAsync_EmptyRootPath_Succeeds(t *testing.T) {
 	t.Parallel()
 	s := newTestServer()
-	svc := newServerService(s)
+	svc := newServerService(s, nil)
 	sess, err := svc.InitializeAsync(t.Context(), "", InitializeServerOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, sess)
@@ -24,7 +45,7 @@ func TestInitializeAsync_EmptyRootPath_Succeeds(t *testing.T) {
 func TestInitializeAsync_WithAuthEndpointAndKey(t *testing.T) {
 	t.Parallel()
 	s := newTestServer()
-	svc := newServerService(s)
+	svc := newServerService(s, nil)
 
 	endpoint := "https://auth.example.com"
 	key := "secret"
@@ -49,7 +70,7 @@ func TestInitializeAsync_CertWithHttpsEndpoint_Succeeds(t *testing.T) {
 	endpoint := "https://svc.example.com"
 
 	s := newTestServer()
-	svc := newServerService(s)
+	svc := newServerService(s, nil)
 
 	sess, err := svc.InitializeAsync(t.Context(), t.TempDir(), InitializeServerOptions{
 		AuthenticationEndpoint:    &endpoint,
@@ -102,7 +123,7 @@ func TestNewWriter_AcceptsAdditionalWriters(t *testing.T) {
 
 func TestNewServerService(t *testing.T) {
 	s := newTestServer()
-	svc := newServerService(s)
+	svc := newServerService(s, nil)
 	require.NotNil(t, svc)
 	require.Same(t, s, svc.server)
 }
@@ -110,12 +131,21 @@ func TestNewServerService(t *testing.T) {
 func TestServerService_StopAsync_NoTelemetrySystem(t *testing.T) {
 	s := newTestServer()
 	s.cancelTelemetryUpload = func() {}
-	svc := newServerService(s)
-	svc.getTelemetrySystem = func() *telemetry.TelemetrySystem {
-		return nil
-	}
+	svc := newServerService(s, nil)
 	rpcConn := connectRPC(t, svc)
 
 	_, err := rpcConn.Call(t.Context(), "StopAsync", []any{}, nil)
 	require.NoError(t, err)
+}
+
+func TestServerService_StopAsync(t *testing.T) {
+	s := newTestServer()
+	s.cancelTelemetryUpload = func() {}
+	ts := &testTelemetrySystem{}
+	svc := newServerService(s, ts)
+	rpcConn := connectRPC(t, svc)
+
+	_, err := rpcConn.Call(t.Context(), "StopAsync", []any{}, nil)
+	require.NoError(t, err)
+	require.True(t, ts.shutdownCalled)
 }

--- a/cli/azd/internal/vsrpc/server_service_test.go
+++ b/cli/azd/internal/vsrpc/server_service_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/azure/azure-dev/cli/azd/internal/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -106,11 +107,13 @@ func TestNewServerService(t *testing.T) {
 	require.Same(t, s, svc.server)
 }
 
-func TestServerService_StopAsync(t *testing.T) {
+func TestServerService_StopAsync_NoTelemetrySystem(t *testing.T) {
 	s := newTestServer()
-	// Must set cancelTelemetryUpload to avoid nil panic
 	s.cancelTelemetryUpload = func() {}
 	svc := newServerService(s)
+	svc.getTelemetrySystem = func() *telemetry.TelemetrySystem {
+		return nil
+	}
 	rpcConn := connectRPC(t, svc)
 
 	_, err := rpcConn.Call(t.Context(), "StopAsync", []any{}, nil)

--- a/cli/azd/internal/vsrpc/server_test.go
+++ b/cli/azd/internal/vsrpc/server_test.go
@@ -228,6 +228,9 @@ func TestServe_WithDebugEndpoints(t *testing.T) {
 	t.Setenv("AZD_DEBUG_SERVER_DEBUG_ENDPOINTS", "true")
 
 	s := newTestServer()
+	s.getTelemetrySystem = func() telemetrySystem {
+		return nil
+	}
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -254,6 +257,7 @@ func TestNewServer(t *testing.T) {
 	require.NotNil(t, s)
 	require.NotNil(t, s.sessions)
 	require.Empty(t, s.sessions)
+	require.NotNil(t, s.getTelemetrySystem)
 }
 
 func TestServeRpc_MethodNotFound(t *testing.T) {


### PR DESCRIPTION
This pull request addresses a nil dereference issue in the `StopAsync` method of the `ServerService` when telemetry is disabled. The problem was identified during testing, where the method would panic due to dereferencing a nil `TelemetrySystem`.

### Changes Made
- Added a nil check before calling `TelemetrySystem.Shutdown()` to ensure it only executes when telemetry is initialized.
- Maintained existing behavior for telemetry shutdown and cancellation when telemetry is enabled.

### Validation
- The test `TestServerService_StopAsync` now passes with `AZURE_DEV_COLLECT_TELEMETRY=no` and also when telemetry is enabled.
- The full `internal/vsrpc` package was tested and passed with telemetry disabled.
- Removed a temporary change in `go.mod` that was used for testing purposes.

This fix resolves a real production bug that could lead to unexpected crashes during graceful shutdown when telemetry is disabled.