### PR TITLE
Update owners for Foundry scenario tooling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,24 +11,24 @@
 /cli/installer/                             @danieljurek @vhvb1989 @tg-msft @RickWinter
 
 # ── CLI extensions registry and test snapshots - anyone added to this can approve extension publishing, provided they pass the `ext-registry-check` workflow.
-/cli/azd/extensions/registry.json           @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft @XiaofuHuang @achauhan-scc @anchenyi @glharper @huimiu @hund030 @kingernupur @saanikaguptamicrosoft @therealjohn @trangevi @trrwilson  @m5i-work @v1212
-/cli/azd/extensions/registry.dev.json       @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft @XiaofuHuang @achauhan-scc @anchenyi @glharper @huimiu @hund030 @kingernupur @saanikaguptamicrosoft @therealjohn @trangevi @trrwilson  @m5i-work @v1212
-/cli/azd/cmd/testdata/TestFigSpec.ts        @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft @XiaofuHuang @achauhan-scc @anchenyi @glharper @huimiu @hund030 @kingernupur @saanikaguptamicrosoft @therealjohn @trangevi @trrwilson  @m5i-work @v1212
+/cli/azd/extensions/registry.json           @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft @XiaofuHuang @achauhan-scc @anchenyi @glharper @huimiu @hund030 @kingernupur @saanikaguptamicrosoft @therealjohn @trangevi @m5i-work @v1212
+/cli/azd/extensions/registry.dev.json       @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft @XiaofuHuang @achauhan-scc @anchenyi @glharper @huimiu @hund030 @kingernupur @saanikaguptamicrosoft @therealjohn @trangevi @m5i-work @v1212
+/cli/azd/cmd/testdata/TestFigSpec.ts        @vhvb1989 @hemarina @JeffreyCA @tg-msft @RickWinter @richardpark-msft @XiaofuHuang @achauhan-scc @anchenyi @glharper @huimiu @hund030 @kingernupur @saanikaguptamicrosoft @therealjohn @trangevi @m5i-work @v1212
 
 # ── CLI extensions (AI) ──────────────────────────────────────────────────────
-/cli/azd/extensions/azure.ai.agents/        @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030 @m5i-work @v1212
-/cli/azd/test/functional/ai_agents/         @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030 @m5i-work @v1212
-/cli/azd/extensions/azure.ai.connections/   @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030 @m5i-work @v1212
+/cli/azd/extensions/azure.ai.agents/        @JeffreyCA @glharper @trangevi @therealjohn @huimiu @hund030 @m5i-work @v1212
+/cli/azd/test/functional/ai_agents/         @JeffreyCA @glharper @trangevi @therealjohn @huimiu @hund030 @m5i-work @v1212
+/cli/azd/extensions/azure.ai.connections/   @JeffreyCA @glharper @trangevi @therealjohn @huimiu @hund030 @m5i-work @v1212
 /cli/azd/extensions/azure.ai.finetune/      @JeffreyCA @trangevi @achauhan-scc @kingernupur @saanikaguptamicrosoft
-/cli/azd/extensions/azure.ai.inspector/     @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @anchenyi @XiaofuHuang
+/cli/azd/extensions/azure.ai.inspector/     @JeffreyCA @glharper @trangevi @therealjohn @anchenyi @XiaofuHuang
 /cli/azd/extensions/azure.ai.models/        @JeffreyCA @trangevi @achauhan-scc @kingernupur @saanikaguptamicrosoft
-/cli/azd/extensions/azure.ai.projects/      @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030 @m5i-work @v1212
-/cli/azd/extensions/azure.ai.rle/           @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030 @m5i-work @v1212
-/cli/azd/extensions/azure.ai.routines/      @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030 @m5i-work @v1212
-/cli/azd/extensions/azure.ai.skills/        @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030 @m5i-work @v1212
-/cli/azd/extensions/azure.ai.toolboxes/     @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030 @m5i-work @v1212
+/cli/azd/extensions/azure.ai.projects/      @JeffreyCA @glharper @trangevi @therealjohn @huimiu @hund030 @m5i-work @v1212
+/cli/azd/extensions/azure.ai.rle/           @JeffreyCA @glharper @trangevi @therealjohn @huimiu @hund030 @m5i-work @v1212
+/cli/azd/extensions/azure.ai.routines/      @JeffreyCA @glharper @trangevi @therealjohn @huimiu @hund030 @m5i-work @v1212
+/cli/azd/extensions/azure.ai.skills/        @JeffreyCA @glharper @trangevi @therealjohn @huimiu @hund030 @m5i-work @v1212
+/cli/azd/extensions/azure.ai.toolboxes/     @JeffreyCA @glharper @trangevi @therealjohn @huimiu @hund030 @m5i-work @v1212
 /cli/azd/extensions/azure.ai.training/      @JeffreyCA @trangevi @achauhan-scc @kingernupur @saanikaguptamicrosoft
-/cli/azd/extensions/microsoft.foundry/      @JeffreyCA @glharper @trangevi @trrwilson @therealjohn @huimiu @hund030 @m5i-work @v1212
+/cli/azd/extensions/microsoft.foundry/      @JeffreyCA @glharper @trangevi @therealjohn @huimiu @hund030 @m5i-work @v1212
 
 # ── Extensions ────────────────────────────────────────────────────────────────
 /ext/                                       @vhvb1989 @tg-msft @RickWinter
@@ -38,6 +38,8 @@
 
 # ── Infra / CI / Engineering ─────────────────────────────────────────────────
 /.github/                                   @danieljurek @vhvb1989 @tg-msft @RickWinter @richardpark-msft
+/.github/agents/foundry-extension-scenario-*.agent.md @JeffreyCA @glharper @trangevi @therealjohn @huimiu @hund030 @m5i-work @v1212
+/.github/skills/foundry-extension-scenario-*/         @JeffreyCA @glharper @trangevi @therealjohn @huimiu @hund030 @m5i-work @v1212
 /eng/                                       @danieljurek @vhvb1989 @tg-msft @RickWinter @richardpark-msft
 /.config/1espt/                             @Azure/azure-sdk-eng
 


### PR DESCRIPTION
The Foundry extension scenario agents and skills introduced in #9342 currently inherit the general `.github` owners instead of the maintainers responsible for the `azure.ai.agents` extension. The CODEOWNERS file also still lists a former maintainer.

This change:
- assigns the existing `azure.ai.agents` owner set to Foundry scenario agent definitions and skill directories
- places the specific rules after the general `.github` rule so last-match-wins precedence applies
- removes `@trrwilson` from all ownership entries